### PR TITLE
Replace reject button with renewal option for last-year contract players

### DIFF
--- a/resources/views/transfers.blade.php
+++ b/resources/views/transfers.blade.php
@@ -146,10 +146,21 @@
                                                         @csrf
                                                         <x-primary-button color="green">{{ __('app.accept') }}</x-primary-button>
                                                     </form>
+                                                    @php $offeredPlayer = $renewalEligiblePlayers->firstWhere('id', $offer->game_player_id); @endphp
+                                                    @if($offeredPlayer)
+                                                        <x-renewal-modal
+                                                            :game="$game"
+                                                            :game-player="$offeredPlayer"
+                                                            :renewal-demand="$renewalDemands[$offeredPlayer->id]"
+                                                            :renewal-midpoint="$renewalMidpoints[$offeredPlayer->id]"
+                                                            :renewal-mood="$renewalMoods[$offeredPlayer->id]"
+                                                        />
+                                                    @else
                                                     <form method="post" action="{{ route('game.transfers.reject', [$game->id, $offer->id]) }}">
                                                         @csrf
                                                         <x-secondary-button type="submit">{{ __('app.reject') }}</x-secondary-button>
                                                     </form>
+                                                    @endif
                                                 </div>
                                             </div>
                                         </div>
@@ -187,10 +198,21 @@
                                                         @csrf
                                                         <x-primary-button color="amber" size="sm">{{ __('squad.let_go') }}</x-primary-button>
                                                     </form>
+                                                    @php $offeredPlayer = $renewalEligiblePlayers->firstWhere('id', $offer->game_player_id); @endphp
+                                                    @if($offeredPlayer)
+                                                        <x-renewal-modal
+                                                            :game="$game"
+                                                            :game-player="$offeredPlayer"
+                                                            :renewal-demand="$renewalDemands[$offeredPlayer->id]"
+                                                            :renewal-midpoint="$renewalMidpoints[$offeredPlayer->id]"
+                                                            :renewal-mood="$renewalMoods[$offeredPlayer->id]"
+                                                        />
+                                                    @else
                                                     <form method="post" action="{{ route('game.transfers.reject', [$game->id, $offer->id]) }}">
                                                         @csrf
                                                         <x-secondary-button type="submit" size="sm">{{ __('app.reject') }}</x-secondary-button>
                                                     </form>
+                                                    @endif
                                                 </div>
                                             </div>
                                         </div>


### PR DESCRIPTION
When a player in their last contract year receives an unsolicited or
pre-contract offer, show an "Offer Renewal" button instead of "Reject".
This gives users the natural strategic response of retaining the player
via contract renewal directly from the offer card.

https://claude.ai/code/session_01UbvCT9XYqwFR6PwL5FyG4C