### PR TITLE
Phase 5: Add competition scope field and clean up role-based queries

### DIFF
--- a/app/Console/Commands/SeedReferenceData.php
+++ b/app/Console/Commands/SeedReferenceData.php
@@ -393,6 +393,7 @@ class SeedReferenceData extends Command
     private function seedCompetitionRecord(string $code, array $data, int $tier, string $type, string $handler, string $country, string $role = 'foreign'): void
     {
         $season = $data['seasonID'] ?? '2025';
+        $scope = ($role === 'european') ? 'continental' : 'domestic';
 
         DB::table('competitions')->updateOrInsert(
             ['id' => $code],
@@ -402,6 +403,7 @@ class SeedReferenceData extends Command
                 'tier' => $tier,
                 'type' => $type,
                 'role' => $role,
+                'scope' => $scope,
                 'handler_type' => $handler,
                 'season' => $season,
             ]

--- a/app/Game/Services/LoanService.php
+++ b/app/Game/Services/LoanService.php
@@ -117,7 +117,8 @@ class LoanService
     {
         $teams = Team::with(['clubProfile', 'competitions'])
             ->whereHas('competitions', function ($q) {
-                $q->whereIn('role', [Competition::ROLE_PRIMARY, Competition::ROLE_FOREIGN]);
+                $q->where('scope', Competition::SCOPE_DOMESTIC)
+                    ->where('type', 'league');
             })
             ->where('id', '!=', $game->team_id)
             ->get();

--- a/app/Game/Services/TransferService.php
+++ b/app/Game/Services/TransferService.php
@@ -695,9 +695,10 @@ class TransferService
         $playerTeamId = $player->team_id;
         $playerValue = $player->market_value_cents;
 
-        // Get all teams in the same league(s) as the player's team, excluding player's team
-        $leagueTeamIds = Team::whereHas('competitions', function ($query) use ($game) {
-            $query->whereIn('role', [Competition::ROLE_PRIMARY, Competition::ROLE_FOREIGN]);
+        // Get all teams in domestic leagues (both playable and foreign), excluding player's team
+        $leagueTeamIds = Team::whereHas('competitions', function ($query) {
+            $query->where('scope', Competition::SCOPE_DOMESTIC)
+                ->where('type', 'league');
         })->where('id', '!=', $playerTeamId)->pluck('id')->toArray();
 
         $squadValues = $this->getSquadValues($game, $leagueTeamIds);

--- a/app/Http/Views/ShowOnboarding.php
+++ b/app/Http/Views/ShowOnboarding.php
@@ -76,10 +76,10 @@ class ShowOnboarding
 
         $competitions = Competition::whereIn('id', $competitionIds)
             ->get()
-            ->sortBy(fn ($c) => match ($c->role) {
-                Competition::ROLE_PRIMARY => 0,
-                Competition::ROLE_DOMESTIC_CUP => 1,
-                Competition::ROLE_EUROPEAN => 2,
+            ->sortBy(fn ($c) => match (true) {
+                $c->scope === Competition::SCOPE_DOMESTIC && $c->type === 'league' => 0,
+                $c->scope === Competition::SCOPE_DOMESTIC && $c->type === 'cup' => 1,
+                $c->scope === Competition::SCOPE_CONTINENTAL => 2,
                 default => 3,
             })
             ->values();

--- a/app/Models/Competition.php
+++ b/app/Models/Competition.php
@@ -21,6 +21,9 @@ class Competition extends Model
     public const ROLE_EUROPEAN = 'european';
     public const ROLE_FOREIGN = 'foreign';
 
+    public const SCOPE_DOMESTIC = 'domestic';
+    public const SCOPE_CONTINENTAL = 'continental';
+
     protected $fillable = [
         'id',
         'name',
@@ -28,6 +31,7 @@ class Competition extends Model
         'tier',
         'type',
         'role',
+        'scope',
         'season',
         'handler_type',
     ];

--- a/database/factories/CompetitionFactory.php
+++ b/database/factories/CompetitionFactory.php
@@ -18,6 +18,7 @@ class CompetitionFactory extends Factory
             'tier' => 1,
             'type' => 'league',
             'role' => Competition::ROLE_PRIMARY,
+            'scope' => Competition::SCOPE_DOMESTIC,
             'handler_type' => 'league',
             'season' => '2024',
         ];
@@ -28,6 +29,7 @@ class CompetitionFactory extends Factory
         return $this->state(fn (array $attributes) => [
             'type' => 'league',
             'role' => Competition::ROLE_PRIMARY,
+            'scope' => Competition::SCOPE_DOMESTIC,
             'handler_type' => 'league',
         ]);
     }
@@ -37,6 +39,7 @@ class CompetitionFactory extends Factory
         return $this->state(fn (array $attributes) => [
             'type' => 'cup',
             'role' => Competition::ROLE_DOMESTIC_CUP,
+            'scope' => Competition::SCOPE_DOMESTIC,
             'handler_type' => 'knockout_cup',
         ]);
     }
@@ -46,6 +49,7 @@ class CompetitionFactory extends Factory
         return $this->state(fn (array $attributes) => [
             'type' => 'cup',
             'role' => Competition::ROLE_EUROPEAN,
+            'scope' => Competition::SCOPE_CONTINENTAL,
             'handler_type' => 'group_stage_cup',
         ]);
     }

--- a/database/migrations/2026_02_15_000001_add_scope_to_competitions_table.php
+++ b/database/migrations/2026_02_15_000001_add_scope_to_competitions_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('competitions', function (Blueprint $table) {
+            $table->string('scope', 20)->default('domestic')->after('role');
+        });
+
+        // Derive scope from existing role values
+        DB::table('competitions')
+            ->where('role', 'european')
+            ->update(['scope' => 'continental']);
+    }
+
+    public function down(): void
+    {
+        Schema::table('competitions', function (Blueprint $table) {
+            $table->dropColumn('scope');
+        });
+    }
+};

