### PR TITLE
Rename "onboarding" route/URL/template to "new-season"

### DIFF
--- a/app/Console/Commands/BackfillActivationEvents.php
+++ b/app/Console/Commands/BackfillActivationEvents.php
@@ -96,7 +96,7 @@ class BackfillActivationEvents extends Command
 
     private function backfillOnboardingCompleted(): void
     {
-        $rows = Game::where('needs_onboarding', false)
+        $rows = Game::where('needs_new_season_setup', false)
             ->where('game_mode', Game::MODE_CAREER)
             ->whereNotNull('setup_completed_at')
             ->get()

--- a/app/Http/Actions/CompleteNewSeason.php
+++ b/app/Http/Actions/CompleteNewSeason.php
@@ -9,7 +9,7 @@ use App\Modules\Finance\Services\BudgetAllocationService;
 use App\Modules\Season\Services\ActivationTracker;
 use Illuminate\Http\Request;
 
-class CompleteOnboarding
+class CompleteNewSeason
 {
     public function __construct(
         private BudgetAllocationService $budgetService,
@@ -20,14 +20,14 @@ class CompleteOnboarding
     {
         $game = Game::findOrFail($gameId);
 
-        // Ensure onboarding is still needed
-        if (!$game->needsOnboarding()) {
+        // Ensure new-season setup is still needed
+        if (!$game->needsNewSeasonSetup()) {
             return redirect()->route('show-game', $gameId);
         }
 
         $finances = $game->currentFinances;
         if (!$finances) {
-            return redirect()->route('game.onboarding', $gameId)
+            return redirect()->route('game.new-season', $gameId)
                 ->with('error', __('messages.budget_no_projections'));
         }
 
@@ -42,13 +42,13 @@ class CompleteOnboarding
         try {
             $this->budgetService->allocate($game, $validated);
         } catch (\InvalidArgumentException $e) {
-            return redirect()->route('game.onboarding', $gameId)
+            return redirect()->route('game.new-season', $gameId)
                 ->with('error', __($e->getMessage()));
         }
 
-        // Complete onboarding
+        // Complete new-season setup
         $game->refresh()->setRelations([]);
-        $game->completeOnboarding();
+        $game->completeNewSeasonSetup();
 
         $this->activationTracker->record($game->user_id, ActivationEvent::EVENT_ONBOARDING_COMPLETED, $gameId, $game->game_mode);
 

--- a/app/Http/Actions/CompleteWelcome.php
+++ b/app/Http/Actions/CompleteWelcome.php
@@ -17,13 +17,13 @@ class CompleteWelcome
         $game = Game::findOrFail($gameId);
 
         if (!$game->needsWelcome()) {
-            return redirect()->route('game.onboarding', $gameId);
+            return redirect()->route('game.new-season', $gameId);
         }
 
         $game->completeWelcome();
 
         $this->activationTracker->record($game->user_id, ActivationEvent::EVENT_WELCOME_COMPLETED, $gameId, $game->game_mode);
 
-        return redirect()->route('game.onboarding', $gameId);
+        return redirect()->route('game.new-season', $gameId);
     }
 }

--- a/app/Http/Actions/SaveSquadSelection.php
+++ b/app/Http/Actions/SaveSquadSelection.php
@@ -20,7 +20,7 @@ class SaveSquadSelection
     {
         $game = Game::with('team')->findOrFail($gameId);
 
-        if (!$game->isTournamentMode() || !$game->needsOnboarding()) {
+        if (!$game->isTournamentMode() || !$game->needsNewSeasonSetup()) {
             return redirect()->route('show-game', $gameId);
         }
 
@@ -49,7 +49,7 @@ class SaveSquadSelection
 
         self::createTournamentGamePlayers($gameId, $game->team_id, $selectedTmIds, $positionByTmId);
 
-        $game->completeOnboarding();
+        $game->completeNewSeasonSetup();
 
         return redirect()->route('show-game', $gameId)
             ->with('success', __('squad.squad_confirmed'));

--- a/app/Http/Views/ShowGame.php
+++ b/app/Http/Views/ShowGame.php
@@ -26,9 +26,9 @@ class ShowGame
             return redirect()->route('game.welcome', $gameId);
         }
 
-        // Redirect to onboarding if setup or onboarding not completed
-        if (!$game->isSetupComplete() || $game->needsOnboarding()) {
-            return redirect()->route('game.onboarding', $gameId);
+        // Redirect to new-season setup if setup or new-season setup not completed
+        if (!$game->isSetupComplete() || $game->needsNewSeasonSetup()) {
+            return redirect()->route('game.new-season', $gameId);
         }
 
         // Show loading screen while season transition runs in background

--- a/app/Http/Views/ShowNewSeason.php
+++ b/app/Http/Views/ShowNewSeason.php
@@ -13,7 +13,7 @@ use App\Models\SeasonArchive;
 use App\Models\TeamReputation;
 use App\Support\PositionMapper;
 
-class ShowOnboarding
+class ShowNewSeason
 {
     public function __construct(
         private readonly BudgetProjectionService $projectionService,
@@ -44,8 +44,8 @@ class ShowOnboarding
             ]);
         }
 
-        // If onboarding is complete, redirect to main game
-        if (!$game->needsOnboarding()) {
+        // If new-season setup is complete, redirect to main game
+        if (!$game->needsNewSeasonSetup()) {
             return redirect()->route('show-game', $gameId);
         }
 
@@ -95,7 +95,7 @@ class ShowOnboarding
             $offseasonRecap = $this->buildOffseasonRecap($game, $squad, $reputationLevel);
         }
 
-        return view('onboarding', [
+        return view('new-season', [
             'game' => $game,
             'finances' => $finances,
             'investment' => $investment,

--- a/app/Http/Views/ShowSquadSelection.php
+++ b/app/Http/Views/ShowSquadSelection.php
@@ -13,14 +13,14 @@ class ShowSquadSelection
     {
         $game = Game::with('team')->findOrFail($gameId);
 
-        // Only for tournament mode during onboarding
-        if (!$game->isTournamentMode() || !$game->needsOnboarding()) {
+        // Only for tournament mode during new-season setup
+        if (!$game->isTournamentMode() || !$game->needsNewSeasonSetup()) {
             return redirect()->route('show-game', $gameId);
         }
 
         // Wait for background setup to finish
         if (!$game->isSetupComplete()) {
-            return redirect()->route('game.onboarding', $gameId);
+            return redirect()->route('game.new-season', $gameId);
         }
 
         $candidates = $this->loadCandidates($game);
@@ -38,7 +38,7 @@ class ShowSquadSelection
             }
 
             SaveSquadSelection::createTournamentGamePlayers($game->id, $game->team_id, $allTmIds, $positionByTmId);
-            $game->completeOnboarding();
+            $game->completeNewSeasonSetup();
 
             return redirect()->route('show-game', $game->id)
                 ->with('success', __('squad.squad_confirmed'));

--- a/app/Http/Views/ShowWelcome.php
+++ b/app/Http/Views/ShowWelcome.php
@@ -11,10 +11,10 @@ class ShowWelcome
     {
         $game = Game::with('team')->findOrFail($gameId);
 
-        // If welcome is already complete, go to onboarding or game
+        // If welcome is already complete, go to new-season setup or game
         if (!$game->needsWelcome()) {
-            if ($game->needsOnboarding()) {
-                return redirect()->route('game.onboarding', $gameId);
+            if ($game->needsNewSeasonSetup()) {
+                return redirect()->route('game.new-season', $gameId);
             }
             return redirect()->route('show-game', $gameId);
         }

--- a/app/Models/Game.php
+++ b/app/Models/Game.php
@@ -21,7 +21,7 @@ use Illuminate\Database\Eloquent\Builder;
  * @property int $current_matchday
  * @property \Illuminate\Support\Carbon|null $created_at
  * @property \Illuminate\Support\Carbon|null $updated_at
- * @property bool $needs_onboarding
+ * @property bool $needs_new_season_setup
  * @property bool $needs_welcome
  * @property bool $pre_season
  * @property string|null $season_goal
@@ -77,7 +77,7 @@ use Illuminate\Database\Eloquent\Builder;
  * @method static Builder<static>|Game whereDefaultMentality($value)
  * @method static Builder<static>|Game whereGameMode($value)
  * @method static Builder<static>|Game whereId($value)
- * @method static Builder<static>|Game whereNeedsOnboarding($value)
+ * @method static Builder<static>|Game whereNeedsNewSeasonSetup($value)
  * @method static Builder<static>|Game wherePlayerName($value)
  * @method static Builder<static>|Game whereSeason($value)
  * @method static Builder<static>|Game whereSeasonGoal($value)
@@ -117,7 +117,7 @@ class Game extends Model
         'current_date',
         'current_matchday',
         'season_goal',
-        'needs_onboarding',
+        'needs_new_season_setup',
         'needs_welcome',
         'pre_season',
         'pending_actions',
@@ -131,7 +131,7 @@ class Game extends Model
         'current_date' => 'date',
         'current_matchday' => 'integer',
         'season_goal' => 'string',
-        'needs_onboarding' => 'boolean',
+        'needs_new_season_setup' => 'boolean',
         'needs_welcome' => 'boolean',
         'pre_season' => 'boolean',
         'pending_actions' => 'array',
@@ -720,7 +720,7 @@ class Game extends Model
     }
 
     // ==========================================
-    // Welcome & Onboarding
+    // Welcome & New Season Setup
     // ==========================================
 
     /**
@@ -740,19 +740,19 @@ class Game extends Model
     }
 
     /**
-     * Check if the game needs onboarding (season budget allocation).
+     * Check if the game needs new-season setup (season budget allocation).
      */
-    public function needsOnboarding(): bool
+    public function needsNewSeasonSetup(): bool
     {
-        return $this->needs_onboarding ?? false;
+        return $this->needs_new_season_setup ?? false;
     }
 
     /**
-     * Complete the onboarding process.
+     * Complete the new-season setup process.
      */
-    public function completeOnboarding(): void
+    public function completeNewSeasonSetup(): void
     {
-        $this->update(['needs_onboarding' => false]);
+        $this->update(['needs_new_season_setup' => false]);
     }
 
     // ==========================================

--- a/app/Modules/Match/Services/CareerActionProcessor.php
+++ b/app/Modules/Match/Services/CareerActionProcessor.php
@@ -171,7 +171,7 @@ class CareerActionProcessor
         $month = (int) $game->current_date->format('n');
 
         // Summer window notification is handled at season start
-        // (SetupNewGame + OnboardingResetProcessor). Only detect winter here.
+        // (SetupNewGame + NewSeasonResetProcessor). Only detect winter here.
         if ($month !== 1) {
             return;
         }

--- a/app/Modules/Season/Jobs/SetupTournamentGame.php
+++ b/app/Modules/Season/Jobs/SetupTournamentGame.php
@@ -206,7 +206,7 @@ class SetupTournamentGame implements ShouldQueue
                 continue;
             }
 
-            // Skip user's team — their players are created during squad selection onboarding
+            // Skip user's team — their players are created during squad selection
             if ($teamData['uuid'] === $this->teamId) {
                 continue;
             }

--- a/app/Modules/Season/Processors/NewSeasonResetProcessor.php
+++ b/app/Modules/Season/Processors/NewSeasonResetProcessor.php
@@ -8,11 +8,11 @@ use App\Modules\Season\DTOs\SeasonTransitionData;
 use App\Models\Game;
 
 /**
- * Resets the onboarding flag so the player must configure
+ * Resets the new-season setup flag so the player must configure
  * their investment allocation for the upcoming season.
  * Also notifies about the summer transfer window being open.
  */
-class OnboardingResetProcessor implements SeasonProcessor
+class NewSeasonResetProcessor implements SeasonProcessor
 {
     public function __construct(
         private NotificationService $notificationService,
@@ -29,7 +29,7 @@ class OnboardingResetProcessor implements SeasonProcessor
             return $data;
         }
 
-        $game->update(['needs_onboarding' => true]);
+        $game->update(['needs_new_season_setup' => true]);
 
         $this->notificationService->notifyTransferWindowOpen($game, 'summer');
 

--- a/app/Modules/Season/Processors/SquadCapEnforcementProcessor.php
+++ b/app/Modules/Season/Processors/SquadCapEnforcementProcessor.php
@@ -11,7 +11,7 @@ class SquadCapEnforcementProcessor implements SeasonProcessor
 {
     public function priority(): int
     {
-        return 109; // After ContinentalAndCupInit (106), before OnboardingReset (110)
+        return 109; // After ContinentalAndCupInit (106), before NewSeasonReset (110)
     }
 
     public function process(Game $game, SeasonTransitionData $data): SeasonTransitionData

--- a/app/Modules/Season/Services/SeasonSetupPipeline.php
+++ b/app/Modules/Season/Services/SeasonSetupPipeline.php
@@ -7,7 +7,7 @@ use App\Modules\Season\DTOs\SeasonTransitionData;
 use App\Modules\Season\Processors\BudgetProjectionProcessor;
 use App\Modules\Season\Processors\ContinentalAndCupInitProcessor;
 use App\Modules\Season\Processors\LeagueFixtureProcessor;
-use App\Modules\Season\Processors\OnboardingResetProcessor;
+use App\Modules\Season\Processors\NewSeasonResetProcessor;
 use App\Modules\Season\Processors\PreSeasonFixtureProcessor;
 use App\Modules\Season\Processors\SquadCapEnforcementProcessor;
 use App\Modules\Season\Processors\StandingsResetProcessor;
@@ -17,7 +17,7 @@ use Illuminate\Support\Facades\Log;
 
 /**
  * Sets up the new season: fixtures, standings, budgets, competitions,
- * academy evaluation, and onboarding. Used by both new game creation
+ * academy evaluation, and new-season setup. Used by both new game creation
  * and season transitions.
  */
 class SeasonSetupPipeline
@@ -33,7 +33,7 @@ class SeasonSetupPipeline
         ContinentalAndCupInitProcessor $competitionInitialization,
         SquadCapEnforcementProcessor $squadCapEnforcement,
         PreSeasonFixtureProcessor $preSeasonFixture,
-        OnboardingResetProcessor $onboardingReset,
+        NewSeasonResetProcessor $newSeasonReset,
     ) {
         $this->processors = [
             $fixtureGeneration,
@@ -43,7 +43,7 @@ class SeasonSetupPipeline
             $competitionInitialization,
             $squadCapEnforcement,
             $preSeasonFixture,
-            $onboardingReset,
+            $newSeasonReset,
         ];
 
         usort($this->processors, fn ($a, $b) => $a->priority() <=> $b->priority());

--- a/app/Modules/Season/Services/TournamentCreationService.php
+++ b/app/Modules/Season/Services/TournamentCreationService.php
@@ -27,7 +27,7 @@ class TournamentCreationService
             'current_date' => '2026-06-11',
             'current_matchday' => 0,
             'needs_welcome' => false,
-            'needs_onboarding' => true,
+            'needs_new_season_setup' => true,
             'setup_completed_at' => null,
         ]);
 

--- a/database/migrations/2026_03_15_000001_rename_needs_onboarding_to_needs_new_season_setup_on_games_table.php
+++ b/database/migrations/2026_03_15_000001_rename_needs_onboarding_to_needs_new_season_setup_on_games_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('games', function (Blueprint $table) {
+            $table->renameColumn('needs_onboarding', 'needs_new_season_setup');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('games', function (Blueprint $table) {
+            $table->renameColumn('needs_new_season_setup', 'needs_onboarding');
+        });
+    }
+};

--- a/docs/game-systems/season-lifecycle.md
+++ b/docs/game-systems/season-lifecycle.md
@@ -36,7 +36,7 @@ Season transitions run two pipelines sequentially. Each processor implements `Se
 
 **Phase 2 — Budget & academy** (priority 50-55): Generate budget projections, trigger academy evaluation.
 
-**Phase 3 — Competitions & onboarding** (priority 106-110): Initialize continental/cup competitions, enforce squad cap, reset onboarding.
+**Phase 3 — Competitions & new-season setup** (priority 106-110): Initialize continental/cup competitions, enforce squad cap, reset new-season setup flag.
 
 ## Key Files
 

--- a/lang/en/admin.php
+++ b/lang/en/admin.php
@@ -39,7 +39,7 @@ return [
     'funnel_game_created' => 'Game created',
     'funnel_setup_completed' => 'Setup completed',
     'funnel_welcome_completed' => 'Welcome completed',
-    'funnel_onboarding_completed' => 'Onboarding completed',
+    'funnel_onboarding_completed' => 'New season setup completed',
     'funnel_first_match_played' => 'First match played',
     'funnel_matchday_5_reached' => 'Matchday 5 reached',
     'funnel_season_completed' => 'Season completed',

--- a/lang/es/admin.php
+++ b/lang/es/admin.php
@@ -39,7 +39,7 @@ return [
     'funnel_game_created' => 'Partida creada',
     'funnel_setup_completed' => 'Configuración completada',
     'funnel_welcome_completed' => 'Bienvenida completada',
-    'funnel_onboarding_completed' => 'Onboarding completado',
+    'funnel_onboarding_completed' => 'Configuración de temporada completada',
     'funnel_first_match_played' => 'Primer partido jugado',
     'funnel_matchday_5_reached' => 'Jornada 5 alcanzada',
     'funnel_season_completed' => 'Temporada completada',

--- a/resources/views/new-season.blade.php
+++ b/resources/views/new-season.blade.php
@@ -244,7 +244,7 @@
                     :available-surplus="$availableSurplus"
                     :tiers="$tiers"
                     :tier-thresholds="$tierThresholds"
-                    :form-action="route('game.onboarding.complete', $game->id)"
+                    :form-action="route('game.new-season.complete', $game->id)"
                     :submit-label="__('game.begin_season')"
                 />
             </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -9,7 +9,7 @@ use App\Http\Views\AdminGameStats;
 use App\Http\Views\AdminUsers;
 use App\Http\Actions\DeleteGame;
 use App\Http\Actions\AcceptCounterOffer;
-use App\Http\Actions\CompleteOnboarding;
+use App\Http\Actions\CompleteNewSeason;
 use App\Http\Actions\CompleteWelcome;
 use App\Http\Actions\AcceptTransferOffer;
 use App\Http\Actions\SignFreeAgent;
@@ -54,7 +54,7 @@ use App\Http\Views\SelectTeam;
 use App\Http\Views\ShowCalendar;
 use App\Http\Views\ShowFinances;
 use App\Http\Views\ShowGame;
-use App\Http\Views\ShowOnboarding;
+use App\Http\Views\ShowNewSeason;
 use App\Http\Views\ShowWelcome;
 use App\Http\Views\ShowCompetition;
 use App\Http\Views\ShowLiveMatch;
@@ -190,11 +190,11 @@ Route::middleware('auth')->group(function () {
         Route::get('/game/{gameId}/welcome', ShowWelcome::class)->name('game.welcome');
         Route::post('/game/{gameId}/welcome', CompleteWelcome::class)->name('game.welcome.complete');
 
-        // Onboarding (season budget allocation)
-        Route::get('/game/{gameId}/onboarding', ShowOnboarding::class)->name('game.onboarding');
-        Route::post('/game/{gameId}/onboarding', CompleteOnboarding::class)->name('game.onboarding.complete');
+        // New Season (season budget allocation)
+        Route::get('/game/{gameId}/new-season', ShowNewSeason::class)->name('game.new-season');
+        Route::post('/game/{gameId}/new-season', CompleteNewSeason::class)->name('game.new-season.complete');
 
-        // Squad Selection (Tournament mode onboarding)
+        // Squad Selection (Tournament mode new-season setup)
         Route::get('/game/{gameId}/squad-selection', ShowSquadSelection::class)->name('game.squad-selection');
         Route::post('/game/{gameId}/squad-selection', SaveSquadSelection::class)->name('game.squad-selection.save');
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -27,7 +27,7 @@ This takes 1-3 minutes and does the following:
 1. **Seeds reference data** (`php artisan app:seed-reference-data --fresh`) — full production profile with La Liga, Segunda Division, Copa del Rey, Champions League, etc. Creates a default user `test@test.com` / `password`.
 2. **Creates a career game** with Real Madrid via `GameCreationService`.
 3. **Processes the setup job** (`queue:work --stop-when-empty`) — generates fixtures, standings, budgets, etc.
-4. **Skips onboarding flows** — disables the welcome screen, onboarding wizard, and pre-season so the video starts in the main game UI.
+4. **Skips setup flows** — disables the welcome screen, new-season setup, and pre-season so the video starts in the main game UI.
 5. **Simulates 8 matchdays** — creates realistic standings, results, and player form.
 6. **Outputs `GAME_ID` and `COMPETITION_ID`** — copy these for the next step.
 

--- a/scripts/setup-promo-game.sh
+++ b/scripts/setup-promo-game.sh
@@ -39,14 +39,14 @@ echo "==> Step 3: Processing SetupNewGame job..."
 php artisan queue:work --stop-when-empty --timeout=120
 echo ""
 
-echo "==> Step 4: Skipping welcome, onboarding, and pre-season..."
+echo "==> Step 4: Skipping welcome, new-season setup, and pre-season..."
 php artisan tinker --execute="
     \$game = \App\Models\Game::find('$GAME_ID');
     \$game->needs_welcome = false;
-    \$game->needs_onboarding = false;
+    \$game->needs_new_season_setup = false;
     \$game->pre_season = false;
     \$game->save();
-    echo 'Done: needs_welcome=false, needs_onboarding=false, pre_season=false';
+    echo 'Done: needs_welcome=false, needs_new_season_setup=false, pre_season=false';
 "
 echo ""
 

--- a/tests/Feature/FrontendSmokeTest.php
+++ b/tests/Feature/FrontendSmokeTest.php
@@ -67,7 +67,7 @@ class FrontendSmokeTest extends TestCase
             'current_matchday' => 1,
             'setup_completed_at' => now(),
             'needs_welcome' => false,
-            'needs_onboarding' => false,
+            'needs_new_season_setup' => false,
             'game_mode' => 'career',
         ]);
 
@@ -394,7 +394,7 @@ class FrontendSmokeTest extends TestCase
     }
 
     // =============================================
-    // Welcome & onboarding (special game state)
+    // Welcome & new-season setup (special game state)
     // =============================================
 
     public function test_welcome_page_loads(): void
@@ -406,12 +406,12 @@ class FrontendSmokeTest extends TestCase
             ->assertOk();
     }
 
-    public function test_onboarding_page_loads(): void
+    public function test_new_season_page_loads(): void
     {
-        $this->game->update(['needs_onboarding' => true]);
+        $this->game->update(['needs_new_season_setup' => true]);
 
         $this->actingAs($this->user)
-            ->get("/game/{$this->game->id}/onboarding")
+            ->get("/game/{$this->game->id}/new-season")
             ->assertOk();
     }
 
@@ -438,7 +438,7 @@ class FrontendSmokeTest extends TestCase
             'current_matchday' => 38,
             'setup_completed_at' => now(),
             'needs_welcome' => false,
-            'needs_onboarding' => false,
+            'needs_new_season_setup' => false,
             'game_mode' => 'career',
         ]);
 
@@ -635,7 +635,7 @@ class FrontendSmokeTest extends TestCase
             'current_date' => '2026-06-01',
             'setup_completed_at' => now(),
             'needs_welcome' => false,
-            'needs_onboarding' => true,
+            'needs_new_season_setup' => true,
             'game_mode' => 'tournament',
         ]);
 
@@ -666,7 +666,7 @@ class FrontendSmokeTest extends TestCase
             'current_date' => '2025-07-15',
             'setup_completed_at' => now(),
             'needs_welcome' => false,
-            'needs_onboarding' => false,
+            'needs_new_season_setup' => false,
             'game_mode' => 'tournament',
         ]);
 

--- a/tests/Feature/PreSeasonTest.php
+++ b/tests/Feature/PreSeasonTest.php
@@ -47,7 +47,7 @@ class PreSeasonTest extends TestCase
             'current_matchday' => 0,
             'pre_season' => true,
             'setup_completed_at' => now(),
-            'needs_onboarding' => false,
+            'needs_new_season_setup' => false,
             'needs_welcome' => false,
         ]);
     }


### PR DESCRIPTION
Aligns the name with the actual purpose: configuring budget allocation
for a new season. Renames the URL from /game/{id}/onboarding to
/game/{id}/new-season, the route names from game.onboarding.* to
game.new-season.*, the DB column from needs_onboarding to
needs_new_season_setup, and all associated classes (ShowOnboarding →
ShowNewSeason, CompleteOnboarding → CompleteNewSeason,
OnboardingResetProcessor → NewSeasonResetProcessor).

https://claude.ai/code/session_01E97qgKFZjnWTdmgA897CoS