### PR TITLE
Prevent reserve teams from being promoted to same division as parent

### DIFF
--- a/app/Console/Commands/SeedReferenceData.php
+++ b/app/Console/Commands/SeedReferenceData.php
@@ -141,6 +141,9 @@ class SeedReferenceData extends Command
         }
         $this->line("  Step 1/4: Done.");
 
+        // Step 1b: Link reserve teams to their parent teams
+        $this->linkReserveTeams($config);
+
         // Step 2: Seed domestic cups — supercup first so main cup can look up
         // supercup teams for entry_round calculation
         $cupIds = array_keys($config['domestic_cups'] ?? []);
@@ -218,6 +221,26 @@ class SeedReferenceData extends Command
                 'season' => '2025',
             ]
         );
+    }
+
+    private function linkReserveTeams(array $config): void
+    {
+        $reserveTeams = $config['reserve_teams'] ?? [];
+        if (empty($reserveTeams)) {
+            return;
+        }
+
+        foreach ($reserveTeams as $childTransfermarktId => $parentTransfermarktId) {
+            $child = DB::table('teams')->where('transfermarkt_id', $childTransfermarktId)->first();
+            $parent = DB::table('teams')->where('transfermarkt_id', $parentTransfermarktId)->first();
+
+            if ($child && $parent) {
+                DB::table('teams')->where('id', $child->id)->update([
+                    'parent_team_id' => $parent->id,
+                ]);
+                $this->line("  Linked reserve team: {$child->name} → {$parent->name}");
+            }
+        }
     }
 
     private function createDefaultUser(): void

--- a/app/Models/Team.php
+++ b/app/Models/Team.php
@@ -47,6 +47,7 @@ class Team extends Model
         'type',
         'name',
         'country',
+        'parent_team_id',
         'image',
         'stadium_name',
         'stadium_seats',
@@ -72,6 +73,21 @@ class Team extends Model
     public function clubProfile(): HasOne
     {
         return $this->hasOne(ClubProfile::class);
+    }
+
+    public function parentTeam(): \Illuminate\Database\Eloquent\Relations\BelongsTo
+    {
+        return $this->belongsTo(Team::class, 'parent_team_id');
+    }
+
+    public function reserveTeam(): HasOne
+    {
+        return $this->hasOne(Team::class, 'parent_team_id');
+    }
+
+    public function isReserveTeam(): bool
+    {
+        return $this->parent_team_id !== null;
     }
 
     public function getNameAttribute(): string

--- a/app/Modules/Competition/Playoffs/ESP2PlayoffGenerator.php
+++ b/app/Modules/Competition/Playoffs/ESP2PlayoffGenerator.php
@@ -5,6 +5,7 @@ namespace App\Modules\Competition\Playoffs;
 use App\Modules\Competition\Contracts\PlayoffGenerator;
 use App\Modules\Competition\DTOs\PlayoffRoundConfig;
 use App\Modules\Competition\Services\LeagueFixtureGenerator;
+use App\Modules\Competition\Services\ReserveTeamFilter;
 use App\Models\Competition;
 use App\Models\CupTie;
 use App\Models\Game;
