### PR TITLE
Centralize player age thresholds in PlayerAge value object

### DIFF
--- a/app/Http/Views/ShowSquad.php
+++ b/app/Http/Views/ShowSquad.php
@@ -6,7 +6,7 @@ use App\Models\AcademyPlayer;
 use App\Models\Game;
 use App\Models\GameMatch;
 use App\Models\GamePlayer;
-use App\Modules\Player\Services\DevelopmentCurve;
+use App\Modules\Player\PlayerAge;
 use App\Modules\Player\Services\InjuryService;
 use App\Modules\Player\Services\PlayerDevelopmentService;
 use App\Modules\Transfer\Services\ContractService;
@@ -36,8 +36,12 @@ class ShowSquad
         // Pre-compute matches missed for injured players
         $matchesMissedMap = InjuryService::getMatchesMissedMap($gameId, $game->team_id, $game->current_date, $allPlayers);
 
-        // Enrich each player with computed data
-        $allPlayers->each(function (GamePlayer $player) use ($game, $seasonEndDate, $nextMatchday, $matchesMissedMap) {
+        // Enrich each player with computed data and count age distribution in a single pass
+        $youngCount = 0;
+        $primeCount = 0;
+        $veteranCount = 0;
+
+        $allPlayers->each(function (GamePlayer $player) use ($game, $seasonEndDate, $nextMatchday, $matchesMissedMap, &$youngCount, &$primeCount, &$veteranCount) {
             // Availability
             $matchData = $matchesMissedMap[$player->id] ?? null;
             $player->setAttribute('is_unavailable', !$player->isAvailable($game->current_date, $nextMatchday));
@@ -46,8 +50,18 @@ class ShowSquad
             ));
 
             // Development projection
+            $age = $player->age($game->current_date);
             $player->setAttribute('projection', $this->developmentService->getNextSeasonProjection($player));
-            $player->setAttribute('dev_status', DevelopmentCurve::getStatus($player->age($game->current_date)));
+            $player->setAttribute('dev_status', PlayerAge::developmentStatus($age));
+
+            // Age distribution
+            if (PlayerAge::isYoung($age)) {
+                $youngCount++;
+            } elseif (PlayerAge::isPrime($age)) {
+                $primeCount++;
+            } else {
+                $veteranCount++;
+            }
 
             // Computed stats
             $player->setAttribute('goal_contributions', $player->goals + $player->assists);
@@ -81,12 +95,6 @@ class ShowSquad
         $lowFitnessCount = $allPlayers->filter(fn ($p) => $p->fitness < 70)->count();
         $lowMoraleCount = $allPlayers->filter(fn ($p) => $p->morale < 65)->count();
         $injuredCount = $allPlayers->filter(fn ($p) => $p->isInjured($game->current_date))->count();
-
-        // Age distribution
-        $currentDate = $game->current_date;
-        $youngCount = $allPlayers->filter(fn ($p) => $p->age($currentDate) <= 23)->count();
-        $primeCount = $allPlayers->filter(fn ($p) => $p->age($currentDate) >= 24 && $p->age($currentDate) <= 31)->count();
-        $veteranCount = $allPlayers->filter(fn ($p) => $p->age($currentDate) >= 32)->count();
 
         // Career mode financial data
         $squadValue = 0;

--- a/app/Models/GamePlayer.php
+++ b/app/Models/GamePlayer.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Modules\Player\PlayerAge;
 use App\Modules\Player\Services\InjuryService;
 use App\Support\CountryCodeMapper;
 use App\Support\Money;
@@ -761,14 +762,7 @@ class GamePlayer extends Model
      */
     public function developmentStatus(Carbon|\DateTimeInterface $currentDate): string
     {
-        $age = $this->age($currentDate);
-        if ($age <= 23) {
-            return 'growing';
-        }
-        if ($age <= 28) {
-            return 'peak';
-        }
-        return 'declining';
+        return PlayerAge::developmentStatus($this->age($currentDate));
     }
 
     /**

--- a/app/Modules/Academy/Services/YouthAcademyService.php
+++ b/app/Modules/Academy/Services/YouthAcademyService.php
@@ -2,6 +2,7 @@
 
 namespace App\Modules\Academy\Services;
 
+use App\Modules\Player\PlayerAge;
 use App\Modules\Squad\DTOs\GeneratedPlayerData;
 use App\Models\AcademyPlayer;
 use App\Models\Game;
@@ -304,7 +305,7 @@ class YouthAcademyService
      */
     public static function mustDecide(AcademyPlayer $player): bool
     {
-        return $player->age >= 21;
+        return $player->age > PlayerAge::ACADEMY_END;
     }
 
     /**

--- a/app/Modules/Player/PlayerAge.php
+++ b/app/Modules/Player/PlayerAge.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Modules\Player;
+
+/**
+ * Single source of truth for player age category boundaries.
+ *
+ * Only lifecycle boundaries belong here. Per-year lookup tables
+ * (AGE_CURVES, AGE_WAGE_MODIFIERS, retirement probabilities)
+ * and match simulation config stay in their respective locations.
+ */
+final class PlayerAge
+{
+    // Career boundaries
+    public const ACADEMY_END = 20;        // 21+ must leave academy
+
+    // Development categories
+    public const YOUNG_END = 23;          // Growing phase ends
+    public const PRIME_END = 34;          // Peak phase ends; PRIME_END + 1 = veteran
+
+    // Retirement boundaries
+    public const MIN_RETIREMENT_OUTFIELD = 33;
+    public const MIN_RETIREMENT_GK = 35;
+    public const MAX_CAREER_OUTFIELD = 40;
+    public const MAX_CAREER_GK = 42;
+
+    /**
+     * Is the player in the growing phase?
+     */
+    public static function isYoung(int $age): bool
+    {
+        return $age <= self::YOUNG_END;
+    }
+
+    /**
+     * Is the player in the peak phase?
+     */
+    public static function isPrime(int $age): bool
+    {
+        return $age > self::YOUNG_END && $age <= self::PRIME_END;
+    }
+
+    /**
+     * Is the player in the veteran/declining phase?
+     */
+    public static function isVeteran(int $age): bool
+    {
+        return $age > self::PRIME_END;
+    }
+
+    /**
+     * Get development status label: 'growing', 'peak', or 'declining'.
+     */
+    public static function developmentStatus(int $age): string
+    {
+        if ($age <= self::YOUNG_END) {
+            return 'growing';
+        }
+
+        if ($age <= self::PRIME_END) {
+            return 'peak';
+        }
+
+        return 'declining';
+    }
+}

--- a/app/Modules/Player/Services/DevelopmentCurve.php
+++ b/app/Modules/Player/Services/DevelopmentCurve.php
@@ -112,20 +112,4 @@ final class DevelopmentCurve
     {
         return $seasonAppearances >= self::MIN_APPEARANCES_FOR_BONUS;
     }
-
-    /**
-     * Get development status label based on age.
-     */
-    public static function getStatus(int $age): string
-    {
-        if ($age <= 23) {
-            return 'growing';
-        }
-
-        if ($age <= 31) {
-            return 'peak';
-        }
-
-        return 'declining';
-    }
 }

--- a/app/Modules/Player/Services/InjuryService.php
+++ b/app/Modules/Player/Services/InjuryService.php
@@ -5,6 +5,7 @@ namespace App\Modules\Player\Services;
 use App\Models\Game;
 use App\Models\GameMatch;
 use App\Models\GamePlayer;
+use App\Modules\Player\PlayerAge;
 use Carbon\Carbon;
 use Illuminate\Support\Collection;
 
@@ -151,14 +152,9 @@ class InjuryService
     ];
 
     /**
-     * Age multipliers for injury risk.
+     * Age multipliers for injury risk, derived from PlayerAge boundaries.
+     * Young (still developing) and veteran players are more injury-prone.
      */
