### PR TITLE
Add pluggable yellow card suspension rules with per-competition tracking

### DIFF
--- a/app/Models/PlayerSuspension.php
+++ b/app/Models/PlayerSuspension.php
@@ -11,6 +11,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  * @property string $game_player_id
  * @property string $competition_id
  * @property int $matches_remaining
+ * @property int $yellow_cards
  * @property \Illuminate\Support\Carbon|null $created_at
  * @property \Illuminate\Support\Carbon|null $updated_at
  * @property-read \App\Models\Competition|null $competition
@@ -34,10 +35,12 @@ class PlayerSuspension extends Model
         'game_player_id',
         'competition_id',
         'matches_remaining',
+        'yellow_cards',
     ];
 
     protected $casts = [
         'matches_remaining' => 'integer',
+        'yellow_cards' => 'integer',
     ];
 
     public function gamePlayer(): BelongsTo
@@ -51,7 +54,7 @@ class PlayerSuspension extends Model
     }
 
     /**
-     * Decrement matches remaining and delete if served.
+     * Decrement matches remaining and clear when fully served.
      *
      * @return bool True if suspension is now cleared
      */
@@ -60,11 +63,14 @@ class PlayerSuspension extends Model
         $this->matches_remaining--;
 
         if ($this->matches_remaining <= 0) {
-            $this->delete();
+            $this->matches_remaining = 0;
+            $this->save();
+
             return true;
         }
 
         $this->save();
+
         return false;
     }
 
@@ -74,14 +80,39 @@ class PlayerSuspension extends Model
     public static function applySuspension(string $gamePlayerId, string $competitionId, int $matches): self
     {
         return self::updateOrCreate(
-            [
-                'game_player_id' => $gamePlayerId,
-                'competition_id' => $competitionId,
-            ],
-            [
-                'matches_remaining' => $matches,
-            ]
+            ['game_player_id' => $gamePlayerId, 'competition_id' => $competitionId],
+            ['matches_remaining' => $matches],
         );
+    }
+
+    /**
+     * Record a yellow card for a player in a competition.
+     *
+     * @return int The updated yellow card count for this competition
+     */
+    public static function recordYellowCard(string $gamePlayerId, string $competitionId): int
+    {
+        $record = self::firstOrCreate(
+            ['game_player_id' => $gamePlayerId, 'competition_id' => $competitionId],
+            ['matches_remaining' => 0, 'yellow_cards' => 0],
+        );
+
+        $record->increment('yellow_cards');
+        $record->refresh();
+
+        return $record->yellow_cards;
+    }
+
+    /**
+     * Revert a yellow card for a player in a competition (used during match resimulation).
+     */
+    public static function revertYellowCard(string $gamePlayerId, string $competitionId): void
+    {
+        $record = self::forPlayerInCompetition($gamePlayerId, $competitionId);
+
+        if ($record && $record->yellow_cards > 0) {
+            $record->decrement('yellow_cards');
+        }
     }
 
     /**
@@ -111,6 +142,17 @@ class PlayerSuspension extends Model
     public static function getMatchesRemaining(string $gamePlayerId, string $competitionId): int
     {
         $suspension = self::forPlayerInCompetition($gamePlayerId, $competitionId);
+
         return $suspension->matches_remaining ?? 0;
+    }
+
+    /**
+     * Get yellow card count for a player in a specific competition.
+     */
+    public static function getYellowCards(string $gamePlayerId, string $competitionId): int
+    {
+        return self::where('game_player_id', $gamePlayerId)
+            ->where('competition_id', $competitionId)
+            ->value('yellow_cards') ?? 0;
     }
 }

