### PR TITLE
Refactor/extract cup competition handler

### DIFF
--- a/app/Modules/Match/Handlers/CupCompetitionHandler.php
+++ b/app/Modules/Match/Handlers/CupCompetitionHandler.php
@@ -1,0 +1,194 @@
+<?php
+
+namespace App\Modules\Match\Handlers;
+
+use App\Modules\Competition\Contracts\CompetitionHandler;
+use App\Modules\Competition\DTOs\PlayoffRoundConfig;
+use App\Modules\Match\Events\CupTieResolved;
+use App\Modules\Match\Services\CupTieResolver;
+use App\Modules\Squad\Services\EligibilityService;
+use App\Models\CupTie;
+use App\Models\Game;
+use App\Models\GameMatch;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
+
+abstract class CupCompetitionHandler implements CompetitionHandler
+{
+    public function __construct(
+        protected readonly CupTieResolver $tieResolver,
+        protected readonly EligibilityService $eligibilityService,
+    ) {}
+
+    public function getRedirectRoute(Game $game, Collection $matches, int $matchday): string
+    {
+        $firstMatch = $matches->first();
+
+        return route('game.results', array_filter([
+            'gameId' => $game->id,
+            'competition' => $firstMatch->competition_id ?? $game->competition_id,
+            'matchday' => $firstMatch->round_number ?? $matchday,
+            'round' => $firstMatch?->round_name,
+        ]));
+    }
+
+    /**
+     * Get match batch for hybrid competitions (league/group phase + knockout phase).
+     * Knockout matches are batched by date; league/group matches by round_number.
+     */
+    protected function getHybridMatchBatch(string $gameId, GameMatch $nextMatch, bool $filterCupTieNull = false): Collection
+    {
+        return GameMatch::with(['homeTeam', 'awayTeam', 'cupTie'])
+            ->where('game_id', $gameId)
+            ->where('competition_id', $nextMatch->competition_id)
+            ->where('played', false)
+            ->where(function ($query) use ($nextMatch, $filterCupTieNull) {
+                if ($nextMatch->cup_tie_id) {
+                    $query->whereDate('scheduled_date', $nextMatch->scheduled_date->toDateString());
+                    if ($filterCupTieNull) {
+                        $query->whereNotNull('cup_tie_id');
+                    }
+                } else {
+                    $query->where('round_number', $nextMatch->round_number);
+                    if ($filterCupTieNull) {
+                        $query->whereNull('cup_tie_id');
+                    }
+                }
+            })
+            ->get();
+    }
+
+    /**
+     * Resolve all completed cup ties from the given matches.
+     */
+    protected function resolveCompletedTies(Game $game, Collection $matches, Collection $allPlayers): void
+    {
+        $tieIds = $matches->pluck('cup_tie_id')->unique()->filter();
+
+        $ties = CupTie::with([
+                'firstLegMatch.homeTeam', 'firstLegMatch.awayTeam',
+                'secondLegMatch.homeTeam', 'secondLegMatch.awayTeam',
+                'competition',
+            ])
+            ->whereIn('id', $tieIds)
+            ->where('completed', false)
+            ->get();
+
+        foreach ($ties as $tie) {
+            $winnerId = $this->tieResolver->resolve($tie, $allPlayers);
+
+            if ($winnerId) {
+                $match = $tie->secondLegMatch ?? $tie->firstLegMatch;
+                CupTieResolved::dispatch($tie, $winnerId, $match, $game, $tie->competition);
+            }
+        }
+    }
+
+    /**
+     * Create a cup tie with its match(es).
+     */
+    protected function createTie(
+        Game $game,
+        string $competitionId,
+        string $homeTeamId,
+        string $awayTeamId,
+        PlayoffRoundConfig $config,
+        ?int $bracketPosition = null,
+    ): void {
+        $tie = CupTie::create([
+            'id' => Str::uuid()->toString(),
+            'game_id' => $game->id,
+            'competition_id' => $competitionId,
+            'round_number' => $config->round,
+            'bracket_position' => $bracketPosition,
+            'home_team_id' => $homeTeamId,
+            'away_team_id' => $awayTeamId,
+        ]);
+
+        $firstLeg = GameMatch::create([
+            'id' => Str::uuid()->toString(),
+            'game_id' => $game->id,
+            'competition_id' => $competitionId,
+            'round_name' => $config->name,
+            'round_number' => $config->round,
+            'home_team_id' => $homeTeamId,
+            'away_team_id' => $awayTeamId,
+            'scheduled_date' => $config->firstLegDate,
+            'cup_tie_id' => $tie->id,
+        ]);
+
+        $tie->update(['first_leg_match_id' => $firstLeg->id]);
+
+        if ($config->twoLegged && $config->secondLegDate) {
+            $secondLeg = GameMatch::create([
+                'id' => Str::uuid()->toString(),
+                'game_id' => $game->id,
+                'competition_id' => $competitionId,
+                'round_name' => $config->name . '_return',
+                'round_number' => $config->round,
+                'home_team_id' => $awayTeamId,
+                'away_team_id' => $homeTeamId,
+                'scheduled_date' => $config->secondLegDate,
+                'cup_tie_id' => $tie->id,
+            ]);
+
+            $tie->update(['second_leg_match_id' => $secondLeg->id]);
+        }
+    }
+
+    /**
+     * Check if a round already exists for the given competition.
+     */
+    protected function roundExists(string $gameId, string $competitionId, int $round): bool
+    {
+        return CupTie::where('game_id', $gameId)
+            ->where('competition_id', $competitionId)
+            ->where('round_number', $round)
+            ->exists();
+    }
+
+    /**
+     * Get the current (highest) round number for the given competition.
+     */
+    protected function getCurrentRound(string $gameId, string $competitionId): int
+    {
+        return CupTie::where('game_id', $gameId)
+            ->where('competition_id', $competitionId)
+            ->max('round_number') ?? 0;
+    }
+
+    /**
+     * Reset yellow cards if the just-completed round matches the reset threshold.
+     */
+    protected function maybeResetYellowCards(string $gameId, string $competitionId, string $handlerType): void
+    {
+        $rules = $this->eligibilityService->rulesForHandlerType($handlerType);
+        if ($rules->yellowCardResetAfterRound === null) {
+            return;
+        }
+
+        $resetRound = $rules->yellowCardResetAfterRound;
+        $allComplete = CupTie::where('game_id', $gameId)
+            ->where('competition_id', $competitionId)
+            ->where('round_number', $resetRound)
+            ->where('completed', false)
+            ->doesntExist();
+
+        $roundExists = CupTie::where('game_id', $gameId)
+            ->where('competition_id', $competitionId)
+            ->where('round_number', $resetRound)
+            ->exists();
+
+        if ($roundExists && $allComplete) {
+            // Only reset once — check if a later round already has ties (reset already happened)
+            $laterRoundExists = CupTie::where('game_id', $gameId)
+                ->where('competition_id', $competitionId)
+                ->where('round_number', '>', $resetRound)
+                ->exists();
+
+            if (!$laterRoundExists) {
+                $this->eligibilityService->resetYellowCardsForCompetition($gameId, $competitionId);
+            }
+        }
+    }
+}

