### PR TITLE
Move season archives from database to object storage

### DIFF
--- a/app/Console/Commands/MigrateArchivesToStorage.php
+++ b/app/Console/Commands/MigrateArchivesToStorage.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\SeasonArchive;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Storage;
+
+class MigrateArchivesToStorage extends Command
+{
+    protected $signature = 'app:migrate-archives-to-storage';
+
+    protected $description = 'Migrate existing season archives from database columns to object storage';
+
+    public function handle(): int
+    {
+        $query = SeasonArchive::whereNull('storage_path');
+        $total = $query->count();
+
+        if ($total === 0) {
+            $this->info('No archives to migrate — all records already use object storage.');
+
+            return self::SUCCESS;
+        }
+
+        $this->info("Migrating {$total} archive(s) to object storage...");
+
+        $migrated = 0;
+        $failed = 0;
+
+        $query->chunk(50, function ($archives) use (&$migrated, &$failed) {
+            foreach ($archives as $archive) {
+                try {
+                    $this->migrateArchive($archive);
+                    $migrated++;
+                } catch (\Throwable $e) {
+                    $failed++;
+                    $this->error("Failed to migrate archive {$archive->id} (game={$archive->game_id}, season={$archive->season}): {$e->getMessage()}");
+                }
+            }
+        });
+
+        $this->info("Done. Migrated: {$migrated}, Failed: {$failed}");
+
+        return $failed > 0 ? self::FAILURE : self::SUCCESS;
+    }
+
+    private function migrateArchive(SeasonArchive $archive): void
+    {
+        // Build archive data from legacy DB columns
+        $archiveData = [
+            'final_standings' => json_decode($archive->getAttributes()['final_standings'] ?? '[]', true) ?? [],
+            'player_season_stats' => json_decode($archive->getAttributes()['player_season_stats'] ?? '[]', true) ?? [],
+            'season_awards' => json_decode($archive->getAttributes()['season_awards'] ?? '[]', true) ?? [],
+            'match_results' => json_decode($archive->getAttributes()['match_results'] ?? '[]', true) ?? [],
+            'transfer_activity' => json_decode($archive->getAttributes()['transfer_activity'] ?? '[]', true) ?? [],
+            'match_events' => $this->decompressLegacyEvents($archive->getAttributes()['match_events_archive'] ?? null),
+        ];
+
+        $path = "{$archive->game_id}/{$archive->season}.json.gz";
+        $compressed = gzcompress(json_encode($archiveData), 9);
+
+        Storage::disk('season-archives')->put($path, $compressed);
+
+        // Update the record: set storage_path and clear blob columns
+        $archive->update([
+            'storage_path' => $path,
+            'final_standings' => null,
+            'player_season_stats' => null,
+            'season_awards' => null,
+            'match_results' => null,
+            'transfer_activity' => null,
+            'match_events_archive' => null,
+        ]);
+
+        $this->line("  Migrated: game={$archive->game_id}, season={$archive->season}");
+    }
+
+    private function decompressLegacyEvents(?string $blob): array
+    {
+        if (empty($blob)) {
+            return [];
+        }
+
+        $decoded = @base64_decode($blob, true);
+        if ($decoded === false) {
+            return [];
+        }
+
+        $decompressed = @gzuncompress($decoded);
+        if ($decompressed === false) {
+            return [];
+        }
+
+        return json_decode($decompressed, true) ?? [];
+    }
+}

