### PR TITLE
Add radar chart to coach assistant panel comparing team vs opponent

### DIFF
--- a/app/Http/Views/ShowLineup.php
+++ b/app/Http/Views/ShowLineup.php
@@ -123,6 +123,10 @@ class ShowLineup
         // Get opponent scouting data (including predicted formation and mentality)
         $opponentData = $this->getOpponentData($gameId, $opponent->id, $matchDate, $competitionId, !$isHome, $userTeamAverage);
 
+        // Radar chart data for coach assistant
+        $userRadar = $this->calculateRadarValues($userBestXI['players']);
+        $opponentRadar = $this->calculateRadarValues($opponentData['bestXIPlayers']);
+
         // Formation modifiers for coach assistant tips (attack/defense per formation)
         $formationModifiers = [];
         foreach (Formation::cases() as $formation) {
@@ -248,6 +252,8 @@ class ShowLineup
             'tacticalInteractions' => $tacticalInteractions,
             'gridConfig' => $gridConfig,
             'currentPitchPositions' => $currentPitchPositions,
+            'userRadar' => $userRadar,
+            'opponentRadar' => $opponentRadar,
         ]);
     }
 
@@ -286,6 +292,37 @@ class ShowLineup
             'form' => $form,
             'formation' => $predictedFormation->value,
             'mentality' => $predictedMentality->value,
+            'bestXIPlayers' => $bestXI,
+        ];
+    }
+
+    /**
+     * Calculate radar chart values from a collection of best XI players.
+     * Returns 8 axes: GK, DEF, MID, FWD averages + fitness, morale, technical, physical.
+     *
+     * @return array<string, int>
+     */
+    private function calculateRadarValues(\Illuminate\Support\Collection $players): array
+    {
+        if ($players->isEmpty()) {
+            return array_fill_keys(['goalkeeper', 'defense', 'midfield', 'attack', 'fitness', 'morale', 'technical', 'physical'], 0);
+        }
+
+        $grouped = $players->groupBy(fn ($p) => $p->position_group);
+
+        $avgOverall = fn (string $group) => (int) round(
+            ($grouped->get($group) ?? collect())->avg('overall_score') ?? 0
+        );
+
+        return [
+            'goalkeeper' => $avgOverall('Goalkeeper'),
+            'defense' => $avgOverall('Defender'),
+            'midfield' => $avgOverall('Midfielder'),
+            'attack' => $avgOverall('Forward'),
+            'fitness' => (int) round($players->avg('fitness')),
+            'morale' => (int) round($players->avg('morale')),
+            'technical' => (int) round($players->avg('technical_ability')),
+            'physical' => (int) round($players->avg('physical_ability')),
         ];
     }
 }

