### PR TITLE
Show full player name instead of surname on lineup pitch

### DIFF
--- a/resources/js/lineup.js
+++ b/resources/js/lineup.js
@@ -391,12 +391,6 @@ export default function lineupManager(config) {
             return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
         },
 
-        getSurname(name) {
-            if (!name) return '';
-            const parts = name.trim().split(/\s+/);
-            return parts[parts.length - 1];
-        },
-
         getAvatarDisplay(player) {
             return player?.number || this.getInitials(player?.name);
         },

--- a/resources/views/lineup.blade.php
+++ b/resources/views/lineup.blade.php
@@ -263,8 +263,8 @@
                                                     x-text="slot.player?.overallScore"></span>
                                             </div>
 
-                                            {{-- Player surname --}}
-                                            <span class="mt-0.5 text-[8px] font-semibold text-white uppercase tracking-wide leading-tight text-center max-w-[60px] truncate drop-shadow-[0_1px_2px_rgba(0,0,0,0.8)]" x-text="getSurname(slot.player?.name)"></span>
+                                            {{-- Player name --}}
+                                            <span class="mt-0.5 text-[8px] font-semibold text-white uppercase tracking-wide leading-tight text-center max-w-[66px] line-clamp-2 break-words drop-shadow-[0_1px_2px_rgba(0,0,0,0.8)]" x-text="slot.player?.name"></span>
                                         </div>
                                     </div>
                                 </template>
@@ -286,8 +286,8 @@
                                                         x-text="(() => { const s = slotAssignments.find(sa => sa.id === draggingSlotId); return s?.player?.number || getInitials(s?.player?.name); })()"></span>
                                                 </div>
                                             </div>
-                                            <span class="mt-0.5 text-[8px] font-semibold text-white uppercase tracking-wide leading-tight text-center max-w-[60px] truncate drop-shadow-[0_1px_2px_rgba(0,0,0,0.8)]"
-                                                x-text="(() => { const s = slotAssignments.find(sa => sa.id === draggingSlotId); return getSurname(s?.player?.name); })()"></span>
+                                            <span class="mt-0.5 text-[8px] font-semibold text-white uppercase tracking-wide leading-tight text-center max-w-[66px] line-clamp-2 break-words drop-shadow-[0_1px_2px_rgba(0,0,0,0.8)]"
+                                                x-text="(() => { const s = slotAssignments.find(sa => sa.id === draggingSlotId); return s?.player?.name; })()"></span>
                                         </div>
                                     </template>
                                 </div>


### PR DESCRIPTION
Display the complete player name (allowing up to two lines) on the
pitch badge instead of just the surname. Width is capped at 66px
(~1.5x the 44px badge) to prevent overlaps with nearby players.

https://claude.ai/code/session_0163UaD9GWzzhJsuJ1s3M3iL