--- a/app/Models/SeasonArchive.php
+++ b/app/Models/SeasonArchive.php
@@ -5,15 +5,18 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Facades\Storage;
 
 /**
  * @property string $id
  * @property string $game_id
  * @property string $season
- * @property array<array-key, mixed> $final_standings
- * @property array<array-key, mixed> $player_season_stats
- * @property array<array-key, mixed> $season_awards
- * @property array<array-key, mixed> $match_results
+ * @property string|null $storage_path
+ * @property array<array-key, mixed>|null $final_standings
+ * @property array<array-key, mixed>|null $player_season_stats
+ * @property array<array-key, mixed>|null $season_awards
+ * @property array<array-key, mixed>|null $match_results
+ * @property array<array-key, mixed>|null $transfer_activity
  * @property string|null $match_events_archive
  * @property \Illuminate\Support\Carbon|null $created_at
  * @property \Illuminate\Support\Carbon|null $updated_at
@@ -23,20 +26,6 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  * @property-read array $match_events
  * @property-read array|null $most_assists
  * @property-read array|null $top_scorer
- * @method static \Illuminate\Database\Eloquent\Builder<static>|SeasonArchive newModelQuery()
- * @method static \Illuminate\Database\Eloquent\Builder<static>|SeasonArchive newQuery()
- * @method static \Illuminate\Database\Eloquent\Builder<static>|SeasonArchive query()
- * @method static \Illuminate\Database\Eloquent\Builder<static>|SeasonArchive whereCreatedAt($value)
- * @method static \Illuminate\Database\Eloquent\Builder<static>|SeasonArchive whereFinalStandings($value)
- * @method static \Illuminate\Database\Eloquent\Builder<static>|SeasonArchive whereGameId($value)
- * @method static \Illuminate\Database\Eloquent\Builder<static>|SeasonArchive whereId($value)
- * @method static \Illuminate\Database\Eloquent\Builder<static>|SeasonArchive whereMatchEventsArchive($value)
- * @method static \Illuminate\Database\Eloquent\Builder<static>|SeasonArchive whereMatchResults($value)
- * @method static \Illuminate\Database\Eloquent\Builder<static>|SeasonArchive wherePlayerSeasonStats($value)
- * @method static \Illuminate\Database\Eloquent\Builder<static>|SeasonArchive whereSeason($value)
- * @method static \Illuminate\Database\Eloquent\Builder<static>|SeasonArchive whereSeasonAwards($value)
- * @method static \Illuminate\Database\Eloquent\Builder<static>|SeasonArchive whereUpdatedAt($value)
- * @mixin \Eloquent
  */
 class SeasonArchive extends Model
 {
@@ -45,6 +34,7 @@ class SeasonArchive extends Model
     protected $fillable = [
         'game_id',
         'season',
+        'storage_path',
         'final_standings',
         'player_season_stats',
         'season_awards',
@@ -61,21 +51,138 @@ class SeasonArchive extends Model
         'transfer_activity' => 'array',
     ];
 
+    /**
+     * Cached archive data loaded from object storage.
+     */
+    private ?array $storageData = null;
+
     public function game(): BelongsTo
     {
         return $this->belongsTo(Game::class);
     }
 
     /**
-     * Get decompressed match events from archive.
+     * Upload archive data to object storage and set the storage_path.
+     */
+    public static function createInStorage(array $attributes, array $archiveData): static
+    {
+        $path = "{$attributes['game_id']}/{$attributes['season']}.json.gz";
+        $compressed = gzcompress(json_encode($archiveData), 9);
+
+        Storage::disk('season-archives')->put($path, $compressed);
+
+        return static::create([
+            'game_id' => $attributes['game_id'],
+            'season' => $attributes['season'],
+            'storage_path' => $path,
+        ]);
+    }
+
+    /**
+     * Load archive data from object storage (cached for request lifecycle).
+     */
+    private function loadFromStorage(): array
+    {
+        if ($this->storageData === null) {
+            $compressed = Storage::disk('season-archives')->get($this->storage_path);
+            $this->storageData = json_decode(gzuncompress($compressed), true) ?? [];
+        }
+
+        return $this->storageData;
+    }
+
+    /**
+     * Check if this archive uses object storage or legacy DB columns.
+     */
+    private function usesStorage(): bool
+    {
+        return $this->storage_path !== null;
+    }
+
+    /**
+     * Get final standings, from storage or legacy DB column.
+     */
+    public function getFinalStandingsAttribute(): array
+    {
+        if ($this->usesStorage()) {
+            return $this->loadFromStorage()['final_standings'] ?? [];
+        }
+
+        $value = $this->attributes['final_standings'] ?? null;
+
+        return $value ? (is_string($value) ? json_decode($value, true) : $value) : [];
+    }
+
+    /**
+     * Get player season stats, from storage or legacy DB column.
+     */
+    public function getPlayerSeasonStatsAttribute(): array
+    {
+        if ($this->usesStorage()) {
+            return $this->loadFromStorage()['player_season_stats'] ?? [];
+        }
+
+        $value = $this->attributes['player_season_stats'] ?? null;
+
+        return $value ? (is_string($value) ? json_decode($value, true) : $value) : [];
+    }
+
+    /**
+     * Get season awards, from storage or legacy DB column.
+     */
+    public function getSeasonAwardsAttribute(): array
+    {
+        if ($this->usesStorage()) {
+            return $this->loadFromStorage()['season_awards'] ?? [];
+        }
+
+        $value = $this->attributes['season_awards'] ?? null;
+
+        return $value ? (is_string($value) ? json_decode($value, true) : $value) : [];
+    }
+
+    /**
+     * Get match results, from storage or legacy DB column.
+     */
+    public function getMatchResultsAttribute(): array
+    {
+        if ($this->usesStorage()) {
+            return $this->loadFromStorage()['match_results'] ?? [];
+        }
+
+        $value = $this->attributes['match_results'] ?? null;
+
+        return $value ? (is_string($value) ? json_decode($value, true) : $value) : [];
+    }
+
+    /**
+     * Get transfer activity, from storage or legacy DB column.
+     */
+    public function getTransferActivityAttribute(): array
+    {
+        if ($this->usesStorage()) {
+            return $this->loadFromStorage()['transfer_activity'] ?? [];
+        }
+
+        $value = $this->attributes['transfer_activity'] ?? null;
+
+        return $value ? (is_string($value) ? json_decode($value, true) : $value) : [];
+    }
+
+    /**
+     * Get decompressed match events from storage or legacy archive column.
      */
     public function getMatchEventsAttribute(): array
     {
-        if (empty($this->match_events_archive)) {
+        if ($this->usesStorage()) {
+            return $this->loadFromStorage()['match_events'] ?? [];
+        }
+
+        if (empty($this->attributes['match_events_archive'] ?? null)) {
             return [];
         }
 
-        $decoded = @base64_decode($this->match_events_archive, true);
+        $decoded = @base64_decode($this->attributes['match_events_archive'], true);
 
         if ($decoded === false) {
             return [];

--- a/app/Modules/Season/Processors/SeasonArchiveProcessor.php
+++ b/app/Modules/Season/Processors/SeasonArchiveProcessor.php
@@ -60,20 +60,21 @@ class SeasonArchiveProcessor implements SeasonProcessor
         // Capture transfer activity
         $transferActivity = $this->captureTransferActivity($game);
 
-        // Compress detailed match events
-        $eventsArchive = $this->compressMatchEvents($game);
+        // Capture match events
+        $matchEvents = $this->captureMatchEvents($game);
 
-        // Create archive record
-        SeasonArchive::create([
-            'game_id' => $game->id,
-            'season' => $season,
-            'final_standings' => $standings,
-            'player_season_stats' => $playerStats,
-            'season_awards' => $awards,
-            'match_results' => $matchResults,
-            'transfer_activity' => $transferActivity,
-            'match_events_archive' => $eventsArchive,
-        ]);
+        // Upload to object storage and create reference record
+        SeasonArchive::createInStorage(
+            ['game_id' => $game->id, 'season' => $season],
+            [
+                'final_standings' => $standings,
+                'player_season_stats' => $playerStats,
+                'season_awards' => $awards,
+                'match_results' => $matchResults,
+                'transfer_activity' => $transferActivity,
+                'match_events' => $matchEvents,
+            ],
+        );
 
         // Delete archived data to free up space
         $this->deleteArchivedData($game);
@@ -292,9 +293,9 @@ class SeasonArchiveProcessor implements SeasonProcessor
     }
 
     /**
-     * Compress all match events into a gzipped blob.
+     * Capture all match events as an array.
      */
-    private function compressMatchEvents(Game $game): ?string
+    private function captureMatchEvents(Game $game): array
     {
         $events = [];
 
@@ -312,11 +313,7 @@ class SeasonArchiveProcessor implements SeasonProcessor
                 }
             });
 
-        if (empty($events)) {
-            return null;
-        }
-
-        return base64_encode(gzcompress(json_encode($events), 9));
+        return $events;
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
         "laravel/nightwatch": "^1.22",
         "laravel/octane": "^2.13",
         "laravel/telescope": "^5.17",
+        "league/flysystem-aws-s3-v3": "^3.0",
         "resend/resend-laravel": "^1.1",
         "sentry/sentry-laravel": "^4.20"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,159 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "be889152f069c6c0ba779644bc8ee3c0",
+    "content-hash": "6022360095cb098297f2d686e813691d",
     "packages": [
+        {
+            "name": "aws/aws-crt-php",
+            "version": "v1.2.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/awslabs/aws-crt-php.git",
+                "reference": "d71d9906c7bb63a28295447ba12e74723bd3730e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/awslabs/aws-crt-php/zipball/d71d9906c7bb63a28295447ba12e74723bd3730e",
+                "reference": "d71d9906c7bb63a28295447ba12e74723bd3730e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35||^5.6.3||^9.5",
+                "yoast/phpunit-polyfills": "^1.0"
+            },
+            "suggest": {
+                "ext-awscrt": "Make sure you install awscrt native extension to use any of the functionality."
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "AWS SDK Common Runtime Team",
+                    "email": "aws-sdk-common-runtime@amazon.com"
+                }
+            ],
+            "description": "AWS Common Runtime for PHP",
+            "homepage": "https://github.com/awslabs/aws-crt-php",
+            "keywords": [
+                "amazon",
+                "aws",
+                "crt",
+                "sdk"
+            ],
+            "support": {
+                "issues": "https://github.com/awslabs/aws-crt-php/issues",
+                "source": "https://github.com/awslabs/aws-crt-php/tree/v1.2.7"
+            },
+            "time": "2024-10-18T22:15:13+00:00"
+        },
+        {
+            "name": "aws/aws-sdk-php",
+            "version": "3.373.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/aws/aws-sdk-php.git",
+                "reference": "d23edc4cf9cd81cb98b5beb9c1fb3737f535b1e5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/d23edc4cf9cd81cb98b5beb9c1fb3737f535b1e5",
+                "reference": "d23edc4cf9cd81cb98b5beb9c1fb3737f535b1e5",
+                "shasum": ""
+            },
+            "require": {
+                "aws/aws-crt-php": "^1.2.3",
+                "ext-json": "*",
+                "ext-pcre": "*",
+                "ext-simplexml": "*",
+                "guzzlehttp/guzzle": "^7.4.5",
+                "guzzlehttp/promises": "^2.0",
+                "guzzlehttp/psr7": "^2.4.5",
+                "mtdowling/jmespath.php": "^2.8.0",
+                "php": ">=8.1",
+                "psr/http-message": "^1.0 || ^2.0",
+                "symfony/filesystem": "^v5.4.45 || ^v6.4.3 || ^v7.1.0 || ^v8.0.0"
+            },
+            "require-dev": {
+                "andrewsville/php-token-reflection": "^1.4",
+                "aws/aws-php-sns-message-validator": "~1.0",
+                "behat/behat": "~3.0",
+                "composer/composer": "^2.7.8",
+                "dms/phpunit-arraysubset-asserts": "^v0.5.0",
+                "doctrine/cache": "~1.4",
+                "ext-dom": "*",
+                "ext-openssl": "*",
+                "ext-sockets": "*",
+                "phpunit/phpunit": "^10.0",
+                "psr/cache": "^2.0 || ^3.0",
+                "psr/simple-cache": "^2.0 || ^3.0",
+                "sebastian/comparator": "^1.2.3 || ^4.0 || ^5.0",
+                "yoast/phpunit-polyfills": "^2.0"
+            },
+            "suggest": {
+                "aws/aws-php-sns-message-validator": "To validate incoming SNS notifications",
+                "doctrine/cache": "To use the DoctrineCacheAdapter",
+                "ext-curl": "To send requests using cURL",
+                "ext-openssl": "Allows working with CloudFront private distributions and verifying received SNS messages",
+                "ext-pcntl": "To use client-side monitoring",
+                "ext-sockets": "To use client-side monitoring"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "Aws\\": "src/"
+                },
+                "exclude-from-classmap": [
+                    "src/data/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Amazon Web Services",
+                    "homepage": "https://aws.amazon.com"
+                }
+            ],
+            "description": "AWS SDK for PHP - Use Amazon Web Services in your PHP project",
+            "homepage": "https://aws.amazon.com/sdk-for-php",
+            "keywords": [
+                "amazon",
+                "aws",
+                "cloud",
+                "dynamodb",
+                "ec2",
+                "glacier",
+                "s3",
+                "sdk"
+            ],
+            "support": {
+                "forum": "https://github.com/aws/aws-sdk-php/discussions",
+                "issues": "https://github.com/aws/aws-sdk-php/issues",
+                "source": "https://github.com/aws/aws-sdk-php/tree/3.373.3"
+            },
+            "time": "2026-03-16T18:15:27+00:00"
+        },
         {
             "name": "brick/math",
             "version": "0.14.7",
@@ -2146,6 +2297,61 @@
             "time": "2026-01-23T15:38:47+00:00"
         },
         {
+            "name": "league/flysystem-aws-s3-v3",
+            "version": "3.32.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/flysystem-aws-s3-v3.git",
+                "reference": "a1979df7c9784d334ea6df356aed3d18ac6673d0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/flysystem-aws-s3-v3/zipball/a1979df7c9784d334ea6df356aed3d18ac6673d0",
+                "reference": "a1979df7c9784d334ea6df356aed3d18ac6673d0",
+                "shasum": ""
+            },
+            "require": {
+                "aws/aws-sdk-php": "^3.295.10",
+                "league/flysystem": "^3.10.0",
+                "league/mime-type-detection": "^1.0.0",
+                "php": "^8.0.2"
+            },
+            "conflict": {
+                "guzzlehttp/guzzle": "<7.0",
+                "guzzlehttp/ringphp": "<1.1.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "League\\Flysystem\\AwsS3V3\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Frank de Jonge",
+                    "email": "info@frankdejonge.nl"
+                }
+            ],
+            "description": "AWS S3 filesystem adapter for Flysystem.",
+            "keywords": [
+                "Flysystem",
+                "aws",
+                "file",
+                "files",
+                "filesystem",
+                "s3",
+                "storage"
+            ],
+            "support": {
+                "source": "https://github.com/thephpleague/flysystem-aws-s3-v3/tree/3.32.0"
+            },
+            "time": "2026-02-25T16:46:44+00:00"
+        },
+        {
             "name": "league/flysystem-local",
             "version": "3.31.0",
             "source": {
@@ -2534,6 +2740,72 @@
                 }
             ],
             "time": "2026-01-02T08:56:05+00:00"