--- a/app/Modules/Match/Services/MatchResultProcessor.php
+++ b/app/Modules/Match/Services/MatchResultProcessor.php
@@ -309,11 +309,12 @@ class MatchResultProcessor
 
             switch ($eventData['event_type']) {
                 case 'yellow_card':
-                    // Player already has updated yellow_cards from stat increment loop above
-                    $suspension = $this->eligibilityService->checkYellowCardAccumulation($player);
+                    $competition = $competitions->get($eventData['competitionId']);
+                    $handlerType = $competition->handler_type ?? 'league';
+                    $suspension = $this->eligibilityService->processYellowCard(
+                        $player->id, $eventData['competitionId'], $handlerType
+                    );
                     if ($suspension) {
-                        $this->eligibilityService->applySuspension($player, $suspension, $eventData['competitionId']);
-
                         // Notifications for the deferred match are created during finalization
                         if ($isUserTeamPlayer && ! $isDeferredMatch) {
                             $this->notificationService->notifySuspension(

--- a/app/Modules/Squad/DTOs/SuspensionRuleSet.php
+++ b/app/Modules/Squad/DTOs/SuspensionRuleSet.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace App\Modules\Squad\DTOs;
+
+class SuspensionRuleSet
+{
+    /**
+     * @param  array<int, int>  $yellowCardThresholds  Mode 1 — exact thresholds: [yellowCount => banMatches]
+     * @param  int|null  $yellowCardSuspendAt  Mode 2 — first suspension at this many yellows
+     * @param  int  $yellowCardRepeatEvery  Mode 2 — suspend again every N yellows after the first
+     * @param  int|null  $yellowCardResetAfterRound  Reset yellow cards after this knockout round (null = no reset)
+     */
+    public function __construct(
+        public readonly array $yellowCardThresholds = [],
+        public readonly ?int $yellowCardSuspendAt = null,
+        public readonly int $yellowCardRepeatEvery = 2,
+        public readonly ?int $yellowCardResetAfterRound = null,
+    ) {}
+
+    /**
+     * Check if a player's yellow card count triggers a suspension.
+     *
+     * @return int|null Number of match ban, or null if no suspension
+     */
+    public function checkAccumulation(int $yellowCards): ?int
+    {
+        // Mode 2 — interval-based (FIFA WC, UCL/UEL)
+        if ($this->yellowCardSuspendAt !== null) {
+            if ($yellowCards >= $this->yellowCardSuspendAt
+                && ($yellowCards - $this->yellowCardSuspendAt) % $this->yellowCardRepeatEvery === 0) {
+                return 1;
+            }
+
+            return null;
+        }
+
+        // Mode 1 — exact thresholds (La Liga)
+        return $this->yellowCardThresholds[$yellowCards] ?? null;
+    }
+
+    /**
+     * Check if one more yellow card would trigger a suspension.
+     */
+    public function isAtRisk(int $yellowCards): bool
+    {
+        return $this->checkAccumulation($yellowCards + 1) !== null;
+    }
+
+    /**
+     * La Liga rules: suspend at 5 (1 match), 10 (2 matches), 15 (3 matches). No reset.
+     */
+    public static function default(): self
+    {
+        return new self(
+            yellowCardThresholds: [5 => 1, 10 => 2, 15 => 3],
+        );
+    }
+
+    /**
+     * FIFA World Cup: suspend every 2 yellows. Reset after quarter-finals.
+     */
+    public static function worldCup(): self
+    {
+        return new self(
+            yellowCardSuspendAt: 2,
+            yellowCardRepeatEvery: 2,
+            yellowCardResetAfterRound: \App\Modules\Competition\Services\WorldCupKnockoutGenerator::ROUND_QUARTER_FINALS,
+        );
+    }
+
+    /**
+     * Copa del Rey: suspend every 3 yellows. Reset after round 3 (Round of 16).
+     */
+    public static function copaDelRey(): self
+    {
+        return new self(
+            yellowCardSuspendAt: 3,
+            yellowCardRepeatEvery: 3,
+            yellowCardResetAfterRound: 3,
+        );
+    }
+
+    /**
+     * UEFA club competitions (UCL/UEL): first suspend at 3, then every 2. Reset after quarter-finals.
+     */
+    public static function uefaClub(): self
+    {
+        return new self(
+            yellowCardSuspendAt: 3,
+            yellowCardRepeatEvery: 2,
+            yellowCardResetAfterRound: 3, // Quarter-finals in UCL bracket
+        );
+    }
+}

--- a/database/migrations/2026_02_23_000002_track_yellow_cards_per_competition.php
+++ b/database/migrations/2026_02_23_000002_track_yellow_cards_per_competition.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('player_suspensions', function (Blueprint $table) {
+            $table->unsignedInteger('yellow_cards')->default(0)->after('matches_remaining');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('player_suspensions', function (Blueprint $table) {
+            $table->dropColumn('yellow_cards');
+        });
+    }
+};

--- a/tests/Unit/Handlers/KnockoutCupHandlerTest.php
+++ b/tests/Unit/Handlers/KnockoutCupHandlerTest.php
@@ -5,6 +5,7 @@ namespace Tests\Unit\Handlers;
 use App\Modules\Match\Handlers\KnockoutCupHandler;
 use App\Modules\Competition\Services\CupDrawService;
 use App\Modules\Match\Services\CupTieResolver;
+use App\Modules\Squad\Services\EligibilityService;
 use App\Models\Competition;
 use App\Models\CupTie;
 use App\Models\Game;
@@ -38,6 +39,7 @@ class KnockoutCupHandlerTest extends TestCase
         $this->handler = new KnockoutCupHandler(
             $this->cupDrawServiceMock,
             $this->cupTieResolverMock,
+            new EligibilityService(),
         );
 
         $user = User::factory()->create();


### PR DESCRIPTION
Different competitions have different disciplinary rules. This replaces the hardcoded La Liga thresholds with a pluggable SuspensionRuleSet DTO where each competition handler type resolves its own rules:

- La Liga (default): suspend at 5/10/15 yellows for 1/2/3 matches
- Copa del Rey: suspend every 3 yellows, reset after round 3 (Art. 112.1)
- FIFA World Cup: suspend every 2 yellows, reset after quarter-finals
- UEFA club (future): first at 3, then every 2, reset after QF

Yellow card accumulation is now tracked per-competition via a yellow_cards counter on player_suspensions, so cards in one competition never bleed into another, and mid-tournament resets don't affect the visible season stat on game_players.