### PR TITLE
Replace regression with gravity-based reputation tier maintenance

### DIFF
--- a/app/Http/Views/ShowSeasonEnd.php
+++ b/app/Http/Views/ShowSeasonEnd.php
@@ -373,7 +373,6 @@ class ShowSeasonEnd
         $competition = Competition::find($game->competition_id);
         $tier = $competition?->tier ?? 1;
         $deltas = config("reputation.position_deltas.{$tier}", config('reputation.position_deltas.1'));
-        $regressionRate = config('reputation.regression_rate', 5);
 
         $pointsDelta = 0;
         foreach ($deltas as $maxPosition => $delta) {
@@ -386,16 +385,12 @@ class ShowSeasonEnd
             $pointsDelta = end($deltas);
         }
 
-        // Apply regression toward base
-        $basePoints = TeamReputation::pointsForTier($reputation->base_reputation_level);
-        $currentPoints = $reputation->reputation_points;
-        if ($currentPoints > $basePoints) {
-            $pointsDelta -= $regressionRate;
-        } elseif ($currentPoints < $basePoints) {
-            $pointsDelta += $regressionRate;
-        }
+        // Apply gravity based on current tier
+        $gravityConfig = config('reputation.gravity', []);
+        $gravity = $gravityConfig[$level] ?? 0;
+        $net = $pointsDelta - $gravity;
 
-        $direction = $pointsDelta > 5 ? 'rising' : ($pointsDelta < -5 ? 'declining' : 'stable');
+        $direction = $net > 5 ? 'rising' : ($net < -5 ? 'declining' : 'stable');
 
         return ['level' => $level, 'direction' => $direction];
     }

