### PR TITLE
Add reminder email for inactive invite codes

### DIFF
--- a/app/Console/Commands/SendInviteReminders.php
+++ b/app/Console/Commands/SendInviteReminders.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Jobs\SendBetaInviteReminder;
+use App\Models\InviteCode;
+use Illuminate\Console\Command;
+
+class SendInviteReminders extends Command
+{
+    protected $signature = 'beta:send-invite-reminders';
+
+    protected $description = 'Send reminder emails to invited users who have not registered after 3 days';
+
+    public function handle(): int
+    {
+        if (! config('beta.enabled')) {
+            $this->info('Beta mode is disabled, skipping.');
+
+            return Command::SUCCESS;
+        }
+
+        $inviteCodes = InviteCode::where('invite_sent', true)
+            ->where('times_used', 0)
+            ->where('invite_sent_at', '<=', now()->subDays(3))
+            ->whereNull('reminder_sent_at')
+            ->where(function ($query) {
+                $query->whereNull('expires_at')
+                    ->orWhere('expires_at', '>', now());
+            })
+            ->get();
+
+        if ($inviteCodes->isEmpty()) {
+            $this->info('No invite codes eligible for reminder.');
+
+            return Command::SUCCESS;
+        }
+
+        foreach ($inviteCodes as $inviteCode) {
+            SendBetaInviteReminder::dispatch($inviteCode);
+            sleep(3);
+            $this->line("  Dispatched reminder for: {$inviteCode->email}");
+        }
+
+        $this->info("Dispatched {$inviteCodes->count()} reminder(s).");
+
+        return Command::SUCCESS;
+    }
+}

--- a/app/Jobs/SendBetaInviteReminder.php
+++ b/app/Jobs/SendBetaInviteReminder.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Mail\BetaInviteReminder;
+use App\Models\InviteCode;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Mail;
+
+class SendBetaInviteReminder implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public function __construct(
+        public InviteCode $inviteCode,
+    ) {}
+
+    public function handle(): void
+    {
+        if (! config('beta.enabled')) {
+            return;
+        }
+
+        $this->inviteCode->refresh();
+
+        if ($this->inviteCode->reminder_sent_at) {
+            return;
+        }
+
+        if ($this->inviteCode->times_used > 0) {
+            return;
+        }
+
+        Mail::to($this->inviteCode->email)->send(new BetaInviteReminder($this->inviteCode));
+
+        $this->inviteCode->update(['reminder_sent_at' => now()]);
+    }
+}

--- a/app/Mail/BetaInviteReminder.php
+++ b/app/Mail/BetaInviteReminder.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Mail;
+
+use App\Models\InviteCode;
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+
+class BetaInviteReminder extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    public function __construct(
+        public InviteCode $inviteCode,
+    ) {}
+
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            subject: __('beta.reminder_email_subject'),
+        );
+    }
+
+    public function content(): Content
+    {
+        return new Content(
+            text: 'mail.beta-invite-reminder',
+            with: [
+                'registerUrl' => url('/register?invite='.$this->inviteCode->code),
+                'code' => $this->inviteCode->code,
+            ],
+        );
+    }
+}

--- a/app/Models/InviteCode.php
+++ b/app/Models/InviteCode.php
@@ -12,6 +12,7 @@ use Illuminate\Database\Eloquent\Model;
  * @property int $times_used
  * @property bool $invite_sent
  * @property \Illuminate\Support\Carbon|null $invite_sent_at
+ * @property \Illuminate\Support\Carbon|null $reminder_sent_at
  * @property \Illuminate\Support\Carbon|null $expires_at
  * @property \Illuminate\Support\Carbon|null $created_at
  * @property \Illuminate\Support\Carbon|null $updated_at
@@ -39,6 +40,7 @@ class InviteCode extends Model
         'times_used',
         'invite_sent',
         'invite_sent_at',
+        'reminder_sent_at',
         'expires_at',
     ];
 
