### PR TITLE
Schedule beta invite command to send 20 invites daily at 21:00

### DIFF
--- a/app/Console/Commands/InviteFromWaitlist.php
+++ b/app/Console/Commands/InviteFromWaitlist.php
@@ -20,6 +20,12 @@ class InviteFromWaitlist extends Command
 
     public function handle(): int
     {
+        if (! config('beta.enabled')) {
+            $this->info('Beta mode is disabled, skipping.');
+
+            return self::SUCCESS;
+        }
+
         $count = (int) $this->argument('count');
 
         if ($count <= 0) {

--- a/config/beta.php
+++ b/config/beta.php
@@ -27,4 +27,15 @@ return [
 
     'feedback_url' => env('BETA_FEEDBACK_URL', 'https://github.com/pabloroman/virtua-fc/issues'),
 
+    /*
+    |--------------------------------------------------------------------------
+    | Daily Invites
+    |--------------------------------------------------------------------------
+    |
+    | Number of waitlist entries to invite each day when the scheduler runs.
+    |
+    */
+
+    'daily_invites' => (int) env('BETA_DAILY_INVITES', 20),
+
 ];

--- a/routes/console.php
+++ b/routes/console.php
@@ -4,3 +4,4 @@ use Illuminate\Support\Facades\Schedule;
 
 Schedule::command('app:cleanup-unplayed-games')->dailyAt('04:00');
 Schedule::command('app:send-beta-feedback-requests')->hourly();
+Schedule::command('beta:invite-waitlist '.config('beta.daily_invites'))->dailyAt('21:00');


### PR DESCRIPTION
Reuses the existing beta:invite-waitlist command with the Laravel
scheduler. Adds a beta.daily_invites config option (default 20,
configurable via BETA_DAILY_INVITES env var) and a beta mode guard
to InviteFromWaitlist so it no-ops when beta is disabled.

https://claude.ai/code/session_01Cq4t7oErcYifhgexVDG9kt