### PR TITLE
Fix recovery notifications reappearing every 7+ game days

### DIFF
--- a/app/Game/Services/EligibilityService.php
+++ b/app/Game/Services/EligibilityService.php
@@ -42,6 +42,16 @@ class EligibilityService
     }
 
     /**
+     * Clear a player's injury after recovery.
+     */
+    public function clearInjury(GamePlayer $player): void
+    {
+        $player->injury_until = null;
+        $player->injury_type = null;
+        $player->save();
+    }
+
+    /**
      * Check if a player has crossed a yellow card threshold and should be suspended.
      * Returns the number of matches to suspend, or null if no suspension.
      */


### PR DESCRIPTION
The injury_until field was never cleared after a player recovered, causing checkRecoveredPlayers() to keep detecting them as "recovered" on every subsequent matchday. The 7-day dedup window in hasRecentNotification() only prevented immediate duplicates — after 7 game days, a new recovery notification was created again.

Now clearInjury() is called when recovery is detected, nulling out injury_until and injury_type so the condition cannot re-trigger.

https://claude.ai/code/session_01LSNo7Ns5kjr8eg7MGnx6Jw