### PR TITLE
Fix squad validation: emergency signings, match forfeits, and contract warnings

### DIFF
--- a/app/Models/GameNotification.php
+++ b/app/Models/GameNotification.php
@@ -72,6 +72,8 @@ class GameNotification extends Model
     public const TYPE_TRANSFER_WINDOW_OPEN = 'transfer_window_open';
     public const TYPE_PLAYER_RELEASED = 'player_released';
     public const TYPE_TRACKING_INTEL_READY = 'tracking_intel_ready';
+    public const TYPE_EMERGENCY_SIGNING = 'emergency_signing';
+    public const TYPE_MATCH_FORFEIT = 'match_forfeit';
 
     // Priorities
     public const PRIORITY_MILESTONE = 'milestone';
@@ -108,6 +110,8 @@ class GameNotification extends Model
         self::TYPE_TRANSFER_WINDOW_OPEN => 'scouting',
         self::TYPE_PLAYER_RELEASED => 'squad',
         self::TYPE_TRACKING_INTEL_READY => 'scouting',
+        self::TYPE_EMERGENCY_SIGNING => 'squad',
+        self::TYPE_MATCH_FORFEIT => 'squad',
     ];
 
     protected $fillable = [
@@ -367,6 +371,16 @@ class GameNotification extends Model
                 'icon_bg' => 'bg-teal-500/10',
                 'icon_text' => 'text-teal-500',
                 'dot' => 'bg-teal-500',
+            ],
+            self::TYPE_EMERGENCY_SIGNING => [
+                'icon_bg' => 'bg-orange-500/10',
+                'icon_text' => 'text-orange-500',
+                'dot' => 'bg-orange-500',
+            ],
+            self::TYPE_MATCH_FORFEIT => [
+                'icon_bg' => 'bg-red-500/10',
+                'icon_text' => 'text-red-500',
+                'dot' => 'bg-red-500',
             ],
             default => [
                 'icon_bg' => 'bg-slate-500/10',

--- a/app/Modules/Match/Services/CareerActionProcessor.php
+++ b/app/Modules/Match/Services/CareerActionProcessor.php
@@ -5,6 +5,7 @@ namespace App\Modules\Match\Services;
 use App\Models\AcademyPlayer;
 use App\Models\Game;
 use App\Models\GameNotification;
+use App\Models\GamePlayer;
 use App\Models\TransferOffer;
 use App\Modules\Academy\Services\YouthAcademyService;
 use App\Modules\Notification\Services\NotificationService;
@@ -108,6 +109,9 @@ class CareerActionProcessor
         // Check for expiring transfer offers (2 days or less)
         $this->checkExpiringOffers($game);
 
+        // Warn about expiring contracts (6 months and 3 months before expiry)
+        $this->checkExpiringContracts($game);
+
         // Develop academy players each matchday
         $this->youthAcademyService->developPlayers($game);
 
@@ -163,6 +167,43 @@ class CareerActionProcessor
             if (! in_array($offer->id, $recentlyNotifiedOfferIds)) {
                 $this->notificationService->notifyExpiringOffer($game, $offer);
             }
+        }
+    }
+
+    private function checkExpiringContracts(Game $game): void
+    {
+        $currentDate = $game->current_date;
+        $sixMonthsOut = $currentDate->copy()->addMonths(6);
+
+        $expiringPlayers = GamePlayer::with('player')
+            ->where('game_id', $game->id)
+            ->where('team_id', $game->team_id)
+            ->whereNull('pending_annual_wage') // not already renewed
+            ->where('contract_until', '<=', $sixMonthsOut)
+            ->where('contract_until', '>', $currentDate)
+            ->get();
+
+        if ($expiringPlayers->isEmpty()) {
+            return;
+        }
+
+        // Batch-load recent contract expiry notifications to avoid per-player queries
+        $cutoff = $currentDate->copy()->subDays(30);
+        $recentlyNotifiedPlayerIds = GameNotification::where('game_id', $game->id)
+            ->where('type', GameNotification::TYPE_CONTRACT_EXPIRING)
+            ->where('game_date', '>', $cutoff)
+            ->get(['metadata'])
+            ->pluck('metadata.player_id')
+            ->filter()
+            ->toArray();
+
+        foreach ($expiringPlayers as $player) {
+            if (in_array($player->id, $recentlyNotifiedPlayerIds)) {
+                continue;
+            }
+
+            $monthsLeft = (int) $currentDate->diffInMonths($player->contract_until);
+            $this->notificationService->notifyExpiringContract($game, $player, $monthsLeft);
         }
     }
 

