### PR TITLE
Improve season transition timing and error diagnostics

### DIFF
--- a/app/Modules/Competition/Promotions/ConfigDrivenPromotionRule.php
+++ b/app/Modules/Competition/Promotions/ConfigDrivenPromotionRule.php
@@ -72,7 +72,7 @@ class ConfigDrivenPromotionRule implements PromotionRelegationRule
                 }
             }
 
-            $this->validateTeamCount($promoted, $expectedCount, 'promoted', $this->bottomDivision);
+            $this->validateTeamCount($promoted, $expectedCount, 'promoted', $this->bottomDivision, $game);
 
             return $promoted;
         }
@@ -82,7 +82,7 @@ class ConfigDrivenPromotionRule implements PromotionRelegationRule
 
         $promoted = $this->getEligibleSimulatedPromotions($game, $totalPromoted);
 
-        $this->validateTeamCount($promoted, $expectedCount, 'promoted', $this->bottomDivision);
+        $this->validateTeamCount($promoted, $expectedCount, 'promoted', $this->bottomDivision, $game);
 
         return $promoted;
     }
@@ -99,7 +99,7 @@ class ConfigDrivenPromotionRule implements PromotionRelegationRule
         );
 
         if (!empty($relegated)) {
-            $this->validateTeamCount($relegated, $expectedCount, 'relegated', $this->topDivision);
+            $this->validateTeamCount($relegated, $expectedCount, 'relegated', $this->topDivision, $game);
 
             return $relegated;
         }
@@ -107,7 +107,7 @@ class ConfigDrivenPromotionRule implements PromotionRelegationRule
         // Fall back to simulated results
         $relegated = $this->getSimulatedTeamsByPosition($game, $this->topDivision, $this->relegatedPositions);
 
-        $this->validateTeamCount($relegated, $expectedCount, 'relegated', $this->topDivision);
+        $this->validateTeamCount($relegated, $expectedCount, 'relegated', $this->topDivision, $game);
 
         return $relegated;
     }
@@ -120,16 +120,27 @@ class ConfigDrivenPromotionRule implements PromotionRelegationRule
      * @param  string  $type  'promoted' or 'relegated'
      * @param  string  $competitionId  The competition being queried
      */
-    private function validateTeamCount(array $teams, int $expectedCount, string $type, string $competitionId): void
+    private function validateTeamCount(array $teams, int $expectedCount, string $type, string $competitionId, ?Game $game = null): void
     {
         if (count($teams) !== $expectedCount) {
             $teamIds = array_column($teams, 'teamId');
+            $season = $game?->season ?? 'unknown';
+
+            $standingsCount = $game ? GameStanding::where('game_id', $game->id)
+                ->where('competition_id', $competitionId)->count() : 'N/A';
+
+            $simulatedExists = $game ? SimulatedSeason::where('game_id', $game->id)
+                ->where('season', $season)
+                ->where('competition_id', $competitionId)
+                ->exists() : false;
 
             throw new \RuntimeException(
                 "Promotion/relegation imbalance: expected {$expectedCount} {$type} teams " .
                 "from {$competitionId}, got " . count($teams) . ". " .
                 "Team IDs: " . json_encode($teamIds) . ". " .
-                "Divisions: {$this->topDivision} <-> {$this->bottomDivision}."
+                "Divisions: {$this->topDivision} <-> {$this->bottomDivision}. " .
+                "Season: {$season}. Standings rows: {$standingsCount}. " .
+                "Simulated data exists: " . ($simulatedExists ? 'yes' : 'no') . "."
             );
         }
     }

--- a/app/Modules/Season/Jobs/ProcessSeasonTransition.php
+++ b/app/Modules/Season/Jobs/ProcessSeasonTransition.php
@@ -40,6 +40,11 @@ class ProcessSeasonTransition implements ShouldQueue
         // Phase 1: Close old season
         $data = $closingPipeline->run($game);
 
+        // Advance game to the new season (after closing processors finish,
+        // so they all see the old season when looking up simulated data)
+        $game->refresh()->setRelations([]);
+        $game->update(['season' => $data->newSeason]);
+
         // Phase 2: Set up new season
         $game->refresh()->setRelations([]);
         $setupPipeline->run($game, $data);

--- a/app/Modules/Season/Processors/SeasonSimulationProcessor.php
+++ b/app/Modules/Season/Processors/SeasonSimulationProcessor.php
@@ -9,6 +9,7 @@ use App\Models\Competition;
 use App\Models\CompetitionEntry;
 use App\Models\Game;
 use App\Models\GameStanding;
+use Illuminate\Support\Facades\Log;
 
 /**
  * Generates simulated standings for non-played leagues at season end.
@@ -60,7 +61,14 @@ class SeasonSimulationProcessor implements SeasonProcessor
                 ->exists();
 
             if (!$hasRealStandings) {
-                $this->simulationService->simulateLeague($game, $league);
+                $simulated = $this->simulationService->simulateLeague($game, $league);
+
+                Log::info('Simulated league season', [
+                    'game_id' => $game->id,
+                    'season' => $game->season,
+                    'competition_id' => $league->id,
+                    'result_count' => count($simulated->results ?? []),
+                ]);
             }
         }
     }

--- a/app/Modules/Season/Processors/StatsResetProcessor.php
+++ b/app/Modules/Season/Processors/StatsResetProcessor.php
@@ -50,10 +50,9 @@ class StatsResetProcessor implements SeasonProcessor
             ->unread()
             ->update(['read_at' => now()]);
 
-        // Reset game state
+        // Reset matchday counter (season is advanced later, after the closing pipeline)
         $game->update([
             'current_matchday' => 0,
-            'season' => $data->newSeason,
         ]);
 
         return $data;


### PR DESCRIPTION
## Summary
This PR refactors the season transition process to advance the game season at the correct point in the pipeline, and enhances error diagnostics for promotion/relegation validation failures.

## Key Changes

- **Season advancement timing**: Moved season update to occur after the closing pipeline completes but before the setup pipeline runs. This ensures all closing processors (including simulation) see the old season when looking up simulated data, preventing race conditions and data consistency issues.

- **Enhanced validation diagnostics**: Updated `validateTeamCount()` to accept an optional `Game` parameter and now includes additional context in error messages:
  - Current season information
  - Count of standings rows in the database
  - Whether simulated season data exists for the competition
  
  This provides better debugging information when promotion/relegation imbalance errors occur.

- **Simulation logging**: Added info-level logging in `SeasonSimulationProcessor` to track when leagues are simulated, including game ID, season, competition ID, and result count.

- **Cleanup**: Removed redundant season update from `StatsResetProcessor` since it's now handled in the job orchestration layer.

## Implementation Details

The season advancement is now explicitly managed in `ProcessSeasonTransition.handle()` with a refresh and relation clearing to ensure a clean state. All four calls to `validateTeamCount()` have been updated to pass the `Game` object for enhanced error context.

https://claude.ai/code/session_01WtTw2JjBuDx9S1hggeLxMN