### PR TITLE
Remove async renewal negotiation notifications and batch processing

### DIFF
--- a/app/Models/GameNotification.php
+++ b/app/Models/GameNotification.php
@@ -62,9 +62,6 @@ class GameNotification extends Model
     public const TYPE_ACADEMY_EVALUATION = 'academy_evaluation';
     public const TYPE_ACADEMY_BATCH = 'academy_batch';
     public const TYPE_TRANSFER_COMPLETE = 'transfer_complete';
-    public const TYPE_RENEWAL_ACCEPTED = 'renewal_accepted';
-    public const TYPE_RENEWAL_COUNTERED = 'renewal_countered';
-    public const TYPE_RENEWAL_REJECTED = 'renewal_rejected';
     public const TYPE_TRANSFER_BID_RESULT = 'transfer_bid_result';
     public const TYPE_LOAN_REQUEST_RESULT = 'loan_request_result';
     public const TYPE_TOURNAMENT_WELCOME = 'tournament_welcome';
@@ -100,9 +97,6 @@ class GameNotification extends Model
         self::TYPE_ACADEMY_EVALUATION => 'academy',
         self::TYPE_ACADEMY_BATCH => 'academy',
         self::TYPE_TRANSFER_COMPLETE => 'squad',
-        self::TYPE_RENEWAL_ACCEPTED => 'transfers',
-        self::TYPE_RENEWAL_COUNTERED => 'transfers',
-        self::TYPE_RENEWAL_REJECTED => 'transfers',
         self::TYPE_TRANSFER_BID_RESULT => 'scouting',
         self::TYPE_LOAN_REQUEST_RESULT => 'scouting',
         self::TYPE_TOURNAMENT_WELCOME => 'competition',

--- a/app/Modules/Match/Services/CareerActionProcessor.php
+++ b/app/Modules/Match/Services/CareerActionProcessor.php
@@ -10,7 +10,6 @@ use App\Models\TransferOffer;
 use App\Modules\Academy\Services\YouthAcademyService;
 use App\Modules\Notification\Services\NotificationService;
 use App\Modules\Transfer\Services\AITransferMarketService;
-use App\Modules\Transfer\Services\ContractService;
 use App\Modules\Transfer\Services\LoanService;
 use App\Modules\Transfer\Services\ScoutingService;
 use App\Modules\Transfer\Services\TransferService;
@@ -19,7 +18,6 @@ class CareerActionProcessor
 {
     public function __construct(
         private readonly TransferService $transferService,
-        private readonly ContractService $contractService,
         private readonly ScoutingService $scoutingService,
         private readonly LoanService $loanService,
         private readonly YouthAcademyService $youthAcademyService,
@@ -48,12 +46,6 @@ class CareerActionProcessor
             foreach ($listedOffers->merge($unsolicitedOffers) as $offer) {
                 $this->notificationService->notifyTransferOffer($game, $offer);
             }
-        }
-
-        // Resolve pending renewal negotiations
-        $renewalResults = $this->contractService->resolveRenewalNegotiations($game);
-        foreach ($renewalResults as $result) {
-            $this->notificationService->notifyRenewalResult($game, $result['negotiation'], $result['result']);
         }
 
         // Pre-contract offers (January onwards for expiring contracts)

--- a/app/Modules/Notification/Services/NotificationService.php
+++ b/app/Modules/Notification/Services/NotificationService.php
@@ -6,7 +6,6 @@ use App\Models\Game;
 use App\Models\GameNotification;
 use App\Models\GamePlayer;
 use App\Modules\Player\Services\InjuryService;
-use App\Models\RenewalNegotiation;
 use App\Models\ScoutReport;
 use App\Models\ShortlistedPlayer;
 use App\Models\Team;
@@ -650,54 +649,6 @@ class NotificationService
     }
 
     // ==========================================
-    // Renewal Negotiation Notifications
-    // ==========================================
-
-    /**
-     * Create a notification for a renewal negotiation result.
-     */
-    public function notifyRenewalResult(Game $game, RenewalNegotiation $negotiation, string $result): GameNotification
-    {
-        $player = $negotiation->gamePlayer;
-
-        return match ($result) {
-            'accepted' => $this->create(
-                game: $game,
-                type: GameNotification::TYPE_RENEWAL_ACCEPTED,
-                title: __('notifications.renewal_accepted_title', ['player' => $player->name]),
-                message: __('notifications.renewal_accepted_message', [
-                    'player' => $player->name,
-                    'wage' => \App\Support\Money::format($negotiation->user_offer),
-                    'years' => $negotiation->contract_years,
-                ]),
-                priority: GameNotification::PRIORITY_MILESTONE,
-                metadata: ['player_id' => $player->id],
-            ),
-            'countered' => $this->create(
-                game: $game,
-                type: GameNotification::TYPE_RENEWAL_COUNTERED,
-                title: __('notifications.renewal_countered_title', ['player' => $player->name]),
-                message: __('notifications.renewal_countered_message', [
-                    'player' => $player->name,
-                    'wage' => \App\Support\Money::format($negotiation->counter_offer),
-                    'years' => $negotiation->preferred_years,
-                ]),
-                priority: GameNotification::PRIORITY_WARNING,
-                metadata: ['player_id' => $player->id],
-            ),
-            'rejected' => $this->create(
-                game: $game,
-                type: GameNotification::TYPE_RENEWAL_REJECTED,
-                title: __('notifications.renewal_rejected_title', ['player' => $player->name]),
-                message: __('notifications.renewal_rejected_message', ['player' => $player->name]),
-                priority: GameNotification::PRIORITY_CRITICAL,
-                metadata: ['player_id' => $player->id],
-            ),
-            default => throw new \InvalidArgumentException("Unexpected renewal result: {$result}"),
-        };
-    }
-
-    // ==========================================
     // AI Transfer Market Notifications
     // ==========================================
 
