### PR TITLE
Show renewal negotiations in transfers/outgoing section

### DIFF
--- a/lang/en/transfers.php
+++ b/lang/en/transfers.php
@@ -173,6 +173,10 @@ return [
     'declined_renewals' => 'Declined Renewals',
 
     // Renewal negotiation
+    'renewal_counter_offers' => 'Renewal Counter-Offers',
+    'renewal_counter_offers_help' => 'These players have responded to your renewal offers',
+    'renewal_offers_sent' => 'Renewals In Progress',
+    'renewal_offers_sent_help' => 'Your renewal offers are being considered',
     'negotiate' => 'Negotiate',
     'negotiating' => 'Negotiating...',
     'player_countered' => 'The player has counter-offered',

--- a/lang/es/transfers.php
+++ b/lang/es/transfers.php
@@ -180,6 +180,10 @@ return [
     'declined_renewals' => 'No renovados',
 
     // Renewal negotiation
+    'renewal_counter_offers' => 'Contraoferta de Renovación',
+    'renewal_counter_offers_help' => 'Estos jugadores han respondido a tu oferta de renovación',
+    'renewal_offers_sent' => 'Renovaciones en Curso',
+    'renewal_offers_sent_help' => 'Tus ofertas de renovación están siendo consideradas',
     'negotiate' => 'Negociar',
     'negotiating' => 'Negociando...',
     'player_countered' => 'El jugador ha contraofertado',


### PR DESCRIPTION
Contract renewal negotiations (both pending offers and player counter-offers) were only visible in the right-side planning table without details or action buttons. Now they appear as action items in the left column with full negotiation details and inline controls.