### PR TITLE
Remove redundant stats summary cards from Squad Stats page and extract season stats into CalendarService

### DIFF
--- a/app/Http/Views/ShowCalendar.php
+++ b/app/Http/Views/ShowCalendar.php
@@ -21,7 +21,7 @@ class ShowCalendar
 
         // Calculate season stats from played fixtures
         $playedMatches = $fixtures->filter(fn($m) => $m->played);
-        $seasonStats = $this->calculateSeasonStats($playedMatches, $game->team_id);
+        $seasonStats = $this->calendarService->calculateSeasonStats($playedMatches, $game->team_id);
 
         return view('calendar', [
             'game' => $game,
@@ -29,107 +29,5 @@ class ShowCalendar
             'seasonStats' => $seasonStats,
             'nextMatchId' => $nextMatchId,
         ]);
-    }
-
-    private function calculateSeasonStats($matches, string $teamId): array
-    {
-        $wins = 0;
-        $draws = 0;
-        $losses = 0;
-        $goalsFor = 0;
-        $goalsAgainst = 0;
-        $homeWins = 0;
-        $homeDraws = 0;
-        $homeLosses = 0;
-        $homeGoalsFor = 0;
-        $homeGoalsAgainst = 0;
-        $awayWins = 0;
-        $awayDraws = 0;
-        $awayLosses = 0;
-        $awayGoalsFor = 0;
-        $awayGoalsAgainst = 0;
-        $form = [];
-
-        foreach ($matches as $match) {
-            $isHome = $match->home_team_id === $teamId;
-            $yourScore = $isHome ? $match->home_score : $match->away_score;
-            $oppScore = $isHome ? $match->away_score : $match->home_score;
-
-            $goalsFor += $yourScore;
-            $goalsAgainst += $oppScore;
-
-            if ($yourScore > $oppScore) {
-                $result = 'W';
-                $wins++;
-                if ($isHome) {
-                    $homeWins++;
-                    $homeGoalsFor += $yourScore;
-                    $homeGoalsAgainst += $oppScore;
-                } else {
-                    $awayWins++;
-                    $awayGoalsFor += $yourScore;
-                    $awayGoalsAgainst += $oppScore;
-                }
-            } elseif ($yourScore < $oppScore) {
-                $result = 'L';
-                $losses++;
-                if ($isHome) {
-                    $homeLosses++;
-                    $homeGoalsFor += $yourScore;
-                    $homeGoalsAgainst += $oppScore;
-                } else {
-                    $awayLosses++;
-                    $awayGoalsFor += $yourScore;
-                    $awayGoalsAgainst += $oppScore;
-                }
-            } else {
-                $result = 'D';
-                $draws++;
-                if ($isHome) {
-                    $homeDraws++;
-                    $homeGoalsFor += $yourScore;
-                    $homeGoalsAgainst += $oppScore;
-                } else {
-                    $awayDraws++;
-                    $awayGoalsFor += $yourScore;
-                    $awayGoalsAgainst += $oppScore;
-                }
-            }
-
-            $form[] = $result;
-        }
-
-        $totalMatches = $wins + $draws + $losses;
-        $homeMatches = $homeWins + $homeDraws + $homeLosses;
-        $awayMatches = $awayWins + $awayDraws + $awayLosses;
-
-        return [
-            'played' => $totalMatches,
-            'wins' => $wins,
-            'draws' => $draws,
-            'losses' => $losses,
-            'winPercent' => $totalMatches > 0 ? round(($wins / $totalMatches) * 100) : 0,
-            'goalsFor' => $goalsFor,
-            'goalsAgainst' => $goalsAgainst,
-            'form' => array_slice(array_reverse($form), 0, 5),
-            'home' => [
-                'played' => $homeMatches,
-                'wins' => $homeWins,
-                'draws' => $homeDraws,
-                'losses' => $homeLosses,
-                'points' => ($homeWins * 3) + $homeDraws,
-                'goalsFor' => $homeGoalsFor,
-                'goalsAgainst' => $homeGoalsAgainst,
-            ],
-            'away' => [
-                'played' => $awayMatches,
-                'wins' => $awayWins,
-                'draws' => $awayDraws,
-                'losses' => $awayLosses,
-                'points' => ($awayWins * 3) + $awayDraws,
-                'goalsFor' => $awayGoalsFor,
-                'goalsAgainst' => $awayGoalsAgainst,
-            ],
-        ];
     }
 }

