### PR TITLE
Add ability to reject incoming counter transfer offers

### DIFF
--- a/app/Http/Actions/RejectCounterOffer.php
+++ b/app/Http/Actions/RejectCounterOffer.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Http\Actions;
+
+use App\Modules\Transfer\Services\TransferService;
+use App\Models\Game;
+use App\Models\TransferOffer;
+use Illuminate\Http\RedirectResponse;
+
+class RejectCounterOffer
+{
+    public function __construct(
+        private readonly TransferService $transferService,
+    ) {}
+
+    public function __invoke(string $gameId, string $offerId): RedirectResponse
+    {
+        $game = Game::findOrFail($gameId);
+        $offer = TransferOffer::with('gamePlayer.player')->where('game_id', $gameId)->findOrFail($offerId);
+
+        if (!$offer->isPending() || !$offer->isIncoming()) {
+            return redirect()->route('game.transfers', $gameId)
+                ->with('error', __('messages.counter_offer_expired'));
+        }
+
+        $playerName = $offer->gamePlayer->player->name ?? 'Player';
+
+        $this->transferService->rejectOffer($offer);
+
+        return redirect()->route('game.transfers', $gameId)
+            ->with('success', __('messages.counter_offer_rejected', ['player' => $playerName]));
+    }
+}

--- a/lang/en/messages.php
+++ b/lang/en/messages.php
@@ -26,6 +26,7 @@ return [
     // Counter offer
     'counter_offer_accepted' => 'Counter offer accepted! :player will join when the :window window opens.',
     'counter_offer_accepted_immediate' => 'Transfer complete! :player has joined your squad.',
+    'counter_offer_rejected' => 'You rejected the counter offer for :player.',
     'counter_offer_expired' => 'This offer is no longer available.',
 
     // Loan messages

--- a/lang/en/transfers.php
+++ b/lang/en/transfers.php
@@ -122,6 +122,7 @@ return [
     'counter_offer_received' => 'Counter Offer Received',
     'transfer_agreed' => 'Transfer Agreed',
     'accept_counter' => 'Accept Counter Offer',
+    'reject_counter' => 'Reject',
     'already_bidding' => 'You already have a bid for this player',
     'scouting_assessment' => 'Scouting Assessment',
     'financial_details' => 'Financial Details',

--- a/lang/es/messages.php
+++ b/lang/es/messages.php
@@ -26,6 +26,7 @@ return [
     // Counter offer
     'counter_offer_accepted' => '¡Contraoferta aceptada! :player se unirá cuando abra la ventana de :window.',
     'counter_offer_accepted_immediate' => '¡Fichaje completado! :player se ha unido a tu plantilla.',
+    'counter_offer_rejected' => 'Has rechazado la contraoferta por :player.',
     'counter_offer_expired' => 'Esta oferta ya no está disponible.',
 
     // Loan messages

--- a/lang/es/transfers.php
+++ b/lang/es/transfers.php
@@ -123,6 +123,7 @@ return [
     'counter_offer_received' => 'Contraoferta Recibida',
     'transfer_agreed' => 'Fichaje Acordado',
     'accept_counter' => 'Aceptar Contraoferta',
+    'reject_counter' => 'Rechazar',
     'already_bidding' => 'Ya tienes una oferta por este jugador',
     'scouting_assessment' => 'Evaluación del Ojeador',
     'financial_details' => 'Detalles Financieros',

--- a/resources/views/incoming-transfers.blade.php
+++ b/resources/views/incoming-transfers.blade.php
@@ -121,10 +121,16 @@
                                                 <div class="md:text-right">
                                                     <div class="text-xl font-bold text-accent-red">{{ \App\Support\Money::format($bid->asking_price) }}</div>
                                                 </div>
-                                                <form method="post" action="{{ route('game.scouting.counter.accept', [$game->id, $bid->id]) }}">
-                                                    @csrf
-                                                    <x-primary-button color="green">{{ __('transfers.accept_counter') }}</x-primary-button>
-                                                </form>
+                                                <div class="flex items-center gap-2">
+                                                    <form method="post" action="{{ route('game.scouting.counter.reject', [$game->id, $bid->id]) }}">
+                                                        @csrf
+                                                        <x-ghost-button color="red">{{ __('transfers.reject_counter') }}</x-ghost-button>
+                                                    </form>
+                                                    <form method="post" action="{{ route('game.scouting.counter.accept', [$game->id, $bid->id]) }}">
+                                                        @csrf
+                                                        <x-primary-button color="green">{{ __('transfers.accept_counter') }}</x-primary-button>
+                                                    </form>
+                                                </div>
                                             </div>
                                         </div>
                                     </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -31,6 +31,7 @@ use App\Http\Actions\ListPlayerForTransfer;
 use App\Http\Actions\AcceptRenewalCounter;
 use App\Http\Actions\SubmitRenewalOffer;
 use App\Http\Actions\ReleasePlayer;
+use App\Http\Actions\RejectCounterOffer;
 use App\Http\Actions\RejectTransferOffer;
 use App\Http\Actions\RequestLoan;
 use App\Http\Actions\SaveLineup;
@@ -167,6 +168,7 @@ Route::middleware('auth')->group(function () {
         Route::post('/game/{gameId}/scouting/{playerId}/sign-free-agent', SignFreeAgent::class)->name('game.scouting.sign-free-agent');
         Route::post('/game/{gameId}/scouting/{playerId}/pre-contract', SubmitPreContractOffer::class)->name('game.scouting.pre-contract');
         Route::post('/game/{gameId}/scouting/counter/{offerId}/accept', AcceptCounterOffer::class)->name('game.scouting.counter.accept');
+        Route::post('/game/{gameId}/scouting/counter/{offerId}/reject', RejectCounterOffer::class)->name('game.scouting.counter.reject');
         Route::post('/game/{gameId}/scouting/shortlist/{playerId}', ToggleShortlist::class)->name('game.scouting.shortlist.toggle');
         Route::post('/game/{gameId}/scouting/shortlist/{playerId}/remove', RemoveFromShortlist::class)->name('game.scouting.shortlist.remove');
         Route::post('/game/{gameId}/scouting/track/{playerId}/start', StartPlayerTracking::class)->name('game.scouting.track.start');


### PR DESCRIPTION
## Summary
This PR adds functionality for users to reject incoming counter transfer offers, complementing the existing accept counter offer feature.

## Key Changes
- **New Action Class**: Created `RejectCounterOffer` action that validates the offer is pending and incoming before rejection
- **UI Update**: Modified incoming transfers view to display both "Reject" and "Accept" buttons side-by-side for counter offers
- **Route Addition**: Added new POST route `game.scouting.counter.reject` to handle counter offer rejections
- **Localization**: Added translation strings for rejection confirmation messages in English and Spanish

## Implementation Details
- The `RejectCounterOffer` action validates that offers are still pending and incoming before allowing rejection, preventing rejection of expired or outgoing offers
- Uses the existing `TransferService::rejectOffer()` method to handle the business logic
- Provides user feedback with localized success messages that include the player's name
- The UI now presents both action options in a flex container, allowing users to easily accept or reject counter offers

https://claude.ai/code/session_01RtgoXsVbtaKwvTZajG3Ut9