--- a/app/Modules/Match/Services/MatchdayOrchestrator.php
+++ b/app/Modules/Match/Services/MatchdayOrchestrator.php
@@ -173,11 +173,50 @@ class MatchdayOrchestrator
         // --- Ensure lineups ---
         $this->lineupService->ensureLineupsForMatches($matches, $game, $allPlayers, $suspendedPlayerIds, $clubProfiles);
 
-        // --- Simulate matches ---
-        $matchResults = $this->simulateMatches($matches, $game, $allPlayers);
+        // --- Check for forfeit (user's team has < 7 available players) ---
+        $playerMatch = $matches->first(fn ($m) => $m->involvesTeam($game->team_id));
+        $forfeitResult = null;
+
+        if ($playerMatch) {
+            $isUserHome = $playerMatch->isHomeTeam($game->team_id);
+            $userLineupField = $isUserHome ? 'home_lineup' : 'away_lineup';
+            $userLineupCount = count($playerMatch->$userLineupField ?? []);
+            $userSquadSize = $allPlayers->get($game->team_id, collect())->count();
+
+            // Only forfeit if the team actually has players but too few available.
+            // A squad of 0 means the game is in a test/setup state — let the simulator handle it.
+            if ($userSquadSize > 0 && $userLineupCount < 7) {
+                // Forfeit: 0-3 loss for the user's team
+                $forfeitResult = [
+                    'matchId' => $playerMatch->id,
+                    'homeTeamId' => $playerMatch->home_team_id,
+                    'awayTeamId' => $playerMatch->away_team_id,
+                    'homeScore' => $isUserHome ? 0 : 3,
+                    'awayScore' => $isUserHome ? 3 : 0,
+                    'homePossession' => 50,
+                    'awayPossession' => 50,
+                    'competitionId' => $playerMatch->competition_id,
+                    'events' => [],
+                ];
+
+                $this->notificationService->notifyMatchForfeit($game);
+            }
+        }
+
+        // --- Simulate matches (skip forfeited match) ---
+        $forfeitedMatchId = $forfeitResult ? $playerMatch->id : null;
+        $matchesToSimulate = $forfeitedMatchId
+            ? $matches->reject(fn ($m) => $m->id === $forfeitedMatchId)
+            : $matches;
+        $matchResults = $this->simulateMatches($matchesToSimulate, $game, $allPlayers);
+
+        if ($forfeitResult) {
+            $matchResults[] = $forfeitResult;
+            // Forfeited match is not a live match — process all effects immediately
+            $playerMatch = null;
+        }
 
         // Identify user's match — its score-dependent effects are deferred to finalization
-        $playerMatch = $matches->first(fn ($m) => $m->involvesTeam($game->team_id));
         $deferMatchId = $playerMatch?->id;
 
         // --- Process results ---

--- a/app/Modules/Notification/Services/NotificationService.php
+++ b/app/Modules/Notification/Services/NotificationService.php
@@ -786,6 +786,41 @@ class NotificationService
     }
 
     // ==========================================
+    // Emergency & Forfeit Notifications
+    // ==========================================
+
+    /**
+     * Create a notification when emergency free agents are signed for the user's team.
+     */
+    public function notifyEmergencySignings(Game $game, array $playerNames): GameNotification
+    {
+        return $this->create(
+            game: $game,
+            type: GameNotification::TYPE_EMERGENCY_SIGNING,
+            title: __('notifications.emergency_signing_title'),
+            message: __('notifications.emergency_signing_message', [
+                'count' => count($playerNames),
+                'players' => implode(', ', $playerNames),
+            ]),
+            priority: GameNotification::PRIORITY_CRITICAL,
+        );
+    }
+
+    /**
+     * Create a notification when a match is forfeited due to insufficient players.
+     */
+    public function notifyMatchForfeit(Game $game): GameNotification
+    {
+        return $this->create(
+            game: $game,
+            type: GameNotification::TYPE_MATCH_FORFEIT,
+            title: __('notifications.match_forfeit_title'),
+            message: __('notifications.match_forfeit_message'),
+            priority: GameNotification::PRIORITY_CRITICAL,
+        );
+    }
+
+    // ==========================================
     // Helpers
     // ==========================================
 