@@ -82,21 +83,42 @@ class ESP2PlayoffGenerator implements PlayoffGenerator
     /**
      * Semifinal matchups: highest seed vs lowest, 2nd vs 3rd.
      * Lower-seeded team hosts the first leg.
+     *
+     * Reserve teams whose parent club is in the top division are excluded
+     * from playoffs. The next-placed eligible team slides into their spot.
      */
     private function generateSemifinalMatchups(Game $game): array
     {
-        $positions = $this->qualifyingPositions;
+        $requiredCount = count($this->qualifyingPositions);
+        $filter = app(ReserveTeamFilter::class);
+
+        // Fetch more standings than needed in case we need to skip reserve teams
+        $maxPosition = max($this->qualifyingPositions) + $requiredCount;
         $standings = GameStanding::where('game_id', $game->id)
             ->where('competition_id', $this->competitionId)
-            ->whereIn('position', $positions)
+            ->whereBetween('position', [min($this->qualifyingPositions), $maxPosition])
             ->orderBy('position')
-            ->pluck('team_id', 'position')
-            ->toArray();
+            ->get();
+
+        // Filter out ineligible reserve teams
+        $topDivisionTeamIds = $filter->getTopDivisionTeamIds($game, $this->competitionId);
+        $eligible = $standings->filter(
+            fn ($s) => !$filter->isBlockedReserveTeam($s->team_id, $topDivisionTeamIds)
+        )->take($requiredCount);
+
+        if ($eligible->count() < $requiredCount) {
+            throw new \RuntimeException(
+                "Not enough eligible teams for playoffs in {$this->competitionId}: " .
+                "need {$requiredCount}, found {$eligible->count()}"
+            );
+        }
+
+        $teamIds = $eligible->pluck('team_id')->values()->toArray();
 
         // Last vs first, second-to-last vs second
         return [
-            [$standings[$positions[3]], $standings[$positions[0]]],
-            [$standings[$positions[2]], $standings[$positions[1]]],
+            [$teamIds[3], $teamIds[0]],
+            [$teamIds[2], $teamIds[1]],
         ];
     }
 

--- a/app/Modules/Competition/Promotions/ConfigDrivenPromotionRule.php
+++ b/app/Modules/Competition/Promotions/ConfigDrivenPromotionRule.php
@@ -4,6 +4,7 @@ namespace App\Modules\Competition\Promotions;
 
 use App\Modules\Competition\Contracts\PlayoffGenerator;
 use App\Modules\Competition\Contracts\PromotionRelegationRule;
+use App\Modules\Competition\Services\ReserveTeamFilter;
 use App\Models\CupTie;
 use App\Models\Game;
 use App\Models\GameStanding;
@@ -57,11 +58,7 @@ class ConfigDrivenPromotionRule implements PromotionRelegationRule
         $expectedCount = count($this->relegatedPositions);
 
         // Try real standings first
-        $promoted = $this->getTeamsByPosition(
-            $game->id,
-            $this->bottomDivision,
-            $this->directPromotionPositions
-        );
+        $promoted = $this->getEligibleDirectPromotions($game);
 
         if (!empty($promoted)) {
             // Real standings exist — check for playoff winner
@@ -70,10 +67,8 @@ class ConfigDrivenPromotionRule implements PromotionRelegationRule
                 if ($playoffWinner) {
                     $promoted[] = $playoffWinner;
                 } else {
-                    // No playoff played — promote next position directly
-                    $nextPosition = max($this->directPromotionPositions) + 1;
-                    $fallback = $this->getTeamsByPosition($game->id, $this->bottomDivision, [$nextPosition]);
-                    $promoted = array_merge($promoted, $fallback);
+                    // No playoff played — promote next eligible position directly
+                    $promoted = array_merge($promoted, $this->getNextEligibleTeam($game, $promoted));
                 }
             }
 
@@ -84,9 +79,8 @@ class ConfigDrivenPromotionRule implements PromotionRelegationRule
 
         // Fall back to simulated results — take top N (no playoffs in simulated leagues)
         $totalPromoted = count($this->directPromotionPositions) + ($this->playoffGenerator ? 1 : 0);
-        $positions = range(1, $totalPromoted);
 
-        $promoted = $this->getSimulatedTeamsByPosition($game, $this->bottomDivision, $positions);
+        $promoted = $this->getEligibleSimulatedPromotions($game, $totalPromoted);
 
         $this->validateTeamCount($promoted, $expectedCount, 'promoted', $this->bottomDivision);
 
@@ -138,6 +132,117 @@ class ConfigDrivenPromotionRule implements PromotionRelegationRule
                 "Divisions: {$this->topDivision} <-> {$this->bottomDivision}."
             );
         }
