### PR TITLE
Fix World Cup 3rd place getting winners instead of losers after semifinals

### DIFF
--- a/app/Modules/Match/Listeners/ConductNextCupRoundDraw.php
+++ b/app/Modules/Match/Listeners/ConductNextCupRoundDraw.php
@@ -13,10 +13,11 @@ class ConductNextCupRoundDraw
 
     public function handle(CupTieResolved $event): void
     {
-        // Swiss format competitions use SwissFormatHandler::maybeGenerateKnockoutRound
-        // with seeded brackets. CupDrawService doesn't handle Swiss-specific entry
-        // logic (top 8 entering directly at R16).
-        if ($event->competition?->handler_type === 'swiss_format') {
+        // Swiss format and group stage cup competitions handle their own knockout
+        // generation via their respective handlers. CupDrawService uses generic
+        // "winners from previous round" logic that breaks for special rounds like
+        // the third-place match (which needs losers, not winners).
+        if (in_array($event->competition?->handler_type, ['swiss_format', 'group_stage_cup'])) {
             return;
         }
 


### PR DESCRIPTION
ConductNextCupRoundDraw listener was firing on CupTieResolved for group_stage_cup competitions, using CupDrawService which generically advances winners from the previous round. This created the 3rd place match with SF winners instead of losers, and prevented the final from being generated. Skip group_stage_cup in the listener since GroupStageCupHandler already handles its own knockout generation.