--- a/app/Modules/Match/Handlers/GroupStageCupHandler.php
+++ b/app/Modules/Match/Handlers/GroupStageCupHandler.php
@@ -3,17 +3,13 @@
 namespace App\Modules\Match\Handlers;
 
 use App\Models\Competition;
-use App\Modules\Competition\Contracts\CompetitionHandler;
-use App\Modules\Competition\DTOs\PlayoffRoundConfig;
 use App\Modules\Competition\Services\WorldCupKnockoutGenerator;
-use App\Modules\Match\Events\CupTieResolved;
 use App\Modules\Match\Services\CupTieResolver;
 use App\Modules\Squad\Services\EligibilityService;
 use App\Models\CupTie;
 use App\Models\Game;
 use App\Models\GameMatch;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Str;
 
 /**
  * Handler for group stage + knockout competitions (World Cup).
@@ -23,13 +19,15 @@ use Illuminate\Support\Str;
  *
  * FIFA 2026 format: 48 teams, 12 groups → R32 → R16 → QF → SF → 3rd place + Final.
  */
-class GroupStageCupHandler implements CompetitionHandler
+class GroupStageCupHandler extends CupCompetitionHandler
 {
     public function __construct(
-        private readonly CupTieResolver $tieResolver,
+        CupTieResolver $tieResolver,
+        EligibilityService $eligibilityService,
         private readonly WorldCupKnockoutGenerator $knockoutGenerator,
-        private readonly EligibilityService $eligibilityService,
-    ) {}
+    ) {
+        parent::__construct($tieResolver, $eligibilityService);
+    }
 
     public function getType(): string
     {
@@ -38,22 +36,7 @@ class GroupStageCupHandler implements CompetitionHandler
 
     public function getMatchBatch(string $gameId, GameMatch $nextMatch): Collection
     {
-        return GameMatch::with(['homeTeam', 'awayTeam', 'cupTie'])
-            ->where('game_id', $gameId)
-            ->where('competition_id', $nextMatch->competition_id)
-            ->where('played', false)
-            ->where(function ($query) use ($nextMatch) {
-                if ($nextMatch->cup_tie_id) {
-                    // Knockout match — batch by date
-                    $query->whereDate('scheduled_date', $nextMatch->scheduled_date->toDateString())
-                        ->whereNotNull('cup_tie_id');
-                } else {
-                    // Group stage match — batch by round_number (matchday)
-                    $query->where('round_number', $nextMatch->round_number)
-                        ->whereNull('cup_tie_id');
-                }
-            })
-            ->get();
+        return $this->getHybridMatchBatch($gameId, $nextMatch, filterCupTieNull: true);
     }
 
     public function beforeMatches(Game $game, string $targetDate): void
@@ -75,24 +58,11 @@ class GroupStageCupHandler implements CompetitionHandler
 
     public function afterMatches(Game $game, Collection $matches, Collection $allPlayers): void
     {
-        // Resolve any completed knockout ties
         $knockoutMatches = $matches->filter(fn ($m) => $m->cup_tie_id !== null);
 
         if ($knockoutMatches->isNotEmpty()) {
-            $this->resolveKnockoutTies($game, $knockoutMatches, $allPlayers);
+            $this->resolveCompletedTies($game, $knockoutMatches, $allPlayers);
         }
-    }
-
-    public function getRedirectRoute(Game $game, Collection $matches, int $matchday): string
-    {
-        $firstMatch = $matches->first();
-
-        return route('game.results', array_filter([
-            'gameId' => $game->id,
-            'competition' => $firstMatch->competition_id ?? $game->competition_id,
-            'matchday' => $firstMatch->round_number ?? $matchday,
-            'round' => $firstMatch?->round_name,
-        ]));
     }
 
     /**
@@ -110,7 +80,7 @@ class GroupStageCupHandler implements CompetitionHandler
             return;
         }
 
-        $currentRound = $this->getCurrentKnockoutRound($game->id, $competitionId);
+        $currentRound = $this->getCurrentRound($game->id, $competitionId);
         $finalRound = $this->knockoutGenerator->getFinalRound($competitionId);
 
         if ($currentRound === 0) {
@@ -118,7 +88,7 @@ class GroupStageCupHandler implements CompetitionHandler
             $qualifiedTeams = $this->knockoutGenerator->getQualifiedTeams($game->id, $competitionId);
             $firstRound = $this->knockoutGenerator->getFirstKnockoutRound(count($qualifiedTeams));
 
-            if (!$this->knockoutRoundExists($game->id, $competitionId, $firstRound)) {
+            if (!$this->roundExists($game->id, $competitionId, $firstRound)) {
                 $this->generateKnockoutRound($game, $competitionId, $firstRound);
             }
 
@@ -147,10 +117,10 @@ class GroupStageCupHandler implements CompetitionHandler
             $thirdPlaceRound = WorldCupKnockoutGenerator::ROUND_THIRD_PLACE;
             $finalRoundNum = WorldCupKnockoutGenerator::ROUND_FINAL;
 
-            if (!$this->knockoutRoundExists($game->id, $competitionId, $thirdPlaceRound)) {
+            if (!$this->roundExists($game->id, $competitionId, $thirdPlaceRound)) {
                 $this->generateKnockoutRound($game, $competitionId, $thirdPlaceRound);
             }
-            if (!$this->knockoutRoundExists($game->id, $competitionId, $finalRoundNum)) {
+            if (!$this->roundExists($game->id, $competitionId, $finalRoundNum)) {
                 $this->generateKnockoutRound($game, $competitionId, $finalRoundNum);
             }
 
@@ -169,80 +139,18 @@ class GroupStageCupHandler implements CompetitionHandler
             return;
         }
 
-        if (!$this->knockoutRoundExists($game->id, $competitionId, $nextRound)) {
+        if (!$this->roundExists($game->id, $competitionId, $nextRound)) {
             $this->generateKnockoutRound($game, $competitionId, $nextRound);
         }
     }
 
-    /**
-     * Generate a knockout round's fixtures.
-     */
     private function generateKnockoutRound(Game $game, string $competitionId, int $round): void
     {
         $config = $this->knockoutGenerator->getRoundConfig($round, $competitionId, $game->season);
         $matchups = $this->knockoutGenerator->generateMatchups($game, $competitionId, $round);
 
         foreach ($matchups as [$homeTeamId, $awayTeamId, $bracketPosition]) {
-            $this->createKnockoutTie($game, $competitionId, $homeTeamId, $awayTeamId, $config, $bracketPosition);
-        }
-    }
-
-    /**
-     * Create a knockout tie with its single-leg match.
-     */
-    private function createKnockoutTie(
-        Game $game,
-        string $competitionId,
-        string $homeTeamId,
-        string $awayTeamId,
-        PlayoffRoundConfig $config,
-        ?int $bracketPosition = null,
-    ): void {
-        $tie = CupTie::create([
-            'id' => Str::uuid()->toString(),
-            'game_id' => $game->id,
-            'competition_id' => $competitionId,
-            'round_number' => $config->round,
-            'bracket_position' => $bracketPosition,
-            'home_team_id' => $homeTeamId,
-            'away_team_id' => $awayTeamId,
-        ]);
-
-        $match = GameMatch::create([
-            'id' => Str::uuid()->toString(),
-            'game_id' => $game->id,
-            'competition_id' => $competitionId,
-            'round_name' => $config->name,
-            'round_number' => $config->round,
-            'home_team_id' => $homeTeamId,
-            'away_team_id' => $awayTeamId,
-            'scheduled_date' => $config->firstLegDate,
-            'cup_tie_id' => $tie->id,
-        ]);
-
-        $tie->update(['first_leg_match_id' => $match->id]);
-    }
-
-    /**
-     * Resolve completed knockout ties.
-     */
-    private function resolveKnockoutTies(Game $game, Collection $knockoutMatches, Collection $allPlayers): void
-    {
-        $tieIds = $knockoutMatches->pluck('cup_tie_id')->unique()->filter();
-
-        foreach ($tieIds as $tieId) {
-            $tie = CupTie::with(['firstLegMatch', 'secondLegMatch', 'competition'])->find($tieId);
-
-            if (!$tie || $tie->completed) {
-                continue;
-            }
-
-            $winnerId = $this->tieResolver->resolve($tie, $allPlayers);
-
-            if ($winnerId) {
-                $match = $tie->secondLegMatch ?? $tie->firstLegMatch;
-                CupTieResolved::dispatch($tie, $winnerId, $match, $game, $tie->competition);
-            }
+            $this->createTie($game, $competitionId, $homeTeamId, $awayTeamId, $config, $bracketPosition);
         }
     }
 
@@ -252,21 +160,6 @@ class GroupStageCupHandler implements CompetitionHandler
             ->where('competition_id', $competitionId)
             ->whereNull('cup_tie_id')
             ->where('played', false)
-            ->exists();
-    }
-
-    private function getCurrentKnockoutRound(string $gameId, string $competitionId): int
-    {
-        return CupTie::where('game_id', $gameId)
-            ->where('competition_id', $competitionId)
-            ->max('round_number') ?? 0;
-    }
-
-    private function knockoutRoundExists(string $gameId, string $competitionId, int $round): bool
-    {
-        return CupTie::where('game_id', $gameId)
-            ->where('competition_id', $competitionId)
-            ->where('round_number', $round)
             ->exists();
     }
 }