@@ -47,6 +49,7 @@ class InviteCode extends Model
         return [
             'invite_sent' => 'boolean',
             'invite_sent_at' => 'datetime',
+            'reminder_sent_at' => 'datetime',
             'expires_at' => 'datetime',
             'max_uses' => 'integer',
             'times_used' => 'integer',

--- a/database/migrations/2026_03_14_223125_add_reminder_sent_at_to_invite_codes_table.php
+++ b/database/migrations/2026_03_14_223125_add_reminder_sent_at_to_invite_codes_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('invite_codes', function (Blueprint $table) {
+            $table->timestamp('reminder_sent_at')->nullable()->after('invite_sent_at');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('invite_codes', function (Blueprint $table) {
+            $table->dropColumn('reminder_sent_at');
+        });
+    }
+};

--- a/lang/en/beta.php
+++ b/lang/en/beta.php
@@ -15,10 +15,17 @@ return [
     // Invite Email
     'email_subject' => 'Your VirtuaFC invitation is ready!',
     'email_greeting' => 'You have been invited to the VirtuaFC beta!',
-    'email_body' => 'You are among the first to try VirtuaFC, the AI-powered football manager. Click the button to create your account and start playing.',
+    'email_body' => 'You are among the first to try VirtuaFC, a new football manager game like the classics. Click the button to create your account and start playing.',
     'email_code_label' => 'Your invite code:',
-    'email_warning' => 'Please note this is a beta version. The game is under active development and your progress may be reset during this period.',
+    'email_warning' => 'Please note this is a beta version. The game is under active development and your progress may be reset during this period or that bugs will appear.',
     'email_thanks' => 'Thanks for being part of the beta',
+
+    // Invite Reminder Email (sent 3 days after invite if not redeemed)
+    'reminder_email_subject' => 'Your VirtuaFC invite is still waiting!',
+    'reminder_email_greeting' => 'Hey! Your VirtuaFC invitation is still available.',
+    'reminder_email_body' => 'I sent you an invite to the VirtuaFC beta a few days ago. Your spot is still reserved: click the link below to create your account and start managing your team.',
+    'reminder_email_code_label' => 'Your invite code:',
+    'reminder_email_thanks' => 'Greetings',
 
     // Feedback Request Email (sent 24h after first game)
     'feedback_email_subject' => 'VirtuaFC — How are you finding it?',

--- a/lang/es/beta.php
+++ b/lang/es/beta.php
@@ -15,10 +15,17 @@ return [
     // Invite Email
     'email_subject' => '¡Tu invitación a VirtuaFC está lista!',
     'email_greeting' => '¡Has sido invitado a la beta de VirtuaFC!',
-    'email_body' => 'Estás entre los primeros en probar VirtuaFC, el manager de fútbol creado con IA. Haz clic en el botón para crear tu cuenta y empezar a jugar.',
+    'email_body' => 'Estás entre los primeros en probar VirtuaFC, un nuevo mánager de fútbol que he construido yo mismo. Haz clic en el botón para crear tu cuenta y empezar a jugar.',
     'email_code_label' => 'Tu código de invitación:',
-    'email_warning' => 'Ten en cuenta que esta es una versión beta. El juego está en desarrollo activo y es posible que tu progreso sea reiniciado durante este periodo.',
+    'email_warning' => 'Ten en cuenta que esta es una versión beta. El juego está en desarrollo activo y es posible que haya errores o que tu progreso sea reiniciado durante este periodo.',
     'email_thanks' => 'Gracias por ser parte de la beta',
+
+    // Invite Reminder Email (sent 3 days after invite if not redeemed)
+    'reminder_email_subject' => '¡Tu invitación a VirtuaFC sigue esperándote!',
+    'reminder_email_greeting' => '¡Hola! Tu invitación a la beta de VirtuaFC sigue disponible.',
+    'reminder_email_body' => 'Te envíe una invitación a la beta de VirtuaFC hace unos días. Tu plaza sigue reservada: haz clic en el enlace de abajo para crear tu cuenta y empezar a dirigir tu equipo.',
+    'reminder_email_code_label' => 'Tu código de invitación:',
+    'reminder_email_thanks' => 'Un saludo',
 
     // Feedback Request Email (sent 24h after first game)
     'feedback_email_subject' => 'VirtuaFC — ¿Qué te está pareciendo?',

--- a/resources/views/mail/beta-invite-reminder.blade.php
+++ b/resources/views/mail/beta-invite-reminder.blade.php
@@ -1,0 +1,10 @@
+{{ __('beta.reminder_email_greeting') }}
+
+{{ __('beta.reminder_email_body') }}
+
+{{ $registerUrl }}
+
+{{ __('beta.reminder_email_code_label') }} {{ $code }}
+
+{{ __('beta.reminder_email_thanks') }}
+Pablo — {{ config('app.name') }}

--- a/routes/console.php
+++ b/routes/console.php
@@ -4,4 +4,5 @@ use Illuminate\Support\Facades\Schedule;
 
 Schedule::command('app:cleanup-games')->dailyAt('04:00');
 Schedule::command('app:send-beta-feedback-requests')->hourly();
+Schedule::command('beta:send-invite-reminders')->dailyAt('10:00');
 // Schedule::command('beta:invite-waitlist '.config('beta.daily_invites'))->dailyAt('21:00');


### PR DESCRIPTION
Send a single reminder email to invited beta users who haven't registered after 3 days, following the existing feedback request pattern.