--- a/resources/views/game.blade.php
+++ b/resources/views/game.blade.php
@@ -14,10 +14,10 @@
                     <div class="md:col-span-2 space-y-8">
                         {{-- Next Match --}}
                         @php
-                            $competitionRole = $nextMatch->competition->role ?? 'primary';
-                            $accent = match($competitionRole) {
-                                'domestic_cup' => ['border' => 'border-l-emerald-500', 'badge' => 'bg-emerald-100 text-emerald-800'],
-                                'european' => ['border' => 'border-l-blue-600', 'badge' => 'bg-blue-100 text-blue-800'],
+                            $comp = $nextMatch->competition;
+                            $accent = match(true) {
+                                ($comp->scope ?? '') === 'continental' => ['border' => 'border-l-blue-600', 'badge' => 'bg-blue-100 text-blue-800'],
+                                ($comp->type ?? '') === 'cup' => ['border' => 'border-l-emerald-500', 'badge' => 'bg-emerald-100 text-emerald-800'],
                                 default => ['border' => 'border-l-amber-500', 'badge' => 'bg-amber-100 text-amber-800'],
                             };
                         @endphp

--- a/resources/views/onboarding.blade.php
+++ b/resources/views/onboarding.blade.php
@@ -57,9 +57,9 @@
                 <div class="grid {{ $gridCols }} gap-3">
                     @foreach($competitions as $comp)
                         @php
-                            $compAccent = match($comp->role) {
-                                'domestic_cup' => ['border' => 'border-t-emerald-500', 'label' => __('game.competition_role_cup')],
-                                'european' => ['border' => 'border-t-blue-600', 'label' => __('game.competition_role_continental')],
+                            $compAccent = match(true) {
+                                $comp->scope === 'continental' => ['border' => 'border-t-blue-600', 'label' => __('game.competition_role_continental')],
+                                $comp->type === 'cup' => ['border' => 'border-t-emerald-500', 'label' => __('game.competition_role_cup')],
                                 default => ['border' => 'border-t-amber-500', 'label' => __('game.competition_role_league')],
                             };
                         @endphp


### PR DESCRIPTION
Add `scope` column to competitions table with values 'domestic' and 'continental', derived from the existing `role` field. This provides a cleaner semantic grouping than role for cross-cutting queries.

Migration:
- Add scope column, default 'domestic'
- Populate 'continental' for existing european-role competitions

Competition model:
- Add SCOPE_DOMESTIC, SCOPE_CONTINENTAL constants
- Add scope to fillable array

Query improvements:
- TransferService: Replace whereIn(role, [PRIMARY, FOREIGN]) with where(scope, domestic)->where(type, league) — clearer intent
- LoanService: Same pattern for loan destination queries

UI accent colors:
- onboarding.blade.php: Use scope + type instead of role for competition card theming (continental → blue, cup → emerald)
- game.blade.php: Same for next match card accent colors
- ShowOnboarding: Sort competitions by scope + type

Also updated SeedReferenceData and CompetitionFactory to set scope.

https://claude.ai/code/session_01PrGEHoYpAfFj8pYBUKF1QB