### PR TITLE
Filter out stale player references from lineups

### DIFF
--- a/app/Http/Views/ShowLineup.php
+++ b/app/Http/Views/ShowLineup.php
@@ -102,6 +102,12 @@ class ShowLineup
             ];
         })->keyBy('id')->toArray();
 
+        // Filter stale player IDs from lineups (e.g. players sold after lineup was saved)
+        $validPlayerIds = array_keys($playersData);
+        if (! empty($currentLineup)) {
+            $currentLineup = array_values(array_intersect($currentLineup, $validPlayerIds));
+        }
+
         // Prepare pitch slots for each formation, adding Spanish display labels
         $formationSlots = [];
         foreach (Formation::cases() as $formation) {
@@ -237,7 +243,9 @@ class ShowLineup
             'midfielders' => $playersByGroup['midfielders'],
             'forwards' => $playersByGroup['forwards'],
             'currentLineup' => $currentLineup,
-            'currentSlotAssignments' => $game->tactics?->default_slot_assignments,
+            'currentSlotAssignments' => ! empty($game->tactics?->default_slot_assignments)
+                ? array_filter($game->tactics->default_slot_assignments, fn ($playerId) => in_array($playerId, $validPlayerIds))
+                : null,
             'autoLineup' => $autoLineup,
             'formationOptions' => $formationOptions,
             'currentFormation' => $currentFormation,
@@ -275,12 +283,14 @@ class ShowLineup
                 'id' => $p->id,
                 'name' => $p->name,
                 'formation' => $p->formation,
-                'lineup' => collect($p->lineup)->sort()->values()->all(),
+                'lineup' => collect($p->lineup)->filter(fn ($id) => in_array($id, $validPlayerIds))->sort()->values()->all(),
                 'mentality' => $p->mentality,
                 'playing_style' => $p->playing_style,
                 'pressing' => $p->pressing,
                 'defensive_line' => $p->defensive_line,
-                'slot_assignments' => $p->slot_assignments,
+                'slot_assignments' => ! empty($p->slot_assignments)
+                    ? array_filter($p->slot_assignments, fn ($playerId) => in_array($playerId, $validPlayerIds))
+                    : null,
                 'pitch_positions' => $p->pitch_positions,
             ])->values(),
         ]);

--- a/resources/js/lineup.js
+++ b/resources/js/lineup.js
@@ -80,14 +80,26 @@ export default function lineupManager(config) {
         isHome: config.isHome || false,
 
         init() {
-            // Snapshot the initial state for dirty detection
-            this._initialPlayers = [...(config.currentLineup || [])].sort();
+            // Filter out players no longer in the squad (e.g. sold after lineup was saved)
+            this.selectedPlayers = this.selectedPlayers.filter(id => this.playersData[id]);
+            if (Object.keys(this.manualAssignments).length > 0) {
+                const clean = {};
+                for (const [slotId, playerId] of Object.entries(this.manualAssignments)) {
+                    if (this.playersData[playerId]) {
+                        clean[slotId] = playerId;
+                    }
+                }
+                this.manualAssignments = clean;
+            }
+
+            // Snapshot the initial state for dirty detection (after filtering)
+            this._initialPlayers = [...this.selectedPlayers].sort();
             this._initialFormation = config.currentFormation;
             this._initialMentality = config.currentMentality;
             this._initialPlayingStyle = config.currentPlayingStyle || 'balanced';
             this._initialPressing = config.currentPressing || 'standard';
             this._initialDefLine = config.currentDefLine || 'normal';
-            this._initialAssignments = JSON.stringify(config.currentSlotAssignments || {});
+            this._initialAssignments = JSON.stringify(this.manualAssignments);
             this._initialPitchPositions = JSON.stringify(config.currentPitchPositions || {});
 
             // Warn on navigation away with unsaved changes


### PR DESCRIPTION
## Summary
This PR adds validation to remove references to players who are no longer in the squad (e.g., sold after a lineup was saved) from both the current lineup and slot assignments across the application.

## Key Changes
- **Backend (ShowLineup.php)**: 
  - Filter `$currentLineup` to only include valid player IDs before passing to frontend
  - Filter `currentSlotAssignments` from game tactics to remove stale player references
  - Filter player lineups and slot assignments in the saved lineups collection to exclude players no longer in the squad

- **Frontend (lineup.js)**:
  - Add filtering logic in `init()` to remove stale player IDs from `selectedPlayers` and `manualAssignments`
  - Update dirty detection snapshots to use filtered data instead of raw config values, ensuring accurate change detection

## Implementation Details
- Filtering is performed using `array_intersect()` on the backend and `.filter()` on the frontend to keep only player IDs that exist in the current `playersData`
- The filtering happens early in the initialization process to ensure all subsequent operations work with clean data
- Dirty detection snapshots are created after filtering to prevent false positives when stale players are removed

https://claude.ai/code/session_012eDd4c4mdwc1Wu1k2FrsVk