--- a/app/Modules/Match/Handlers/KnockoutCupHandler.php
+++ b/app/Modules/Match/Handlers/KnockoutCupHandler.php
@@ -2,22 +2,12 @@
 
 namespace App\Modules\Match\Handlers;
 
-use App\Modules\Competition\Contracts\CompetitionHandler;
-use App\Modules\Match\Events\CupTieResolved;
-use App\Modules\Match\Services\CupTieResolver;
-use App\Modules\Squad\Services\EligibilityService;
-use App\Models\CupTie;
 use App\Models\Game;
 use App\Models\GameMatch;
 use Illuminate\Support\Collection;
 
-class KnockoutCupHandler implements CompetitionHandler
+class KnockoutCupHandler extends CupCompetitionHandler
 {
-    public function __construct(
-        private readonly CupTieResolver $cupTieResolver,
-        private readonly EligibilityService $eligibilityService,
-    ) {}
-
     public function getType(): string
     {
         return 'knockout_cup';
@@ -50,98 +40,11 @@ class KnockoutCupHandler implements CompetitionHandler
      */
     public function afterMatches(Game $game, Collection $matches, Collection $allPlayers): void
     {
-        $this->resolveCupTies($game, $matches, $allPlayers);
+        $this->resolveCompletedTies($game, $matches, $allPlayers);
 
-        // Reset yellow cards if a completed round matches the reset threshold
-        $this->maybeResetYellowCards($game, $matches);
-    }
-
-    /**
-     * Redirect to the match results page to show cup results.
-     */
-    public function getRedirectRoute(Game $game, Collection $matches, int $matchday): string
-    {
-        $firstMatch = $matches->first();
-
-        return route('game.results', array_filter([
-            'gameId' => $game->id,
-            'competition' => $firstMatch->competition_id ?? $game->competition_id,
-            'matchday' => $firstMatch->round_number ?? $matchday,
-            'round' => $firstMatch?->round_name,
-        ]));
-    }
-
-    /**
-     * Resolve cup ties after matches have been played.
-     */
-    private function resolveCupTies(Game $game, Collection $cupMatches, Collection $allPlayers): void
-    {
-        $tieIds = $cupMatches->pluck('cup_tie_id')->unique()->filter()->values();
-        $ties = CupTie::with([
-                'firstLegMatch.homeTeam', 'firstLegMatch.awayTeam',
-                'secondLegMatch.homeTeam', 'secondLegMatch.awayTeam',
-                'competition',
-            ])
-            ->whereIn('id', $tieIds)
-            ->where('completed', false)
-            ->get();
-
-        if ($ties->isEmpty()) {
-            return;
-        }
-
-        $firstTie = $ties->first();
-        $roundConfig = $firstTie->getRoundConfig();
-
-        foreach ($ties as $tie) {
-            $winnerId = $this->cupTieResolver->resolve($tie, $allPlayers, $roundConfig);
-
-            if ($winnerId) {
-                $match = $tie->secondLegMatch ?? $tie->firstLegMatch;
-                CupTieResolved::dispatch($tie, $winnerId, $match, $game, $tie->competition);
-            }
-        }
-    }
-
-    /**
-     * Reset yellow cards if the just-completed round matches the reset threshold.
-     */
-    private function maybeResetYellowCards(Game $game, Collection $matches): void
-    {
         $competitionId = $matches->first()?->competition_id;
-        if (!$competitionId) {
-            return;
-        }
-
-        $rules = $this->eligibilityService->rulesForHandlerType('knockout_cup');
-        if ($rules->yellowCardResetAfterRound === null) {
-            return;
-        }
-
-        // Check if the reset round just completed (all ties resolved)
-        $resetRound = $rules->yellowCardResetAfterRound;
-        $allComplete = CupTie::where('game_id', $game->id)
-            ->where('competition_id', $competitionId)
-            ->where('round_number', $resetRound)
-            ->where('completed', false)
-            ->doesntExist();
-
-        $roundExists = CupTie::where('game_id', $game->id)
-            ->where('competition_id', $competitionId)
-            ->where('round_number', $resetRound)
-            ->exists();
-
-        if ($roundExists && $allComplete) {
-            // Only reset once — check if a later round already has ties (reset already happened)
-            $laterRoundExists = CupTie::where('game_id', $game->id)
-                ->where('competition_id', $competitionId)
-                ->where('round_number', '>', $resetRound)
-                ->exists();
-
-            if (!$laterRoundExists) {
-                $this->eligibilityService->resetYellowCardsForCompetition($game->id, $competitionId);
-            }
+        if ($competitionId) {
+            $this->maybeResetYellowCards($game->id, $competitionId, 'knockout_cup');
         }
     }
-
 }

--- a/app/Modules/Match/Handlers/LeagueWithPlayoffHandler.php
+++ b/app/Modules/Match/Handlers/LeagueWithPlayoffHandler.php
@@ -2,17 +2,14 @@
 
 namespace App\Modules\Match\Handlers;
 
-use App\Modules\Competition\Contracts\CompetitionHandler;
 use App\Modules\Competition\Contracts\PlayoffGenerator;
-use App\Modules\Competition\DTOs\PlayoffRoundConfig;
 use App\Modules\Competition\Playoffs\PlayoffGeneratorFactory;
-use App\Modules\Match\Events\CupTieResolved;
 use App\Modules\Match\Services\CupTieResolver;
+use App\Modules\Squad\Services\EligibilityService;
 use App\Models\CupTie;
 use App\Models\Game;
 use App\Models\GameMatch;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Str;
 
 /**
  * Handler for league competitions that have end-of-season playoffs.
@@ -20,12 +17,15 @@ use Illuminate\Support\Str;
  * Combines regular league handling with knockout playoff generation
  * and resolution after the regular season ends.
  */
-class LeagueWithPlayoffHandler implements CompetitionHandler
+class LeagueWithPlayoffHandler extends CupCompetitionHandler
 {
     public function __construct(
-        private PlayoffGeneratorFactory $playoffFactory,
-        private CupTieResolver $tieResolver,
-    ) {}
+        CupTieResolver $tieResolver,
+        EligibilityService $eligibilityService,
+        private readonly PlayoffGeneratorFactory $playoffFactory,
+    ) {
+        parent::__construct($tieResolver, $eligibilityService);
+    }
 
     public function getType(): string
     {
@@ -34,21 +34,7 @@ class LeagueWithPlayoffHandler implements CompetitionHandler
 
     public function getMatchBatch(string $gameId, GameMatch $nextMatch): Collection
     {
-        // Return all matches for the same matchday (league) or date (playoffs)
-        return GameMatch::with(['homeTeam', 'awayTeam', 'cupTie'])
-            ->where('game_id', $gameId)
-            ->where('competition_id', $nextMatch->competition_id)
-            ->where('played', false)
-            ->where(function ($query) use ($nextMatch) {
-                if ($nextMatch->cup_tie_id) {
-                    // Playoff match - get all matches on same date
-                    $query->whereDate('scheduled_date', $nextMatch->scheduled_date->toDateString());
-                } else {
-                    // League match - get all matches in same matchday
-                    $query->where('round_number', $nextMatch->round_number);
-                }
-            })
-            ->get();
+        return $this->getHybridMatchBatch($gameId, $nextMatch);
     }
 
     public function beforeMatches(Game $game, string $targetDate): void
@@ -58,33 +44,19 @@ class LeagueWithPlayoffHandler implements CompetitionHandler
             return;
         }
 
-        // Check if we should generate the next playoff round
         if ($this->shouldGeneratePlayoffRound($game, $generator)) {
-            $nextRound = $this->getCurrentPlayoffRound($game, $generator) + 1;
+            $nextRound = $this->getCurrentRound($game->id, $generator->getCompetitionId()) + 1;
             $this->generatePlayoffRound($game, $generator, $nextRound);
         }
     }
 
     public function afterMatches(Game $game, Collection $matches, Collection $allPlayers): void
     {
-        // Resolve any completed playoff ties
         $playoffMatches = $matches->filter(fn ($m) => $m->cup_tie_id !== null);
 
         if ($playoffMatches->isNotEmpty()) {
-            $this->resolvePlayoffTies($game, $playoffMatches, $allPlayers);
+            $this->resolveCompletedTies($game, $playoffMatches, $allPlayers);
         }
-    }
-
-    public function getRedirectRoute(Game $game, Collection $matches, int $matchday): string
-    {
-        $firstMatch = $matches->first();
-
-        return route('game.results', array_filter([
-            'gameId' => $game->id,
-            'competition' => $firstMatch->competition_id ?? $game->competition_id,
-            'matchday' => $firstMatch->round_number ?? $matchday,
-            'round' => $firstMatch?->round_name,
-        ]));
     }
 
     /**
@@ -92,7 +64,6 @@ class LeagueWithPlayoffHandler implements CompetitionHandler
      */
     public function isSeasonComplete(Game $game): bool
     {
-        // First check if all league matches are played
         $unplayedLeague = GameMatch::where('game_id', $game->id)
             ->where('competition_id', $game->competition_id)
             ->whereNull('cup_tie_id')
@@ -103,10 +74,9 @@ class LeagueWithPlayoffHandler implements CompetitionHandler
             return false;
         }
 
-        // Then check playoff completion
         $generator = $this->playoffFactory->forCompetition($game->competition_id);
         if (!$generator) {
-            return true; // No playoffs configured
+            return true;
         }
 
         return $generator->isComplete($game);
@@ -117,7 +87,6 @@ class LeagueWithPlayoffHandler implements CompetitionHandler
      */
     private function shouldGeneratePlayoffRound(Game $game, PlayoffGenerator $generator): bool
     {
-        // Check if regular season is complete
         $regularSeasonComplete = !GameMatch::where('game_id', $game->id)
             ->where('competition_id', $game->competition_id)
             ->whereNull('cup_tie_id')
@@ -134,135 +103,37 @@ class LeagueWithPlayoffHandler implements CompetitionHandler
             return false;
         }
 
-        $currentRound = $this->getCurrentPlayoffRound($game, $generator);
+        $competitionId = $generator->getCompetitionId();
+        $currentRound = $this->getCurrentRound($game->id, $competitionId);
         $nextRound = $currentRound + 1;
 
-        // Check if we've already generated all rounds
         if ($nextRound > $generator->getTotalRounds()) {
             return false;
         }
 
         // For round 1, generate if it doesn't exist
         if ($nextRound === 1) {
-            return !$this->playoffRoundExists($game, $generator, 1);
+            return !$this->roundExists($game->id, $competitionId, 1);
         }
 
         // For later rounds, check if previous round is complete
         $previousRoundComplete = CupTie::where('game_id', $game->id)
-            ->where('competition_id', $generator->getCompetitionId())
+            ->where('competition_id', $competitionId)
             ->where('round_number', $currentRound)
             ->where('completed', false)
             ->doesntExist();
 
-        return $previousRoundComplete && !$this->playoffRoundExists($game, $generator, $nextRound);
+        return $previousRoundComplete && !$this->roundExists($game->id, $competitionId, $nextRound);
     }
 
