### PR TITLE
Add AI formation & mentality prediction with fitness-aware rotation

### DIFF
--- a/app/Modules/Match/Services/MatchdayOrchestrator.php
+++ b/app/Modules/Match/Services/MatchdayOrchestrator.php
@@ -17,6 +17,7 @@ use App\Modules\Transfer\Services\LoanService;
 use App\Modules\Transfer\Services\ScoutingService;
 use App\Modules\Transfer\Services\TransferService;
 use App\Models\AcademyPlayer;
+use App\Models\ClubProfile;
 use App\Models\Competition;
 use App\Models\CupTie;
 use App\Models\Game;
@@ -136,8 +137,11 @@ class MatchdayOrchestrator
             ->pluck('game_player_id')
             ->toArray();
 
+        // Batch load club profiles for AI mentality selection (1 query per batch)
+        $clubProfiles = ClubProfile::whereIn('team_id', $teamIds)->get()->keyBy('team_id');
+
         // Prepare lineups for all matches (pass pre-loaded data)
-        $this->lineupService->ensureLineupsForMatches($matches, $game, $allPlayers, $suspendedPlayerIds);
+        $this->lineupService->ensureLineupsForMatches($matches, $game, $allPlayers, $suspendedPlayerIds, $clubProfiles);
 
         // Simulate all matches (pass game for medical tier effects on injuries)
         $matchResults = $this->simulateMatches($matches, $game, $allPlayers);

--- a/lang/en/squad.php
+++ b/lang/en/squad.php
@@ -94,6 +94,13 @@ return [
     'coach_low_fitness' => ':count player(s) with low fitness (<70). They perform worse and have higher injury risk.',
     'coach_low_morale' => ':count player(s) with low morale. They\'ll perform worse in the match.',
     'coach_bench_frustration' => ':count quality player(s) not playing and losing morale. Rotate to keep them happy.',
+    'coach_opponent_expected_label' => 'Expected',
+    'coach_opponent_defensive_setup' => 'Opponent expected to play :formation (:mentality). Consider an attacking approach to break them down.',
+    'coach_opponent_attacking_setup' => 'Opponent expected to play :formation (:mentality). They\'ll leave space — a solid defense can exploit this.',
+    'coach_opponent_deep_block' => 'Opponent playing with 5 defenders. Width and patience will be key.',
+    'mentality_defensive' => 'Defensive',
+    'mentality_balanced' => 'Balanced',
+    'mentality_attacking' => 'Attacking',
 
     // Unavailability reasons
     'suspended_matches' => 'Suspended (:count match)|Suspended (:count matches)',

--- a/lang/es/squad.php
+++ b/lang/es/squad.php
@@ -94,6 +94,13 @@ return [
     'coach_low_fitness' => ':count jugador(es) con forma baja (<70). Rinden peor y tienen mayor riesgo de lesión.',
     'coach_low_morale' => ':count jugador(es) con moral baja. Tendrán peor rendimiento en el partido.',
     'coach_bench_frustration' => ':count jugador(es) de calidad sin jugar y perdiendo moral. Rota para mantenerlos contentos.',
+    'coach_opponent_expected_label' => 'Previsto',
+    'coach_opponent_defensive_setup' => 'Rival previsto con :formation (:mentality). Considera un enfoque ofensivo para desbloquearlos.',
+    'coach_opponent_attacking_setup' => 'Rival previsto con :formation (:mentality). Dejarán espacios — una defensa sólida puede aprovecharlos.',
+    'coach_opponent_deep_block' => 'Rival con 5 defensas. Amplitud y paciencia serán clave.',
+    'mentality_defensive' => 'Defensiva',
+    'mentality_balanced' => 'Equilibrada',
+    'mentality_attacking' => 'Ofensiva',
 
     // Unavailability reasons
     'suspended_matches' => 'Sancionado (:count partido)|Sancionado (:count partidos)',

--- a/resources/views/lineup.blade.php
+++ b/resources/views/lineup.blade.php
@@ -21,6 +21,8 @@
         teamColors: @js($teamColors),
         formationModifiers: @js($formationModifiers),
         opponentAverage: {{ $opponentData['teamAverage'] ?: 0 }},
+        opponentFormation: @js($opponentData['formation'] ?? null),
+        opponentMentality: @js($opponentData['mentality'] ?? null),
         userTeamAverage: {{ $userTeamAverage ?: 0 }},
         isHome: @js($isHome),
         translations: {
@@ -30,15 +32,21 @@
             okay: '{{ __('squad.okay') }}',
             poor: '{{ __('squad.poor') }}',
             unsuitable: '{{ __('squad.unsuitable') }}',
-            coach_defensive_recommended: '{{ __('squad.coach_defensive_recommended') }}',
-            coach_attacking_recommended: '{{ __('squad.coach_attacking_recommended') }}',
-            coach_risky_formation: '{{ __('squad.coach_risky_formation') }}',
-            coach_home_advantage: '{{ __('squad.coach_home_advantage') }}',
-            coach_critical_fitness: '{{ __('squad.coach_critical_fitness') }}',
-            coach_low_fitness: '{{ __('squad.coach_low_fitness') }}',
-            coach_low_morale: '{{ __('squad.coach_low_morale') }}',
-            coach_bench_frustration: '{{ __('squad.coach_bench_frustration') }}',
-            coach_no_tips: '{{ __('squad.coach_no_tips') }}',
+            coach_defensive_recommended: @js(__('squad.coach_defensive_recommended')),
+            coach_attacking_recommended: @js(__('squad.coach_attacking_recommended')),
+            coach_risky_formation: @js(__('squad.coach_risky_formation')),
+            coach_home_advantage: @js(__('squad.coach_home_advantage')),
+            coach_critical_fitness: @js(__('squad.coach_critical_fitness')),
+            coach_low_fitness: @js(__('squad.coach_low_fitness')),
+            coach_low_morale: @js(__('squad.coach_low_morale')),
+            coach_bench_frustration: @js(__('squad.coach_bench_frustration')),
+            coach_no_tips: @js(__('squad.coach_no_tips')),
+            coach_opponent_defensive_setup: @js(__('squad.coach_opponent_defensive_setup')),
+            coach_opponent_attacking_setup: @js(__('squad.coach_opponent_attacking_setup')),
+            coach_opponent_deep_block: @js(__('squad.coach_opponent_deep_block')),
+            mentality_defensive: @js(__('squad.mentality_defensive')),
+            mentality_balanced: @js(__('squad.mentality_balanced')),
+            mentality_attacking: @js(__('squad.mentality_attacking')),
         },
     })">
         <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