-    private const AGE_THRESHOLDS = [
-        ['max' => 20, 'multiplier' => 1.3],   // Young, still developing
-        ['max' => 29, 'multiplier' => 1.0],   // Prime years
-        ['max' => 32, 'multiplier' => 1.2],   // Early decline
-        ['max' => 99, 'multiplier' => 1.5],   // Veteran
-    ];
 
     /**
      * Fitness multipliers for injury risk.
@@ -269,9 +265,9 @@ class InjuryService
 
         // Older players take slightly longer to recover
         $age = $player->age($player->game->current_date);
-        if ($age >= 32) {
+        if ($age > PlayerAge::PRIME_END) {
             $baseWeeks = (int) ceil($baseWeeks * 1.2);
-        } elseif ($age >= 30) {
+        } elseif ($age > PlayerAge::YOUNG_END) {
             $baseWeeks = (int) ceil($baseWeeks * 1.1);
         }
 
@@ -304,13 +300,11 @@ class InjuryService
      */
     private function getAgeMultiplier(int $age): float
     {
-        foreach (self::AGE_THRESHOLDS as $threshold) {
-            if ($age <= $threshold['max']) {
-                return $threshold['multiplier'];
-            }
-        }
-
-        return 1.0;
+        return match (true) {
+            $age <= PlayerAge::ACADEMY_END => 1.3,  // Young, still developing
+            $age <= PlayerAge::PRIME_END => 1.0,    // Prime years
+            default => 1.5,                          // Veteran
+        };
     }
 
     /**

--- a/app/Modules/Player/Services/PlayerDevelopmentService.php
+++ b/app/Modules/Player/Services/PlayerDevelopmentService.php
@@ -3,6 +3,7 @@
 namespace App\Modules\Player\Services;
 
 use App\Models\GamePlayer;
+use App\Modules\Player\PlayerAge;
 use App\Modules\Player\Services\DevelopmentCurve;
 
 /**
@@ -142,7 +143,7 @@ class PlayerDevelopmentService
         $valueBonus = $this->getValuePotentialBonus($age, $marketValueCents);
 
         // Calculate potential range based on age
-        if ($age <= 20) {
+        if ($age <= PlayerAge::ACADEMY_END) {
             // Young players: high potential ceiling
             // Base range 8-20, plus value bonus for proven youngsters
             $basePotentialRange = rand(8, 20);
@@ -154,14 +155,14 @@ class PlayerDevelopmentService
             $basePotentialRange = rand(4, 12);
             $potentialRange = $basePotentialRange + (int) ($valueBonus * 0.6);
             $uncertainty = rand(4, 7);
-        } elseif ($age <= 31) {
+        } elseif ($age <= PlayerAge::PRIME_END) {
             // Peak players: small potential margin
             // Base range 0-5, plus small value bonus
             $basePotentialRange = rand(0, 5);
             $potentialRange = $basePotentialRange + (int) ($valueBonus * 0.3);
             $uncertainty = rand(2, 4);
         } else {
-            // Veterans (32+): potential reflects proven quality
+            // Veterans: potential reflects proven quality
             // Exceptional market value = they've proven their ceiling
             $potentialRange = $this->getVeteranPotentialBonus($age, $currentAbility, $marketValueCents);
             $uncertainty = 2; // Low uncertainty - we know what they can do
@@ -316,7 +317,7 @@ class PlayerDevelopmentService
                 'technical' => $projectedTech,
                 'physical' => $projectedPhys,
                 'overall' => (int) round(($projectedTech + $projectedPhys) / 2),
-                'status' => DevelopmentCurve::getStatus($age),
+                'status' => PlayerAge::developmentStatus($age),
             ];
 
             // Use projected values for next iteration

--- a/app/Modules/Player/Services/PlayerRetirementService.php
+++ b/app/Modules/Player/Services/PlayerRetirementService.php
@@ -3,6 +3,7 @@
 namespace App\Modules\Player\Services;
 
 use App\Models\GamePlayer;
+use App\Modules\Player\PlayerAge;
 
 class PlayerRetirementService
 {
@@ -35,18 +36,6 @@ class PlayerRetirementService
     ];
 
     /**
-     * Minimum age at which retirement can be considered.
-     */
-    private const MIN_RETIREMENT_AGE_OUTFIELD = 33;
-    private const MIN_RETIREMENT_AGE_GOALKEEPER = 35;
-
-    /**
-     * Age at which retirement is guaranteed.
-     */
-    private const MAX_CAREER_AGE_OUTFIELD = 40;
-    private const MAX_CAREER_AGE_GOALKEEPER = 42;
-
-    /**
      * Starter threshold: appearances that count as a regular starter.
      */
     private const STARTER_APPEARANCES = 25;
