### PR TITLE
Exclude substituted-out players from match resimulation

### DIFF
--- a/app/Modules/Lineup/Services/SubstitutionService.php
+++ b/app/Modules/Lineup/Services/SubstitutionService.php
@@ -168,6 +168,19 @@ class SubstitutionService
             ->get();
 
         $opponentLineupIds = $isUserHome ? ($match->away_lineup ?? []) : ($match->home_lineup ?? []);
+
+        // Apply opponent substitutions from match record (auto-subs from initial simulation)
+        // so that injured/subbed-out players are excluded and their replacements are included.
+        foreach ($match->substitutions ?? [] as $sub) {
+            if ($sub['team_id'] === $opponentTeamId) {
+                $opponentLineupIds = array_values(array_filter(
+                    $opponentLineupIds,
+                    fn ($id) => $id !== $sub['player_out_id']
+                ));
+                $opponentLineupIds[] = $sub['player_in_id'];
+            }
+        }
+
         $opponentPlayers = $opponentSquad->filter(fn ($p) => in_array($p->id, $opponentLineupIds));
         $opponentBench = $opponentSquad
             ->reject(fn ($p) => in_array($p->id, $opponentLineupIds))

--- a/app/Modules/Match/Services/MatchResimulationService.php
+++ b/app/Modules/Match/Services/MatchResimulationService.php
@@ -84,15 +84,15 @@ class MatchResimulationService
         $homeDefLine = DefensiveLineHeight::tryFrom($match->home_defensive_line ?? '') ?? DefensiveLineHeight::NORMAL;
         $awayDefLine = DefensiveLineHeight::tryFrom($match->away_defensive_line ?? '') ?? DefensiveLineHeight::NORMAL;
 
-        // 5. Exclude red-carded players
-        $redCardedPlayerIds = MatchEvent::where('game_match_id', $match->id)
-            ->where('event_type', 'red_card')
+        // 5. Exclude red-carded and substituted-out players
+        $unavailablePlayerIds = MatchEvent::where('game_match_id', $match->id)
+            ->whereIn('event_type', ['red_card', 'substitution'])
             ->where('minute', '<=', $minute)
             ->pluck('game_player_id')
             ->all();
 
-        $homePlayers = $homePlayers->reject(fn ($p) => in_array($p->id, $redCardedPlayerIds));
-        $awayPlayers = $awayPlayers->reject(fn ($p) => in_array($p->id, $redCardedPlayerIds));
+        $homePlayers = $homePlayers->reject(fn ($p) => in_array($p->id, $unavailablePlayerIds));
+        $awayPlayers = $awayPlayers->reject(fn ($p) => in_array($p->id, $unavailablePlayerIds));
 
         // 6. Get existing injuries/yellows for context
         $existingInjuryTeamIds = MatchEvent::where('game_match_id', $match->id)
@@ -212,15 +212,15 @@ class MatchResimulationService
             $homeDefLine = DefensiveLineHeight::tryFrom($match->home_defensive_line ?? '') ?? DefensiveLineHeight::NORMAL;
             $awayDefLine = DefensiveLineHeight::tryFrom($match->away_defensive_line ?? '') ?? DefensiveLineHeight::NORMAL;
 
-            // 5. Exclude red-carded players
-            $redCardedPlayerIds = MatchEvent::where('game_match_id', $match->id)
-                ->where('event_type', 'red_card')
+            // 5. Exclude red-carded and substituted-out players
+            $unavailablePlayerIds = MatchEvent::where('game_match_id', $match->id)
+                ->whereIn('event_type', ['red_card', 'substitution'])
                 ->where('minute', '<=', $minute)
                 ->pluck('game_player_id')
                 ->all();
 
-            $homePlayers = $homePlayers->reject(fn ($p) => in_array($p->id, $redCardedPlayerIds));
-            $awayPlayers = $awayPlayers->reject(fn ($p) => in_array($p->id, $redCardedPlayerIds));
+            $homePlayers = $homePlayers->reject(fn ($p) => in_array($p->id, $unavailablePlayerIds));
+            $awayPlayers = $awayPlayers->reject(fn ($p) => in_array($p->id, $unavailablePlayerIds));
 
             // 6. Build entry minute maps from substitutions
             $isUserHome = $match->isHomeTeam($game->team_id);

--- a/app/Modules/Match/Services/MatchSimulator.php
+++ b/app/Modules/Match/Services/MatchSimulator.php
@@ -152,7 +152,7 @@ class MatchSimulator
         // Build map of player_id => minute they were removed
         $removedAt = [];
         foreach ($events as $event) {
-            if (in_array($event->type, ['injury', 'red_card']) && ! isset($removedAt[$event->gamePlayerId])) {
+            if (in_array($event->type, ['injury', 'red_card', 'substitution']) && ! isset($removedAt[$event->gamePlayerId])) {
                 $removedAt[$event->gamePlayerId] = $event->minute;
             }
         }


### PR DESCRIPTION
## Summary
This PR updates the match resimulation logic to properly exclude players who have been substituted out, in addition to red-carded players. This ensures that when resimulating match events, only players currently on the field are considered for generating new events.

## Key Changes

- **MatchResimulationService**: Updated both `doResimulate()` and `resimulateExtraTime()` methods to query for both `red_card` and `substitution` events when determining unavailable players, replacing the previous red-card-only logic
  - Renamed `$redCardedPlayerIds` to `$unavailablePlayerIds` for clarity
  - Changed query to use `whereIn('event_type', ['red_card', 'substitution'])` instead of single `where('event_type', 'red_card')`

- **SubstitutionService**: Enhanced `loadTeamsForResimulation()` to apply opponent substitutions from the match record
  - Processes auto-substitutions from the initial simulation to ensure injured/subbed-out players are excluded
  - Updates the opponent lineup to remove substituted-out players and add their replacements

- **MatchSimulator**: Updated `reassignEventsFromUnavailablePlayers()` to treat substitutions the same as injuries and red cards
  - Added `'substitution'` to the event types that mark when a player becomes unavailable for generating future events

## Implementation Details
The changes ensure consistency across the resimulation pipeline: players who leave the field via substitution are now properly tracked and excluded from event generation, matching the behavior for red-carded and injured players.

https://claude.ai/code/session_01LGQaStDAWuY7CsM1QxkA9T