### PR TITLE
Optimize squad overview renewal eligibility filtering

### DIFF
--- a/app/Modules/Squad/Services/SquadService.php
+++ b/app/Modules/Squad/Services/SquadService.php
@@ -25,7 +25,7 @@ class SquadService
         $gameId = $game->id;
 
         // Get all players for user's team with relationships
-        $allPlayers = GamePlayer::with(['player', 'activeLoan', 'transferOffers', 'suspensions', 'activeRenewalNegotiation', 'latestRenewalNegotiation'])
+        $allPlayers = GamePlayer::with(['player', 'game', 'team', 'activeLoan', 'transferOffers', 'suspensions', 'activeRenewalNegotiation', 'latestRenewalNegotiation'])
             ->where('game_id', $gameId)
             ->where('team_id', $game->team_id)
             ->get();
@@ -145,7 +145,8 @@ class SquadService
         // --- Renewal data (career mode) ---
         $renewalData = [];
         if ($isCareerMode) {
-            $renewalEligible = $this->contractService->getPlayersEligibleForRenewal($game);
+            $renewalEligible = $allPlayers->filter(fn ($p) => $p->canBeOfferedRenewal($seasonEndDate))
+                ->sortBy('contract_until');
             foreach ($renewalEligible as $player) {
                 $demand = $this->contractService->calculateRenewalDemand($player);
                 $midpoint = (int) (ceil(($player->annual_wage + $demand['wage']) / 2 / 100 / 10000) * 10000);


### PR DESCRIPTION
## Summary
Refactored the renewal eligibility logic in the squad overview builder to use in-memory filtering instead of a separate database query, improving performance and reducing database calls.

## Key Changes
- Added `game` and `team` relationships to the initial GamePlayer query to ensure all necessary data is loaded upfront
- Replaced `$this->contractService->getPlayersEligibleForRenewal($game)` with inline filtering using `$allPlayers->filter()` and the `canBeOfferedRenewal()` method
- Simplified the renewal eligibility check by leveraging already-loaded player data instead of making an additional service call
- Added sorting by `contract_until` to maintain consistent ordering of renewal-eligible players

## Implementation Details
The change consolidates the player data fetching into a single query with all required relationships, then performs the renewal eligibility filtering in-memory. This eliminates the need for a separate database query while maintaining the same filtering logic through the `canBeOfferedRenewal()` method.

https://claude.ai/code/session_01UZd9EqQXzHc22oaPnnms3P