### PR TITLE
Fix Spanish grammar for team names with prepositions (del/de la/de)

### DIFF
--- a/app/Http/Actions/AcceptTransferOffer.php
+++ b/app/Http/Actions/AcceptTransferOffer.php
@@ -30,7 +30,7 @@ class AcceptTransferOffer
         }
 
         $playerName = $offer->gamePlayer->player->name;
-        $teamName = $offer->offeringTeam->name;
+        $team = $offer->offeringTeam;
         $fee = $offer->formatted_transfer_fee;
 
         $completedImmediately = $this->transferService->acceptOffer($offer);
@@ -38,14 +38,14 @@ class AcceptTransferOffer
         if ($completedImmediately) {
             $message = __('messages.offer_accepted_sale', [
                 'player' => $playerName,
-                'team' => $teamName,
+                'team_a' => $team->nameWithA(),
                 'fee' => $fee,
             ]);
         } else {
             $nextWindow = $game->getNextWindowName();
             $message = __('messages.offer_accepted_pre_contract', [
                 'player' => $playerName,
-                'team' => $teamName,
+                'team' => $team->name,
                 'fee' => $fee,
                 'window' => $nextWindow,
             ]);

--- a/app/Http/Actions/CompleteOnboarding.php
+++ b/app/Http/Actions/CompleteOnboarding.php
@@ -84,6 +84,6 @@ class CompleteOnboarding
         event(new SeasonStarted($game));
 
         return redirect()->route('show-game', $gameId)
-            ->with('success', __('messages.welcome_to_team', ['team' => $game->team->name]));
+            ->with('success', __('messages.welcome_to_team', ['team_a' => $game->team->nameWithA()]));
     }
 }

--- a/app/Http/Actions/RejectTransferOffer.php
+++ b/app/Http/Actions/RejectTransferOffer.php
@@ -29,12 +29,12 @@ class RejectTransferOffer
             abort(403, 'You can only reject offers for your own players.');
         }
 
-        $teamName = $offer->offeringTeam->name;
+        $team = $offer->offeringTeam;
 
         $this->transferService->rejectOffer($offer);
 
         return redirect()
             ->route('game.transfers', $gameId)
-            ->with('success', __('messages.offer_rejected', ['team' => $teamName]));
+            ->with('success', __('messages.offer_rejected', ['team_de' => $team->nameWithDe()]));
     }
 }

--- a/app/Models/Team.php
+++ b/app/Models/Team.php
@@ -108,4 +108,62 @@ class Team extends Model
     {
         return 0; // Placeholder for team-level stats
     }
+
+    /**
+     * Get the Spanish grammatical article for this team name.
+     *
+     * Most teams use "el" (masculine): "del Real Madrid", "al Barcelona"
+     * Some use "la" (feminine): "de la Real Sociedad", "a la UD Almería"
+     * Some use no article: "de Osasuna", "a Osasuna"
+     */
+    public function getArticleAttribute(): ?string
+    {
+        $name = $this->attributes['name'] ?? '';
+
+        if ($name === 'CA Osasuna') {
+            return null;
+        }
+
+        if (str_starts_with($name, 'UD ') || str_starts_with($name, 'Real Sociedad') || $name === 'Cultural Leonesa') {
+            return 'la';
+        }
+
+        return 'el';
+    }
+
+    /**
+     * Team name with "de" preposition: "del Real Madrid", "de la Real Sociedad", "de Osasuna"
+     */
+    public function nameWithDe(): string
+    {
+        return match ($this->article) {
+            'la' => 'de la ' . $this->name,
+            null => 'de ' . $this->name,
+            default => 'del ' . $this->name,
+        };
+    }
+
+    /**
+     * Team name with "a" preposition: "al Real Madrid", "a la Real Sociedad", "a Osasuna"
+     */
+    public function nameWithA(): string
+    {
+        return match ($this->article) {
+            'la' => 'a la ' . $this->name,
+            null => 'a ' . $this->name,
+            default => 'al ' . $this->name,
+        };
+    }
+
+    /**
+     * Team name with "en" preposition: "en el Real Madrid", "en la Real Sociedad", "en Osasuna"
+     */
+    public function nameWithEn(): string
+    {
+        return match ($this->article) {
+            'la' => 'en la ' . $this->name,
+            null => 'en ' . $this->name,
+            default => 'en el ' . $this->name,
+        };
+    }
 }