--- a/lang/en/squad.php
+++ b/lang/en/squad.php
@@ -243,6 +243,16 @@ return [
     'squad_confirmed' => 'Squad confirmed!',
     'invalid_selection' => 'Invalid selection. Please check the selected players.',
 
+    // Radar chart
+    'radar_gk' => 'Goalkeeping',
+    'radar_def' => 'Defense',
+    'radar_mid' => 'Midfield',
+    'radar_att' => 'Attack',
+    'radar_fit' => 'Fitness',
+    'radar_mor' => 'Morale',
+    'radar_tec' => 'Technical',
+    'radar_phy' => 'Physical',
+
     // Grid positioning
     'drag_or_tap' => 'Tap a cell or drag the player',
     'select_player_for_slot' => 'Select a player from the list',

--- a/lang/es/squad.php
+++ b/lang/es/squad.php
@@ -243,6 +243,16 @@ return [
     'squad_confirmed' => '¡Convocatoria confirmada!',
     'invalid_selection' => 'Selección inválida. Verifica los jugadores seleccionados.',
 
+    // Radar chart
+    'radar_gk' => 'Portería',
+    'radar_def' => 'Defensa',
+    'radar_mid' => 'Mediocampo',
+    'radar_att' => 'Ataque',
+    'radar_fit' => 'Forma',
+    'radar_mor' => 'Moral',
+    'radar_tec' => 'Técnica',
+    'radar_phy' => 'Físico',
+
     // Grid positioning
     'drag_or_tap' => 'Toca una celda o arrastra al jugador',
     'select_player_for_slot' => 'Selecciona un jugador de la lista',

--- a/resources/views/components/radar-chart.blade.php
+++ b/resources/views/components/radar-chart.blade.php
@@ -1,0 +1,190 @@
+@props([
+    'userValues' => [],    // [label => value (0-100)]
+    'opponentValues' => [], // [label => value (0-100)]
+    'labels' => [],         // [key => translated label]
+    'size' => 200,
+])
+
+@php
+    $axes = array_keys($labels);
+    $numAxes = count($axes);
+    if ($numAxes < 3) return;
+
+    $cx = $size / 2;
+    $cy = $size / 2;
+    $radius = ($size / 2) - 28; // Leave room for labels
+
+    // Calculate point positions for each axis
+    $angleStep = (2 * M_PI) / $numAxes;
+    // Start from top (-π/2) so first axis points up
+    $startAngle = -M_PI / 2;
+
+    $getPoint = function (int $index, float $value) use ($cx, $cy, $radius, $angleStep, $startAngle) {
+        $angle = $startAngle + ($index * $angleStep);
+        $r = ($value / 100) * $radius;
+        return [
+            round($cx + $r * cos($angle), 2),
+            round($cy + $r * sin($angle), 2),
+        ];
+    };
+
+    // Build polygon points for user and opponent
+    $userPoints = [];
+    $opponentPoints = [];
+    $labelPositions = [];
+
+    foreach ($axes as $i => $key) {
+        $uv = $userValues[$key] ?? 0;
+        $ov = $opponentValues[$key] ?? 0;
+        $userPoints[] = $getPoint($i, $uv);
+        $opponentPoints[] = $getPoint($i, $ov);
+
+        // Label position (slightly beyond the outer ring)
+        $angle = $startAngle + ($i * $angleStep);
+        $labelR = $radius + 16;
+        $labelPositions[] = [
+            'x' => round($cx + $labelR * cos($angle), 2),
+            'y' => round($cy + $labelR * sin($angle), 2),
+            'label' => $labels[$key],
+            'userValue' => $uv,
+            'opponentValue' => $ov,
+            'anchor' => abs(cos($angle)) < 0.01 ? 'middle' : (cos($angle) > 0 ? 'start' : 'end'),
+        ];
+    }
+
+    $toPolygon = fn (array $points) => implode(' ', array_map(fn ($p) => "{$p[0]},{$p[1]}", $points));
+
+    // Grid rings at 25%, 50%, 75%, 100%
+    $rings = [25, 50, 75, 100];
+@endphp
+
+<div
+    x-data="{
+        hoveredAxis: null,
+        userValues: @js($userValues),
+        opponentValues: @js($opponentValues),
+    }"
+    class="relative"
+>
+    <svg
+        viewBox="0 0 {{ $size }} {{ $size }}"
+        class="w-full max-w-[280px] mx-auto"
+        xmlns="http://www.w3.org/2000/svg"
+    >
+        {{-- Grid rings --}}
+        @foreach ($rings as $ring)
+            @php
+                $ringPoints = [];
+                for ($i = 0; $i < $numAxes; $i++) {
+                    $ringPoints[] = $getPoint($i, $ring);
+                }
+            @endphp
+            <polygon
+                points="{{ $toPolygon($ringPoints) }}"
+                fill="none"
+                stroke="#e2e8f0"
+                stroke-width="{{ $ring === 100 ? 1 : 0.5 }}"
+            />
+        @endforeach
+
+        {{-- Axis lines --}}
+        @foreach ($axes as $i => $key)
+            @php
+                $end = $getPoint($i, 100);
+            @endphp
+            <line
+                x1="{{ $cx }}" y1="{{ $cy }}"
+                x2="{{ $end[0] }}" y2="{{ $end[1] }}"
+                stroke="#e2e8f0"
+                stroke-width="0.5"
+            />
+        @endforeach
+
+        {{-- Opponent polygon (behind) --}}
+        <polygon
+            points="{{ $toPolygon($opponentPoints) }}"
+            fill="rgba(239, 68, 68, 0.1)"
+            stroke="rgba(239, 68, 68, 0.6)"
+            stroke-width="1.5"
+        />
+
+        {{-- User polygon (front) --}}
+        <polygon
+            points="{{ $toPolygon($userPoints) }}"
+            fill="rgba(14, 165, 233, 0.15)"
+            stroke="rgba(14, 165, 233, 0.8)"
+            stroke-width="1.5"
+        />
+
+        {{-- Data points - user --}}
+        @foreach ($userPoints as $i => $point)
+            <circle
+                cx="{{ $point[0] }}" cy="{{ $point[1] }}" r="2.5"
+                fill="#0ea5e9"
+                class="transition-all duration-150"
+                :r="hoveredAxis === {{ $i }} ? 3.5 : 2.5"
+            />
+        @endforeach
+
+        {{-- Data points - opponent --}}
+        @foreach ($opponentPoints as $i => $point)
+            <circle
+                cx="{{ $point[0] }}" cy="{{ $point[1] }}" r="2"
+                fill="#ef4444"
+                class="transition-all duration-150"
+                :r="hoveredAxis === {{ $i }} ? 3 : 2"
+            />
+        @endforeach
+
+        {{-- Axis labels --}}
+        @foreach ($labelPositions as $i => $pos)
+            <text
+                x="{{ $pos['x'] }}"
+                y="{{ $pos['y'] }}"
+                text-anchor="{{ $pos['anchor'] }}"
+                dominant-baseline="central"
+                class="fill-slate-500 transition-colors duration-150 cursor-default select-none"
+                :class="hoveredAxis === {{ $i }} ? 'fill-slate-900 font-semibold' : 'fill-slate-500'"
+                style="font-size: 7.5px;"
+                @mouseenter="hoveredAxis = {{ $i }}"
+                @mouseleave="hoveredAxis = null"
+            >{{ $pos['label'] }}</text>
+        @endforeach
+
+        {{-- Invisible hover zones on each axis for easier interaction --}}
+        @foreach ($axes as $i => $key)
+            @php
+                $end = $getPoint($i, 100);
+            @endphp
+            <line
+                x1="{{ $cx }}" y1="{{ $cy }}"
+                x2="{{ $end[0] }}" y2="{{ $end[1] }}"
+                stroke="transparent"
+                stroke-width="14"
+                @mouseenter="hoveredAxis = {{ $i }}"
+                @mouseleave="hoveredAxis = null"
+                class="cursor-default"
+            />
+        @endforeach
+    </svg>
+
+    {{-- Tooltip on hover --}}
+    @foreach ($labelPositions as $i => $pos)
+        <div
+            x-show="hoveredAxis === {{ $i }}"
+            x-cloak
+            x-transition.opacity.duration.150ms
+            class="absolute left-1/2 -translate-x-1/2 bottom-0 bg-slate-800/95 text-white text-[10px] px-2.5 py-1.5 rounded-md shadow-lg whitespace-nowrap z-10 flex items-center gap-2.5"
+        >
+            <span class="font-medium">{{ $pos['label'] }}</span>
+            <span class="flex items-center gap-1">
+                <span class="w-1.5 h-1.5 rounded-full bg-sky-400 inline-block"></span>
+                {{ $pos['userValue'] }}
+            </span>
+            <span class="flex items-center gap-1">
+                <span class="w-1.5 h-1.5 rounded-full bg-red-400 inline-block"></span>
+                {{ $pos['opponentValue'] }}
+            </span>
+        </div>
+    @endforeach
+</div>

--- a/resources/views/partials/lineup-coach-panel.blade.php
+++ b/resources/views/partials/lineup-coach-panel.blade.php
@@ -79,6 +79,34 @@
         </div>
     </div>
 
+    {{-- Radar Chart --}}
+    <div class="border-t border-slate-200 pt-3 mb-3">
+        <div class="flex items-center justify-center gap-4 mb-1">
+            <span class="flex items-center gap-1 text-[10px] text-slate-500">
+                <span class="w-2 h-1 rounded-sm bg-sky-400 inline-block"></span>
+                {{ $game->team->short_name ?? $game->team->name }}
+            </span>
+            <span class="flex items-center gap-1 text-[10px] text-slate-500">
+                <span class="w-2 h-1 rounded-sm bg-red-400 inline-block"></span>
+                {{ $opponent->short_name ?? $opponent->name }}
+            </span>
+        </div>
+        <x-radar-chart
+            :userValues="$userRadar"
+            :opponentValues="$opponentRadar"
+            :labels="[
+                'goalkeeper' => __('squad.radar_gk'),
+                'defense' => __('squad.radar_def'),
+                'midfield' => __('squad.radar_mid'),
+                'attack' => __('squad.radar_att'),
+                'fitness' => __('squad.radar_fit'),
+                'morale' => __('squad.radar_mor'),
+                'technical' => __('squad.radar_tec'),
+                'physical' => __('squad.radar_phy'),
+            ]"
+        />
+    </div>
+
     {{-- Tips Section --}}
     <div class="border-t border-slate-200 pt-3">
         <div class="text-[10px] font-semibold text-slate-400 uppercase tracking-wide mb-2">{{ __('squad.coach_recommendations') }}</div>


### PR DESCRIPTION
Pure SVG octagon radar chart (no dependencies) with 8 axes: Goalkeeping, Defense, Midfield, Attack, Fitness, Morale, Technical, Physical. Shows overlapping polygons for user (blue) and opponent (red) with hover tooltips. Integrated into the lineup page's coach assistant section.

https://claude.ai/code/session_01BDTzGy5LYbCJ25F11CTBCL