### PR TITLE
Fix standings zone legend colors not showing

### DIFF
--- a/resources/views/partials/standings-flat.blade.php
+++ b/resources/views/partials/standings-flat.blade.php
@@ -14,12 +14,12 @@ $borderColorMap = [
 ];
 
 $bgColorMap = [
-    'bg-accent-blue' => 'bg-accent-blue',
+    'bg-blue-500' => 'bg-blue-500',
     'bg-orange-500' => 'bg-orange-500',
-    'bg-accent-red' => 'bg-accent-red',
+    'bg-red-500' => 'bg-red-500',
     'bg-green-300' => 'bg-green-300',
-    'bg-accent-green' => 'bg-accent-green',
-    'bg-accent-gold' => 'bg-accent-gold',
+    'bg-green-500' => 'bg-green-500',
+    'bg-yellow-500' => 'bg-yellow-500',
 ];
 
 $getZoneClass = function($position) use ($standingsZones, $borderColorMap) {

--- a/resources/views/season-end.blade.php
+++ b/resources/views/season-end.blade.php
@@ -19,12 +19,12 @@ $borderColorMap = [
 ];
 
 $bgColorMap = [
-    'bg-accent-blue' => 'bg-accent-blue',
+    'bg-blue-500' => 'bg-blue-500',
     'bg-orange-500' => 'bg-orange-500',
-    'bg-accent-red' => 'bg-accent-red',
+    'bg-red-500' => 'bg-red-500',
     'bg-green-300' => 'bg-green-300',
-    'bg-accent-green' => 'bg-accent-green',
-    'bg-accent-gold' => 'bg-accent-gold',
+    'bg-green-500' => 'bg-green-500',
+    'bg-yellow-500' => 'bg-yellow-500',
 ];
 
 $getZoneClass = function($position) use ($standingsZones, $borderColorMap) {


### PR DESCRIPTION
The bgColorMap keys used design system tokens (bg-accent-blue, bg-accent-red,
bg-accent-green) but the competition configs return standard Tailwind classes
(bg-blue-500, bg-red-500, bg-green-500). Only bg-orange-500 matched, which is
why only Europa League showed its legend color dot.

https://claude.ai/code/session_01ShBvtW9hwkNEXDU3p6WpUZ