### PR TITLE
Rebalance injury system to reduce overall injury frequency

### DIFF
--- a/app/Modules/Player/Services/InjuryService.php
+++ b/app/Modules/Player/Services/InjuryService.php
@@ -13,13 +13,13 @@ class InjuryService
     /**
      * Base injury chance per player per match (percentage).
      */
-    private const BASE_INJURY_CHANCE = 1.2;
+    private const BASE_INJURY_CHANCE = 0.8;
 
     /**
      * Base training injury chance per player per matchday (percentage).
      * Applies to all squad members (playing and non-playing).
      */
-    private const TRAINING_INJURY_CHANCE = 1.5;
+    private const TRAINING_INJURY_CHANCE = 0.6;
 
     /**
      * Medical tier multipliers for injury prevention.
@@ -143,8 +143,8 @@ class InjuryService
      * Durability multipliers based on player's hidden durability attribute (1-100).
      */
     private const DURABILITY_THRESHOLDS = [
-        ['max' => 20, 'multiplier' => 2.0],   // Very injury prone
-        ['max' => 40, 'multiplier' => 1.5],   // Injury prone
+        ['max' => 20, 'multiplier' => 1.6],   // Very injury prone
+        ['max' => 40, 'multiplier' => 1.3],   // Injury prone
         ['max' => 60, 'multiplier' => 1.0],   // Average
         ['max' => 80, 'multiplier' => 0.7],   // Resilient
         ['max' => 100, 'multiplier' => 0.4],  // Ironman
@@ -154,19 +154,19 @@ class InjuryService
      * Age multipliers for injury risk.
      */
     private const AGE_THRESHOLDS = [
-        ['max' => 20, 'multiplier' => 1.3],   // Young, still developing
+        ['max' => 20, 'multiplier' => 1.1],   // Young, still developing
         ['max' => 29, 'multiplier' => 1.0],   // Prime years
-        ['max' => 32, 'multiplier' => 1.2],   // Early decline
-        ['max' => 99, 'multiplier' => 1.5],   // Veteran
+        ['max' => 32, 'multiplier' => 1.1],   // Early decline
+        ['max' => 99, 'multiplier' => 1.3],   // Veteran
     ];
 
     /**
      * Fitness multipliers for injury risk.
      */
     private const FITNESS_THRESHOLDS = [
-        ['max' => 30, 'multiplier' => 2.5],   // Exhausted
-        ['max' => 50, 'multiplier' => 2.0],   // Very tired
-        ['max' => 70, 'multiplier' => 1.5],   // Tired
+        ['max' => 30, 'multiplier' => 2.0],   // Exhausted
+        ['max' => 50, 'multiplier' => 1.5],   // Very tired
+        ['max' => 70, 'multiplier' => 1.2],   // Tired
         ['max' => 85, 'multiplier' => 1.0],   // Normal
         ['max' => 100, 'multiplier' => 0.8],  // Fresh
     ];
@@ -339,11 +339,11 @@ class InjuryService
         $daysSinceLastMatch = $lastMatchDate->diffInDays($currentMatchDate);
 
         if ($daysSinceLastMatch <= 2) {
-            return 2.0; // Back-to-back games
+            return 1.6; // Back-to-back games
         } elseif ($daysSinceLastMatch <= 3) {
-            return 1.5; // Very congested
+            return 1.3; // Very congested
         } elseif ($daysSinceLastMatch <= 4) {
-            return 1.2; // Slightly congested
+            return 1.1; // Slightly congested
         }
 
         return 1.0; // Normal rest

--- a/config/match_simulation.php
+++ b/config/match_simulation.php
@@ -78,8 +78,8 @@ return [
     'assist_chance' => 60.0,            // % chance a goal has an assist
     'yellow_cards_per_team' => 1.4,     // Average yellow cards per team per match
     'direct_red_chance' => 0.5,         // % chance of direct red card per team
-    'injury_chance' => 1.2,             // % chance of injury per player per match
-    'training_injury_chance' => 1.5,    // % chance of training injury per player per matchday (all squad members)
+    'injury_chance' => 0.8,             // % chance of injury per player per match
+    'training_injury_chance' => 0.6,    // % chance of training injury per player per matchday (all squad members)
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
This PR reduces injury rates across the game by lowering base injury chances and adjusting multipliers for various injury risk factors. The changes aim to create a more balanced gameplay experience with fewer injuries overall.

## Key Changes
- **Base injury rates**: Reduced match injury chance from 1.2% to 0.8% and training injury chance from 1.5% to 0.6%
- **Durability multipliers**: Lowered multipliers for injury-prone players (very injury prone: 2.0→1.6, injury prone: 1.5→1.3)
- **Age-based multipliers**: Reduced injury risk for young players (1.3→1.1) and early decline players (1.2→1.1), while slightly reducing veteran risk (1.5→1.3)
- **Fitness multipliers**: Decreased injury risk across all fitness levels (exhausted: 2.5→2.0, very tired: 2.0→1.5, tired: 1.5→1.2)
- **Match congestion multipliers**: Reduced injury risk from fixture congestion (back-to-back: 2.0→1.6, very congested: 1.5→1.3, slightly congested: 1.2→1.1)
- **Config synchronization**: Updated `config/match_simulation.php` to reflect the new base injury rates

## Implementation Details
All changes maintain the relative hierarchy of risk factors while proportionally reducing the overall injury impact. The adjustments are consistent across both the service layer and configuration files, ensuring the system behaves as intended.

https://claude.ai/code/session_01QaJ7cereu1zWos9SP9aJ5v