### PR TITLE
Add season-end cleanup for scout reports and player shortlists

### DIFF
--- a/app/Modules/Season/Processors/TransferMarketResetProcessor.php
+++ b/app/Modules/Season/Processors/TransferMarketResetProcessor.php
@@ -14,7 +14,7 @@ use App\Models\Game;
  * Clears scouting and transfer market data for the new season.
  * Priority: 20 (runs after settlement so transfer offer history is available for wage calculations)
  */
-class ScoutDataResetProcessor implements SeasonEndProcessor
+class TransferMarketResetProcessor implements SeasonEndProcessor
 {
     public function priority(): int
     {

--- a/app/Modules/Season/Services/SeasonEndPipeline.php
+++ b/app/Modules/Season/Services/SeasonEndPipeline.php
@@ -22,7 +22,7 @@ use App\Modules\Season\Processors\SupercupQualificationProcessor;
 use App\Modules\Season\Processors\UefaQualificationProcessor;
 use App\Modules\Season\Processors\ContinentalAndCupInitProcessor;
 use App\Modules\Season\Processors\OnboardingResetProcessor;
-use App\Modules\Season\Processors\ScoutDataResetProcessor;
+use App\Modules\Season\Processors\TransferMarketResetProcessor;
 use App\Modules\Season\Processors\YouthAcademyProcessor;
 use App\Models\Game;
 
@@ -52,7 +52,7 @@ class SeasonEndPipeline
         StandingsResetProcessor $standingsReset,
         BudgetProjectionProcessor $budgetProjection,
         YouthAcademyProcessor $youthAcademy,
-        ScoutDataResetProcessor $scoutDataReset,
+        TransferMarketResetProcessor $transferMarketReset,
         ContinentalAndCupInitProcessor $competitionInitialization,
         OnboardingResetProcessor $onboardingReset,
     ) {
@@ -74,7 +74,7 @@ class SeasonEndPipeline
             $standingsReset,
             $budgetProjection,
             $youthAcademy,
-            $scoutDataReset,
+            $transferMarketReset,
             $competitionInitialization,
             $onboardingReset,
         ];

--- a/tests/Unit/TransferMarketResetProcessorTest.php
+++ b/tests/Unit/TransferMarketResetProcessorTest.php
@@ -9,20 +9,20 @@ use App\Models\ShortlistedPlayer;
 use App\Models\Team;
 use App\Models\TransferOffer;
 use App\Modules\Season\DTOs\SeasonTransitionData;
-use App\Modules\Season\Processors\ScoutDataResetProcessor;
+use App\Modules\Season\Processors\TransferMarketResetProcessor;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
-class ScoutDataResetProcessorTest extends TestCase
+class TransferMarketResetProcessorTest extends TestCase
 {
     use RefreshDatabase;
 
-    private ScoutDataResetProcessor $processor;
+    private TransferMarketResetProcessor $processor;
 
     protected function setUp(): void
     {
         parent::setUp();
-        $this->processor = new ScoutDataResetProcessor();
+        $this->processor = new TransferMarketResetProcessor();
     }
 
     public function test_deletes_all_scout_reports_for_game(): void


### PR DESCRIPTION
Scout searches and shortlisted players were persisting across seasons,
cluttering the scouting hub with stale data. This adds a new
ScoutDataResetProcessor that deletes all scout reports and shortlisted
players at season end, giving the user a clean slate for the new season.

https://claude.ai/code/session_01TLijmRo82YeU1siWQTVxsz