-    /**
-     * Generate fixtures for a playoff round.
-     */
     private function generatePlayoffRound(Game $game, PlayoffGenerator $generator, int $round): void
     {
+        $competitionId = $generator->getCompetitionId();
         $config = $generator->getRoundConfig($round, $game->season);
         $matchups = $generator->generateMatchups($game, $round);
 
         foreach ($matchups as [$homeTeamId, $awayTeamId]) {
-            $this->createPlayoffTie($game, $generator, $homeTeamId, $awayTeamId, $config);
+            $this->createTie($game, $competitionId, $homeTeamId, $awayTeamId, $config);
         }
-    }
-
-    /**
-     * Create a playoff tie with its matches.
-     */
-    private function createPlayoffTie(
-        Game $game,
-        PlayoffGenerator $generator,
-        string $homeTeamId,
-        string $awayTeamId,
-        PlayoffRoundConfig $config,
-    ): void {
-        $tie = CupTie::create([
-            'id' => Str::uuid()->toString(),
-            'game_id' => $game->id,
-            'competition_id' => $generator->getCompetitionId(),
-            'round_number' => $config->round,
-            'home_team_id' => $homeTeamId,
-            'away_team_id' => $awayTeamId,
-        ]);
-
-        // Create first leg match
-        $firstLeg = GameMatch::create([
-            'id' => Str::uuid()->toString(),
-            'game_id' => $game->id,
-            'competition_id' => $generator->getCompetitionId(),
-            'round_name' => $config->name,
-            'round_number' => $config->round,
-            'home_team_id' => $homeTeamId,
-            'away_team_id' => $awayTeamId,
-            'scheduled_date' => $config->firstLegDate,
-            'cup_tie_id' => $tie->id,
-        ]);
-
-        $tie->update(['first_leg_match_id' => $firstLeg->id]);
-
-        // Create second leg if two-legged
-        if ($config->twoLegged && $config->secondLegDate) {
-            $secondLeg = GameMatch::create([
-                'id' => Str::uuid()->toString(),
-                'game_id' => $game->id,
-                'competition_id' => $generator->getCompetitionId(),
-                'round_name' => $config->name . '_return',
-                'round_number' => $config->round,
-                'home_team_id' => $awayTeamId, // Teams swap for second leg
-                'away_team_id' => $homeTeamId,
-                'scheduled_date' => $config->secondLegDate,
-                'cup_tie_id' => $tie->id,
-            ]);
-
-            $tie->update(['second_leg_match_id' => $secondLeg->id]);
-        }
-    }
-
-    /**
-     * Resolve completed playoff ties.
-     */
-    private function resolvePlayoffTies(Game $game, Collection $playoffMatches, Collection $allPlayers): void
-    {
-        $tieIds = $playoffMatches->pluck('cup_tie_id')->unique()->filter();
-
-        foreach ($tieIds as $tieId) {
-            $tie = CupTie::with(['firstLegMatch', 'secondLegMatch', 'competition'])->find($tieId);
-
-            if (!$tie || $tie->completed) {
-                continue;
-            }
-
-            $winnerId = $this->tieResolver->resolve($tie, $allPlayers);
-
-            if ($winnerId) {
-                $match = $tie->secondLegMatch ?? $tie->firstLegMatch;
-                CupTieResolved::dispatch($tie, $winnerId, $match, $game, $tie->competition);
-            }
-        }
-    }
-
-    /**
-     * Get the current (highest) playoff round that has been generated.
-     */
-    private function getCurrentPlayoffRound(Game $game, PlayoffGenerator $generator): int
-    {
-        return CupTie::where('game_id', $game->id)
-            ->where('competition_id', $generator->getCompetitionId())
-            ->max('round_number') ?? 0;
-    }
-
-    /**
-     * Check if a playoff round already exists.
-     */
-    private function playoffRoundExists(Game $game, PlayoffGenerator $generator, int $round): bool
-    {
-        return CupTie::where('game_id', $game->id)
-            ->where('competition_id', $generator->getCompetitionId())
-            ->where('round_number', $round)
-            ->exists();
     }
 }

