### PR TITLE
Remove away goals rule from knockout tiebreaker

### DIFF
--- a/app/Game/Services/CupTieResolver.php
+++ b/app/Game/Services/CupTieResolver.php
@@ -137,22 +137,7 @@ class CupTieResolver
             return $winnerId;
         }
 
-        // Tied on aggregate - check away goals (tie's home team = first leg home team)
-        // Away goals rule: if aggregate is tied, team with more away goals wins
-        $homeAwayGoals = $aggregate['home_away_goals']; // Home team's goals scored away
-        $awayAwayGoals = $aggregate['away_away_goals']; // Away team's goals scored away
-
-        if ($homeAwayGoals !== $awayAwayGoals) {
-            $winnerId = $homeAwayGoals > $awayAwayGoals ? $tie->home_team_id : $tie->away_team_id;
-            $this->completeTie($tie, $winnerId, [
-                'type' => 'away_goals',
-                'aggregate' => "{$homeTotal}-{$awayTotal}",
-                'away_goals' => "{$homeAwayGoals}-{$awayAwayGoals}",
-            ]);
-            return $winnerId;
-        }
-
-        // Still tied - extra time in second leg
+        // Tied on aggregate - extra time in second leg
         $homePlayers = $allPlayers->get($secondLeg->home_team_id, collect());
         $awayPlayers = $allPlayers->get($secondLeg->away_team_id, collect());
         $homeTeam = $secondLeg->relationLoaded('homeTeam') ? $secondLeg->homeTeam : Team::find($secondLeg->home_team_id);

--- a/app/Models/CupTie.php
+++ b/app/Models/CupTie.php
@@ -82,7 +82,7 @@ class CupTie extends Model
     /**
      * Get aggregate score for two-legged ties.
      *
-     * @return array{home: int, away: int, home_away_goals: int, away_away_goals: int}
+     * @return array{home: int, away: int}
      */
     public function getAggregateScore(): array
     {
@@ -91,28 +91,21 @@ class CupTie extends Model
 
         $homeTotal = 0;
         $awayTotal = 0;
-        $homeAwayGoals = 0;
-        $awayAwayGoals = 0;
 
         if ($firstLeg?->played) {
-            // First leg: home team plays at home
             $homeTotal += $firstLeg->home_score ?? 0;
             $awayTotal += $firstLeg->away_score ?? 0;
-            $awayAwayGoals = $firstLeg->away_score ?? 0; // Away team's goals at home team's stadium
         }
 
         if ($secondLeg?->played) {
             // Second leg: away team plays at home (teams swap)
             $homeTotal += $secondLeg->away_score ?? 0;
             $awayTotal += $secondLeg->home_score ?? 0;
-            $homeAwayGoals = $secondLeg->away_score ?? 0; // Home team's goals at away team's stadium
         }
 
         return [
             'home' => $homeTotal,
             'away' => $awayTotal,
-            'home_away_goals' => $homeAwayGoals,
-            'away_away_goals' => $awayAwayGoals,
         ];
     }
 

--- a/lang/es/cup.php
+++ b/lang/es/cup.php
@@ -24,7 +24,6 @@ return [
     // Resolution types
     'pens' => 'Pen:',
     'aet' => 'Prórroga',
-    'away_goals' => 'Goles fuera',
     'agg' => 'Agg:',
 
     // Legend

--- a/resources/views/components/cup-tie-card.blade.php
+++ b/resources/views/components/cup-tie-card.blade.php
@@ -45,8 +45,6 @@
                 {{ __('cup.pens') }} {{ $tie->resolution['penalties'] }}
             @elseif($tie->resolution['type'] === 'extra_time')
                 {{ __('cup.aet') }}
-            @elseif($tie->resolution['type'] === 'away_goals')
-                {{ __('cup.away_goals') }}
             @elseif($tie->resolution['type'] === 'aggregate')
                 {{ __('cup.agg') }} {{ $tie->resolution['aggregate'] }}
             @endif


### PR DESCRIPTION
The away goals rule was abolished by UEFA in 2021. Two-legged ties
now go directly from aggregate to extra time when level on aggregate.

https://claude.ai/code/session_016rXuorX5YdjUrr3tHTGQ7U