@@ -845,9 +796,6 @@ class NotificationService
             GameNotification::TYPE_COMPETITION_ELIMINATION => 'eliminated',
             GameNotification::TYPE_ACADEMY_PROSPECT => 'academy',
             GameNotification::TYPE_TRANSFER_COMPLETE => 'transfer_complete',
-            GameNotification::TYPE_RENEWAL_ACCEPTED => 'contract',
-            GameNotification::TYPE_RENEWAL_COUNTERED => 'contract',
-            GameNotification::TYPE_RENEWAL_REJECTED => 'contract',
             GameNotification::TYPE_TRANSFER_BID_RESULT => 'transfer',
             GameNotification::TYPE_LOAN_REQUEST_RESULT => 'loan',
             GameNotification::TYPE_TOURNAMENT_WELCOME => 'trophy',

--- a/app/Modules/Transfer/Services/ContractService.php
+++ b/app/Modules/Transfer/Services/ContractService.php
@@ -567,7 +567,7 @@ class ContractService
     }
 
     /**
-     * Evaluate a pending negotiation offer. Called during matchday advance.
+     * Evaluate a pending negotiation offer. Called synchronously during chat negotiation.
      *
      * @return string 'accepted' | 'countered' | 'rejected'
      */
@@ -733,43 +733,6 @@ class ContractService
             'result' => $result,
             'negotiation' => $negotiation,
         ];