+        },
+        {
+            "name": "mtdowling/jmespath.php",
+            "version": "2.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/jmespath/jmespath.php.git",
+                "reference": "a2a865e05d5f420b50cc2f85bb78d565db12a6bc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/jmespath/jmespath.php/zipball/a2a865e05d5f420b50cc2f85bb78d565db12a6bc",
+                "reference": "a2a865e05d5f420b50cc2f85bb78d565db12a6bc",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5 || ^8.0",
+                "symfony/polyfill-mbstring": "^1.17"
+            },
+            "require-dev": {
+                "composer/xdebug-handler": "^3.0.3",
+                "phpunit/phpunit": "^8.5.33"
+            },
+            "bin": [
+                "bin/jp.php"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.8-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/JmesPath.php"
+                ],
+                "psr-4": {
+                    "JmesPath\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Graham Campbell",
+                    "email": "hello@gjcampbell.co.uk",
+                    "homepage": "https://github.com/GrahamCampbell"
+                },
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Declaratively specify how to extract elements from a JSON document",
+            "keywords": [
+                "json",
+                "jsonpath"
+            ],
+            "support": {
+                "issues": "https://github.com/jmespath/jmespath.php/issues",
+                "source": "https://github.com/jmespath/jmespath.php/tree/2.8.0"
+            },
+            "time": "2024-09-04T18:46:31+00:00"
         },
         {
             "name": "nesbot/carbon",
@@ -4501,6 +4773,76 @@
                 }
             ],
             "time": "2024-09-25T14:21:43+00:00"
