### PR TITLE
Fix red card/yellow accumulation suspensions being consumed during finalization

### DIFF
--- a/app/Modules/Match/Services/MatchFinalizationService.php
+++ b/app/Modules/Match/Services/MatchFinalizationService.php
@@ -56,67 +56,25 @@ class MatchFinalizationService
      * Serve suspensions that were deferred during batch processing.
      * These belong to players on the two teams in the deferred match.
      *
-     * Excludes players who received new suspensions FROM this match's card
-     * events — those suspensions apply to future matches, not this one.
+     * Excludes players who received cards in this match — any active suspension
+     * they carry was created from this match's events (suspended players can't
+     * be in lineups) and applies to future matches, not this one.
      */
     private function serveDeferredSuspensions(GameMatch $match): void
     {
-        $playerIds = GamePlayer::where('game_id', $match->game_id)
+        $teamPlayerSubquery = GamePlayer::where('game_id', $match->game_id)
             ->whereIn('team_id', [$match->home_team_id, $match->away_team_id])
-            ->pluck('id')
-            ->toArray();
+            ->select('id');
 
-        if (empty($playerIds)) {
-            return;
-        }
+        $cardPlayerSubquery = MatchEvent::where('game_match_id', $match->id)
+            ->whereIn('event_type', [MatchEvent::TYPE_RED_CARD, MatchEvent::TYPE_YELLOW_CARD])
+            ->select('game_player_id');
 
-        // Find players who received cards in this match and now have active
-        // suspensions. These suspensions were created during processAll() from
-        // this match's events and must NOT be served — they apply to future matches.
-        $newlySuspendedIds = $this->getNewlySuspendedPlayerIds($match, $playerIds);
-
-        $query = PlayerSuspension::where('competition_id', $match->competition_id)
+        PlayerSuspension::where('competition_id', $match->competition_id)
             ->where('matches_remaining', '>', 0)
-            ->whereIn('game_player_id', $playerIds);
-
-        if (! empty($newlySuspendedIds)) {
-            $query->whereNotIn('game_player_id', $newlySuspendedIds);
-        }
-
-        $suspensionIds = $query->pluck('id')->all();
-
-        if (! empty($suspensionIds)) {
-            PlayerSuspension::whereIn('id', $suspensionIds)->decrement('matches_remaining');
-            PlayerSuspension::whereIn('id', $suspensionIds)
-                ->where('matches_remaining', '<', 0)
-                ->update(['matches_remaining' => 0]);
-        }
-    }
-
-    /**
-     * Find players who received cards in this match and have active suspensions.
-     * A player who participated in the match cannot have had a pre-existing
-     * suspension (suspended players are excluded from lineups), so any active
-     * suspension they carry was created from this match's card events.
-     */
-    private function getNewlySuspendedPlayerIds(GameMatch $match, array $teamPlayerIds): array
-    {
-        $cardRecipientIds = MatchEvent::where('game_match_id', $match->id)
-            ->whereIn('event_type', ['red_card', 'yellow_card'])
-            ->whereIn('game_player_id', $teamPlayerIds)
-            ->pluck('game_player_id')
-            ->unique()
-            ->toArray();
-
-        if (empty($cardRecipientIds)) {
-            return [];
-        }
-
-        return PlayerSuspension::where('competition_id', $match->competition_id)
-            ->where('matches_remaining', '>', 0)
-            ->whereIn('game_player_id', $cardRecipientIds)
-            ->pluck('game_player_id')
-            ->toArray();
+            ->whereIn('game_player_id', $teamPlayerSubquery)
+            ->whereNotIn('game_player_id', $cardPlayerSubquery)
+            ->decrement('matches_remaining');
     }
 
     private function resolveCupTie(GameMatch $match, Game $game, ?Competition $competition): void

--- a/tests/Feature/SuspensionDeferralTest.php
+++ b/tests/Feature/SuspensionDeferralTest.php
@@ -84,21 +84,7 @@ class SuspensionDeferralTest extends TestCase
             'scheduled_date' => Carbon::parse('2024-08-16'),
         ]);
 
-        foreach ([$this->playerTeam, $this->opponentTeam] as $team) {
-            GameStanding::create([
-                'game_id' => $this->game->id,
-                'competition_id' => $this->competition->id,
-                'team_id' => $team->id,
-                'position' => 0,
-                'played' => 0,
-                'won' => 0,
-                'drawn' => 0,
-                'lost' => 0,
-                'goals_for' => 0,
-                'goals_against' => 0,
-                'points' => 0,
-            ]);
-        }
+        $this->createStandings();
 
         // Advance matchday — match is simulated but finalization is deferred
         $action = app(AdvanceMatchday::class);