+    }
+
+    /**
+     * Get eligible teams for direct promotion, skipping blocked reserve teams.
+     *
+     * If a reserve team (e.g. Real Sociedad B) finishes in a direct promotion
+     * spot but their parent (Real Sociedad) is in the top division, the next
+     * eligible team below slides into their promotion spot.
+     *
+     * @return array<array{teamId: string, position: int, teamName: string}>
+     */
+    private function getEligibleDirectPromotions(Game $game): array
+    {
+        $filter = app(ReserveTeamFilter::class);
+        $topDivisionTeamIds = $filter->getTopDivisionTeamIds($game, $this->bottomDivision);
+
+        if ($topDivisionTeamIds->isEmpty()) {
+            return $this->getTeamsByPosition($game->id, $this->bottomDivision, $this->directPromotionPositions);
+        }
+
+        $requiredCount = count($this->directPromotionPositions);
+        $maxPosition = max($this->directPromotionPositions) + $requiredCount;
+
+        $standings = GameStanding::where('game_id', $game->id)
+            ->where('competition_id', $this->bottomDivision)
+            ->whereBetween('position', [min($this->directPromotionPositions), $maxPosition])
+            ->with('team')
+            ->orderBy('position')
+            ->get();
+
+        if ($standings->isEmpty()) {
+            return [];
+        }
+
+        $eligible = $standings->filter(
+            fn ($s) => !$filter->isBlockedReserveTeam($s->team_id, $topDivisionTeamIds)
+        )->take($requiredCount);
+
+        return $eligible->map(fn ($standing) => [
+            'teamId' => $standing->team_id,
+            'position' => $standing->position,
+            'teamName' => $standing->team->name ?? 'Unknown',
+        ])->values()->toArray();
+    }
+
+    /**
+     * Get the next eligible team after the already-promoted teams (for non-playoff fallback).
+     *
+     * @return array<array{teamId: string, position: int, teamName: string}>
+     */
+    private function getNextEligibleTeam(Game $game, array $alreadyPromoted): array
+    {
+        $filter = app(ReserveTeamFilter::class);
+        $topDivisionTeamIds = $filter->getTopDivisionTeamIds($game, $this->bottomDivision);
+        $promotedIds = array_column($alreadyPromoted, 'teamId');
+
+        $nextPosition = max($this->directPromotionPositions) + 1;
+        $maxPosition = $nextPosition + 4; // Check a few positions ahead
+
+        $standings = GameStanding::where('game_id', $game->id)
+            ->where('competition_id', $this->bottomDivision)
+            ->whereBetween('position', [$nextPosition, $maxPosition])
+            ->with('team')
+            ->orderBy('position')
+            ->get();
+
+        $eligible = $standings
+            ->filter(fn ($s) => !in_array($s->team_id, $promotedIds))
+            ->filter(fn ($s) => !$filter->isBlockedReserveTeam($s->team_id, $topDivisionTeamIds))
+            ->first();
+
+        if (!$eligible) {
+            return [];
+        }
+
+        return [[
+            'teamId' => $eligible->team_id,
+            'position' => $eligible->position,
+            'teamName' => $eligible->team->name ?? 'Unknown',
+        ]];
+    }
+
+    /**
+     * Get eligible simulated promotions, skipping blocked reserve teams.
+     *
+     * @return array<array{teamId: string, position: int, teamName: string}>
+     */
+    private function getEligibleSimulatedPromotions(Game $game, int $totalNeeded): array
+    {
+        $filter = app(ReserveTeamFilter::class);
+        $topDivisionTeamIds = $filter->getTopDivisionTeamIds($game, $this->bottomDivision);
+
+        if ($topDivisionTeamIds->isEmpty()) {
+            return $this->getSimulatedTeamsByPosition($game, $this->bottomDivision, range(1, $totalNeeded));
+        }
+
+        // Fetch extra positions to account for skipped reserve teams
+        $positions = range(1, $totalNeeded + 3);
+        $candidates = $this->getSimulatedTeamsByPosition($game, $this->bottomDivision, $positions);
+
+        $eligible = [];
+        foreach ($candidates as $candidate) {
+            if (!$filter->isBlockedReserveTeam($candidate['teamId'], $topDivisionTeamIds)) {
+                $eligible[] = $candidate;
+            }
+            if (count($eligible) >= $totalNeeded) {
+                break;
+            }
+        }
+
+        return $eligible;
     }
 
     /**

--- a/app/Modules/Competition/Services/ReserveTeamFilter.php
+++ b/app/Modules/Competition/Services/ReserveTeamFilter.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Modules\Competition\Services;
+
+use App\Models\CompetitionEntry;
+use App\Models\Game;
+use App\Models\Team;
+use Illuminate\Support\Collection;
+
+/**
+ * Determines which teams are reserve/B teams that cannot be promoted
+ * to the same division as their parent club.
+ *
+ * In Spanish football, reserve teams (e.g. Real Sociedad B) cannot play
+ * in the same division as their parent team. If a reserve team qualifies
+ * for promotion or playoffs, they are skipped and the next eligible team
+ * takes their place.
+ */
+class ReserveTeamFilter
+{
+    /**
+     * Get team IDs currently in the top division for a given bottom division.
+     *
+     * @return Collection<int, string> Team UUIDs in the top division
+     */
+    public function getTopDivisionTeamIds(Game $game, string $bottomDivision): Collection
+    {
+        $countryConfig = app(CountryConfig::class);
+        $topDivision = $this->findTopDivision($countryConfig, $bottomDivision);
+
+        if (!$topDivision) {
+            return collect();
+        }
+
+        return CompetitionEntry::where('game_id', $game->id)
+            ->where('competition_id', $topDivision)
+            ->pluck('team_id');
+    }
+
+    /**
+     * Check if a team is a reserve team whose parent is in the top division.
+     *
+     * @param string $teamId The team UUID to check
+     * @param Collection<int, string> $topDivisionTeamIds Team UUIDs in the top division
+     */
+    public function isBlockedReserveTeam(string $teamId, Collection $topDivisionTeamIds): bool
+    {
+        $team = Team::find($teamId);
+
+        if (!$team || !$team->parent_team_id) {
+            return false;
+        }
+
+        return $topDivisionTeamIds->contains($team->parent_team_id);
+    }
+
+    private function findTopDivision(CountryConfig $countryConfig, string $bottomDivision): ?string
+    {
+        foreach ($countryConfig->allCountryCodes() as $countryCode) {
+            foreach ($countryConfig->promotions($countryCode) as $promotion) {
+                if ($promotion['bottom_division'] === $bottomDivision) {
+                    return $promotion['top_division'];
+                }
+            }
+        }
+
+        return null;
+    }
+}