@@ -71,8 +60,8 @@ class PlayerRetirementService
         $age = $player->age($player->game->current_date);
         $isGoalkeeper = $player->position === 'Goalkeeper';
 
-        $minAge = $isGoalkeeper ? self::MIN_RETIREMENT_AGE_GOALKEEPER : self::MIN_RETIREMENT_AGE_OUTFIELD;
-        $maxAge = $isGoalkeeper ? self::MAX_CAREER_AGE_GOALKEEPER : self::MAX_CAREER_AGE_OUTFIELD;
+        $minAge = $isGoalkeeper ? PlayerAge::MIN_RETIREMENT_GK : PlayerAge::MIN_RETIREMENT_OUTFIELD;
+        $maxAge = $isGoalkeeper ? PlayerAge::MAX_CAREER_GK : PlayerAge::MAX_CAREER_OUTFIELD;
 
         // Too young to retire
         if ($age < $minAge) {

--- a/app/Modules/Player/Services/PlayerValuationService.php
+++ b/app/Modules/Player/Services/PlayerValuationService.php
@@ -2,6 +2,8 @@
 
 namespace App\Modules\Player\Services;
 
+use App\Modules\Player\PlayerAge;
+
 /**
  * Single source of truth for all ability <-> market value conversions.
  *
@@ -48,10 +50,8 @@ class PlayerValuationService
         $technical = (int) round($baseAbility + ($technicalRatio - 0.5) * $variance * 2);
         $physical = (int) round($baseAbility + (0.5 - $technicalRatio) * $variance * 2);
 
-        if ($age > 33) {
-            $physical = (int) round($physical * 0.92);
-        } elseif ($age > 30) {
-            $physical = (int) round($physical * 0.96);
+        if ($age > PlayerAge::PRIME_END) {
+            $physical = (int) round($physical * 0.90);
         }
 
         $technical = max(30, min(99, $technical));
@@ -94,7 +94,7 @@ class PlayerValuationService
         if ($previousAbility !== null) {
             $change = $averageAbility - $previousAbility;
 
-            if ($age <= 24 && $change > 0) {
+            if ($age <= PlayerAge::YOUNG_END && $change > 0) {
                 // Young players who improve get bigger boost (confirming potential)
                 $trendMultiplier = match (true) {
                     $change >= 5 => 1.4,
@@ -147,7 +147,7 @@ class PlayerValuationService
      */
     private function adjustAbilityForAge(int $rawAbility, int $marketValueCents, int $age): int
     {
-        if ($age < 23) {
+        if ($age < PlayerAge::YOUNG_END) {
             // Base cap increases with age: 17yo = 75, 22yo = 85
             $ageCap = 75 + ($age - 17) * 2;
 
@@ -165,7 +165,8 @@ class PlayerValuationService
             return min($rawAbility, $ageCap);
         }
 
-        if ($age <= 31) {
+        // Boost starts 3 years before official veteran age.
+        if ($age <= PlayerAge::PRIME_END - 3) {
             return $rawAbility;
         }
 

--- a/app/Modules/Transfer/Services/ContractService.php
+++ b/app/Modules/Transfer/Services/ContractService.php
@@ -3,6 +3,7 @@
 namespace App\Modules\Transfer\Services;
 
 use App\Models\Competition;
+use App\Modules\Player\PlayerAge;
 use App\Models\FinancialTransaction;
 use App\Models\ClubProfile;
 use App\Models\Game;
@@ -48,27 +49,18 @@ class ContractService
     ];
 
     /**
-     * Age-based wage modifiers.
+     * Age-based wage modifiers by PlayerAge tier.
      *
-     * Young players: Signed rookie contracts with no leverage - underpaid relative to value.
-     * Prime players: Fair market contracts.
-     * Veterans: Legacy contracts from peak years - overpaid relative to current value.
+     * Academy: Rookie contracts with no leverage - underpaid relative to value.
+     * Young: Developing players, still below market rate.
+     * Prime: Fair market contracts.
+     * Veteran: Legacy contracts from peak years - overpaid relative to current value.
      */
     private const AGE_WAGE_MODIFIERS = [
-        17 => 0.40,  // First pro contract, minimal leverage
-        18 => 0.50,
-        19 => 0.60,
-        20 => 0.70,
-        21 => 0.80,
-        22 => 0.90,
-        // 23-31: 1.0 (fair market)
-        32 => 1.30,  // Starting to be "overpaid" relative to declining value
-        33 => 1.60,
-        34 => 2.00,
-        35 => 2.50,
-        36 => 3.00,
-        37 => 4.00,  // Significant legacy premium
-        38 => 7.00,  // Legends like Modric
+        'academy' => 0.60,
+        'young' => 0.85,
+        'prime' => 1.0,
+        'veteran' => 5.0,
     ];
 
     private const FLEXIBILITY_RATIO = 0.18;
@@ -109,38 +101,24 @@ class ContractService
     }
 
     /**
-     * Get age-based wage modifier.
+     * Get age-based wage modifier using PlayerAge tiers.
      *
-     * @param int|null $age
-     * @return float Multiplier (0.4 for 17yo rookies to 7.0 for 38yo legends)
+     * @return float Multiplier (0.60 for academy to 5.0 for veterans)
      */
     private function getAgeWageModifier(?int $age): float
     {
         if ($age === null) {
-            return 1.0; // Default to prime-age modifier
+            return self::AGE_WAGE_MODIFIERS['prime'];
         }
 
-        // Check exact age match
-        if (isset(self::AGE_WAGE_MODIFIERS[$age])) {
-            return self::AGE_WAGE_MODIFIERS[$age];
-        }
+        $tier = match (true) {
+            $age <= PlayerAge::ACADEMY_END => 'academy',
+            $age <= PlayerAge::YOUNG_END => 'young',
+            $age <= PlayerAge::PRIME_END => 'prime',
+            default => 'veteran',
+        };
 
-        // Young players under 17: use 17's modifier
-        if ($age < 17) {
-            return self::AGE_WAGE_MODIFIERS[17];
-        }
-
-        // Prime years (23-29): fair market
-        if ($age >= 23 && $age <= 29) {
-            return 1.0;
-        }
-
-        // Very old players (39+): use 38's modifier
-        if ($age > 38) {
-            return self::AGE_WAGE_MODIFIERS[38];
-        }
-
-        return 1.0; // Fallback
+        return self::AGE_WAGE_MODIFIERS[$tier];
     }
 
     /**
@@ -333,14 +311,11 @@ class ContractService
      */
     private function calculateRenewalYears(int $age): int
     {
-        if ($age >= 33) {
-            return 1; // Veterans get 1-year deals
-        }
-        if ($age >= 30) {
-            return 2; // 30-32 get 2-year deals
-        }
-
-        return self::DEFAULT_RENEWAL_YEARS; // Under 30 get 3-year deals
+        return match (true) {
+            $age >= PlayerAge::PRIME_END => 1,
+            $age < PlayerAge::YOUNG_END => 5,
+            default => self::DEFAULT_RENEWAL_YEARS,
+        };
     }
 
     /**

--- a/app/Modules/Transfer/Services/TransferService.php
+++ b/app/Modules/Transfer/Services/TransferService.php
@@ -2,6 +2,7 @@
 
 namespace App\Modules\Transfer\Services;
 
+use App\Modules\Player\PlayerAge;
 use App\Modules\Transfer\Services\ContractService;
 use App\Modules\Transfer\Services\ScoutingService;
 use App\Models\ClubProfile;
@@ -36,7 +37,7 @@ class TransferService
     /**
      * Age adjustments for transfer pricing.
      */
-    private const AGE_PREMIUM_UNDER_23 = 1.10;  // Young talent premium
+    private const AGE_PREMIUM_YOUNG = 1.10;  // Young talent premium
     private const AGE_PENALTY_PER_YEAR_OVER_29 = 0.05;  // 5% per year
 
     /**
@@ -891,8 +892,8 @@ class TransferService
         $age = $player->age($player->game->current_date);
         $ageModifier = 1.0;
 
-        if ($age < 23) {
-            $ageModifier = self::AGE_PREMIUM_UNDER_23;
+        if ($age < PlayerAge::YOUNG_END) {
+            $ageModifier = self::AGE_PREMIUM_YOUNG;
         } elseif ($age > 29) {
             $yearsOver29 = $age - 29;
             $ageModifier = max(0.5, 1.0 - ($yearsOver29 * self::AGE_PENALTY_PER_YEAR_OVER_29));

--- a/resources/views/partials/squad/sidebar.blade.php
+++ b/resources/views/partials/squad/sidebar.blade.php
@@ -104,15 +104,15 @@
         <div class="flex items-center justify-between mt-2 text-xs">
             <span class="flex items-center gap-1">
                 <span class="w-2 h-2 rounded-full bg-green-400"></span>
-                <span class="text-text-secondary">≤23: {{ $youngCount }}</span>
+                <span class="text-text-secondary">≤{{ \App\Modules\Player\PlayerAge::YOUNG_END }}: {{ $youngCount }}</span>
             </span>
             <span class="flex items-center gap-1">
                 <span class="w-2 h-2 rounded-full bg-sky-400"></span>
-                <span class="text-text-secondary">24-31: {{ $primeCount }}</span>
+                <span class="text-text-secondary">{{ \App\Modules\Player\PlayerAge::YOUNG_END + 1 }}-{{ \App\Modules\Player\PlayerAge::PRIME_END }}: {{ $primeCount }}</span>
             </span>
             <span class="flex items-center gap-1">
                 <span class="w-2 h-2 rounded-full bg-orange-400"></span>
-                <span class="text-text-secondary">32+: {{ $veteranCount }}</span>
+                <span class="text-text-secondary">{{ \App\Modules\Player\PlayerAge::PRIME_END + 1 }}+: {{ $veteranCount }}</span>
             </span>
         </div>
     </div>


### PR DESCRIPTION
Introduce PlayerAge as the single source of truth for age category boundaries (ACADEMY_END, YOUNG_END, PRIME_END, retirement ages). Replace hardcoded thresholds across 11 files, simplify ContractService wage modifiers to 4 tiers, remove unused DevelopmentCurve::getStatus(), and consolidate ShowSquad age distribution into a single pass.