### PR TITLE
Fix academy evaluation doom loop when loaned players exceed capacity

### DIFF
--- a/app/Http/Actions/EvaluateAcademy.php
+++ b/app/Http/Actions/EvaluateAcademy.php
@@ -61,15 +61,6 @@ class EvaluateAcademy
             }
         }
 
-        // Count loaned players (they still occupy virtual seats at season end)
-        $loanedCount = AcademyPlayer::where('game_id', $gameId)
-            ->where('team_id', $game->team_id)
-            ->where('is_on_loan', true)
-            ->count();
-
-        // Returning loans take seats at season end
-        $seatsAfter += $loanedCount;
-
         if ($seatsAfter > $capacity && $capacity > 0) {
             $excess = $seatsAfter - $capacity;
 

--- a/resources/views/squad-academy-evaluation.blade.php
+++ b/resources/views/squad-academy-evaluation.blade.php
@@ -332,7 +332,7 @@
                     }
                     // Players without a decision yet count as kept
                     const undecided = this.playerCount - Object.values(this.decisions).filter(v => v).length;
-                    return kept + undecided + {{ $loanedCount }};
+                    return kept + undecided;
                 },
 
                 get allDecided() {


### PR DESCRIPTION
Loaned-out players were counted against academy capacity in both the backend validation and the Alpine.js UI, but the evaluation form only shows non-loaned players. This created an unresolvable state where the capacity check always failed and the pending action could never be cleared, permanently blocking matchday advancement.