--- a/app/Modules/Notification/Services/NotificationService.php
+++ b/app/Modules/Notification/Services/NotificationService.php
@@ -221,7 +221,7 @@ class NotificationService
         return $this->create(
             game: $game,
             type: GameNotification::TYPE_TRANSFER_OFFER_RECEIVED,
-            title: __('notifications.transfer_offer_title', ['team' => $offer->offeringTeam->name]),
+            title: __('notifications.transfer_offer_title', ['team_de' => $offer->offeringTeam->nameWithDe()]),
             message: __('notifications.transfer_offer_message', [
                 'team' => $offer->offeringTeam->name,
                 'player' => $player->name,
@@ -249,7 +249,7 @@ class NotificationService
             type: GameNotification::TYPE_TRANSFER_OFFER_EXPIRING,
             title: __('notifications.offer_expiring_title', ['player' => $player->name]),
             message: __('notifications.offer_expiring_message', [
-                'team' => $offer->offeringTeam->name,
+                'team_de' => $offer->offeringTeam->nameWithDe(),
                 'player' => $player->name,
                 'days' => $offer->days_until_expiry,
             ]),
@@ -271,7 +271,7 @@ class NotificationService
         $isIncoming = $offer->direction === TransferOffer::DIRECTION_INCOMING;
 
         if ($isIncoming) {
-            $fromTeam = $offer->sellingTeam->name ?? $player->team->name ?? '';
+            $fromTeam = $offer->sellingTeam ?? $player->team;
             $fee = $offer->transfer_fee > 0
                 ? $offer->formatted_transfer_fee
                 : __('notifications.free_transfer');
@@ -279,14 +279,14 @@ class NotificationService
             $title = __('notifications.transfer_complete_incoming_title', ['player' => $player->name]);
             $message = __('notifications.transfer_complete_incoming_message', [
                 'player' => $player->name,
-                'team' => $fromTeam,
+                'team_de' => $fromTeam?->nameWithDe() ?? '',
                 'fee' => $fee,
             ]);
         } else {
             $title = __('notifications.transfer_complete_outgoing_title', ['player' => $player->name]);
             $message = __('notifications.transfer_complete_outgoing_message', [
                 'player' => $player->name,
-                'team' => $offer->offeringTeam->name,
+                'team_a' => $offer->offeringTeam->nameWithA(),
                 'fee' => $offer->formatted_transfer_fee,
             ]);
         }
@@ -387,7 +387,7 @@ class NotificationService
     /**
      * Create a loan return notification.
      */
-    public function notifyLoanReturn(Game $game, GamePlayer $player, string $fromTeam): GameNotification
+    public function notifyLoanReturn(Game $game, GamePlayer $player, Team $fromTeam): GameNotification
     {
         return $this->create(
             game: $game,
@@ -395,12 +395,12 @@ class NotificationService
             title: __('notifications.loan_return_title', ['player' => $player->name]),
             message: __('notifications.loan_return_message', [
                 'player' => $player->name,
-                'team' => $fromTeam,
+                'team_en' => $fromTeam->nameWithEn(),
             ]),
             priority: GameNotification::PRIORITY_INFO,
             metadata: [
                 'player_id' => $player->id,
-                'from_team' => $fromTeam,
+                'from_team' => $fromTeam->name,
             ],
         );
     }
@@ -411,8 +411,8 @@ class NotificationService
     public function notifyLoanDestinationFound(Game $game, GamePlayer $player, Team $destination, bool $windowOpen): GameNotification
     {
         $message = $windowOpen
-            ? __('notifications.loan_destination_found_message', ['player' => $player->name, 'team' => $destination->name])
-            : __('notifications.loan_destination_found_waiting', ['player' => $player->name, 'team' => $destination->name]);
+            ? __('notifications.loan_destination_found_message', ['player' => $player->name, 'team_a' => $destination->nameWithA()])
+            : __('notifications.loan_destination_found_waiting', ['player' => $player->name, 'team_a' => $destination->nameWithA()]);
 
         return $this->create(
             game: $game,

--- a/app/Modules/Season/Processors/LoanReturnProcessor.php
+++ b/app/Modules/Season/Processors/LoanReturnProcessor.php
@@ -43,7 +43,7 @@ class LoanReturnProcessor implements SeasonEndProcessor
                 $this->notificationService->notifyLoanReturn(
                     $game,
                     $loan->gamePlayer,
-                    $loan->loanTeam->name
+                    $loan->loanTeam
                 );
             }
         }

--- a/lang/es/finances.php
+++ b/lang/es/finances.php
@@ -2,7 +2,7 @@
 
 return [
     // Page title
-    'title' => 'Finanzas de :team - Temporada :season',
+    'title' => 'Finanzas :team_de - Temporada :season',
 
     // Overview cards
     'projected_position' => 'Posición Proyectada',

--- a/lang/es/game.php
+++ b/lang/es/game.php
@@ -130,7 +130,7 @@ return [
 
     // Welcome Tutorial
     'welcome_name' => 'Bienvenido, :name',
-    'welcome_appointed' => 'Has sido nombrado nuevo entrenador del :team',
+    'welcome_appointed' => 'Has sido nombrado nuevo entrenador :team_de',
     'welcome_how_it_works' => '¿Cómo funciona?',
     'welcome_step_matches' => 'Juega los partidos',
     'welcome_step_matches_desc' => 'Elige tu alineación, formación y mentalidad antes de cada partido. Observa el partido en directo y haz sustituciones tácticas.',
@@ -143,7 +143,7 @@ return [
     'welcome_start_journey' => 'Comenzar',
 
     // Onboarding
-    'welcome_to_team' => 'Bienvenido a :team',
+    'welcome_to_team' => 'Bienvenido :team_a',
     'season_preview' => 'Previa de Temporada',
     'season_objective' => 'Objetivo de Temporada',
     'your_competitions' => 'Tus Competiciones',

--- a/lang/es/messages.php
+++ b/lang/es/messages.php
@@ -9,8 +9,8 @@ return [
     'bid_exceeds_budget' => 'La oferta supera tu presupuesto de fichajes.',
     'player_listed' => ':player puesto a la venta. Las ofertas pueden llegar tras la próxima jornada.',
     'player_unlisted' => ':player retirado de la lista de fichajes.',
-    'offer_rejected' => 'Oferta de :team rechazada.',
-    'offer_accepted_sale' => ':player vendido a :team por :fee.',
+    'offer_rejected' => 'Oferta :team_de rechazada.',
+    'offer_accepted_sale' => ':player vendido :team_a por :fee.',
     'offer_accepted_pre_contract' => '¡Acuerdo cerrado! :player fichará por :team por :fee cuando abra la ventana de :window.',
 
     // Counter offer
@@ -19,7 +19,7 @@ return [
     'counter_offer_expired' => 'Esta oferta ya no está disponible.',
 
     // Loan messages
-    'loan_complete' => ':player ha sido cedido a :team.',
+    'loan_complete' => ':player ha sido cedido :team_a.',
     'loan_agreed' => ':message La cesión comenzará cuando abra la ventana de :window.',
     'loan_in_complete' => ':message La cesión ya está activa.',
     'loan_failed' => ':message',
@@ -62,7 +62,7 @@ return [
     'budget_minimum_tier' => 'Todas las áreas de infraestructura deben ser al menos Nivel 1.',
 
     // Onboarding
-    'welcome_to_team' => '¡Bienvenido a :team! Tu temporada te espera.',
+    'welcome_to_team' => '¡Bienvenido :team_a! Tu temporada te espera.',
 
     // Season
     'season_not_complete' => 'No se puede iniciar una nueva temporada - la temporada actual no ha terminado.',

--- a/lang/es/notifications.php
+++ b/lang/es/notifications.php
@@ -34,19 +34,19 @@ return [
     'player_recovered_message' => ':player se ha recuperado y está disponible para jugar.',
 
     // Transfer offers
-    'transfer_offer_title' => 'Oferta de :team',
+    'transfer_offer_title' => 'Oferta :team_de',
     'transfer_offer_message' => ':team ha ofrecido :fee por :player.',
     'free_transfer' => 'Traspaso Libre',
 
     // Transfer complete
     'transfer_complete_incoming_title' => ':player fichado',
-    'transfer_complete_incoming_message' => ':player se ha unido a tu plantilla procedente de :team por :fee.',
+    'transfer_complete_incoming_message' => ':player se ha unido a tu plantilla procedente :team_de por :fee.',
     'transfer_complete_outgoing_title' => ':player vendido',
-    'transfer_complete_outgoing_message' => ':player ha sido traspasado a :team por :fee.',
+    'transfer_complete_outgoing_message' => ':player ha sido traspasado :team_a por :fee.',
 
     // Expiring offers
     'offer_expiring_title' => 'Oferta por :player expira pronto',
-    'offer_expiring_message' => 'La oferta de :team por :player expira en :days días.',
+    'offer_expiring_message' => 'La oferta :team_de por :player expira en :days días.',
 
     // Scout
     'scout_complete_title' => 'Informe de Ojeador Listo',
@@ -58,7 +58,7 @@ return [
 
     // Loan returns
     'loan_return_title' => ':player regresa de cesión',
-    'loan_return_message' => ':player ha regresado de su cesión en :team.',
+    'loan_return_message' => ':player ha regresado de su cesión :team_en.',
 
     // Low fitness
     'low_fitness_title' => ':player con baja forma física',
@@ -66,8 +66,8 @@ return [
 
     // Loan search
     'loan_destination_found_title' => 'Destino encontrado para :player',
-    'loan_destination_found_message' => ':player ha sido cedido a :team.',
-    'loan_destination_found_waiting' => ':player será cedido a :team cuando abra la ventana de fichajes.',
+    'loan_destination_found_message' => ':player ha sido cedido :team_a.',
+    'loan_destination_found_waiting' => ':player será cedido :team_a cuando abra la ventana de fichajes.',
     'loan_search_failed_title' => 'Búsqueda de cesión fallida',
     'loan_search_failed_message' => 'No se encontró un club interesado en ceder a :player. El jugador vuelve a estar disponible.',
 

--- a/lang/es/season.php
+++ b/lang/es/season.php
@@ -5,7 +5,7 @@ return [
     'season_honours' => 'Honores Temporada :season',
     'league_champion' => 'Campeón de :league',
     'cup_winner' => 'Campeón de Copa',
-    'beat' => 'Venció a :team',
+    'beat' => 'Venció :team_a',
     'competition_in_progress' => 'Competición en curso',
     'other_league_results' => 'Otras Ligas',
 

--- a/lang/es/squad.php
+++ b/lang/es/squad.php
@@ -2,7 +2,7 @@
 
 return [
     // Page title
-    'title' => 'Plantilla de :team',
+    'title' => 'Plantilla :team_de',
     'squad' => 'Plantilla',
     'contracts' => 'Contratos',
     'development' => 'Desarrollo',

--- a/lang/es/transfers.php
+++ b/lang/es/transfers.php
@@ -128,7 +128,7 @@ return [
     // Scouting player page
     'scouting_report' => 'Informe de Ojeador',
     'back_to_results' => 'Volver a Resultados',
-    'from_team' => 'de :team',
+    'from_team' => ':team_de',
     'estimated_ability' => 'Habilidad Estimada',
     'market_value' => 'Valor de Mercado',
     'contract_until' => 'Contrato hasta',
@@ -179,11 +179,11 @@ return [
     // Loans page
     'loans_title' => 'Cesiones',
     'active_loans_out' => 'Cesiones Activas (Salidas)',
-    'loaned_to' => 'Cedido a :team',
+    'loaned_to' => 'Cedido :team_a',
     'until' => 'Hasta',
     'end_of_season' => 'Fin de Temporada',
     'active_loans_in' => 'Cesiones Activas (Entradas)',
-    'loaned_from' => 'Cedido de :team',
+    'loaned_from' => 'Cedido :team_de',
     'no_active_loans' => 'Sin cesiones activas.',
     'no_loans_in' => 'Ningún jugador cedido a tu club actualmente.',
     'no_loans_out' => 'Ningún jugador cedido desde tu club.',

--- a/resources/views/scouting.blade.php
+++ b/resources/views/scouting.blade.php
@@ -210,7 +210,7 @@
                                                 <div class="font-medium text-sm text-slate-900 truncate">{{ $loan->gamePlayer->name }}</div>
                                                 <div class="text-xs text-slate-500">
                                                     {{ $loan->gamePlayer->position_name }} &middot; {{ $loan->gamePlayer->age }} {{ __('app.years') }}
-                                                    &middot; {{ __('transfers.loaned_from', ['team' => $loan->parentTeam->name]) }}
+                                                    &middot; {{ __('transfers.loaned_from', ['team_de' => $loan->parentTeam->nameWithDe()]) }}
                                                 </div>
                                                 <div class="text-xs text-slate-400 mt-0.5">
                                                     {{ __('transfers.returns') }}: {{ $loan->return_at->format('M j, Y') }}

--- a/resources/views/season-end.blade.php
+++ b/resources/views/season-end.blade.php
@@ -37,7 +37,7 @@
                                 </div>
                                 <div class="text-xl font-bold text-slate-900">{{ $cupWinner->name }}</div>
                                 <div class="text-sm text-slate-500">
-                                    {{ __('season.beat', ['team' => $cupRunnerUp?->name ?? 'opponent']) }}
+                                    {{ __('season.beat', ['team_a' => $cupRunnerUp ? $cupRunnerUp->nameWithA() : 'al rival']) }}
                                 </div>
                             @else
                                 <div class="text-slate-400 py-4">{{ __('season.competition_in_progress') }}</div>

--- a/resources/views/squad-selection.blade.php
+++ b/resources/views/squad-selection.blade.php
@@ -52,7 +52,7 @@ $tabs = [
             <div class="text-center mb-6 md:mb-8">
                 <img src="{{ $game->team->image }}" alt="{{ $game->team->name }}" class="w-16 h-16 md:w-20 md:h-20 mx-auto mb-3 md:mb-4">
                 <h1 class="text-2xl md:text-3xl font-bold text-white mb-1">
-                    {{ __('game.welcome_to_team', ['team' => $game->team->name]) }}, {{ $game->player_name }}
+                    {{ __('game.welcome_to_team', ['team_a' => $game->team->nameWithA()]) }}, {{ $game->player_name }}
                 </h1>
                 <p class="text-slate-500">{{ __('game.season_n', ['season' => $game->formatted_season]) }}</p>
             </div>

--- a/resources/views/transfers.blade.php
+++ b/resources/views/transfers.blade.php
@@ -531,7 +531,7 @@
                                                 <div class="font-medium text-sm text-slate-900 truncate">{{ $loan->gamePlayer->name }}</div>
                                                 <div class="text-xs text-slate-500">
                                                     {{ $loan->gamePlayer->position_name }} &middot;
-                                                    {{ __('transfers.loaned_to', ['team' => $loan->loanTeam->name]) }}
+                                                    {{ __('transfers.loaned_to', ['team_a' => $loan->loanTeam->nameWithA()]) }}
                                                 </div>
                                                 <div class="text-xs text-slate-400 mt-0.5">
                                                     {{ __('transfers.returns') }}: {{ $loan->return_at->format('M j, Y') }}

--- a/resources/views/welcome-tutorial.blade.php
+++ b/resources/views/welcome-tutorial.blade.php
@@ -11,7 +11,7 @@
             <div class="text-center mb-10">
                 <img src="{{ $game->team->image }}" alt="{{ $game->team->name }}" class="w-24 h-24 md:w-32 md:h-32 mx-auto mb-6 drop-shadow-lg">
                 <h1 class="text-3xl md:text-4xl font-bold text-white mb-2">{{ __('game.welcome_name', ['name' => $game->player_name]) }}</h1>
-                <p class="text-lg text-slate-400">{{ __('game.welcome_appointed', ['team' => $game->team->name]) }}</p>
+                <p class="text-lg text-slate-400">{{ __('game.welcome_appointed', ['team_de' => $game->team->nameWithDe()]) }}</p>
             </div>
 
             {{-- How it works --}}


### PR DESCRIPTION
Spanish team names require different prepositions depending on the grammatical gender of the team name:
- Masculine (most teams): "del Real Madrid", "al Barcelona"
- Feminine (UD/Real Sociedad/Cultural Leonesa): "de la Real Sociedad", "a la UD Almería"
- No article (CA Osasuna): "de Osasuna", "a Osasuna"

Added computed `article` attribute and `nameWithDe()`, `nameWithA()`, `nameWithEn()` helper methods to the Team model. Updated all translation keys and call sites to use grammatically correct prepositions.

https://claude.ai/code/session_01QHdpYBvQ1nm5qQMc5vmzq9