### PR TITLE
Improve match result realism with ratio-based xG formula

### DIFF
--- a/app/Console/Commands/SimulateMatch.php
+++ b/app/Console/Commands/SimulateMatch.php
@@ -105,13 +105,12 @@ class SimulateMatch extends Command
         $this->table(
             ['Parameter', 'Value'],
             [
-                ['base_home_goals', config('match_simulation.base_home_goals', 1.4)],
-                ['base_away_goals', config('match_simulation.base_away_goals', 0.9)],
-                ['strength_multiplier', config('match_simulation.strength_multiplier', 1.0)],
-                ['strength_exponent', config('match_simulation.strength_exponent', 1.0)],
-                ['home_advantage_goals', config('match_simulation.home_advantage_goals', 0.2)],
-                ['away_disadvantage_multiplier', config('match_simulation.away_disadvantage_multiplier', 1.0)],
-                ['performance_std_dev', config('match_simulation.performance_std_dev', 0.12)],
+                ['base_goals', config('match_simulation.base_goals', 1.3)],
+                ['ratio_exponent', config('match_simulation.ratio_exponent', 2.0)],
+                ['home_advantage_goals', config('match_simulation.home_advantage_goals', 0.15)],
+                ['performance_std_dev', config('match_simulation.performance_std_dev', 0.05)],
+                ['performance_min', config('match_simulation.performance_min', 0.90)],
+                ['performance_max', config('match_simulation.performance_max', 1.10)],
             ]
         );
 

--- a/config/match_simulation.php
+++ b/config/match_simulation.php
@@ -11,66 +11,24 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Expected Goals Base Values
+    | Expected Goals (Ratio-Based Formula)
     |--------------------------------------------------------------------------
     |
-    | These are the starting expected goals before strength is applied.
-    | Lower values mean team strength matters more.
+    | The xG formula uses strength RATIOS rather than shares:
+    |
+    |   homeXG = (strengthRatio ^ ratioExponent) × baseGoals + homeAdvantage
+    |   awayXG = (1/strengthRatio ^ ratioExponent) × baseGoals
+    |
+    | When teams are equal (ratio=1.0), both get base_goals (1.3 xG).
+    | When elite faces bottom (ratio ~1.30), elite gets ~2.20 xG vs ~0.77.
+    | The stronger team is ALWAYS favored regardless of venue.
     |
     | Real-world La Liga average: ~2.5 goals per match
-    | Home teams score ~1.5 goals on average, away teams ~1.0
     |
     */
-    'base_home_goals' => 0.8,
-    'base_away_goals' => 0.5,
-
-    /*
-    |--------------------------------------------------------------------------
-    | Strength Impact
-    |--------------------------------------------------------------------------
-    |
-    | Controls how much team quality affects the result.
-    |
-    | strength_multiplier: How much strength adds to expected goals (0.5-2.0)
-    |   - 1.0 = moderate impact (default)
-    |   - 1.5 = stronger teams score significantly more
-    |   - 0.5 = more parity, weaker teams can compete
-    |
-    | strength_exponent: Amplifies differences between strong and weak teams (1.0-2.0)
-    |   - 1.0 = linear (default)
-    |   - 1.5 = strong teams get bonus, weak teams get penalty
-    |   - 2.0 = very strong amplification (top teams dominate)
-    |
-    | Example with 85 vs 65 rated teams:
-    |   - exponent 1.0: ratio stays ~57% vs 43%
-    |   - exponent 1.5: ratio becomes ~61% vs 39%
-    |   - exponent 1.8: ratio becomes ~65% vs 35%
-    |
-    */
-    'strength_multiplier' => 1.2,
-    'strength_exponent' => 1.8,
-
-    /*
-    |--------------------------------------------------------------------------
-    | Home Advantage
-    |--------------------------------------------------------------------------
-    |
-    | Additional bonus for the home team beyond base goals.
-    |
-    | home_advantage_goals: Extra expected goals for home team (0.0-0.5)
-    |   - 0.0 = no home advantage
-    |   - 0.2 = slight advantage
-    |   - 0.3 = moderate advantage (realistic)
-    |   - 0.5 = strong advantage
-    |
-    | away_disadvantage_multiplier: Reduces away team's effectiveness (0.7-1.0)
-    |   - 1.0 = no penalty (default)
-    |   - 0.9 = 10% reduction in away team's strength contribution
-    |   - 0.8 = 20% reduction (significant away disadvantage)
-    |
-    */
-    'home_advantage_goals' => 0.2,
-    'away_disadvantage_multiplier' => 0.9,
+    'base_goals' => 1.3,                // avg xG per team when evenly matched (~2.6 total)
+    'ratio_exponent' => 2.0,            // amplifies strength ratio into xG gap
+    'home_advantage_goals' => 0.15,     // fixed home xG bonus
 
     /*
     |--------------------------------------------------------------------------
@@ -80,19 +38,19 @@ return [
     | Controls the "form on the day" randomness for each player.
     | Each player gets a performance modifier that affects their contribution.
     |
-    | performance_std_dev: Standard deviation of the bell curve (0.05-0.20)
-    |   - 0.05 = very consistent, best team almost always wins
-    |   - 0.08 = low variance, fewer upsets
-    |   - 0.12 = moderate variance (default)
-    |   - 0.20 = high variance, more upsets
+    | performance_std_dev: Standard deviation of the bell curve (0.03-0.20)
+    |   - 0.03 = very consistent, best team almost always wins
+    |   - 0.05 = low variance, lineup quality is decisive (default)
+    |   - 0.08 = moderate variance, some upsets
+    |   - 0.20 = high variance, many upsets
     |
     | performance_min/max: Absolute bounds for performance modifier
-    |   - Default 0.80-1.20 means players can perform 20% below or above their rating
+    |   - Default 0.90-1.10 means players can perform 10% below or above their rating
     |
     */
