### PR TITLE
Fix cup extra time incorrectly triggered against teams with empty squads

### DIFF
--- a/app/Modules/Match/Services/MatchSimulator.php
+++ b/app/Modules/Match/Services/MatchSimulator.php
@@ -929,25 +929,9 @@ class MatchSimulator
             // One team has no players (e.g. lower-division cup opponent).
             // Generate goal events only for the team with players so that
             // goals are backed by events and survive resimulation.
-            $teamWithPlayers = $homePlayers->isNotEmpty() ? 'home' : 'away';
-            $scoringPlayers = $teamWithPlayers === 'home' ? $homePlayers : $awayPlayers;
-            $scoringTeamId = $teamWithPlayers === 'home' ? $homeTeam->id : $awayTeam->id;
-            $concedingTeamId = $teamWithPlayers === 'home' ? $awayTeam->id : $homeTeam->id;
-            $goalCount = $teamWithPlayers === 'home' ? $homeScore : $awayScore;
-
-            $maxGoalsCap = config('match_simulation.max_goals_cap', 0);
-            if ($maxGoalsCap > 0) {
-                $goalCount = min($goalCount, $maxGoalsCap);
-                if ($teamWithPlayers === 'home') {
-                    $homeScore = $goalCount;
-                } else {
-                    $awayScore = $goalCount;
-                }
-            }
-
-            $goalEvents = $this->generateGoalEventsInRange(
-                $goalCount, $scoringTeamId, $concedingTeamId,
-                $scoringPlayers, collect(), $fromMinute + 1, 93
+            [$homeScore, $awayScore, $goalEvents] = $this->generateSingleTeamGoalEvents(
+                $homeTeam, $awayTeam, $homePlayers, $awayPlayers,
+                $homeScore, $awayScore, $fromMinute + 1, 93,
             );
             $events = $events->merge($goalEvents)->sortBy('minute')->values();
         }
@@ -1185,6 +1169,46 @@ class MatchSimulator
         }
 
         return $candidates->sortByDesc(fn ($p) => $p->overall_score)->first();
+    }
+
+    /**
+     * Generate goal events when only one team has players (the other squad is empty).
+     * Applies max_goals_cap and returns updated scores alongside the events.
+     *
+     * @return array{0: int, 1: int, 2: Collection<MatchEventData>} [homeScore, awayScore, goalEvents]
+     */
+    private function generateSingleTeamGoalEvents(
+        Team $homeTeam,
+        Team $awayTeam,
+        Collection $homePlayers,
+        Collection $awayPlayers,
+        int $homeScore,
+        int $awayScore,
+        int $minMinute,
+        int $maxMinute,
+    ): array {
+        $homeHasPlayers = $homePlayers->isNotEmpty();
+        $scoringPlayers = $homeHasPlayers ? $homePlayers : $awayPlayers;
+        $scoringTeamId = $homeHasPlayers ? $homeTeam->id : $awayTeam->id;
+        $concedingTeamId = $homeHasPlayers ? $awayTeam->id : $homeTeam->id;
+        $goalCount = $homeHasPlayers ? $homeScore : $awayScore;
+
+        $maxGoalsCap = config('match_simulation.max_goals_cap', 0);
+        if ($maxGoalsCap > 0) {
+            $goalCount = min($goalCount, $maxGoalsCap);
+            if ($homeHasPlayers) {
+                $homeScore = $goalCount;
+            } else {
+                $awayScore = $goalCount;
+            }
+        }
+
+        $events = $this->generateGoalEventsInRange(
+            $goalCount, $scoringTeamId, $concedingTeamId,
+            $scoringPlayers, collect(), $minMinute, $maxMinute,
+        );
+
+        return [$homeScore, $awayScore, $events];
     }
 
     /**
@@ -1465,15 +1489,9 @@ class MatchSimulator
             );
         } elseif ($homePlayers->isNotEmpty() || $awayPlayers->isNotEmpty()) {
             // One team has no players — generate events only for the team with players.
-            $teamWithPlayers = $homePlayers->isNotEmpty() ? 'home' : 'away';
-            $scoringPlayers = $teamWithPlayers === 'home' ? $homePlayers : $awayPlayers;
-            $scoringTeamId = $teamWithPlayers === 'home' ? $homeTeam->id : $awayTeam->id;
-            $concedingTeamId = $teamWithPlayers === 'home' ? $awayTeam->id : $homeTeam->id;
-            $goalCount = $teamWithPlayers === 'home' ? $homeScore : $awayScore;
-
-            $goalEvents = $this->generateGoalEventsInRange(
-                $goalCount, $scoringTeamId, $concedingTeamId,
-                $scoringPlayers, collect(), $minMinute, $maxMinute
+            [$homeScore, $awayScore, $goalEvents] = $this->generateSingleTeamGoalEvents(
+                $homeTeam, $awayTeam, $homePlayers, $awayPlayers,
+                $homeScore, $awayScore, $minMinute, $maxMinute,
             );
             $events = $events->merge($goalEvents)->sortBy('minute')->values();
         }

--- a/tests/Traits/CreatesLineups.php
+++ b/tests/Traits/CreatesLineups.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Tests\Traits;
+
+use App\Models\Game;
+use App\Models\GamePlayer;
+use App\Models\Team;
+use Illuminate\Support\Collection;
+
+trait CreatesLineups
+{
+    /**
+     * Create a lineup of GamePlayers for a team.
+     */
+    private function createLineup(Game $game, Team $team, int $count = 11, int $ability = 70): Collection
+    {
+        $positions = [
+            'Goalkeeper',
+            'Centre-Back', 'Centre-Back', 'Left-Back', 'Right-Back',
+            'Central Midfield', 'Central Midfield', 'Defensive Midfield',
+            'Right Winger', 'Left Winger',
+            'Centre-Forward',
+        ];
+
+        $players = collect();
+        for ($i = 0; $i < $count; $i++) {
+            $player = GamePlayer::factory()
+                ->forGame($game)
+                ->forTeam($team)
+                ->create([
+                    'position' => $positions[$i] ?? 'Central Midfield',
+                    'game_technical_ability' => $ability,
+                    'game_physical_ability' => $ability,
+                    'fitness' => 95,
+                    'morale' => 80,
+                ]);
+
+            $player->setRelation('game', $game);
+            $players->push($player);
+        }
+
+        return $players;
+    }
+}