@@ -820,6 +855,8 @@ class NotificationService
             GameNotification::TYPE_TRANSFER_WINDOW_OPEN => 'transfer',
             GameNotification::TYPE_PLAYER_RELEASED => 'transfer_complete',
             GameNotification::TYPE_TRACKING_INTEL_READY => 'scout',
+            GameNotification::TYPE_EMERGENCY_SIGNING => 'transfer_complete',
+            GameNotification::TYPE_MATCH_FORFEIT => 'eliminated',
             default => 'bell',
         };
     }

--- a/app/Modules/Season/Processors/SquadReplenishmentProcessor.php
+++ b/app/Modules/Season/Processors/SquadReplenishmentProcessor.php
@@ -2,6 +2,7 @@
 
 namespace App\Modules\Season\Processors;
 
+use App\Modules\Notification\Services\NotificationService;
 use App\Modules\Season\Contracts\SeasonProcessor;
 use App\Modules\Season\DTOs\SeasonTransitionData;
 use App\Modules\Squad\DTOs\GeneratedPlayerData;
@@ -118,6 +119,7 @@ class SquadReplenishmentProcessor implements SeasonProcessor
 
     public function __construct(
         private readonly PlayerGeneratorService $playerGenerator,
+        private readonly NotificationService $notificationService,
     ) {}
 
     public function priority(): int
@@ -169,6 +171,41 @@ class SquadReplenishmentProcessor implements SeasonProcessor
 
             foreach ($youthPlayers as $youth) {
                 $generatedPlayers[] = $youth;
+            }
+        }
+
+        // Emergency replenishment for user's team (safety net for expired contracts/retirements)
+        $userPlayers = GamePlayer::where('game_id', $game->id)
+            ->where('team_id', $game->team_id)
+            ->get();
+
+        if ($userPlayers->count() < self::MIN_SQUAD_SIZE) {
+            $teamAvgAbility = $this->calculateTeamAverageAbility($userPlayers);
+            $positionCounts = $userPlayers->groupBy('position')->map->count();
+            $positionsToFill = $this->determinePositionsToFill($positionCounts, $userPlayers->count());
+
+            $emergencyNames = [];
+            foreach ($positionsToFill as $position) {
+                $newPlayer = $this->generatePlayer(
+                    $game,
+                    $game->team_id,
+                    $position,
+                    $teamAvgAbility,
+                    $data->newSeason,
+                );
+
+                $emergencyNames[] = $newPlayer->player->name;
+                $generatedPlayers[] = [
+                    'playerId' => $newPlayer->id,
+                    'playerName' => $newPlayer->player->name,
+                    'position' => $newPlayer->position,
+                    'teamId' => $game->team_id,
+                    'type' => 'emergency_replenishment',
+                ];
+            }
+
+            if (! empty($emergencyNames)) {
+                $this->notificationService->notifyEmergencySignings($game, $emergencyNames);
             }
         }
 

