### PR TITLE
Batch player_suspensions queries to eliminate N+1 in hot paths

### DIFF
--- a/app/Modules/Lineup/Services/SubstitutionService.php
+++ b/app/Modules/Lineup/Services/SubstitutionService.php
@@ -67,6 +67,12 @@ class SubstitutionService
             $activeLineupIds[] = $sub['playerInId'];
         }
 
+        // Pre-load all suspended player IDs for this competition (single query)
+        $suspendedPlayerIds = PlayerSuspension::where('competition_id', $match->competition_id)
+            ->where('matches_remaining', '>', 0)
+            ->pluck('game_player_id')
+            ->all();
+
         // Validate each sub in the batch
         $batchOutIds = [];
         $batchInIds = [];
@@ -111,7 +117,7 @@ class SubstitutionService
                 throw new \InvalidArgumentException('game.sub_error_already_on_pitch');
             }
 
-            if (PlayerSuspension::isSuspended($playerInId, $match->competition_id)) {
+            if (in_array($playerInId, $suspendedPlayerIds)) {
                 throw new \InvalidArgumentException('game.sub_error_player_suspended');
             }
 

--- a/app/Modules/Match/Services/MatchResultProcessor.php
+++ b/app/Modules/Match/Services/MatchResultProcessor.php
@@ -164,8 +164,13 @@ class MatchResultProcessor
                 })
                 ->get();
 
-            foreach ($suspensions as $suspension) {
-                $suspension->serveMatch();
+            $suspensionIds = $suspensions->pluck('id')->all();
+            if (!empty($suspensionIds)) {
+                PlayerSuspension::whereIn('id', $suspensionIds)->decrement('matches_remaining');
+                // Ensure matches_remaining doesn't go negative
+                PlayerSuspension::whereIn('id', $suspensionIds)
+                    ->where('matches_remaining', '<', 0)
+                    ->update(['matches_remaining' => 0]);
             }
         }
     }


### PR DESCRIPTION
Pre-load suspended player IDs before validation loop in SubstitutionService, replace per-record serveMatch() with bulk decrement in MatchResultProcessor, and batch-load suspensions for affected players in MatchResimulationService.