--- a/tests/Unit/EmptySquadSimulationTest.php
+++ b/tests/Unit/EmptySquadSimulationTest.php
@@ -3,15 +3,16 @@
 namespace Tests\Unit;
 
 use App\Models\Game;
-use App\Models\GamePlayer;
 use App\Models\Team;
 use App\Modules\Match\Services\MatchSimulator;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
+use Tests\Traits\CreatesLineups;
 
 class EmptySquadSimulationTest extends TestCase
 {
     use RefreshDatabase;
+    use CreatesLineups;
 
     private MatchSimulator $simulator;
 
@@ -19,36 +20,6 @@ class EmptySquadSimulationTest extends TestCase
     {
         parent::setUp();
         $this->simulator = new MatchSimulator;
-    }
-
-    private function createLineup(Game $game, Team $team, int $count = 11, int $ability = 70): \Illuminate\Support\Collection
-    {
-        $positions = [
-            'Goalkeeper',
-            'Centre-Back', 'Centre-Back', 'Left-Back', 'Right-Back',
-            'Central Midfield', 'Central Midfield', 'Defensive Midfield',
-            'Right Winger', 'Left Winger',
-            'Centre-Forward',
-        ];
-
-        $players = collect();
-        for ($i = 0; $i < $count; $i++) {
-            $player = GamePlayer::factory()
-                ->forGame($game)
-                ->forTeam($team)
-                ->create([
-                    'position' => $positions[$i] ?? 'Central Midfield',
-                    'game_technical_ability' => $ability,
-                    'game_physical_ability' => $ability,
-                    'fitness' => 95,
-                    'morale' => 80,
-                ]);
-
-            $player->setRelation('game', $game);
-            $players->push($player);
-        }
-
-        return $players;
     }
 
     public function test_empty_away_squad_always_scores_zero(): void

--- a/tests/Unit/RedCardSimulationTest.php
+++ b/tests/Unit/RedCardSimulationTest.php
@@ -15,10 +15,12 @@ use App\Modules\Match\Services\MatchSimulator;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use ReflectionMethod;
 use Tests\TestCase;
+use Tests\Traits\CreatesLineups;
 
 class RedCardSimulationTest extends TestCase
 {
     use RefreshDatabase;
+    use CreatesLineups;
 
     private MatchSimulator $simulator;
 
@@ -33,39 +35,6 @@ class RedCardSimulationTest extends TestCase
 
         $this->calculateTeamStrength = new ReflectionMethod(MatchSimulator::class, 'calculateTeamStrength');
         $this->simulateGoalsWithRedCardSplit = new ReflectionMethod(MatchSimulator::class, 'simulateGoalsWithRedCardSplit');
-    }
-
-    /**
-     * Create a lineup of GamePlayers for a team.
-     */
-    private function createLineup(Game $game, Team $team, int $count = 11, int $ability = 70): \Illuminate\Support\Collection
-    {
-        $positions = [
-            'Goalkeeper',
-            'Centre-Back', 'Centre-Back', 'Left-Back', 'Right-Back',
-            'Central Midfield', 'Central Midfield', 'Defensive Midfield',
-            'Right Winger', 'Left Winger',
-            'Centre-Forward',
-        ];
-
-        $players = collect();
-        for ($i = 0; $i < $count; $i++) {
-            $player = GamePlayer::factory()
-                ->forGame($game)
-                ->forTeam($team)
-                ->create([
-                    'position' => $positions[$i] ?? 'Central Midfield',
-                    'game_technical_ability' => $ability,
-                    'game_physical_ability' => $ability,
-                    'fitness' => 95,
-                    'morale' => 80,
-                ]);
-
-            $player->setRelation('game', $game);
-            $players->push($player);
-        }
-
-        return $players;
     }
 
     public function test_team_strength_with_10_players_is_not_amateur_fallback(): void


### PR DESCRIPTION
When a cup match opponent has no GamePlayer records (lower-division teams),
the simulator generated Poisson-random goals but no match events. If the
user made a substitution or tactical change, the resimulation would
recalculate scores from events (finding 0-0) and generate a new independent
random result — losing the original score entirely. This could turn a
decisive win into a draw and incorrectly trigger extra time.

Two fixes:
1. Force 0 goals for any team with an empty player collection — a team
   with no players on the pitch cannot score.
2. Generate goal events for the team that HAS players even when the
   opponent has none, so goals survive resimulation.