--- a/lang/en/notifications.php
+++ b/lang/en/notifications.php
@@ -137,6 +137,14 @@ return [
     'tracking_report_ready' => 'Your scout has gathered a report on :player — ability range and financial details are now available.',
     'tracking_deep_intel_ready' => 'Your scout has completed deep intel on :player — transfer willingness and rival interest revealed.',
 
+    // Emergency signings
+    'emergency_signing_title' => 'Emergency squad reinforcement',
+    'emergency_signing_message' => 'Your squad was critically low. :count free agents have been signed to ensure you can field a team: :players.',
+
+    // Match forfeit
+    'match_forfeit_title' => 'Match forfeited',
+    'match_forfeit_message' => 'Your team could not field the minimum 7 players. The match has been recorded as a 0-3 defeat.',
+
     // Reputation changes
     'reputation_change_title' => 'Club reputation changed',
     'reputation_improved' => 'Your club\'s reputation has grown to :tier. Sponsors, players and fans are taking notice.',

--- a/lang/es/notifications.php
+++ b/lang/es/notifications.php
@@ -137,6 +137,14 @@ return [
     'tracking_report_ready' => 'Tu ojeador ha elaborado un informe sobre :player — rango de habilidad y detalles financieros disponibles.',
     'tracking_deep_intel_ready' => 'Tu ojeador ha completado la intel profunda de :player — disposición a salir e interés de rivales revelados.',
 
+    // Fichajes de emergencia
+    'emergency_signing_title' => 'Refuerzo de emergencia',
+    'emergency_signing_message' => 'Tu plantilla estaba en niveles críticos. Se han fichado :count agentes libres para asegurar que puedas alinear un equipo: :players.',
+
+    // Partido perdido por incomparecencia
+    'match_forfeit_title' => 'Partido perdido por incomparecencia',
+    'match_forfeit_message' => 'Tu equipo no pudo alinear el mínimo de 7 jugadores. El partido se ha registrado como una derrota 0-3.',
+
     // Reputation changes
     'reputation_change_title' => 'Reputación del club modificada',
     'reputation_improved' => 'La reputación de tu club ha ascendido a :tier. Patrocinadores, jugadores y aficionados lo notan.',

--- a/tests/Feature/SquadReplenishmentTest.php
+++ b/tests/Feature/SquadReplenishmentTest.php
@@ -161,10 +161,31 @@ class SquadReplenishmentTest extends TestCase
         $this->assertGreaterThanOrEqual(2, $gkAfter);
     }
 
-    public function test_user_team_is_never_replenished(): void
+    public function test_user_team_is_replenished_when_below_minimum(): void
     {
         // Create user team with only 10 players (well below minimum)
         $this->createSquadForTeam($this->userTeam, 10);
+
+        $processor = app(SquadReplenishmentProcessor::class);
+        $data = new SeasonTransitionData(oldSeason: '2024', newSeason: '2025', competitionId: 'ESP1');
+
+        $result = $processor->process($this->game, $data);
+
+        $finalCount = GamePlayer::where('game_id', $this->game->id)
+            ->where('team_id', $this->userTeam->id)
+            ->count();
+        // Should be replenished to MIN_SQUAD_SIZE (22)
+        $this->assertEquals(22, $finalCount);
+
+        $generated = $result->getMetadata('squadReplenishment');
+        $emergencyEntries = array_filter($generated, fn ($e) => $e['type'] === 'emergency_replenishment');
+        $this->assertCount(12, $emergencyEntries);
+    }
+
+    public function test_user_team_at_or_above_minimum_is_not_replenished(): void
+    {
+        // Create user team with 22 players (at minimum) — should NOT be replenished
+        $this->createSquadForTeam($this->userTeam, 22);
 
         $processor = app(SquadReplenishmentProcessor::class);
         $data = new SeasonTransitionData(oldSeason: '2024', newSeason: '2025', competitionId: 'ESP1');
@@ -174,7 +195,7 @@ class SquadReplenishmentTest extends TestCase
         $finalCount = GamePlayer::where('game_id', $this->game->id)
             ->where('team_id', $this->userTeam->id)
             ->count();
-        $this->assertEquals(10, $finalCount);
+        $this->assertEquals(22, $finalCount);
     }
 
     public function test_generated_players_fill_depleted_positions(): void
@@ -320,6 +341,8 @@ class SquadReplenishmentTest extends TestCase
     public function test_metadata_contains_generated_player_info(): void
     {
         $this->createSquadForTeam($this->aiTeam, 20);
+        // Give user team enough players to avoid emergency replenishment
+        $this->createSquadForTeam($this->userTeam, 22);
 
         $processor = app(SquadReplenishmentProcessor::class);
         $data = new SeasonTransitionData(oldSeason: '2024', newSeason: '2025', competitionId: 'ESP1');
@@ -330,7 +353,8 @@ class SquadReplenishmentTest extends TestCase
         // 2 replenishment + 2-3 youth = 4-5 total
         $this->assertGreaterThanOrEqual(4, count($generated));
 
-        foreach ($generated as $entry) {
+        $aiEntries = array_filter($generated, fn ($e) => $e['teamId'] === $this->aiTeam->id);
+        foreach ($aiEntries as $entry) {
             $this->assertArrayHasKey('playerId', $entry);
             $this->assertArrayHasKey('playerName', $entry);
             $this->assertArrayHasKey('position', $entry);


### PR DESCRIPTION
- **Emergency squad replenishment:** SquadReplenishmentProcessor now includes the user’s team when squad drops below minimum (22) at season transition, signing emergency free agents as a safety net

- **Match forfeit**: MatchdayOrchestrator checks if the user has < 7 available players before simulation — match is recorded as a 0-3 forfeit per football rules

- **Contract expiry notifications**: Wired up the existing (but never called) notifyExpiringContract() in CareerActionProcessor, warning users about contracts expiring within 6 months