--- a/app/Http/Views/ShowSquadStats.php
+++ b/app/Http/Views/ShowSquadStats.php
@@ -28,23 +28,11 @@ class ShowSquadStats
                 return $player;
             });
 
-        // Calculate squad totals
-        $totals = [
-            'appearances' => $players->sum('appearances'),
-            'goals' => $players->sum('goals'),
-            'assists' => $players->sum('assists'),
-            'own_goals' => $players->sum('own_goals'),
-            'yellow_cards' => $players->sum('yellow_cards'),
-            'red_cards' => $players->sum('red_cards'),
-            'clean_sheets' => $players->where('position', 'Goalkeeper')->sum('clean_sheets'),
-        ];
-
         $academyCount = AcademyPlayer::where('game_id', $gameId)->where('team_id', $game->team_id)->count();
 
         return view('squad-stats', [
             'game' => $game,
             'players' => $players,
-            'totals' => $totals,
             'academyCount' => $academyCount,
         ]);
     }

--- a/resources/views/squad-stats.blade.php
+++ b/resources/views/squad-stats.blade.php
@@ -33,38 +33,6 @@
 
                     <div class="mt-6"></div>
 
-                    {{-- Season summary card --}}
-                    <div class="flex flex-wrap items-stretch gap-4 mb-6">
-                        <div class="flex items-center gap-3 px-5 py-3 bg-slate-50 rounded-lg border border-slate-200">
-                            <div class="text-2xl font-bold text-green-600">{{ $totals['goals'] }}</div>
-                            <div class="text-xs text-slate-500 leading-tight">{{ __('squad.legend_goals') }}</div>
-                        </div>
-                        <div class="flex items-center gap-3 px-5 py-3 bg-slate-50 rounded-lg border border-slate-200">
-                            <div class="text-2xl font-bold text-sky-600">{{ $totals['assists'] }}</div>
-                            <div class="text-xs text-slate-500 leading-tight">{{ __('squad.legend_assists') }}</div>
-                        </div>
-                        <div class="flex items-center gap-3 px-5 py-3 bg-slate-50 rounded-lg border border-slate-200">
-                            <div class="flex items-center gap-2">
-                                <span class="w-3 h-4 bg-yellow-400 rounded-sm"></span>
-                                <span class="text-2xl font-bold text-yellow-600">{{ $totals['yellow_cards'] }}</span>
-                            </div>
-                            <div class="flex items-center gap-2">
-                                <span class="w-3 h-4 bg-red-500 rounded-sm"></span>
-                                <span class="text-2xl font-bold text-red-600">{{ $totals['red_cards'] }}</span>
-                            </div>
-                        </div>
-                        <div class="flex items-center gap-3 px-5 py-3 bg-slate-50 rounded-lg border border-slate-200">
-                            <div class="text-2xl font-bold text-green-600">{{ $totals['clean_sheets'] }}</div>
-                            <div class="text-xs text-slate-500 leading-tight">{{ __('squad.legend_clean_sheets') }}</div>
-                        </div>
-                        @if($totals['own_goals'] > 0)
-                        <div class="flex items-center gap-3 px-5 py-3 bg-slate-50 rounded-lg border border-slate-200">
-                            <div class="text-2xl font-bold text-red-500">{{ $totals['own_goals'] }}</div>
-                            <div class="text-xs text-slate-500 leading-tight">{{ __('squad.legend_own_goals') }}</div>
-                        </div>
-                        @endif
-                    </div>
-
                     <div x-data="{
                         sortColumn: 'appearances',
                         sortAsc: false,


### PR DESCRIPTION
The summary cards (goals, assists, cards, clean sheets) duplicated data already
visible in the sortable table below them and overlapped with the Calendar
sidebar's richer season overview. Removing them keeps Squad Stats focused on
individual player performance. The calculateSeasonStats() logic moves from
ShowCalendar into CalendarService for reusability.

https://claude.ai/code/session_01UpiQxvXquq1et2jTyPjCqh