--- a/app/Modules/Match/Handlers/SwissFormatHandler.php
+++ b/app/Modules/Match/Handlers/SwissFormatHandler.php
@@ -3,16 +3,13 @@
 namespace App\Modules\Match\Handlers;
 
 use App\Models\Competition;
-use App\Modules\Competition\Contracts\CompetitionHandler;
-use App\Modules\Competition\DTOs\PlayoffRoundConfig;
 use App\Modules\Competition\Services\SwissKnockoutGenerator;
-use App\Modules\Match\Events\CupTieResolved;
 use App\Modules\Match\Services\CupTieResolver;
+use App\Modules\Squad\Services\EligibilityService;
 use App\Models\CupTie;
 use App\Models\Game;
 use App\Models\GameMatch;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Str;
 
 /**
  * Handler for UEFA-style Swiss format competitions (Champions League, Europa League, Conference League).
@@ -20,12 +17,15 @@ use Illuminate\Support\Str;
  * League phase: 36 teams, 8 matchdays, single standings table.
  * Knockout phase: Playoff (9-24) → R16 (top 8 + playoff winners) → QF → SF → Final.
  */
-class SwissFormatHandler implements CompetitionHandler
+class SwissFormatHandler extends CupCompetitionHandler
 {
     public function __construct(
-        private readonly CupTieResolver $tieResolver,
+        CupTieResolver $tieResolver,
+        EligibilityService $eligibilityService,
         private readonly SwissKnockoutGenerator $knockoutGenerator,
-    ) {}
+    ) {
+        parent::__construct($tieResolver, $eligibilityService);
+    }
 
     public function getType(): string
     {
@@ -34,20 +34,7 @@ class SwissFormatHandler implements CompetitionHandler
 
     public function getMatchBatch(string $gameId, GameMatch $nextMatch): Collection
     {
-        return GameMatch::with(['homeTeam', 'awayTeam', 'cupTie'])
-            ->where('game_id', $gameId)
-            ->where('competition_id', $nextMatch->competition_id)
-            ->where('played', false)
-            ->where(function ($query) use ($nextMatch) {
-                if ($nextMatch->cup_tie_id) {
-                    // Knockout match - batch by date
-                    $query->whereDate('scheduled_date', $nextMatch->scheduled_date->toDateString());
-                } else {
-                    // League phase match - batch by round_number (matchday)
-                    $query->where('round_number', $nextMatch->round_number);
-                }
-            })
-            ->get();
+        return $this->getHybridMatchBatch($gameId, $nextMatch);
     }
 
     public function beforeMatches(Game $game, string $targetDate): void
@@ -70,24 +57,11 @@ class SwissFormatHandler implements CompetitionHandler
 
     public function afterMatches(Game $game, Collection $matches, Collection $allPlayers): void
     {
-        // Resolve any completed knockout ties
         $knockoutMatches = $matches->filter(fn ($m) => $m->cup_tie_id !== null);
 
         if ($knockoutMatches->isNotEmpty()) {
-            $this->resolveKnockoutTies($game, $knockoutMatches, $allPlayers);
+            $this->resolveCompletedTies($game, $knockoutMatches, $allPlayers);
         }
-    }
-
-    public function getRedirectRoute(Game $game, Collection $matches, int $matchday): string
-    {
-        $firstMatch = $matches->first();
-
-        return route('game.results', array_filter([
-            'gameId' => $game->id,
-            'competition' => $firstMatch->competition_id ?? $game->competition_id,
-            'matchday' => $firstMatch->round_number ?? $matchday,
-            'round' => $firstMatch?->round_name,
-        ]));
     }
 
     /**
@@ -95,7 +69,6 @@ class SwissFormatHandler implements CompetitionHandler
      */
     public function isSeasonComplete(Game $game, string $competitionId): bool
     {
-        // Check if all league phase matches are played
         $unplayedLeague = GameMatch::where('game_id', $game->id)
             ->where('competition_id', $competitionId)
             ->whereNull('cup_tie_id')
@@ -106,7 +79,6 @@ class SwissFormatHandler implements CompetitionHandler
             return false;
         }
 
-        // Check if final has been completed
         $finalTie = CupTie::where('game_id', $game->id)
             ->where('competition_id', $competitionId)
             ->where('round_number', SwissKnockoutGenerator::ROUND_FINAL)
@@ -120,7 +92,6 @@ class SwissFormatHandler implements CompetitionHandler
      */
     private function maybeGenerateKnockoutRound(Game $game, string $competitionId): void
     {
-        // Check if league phase is complete
         if (!$this->isLeaguePhaseComplete($game->id, $competitionId)) {
             return;
         }
@@ -131,17 +102,16 @@ class SwissFormatHandler implements CompetitionHandler
             return;
         }
 
-        $currentRound = $this->getCurrentKnockoutRound($game->id, $competitionId);
+        $currentRound = $this->getCurrentRound($game->id, $competitionId);
         $nextRound = $currentRound + 1;
 
-        // Don't generate beyond the final
         if ($nextRound > SwissKnockoutGenerator::ROUND_FINAL) {
             return;
         }
 
         // For round 1 (knockout playoff), generate if it doesn't exist
         if ($nextRound === SwissKnockoutGenerator::ROUND_KNOCKOUT_PLAYOFF) {
-            if (!$this->knockoutRoundExists($game->id, $competitionId, $nextRound)) {
+            if (!$this->roundExists($game->id, $competitionId, $nextRound)) {
                 $this->generateKnockoutRound($game, $competitionId, $nextRound);
             }
             return;
@@ -154,96 +124,18 @@ class SwissFormatHandler implements CompetitionHandler
             ->where('completed', false)
             ->doesntExist();
 
-        if ($previousRoundComplete && !$this->knockoutRoundExists($game->id, $competitionId, $nextRound)) {
+        if ($previousRoundComplete && !$this->roundExists($game->id, $competitionId, $nextRound)) {
             $this->generateKnockoutRound($game, $competitionId, $nextRound);
         }
     }
 
-    /**
-     * Generate a knockout round's fixtures.
-     */
     private function generateKnockoutRound(Game $game, string $competitionId, int $round): void
     {
         $config = $this->knockoutGenerator->getRoundConfig($round, $competitionId, $game->season);
         $matchups = $this->knockoutGenerator->generateMatchups($game, $competitionId, $round);
 
         foreach ($matchups as [$homeTeamId, $awayTeamId]) {
-            $this->createKnockoutTie($game, $competitionId, $homeTeamId, $awayTeamId, $config);
-        }
-    }
-
-    /**
-     * Create a knockout tie with its match(es).
-     */
-    private function createKnockoutTie(
-        Game $game,
-        string $competitionId,
-        string $homeTeamId,
-        string $awayTeamId,
-        PlayoffRoundConfig $config,
-    ): void {
-        $tie = CupTie::create([
-            'id' => Str::uuid()->toString(),
-            'game_id' => $game->id,
-            'competition_id' => $competitionId,
-            'round_number' => $config->round,
-            'home_team_id' => $homeTeamId,
-            'away_team_id' => $awayTeamId,
-        ]);
-
-        // Create first leg match
-        $firstLeg = GameMatch::create([
-            'id' => Str::uuid()->toString(),
-            'game_id' => $game->id,
-            'competition_id' => $competitionId,
-            'round_name' => $config->name,
-            'round_number' => $config->round,
-            'home_team_id' => $homeTeamId,
-            'away_team_id' => $awayTeamId,
-            'scheduled_date' => $config->firstLegDate,
-            'cup_tie_id' => $tie->id,
-        ]);
-
-        $tie->update(['first_leg_match_id' => $firstLeg->id]);
-
-        // Create second leg if two-legged
-        if ($config->twoLegged && $config->secondLegDate) {
-            $secondLeg = GameMatch::create([
-                'id' => Str::uuid()->toString(),
-                'game_id' => $game->id,
-                'competition_id' => $competitionId,
-                'round_name' => $config->name . '_return',
-                'round_number' => $config->round,
-                'home_team_id' => $awayTeamId,
-                'away_team_id' => $homeTeamId,
-                'scheduled_date' => $config->secondLegDate,
-                'cup_tie_id' => $tie->id,
-            ]);
-
-            $tie->update(['second_leg_match_id' => $secondLeg->id]);
-        }
-    }
-
-    /**
-     * Resolve completed knockout ties.
-     */
-    private function resolveKnockoutTies(Game $game, Collection $knockoutMatches, Collection $allPlayers): void
-    {
-        $tieIds = $knockoutMatches->pluck('cup_tie_id')->unique()->filter();
-
-        foreach ($tieIds as $tieId) {
-            $tie = CupTie::with(['firstLegMatch', 'secondLegMatch', 'competition'])->find($tieId);
-
-            if (!$tie || $tie->completed) {
-                continue;
-            }
-
-            $winnerId = $this->tieResolver->resolve($tie, $allPlayers);
-
-            if ($winnerId) {
-                $match = $tie->secondLegMatch ?? $tie->firstLegMatch;
-                CupTieResolved::dispatch($tie, $winnerId, $match, $game, $tie->competition);
-            }
+            $this->createTie($game, $competitionId, $homeTeamId, $awayTeamId, $config);
         }
     }
 
@@ -253,21 +145,6 @@ class SwissFormatHandler implements CompetitionHandler
             ->where('competition_id', $competitionId)
             ->whereNull('cup_tie_id')
             ->where('played', false)
-            ->exists();
-    }
-
-    private function getCurrentKnockoutRound(string $gameId, string $competitionId): int
-    {
-        return CupTie::where('game_id', $gameId)
-            ->where('competition_id', $competitionId)
-            ->max('round_number') ?? 0;
-    }
-
-    private function knockoutRoundExists(string $gameId, string $competitionId, int $round): bool
-    {
-        return CupTie::where('game_id', $gameId)
-            ->where('competition_id', $competitionId)
-            ->where('round_number', $round)
             ->exists();
     }
 }

--- a/docs/game-systems/README.md
+++ b/docs/game-systems/README.md
@@ -10,6 +10,7 @@ High-level documentation of the game systems that power VirtuaFC. These document
 | [Player Potential](player-potential.md) | How potential is generated and influences development |
 | [Player Development](player-development.md) | How players grow and decline over seasons |
 | [Market Value Dynamics](market-value-dynamics.md) | How market value evolves with ability and age |
+| [Matchday Advancement](matchday-advancement.md) | Core gameplay loop: batch finding, simulation, round generation, deferred finalization |
 | [Match Simulation](match-simulation.md) | xG formula, energy system, formations, mentality, events, penalties |
 | [Injury System](injury-system.md) | Injury probability, durability, medical tiers, recovery |
 | [Season Lifecycle](season-lifecycle.md) | Season flow, matchday progression, end-of-season pipeline |

--- a/docs/game-systems/matchday-advancement.md
+++ b/docs/game-systems/matchday-advancement.md
@@ -1,0 +1,241 @@
+# Matchday Advancement System
+
+How matches are found, simulated, and processed — the core gameplay loop.
+
+## Overview
+
+The matchday advancement system handles: finding the next batch of matches, simulating them, processing results (standings, tie resolution, suspensions), generating the next round of knockout/playoff matches, and determining when a season or tournament is complete.
+
+```
+User clicks "Play"
+    │
+    ├─ Generate pending knockout/playoff rounds
+    ├─ Find next batch of matches
+    ├─ Simulate batch
+    ├─ Process results (standings, suspensions, GK stats)
+    ├─ Resolve completed cup ties
+    ├─ Generate next knockout/playoff round
+    ├─ Award prize money, send notifications
+    └─ Return: live match (user plays) | done | season complete
+```
+
+## Entry Points
+
+There are three ways matchday advancement starts:
+
+| Entry | Route | When |
+|-------|-------|------|
+| `AdvanceMatchday` | `POST /game/{id}/advance` | User clicks "Play next match" |
+| `FinalizeMatch` | `POST /game/{id}/finalize-match` | User finishes viewing their live match |
+| `SimulateTournament` | `GET /game/{id}/simulate-tournament` | Auto-simulate remaining matches after user is eliminated (tournament mode) |
+
+All three ultimately call `MatchdayOrchestrator::advance()`.
+
+## Key Components
+
+### MatchdayOrchestrator
+
+**File:** `app/Modules/Match/Services/MatchdayOrchestrator.php`
+
+The main coordinator. `advance(Game)` runs inside a DB transaction with a row lock to prevent concurrent calls. It:
+
+1. Safety-finalizes any stuck pending match (browser close recovery)
+2. Checks for blocking conditions (career actions, pending user actions)
+3. Loops through match batches until the user's team plays or season ends
+4. For each batch: simulates, processes results, runs post-match actions
+5. Returns a `MatchdayAdvanceResult` (live_match, done, blocked, season_complete)
+
+### MatchdayService
+
+**File:** `app/Modules/Match/Services/MatchdayService.php`
+
+Finds and assembles the next batch of matches. `getNextMatchBatch(Game)`:
+
+1. Calls `generatePendingMatches()` — triggers `beforeMatches()` on hybrid handlers (league_with_playoff, swiss_format, group_stage_cup) to create knockout rounds if a phase just completed
+2. Calls `KnockoutCupHandler::beforeMatches()` — conducts draws for simple knockout cups
+3. Finds the next unplayed match by `scheduled_date`
+4. Gathers all matches on that date + expands league matches to include the full round
+5. Returns the batch with resolved handlers per competition
+
+### MatchFinalizationService
+
+**File:** `app/Modules/Match/Services/MatchFinalizationService.php`
+
+Handles deferred finalization for the user's match (see Deferred Finalization below). Steps:
+
+1. Serve deferred suspensions
+2. Resolve cup tie if applicable → dispatch `CupTieResolved`
+3. Dispatch `MatchFinalized` → triggers standings update, GK stats, notifications
+4. Clear `pending_finalization_match_id`
+5. Call `handler->beforeMatches()` to generate next round (only for group-phase matches)
+
+### Competition Handlers
+
+**Interface:** `app/Modules/Competition/Contracts/CompetitionHandler.php`
+
+Each competition type has a handler that implements four methods:
+
+| Method | Purpose |
+|--------|---------|
+| `getMatchBatch()` | Which matches play together? League: by round. Cup: by date. |
+| `beforeMatches()` | Generate next round if previous completed. No-op for simple types. |
+| `afterMatches()` | Resolve cup ties, dispatch events. No-op for leagues. |
+| `getRedirectRoute()` | Where to redirect after the batch plays |
+
+## Competition Handlers in Detail
+
+### LeagueHandler (`league`)
+
+Simplest handler. Batches by `round_number`. `beforeMatches()` and `afterMatches()` are no-ops — standings are updated by the `UpdateLeagueStandings` listener on `MatchFinalized`.
+
+### KnockoutCupHandler (`knockout_cup`)
+
+Used for Copa del Rey, Supercopa. Batches by `scheduled_date`. `beforeMatches()` is a no-op. `afterMatches()` resolves cup ties and dispatches `CupTieResolved`. Next round generation happens via the `ConductNextCupRoundDraw` listener, which calls `CupDrawService` for random draw pairing.
+
+### SwissFormatHandler (`swiss_format`)
+
+Used for Champions League, Europa League, Conference League. Hybrid batching: by round for league phase, by date for knockout. `beforeMatches()` checks if the league phase is complete and generates knockout rounds via `SwissKnockoutGenerator`. `afterMatches()` resolves knockout ties.
+
+### GroupStageCupHandler (`group_stage_cup`)
+
+Used for World Cup. Hybrid batching like Swiss. `beforeMatches()` checks if group stage is complete and generates knockout rounds via `WorldCupKnockoutGenerator`. Special logic after semi-finals: generates both 3rd-place match (SF losers) and final (SF winners) together. `afterMatches()` resolves knockout ties.
+
+### LeagueWithPlayoffHandler (`league_with_playoff`)
+
+Used for Segunda Division. Hybrid batching. `beforeMatches()` checks if the regular season is complete and generates playoff rounds via `PlayoffGeneratorFactory`. `afterMatches()` resolves playoff ties.
+
+### PreSeasonHandler (`preseason`)
+
+Batches by date. Everything is a no-op — friendly matches have no consequences.
+
+## Round Generation
+
+This is the most complex part of the system. Different handlers generate knockout/playoff rounds through different mechanisms:
+
+```
+                           ┌─────────────────────────────────────┐
+                           │ How next round gets generated       │
+                           └─────────────────────────────────────┘
+
+knockout_cup:    CupTieResolved event → ConductNextCupRoundDraw listener → CupDrawService
+swiss_format:    handler.beforeMatches() → maybeGenerateKnockoutRound() → SwissKnockoutGenerator
+group_stage_cup: handler.beforeMatches() → maybeGenerateKnockoutRound() → WorldCupKnockoutGenerator
+league_playoff:  handler.beforeMatches() → shouldGeneratePlayoffRound()  → PlayoffGeneratorFactory
+```
+
+The `ConductNextCupRoundDraw` listener explicitly skips `swiss_format` and `group_stage_cup` — those handlers own their round generation internally. This split exists because Swiss and World Cup formats need specialized generation (seeded brackets, 3rd-place logic) while Copa del Rey uses simple random draws.
+
+### When round generation is triggered
+
+Round generation happens at multiple points:
+
+1. **`MatchdayService::generatePendingMatches()`** — before finding the next batch. Covers hybrid handlers.
+2. **`MatchdayService::getNextMatchBatch()`** — calls `KnockoutCupHandler::beforeMatches()` and per-competition `handler->beforeMatches()`.
+3. **`ConductNextCupRoundDraw` listener** — fires synchronously on `CupTieResolved` for knockout cups.
+4. **`MatchFinalizationService::finalize()`** — after deferred match finalization, calls `handler->beforeMatches()` for group-phase matches.
+
+Handlers use idempotency guards (`knockoutRoundExists()`) to handle being called multiple times safely.
+
+### Pending finalization guard
+
+Round generation is blocked while a match is pending finalization for the same competition. The deferred match's result might affect standings, which affect seeding for the next round. Handlers check `game->hasPendingFinalizationForCompetition()` before generating.
+
+## Deferred Finalization
+
+When the user's team plays, their match is "deferred" — simulated but not fully processed until the user finishes viewing the live match result.
+
+```
+Batch includes user's match
+    │
+    ├─ All matches simulated (scores determined)
+    ├─ AI matches: results processed immediately (standings, ties)
+    ├─ User's match: marked as pending_finalization_match_id
+    ├─ User redirected to live match view
+    │
+    ├─ User views match, makes substitutions/tactical changes
+    ├─ User clicks "Continue"
+    │
+    └─ FinalizeMatch action → MatchFinalizationService::finalize()
+        ├─ Apply deferred standings, suspensions, GK stats
+        ├─ Resolve cup tie if applicable
+        ├─ Generate next round (now that standings are final)
+        └─ Clear pending flag
+```
+
+Why defer? Because all matches in a batch are simulated simultaneously, but the user's match is experienced in real-time. Standings and seedings must wait for all results.
+
+## Event-Driven Side Effects
+
+Two events drive post-match side effects:
+
+### MatchFinalized
+
+Dispatched after a match's results are fully applied (either immediately for AI matches via `MatchResultProcessor`, or deferred for user matches via `MatchFinalizationService`).
+
+| Listener | Purpose |
+|----------|---------|
+| `UpdateLeagueStandings` | Update standings for league matches (not cup) |
+| `UpdateGoalkeeperStats` | Increment goals_conceded, clean_sheets |
+| `SendMatchNotifications` | Red cards, injuries, yellow card accumulation |
+| `SendCompetitionProgressNotifications` | Advancement/elimination notifications |
+
+### CupTieResolved
+
+Dispatched when a cup tie has a definitive winner (after 90 min, extra time, or penalties).
+
+| Listener | Purpose |
+|----------|---------|
+| `AwardCupPrizeMoney` | Record prize money for advancing |
+| `ConductNextCupRoundDraw` | Generate next round draw (knockout_cup only) |
+| `SendCupTieNotifications` | Advancement/elimination notifications |
+
+## Season/Tournament Completion
+
+`ShowGame` determines what to show the user:
+
+```php
+$nextMatch = $game->next_match;                                    // User's next unplayed match
+$hasRemainingMatches = $game->matches()->where('played', false)->exists(); // Any unplayed matches
+
+if (tournament && !$nextMatch && $hasRemainingMatches)  → simulate remaining (user eliminated)
+if (!$nextMatch && !$hasRemainingMatches)                → season-end / tournament-end
+else                                                     → show dashboard with next match
+```
+
+In tournament mode, if the user is eliminated but matches remain, `SimulateTournament` auto-advances up to 500 batches to finish the tournament.
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `app/Modules/Match/Services/MatchdayOrchestrator.php` | Main coordinator — advance, simulate, process |
+| `app/Modules/Match/Services/MatchdayService.php` | Batch assembly, pending round generation |
+| `app/Modules/Match/Services/MatchFinalizationService.php` | Deferred match finalization |
+| `app/Modules/Match/Services/MatchSimulator.php` | Match simulation engine |
+| `app/Modules/Match/Services/MatchResultProcessor.php` | Batch result processing |
+| `app/Modules/Match/Services/CupTieResolver.php` | Cup tie resolution (aggregate, ET, penalties) |
+| `app/Modules/Competition/Contracts/CompetitionHandler.php` | Handler interface |
+| `app/Modules/Match/Handlers/` | All 6 handler implementations |
+| `app/Modules/Match/Events/` | MatchFinalized, CupTieResolved |
+| `app/Modules/Match/Listeners/` | Event listeners for side effects |
+| `app/Modules/Competition/Services/CupDrawService.php` | Random cup draw mechanics |
+| `app/Modules/Competition/Services/WorldCupKnockoutGenerator.php` | World Cup bracket generation |
+| `app/Modules/Competition/Services/SwissKnockoutGenerator.php` | Champions League knockout generation |
+| `app/Http/Actions/AdvanceMatchday.php` | Entry point: user clicks "Play" |
+| `app/Http/Actions/FinalizeMatch.php` | Entry point: user finishes live match |
+| `app/Http/Actions/SimulateTournament.php` | Entry point: auto-simulate after elimination |
+| `app/Http/Views/ShowGame.php` | Dashboard — determines next action |
+
+## Known Design Debt
+
+The system evolved organically as competition types were added. Key areas of debt:
+
+1. **Inconsistent round generation**: KnockoutCupHandler uses a listener while other handlers generate internally. The listener hardcodes which types to skip.
+
+2. **Redundant `beforeMatches()` calls**: Handlers are called 2-3 times per cycle from different call sites. Relies on idempotency guards.
+
+3. **Cup tie resolution duplication**: Nearly identical `resolveTies()` method copy-pasted across 4 handlers.
+
+4. **`ShowGame` doesn't trigger round generation**: It queries for existing matches directly. If rounds haven't been generated yet, the game can appear "complete" prematurely.
+
+5. **Pending finalization timing**: `CupTieResolved` events fire before `pending_finalization_match_id` is cleared, creating ordering constraints between listeners and handlers.

--- a/docs/game-systems/season-lifecycle.md
+++ b/docs/game-systems/season-lifecycle.md
@@ -14,28 +14,7 @@ Pending actions (academy evaluation, budget allocation) block matchday advanceme
 
 ## Matchday Progression
 
-1. Check for pending actions (blocks if any)
-2. Fetch unplayed matches for current matchday across all competitions
-3. Route to appropriate handler (LeagueHandler, KnockoutCupHandler, SwissFormatHandler, etc.)
-4. Set lineups (auto-select for AI, user's saved lineup otherwise)
-5. Simulate match
-6. Post-match: update standings, award prize money, apply suspensions
-7. Between-matchday: transfer market, injuries, notifications
-8. Check for season end
-
-See `MatchdayService` for the full flow.
-
-## Competition Handlers
-
-Different competition formats use different handlers implementing `CompetitionHandler`:
-
-- **LeagueHandler** — Standard league with standings
-- **KnockoutCupHandler** — Bracket/draws with single-leg or two-legged ties, extra time, penalties
-- **LeagueWithPlayoffHandler** — League phase followed by playoff rounds
-- **SwissFormatHandler** — Champions League Swiss-system (all teams play, paired by points)
-- **GroupStageCupHandler** — Groups play round-robin, top teams advance to knockout
-
-Resolved via `CompetitionHandlerResolver` based on competition's `handler_type` field.
+See [Matchday Advancement](matchday-advancement.md) for the full system documentation — it covers batch finding, competition handlers, round generation, deferred finalization, event-driven side effects, and season completion detection.
 
 ## Season Pipelines
 


### PR DESCRIPTION
Extract shared cup logic into CupCompetitionHandler base class
    
Deduplicate ~466 lines of near-identical code across the 4 cup handlers (KnockoutCup, SwissFormat, GroupStageCup, LeagueWithPlayoff) into an abstract base class. Shared methods: getRedirectRoute, getHybridMatchBatch, resolveCompletedTies, createTie, roundExists, getCurrentRound, and maybeResetYellowCards. Pure refactoring — no behavior change.