+        },
+        {
+            "name": "symfony/filesystem",
+            "version": "v8.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/filesystem.git",
+                "reference": "7bf9162d7a0dff98d079b72948508fa48018a770"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/7bf9162d7a0dff98d079b72948508fa48018a770",
+                "reference": "7bf9162d7a0dff98d079b72948508fa48018a770",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4",
+                "symfony/polyfill-ctype": "~1.8",
+                "symfony/polyfill-mbstring": "~1.8"
+            },
+            "require-dev": {
+                "symfony/process": "^7.4|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Filesystem\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides basic utilities for the filesystem",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/filesystem/tree/v8.0.6"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-02-25T16:59:43+00:00"
         },
         {
             "name": "symfony/finder",
@@ -9942,5 +10284,5 @@
         "php": "^8.4"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -59,6 +59,12 @@ return [
             'throw' => false,
         ],
 
+        'season-archives' => [
+            'driver' => env('SEASON_ARCHIVES_DISK_DRIVER', 'local'),
+            'root' => storage_path('app/season-archives'),
+            'throw' => true,
+        ],
+
         's3' => [
             'driver' => 's3',
             'key' => env('AWS_ACCESS_KEY_ID'),

--- a/database/migrations/2026_03_16_200000_add_storage_path_to_season_archives_table.php
+++ b/database/migrations/2026_03_16_200000_add_storage_path_to_season_archives_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('season_archives', function (Blueprint $table) {
+            $table->string('storage_path')->nullable()->after('season');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('season_archives', function (Blueprint $table) {
+            $table->dropColumn('storage_path');
+        });
+    }
+};

--- a/database/migrations/2026_03_16_200001_drop_blob_columns_from_season_archives_table.php
+++ b/database/migrations/2026_03_16_200001_drop_blob_columns_from_season_archives_table.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Final cleanup: drop blob columns after all existing archives
+ * have been migrated to object storage via app:migrate-archives-to-storage.
+ *
+ * IMPORTANT: Run app:migrate-archives-to-storage BEFORE deploying this migration.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('season_archives', function (Blueprint $table) {
+            $table->dropColumn([
+                'final_standings',
+                'player_season_stats',
+                'season_awards',
+                'match_results',
+                'transfer_activity',
+                'match_events_archive',
+            ]);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('season_archives', function (Blueprint $table) {
+            $table->json('final_standings')->nullable();
+            $table->json('player_season_stats')->nullable();
+            $table->json('season_awards')->nullable();
+            $table->json('match_results')->nullable();
+            $table->json('transfer_activity')->nullable();
+            $table->binary('match_events_archive')->nullable();
+        });
+    }
+};


### PR DESCRIPTION
Season archives (1-3 MB per game per season) were stored as JSON/binary
blobs in PostgreSQL, driving up Neon database costs. This moves them to
Laravel Cloud's object storage (Cloudflare R2), which is orders of
magnitude cheaper for write-once/read-rarely data.

- Add `season-archives` filesystem disk (local in dev, S3/R2 in prod)
- SeasonArchiveProcessor now uploads gzipped JSON to object storage
- SeasonArchive model transparently loads from storage or legacy DB cols
- Add `app:migrate-archives-to-storage` command for existing data
- Two-phase migration: add storage_path, then drop blob columns

https://claude.ai/code/session_01WsAHzBEQT3P5sAPDf3GECJ