--- a/app/Models/TeamReputation.php
+++ b/app/Models/TeamReputation.php
@@ -53,7 +53,7 @@ class TeamReputation extends Model
      */
     public static function pointsForTier(string $level): int
     {
-        return self::TIER_THRESHOLDS[$level] ?? 0;
+        return (self::TIER_THRESHOLDS[$level] ?? 0) + 50;
     }
 
     /**

--- a/app/Modules/Season/Jobs/SetupNewGame.php
+++ b/app/Modules/Season/Jobs/SetupNewGame.php
@@ -13,6 +13,7 @@ use App\Modules\Season\Processors\LeagueFixtureProcessor;
 use App\Modules\Season\Processors\StandingsResetProcessor;
 use App\Support\Money;
 use App\Models\ClubProfile;
+use App\Models\Competition;
 use App\Models\CompetitionEntry;
 use App\Models\CompetitionTeam;
 use App\Models\Game;
@@ -143,6 +144,7 @@ class SetupNewGame implements ShouldQueue
     /**
      * Initialize per-game reputation records for all teams with competition entries.
      * Copies the static ClubProfile reputation as the starting point.
+     * Applies a division bonus for lower-tier teams in top-division leagues.
      */
     private function initializeTeamReputations(): void
     {
@@ -154,18 +156,40 @@ class SetupNewGame implements ShouldQueue
         $game = Game::find($this->gameId);
         $countryCode = $game->country ?? 'ES';
 
-        $teamIds = CompetitionEntry::where('game_id', $this->gameId)
+        // Load competition entries with their competition tier
+        $entries = CompetitionEntry::where('game_id', $this->gameId)
             ->whereHas('competition', fn ($q) => $q->where('country', $countryCode))
-            ->pluck('team_id')
-            ->unique();
+            ->get();
+
+        $teamIds = $entries->pluck('team_id')->unique();
 
         $clubProfiles = ClubProfile::whereIn('team_id', $teamIds)
             ->pluck('reputation_level', 'team_id');
+
+        // Build a map of team_id => lowest competition tier (1 = top division)
+        $competitionTiers = Competition::whereIn('id', $entries->pluck('competition_id')->unique())
+            ->pluck('tier', 'id');
+
+        $teamCompetitionTier = [];
+        foreach ($entries as $entry) {
+            $tier = $competitionTiers[$entry->competition_id] ?? 99;
+            if (!isset($teamCompetitionTier[$entry->team_id]) || $tier < $teamCompetitionTier[$entry->team_id]) {
+                $teamCompetitionTier[$entry->team_id] = $tier;
+            }
+        }
+
+        $divisionBonus = (int) config('reputation.division_bonus', 25);
 
         $rows = [];
         foreach ($teamIds as $teamId) {
             $level = $clubProfiles[$teamId] ?? ClubProfile::REPUTATION_LOCAL;
             $points = TeamReputation::pointsForTier($level);
+
+            // Apply division bonus for Modest/Local teams in tier 1
+            $competitionTier = $teamCompetitionTier[$teamId] ?? 99;
+            if ($competitionTier === 1 && in_array($level, [ClubProfile::REPUTATION_MODEST, ClubProfile::REPUTATION_LOCAL])) {
+                $points += $divisionBonus;
+            }
 
             $rows[] = [
                 'id' => Str::uuid()->toString(),

--- a/app/Modules/Season/Processors/ReputationUpdateProcessor.php
+++ b/app/Modules/Season/Processors/ReputationUpdateProcessor.php
@@ -87,7 +87,7 @@ class ReputationUpdateProcessor implements SeasonProcessor
 
         $tier = $competition->tier ?? 1;
         $deltas = config("reputation.position_deltas.{$tier}", config('reputation.position_deltas.1'));
-        $regressionRate = config('reputation.regression_rate', 5);
+        $gravityConfig = config('reputation.gravity', []);
 
         foreach ($positions as $teamId => $position) {
             $reputation = TeamReputation::where('game_id', $game->id)
@@ -101,18 +101,12 @@ class ReputationUpdateProcessor implements SeasonProcessor
             // Calculate points delta based on final position
             $pointsDelta = $this->getPointsDelta($position, $deltas);
 
-            // Apply regression toward base tier
-            $basePoints = TeamReputation::pointsForTier($reputation->base_reputation_level);
-            $currentPoints = $reputation->reputation_points;
-
-            if ($currentPoints > $basePoints) {
-                $pointsDelta -= $regressionRate;
-            } elseif ($currentPoints < $basePoints) {
-                $pointsDelta += $regressionRate;
-            }
+            // Apply gravity based on current tier
+            $gravity = $gravityConfig[$reputation->reputation_level] ?? 0;
+            $net = $pointsDelta - $gravity;
 
             // Update points and recalculate tier
-            $reputation->reputation_points = max(0, $currentPoints + $pointsDelta);
+            $reputation->reputation_points = max(0, $reputation->reputation_points + $net);
             $reputation->recalculateTier();
             $reputation->save();
         }

--- a/config/reputation.php
+++ b/config/reputation.php
@@ -11,9 +11,8 @@ return [
             4  => 30,   // 3rd-4th: Champions League places
             6  => 15,   // 5th-6th: Europa League
             10 => 5,    // 7th-10th: upper mid-table
-            14 => 0,    // 11th-14th: mid-table (neutral)
-            17 => -10,  // 15th-17th: relegation fight
-            99 => -25,  // 18th+: relegated
+            17 => 0,    // 11th-17th: mid/lower table (neutral)
+            99 => -15,  // 18th+: relegated
         ],
         2 => [ // Second division (Segunda, Championship, etc.)
             1  => 15,   // 1st: champion
@@ -25,11 +24,20 @@ return [
         ],
     ],
 
-    // Regression pull toward base tier each season (in points).
-    // Applied as a drag toward the base tier's starting points.
-    // e.g., if a team is above its base, this pulls it down slightly;
-    // if below, it pulls it up slightly.
-    'regression_rate' => 5,
+    // Gravity cost per tier, subtracted each season.
+    // Teams must offset gravity with positive position deltas or decline.
+    // Lower tiers have zero gravity: only actual performance moves their points.
+    'gravity' => [
+        'local'        => 0,
+        'modest'       => 0,
+        'established'  => 5,
+        'continental'  => 15,
+        'elite'        => 25,
+    ],
+
+    // Bonus points for lower-tier teams competing in top-division leagues.
+    // Applied at game initialization for Modest/Local teams in tier 1.
+    'division_bonus' => 25,
 
     // Maximum number of tiers a team can drop below its seeded base.
     'max_tier_drop_below_base' => 2,


### PR DESCRIPTION
The old ±5 regression-toward-base mechanic penalized all teams equally regardless of tier, causing lower-tier teams like Girona to unfairly drop after mid-table finishes. Gravity replaces regression: higher tiers pay a seasonal cost (elite: 25, continental: 15, established: 5) that must be offset by performance, while modest/local tiers have zero gravity and only move on actual position deltas.

Also widens the tier 1 neutral zone (11th-17th now neutral instead of penalizing 15th-17th), starts teams at tier midpoints (+50 buffer), and adds a +25 division bonus for modest/local teams in top-flight.