@@ -255,6 +263,20 @@
                                             <img src="{{ $opponent->image }}" class="w-7 h-7 shrink-0" alt="{{ $opponent->name }}">
                                         </div>
                                     </div>
+
+                                    {{-- Opponent Expected Tactics --}}
+                                    @if(!empty($opponentData['formation']))
+                                        <div class="flex items-center justify-end gap-1.5 mb-2">
+                                            <span class="text-[10px] text-slate-400 uppercase tracking-wide">{{ __('squad.coach_opponent_expected_label') }}</span>
+                                            <span class="text-xs font-semibold text-slate-700 bg-slate-100 px-1.5 py-0.5 rounded">{{ $opponentData['formation'] }}</span>
+                                            <span class="text-slate-300">&middot;</span>
+                                            <span class="text-xs font-medium
+                                                @if($opponentData['mentality'] === 'defensive') text-blue-600
+                                                @elseif($opponentData['mentality'] === 'attacking') text-red-600
+                                                @else text-slate-600
+                                                @endif">{{ __('squad.mentality_' . $opponentData['mentality']) }}</span>
+                                        </div>
+                                    @endif
 
                                     {{-- Form (symmetrical) --}}
                                     <div class="flex items-center justify-between gap-2 mb-3">


### PR DESCRIPTION
## Summary
Implements intelligent AI team selection with squad-fitted formations, reputation-driven mentality decisions, and fitness-aware player rotation. AI opponents now have predictable tactical setups that are displayed to the player for strategic planning.

## Key Changes

**AI Team Intelligence:**
- Added `selectAIFormation()` to recommend formations based on squad composition using `FormationRecommender`
- Added `selectAIMentality()` to determine mentality based on team reputation, home/away status, and relative strength vs opponent
- Mentality selection uses deterministic logic: elite/contender teams play bolder, weaker teams play more defensively

**Player Selection & Rotation:**
- Enhanced `selectBestXI()` with optional `$applyFitnessRotation` parameter
- Added `effectiveScore()` to penalize low-fitness players (below 65 fitness) in AI team selection, encouraging natural rotation
- Fitness multiplier formula: `0.85 + fitness * 0.0023` for smooth degradation

**Lineup Generation:**
- Updated `ensureLineupsForMatches()` to accept pre-loaded `$clubProfiles` for AI mentality calculation
- AI teams now use squad-fitted formations with fitness rotation enabled
- Player teams continue using their chosen formation/mentality without fitness penalties

**Opponent Prediction UI:**
- Enhanced `ShowLineup` view to predict opponent formation and mentality
- Displays predicted tactics in the lineup interface with contextual coaching tips
- Added new coach assistant tips for opponent defensive/attacking setups and deep blocks (5-at-back)

**Localization:**
- Added English and Spanish translations for mentality labels and opponent tactical tips

**Performance:**
- Batch-loads `ClubProfile` records in `MatchdayOrchestrator` to avoid N+1 queries during lineup generation

## Implementation Details
- Mentality selection uses a "tier" system (bold/mid/cautious) based on reputation grouping
- Strength comparison threshold: ±5 points average difference triggers tactical adjustments
- Home teams play more aggressively when stronger; away teams default to defensive when weaker
- Fitness rotation only applies to AI teams; player teams maintain full control over selection

https://claude.ai/code/session_01KM3uD5cHkMDVowJW7tEsYt