### PR TITLE
Show yellow card indicator on players in substitution picker

### DIFF
--- a/lang/en/game.php
+++ b/lang/en/game.php
@@ -222,6 +222,7 @@ return [
     'live_other_results' => 'Others',
     'live_continue_dashboard' => 'Continue',
     'live_injury_alert' => 'has been injured. Make a substitution.',
+    'player_booked' => 'Booked',
     'live_injuries_report' => 'Injury Report',
     'live_weeks_out' => ':count week out|:count weeks out',
     'live_extra_time' => 'Extra Time',

--- a/lang/es/game.php
+++ b/lang/es/game.php
@@ -222,6 +222,7 @@ return [
     'live_other_results' => 'Otros',
     'live_continue_dashboard' => 'Continuar',
     'live_injury_alert' => 'se ha lesionado. Realiza una sustitución.',
+    'player_booked' => 'Amonestado',
     'live_injuries_report' => 'Parte de Lesiones',
     'live_weeks_out' => ':count semana de baja|:count semanas de baja',
     'live_extra_time' => 'Prórroga',

--- a/resources/js/live-match.js
+++ b/resources/js/live-match.js
@@ -998,6 +998,16 @@ export default function liveMatch(config) {
                 .map(e => e.gamePlayerId);
         },
 
+        get yellowCardedPlayerIds() {
+            return this.revealedEvents
+                .filter(e => e.type === 'yellow_card' && e.teamId === this.userTeamId)
+                .map(e => e.gamePlayerId);
+        },
+
+        isPlayerYellowCarded(playerId) {
+            return this.yellowCardedPlayerIds.includes(playerId);
+        },
+
         // Dynamic limits: 6 subs / 4 windows during ET in knockout, 5/3 otherwise
         get effectiveMaxSubstitutions() {
             return (this.isKnockout && this.hasExtraTime) ? 6 : this.maxSubstitutions;

--- a/resources/views/partials/live-match/tactical-panel.blade.php
+++ b/resources/views/partials/live-match/tactical-panel.blade.php
@@ -204,6 +204,10 @@
                                                     <span class="skew-x-12" x-text="player.positionAbbr"></span>
                                                 </span>
                                                 <span class="flex-1 truncate font-medium" x-text="player.name"></span>
+                                                {{-- Yellow card indicator --}}
+                                                <span x-show="isPlayerYellowCarded(player.id)"
+                                                      x-tooltip.raw="{{ __('game.player_booked') }}"
+                                                      class="shrink-0 w-3.5 h-4.5 rounded-[1px] bg-yellow-400 border border-yellow-500"></span>
                                                 {{-- Energy bar --}}
                                                 <span class="ml-auto flex items-center gap-1 shrink-0">
                                                     <span class="text-[10px] tabular-nums font-semibold"


### PR DESCRIPTION
Display a yellow card badge next to booked players in the tactical
center's substitution panel, helping managers make informed decisions
about protecting carded players from a second yellow.

https://claude.ai/code/session_01QJpWrBAKNAinFJx4DEaE99