--- a/config/countries.php
+++ b/config/countries.php
@@ -63,6 +63,12 @@ return [
             ],
         ],
 
+        // Reserve teams that cannot be promoted to the same division as their parent.
+        // Maps child transfermarkt_id => parent transfermarkt_id.
+        'reserve_teams' => [
+            9899 => 681,   // Real Sociedad B → Real Sociedad
+        ],
+
         'continental_slots' => [
             'ESP1' => [
                 'UCL' => [1, 2, 3, 4, 5],

--- a/database/migrations/2026_03_10_000001_add_parent_team_id_to_teams_table.php
+++ b/database/migrations/2026_03_10_000001_add_parent_team_id_to_teams_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('teams', function (Blueprint $table) {
+            $table->uuid('parent_team_id')->nullable()->after('country');
+            $table->foreign('parent_team_id')->references('id')->on('teams')->nullOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('teams', function (Blueprint $table) {
+            $table->dropForeign(['parent_team_id']);
+            $table->dropColumn('parent_team_id');
+        });
+    }
+};


### PR DESCRIPTION
Reserve teams (e.g. Real Sociedad B) are now blocked from promotion
to the top division when their parent club is already there, matching
real Spanish football rules. B teams are also excluded from promotion
playoffs, with the next eligible team sliding into their spot.

Changes:
- Add parent_team_id column to teams table
- Add parent/reserve team relationships to Team model
- Add reserve_teams mapping to ES country config
- Link reserve teams to parents during seeding
- Create ReserveTeamFilter service for shared eligibility logic
- Filter blocked reserve teams in ConfigDrivenPromotionRule
- Filter blocked reserve teams in ESP2PlayoffGenerator

https://claude.ai/code/session_018MFj5L2M2c5FmUzShcrKgY