### PR TITLE
Balance squad building: reduce academy output, youth development rates, and quality gap bonus

### DIFF
--- a/app/Modules/Academy/Services/YouthAcademyService.php
+++ b/app/Modules/Academy/Services/YouthAcademyService.php
@@ -20,8 +20,8 @@ class YouthAcademyService
         0 => [0, 0, 0, 0, 0, 0, 0],
         1 => [4, 2, 3, 60, 70, 35, 50],
         2 => [6, 3, 5, 65, 75, 40, 55],
-        3 => [8, 5, 7, 70, 82, 45, 60],
-        4 => [10, 6, 8, 75, 90, 50, 70],
+        3 => [7, 4, 6, 68, 78, 40, 55],
+        4 => [8, 4, 6, 75, 85, 45, 60],
     ];
 
     private const ESTIMATED_MATCHDAYS = 38;
@@ -29,8 +29,8 @@ class YouthAcademyService
     /**
      * Season growth rates for development.
      */
-    private const GROWTH_RATE_ACADEMY = 0.35;
-    private const GROWTH_RATE_LOAN = 0.50;
+    private const GROWTH_RATE_ACADEMY = 0.30;
+    private const GROWTH_RATE_LOAN = 0.38;
 
     /**
      * Positions with weights for random selection.

--- a/app/Modules/Player/Services/DevelopmentCurve.php
+++ b/app/Modules/Player/Services/DevelopmentCurve.php
@@ -35,11 +35,11 @@ final class DevelopmentCurve
      * - 32+: Veteran decline (physical declines faster than technical)
      */
     public const AGE_CURVES = [
-        16 => ['technical' => 1.8, 'physical' => 2.0],
-        17 => ['technical' => 1.6, 'physical' => 1.8],
-        18 => ['technical' => 1.4, 'physical' => 1.5],
-        19 => ['technical' => 1.3, 'physical' => 1.3],
-        20 => ['technical' => 1.2, 'physical' => 1.2],
+        16 => ['technical' => 1.4, 'physical' => 1.5],
+        17 => ['technical' => 1.3, 'physical' => 1.4],
+        18 => ['technical' => 1.2, 'physical' => 1.3],
+        19 => ['technical' => 1.15, 'physical' => 1.2],
+        20 => ['technical' => 1.1, 'physical' => 1.1],
         21 => ['technical' => 1.1, 'physical' => 1.1],
         22 => ['technical' => 1.05, 'physical' => 1.0],
         23 => ['technical' => 1.0, 'physical' => 1.0],

--- a/app/Modules/Player/Services/PlayerDevelopmentService.php
+++ b/app/Modules/Player/Services/PlayerDevelopmentService.php
@@ -117,7 +117,7 @@ class PlayerDevelopmentService
 
         // Gap bonus: up to 50% faster development for players with 20+ point gap
         // 10 point gap = 25% bonus, 20 point gap = 50% bonus
-        return min(1.5, 1.0 + ($gap / 40));
+        return min(1.3, 1.0 + ($gap / 50));
     }
 
     /**


### PR DESCRIPTION
Academy was too generous — Tier 4 could produce 90-potential players with
ability 70 (ready to contribute immediately). Youth development multipliers
allowed 16-year-olds to gain 8-9 ability points per season. Combined with
50% loan growth rate and 1.5x quality gap bonus, the academy-to-star pipeline
produced elite players by age 18.

Changes:
- Academy Tier 3-4: lower max potential (90→85, 82→78), max ability (70→60,
  60→55), batch sizes, and capacity
- Academy growth rates: on-campus 0.35→0.30, loan 0.50→0.38
- DevelopmentCurve ages 16-20: reduce multipliers (e.g. age 16 physical
  2.0→1.5) so young starters gain ~5-6 pts/season instead of 8-9
- Quality gap bonus: cap 1.5→1.3, scaling denominator 40→50

Net effect: academy prospects now reach potential around age 22-23 instead of
18-19. Young players are still the best long-term investment but require
sustained playing time over 4-5 seasons.

https://claude.ai/code/session_01ER9JsmXqKnbEgQWgRFiHYF