-    'performance_std_dev' => 0.10,
-    'performance_min' => 0.80,
-    'performance_max' => 1.20,
+    'performance_std_dev' => 0.05,
+    'performance_min' => 0.90,
+    'performance_max' => 1.10,
 
     /*
     |--------------------------------------------------------------------------

--- a/docs/game-systems/match-simulation.md
+++ b/docs/game-systems/match-simulation.md
@@ -5,7 +5,7 @@ This document describes how match results are simulated in VirtuaFC.
 ## Overview
 
 Match simulation uses a **Poisson distribution** to generate realistic scorelines based on:
-- Team strength (from player abilities)
+- Team strength ratios (from player abilities)
 - Formation and mentality
 - Home advantage
 - Striker quality bonus
@@ -13,32 +13,33 @@ Match simulation uses a **Poisson distribution** to generate realistic scoreline
 
 ## Expected Goals Calculation
 
-The core of match simulation is calculating **expected goals** for each team.
+The core of match simulation is calculating **expected goals** for each team using a **ratio-based** formula.
 
 ### Base Formula
 
 ```
-homeExpectedGoals = (baseHomeGoals + homeAdvantage + strengthContribution)
-                    × formationModifiers × mentalityModifiers + strikerBonus
+strengthRatio = homeStrength / awayStrength
 
-awayExpectedGoals = (baseAwayGoals + strengthContribution × awayDisadvantage)
-                    × formationModifiers × mentalityModifiers + strikerBonus
+homeXG = (strengthRatio ^ ratioExponent) × baseGoals + homeAdvantage
+         × formationModifiers × mentalityModifiers + strikerBonus
+
+awayXG = ((1/strengthRatio) ^ ratioExponent) × baseGoals
+         × formationModifiers × mentalityModifiers + strikerBonus
 ```
+
+When teams are equal (ratio = 1.0), both get `baseGoals` (1.3 xG). The stronger team is **always** favored regardless of venue — home advantage is a modest +0.15 on top.
 
 ### Configuration Values
 
 | Parameter | Value | Description |
 |-----------|-------|-------------|
-| `base_home_goals` | 0.5 | Base expected goals for home team |
-| `base_away_goals` | 0.3 | Base expected goals for away team |
-| `strength_multiplier` | 3.0 | How much strength adds to xG |
-| `strength_exponent` | 2.0 | Amplifies strong vs weak gaps |
-| `home_advantage_goals` | 0.15 | Extra xG for home team |
-| `away_disadvantage_multiplier` | 0.8 | Away team strength reduction |
+| `base_goals` | 1.3 | xG per team when evenly matched (~2.6 total) |
+| `ratio_exponent` | 2.0 | Amplifies strength ratio into xG gap |
+| `home_advantage_goals` | 0.15 | Fixed home xG bonus |
 
 ### Team Strength Calculation
 
-Team strength is calculated from the 11 players in the lineup:
+Team strength is calculated from the 11 players in the lineup. Ability is dominant (90% weight), while fitness/morale provide a small nudge:
 
 ```php
 foreach ($lineup as $player) {
@@ -47,10 +48,10 @@ foreach ($lineup as $player) {
     $effectiveTechnical = $player->technical_ability × $performance;
     $effectivePhysical = $player->physical_ability × (0.5 + $performance × 0.5);
 
-    $playerStrength = ($effectiveTechnical × 0.40) +
-                      ($effectivePhysical × 0.25) +
-                      ($player->fitness × 0.20) +
-                      ($player->morale × 0.15);
+    $playerStrength = ($effectiveTechnical × 0.55) +
+                      ($effectivePhysical × 0.35) +
+                      ($player->fitness × 0.05) +
+                      ($player->morale × 0.05);
 
     $totalStrength += $playerStrength;
 }
@@ -58,14 +59,7 @@ foreach ($lineup as $player) {
 $teamStrength = ($totalStrength / 11) / 100; // Normalized to 0-1
 ```
 
-The strength exponent amplifies differences:
-
-```php
-$homeStrength = pow($homeStrength, 2.0);
-$awayStrength = pow($awayStrength, 2.0);
-```
-
-This means an 85-rated team vs a 75-rated team has a larger effective gap than the raw 10-point difference.
+Fitness and morale still affect matches through `getMatchPerformance()` modifiers — they influence the daily performance bell curve for each player.
 
 ### Striker Quality Bonus
 
@@ -75,31 +69,31 @@ Elite forwards boost their team's expected goals:
 $forwardPositions = ['Centre-Forward', 'Second Striker', 'Left Winger', 'Right Winger'];
 $bestForwardScore = max(forwards' effective scores);
 
-if ($bestForwardScore >= 80) {
-    $strikerBonus = ($bestForwardScore - 80) / 40; // 0.0 to 0.5
+if ($bestForwardScore >= 85) {
+    $strikerBonus = ($bestForwardScore - 85) / 60; // 0.0 to 0.25
 }
 ```
 
 | Best Forward Rating | Bonus xG |
 |---------------------|----------|
-| 94 (Mbappé) | +0.35 |
-| 90 | +0.25 |
-| 85 | +0.125 |
-| <80 | +0.0 |
+| 94 (Mbappé) | +0.15 |
+| 90 | +0.08 |
+| 85 | +0.0 |
+| <85 | +0.0 |
 
 ## Match Performance Variance
 
 Each player gets a random "form on the day" modifier:
 
 ```
-performance = 1.0 + (normal_distribution × 0.06)
-clamped to: 0.85 - 1.15
+performance = 1.0 + (normal_distribution × 0.05)
+clamped to: 0.90 - 1.10
 ```
 
 This means:
-- ~68% of performances are within ±6% of base ability
-- ~95% are within ±12%
-- Extreme performances (0.85 or 1.15) are rare
+- ~68% of performances are within ±5% of base ability
+- ~95% are within ±10%
+- The tight range rewards careful lineup crafting — the better squad reliably wins
 
 ### Morale & Fitness Influence
 
@@ -116,41 +110,72 @@ $homeScore = poissonRandom($homeExpectedGoals);
 $awayScore = poissonRandom($awayExpectedGoals);
 ```
 
-Scores are capped at 7 to prevent unrealistic cricket scores.
+Scores are capped at 6 to prevent unrealistic cricket scores.
 
 ### Example Calculations
 
-**Real Madrid (92 avg) vs Rayo Vallecano (73 avg) at Home**
+**Real Madrid (90 avg) HOME vs Rayo Vallecano (72 avg)**
 
 ```
-Home strength: (0.92)^2 = 0.85
-Away strength: (0.73)^2 = 0.53
-Total: 1.38
+Home strength: 0.90 (normalized)
+Away strength: 0.72 (normalized)
+Ratio: 0.90 / 0.72 = 1.25
 
-Home xG contribution: (0.85 / 1.38) × 3.0 = 1.85
-Away xG contribution: (0.53 / 1.38) × 3.0 × 0.8 = 0.92
+Home xG: (1.25^2) × 1.3 + 0.15 = 2.18
+Away xG: (0.80^2) × 1.3 = 0.83
 
-Home xG: 0.5 + 0.15 + 1.85 + 0.35 (striker) = 2.85
-Away xG: 0.3 + 0.92 = 1.22
-
-Typical result: 3-1 or 2-1 to Real Madrid
+Typical result: 2-0 or 2-1 to Real Madrid
+Home win ~73%
 ```
 
-**Even Match (both 85 avg)**
+**Rayo Vallecano (72 avg) HOME vs Real Madrid (90 avg)**
 
 ```
-Home strength: (0.85)^2 = 0.72
-Away strength: (0.85)^2 = 0.72
-Total: 1.44
+Home strength: 0.72 (normalized)
+Away strength: 0.90 (normalized)
+Ratio: 0.72 / 0.90 = 0.80
 
-Home xG contribution: 0.5 × 3.0 = 1.5
-Away xG contribution: 0.5 × 3.0 × 0.8 = 1.2
+Home xG: (0.80^2) × 1.3 + 0.15 = 0.98
+Away xG: (1.25^2) × 1.3 = 2.03
 
-Home xG: 0.5 + 0.15 + 1.5 + 0.2 = 2.35
-Away xG: 0.3 + 1.2 + 0.2 = 1.7
-
-Typical result: 2-1 or 2-2
+Typical result: 0-2 or 1-2 to Real Madrid
+Real Madrid win even away ~55%
 ```
+
+**Even Match (both 82 avg)**
+
+```
+Ratio: 1.0
+
+Home xG: (1.0^2) × 1.3 + 0.15 = 1.45
+Away xG: (1.0^2) × 1.3 = 1.30
+
+Typical result: 1-1 or 2-1
+Home win ~39%, Draw ~28%, Away win ~33%
+```
+
+## Extra Time
+
+Extra time uses the same ratio-based formula, scaled to 30 minutes with a 20% fatigue reduction:
+
+```php
+$etFraction = 30.0 / 90.0;
+$etBaseGoals = $baseGoals × 0.8; // fatigue
+$homeXG = (ratio^exp × etBaseGoals + homeAdvantage) × etFraction;
+$awayXG = ((1/ratio)^exp × etBaseGoals) × etFraction;
+```
+
+## Season Simulation (Non-Played Leagues)
+
+Leagues that the player doesn't participate in are simulated using the same ratio-based formula on a **match-by-match** basis:
+
+1. Calculate squad strength for each team (0-100 scale from `BudgetProjectionService`)
+2. Simulate all N×(N-1) fixtures (home and away for each pair)
+3. Generate Poisson-distributed goals per match using ratio-based xG
+4. Accumulate points (3W/1D/0L)
+5. Sort by points → goal difference → goals for
+
+This produces realistic standings with ~380 matches for a 20-team league — computationally trivial but statistically sound, as match-by-match averaging naturally produces realistic variance.
 
 ## Match Events
 
@@ -175,26 +200,21 @@ Goal scorer selection uses `pickGoalScorer()` with two mechanisms to prevent unr
 | Second Striker | 22 |
 | Left/Right Winger | 15 |
 | Attacking Midfield | 12 |
-| Central Midfield | 8 |
-| Left/Right Midfield | 6 |
-| Defensive Midfield | 4 |
-| Left/Right-Back | 3 |
+| Central Midfield | 6 |
+| Left/Right Midfield | 5 |
+| Defensive Midfield | 3 |
+| Left/Right-Back | 2 |
 | Centre-Back | 2 |
 | Goalkeeper | 0 |
 
-Expected season outcomes:
-- Top scorer accounts for ~28-33% of team goals (vs real La Liga ~25-35%)
-- Top scorer: 18-23 goals in 38 games
-- 3-5 players per team with 8+ goals
-
 ### Cards
-- ~1.7 yellow cards per team per match
+- ~1.5 yellow cards per team per match
 - Losing teams get more cards (frustration)
-- ~1.5% chance of direct red per team
+- ~1% chance of direct red per team
 
 ### Injuries
-- ~5% chance per team per match
-- Random injury type and duration (1-6 weeks)
+- ~4% chance per team per match
+- Random injury type and duration
 
 ## Configuration
 
@@ -202,16 +222,13 @@ All parameters are tunable in `config/match_simulation.php`:
 
 ```php
 return [
-    'base_home_goals' => 0.5,
-    'base_away_goals' => 0.3,
-    'strength_multiplier' => 3.0,
-    'strength_exponent' => 2.0,
+    'base_goals' => 1.3,
+    'ratio_exponent' => 2.0,
     'home_advantage_goals' => 0.15,
-    'away_disadvantage_multiplier' => 0.8,
-    'performance_std_dev' => 0.06,
-    'performance_min' => 0.85,
-    'performance_max' => 1.15,
-    'max_goals_cap' => 7,
+    'performance_std_dev' => 0.05,
+    'performance_min' => 0.90,
+    'performance_max' => 1.10,
+    'max_goals_cap' => 6,
     // ... event probabilities
 ];
 ```
@@ -220,32 +237,41 @@ return [
 
 See `app/Game/Services/MatchSimulator.php`:
 - `simulate()` - Main match simulation
-- `calculateTeamStrength()` - Lineup strength calculation
+- `simulateRemainder()` - Resume from a given minute (substitution support)
+- `calculateTeamStrength()` - Lineup strength calculation (ability-dominant weights)
 - `calculateStrikerBonus()` - Forward quality bonus
 - `getMatchPerformance()` - Per-player daily form
 - `poissonRandom()` - Score generation
+- `simulateExtraTime()` - Extra time with fatigue
+
+See `app/Game/Services/SeasonSimulationService.php`:
+- `simulateLeague()` - Full match-by-match season simulation
+- `simulateMatchResult()` - Single match using ratio-based xG + Poisson
 
 ## Design Rationale
+
+### Why ratio-based xG?
+The previous additive share-based formula created a "floor" that made weak teams unrealistically competitive. With the old formula, a weak team at home was actually favored vs an elite team away. The ratio-based formula ensures the stronger team is always favored, with home advantage as a modest bonus on top.
 
 ### Why Poisson distribution?
 Real football goals follow a Poisson distribution. It naturally creates realistic scorelines like 1-0, 2-1, 3-2 while occasionally allowing 5-0 blowouts.
 
-### Why the strength exponent?
-Without amplification, an 85 vs 75 rated match is too close to 50-50. The exponent ensures quality differences translate to meaningful result differences over a season.
+### Why ability-dominant weights (55/35/5/5)?
+The old 40/25/20/15 weights gave fitness (90-100) and morale (65-80) too much influence, compressing the elite-to-bottom strength range from ~20 points to ~14 points. With 55/35/5/5 weights, the full ability gap is preserved while fitness/morale still contribute through the per-player performance modifier.
 
 ### Why a striker bonus?
 Team overall strength averages all 11 players, but a world-class striker creates chances from nothing. Mbappé vs an average striker should mean more goals for that team.
 
-### Why low base goals?
-Low base goals (0.5, 0.3) make strength contribution the dominant factor. This ensures better teams consistently outperform weaker ones rather than relying on random base goals.
+### Why match-by-match season simulation?
+The old single-shot approach (`strength + random_noise(±4.0) → sort`) was chaotic — the ±4.0 noise was 30-50% of typical strength gaps. Match-by-match simulation produces ~380 data points per season, averaging out randomness while still allowing upsets on individual matchdays.
 
 ## Expected Season Outcomes
 
 With these parameters, a 38-game La Liga season should show:
 - ~2.5-2.8 average goals per match
-- Top scorer: 18-23 goals (28-33% of team goals)
-- 3-5 players per team with 8+ goals
-- Top teams (90+ rated) finishing top 4
+- Elite teams (Real Madrid): ~75-85 pts
+- Strong teams (Atletico): ~65-75 pts
+- Mid-table: ~48-58 pts
+- Bottom: ~28-38 pts
 - Clear separation between quality tiers
 - Occasional upsets, but not chaos
-- Hat-tricks: 1-3 per season league-wide (realistic)


### PR DESCRIPTION
Replace the additive share-based xG formula with a ratio-based approach where the stronger team is always favored regardless of venue. Widen the effective strength range by making ability dominant (55/35/5/5 weights), tighten performance variance (±5%, bounds 0.90–1.10) so lineup quality is more decisive, and rewrite season simulation to use match-by-match Poisson results instead of single-shot noise ranking.