### PR TITLE
Prevent sent-off players from being injured in match simulation

### DIFF
--- a/app/Modules/Match/Services/MatchSimulator.php
+++ b/app/Modules/Match/Services/MatchSimulator.php
@@ -821,13 +821,20 @@ class MatchSimulator
             $awayCardEvents = $this->generateCardEventsInRange($awayTeam->id, $awayPlayers, $goalDifference, $fromMinute + 1, 93, $matchFraction, $existingYellowPlayerIds);
             $events = $events->merge($homeCardEvents)->merge($awayCardEvents);
 
+            // Exclude sent-off players from injury generation
+            $sentOffPlayerIds = $events->filter(fn ($e) => $e->type === 'red_card')
+                ->pluck('gamePlayerId')
+                ->all();
+            $homePlayersForInjury = $homePlayers->reject(fn ($p) => in_array($p->id, $sentOffPlayerIds));
+            $awayPlayersForInjury = $awayPlayers->reject(fn ($p) => in_array($p->id, $sentOffPlayerIds));
+
             // Generate injuries and auto-substitute before goal generation
             // so team strength reflects the replacement player
             $injuryMaxMinute = 85;
             $lineupChanged = false;
 
             if (! in_array($homeTeam->id, $existingInjuryTeamIds) && $fromMinute + 1 <= $injuryMaxMinute) {
-                $homeInjuryEvents = $this->generateInjuryEventsInRange($homeTeam->id, $homePlayers, $fromMinute + 1, $injuryMaxMinute, $game);
+                $homeInjuryEvents = $this->generateInjuryEventsInRange($homeTeam->id, $homePlayersForInjury, $fromMinute + 1, $injuryMaxMinute, $game);
                 $events = $events->merge($homeInjuryEvents);
                 if ($homeInjuryEvents->isNotEmpty() && $homeBenchPlayers !== null && $homeBenchPlayers->isNotEmpty()) {
                     [$subEvents, $homePlayers, $homeBenchPlayers] = $this->processInjurySubstitution(
@@ -840,7 +847,7 @@ class MatchSimulator
                 }
             }
             if (! in_array($awayTeam->id, $existingInjuryTeamIds) && $fromMinute + 1 <= $injuryMaxMinute) {
-                $awayInjuryEvents = $this->generateInjuryEventsInRange($awayTeam->id, $awayPlayers, $fromMinute + 1, $injuryMaxMinute, $game);
+                $awayInjuryEvents = $this->generateInjuryEventsInRange($awayTeam->id, $awayPlayersForInjury, $fromMinute + 1, $injuryMaxMinute, $game);
                 $events = $events->merge($awayInjuryEvents);
                 if ($awayInjuryEvents->isNotEmpty() && $awayBenchPlayers !== null && $awayBenchPlayers->isNotEmpty()) {
                     [$subEvents, $awayPlayers, $awayBenchPlayers] = $this->processInjurySubstitution(


### PR DESCRIPTION
## Summary
Fixed a logic issue in the match simulator where players who were sent off (red card) could still be selected for injury events in the remainder of the match. This is unrealistic since sent-off players are no longer on the field.

## Changes
- Extract player IDs of sent-off players from generated red card events
- Filter out sent-off players from both home and away player lists before generating injury events
- Pass the filtered player lists to `generateInjuryEventsInRange()` for both teams

## Implementation Details
The fix identifies all players with red cards in the current event batch and excludes them from the injury generation pool. This ensures that only active players on the field can be injured, maintaining match simulation realism and preventing invalid game states where sent-off players receive injury events.

https://claude.ai/code/session_01MNru7Ku6cCRdokyxybx4dw