### PR TITLE
Add realistic contract negotiation rules: salary floor, reduced flexibility, ambition penalty

### DIFF
--- a/app/Modules/Transfer/Services/ContractService.php
+++ b/app/Modules/Transfer/Services/ContractService.php
@@ -4,9 +4,11 @@ namespace App\Modules\Transfer\Services;
 
 use App\Models\Competition;
 use App\Models\FinancialTransaction;
+use App\Models\ClubProfile;
 use App\Models\Game;
 use App\Models\GameNotification;
 use App\Models\GamePlayer;
+use App\Models\TeamReputation;
 use App\Models\RenewalNegotiation;
 use App\Models\Team;
 use App\Models\TransferOffer;
@@ -68,6 +70,9 @@ class ContractService
         37 => 4.00,  // Significant legacy premium
         38 => 7.00,  // Legends like Modric
     ];
+
+    private const FLEXIBILITY_RATIO = 0.18;
+    private const AMBITION_PENALTY_PER_TIER_GAP = 0.12;
 
     /**
      * Calculate annual wage for a player based on market value and age.
@@ -507,6 +512,16 @@ class ContractService
             }
         }
 
+        // Ambition: players too good for their team's reputation want to move up
+        $reputationLevel = TeamReputation::resolveLevel($player->game_id, $player->team_id);
+        $teamReputationIndex = ClubProfile::getReputationTierIndex($reputationLevel); // 0-4
+        $playerTierIndex = $player->tier - 1; // normalize to 0-4
+
+        $tierGap = $playerTierIndex - $teamReputationIndex;
+        if ($tierGap > 0) {
+            $disposition -= $tierGap * self::AMBITION_PENALTY_PER_TIER_GAP;
+        }
+
         return max(0.10, min(0.95, $disposition));
     }
 
@@ -587,8 +602,15 @@ class ContractService
         $disposition = $this->calculateDisposition($player, $negotiation->round);
 
         // Calculate minimum acceptable wage
-        $flexibility = $disposition * 0.30;
+        $flexibility = $disposition * self::FLEXIBILITY_RATIO;
         $minimumAcceptable = (int) ($negotiation->player_demand * (1.0 - $flexibility));
+
+        // Salary floor: players don't take pay cuts
+        // Exception: veterans (33+) with high morale value stability over money
+        $age = $player->age($player->game->current_date);
+        if (!($age >= 33 && $player->morale >= 70)) {
+            $minimumAcceptable = max($minimumAcceptable, $player->annual_wage);
+        }
 
         // Apply years modifier to effective offer
         $yearsModifier = $this->calculateYearsModifier($negotiation->offered_years, $negotiation->preferred_years);

--- a/docs/game-systems/transfer-market.md
+++ b/docs/game-systems/transfer-market.md
@@ -47,7 +47,9 @@ Annual wages are calculated from market value (tiered percentage) × age modifie
 
 ### Renewals
 
-Multi-round negotiation. The player's **disposition** (flexibility) is influenced by morale, appearances, age, negotiation round, and whether they have pending pre-contract offers. Disposition determines how far below their demand they'll accept. Offering more/fewer contract years also adjusts the effective offer. See `ContractService`.
+Multi-round negotiation. The player's **disposition** (flexibility) is influenced by morale, appearances, age, negotiation round, whether they have pending pre-contract offers, and **ambition** (tier gap between player and team reputation — high-tier players at low-reputation clubs are progressively harder to retain). Disposition determines how far below their demand they'll accept (max ~17% discount). Offering more/fewer contract years also adjusts the effective offer.
+
+Players will not accept wages below their current salary (**salary floor**), except veterans (33+) with high morale who value stability over money. See `ContractService`.
 
 ### Pre-Contracts
 


### PR DESCRIPTION
Players no longer accept wages below their current salary (unless 33+ with high morale), flexibility is reduced from 30% to 18%, and high-tier players at low-reputation clubs receive a disposition penalty that makes renewal progressively harder as the tier gap grows.