@@ -159,21 +145,7 @@ class SuspensionDeferralTest extends TestCase
             'scheduled_date' => Carbon::parse('2024-08-16'),
         ]);
 
-        foreach ([$this->playerTeam, $this->opponentTeam] as $team) {
-            GameStanding::create([
-                'game_id' => $this->game->id,
-                'competition_id' => $this->competition->id,
-                'team_id' => $team->id,
-                'position' => 0,
-                'played' => 0,
-                'won' => 0,
-                'drawn' => 0,
-                'lost' => 0,
-                'goals_for' => 0,
-                'goals_against' => 0,
-                'points' => 0,
-            ]);
-        }
+        $this->createStandings();
 
         // Advance matchday
         $action = app(AdvanceMatchday::class);
@@ -238,21 +210,7 @@ class SuspensionDeferralTest extends TestCase
                 ->toArray(),
         ]);
 
-        foreach ([$this->playerTeam, $this->opponentTeam] as $team) {
-            GameStanding::create([
-                'game_id' => $this->game->id,
-                'competition_id' => $this->competition->id,
-                'team_id' => $team->id,
-                'position' => 0,
-                'played' => 0,
-                'won' => 0,
-                'drawn' => 0,
-                'lost' => 0,
-                'goals_for' => 0,
-                'goals_against' => 0,
-                'points' => 0,
-            ]);
-        }
+        $this->createStandings();
 
         // Simulate what processAll does: create a red card event and suspension
         MatchEvent::create([
@@ -261,7 +219,7 @@ class SuspensionDeferralTest extends TestCase
             'game_player_id' => $redCardPlayer->id,
             'team_id' => $this->playerTeam->id,
             'minute' => 75,
-            'event_type' => 'red_card',
+            'event_type' => MatchEvent::TYPE_RED_CARD,
             'metadata' => ['second_yellow' => false],
         ]);
 
@@ -349,21 +307,7 @@ class SuspensionDeferralTest extends TestCase
                 ->toArray(),
         ]);
 
-        foreach ([$this->playerTeam, $this->opponentTeam] as $team) {
-            GameStanding::create([
-                'game_id' => $this->game->id,
-                'competition_id' => $this->competition->id,
-                'team_id' => $team->id,
-                'position' => 0,
-                'played' => 0,
-                'won' => 0,
-                'drawn' => 0,
-                'lost' => 0,
-                'goals_for' => 0,
-                'goals_against' => 0,
-                'points' => 0,
-            ]);
-        }
+        $this->createStandings();
 
         // Red card event and suspension for the starter
         MatchEvent::create([
@@ -372,7 +316,7 @@ class SuspensionDeferralTest extends TestCase
             'game_player_id' => $redCardPlayer->id,
             'team_id' => $this->playerTeam->id,
             'minute' => 75,
-            'event_type' => 'red_card',
+            'event_type' => MatchEvent::TYPE_RED_CARD,
             'metadata' => ['second_yellow' => false],
         ]);
 
@@ -407,6 +351,25 @@ class SuspensionDeferralTest extends TestCase
         );
     }
 
+    private function createStandings(): void
+    {
+        foreach ([$this->playerTeam, $this->opponentTeam] as $team) {
+            GameStanding::create([
+                'game_id' => $this->game->id,
+                'competition_id' => $this->competition->id,
+                'team_id' => $team->id,
+                'position' => 0,
+                'played' => 0,
+                'won' => 0,
+                'drawn' => 0,
+                'lost' => 0,
+                'goals_for' => 0,
+                'goals_against' => 0,
+                'points' => 0,
+            ]);
+        }
+    }
+
     /**
      * Create a minimal 11-player squad for a team (1 GK + 10 outfield).
      */
@@ -428,12 +391,11 @@ class SuspensionDeferralTest extends TestCase
         }
 
         // 4 Midfielders
-        foreach (['Central Midfield', 'Central Midfield', 'Central Midfield', 'Central Midfield'] as $position) {
-            GamePlayer::factory()
-                ->forGame($this->game)
-                ->forTeam($team)
-                ->create(['position' => $position]);
-        }
+        GamePlayer::factory()
+            ->forGame($this->game)
+            ->forTeam($team)
+            ->count(4)
+            ->create(['position' => 'Central Midfield']);
 
         // 2 Forwards
         foreach (['Centre-Forward', 'Centre-Forward'] as $position) {


### PR DESCRIPTION
When a player received a red card (or accumulated enough yellows for a
ban) in the user's deferred match, serveDeferredSuspensions() would
decrement the newly-created suspension along with pre-existing ones.
This effectively "used up" the 1-match ban on the match where the card
was received, leaving the player available for the next match.

The fix excludes players who received cards in the match and have active
suspensions from the serving query. Since suspended players cannot play,
any active suspension on a match participant must be new (from this
match's events) and should apply to future matches, not this one.