### PR TITLE
Seed WC group assignments and validate match schedule

### DIFF
--- a/database/migrations/2026_02_22_000001_add_group_label_to_competition_teams.php
+++ b/database/migrations/2026_02_22_000001_add_group_label_to_competition_teams.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('competition_teams', function (Blueprint $table) {
+            $table->char('group_label', 1)->nullable()->after('season');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('competition_teams', function (Blueprint $table) {
+            $table->dropColumn('group_label');
+        });
+    }
+};


### PR DESCRIPTION
- Add group_label column to competition_teams for WC group tracking
- Enhance SeedWorldCupData to read groups.json and store group labels
- Guess player nationality from team name when missing in JSON data
- Populate image, stadium fields from team JSON (previously null)
- Validate all team references in groups.json are resolvable
- Display complete group stage + knockout schedule during seeding
- Update SetupTournamentGame to read group assignments from DB

https://claude.ai/code/session_0115ivvEirYqAhxiATR9H2f1