### PR TITLE
Phase 6: Add country field to games table

### DIFF
--- a/app/Game/GameProjector.php
+++ b/app/Game/GameProjector.php
@@ -64,6 +64,7 @@ class GameProjector extends Projector
             'id' => $gameId,
             'user_id' => $event->userId,
             'game_mode' => $event->gameMode,
+            'country' => $team->country ?? 'ES',
             'player_name' => $event->playerName,
             'team_id' => $teamId,
             'competition_id' => $competitionId,

--- a/app/Game/Services/ScoutingService.php
+++ b/app/Game/Services/ScoutingService.php
@@ -202,7 +202,7 @@ class ScoutingService
             $scope = ['domestic'];
         }
         if (count($scope) === 1) {
-            $teamCountry = $game->team->country;
+            $teamCountry = $game->country;
             $scopeCompetitionIds = Competition::where('country', in_array('domestic', $scope) ? '=' : '!=', $teamCountry)
                 ->pluck('id');
             $scopeTeamIds = Team::whereHas('competitions', function ($q) use ($scopeCompetitionIds) {

--- a/app/Http/Views/ShowScouting.php
+++ b/app/Http/Views/ShowScouting.php
@@ -139,7 +139,7 @@ class ShowScouting
             'scoutedPlayers' => $scoutedPlayers,
             'playerDetails' => $playerDetails,
             'existingOffers' => $existingOffers,
-            'teamCountry' => $game->team->country,
+            'teamCountry' => $game->country,
             'isTransferWindow' => $isTransferWindow,
             'currentWindow' => $currentWindow,
             'isPreContractPeriod' => $isPreContractPeriod,

--- a/app/Jobs/SetupNewGame.php
+++ b/app/Jobs/SetupNewGame.php
@@ -176,8 +176,8 @@ class SetupNewGame implements ShouldQueue
         }
 
         $countryConfig = app(CountryConfig::class);
-        $team = Team::find($this->teamId);
-        $countryCode = $team?->country ?? 'ES';
+        $game = Game::find($this->gameId);
+        $countryCode = $game?->country ?? 'ES';
 
         // Get competitions in dependency order from country config
         $competitionIds = $countryConfig->playerInitializationOrder($countryCode);
@@ -269,8 +269,8 @@ class SetupNewGame implements ShouldQueue
         StandingsCalculator $standingsCalculator,
     ): void {
         $countryConfig = app(CountryConfig::class);
-        $team = Team::find($this->teamId);
-        $countryCode = $team?->country ?? 'ES';
+        $game = Game::find($this->gameId);
+        $countryCode = $game?->country ?? 'ES';
         $continentalIds = $countryConfig->continentalSupportIds($countryCode);
 
         // Also include any swiss_format competitions not in the config (backward compat)

--- a/app/Models/Game.php
+++ b/app/Models/Game.php
@@ -34,6 +34,7 @@ class Game extends Model
         'id',
         'user_id',
         'game_mode',
+        'country',
         'player_name',
         'team_id',
         'competition_id',

--- a/database/migrations/2026_02_15_000002_add_country_to_games_table.php
+++ b/database/migrations/2026_02_15_000002_add_country_to_games_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('games', function (Blueprint $table) {
+            $table->string('country', 5)->default('ES')->after('game_mode');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('games', function (Blueprint $table) {
+            $table->dropColumn('country');
+        });
+    }
+};


### PR DESCRIPTION
The Game model now explicitly stores which country the career is in, removing the need to derive it from team.country at runtime.

Migration:
- Add country column (string, default 'ES') to games table

GameProjector:
- Set country from team.country when creating a new game

SetupNewGame:
- Read country from game record instead of loading the team to get its country (2 places: initializeGamePlayers, initializeSwiss)

ScoutingService + ShowScouting:
- Use $game->country instead of $game->team->country, avoiding an extra relationship load

This enables multi-country support — the game knows "I'm a Spain career" and can set up the right ecosystem from config.

https://claude.ai/code/session_01PrGEHoYpAfFj8pYBUKF1QB