### PR TITLE
Use position-badge component in lineup player list for colored positions

### DIFF
--- a/resources/views/lineup.blade.php
+++ b/resources/views/lineup.blade.php
@@ -463,7 +463,6 @@
                                                     $matchData['count'] ?? null,
                                                     $matchData['approx'] ?? false,
                                                 );
-                                                $posAbbrev = \App\Support\PositionMapper::toAbbreviation($player->position);
                                                 $posGroup = \App\Support\PositionMapper::getPositionGroup($player->position);
                                             @endphp
                                             <div
@@ -489,7 +488,7 @@
                                                             @endif
                                                         </div>
                                                         <div class="flex items-center gap-2 mt-0.5">
-                                                            <span class="text-[9px] text-text-muted font-heading uppercase">{{ $posAbbrev }}</span>
+                                                            <x-position-badge :position="$player->position" size="sm" />
                                                             @if(!$isUnavailable)
                                                             <div class="flex items-center gap-1">
                                                                 <div class="w-8 h-1 rounded-full bg-surface-600 overflow-hidden">


### PR DESCRIPTION
Replace plain text position abbreviations with the <x-position-badge> component in the lineup view's player list, matching the color-coded style used elsewhere (GK=amber, DEF=blue, MID=green, FWD=red).

https://claude.ai/code/session_0153PxNGdY1NDcLqm9BHwrgv