-    }
-
-    /**
-     * Resolve all pending negotiations for a game. Called during matchday advance.
-     *
-     * @return Collection<array{negotiation: RenewalNegotiation, result: string}>
-     */
-    public function resolveRenewalNegotiations(Game $game): Collection
-    {
-        $pending = RenewalNegotiation::with(['gamePlayer.player', 'gamePlayer.game', 'gamePlayer.transferOffers'])
-            ->where('game_id', $game->id)
-            ->where('status', RenewalNegotiation::STATUS_OFFER_PENDING)
-            ->get();
-
-        $results = collect();
-
-        foreach ($pending as $negotiation) {
-            $result = $this->evaluateOffer($negotiation);
-            $results->push([
-                'negotiation' => $negotiation->fresh(),
-                'result' => $result,
-            ]);
-        }
-
-        return $results;
-    }
-
-    /**
-     * Get active negotiations for a game (pending or countered).
-     */
-    public function getActiveNegotiations(Game $game): Collection
-    {
-        return RenewalNegotiation::with(['gamePlayer.player'])
-            ->where('game_id', $game->id)
-            ->whereIn('status', [RenewalNegotiation::STATUS_OFFER_PENDING, RenewalNegotiation::STATUS_PLAYER_COUNTERED])
-            ->get()
-            ->keyBy('game_player_id');
     }
 
     /**

--- a/lang/en/messages.php
+++ b/lang/en/messages.php
@@ -43,7 +43,6 @@ return [
     'renewal_declined' => 'You have decided not to renew :player. They will leave at the end of the season.',
     'renewal_reconsidered' => 'You have reconsidered :player\'s renewal.',
     'cannot_renew' => 'This player cannot receive a renewal offer.',
-    'renewal_offer_submitted' => 'Renewal offer sent to :player for :wage/yr. Response on the next matchday.',
     'renewal_invalid_offer' => 'The offer must be greater than zero.',
 
     // Pre-contract messages

--- a/lang/en/notifications.php
+++ b/lang/en/notifications.php
@@ -124,14 +124,6 @@ return [
     'player_released_message' => ':player has been released from your squad. Severance paid: :severance.',
     'player_released_message_free' => ':player has been released from your squad.',
 
-    // Renewal negotiations
-    'renewal_accepted_title' => ':player accepts renewal',
-    'renewal_accepted_message' => ':player has accepted the renewal for :wage/yr over :years years.',
-    'renewal_countered_title' => ':player counter offer',
-    'renewal_countered_message' => ':player is asking for :wage/yr over :years years to renew.',
-    'renewal_rejected_title' => ':player rejects renewal',
-    'renewal_rejected_message' => ':player has rejected your renewal offer. They will leave at the end of the season.',
-
     // Tracking intel
     'tracking_intel_title' => 'Intel on :player ready',
     'tracking_report_ready' => 'Your scout has gathered a report on :player — ability range and financial details are now available.',

--- a/lang/en/transfers.php
+++ b/lang/en/transfers.php
@@ -236,10 +236,6 @@ return [
     'declined_renewals' => 'Declined Renewals',
 
     // Renewal negotiation
-    'renewal_counter_offers' => 'Renewal Counter-Offers',
-    'renewal_counter_offers_help' => 'These players have responded to your renewal offers',
-    'renewal_offers_sent' => 'Renewals In Progress',
-    'renewal_offers_sent_help' => 'Your renewal offers are being considered',
     'negotiate' => 'Negotiate',
     'negotiating' => 'Negotiating...',
     'player_countered' => 'The player has counter-offered',

--- a/lang/es/messages.php
+++ b/lang/es/messages.php
@@ -43,7 +43,6 @@ return [
     'renewal_declined' => 'Has decidido no renovar a :player. Se marchará al final de la temporada.',
     'renewal_reconsidered' => 'Has reconsiderado la renovación de :player.',
     'cannot_renew' => 'Este jugador no puede recibir una oferta de renovación.',
-    'renewal_offer_submitted' => 'Oferta de renovación enviada a :player por :wage/año. Respuesta en la próxima jornada.',
     'renewal_invalid_offer' => 'La oferta debe ser mayor que cero.',
 
     // Pre-contract messages

--- a/lang/es/notifications.php
+++ b/lang/es/notifications.php
@@ -124,14 +124,6 @@ return [
     'player_released_message' => ':player ha sido liberado de tu plantilla. Indemnización pagada: :severance.',
     'player_released_message_free' => ':player ha sido liberado de tu plantilla.',
 
-    // Renewal negotiations
-    'renewal_accepted_title' => ':player acepta renovar',
-    'renewal_accepted_message' => ':player ha aceptado la renovación por :wage/año durante :years años.',
-    'renewal_countered_title' => ':player contraoferta',
-    'renewal_countered_message' => ':player pide :wage/año durante :years años para renovar.',
-    'renewal_rejected_title' => ':player rechaza renovar',
-    'renewal_rejected_message' => ':player ha rechazado tu oferta de renovación. Se marchará al final de la temporada.',
-
     // Tracking intel
     'tracking_intel_title' => 'Intel sobre :player lista',
     'tracking_report_ready' => 'Tu ojeador ha elaborado un informe sobre :player — rango de habilidad y detalles financieros disponibles.',

--- a/lang/es/transfers.php
+++ b/lang/es/transfers.php
@@ -241,10 +241,6 @@ return [
     'declined_renewals' => 'No renovados',
 
     // Renewal negotiation
-    'renewal_counter_offers' => 'Contraoferta de Renovación',
-    'renewal_counter_offers_help' => 'Estos jugadores han respondido a tu oferta de renovación',
-    'renewal_offers_sent' => 'Renovaciones en Curso',
-    'renewal_offers_sent_help' => 'Tus ofertas de renovación están siendo consideradas',
     'negotiate' => 'Negociar',
     'negotiating' => 'Negociando...',
     'player_countered' => 'El jugador ha contraofertado',


### PR DESCRIPTION
## Summary
This PR removes the asynchronous renewal negotiation notification system that was previously triggered during matchday advancement. Renewal negotiations now operate synchronously through chat-based interactions only, eliminating the need for batch processing and associated notifications.

## Key Changes
- **Removed async notification methods**: Deleted `notifyRenewalResult()` from `NotificationService` that created notifications for renewal acceptance, counter-offers, and rejections
- **Removed batch processing**: Deleted `resolveRenewalNegotiations()` and `getActiveNegotiations()` methods from `ContractService` that processed pending negotiations during matchday advance
- **Removed CareerActionProcessor integration**: Eliminated the renewal negotiation resolution loop from `CareerActionProcessor.process()` that was called during game advancement
- **Cleaned up notification types**: Removed `TYPE_RENEWAL_ACCEPTED`, `TYPE_RENEWAL_COUNTERED`, and `TYPE_RENEWAL_REJECTED` constants from `GameNotification` model
- **Removed UI strings**: Deleted renewal negotiation-related translation keys from English and Spanish language files for notifications and transfer screens
- **Updated documentation**: Changed `ContractService.evaluateOffer()` docstring to reflect synchronous chat-based usage instead of matchday processing

## Implementation Details
- The `negotiateSync()` method in `ContractService` remains as the primary interface for synchronous contract negotiations
- Renewal negotiations are now exclusively handled through real-time chat interactions rather than batch processing during game state transitions
- This simplifies the game loop and removes the need for deferred notification handling for contract renewals

https://claude.ai/code/session_01LbU3Fw7mtf4si1Uiyn7JUz