### PR TITLE
Enhance live match with narrative events, stats dashboard, player ratings, and tactical insights

### DIFF
--- a/app/Http/Views/ShowLiveMatch.php
+++ b/app/Http/Views/ShowLiveMatch.php
@@ -60,6 +60,25 @@ class ShowLiveMatch
 
         $events = MatchResimulationService::formatMatchEvents($regularEvents);
 
+        // Merge narrative events (stored on match, not in DB events table)
+        $narrativeEvents = $playerMatch->narrative_events ?? [];
+        $regularNarrative = array_filter($narrativeEvents, fn ($e) => ($e['minute'] ?? 0) <= 93);
+        foreach ($regularNarrative as $ne) {
+            $events[] = [
+                'minute' => $ne['minute'],
+                'type' => $ne['event_type'],
+                'playerName' => '',
+                'teamId' => $ne['team_id'],
+                'gamePlayerId' => $ne['game_player_id'] ?? '',
+                'metadata' => $ne['metadata'] ?? null,
+            ];
+        }
+        // Sort all events by minute
+        usort($events, fn ($a, $b) => $a['minute'] <=> $b['minute']);
+
+        // Player ratings for live display
+        $playerRatings = $playerMatch->player_ratings ?? [];
+
         // Load other matches from the same competition/matchday for the ticker
         // For Swiss-format competitions, round_number overlaps between league phase
         // and knockout phase, so also filter by round_name to avoid mixing results.
@@ -187,6 +206,7 @@ class ShowLiveMatch
             ->whereIn('id', $ids)
             ->get()
             ->map(fn ($p) => [
+                'id' => $p->id,
                 'name' => $p->player->name ?? '',
                 'positionAbbr' => PositionMapper::toAbbreviation($p->position),
                 'positionGroup' => $p->position_group,
@@ -313,6 +333,7 @@ class ShowLiveMatch
             'gridConfig' => $gridConfig,
             'pitchPositions' => $game->tactics?->default_pitch_positions ?? [],
             'slotAssignments' => $game->tactics?->default_slot_assignments ?? [],
+            'playerRatings' => $playerRatings,
         ]);
     }
 

--- a/app/Models/GameMatch.php
+++ b/app/Models/GameMatch.php
@@ -117,6 +117,8 @@ class GameMatch extends Model
         'away_possession',
         'mvp_player_id',
         'substitutions',
+        'narrative_events',
+        'player_ratings',
     ];
 
     protected $casts = [
@@ -145,6 +147,8 @@ class GameMatch extends Model
         'home_possession' => 'integer',
         'away_possession' => 'integer',
         'substitutions' => 'array',
+        'narrative_events' => 'array',
+        'player_ratings' => 'array',
     ];
 
     public function game(): BelongsTo

--- a/app/Modules/Lineup/Services/TacticalChangeService.php
+++ b/app/Modules/Lineup/Services/TacticalChangeService.php
@@ -154,6 +154,8 @@ class TacticalChangeService
             'homePossession' => $result->homePossession,
             'awayPossession' => $result->awayPossession,
             'substitutions' => $substitutionDetails,
+            'narrativeEvents' => $result->narrativeEvents,
+            'playerRatings' => $result->playerRatings,
         ];
 
         if ($isExtraTime) {

--- a/app/Modules/Match/DTOs/MatchEventData.php
+++ b/app/Modules/Match/DTOs/MatchEventData.php
@@ -78,6 +78,86 @@ readonly class MatchEventData
         ]);
     }
 
+    /**
+     * Create a shot on target event (narrative).
+     */
+    public static function shotOnTarget(string $teamId, string $gamePlayerId, int $minute): self
+    {
+        return new self($teamId, $gamePlayerId, $minute, 'shot_on_target');
+    }
+
+    /**
+     * Create a shot off target event (narrative).
+     */
+    public static function shotOffTarget(string $teamId, string $gamePlayerId, int $minute): self
+    {
+        return new self($teamId, $gamePlayerId, $minute, 'shot_off_target');
+    }
+
+    /**
+     * Create a dangerous attack event (narrative).
+     */
+    public static function dangerousAttack(string $teamId, string $gamePlayerId, int $minute): self
+    {
+        return new self($teamId, $gamePlayerId, $minute, 'dangerous_attack');
+    }
+
+    /**
+     * Create a great save event (narrative).
+     */
+    public static function greatSave(string $teamId, string $gamePlayerId, int $minute): self
+    {
+        return new self($teamId, $gamePlayerId, $minute, 'great_save');
+    }
+
+    /**
+     * Create a near miss event (narrative).
+     */
+    public static function nearMiss(string $teamId, string $gamePlayerId, int $minute): self
+    {
+        return new self($teamId, $gamePlayerId, $minute, 'near_miss');
+    }
+
+    /**
+     * Create a key pass event (narrative).
+     */
+    public static function keyPass(string $teamId, string $gamePlayerId, int $minute): self
+    {
+        return new self($teamId, $gamePlayerId, $minute, 'key_pass');
+    }
+
+    /**
+     * Create a tactical insight event.
+     */
+    public static function insight(string $teamId, int $minute, string $insightKey, array $params = []): self
+    {
+        return new self($teamId, '', $minute, 'insight', [
+            'insight_key' => $insightKey,
+            'params' => $params,
+        ]);
+    }
+
+    /**
+     * Check if this is a narrative event (not persisted to DB).
+     */
+    public function isNarrative(): bool
+    {
+        return in_array($this->type, self::NARRATIVE_TYPES);
+    }
+
+    /**
+     * Event types that are narrative only (not stored in DB).
+     */
+    public const NARRATIVE_TYPES = [
+        'shot_on_target',
+        'shot_off_target',
+        'dangerous_attack',
+        'great_save',
+        'near_miss',
+        'key_pass',
+        'insight',
+    ];
+
     public function toArray(): array
     {
         return [

--- a/app/Modules/Match/DTOs/ResimulationResult.php
+++ b/app/Modules/Match/DTOs/ResimulationResult.php
@@ -11,5 +11,7 @@ readonly class ResimulationResult
         public int $oldAwayScore,
         public int $homePossession = 50,
         public int $awayPossession = 50,
+        public array $narrativeEvents = [],
+        public array $playerRatings = [],
     ) {}
 }

--- a/app/Modules/Match/Services/MatchResimulationService.php
+++ b/app/Modules/Match/Services/MatchResimulationService.php
@@ -154,7 +154,21 @@ class MatchResimulationService
         // 10. Apply the new remainder events
         $this->applyNewEvents($match, $game, $remainderResult, $competitionId);
 
-        // 11. Update match score and possession
+        // 10b. Extract narrative events from remainder result for frontend
+        $narrativeEvents = $remainderResult->events
+            ->filter(fn (MatchEventData $e) => $e->isNarrative())
+            ->map(fn (MatchEventData $e) => $e->toArray())
+            ->values()
+            ->all();
+
+        // 10c. Capture player ratings from simulator
+        $performances = $this->matchSimulator->getMatchPerformances();
+        $playerRatings = [];
+        foreach ($performances as $playerId => $perf) {
+            $playerRatings[$playerId] = \App\Modules\Match\Services\MatchSimulator::performanceToRating($perf);
+        }
+
+        // 11. Update match score, possession, narrative events, and ratings
         // Note: Score-dependent side effects (standings, cup ties, GK stats, prize money)
         // are NOT handled here. They are deferred to FinalizeMatch, which applies them
         // once after the user finishes the live match. This eliminates the need for
@@ -164,11 +178,14 @@ class MatchResimulationService
             'away_score' => $newAwayScore,
             'home_possession' => $remainderResult->homePossession,
             'away_possession' => $remainderResult->awayPossession,
+            'narrative_events' => $narrativeEvents,
+            'player_ratings' => $playerRatings,
         ]);
 
         return new ResimulationResult(
             $newHomeScore, $newAwayScore, $oldHomeScore, $oldAwayScore,
             $remainderResult->homePossession, $remainderResult->awayPossession,
+            $narrativeEvents, $playerRatings,
         );
     }
 
@@ -262,17 +279,33 @@ class MatchResimulationService
             // 9. Apply the new remainder events
             $this->applyNewEvents($match, $game, $remainderResult, $competitionId);
 
-            // 10. Update ET scores and possession (not regular-time scores)
+            // 9b. Extract narrative events and player ratings
+            $narrativeEvents = $remainderResult->events
+                ->filter(fn (MatchEventData $e) => $e->isNarrative())
+                ->map(fn (MatchEventData $e) => $e->toArray())
+                ->values()
+                ->all();
+
+            $performances = $this->matchSimulator->getMatchPerformances();
+            $playerRatings = [];
+            foreach ($performances as $playerId => $perf) {
+                $playerRatings[$playerId] = MatchSimulator::performanceToRating($perf);
+            }
+
+            // 10. Update ET scores, possession, narrative events, and ratings
             $match->update([
                 'home_score_et' => $newHomeScore,
                 'away_score_et' => $newAwayScore,
                 'home_possession' => $remainderResult->homePossession,
                 'away_possession' => $remainderResult->awayPossession,
+                'narrative_events' => $narrativeEvents,
+                'player_ratings' => $playerRatings,
             ]);
 
             return new ResimulationResult(
                 $newHomeScore, $newAwayScore, $oldHomeScore, $oldAwayScore,
                 $remainderResult->homePossession, $remainderResult->awayPossession,
+                $narrativeEvents, $playerRatings,
             );
         });
     }
@@ -444,8 +477,11 @@ class MatchResimulationService
         $competition = \App\Models\Competition::find($competitionId);
         $handlerType = $competition->handler_type ?? 'league';
 
+        // Filter out narrative events (not persisted to DB)
+        $persistableEvents = $events->reject(fn (MatchEventData $e) => $e->isNarrative());
+
         // Bulk insert match events
-        $rows = $events->map(fn (MatchEventData $e) => [
+        $rows = $persistableEvents->map(fn (MatchEventData $e) => [
             'id' => Str::uuid()->toString(),
             'game_id' => $game->id,
             'game_match_id' => $match->id,
@@ -465,7 +501,7 @@ class MatchResimulationService
         $statIncrements = [];
         $specialEvents = [];
 
-        foreach ($events as $event) {
+        foreach ($persistableEvents as $event) {
             $playerId = $event->gamePlayerId;
             $type = $event->type;
 

--- a/app/Modules/Match/Services/MatchSimulator.php
+++ b/app/Modules/Match/Services/MatchSimulator.php
@@ -943,6 +943,16 @@ class MatchSimulator
             $events = $events->merge($goalEvents)->sortBy('minute')->values();
         }
 
+        // Generate narrative events (shots, saves, attacks) for match texture
+        $narrativeEvents = $this->generateNarrativeEvents(
+            $homeTeam->id, $awayTeam->id,
+            $homePlayers, $awayPlayers,
+            $homeExpectedGoals, $awayExpectedGoals,
+            $fromMinute, 93,
+            $homeScore, $awayScore,
+        );
+        $events = $events->merge($narrativeEvents)->sortBy('minute')->values();
+
         $possession = $this->calculatePossession(
             $homeStrength, $awayStrength,
             $homeFormation, $awayFormation,
@@ -1726,5 +1736,233 @@ class MatchSimulator
         $base = max(50, min(95, $base));
 
         return $this->percentChance($base);
+    }
+
+    /**
+     * Generate narrative events (shots, saves, attacks) to fill in the match story.
+     * These are derived from xG to maintain consistency with simulation results.
+     * They do NOT affect match outcomes — purely for display.
+     *
+     * @return Collection<MatchEventData>
+     */
+    private function generateNarrativeEvents(
+        string $homeTeamId,
+        string $awayTeamId,
+        Collection $homePlayers,
+        Collection $awayPlayers,
+        float $homeXG,
+        float $awayXG,
+        int $fromMinute,
+        int $toMinute,
+        int $homeGoals,
+        int $awayGoals,
+    ): Collection {
+        $cfg = config('match_simulation.narrative', []);
+        $events = collect();
+
+        if ($homePlayers->isEmpty() && $awayPlayers->isEmpty()) {
+            return $events;
+        }
+
+        foreach ([
+            ['team' => $homeTeamId, 'opp' => $awayTeamId, 'players' => $homePlayers, 'oppPlayers' => $awayPlayers, 'xg' => $homeXG, 'goals' => $homeGoals],
+            ['team' => $awayTeamId, 'opp' => $homeTeamId, 'players' => $awayPlayers, 'oppPlayers' => $homePlayers, 'xg' => $awayXG, 'goals' => $awayGoals],
+        ] as $side) {
+            if ($side['players']->isEmpty()) {
+                continue;
+            }
+
+            $xg = max(0.1, $side['xg']);
+
+            // Calculate counts from xG (subtract actual goals since those are already events)
+            $shotsOnTarget = max(0, $this->poissonRandom($xg * ($cfg['shots_on_target_per_xg'] ?? 3.5)) - $side['goals']);
+            $shotsOffTarget = max(0, $this->poissonRandom($xg * ($cfg['shots_off_target_per_xg'] ?? 2.5)));
+            $totalShots = $shotsOnTarget + $shotsOffTarget;
+            $dangerousAttacks = max(0, $this->poissonRandom($totalShots * ($cfg['dangerous_attacks_per_shot'] ?? 1.8)));
+            $greatSaves = 0;
+            $nearMisses = 0;
+            $keyPasses = 0;
+
+            // Great saves come from this team's shots on target being saved by opponent GK
+            for ($i = 0; $i < $shotsOnTarget; $i++) {
+                if ($this->percentChance(($cfg['great_save_chance'] ?? 0.35) * 100)) {
+                    $greatSaves++;
+                }
+            }
+
+            // Near misses come from shots off target
+            for ($i = 0; $i < $shotsOffTarget; $i++) {
+                if ($this->percentChance(($cfg['near_miss_chance'] ?? 0.30) * 100)) {
+                    $nearMisses++;
+                }
+            }
+
+            // Key passes
+            $keyPasses = max(0, $this->poissonRandom($shotsOnTarget * ($cfg['key_passes_per_shot_on_target'] ?? 0.8)));
+
+            // Generate events distributed across match minutes
+            $minuteRange = max(1, $toMinute - $fromMinute);
+
+            // Shots on target
+            for ($i = 0; $i < $shotsOnTarget; $i++) {
+                $minute = $fromMinute + 1 + mt_rand(0, $minuteRange - 1);
+                $shooter = $this->pickPlayerByPosition($side['players'], self::GOAL_SCORING_WEIGHTS);
+                $events->push(MatchEventData::shotOnTarget($side['team'], $shooter->id, $minute));
+            }
+
+            // Shots off target
+            for ($i = 0; $i < $shotsOffTarget; $i++) {
+                $minute = $fromMinute + 1 + mt_rand(0, $minuteRange - 1);
+                $shooter = $this->pickPlayerByPosition($side['players'], self::GOAL_SCORING_WEIGHTS);
+                $events->push(MatchEventData::shotOffTarget($side['team'], $shooter->id, $minute));
+            }
+
+            // Dangerous attacks
+            for ($i = 0; $i < $dangerousAttacks; $i++) {
+                $minute = $fromMinute + 1 + mt_rand(0, $minuteRange - 1);
+                $attacker = $this->pickPlayerByPosition($side['players'], self::ASSIST_WEIGHTS);
+                $events->push(MatchEventData::dangerousAttack($side['team'], $attacker->id, $minute));
+            }
+
+            // Great saves (attributed to opponent's goalkeeper)
+            $oppGk = $side['oppPlayers']->first(fn ($p) => $p->position === 'Goalkeeper');
+            if ($oppGk && $greatSaves > 0) {
+                for ($i = 0; $i < $greatSaves; $i++) {
+                    $minute = $fromMinute + 1 + mt_rand(0, $minuteRange - 1);
+                    $events->push(MatchEventData::greatSave($side['opp'], $oppGk->id, $minute));
+                }
+            }
+
+            // Near misses
+            for ($i = 0; $i < $nearMisses; $i++) {
+                $minute = $fromMinute + 1 + mt_rand(0, $minuteRange - 1);
+                $shooter = $this->pickPlayerByPosition($side['players'], self::GOAL_SCORING_WEIGHTS);
+                $events->push(MatchEventData::nearMiss($side['team'], $shooter->id, $minute));
+            }
+
+            // Key passes
+            for ($i = 0; $i < $keyPasses; $i++) {
+                $minute = $fromMinute + 1 + mt_rand(0, $minuteRange - 1);
+                $passer = $this->pickPlayerByPosition($side['players'], self::ASSIST_WEIGHTS);
+                $events->push(MatchEventData::keyPass($side['team'], $passer->id, $minute));
+            }
+        }
+
+        return $events;
+    }
+
+    /**
+     * Generate tactical insight events based on match state and tactical context.
+     * These provide actionable advice to help users make better decisions.
+     * Called from the view/action layer where user team context is available.
+     *
+     * @return Collection<MatchEventData>
+     */
+    public function generateInsights(
+        string $userTeamId,
+        string $opponentTeamId,
+        Collection $userPlayers,
+        Collection $opponentPlayers,
+        int $fromMinute,
+        PressingIntensity $userPressing,
+        PressingIntensity $oppPressing,
+        DefensiveLineHeight $userDefLine,
+        DefensiveLineHeight $oppDefLine,
+        Mentality $userMentality,
+        Mentality $oppMentality,
+        PlayingStyle $userPlayingStyle,
+    ): Collection {
+        $insights = collect();
+
+        if ($userPlayers->isEmpty()) {
+            return $insights;
+        }
+
+        // Insight: User's high press is fading (minute 60-65)
+        if ($userPressing === PressingIntensity::HIGH_PRESS && $fromMinute <= 60) {
+            $insights->push(MatchEventData::insight($userTeamId, mt_rand(60, 65), 'press_fading'));
+        }
+
+        // Insight: Opponent's high press is fading
+        if ($oppPressing === PressingIntensity::HIGH_PRESS && $fromMinute <= 60) {
+            $insights->push(MatchEventData::insight($userTeamId, mt_rand(60, 65), 'opponent_press_fading'));
+        }
+
+        // Insight: High line being exploited by fast forward
+        if ($userDefLine === DefensiveLineHeight::HIGH_LINE) {
+            $bestOppForward = $opponentPlayers
+                ->filter(fn ($p) => in_array($p->position, ['Centre-Forward', 'Second Striker', 'Left Winger', 'Right Winger']))
+                ->sortByDesc('physical_ability')
+                ->first();
+
+            $threshold = config('match_simulation.defensive_line.high_line.physical_threshold', 80);
+            if ($bestOppForward && $bestOppForward->physical_ability >= $threshold) {
+                $minute = max($fromMinute + 5, mt_rand(20, 35));
+                if ($minute <= 90) {
+                    $insights->push(MatchEventData::insight($userTeamId, $minute, 'high_line_exploited', [
+                        'playerName' => $bestOppForward->player?->name ?? '',
+                    ]));
+                }
+            }
+        }
+
+        // Insight: Counter-attack opportunity (opponent has high line + attacking)
+        if ($oppDefLine === DefensiveLineHeight::HIGH_LINE
+            && $oppMentality === Mentality::ATTACKING
+            && $userPlayingStyle !== PlayingStyle::COUNTER_ATTACK
+        ) {
+            $minute = max($fromMinute + 3, mt_rand(15, 30));
+            if ($minute <= 90) {
+                $insights->push(MatchEventData::insight($userTeamId, $minute, 'counter_opportunity'));
+            }
+        }
+
+        // Insight: Player struggling (at half-time, minute 45-50)
+        if ($fromMinute <= 45) {
+            foreach ($userPlayers as $player) {
+                $perf = $this->getMatchPerformance($player);
+                $rating = self::performanceToRating($perf);
+                if ($rating < 5.5) {
+                    $insights->push(MatchEventData::insight($userTeamId, mt_rand(45, 50), 'player_struggling', [
+                        'playerName' => $player->player?->name ?? '',
+                        'playerId' => $player->id,
+                        'rating' => round($rating, 1),
+                    ]));
+                    break; // Only highlight worst performer
+                }
+            }
+        }
+
+        // Insight: Player having outstanding match (at half-time)
+        if ($fromMinute <= 45) {
+            $bestPerformer = null;
+            $bestRating = 0;
+            foreach ($userPlayers as $player) {
+                $perf = $this->getMatchPerformance($player);
+                $rating = self::performanceToRating($perf);
+                if ($rating > 8.0 && $rating > $bestRating) {
+                    $bestPerformer = $player;
+                    $bestRating = $rating;
+                }
+            }
+            if ($bestPerformer) {
+                $insights->push(MatchEventData::insight($userTeamId, 45, 'player_excellent', [
+                    'playerName' => $bestPerformer->player?->name ?? '',
+                    'playerId' => $bestPerformer->id,
+                    'rating' => round($bestRating, 1),
+                ]));
+            }
+        }
+
+        // Insight: Squad tiring (minute 70+)
+        if ($fromMinute <= 70) {
+            $avgFitness = $userPlayers->avg('fitness');
+            if ($avgFitness < 75) {
+                $insights->push(MatchEventData::insight($userTeamId, mt_rand(68, 72), 'energy_low'));
+            }
+        }
+
+        // Filter out insights that are before fromMinute
+        return $insights->filter(fn ($e) => $e->minute > $fromMinute);
     }
 }

--- a/app/Modules/Match/Services/MatchdayOrchestrator.php
+++ b/app/Modules/Match/Services/MatchdayOrchestrator.php
@@ -338,6 +338,52 @@ class MatchdayOrchestrator
         $performances = $this->matchSimulator->getMatchPerformances();
         $mvpPlayerId = $this->calculateMvp($result, $performances);
 
+        // Extract narrative events and player ratings for the live match experience
+        $narrativeEvents = $result->events
+            ->filter(fn (MatchEventData $e) => $e->isNarrative())
+            ->map(fn (MatchEventData $e) => $e->toArray())
+            ->values()
+            ->all();
+
+        // Convert performances to display ratings (1-10 scale)
+        $playerRatings = [];
+        foreach ($performances as $playerId => $perf) {
+            $playerRatings[$playerId] = MatchSimulator::performanceToRating($perf);
+        }
+
+        // Generate tactical insights for user's match
+        if ($isUserMatch) {
+            $userTeamId = $game->team_id;
+            $opponentTeamId = $isUserHome ? $match->away_team_id : $match->home_team_id;
+            $userPlayers = $isUserHome ? $homePlayers : $awayPlayers;
+            $opponentPlayers = $isUserHome ? $awayPlayers : $homePlayers;
+            $userPressing = $isUserHome ? $homePressing : $awayPressing;
+            $oppPressing = $isUserHome ? $awayPressing : $homePressing;
+            $userDefLine = $isUserHome ? $homeDefLine : $awayDefLine;
+            $oppDefLine = $isUserHome ? $awayDefLine : $homeDefLine;
+            $userMentality = $isUserHome ? $homeMentality : $awayMentality;
+            $oppMentality = $isUserHome ? $awayMentality : $homeMentality;
+            $userPlayingStyle = $isUserHome ? $homePlayingStyle : $awayPlayingStyle;
+
+            $insights = $this->matchSimulator->generateInsights(
+                $userTeamId, $opponentTeamId,
+                $userPlayers, $opponentPlayers,
+                0, $userPressing, $oppPressing,
+                $userDefLine, $oppDefLine,
+                $userMentality, $oppMentality,
+                $userPlayingStyle,
+            );
+
+            $insightEvents = $insights->map(fn (MatchEventData $e) => $e->toArray())->values()->all();
+            $narrativeEvents = array_merge($narrativeEvents, $insightEvents);
+        }
+
+        // Store narrative events and ratings on the match for live match display
+        $match->update([
+            'narrative_events' => $narrativeEvents,
+            'player_ratings' => $playerRatings,
+        ]);
+
         return [
             'matchId' => $match->id,
             'homeTeamId' => $match->home_team_id,
@@ -348,7 +394,7 @@ class MatchdayOrchestrator
             'awayPossession' => $result->awayPossession,
             'competitionId' => $match->competition_id,
             'mvpPlayerId' => $mvpPlayerId,
-            'events' => $result->events->map(fn (MatchEventData $e) => $e->toArray())->all(),
+            'events' => $result->events->reject(fn (MatchEventData $e) => $e->isNarrative())->map(fn (MatchEventData $e) => $e->toArray())->all(),
         ];
     }
 

--- a/config/match_simulation.php
+++ b/config/match_simulation.php
@@ -325,6 +325,31 @@ return [
     | reduction from recalculating with 10 players instead of 11.
     |
     */
+    /*
+    |--------------------------------------------------------------------------
+    | Narrative Events
+    |--------------------------------------------------------------------------
+    |
+    | Controls the generation of narrative events (shots, saves, attacks, etc.)
+    | that provide match texture without affecting outcomes. Counts are derived
+    | from xG to maintain consistency with simulation results.
+    |
+    */
+    'narrative' => [
+        // Shots on target ≈ xG × this multiplier (goals are a subset)
+        'shots_on_target_per_xg' => 3.5,
+        // Shots off target ≈ xG × this multiplier
+        'shots_off_target_per_xg' => 2.5,
+        // Dangerous attacks ≈ total shots × this multiplier
+        'dangerous_attacks_per_shot' => 1.8,
+        // Fraction of opponent's shots on target that become great saves
+        'great_save_chance' => 0.35,
+        // Fraction of shots off target that become near misses
+        'near_miss_chance' => 0.30,
+        // Key passes ≈ shots on target × this multiplier
+        'key_passes_per_shot_on_target' => 0.8,
+    ],
+
     'red_card_impact' => [
         'attack_modifier' => 0.80,      // 20% reduction in xG for the 10-man team
         'defense_modifier' => 1.15,     // 15% boost in opponent xG when facing 10 men

--- a/database/migrations/2026_03_21_000000_add_narrative_events_to_game_matches.php
+++ b/database/migrations/2026_03_21_000000_add_narrative_events_to_game_matches.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('game_matches', function (Blueprint $table) {
+            $table->json('narrative_events')->nullable()->after('substitutions');
+            $table->json('player_ratings')->nullable()->after('narrative_events');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('game_matches', function (Blueprint $table) {
+            $table->dropColumn(['narrative_events', 'player_ratings']);
+        });
+    }
+};

--- a/lang/en/game.php
+++ b/lang/en/game.php
@@ -446,4 +446,29 @@ return [
     // MVP
     'mvp' => 'MVP',
     'mvp_of_the_match' => 'MVP of the Match',
+
+    // Narrative events
+    'live_shot_on_target' => 'Shot on target',
+    'live_shot_off_target' => 'Shot off target',
+    'live_dangerous_attack' => 'Dangerous attack',
+    'live_great_save' => 'Great save',
+    'live_near_miss' => 'Near miss',
+    'live_key_pass' => 'Key pass',
+
+    // Live stats
+    'live_stat_shots' => 'Shots',
+    'live_stat_shots_on_target' => 'Shots on Target',
+    'live_stat_dangerous_attacks' => 'Dangerous Attacks',
+    'live_stat_momentum' => 'Momentum',
+    'live_match_rating' => 'Match Rating',
+
+    // Tactical insights
+    'tactical_insight' => 'Tactical Insight',
+    'insight_press_fading' => 'Your high press is losing effectiveness',
+    'insight_opponent_press_fading' => "Opponent's pressing is fading — consider pushing higher",
+    'insight_high_line_exploited' => 'Your high line is being beaten by :player\'s pace',
+    'insight_counter_opportunity' => "Opponent's high line is vulnerable to counters",
+    'insight_player_struggling' => ':player is having a poor match (:rating)',
+    'insight_player_excellent' => ':player is having an outstanding match',
+    'insight_energy_low' => 'Your squad is tiring — consider fresh legs',
 ];

--- a/lang/es/game.php
+++ b/lang/es/game.php
@@ -446,4 +446,29 @@ return [
     // MVP
     'mvp' => 'MVP',
     'mvp_of_the_match' => 'MVP del partido',
+
+    // Narrative events
+    'live_shot_on_target' => 'Tiro a puerta',
+    'live_shot_off_target' => 'Tiro fuera',
+    'live_dangerous_attack' => 'Ataque peligroso',
+    'live_great_save' => 'Gran parada',
+    'live_near_miss' => 'Casi gol',
+    'live_key_pass' => 'Pase clave',
+
+    // Live stats
+    'live_stat_shots' => 'Tiros',
+    'live_stat_shots_on_target' => 'Tiros a puerta',
+    'live_stat_dangerous_attacks' => 'Ataques peligrosos',
+    'live_stat_momentum' => 'Inercia',
+    'live_match_rating' => 'Valoración',
+
+    // Tactical insights
+    'tactical_insight' => 'Consejo táctico',
+    'insight_press_fading' => 'Tu presión alta está perdiendo efectividad',
+    'insight_opponent_press_fading' => 'La presión del rival está disminuyendo — considera presionar más',
+    'insight_high_line_exploited' => 'Tu línea alta está siendo superada por la velocidad de :player',
+    'insight_counter_opportunity' => 'La línea alta del rival es vulnerable al contraataque',
+    'insight_player_struggling' => ':player está teniendo un mal partido (:rating)',
+    'insight_player_excellent' => ':player está teniendo un partido excepcional',
+    'insight_energy_low' => 'Tu equipo se está cansando — considera hacer cambios',
 ];

--- a/resources/js/live-match.js
+++ b/resources/js/live-match.js
@@ -172,6 +172,19 @@ export default function liveMatch(config) {
         processingStatusUrl: config.processingStatusUrl || '',
         _processingPollTimer: null,
 
+        // Player ratings state
+        playerRatings: config.playerRatings || {},
+        _liveRatingModifiers: {},  // Event-based modifiers applied on top of base ratings
+
+        // Lineup display (Alpine-rendered for dynamic ratings)
+        homeLineupDisplay: config.homeLineupDisplay || [],
+        awayLineupDisplay: config.awayLineupDisplay || [],
+
+        // Insight state
+        activeInsight: null,
+        activeInsightText: '',
+        _insightDismissTimer: null,
+
         // Animation loop
         _lastTick: null,
         _animFrame: null,
@@ -372,10 +385,18 @@ export default function liveMatch(config) {
             this.revealedEvents.unshift(event); // newest first
             this.latestEvent = event;
 
+            // Apply player rating modifier for this event
+            this.applyRatingModifier(event);
+
             if (event.type === 'goal' || event.type === 'own_goal') {
                 this.updateScore(event);
                 this.triggerGoalFlash();
                 this.pauseForDrama(1500);
+            }
+
+            // Auto-pause and show banner for tactical insights
+            if (event.type === 'insight') {
+                this.showInsightBanner(event);
             }
 
             // Auto-open tactical panel on substitutions tab when user's player gets injured
@@ -394,6 +415,14 @@ export default function liveMatch(config) {
             this.lastRevealedETIndex = index;
             this.revealedEvents.unshift(event);
             this.latestEvent = event;
+
+            // Apply player rating modifier for this event
+            this.applyRatingModifier(event);
+
+            // Auto-pause and show banner for tactical insights
+            if (event.type === 'insight') {
+                this.showInsightBanner(event);
+            }
 
             if (event.type === 'goal' || event.type === 'own_goal') {
                 this.updateScore(event);
@@ -1321,6 +1350,23 @@ export default function liveMatch(config) {
                     this.resetPossessionTarget();
                 }
 
+                // Merge narrative events from resimulation
+                if (result.narrativeEvents && result.narrativeEvents.length > 0) {
+                    if (isET) {
+                        this.extraTimeEvents.push(...result.narrativeEvents);
+                        this.extraTimeEvents.sort((a, b) => a.minute - b.minute);
+                    } else {
+                        this.events.push(...result.narrativeEvents);
+                        this.events.sort((a, b) => a.minute - b.minute);
+                    }
+                }
+
+                // Update player ratings (reset modifiers since server recalculated)
+                if (result.playerRatings) {
+                    this.playerRatings = result.playerRatings;
+                    this._liveRatingModifiers = {};
+                }
+
                 // Close the panel and resume
                 this.closeTacticalPanel();
             } catch (err) {
@@ -1879,6 +1925,172 @@ export default function liveMatch(config) {
                 const eventSide = this.getEventSide(event);
                 return eventSide === side;
             }).length;
+        },
+
+        // =====================================================================
+        // Live Stats (computed from narrative events)
+        // =====================================================================
+
+        _narrativeTypes: ['shot_on_target', 'shot_off_target', 'dangerous_attack', 'great_save', 'near_miss', 'key_pass'],
+
+        isNarrativeEvent(type) {
+            return this._narrativeTypes.includes(type);
+        },
+
+        getLiveStat(stat, side) {
+            const allEvents = [...this.revealedEvents, ...this.extraTimeEvents.filter(e => this.revealedEvents.length >= this.events.length)];
+            switch (stat) {
+                case 'shots':
+                    return allEvents.filter(e => {
+                        if (!['shot_on_target', 'shot_off_target', 'goal'].includes(e.type)) return false;
+                        return this.getEventSide(e) === side;
+                    }).length;
+                case 'shotsOnTarget':
+                    return allEvents.filter(e => {
+                        if (!['shot_on_target', 'goal'].includes(e.type)) return false;
+                        return this.getEventSide(e) === side;
+                    }).length;
+                case 'dangerousAttacks':
+                    return allEvents.filter(e => {
+                        if (e.type !== 'dangerous_attack') return false;
+                        return this.getEventSide(e) === side;
+                    }).length;
+                default:
+                    return 0;
+            }
+        },
+
+        getShotBarWidth(side) {
+            const home = this.getLiveStat('shots', 'home');
+            const away = this.getLiveStat('shots', 'away');
+            const total = home + away;
+            if (total === 0) return 50;
+            return side === 'home'
+                ? Math.round((home / total) * 100)
+                : Math.round((away / total) * 100);
+        },
+
+        getMomentum() {
+            // Rolling 15-minute window: positive = home momentum, negative = away
+            const windowSize = 15;
+            const minute = this.currentMinute;
+            const minStart = Math.max(0, minute - windowSize);
+            const allEvents = [...this.revealedEvents, ...this.extraTimeEvents.filter(e => this.revealedEvents.length >= this.events.length)];
+            const recentEvents = allEvents.filter(e =>
+                e.minute >= minStart && e.minute <= minute &&
+                ['shot_on_target', 'dangerous_attack', 'goal', 'key_pass'].includes(e.type)
+            );
+            let score = 0;
+            recentEvents.forEach(e => {
+                const side = this.getEventSide(e);
+                const weight = e.type === 'goal' ? 3 : (e.type === 'shot_on_target' ? 2 : 1);
+                score += (side === 'home' ? weight : -weight);
+            });
+            return Math.max(-5, Math.min(5, score)); // Clamp to ±5
+        },
+
+        // =====================================================================
+        // Narrative Event Labels
+        // =====================================================================
+
+        getNarrativeLabel(event) {
+            const labels = {
+                'shot_on_target': this.translations.shotOnTarget || 'Shot on target',
+                'shot_off_target': this.translations.shotOffTarget || 'Shot off target',
+                'dangerous_attack': this.translations.dangerousAttack || 'Dangerous attack',
+                'great_save': this.translations.greatSave || 'Great save',
+                'near_miss': this.translations.nearMiss || 'Near miss',
+                'key_pass': this.translations.keyPass || 'Key pass',
+            };
+            return labels[event.type] || event.type;
+        },
+
+        // =====================================================================
+        // Tactical Insights
+        // =====================================================================
+
+        getInsightText(event) {
+            const key = event.metadata?.insight_key;
+            const params = event.metadata?.params || {};
+            const texts = {
+                'press_fading': this.translations.insightPressFading || 'Your high press is losing effectiveness',
+                'opponent_press_fading': this.translations.insightOpponentPressFading || "Opponent's pressing is fading",
+                'high_line_exploited': (this.translations.insightHighLineExploited || 'Your high line is being beaten by their pace').replace(':player', params.playerName || ''),
+                'counter_opportunity': this.translations.insightCounterOpportunity || "Opponent's high line is vulnerable to counters",
+                'player_struggling': (this.translations.insightPlayerStruggling || ':player is having a poor match (:rating)').replace(':player', params.playerName || '').replace(':rating', params.rating || ''),
+                'player_excellent': (this.translations.insightPlayerExcellent || ':player is having an outstanding match').replace(':player', params.playerName || ''),
+                'energy_low': this.translations.insightEnergyLow || 'Your squad is tiring — consider fresh legs',
+            };
+            return texts[key] || key || '';
+        },
+
+        showInsightBanner(event) {
+            this.activeInsight = event;
+            this.activeInsightText = this.getInsightText(event);
+            // Auto-pause for insight
+            if (!this.userPaused) {
+                this.isPaused = true;
+            }
+            // Auto-dismiss after 4 seconds
+            if (this._insightDismissTimer) clearTimeout(this._insightDismissTimer);
+            this._insightDismissTimer = setTimeout(() => this.dismissInsight(), 4000);
+        },
+
+        dismissInsight() {
+            this.activeInsight = null;
+            this.activeInsightText = '';
+            if (this._insightDismissTimer) {
+                clearTimeout(this._insightDismissTimer);
+                this._insightDismissTimer = null;
+            }
+            // Resume if we auto-paused
+            if (this.isPaused && !this.userPaused) {
+                this.isPaused = false;
+            }
+        },
+
+        // =====================================================================
+        // Player Ratings
+        // =====================================================================
+
+        _ratingEventModifiers: {
+            'goal': 0.8,
+            'assist': 0.5,
+            'key_pass': 0.2,
+            'shot_on_target': 0.1,
+            'yellow_card': -0.3,
+            'red_card': -1.5,
+            'own_goal': -1.0,
+            'injury': -0.5,
+        },
+
+        applyRatingModifier(event) {
+            const mod = this._ratingEventModifiers[event.type];
+            if (!mod || !event.gamePlayerId) return;
+            if (!this._liveRatingModifiers[event.gamePlayerId]) {
+                this._liveRatingModifiers[event.gamePlayerId] = 0;
+            }
+            this._liveRatingModifiers[event.gamePlayerId] += mod;
+        },
+
+        getPlayerRating(playerId) {
+            const base = this.playerRatings[playerId];
+            if (base === undefined) return '-';
+            const mod = this._liveRatingModifiers[playerId] || 0;
+            const rating = Math.max(1.0, Math.min(10.0, base + mod));
+            return rating.toFixed(1);
+        },
+
+        getPlayerRatingClass(playerId) {
+            const base = this.playerRatings[playerId];
+            if (base === undefined) return 'bg-surface-700 text-text-secondary';
+            const mod = this._liveRatingModifiers[playerId] || 0;
+            const rating = Math.max(1.0, Math.min(10.0, base + mod));
+            if (rating >= 8.0) return 'bg-accent-green/20 text-accent-green';
+            if (rating >= 7.0) return 'bg-accent-green/10 text-accent-green';
+            if (rating <= 5.0) return 'bg-accent-red/20 text-accent-red';
+            if (rating <= 5.5) return 'bg-accent-orange/15 text-accent-orange';
+            return 'bg-surface-700 text-text-secondary';
         },
 
         // =============================

--- a/resources/views/live-match.blade.php
+++ b/resources/views/live-match.blade.php
@@ -67,6 +67,9 @@
                 manualAssignments: {{ Js::from($slotAssignments) }},
                 mvpPlayerName: {!! $mvpPlayerName ? Js::from($mvpPlayerName) : 'null' !!},
                 mvpPlayerTeamId: {!! $mvpPlayerTeamId ? "'" . $mvpPlayerTeamId . "'" : 'null' !!},
+                playerRatings: {{ Js::from($playerRatings) }},
+                homeLineupDisplay: {{ Js::from($homeLineupDisplay) }},
+                awayLineupDisplay: {{ Js::from($awayLineupDisplay) }},
                 translations: {
                     unsavedTacticalChanges: {!! Js::from(__('game.tactical_unsaved_changes')) !!},
                     extraTime: {!! Js::from(__('game.live_extra_time')) !!},
@@ -95,6 +98,25 @@
                     confirmPressing: {!! Js::from(__('game.confirm_pressing')) !!},
                     confirmDefLine: {!! Js::from(__('game.confirm_def_line')) !!},
                     mvpOfTheMatch: {!! Js::from(__('game.mvp_of_the_match')) !!},
+                    shotOnTarget: {!! Js::from(__('game.live_shot_on_target')) !!},
+                    shotOffTarget: {!! Js::from(__('game.live_shot_off_target')) !!},
+                    dangerousAttack: {!! Js::from(__('game.live_dangerous_attack')) !!},
+                    greatSave: {!! Js::from(__('game.live_great_save')) !!},
+                    nearMiss: {!! Js::from(__('game.live_near_miss')) !!},
+                    keyPass: {!! Js::from(__('game.live_key_pass')) !!},
+                    statShots: {!! Js::from(__('game.live_stat_shots')) !!},
+                    statShotsOnTarget: {!! Js::from(__('game.live_stat_shots_on_target')) !!},
+                    statDangerousAttacks: {!! Js::from(__('game.live_stat_dangerous_attacks')) !!},
+                    statMomentum: {!! Js::from(__('game.live_stat_momentum')) !!},
+                    matchRating: {!! Js::from(__('game.live_match_rating')) !!},
+                    insightPressFading: {!! Js::from(__('game.insight_press_fading')) !!},
+                    insightOpponentPressFading: {!! Js::from(__('game.insight_opponent_press_fading')) !!},
+                    insightHighLineExploited: {!! Js::from(__('game.insight_high_line_exploited')) !!},
+                    insightCounterOpportunity: {!! Js::from(__('game.insight_counter_opportunity')) !!},
+                    insightPlayerStruggling: {!! Js::from(__('game.insight_player_struggling')) !!},
+                    insightPlayerExcellent: {!! Js::from(__('game.insight_player_excellent')) !!},
+                    insightEnergyLow: {!! Js::from(__('game.insight_energy_low')) !!},
+                    tacticalInsight: {!! Js::from(__('game.tactical_insight')) !!},
                 },
              })"
              x-on:keydown.escape.window="if (!tacticalPanelOpen) skipToEnd()"
@@ -310,6 +332,28 @@
 
                 </div>{{-- /sticky padding --}}
                 </div>{{-- /sticky header --}}
+
+                {{-- Tactical Insight Banner --}}
+                <div x-show="activeInsight" x-cloak
+                     x-transition:enter="transition ease-out duration-300"
+                     x-transition:enter-start="opacity-0 -translate-y-2"
+                     x-transition:enter-end="opacity-100 translate-y-0"
+                     x-transition:leave="transition ease-in duration-200"
+                     x-transition:leave-start="opacity-100"
+                     x-transition:leave-end="opacity-0"
+                     class="mx-4 mb-2">
+                    <div class="flex items-start gap-2.5 px-3 py-2.5 rounded-lg bg-accent-blue/10 border border-accent-blue/20"
+                         @click="dismissInsight()">
+                        <svg class="w-4 h-4 text-accent-blue shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z"/>
+                        </svg>
+                        <div class="flex-1 min-w-0">
+                            <span class="text-[10px] font-semibold uppercase tracking-wider text-accent-blue" x-text="translations.tacticalInsight"></span>
+                            <p class="text-xs text-text-body mt-0.5" x-text="activeInsightText"></p>
+                        </div>
+                        <span class="text-[10px] text-text-muted shrink-0 mt-0.5">✕</span>
+                    </div>
+                </div>
 
                 {{-- Tab Navigation --}}
                 <div class="flex items-center justify-center gap-0 px-4 border-b border-border-default overflow-x-auto scrollbar-hide">
@@ -541,7 +585,29 @@
 
                 {{-- Tab: Stats --}}
                 <div x-show="activeTab === 'stats'" x-cloak class="px-4 sm:px-6 md:px-8 py-4">
-                    <div class="max-w-lg mx-auto space-y-4">
+                    <div class="max-w-lg mx-auto space-y-3">
+
+                        {{-- Momentum Indicator --}}
+                        <div class="mb-2">
+                            <div class="flex items-center justify-between mb-1">
+                                <span class="text-[10px] font-semibold uppercase tracking-wider"
+                                      :class="getMomentum() > 0 ? 'text-accent-green' : 'text-text-muted'"
+                                      x-text="getMomentum() > 0 ? '▲' : ''"></span>
+                                <span class="text-[10px] text-text-muted uppercase tracking-wider" x-text="translations.statMomentum"></span>
+                                <span class="text-[10px] font-semibold uppercase tracking-wider"
+                                      :class="getMomentum() < 0 ? 'text-accent-red' : 'text-text-muted'"
+                                      x-text="getMomentum() < 0 ? '▲' : ''"></span>
+                            </div>
+                            <div class="flex h-2.5 rounded-full overflow-hidden bg-surface-700">
+                                <div class="h-full transition-all duration-1000 ease-out rounded-l-full"
+                                     :class="getMomentum() >= 0 ? 'bg-accent-green' : 'bg-surface-700'"
+                                     :style="'width: ' + (50 + getMomentum() * 3) + '%'"></div>
+                                <div class="w-0.5 h-full bg-surface-600 shrink-0"></div>
+                                <div class="h-full transition-all duration-1000 ease-out rounded-r-full flex-1"
+                                     :class="getMomentum() < 0 ? 'bg-accent-red' : 'bg-surface-700'"></div>
+                            </div>
+                        </div>
+
                         {{-- Possession --}}
                         <div>
                             <div class="flex items-center justify-between mb-1.5">
@@ -550,13 +616,44 @@
                                 <span class="font-heading font-bold text-sm text-text-primary tabular-nums" x-text="awayPossession + '%'"></span>
                             </div>
                             <div class="flex h-2 rounded-full overflow-hidden gap-0.5">
-                                <div class="h-full rounded-l-full bg-blue-500 transition-all duration-700" :style="'width: ' + homePossession + '%'"></div>
-                                <div class="h-full rounded-r-full bg-blue-800 transition-all duration-700" :style="'width: ' + awayPossession + '%'"></div>
+                                <div class="h-full rounded-l-full bg-accent-blue transition-all duration-700" :style="'width: ' + homePossession + '%'"></div>
+                                <div class="h-full rounded-r-full bg-accent-blue/40 transition-all duration-700" :style="'width: ' + awayPossession + '%'"></div>
+                            </div>
+                        </div>
+
+                        {{-- Shots --}}
+                        <div>
+                            <div class="flex items-center justify-between mb-1.5">
+                                <span class="font-heading font-bold text-sm text-text-primary tabular-nums" x-text="getLiveStat('shots', 'home')"></span>
+                                <span class="text-[10px] text-text-muted uppercase tracking-wider" x-text="translations.statShots"></span>
+                                <span class="font-heading font-bold text-sm text-text-primary tabular-nums" x-text="getLiveStat('shots', 'away')"></span>
+                            </div>
+                            <div class="flex h-1.5 rounded-full overflow-hidden gap-0.5">
+                                <div class="h-full rounded-l-full bg-accent-blue/60 transition-all duration-700" :style="'width: ' + getShotBarWidth('home') + '%'"></div>
+                                <div class="h-full rounded-r-full bg-accent-blue/30 transition-all duration-700" :style="'width: ' + getShotBarWidth('away') + '%'"></div>
+                            </div>
+                        </div>
+
+                        {{-- Shots on Target --}}
+                        <div>
+                            <div class="flex items-center justify-between">
+                                <span class="font-heading font-bold text-sm text-text-primary tabular-nums" x-text="getLiveStat('shotsOnTarget', 'home')"></span>
+                                <span class="text-[10px] text-text-muted uppercase tracking-wider" x-text="translations.statShotsOnTarget"></span>
+                                <span class="font-heading font-bold text-sm text-text-primary tabular-nums" x-text="getLiveStat('shotsOnTarget', 'away')"></span>
+                            </div>
+                        </div>
+
+                        {{-- Dangerous Attacks --}}
+                        <div>
+                            <div class="flex items-center justify-between">
+                                <span class="font-heading font-bold text-sm text-text-primary tabular-nums" x-text="getLiveStat('dangerousAttacks', 'home')"></span>
+                                <span class="text-[10px] text-text-muted uppercase tracking-wider" x-text="translations.statDangerousAttacks"></span>
+                                <span class="font-heading font-bold text-sm text-text-primary tabular-nums" x-text="getLiveStat('dangerousAttacks', 'away')"></span>
                             </div>
                         </div>
 
                         {{-- Goals --}}
-                        <div>
+                        <div class="pt-3 border-t border-border-default">
                             <div class="flex items-center justify-between">
                                 <span class="font-heading font-bold text-sm text-text-primary tabular-nums" x-text="homeScore"></span>
                                 <span class="text-[10px] text-text-muted uppercase tracking-wider">{{ __('game.live_stat_goals') }}</span>
@@ -565,7 +662,7 @@
                         </div>
 
                         {{-- Cards --}}
-                        <div class="flex items-center justify-between pt-3 border-t border-border-default">
+                        <div class="flex items-center justify-between">
                             <div class="flex items-center gap-3">
                                 <div class="flex items-center gap-1">
                                     <div class="w-3 h-4 rounded-[2px] bg-accent-gold"></div>
@@ -591,19 +688,10 @@
 
                         {{-- Substitutions --}}
                         <div>
-                            <div class="flex items-center justify-between mb-1.5">
+                            <div class="flex items-center justify-between">
                                 <span class="font-heading font-bold text-sm text-text-primary tabular-nums" x-text="getStatCount('substitution', 'home')"></span>
                                 <span class="text-[10px] text-text-muted uppercase tracking-wider">{{ __('game.live_stat_subs') }}</span>
                                 <span class="font-heading font-bold text-sm text-text-primary tabular-nums" x-text="getStatCount('substitution', 'away')"></span>
-                            </div>
-                        </div>
-
-                        {{-- Injuries --}}
-                        <div>
-                            <div class="flex items-center justify-between mb-1.5">
-                                <span class="font-heading font-bold text-sm text-text-primary tabular-nums" x-text="getStatCount('injury', 'home')"></span>
-                                <span class="text-[10px] text-text-muted uppercase tracking-wider">{{ __('game.live_stat_injuries') }}</span>
-                                <span class="font-heading font-bold text-sm text-text-primary tabular-nums" x-text="getStatCount('injury', 'away')"></span>
                             </div>
                         </div>
                     </div>
@@ -620,24 +708,18 @@
                                 <span class="text-[10px] text-text-muted ml-auto">{{ $homeFormation }}</span>
                             </div>
                             <div class="space-y-0.5">
-                                @forelse($homeLineupDisplay as $p)
-                                    <div class="flex items-center gap-2.5 px-3 py-1.5 rounded-lg hover:bg-surface-800/50">
-                                        <span class="inline-flex items-center justify-center w-6 h-6 text-[10px] -skew-x-12 font-semibold text-white shrink-0
-                                            {{ match($p['positionGroup']) {
-                                                'GK' => 'bg-amber-600',
-                                                'DEF' => 'bg-blue-600',
-                                                'MID' => 'bg-green-600',
-                                                'FWD' => 'bg-red-600',
-                                                default => 'bg-surface-600',
-                                            } }}">
-                                            <span class="skew-x-12">{{ $p['positionAbbr'] }}</span>
+                                <template x-for="p in homeLineupDisplay" :key="p.id">
+                                    <div class="flex items-center gap-2.5 px-3 py-1.5 rounded-lg hover:bg-surface-700/50">
+                                        <span class="inline-flex items-center justify-center w-6 h-6 text-[10px] -skew-x-12 font-semibold text-white shrink-0"
+                                              :class="{'bg-amber-600': p.positionGroup==='GK', 'bg-blue-600': p.positionGroup==='DEF', 'bg-green-600': p.positionGroup==='MID', 'bg-red-600': p.positionGroup==='FWD', 'bg-surface-600': !['GK','DEF','MID','FWD'].includes(p.positionGroup)}">
+                                            <span class="skew-x-12" x-text="p.positionAbbr"></span>
                                         </span>
-                                        <span class="text-xs text-text-body flex-1 truncate">{{ $p['name'] }}</span>
-                                        <span class="inline-flex items-center justify-center w-5 h-5 rounded-full text-[9px] font-semibold bg-surface-700 text-text-secondary shrink-0">{{ $p['overallScore'] }}</span>
+                                        <span class="text-xs text-text-body flex-1 truncate" x-text="p.name"></span>
+                                        <span class="inline-flex items-center justify-center min-w-[28px] h-5 rounded-full text-[9px] font-semibold shrink-0 tabular-nums px-1"
+                                              :class="getPlayerRatingClass(p.id)"
+                                              x-text="getPlayerRating(p.id)"></span>
                                     </div>
-                                @empty
-                                    <p class="text-xs text-text-muted italic px-3 py-3">{{ __('game.lineup_unknown') }}</p>
-                                @endforelse
+                                </template>
                             </div>
                         </div>
 
@@ -649,24 +731,18 @@
                                 <span class="text-[10px] text-text-muted ml-auto">{{ $awayFormation }}</span>
                             </div>
                             <div class="space-y-0.5">
-                                @forelse($awayLineupDisplay as $p)
-                                    <div class="flex items-center gap-2.5 px-3 py-1.5 rounded-lg hover:bg-surface-800/50">
-                                        <span class="inline-flex items-center justify-center w-6 h-6 text-[10px] -skew-x-12 font-semibold text-white shrink-0
-                                            {{ match($p['positionGroup']) {
-                                                'GK' => 'bg-amber-600',
-                                                'DEF' => 'bg-blue-600',
-                                                'MID' => 'bg-green-600',
-                                                'FWD' => 'bg-red-600',
-                                                default => 'bg-surface-600',
-                                            } }}">
-                                            <span class="skew-x-12">{{ $p['positionAbbr'] }}</span>
+                                <template x-for="p in awayLineupDisplay" :key="p.id">
+                                    <div class="flex items-center gap-2.5 px-3 py-1.5 rounded-lg hover:bg-surface-700/50">
+                                        <span class="inline-flex items-center justify-center w-6 h-6 text-[10px] -skew-x-12 font-semibold text-white shrink-0"
+                                              :class="{'bg-amber-600': p.positionGroup==='GK', 'bg-blue-600': p.positionGroup==='DEF', 'bg-green-600': p.positionGroup==='MID', 'bg-red-600': p.positionGroup==='FWD', 'bg-surface-600': !['GK','DEF','MID','FWD'].includes(p.positionGroup)}">
+                                            <span class="skew-x-12" x-text="p.positionAbbr"></span>
                                         </span>
-                                        <span class="text-xs text-text-body flex-1 truncate">{{ $p['name'] }}</span>
-                                        <span class="inline-flex items-center justify-center w-5 h-5 rounded-full text-[9px] font-semibold bg-surface-700 text-text-secondary shrink-0">{{ $p['overallScore'] }}</span>
+                                        <span class="text-xs text-text-body flex-1 truncate" x-text="p.name"></span>
+                                        <span class="inline-flex items-center justify-center min-w-[28px] h-5 rounded-full text-[9px] font-semibold shrink-0 tabular-nums px-1"
+                                              :class="getPlayerRatingClass(p.id)"
+                                              x-text="getPlayerRating(p.id)"></span>
                                     </div>
-                                @empty
-                                    <p class="text-xs text-text-muted italic px-3 py-3">{{ __('game.lineup_unknown') }}</p>
-                                @endforelse
+                                </template>
                             </div>
                         </div>
                     </div>

--- a/resources/views/partials/live-match/event-row.blade.php
+++ b/resources/views/partials/live-match/event-row.blade.php
@@ -1,53 +1,105 @@
-<span class="font-heading font-bold text-xs text-text-muted w-8 text-right shrink-0 tabular-nums"
-      x-text="event.minute + '\''"></span>
-<span class="w-6 text-center shrink-0 flex items-center justify-center"
-      x-show="event.type === 'goal'">
-    <svg class="w-3.5 h-3.5 text-accent-green" viewBox="0 0 16 16" fill="currentColor"><circle cx="8" cy="8" r="8"/></svg>
-</span>
-<span class="w-6 text-center shrink-0 flex items-center justify-center"
-      x-show="event.type === 'own_goal'">
-    <svg class="w-3.5 h-3.5 text-accent-red" viewBox="0 0 16 16" fill="currentColor"><circle cx="8" cy="8" r="8"/></svg>
-</span>
-<span class="w-6 text-center shrink-0 flex items-center justify-center"
-      x-show="event.type === 'yellow_card'">
-    <div class="w-2.5 h-3.5 rounded-[2px] bg-accent-gold"></div>
-</span>
-<span class="w-6 text-center shrink-0 flex items-center justify-center"
-      x-show="event.type === 'red_card'">
-    <div class="w-2.5 h-3.5 rounded-[2px] bg-accent-red"></div>
-</span>
-<span class="w-6 text-center shrink-0 flex items-center justify-center"
-      x-show="event.type === 'injury'">
-    <svg class="w-3.5 h-3.5 text-accent-orange" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"/></svg>
-</span>
-<span class="w-6 text-center shrink-0 flex items-center justify-center"
-      x-show="event.type === 'substitution'">
-    <svg class="w-3.5 h-3.5 text-accent-blue" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 16V4m0 0L3 8m4-4l4 4m6 0v12m0 0l4-4m-4 4l-4-4"/></svg>
-</span>
-<img :src="getEventSide(event) === 'home' ? homeTeamImage : awayTeamImage"
-     class="w-5 h-5 shrink-0 object-contain"
-     :alt="getEventSide(event) === 'home' ? 'Home' : 'Away'">
-<div class="flex-1 min-w-0">
-    <span class="font-semibold text-xs text-text-primary" x-text="event.type === 'substitution' ? event.playerInName : event.playerName"></span>
-    <template x-if="event.type === 'goal'">
-        <span class="text-[10px] text-text-muted ml-1">{{ __('game.live_goal') }}</span>
-    </template>
-    <template x-if="event.type === 'own_goal'">
-        <span class="text-[10px] text-accent-red ml-1">({{ __('game.og') }})</span>
-    </template>
-    <template x-if="event.type === 'yellow_card'">
-        <span class="text-[10px] text-text-muted ml-1">{{ __('game.live_yellow_card') }}</span>
-    </template>
-    <template x-if="event.type === 'red_card'">
-        <span class="text-[10px] text-accent-red ml-1" x-text="event.metadata?.second_yellow ? '{{ __('game.live_second_yellow') }}' : '{{ __('game.live_red_card') }}'"></span>
-    </template>
-    <template x-if="event.type === 'injury'">
-        <span class="text-[10px] text-accent-orange ml-1">{{ __('game.live_injury') }}</span>
-    </template>
-    <template x-if="event.type === 'substitution'">
-        <div class="text-[10px] text-text-secondary"><span class="text-[10px] text-accent-red font-semibold">OFF</span> <span x-text="event.playerName"></span></div>
-    </template>
-    <template x-if="event.assistPlayerName">
-        <div class="text-[10px] text-text-secondary" x-text="'{{ __('game.live_assist') }} ' + event.assistPlayerName"></div>
-    </template>
-</div>
+{{-- Narrative events: compact inline rows --}}
+<template x-if="isNarrativeEvent(event.type)">
+    <div class="flex items-center gap-2 py-0.5 opacity-60">
+        <span class="font-heading text-[10px] text-text-muted w-8 text-right shrink-0 tabular-nums"
+              x-text="event.minute + '\''"></span>
+        <span class="w-5 text-center shrink-0 flex items-center justify-center">
+            {{-- Shot on target --}}
+            <template x-if="event.type === 'shot_on_target'">
+                <svg class="w-3 h-3 text-text-muted" fill="currentColor" viewBox="0 0 16 16"><circle cx="8" cy="8" r="6" fill="none" stroke="currentColor" stroke-width="1.5"/><circle cx="8" cy="8" r="2"/></svg>
+            </template>
+            {{-- Shot off target --}}
+            <template x-if="event.type === 'shot_off_target'">
+                <svg class="w-3 h-3 text-text-muted" fill="none" stroke="currentColor" viewBox="0 0 16 16"><circle cx="8" cy="8" r="6" stroke-width="1.5"/><path stroke-width="1.5" d="M5 11L11 5"/></svg>
+            </template>
+            {{-- Dangerous attack --}}
+            <template x-if="event.type === 'dangerous_attack'">
+                <svg class="w-3 h-3 text-text-muted" fill="currentColor" viewBox="0 0 16 16"><path d="M8 1l2 5h5l-4 3 1.5 5L8 11l-4.5 3L5 9 1 6h5z"/></svg>
+            </template>
+            {{-- Great save --}}
+            <template x-if="event.type === 'great_save'">
+                <svg class="w-3 h-3 text-text-muted" fill="none" stroke="currentColor" viewBox="0 0 16 16"><path stroke-width="1.5" d="M3 8a5 5 0 0110 0M8 3v2M5 4l1 1.5M11 4l-1 1.5"/></svg>
+            </template>
+            {{-- Near miss --}}
+            <template x-if="event.type === 'near_miss'">
+                <svg class="w-3 h-3 text-text-muted" fill="none" stroke="currentColor" viewBox="0 0 16 16"><rect x="2" y="4" width="12" height="8" rx="1" stroke-width="1.5"/><path stroke-width="1.5" d="M14 5l-3 3"/></svg>
+            </template>
+            {{-- Key pass --}}
+            <template x-if="event.type === 'key_pass'">
+                <svg class="w-3 h-3 text-text-muted" fill="none" stroke="currentColor" viewBox="0 0 16 16"><path stroke-width="1.5" d="M3 8h7m0 0l-3-3m3 3l-3 3"/></svg>
+            </template>
+        </span>
+        <span class="text-[10px] text-text-muted truncate" x-text="getNarrativeLabel(event)"></span>
+    </div>
+</template>
+
+{{-- Insight events: distinctive accent styling --}}
+<template x-if="event.type === 'insight'">
+    <div class="flex items-start gap-2 py-1.5 px-2 -mx-2 rounded-lg bg-accent-blue/5 border border-accent-blue/10">
+        <span class="font-heading text-[10px] text-accent-blue w-8 text-right shrink-0 tabular-nums mt-0.5"
+              x-text="event.minute + '\''"></span>
+        <svg class="w-3.5 h-3.5 text-accent-blue shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z"/>
+        </svg>
+        <span class="text-[10px] text-accent-blue font-medium" x-text="getInsightText(event)"></span>
+    </div>
+</template>
+
+{{-- Standard events (goal, card, injury, substitution) --}}
+<template x-if="!isNarrativeEvent(event.type) && event.type !== 'insight'">
+    <div class="flex items-center gap-2">
+        <span class="font-heading font-bold text-xs text-text-muted w-8 text-right shrink-0 tabular-nums"
+              x-text="event.minute + '\''"></span>
+        <span class="w-6 text-center shrink-0 flex items-center justify-center"
+              x-show="event.type === 'goal'">
+            <svg class="w-3.5 h-3.5 text-accent-green" viewBox="0 0 16 16" fill="currentColor"><circle cx="8" cy="8" r="8"/></svg>
+        </span>
+        <span class="w-6 text-center shrink-0 flex items-center justify-center"
+              x-show="event.type === 'own_goal'">
+            <svg class="w-3.5 h-3.5 text-accent-red" viewBox="0 0 16 16" fill="currentColor"><circle cx="8" cy="8" r="8"/></svg>
+        </span>
+        <span class="w-6 text-center shrink-0 flex items-center justify-center"
+              x-show="event.type === 'yellow_card'">
+            <div class="w-2.5 h-3.5 rounded-[2px] bg-accent-gold"></div>
+        </span>
+        <span class="w-6 text-center shrink-0 flex items-center justify-center"
+              x-show="event.type === 'red_card'">
+            <div class="w-2.5 h-3.5 rounded-[2px] bg-accent-red"></div>
+        </span>
+        <span class="w-6 text-center shrink-0 flex items-center justify-center"
+              x-show="event.type === 'injury'">
+            <svg class="w-3.5 h-3.5 text-accent-orange" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"/></svg>
+        </span>
+        <span class="w-6 text-center shrink-0 flex items-center justify-center"
+              x-show="event.type === 'substitution'">
+            <svg class="w-3.5 h-3.5 text-accent-blue" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 16V4m0 0L3 8m4-4l4 4m6 0v12m0 0l4-4m-4 4l-4-4"/></svg>
+        </span>
+        <img :src="getEventSide(event) === 'home' ? homeTeamImage : awayTeamImage"
+             class="w-5 h-5 shrink-0 object-contain"
+             :alt="getEventSide(event) === 'home' ? 'Home' : 'Away'">
+        <div class="flex-1 min-w-0">
+            <span class="font-semibold text-xs text-text-primary" x-text="event.type === 'substitution' ? event.playerInName : event.playerName"></span>
+            <template x-if="event.type === 'goal'">
+                <span class="text-[10px] text-text-muted ml-1">{{ __('game.live_goal') }}</span>
+            </template>
+            <template x-if="event.type === 'own_goal'">
+                <span class="text-[10px] text-accent-red ml-1">({{ __('game.og') }})</span>
+            </template>
+            <template x-if="event.type === 'yellow_card'">
+                <span class="text-[10px] text-text-muted ml-1">{{ __('game.live_yellow_card') }}</span>
+            </template>
+            <template x-if="event.type === 'red_card'">
+                <span class="text-[10px] text-accent-red ml-1" x-text="event.metadata?.second_yellow ? '{{ __('game.live_second_yellow') }}' : '{{ __('game.live_red_card') }}'"></span>
+            </template>
+            <template x-if="event.type === 'injury'">
+                <span class="text-[10px] text-accent-orange ml-1">{{ __('game.live_injury') }}</span>
+            </template>
+            <template x-if="event.type === 'substitution'">
+                <div class="text-[10px] text-text-secondary"><span class="text-[10px] text-accent-red font-semibold">OFF</span> <span x-text="event.playerName"></span></div>
+            </template>
+            <template x-if="event.assistPlayerName">
+                <div class="text-[10px] text-text-secondary" x-text="'{{ __('game.live_assist') }} ' + event.assistPlayerName"></div>
+            </template>
+        </div>
+    </div>
+</template>

--- a/resources/views/partials/live-match/tactical-panel.blade.php
+++ b/resources/views/partials/live-match/tactical-panel.blade.php
@@ -253,8 +253,8 @@
                                                             <span class="skew-x-12" x-text="player.positionAbbr"></span>
                                                         </span>
                                                         <span class="inline-flex items-center justify-center w-6 h-6 rounded-full text-[10px] font-semibold shrink-0"
-                                                              :class="getOvrBadgeClasses(player.overallScore)"
-                                                              x-text="player.overallScore"></span>
+                                                              :class="getPlayerRating(player.id) ? getPlayerRatingClass(getPlayerRating(player.id)) : getOvrBadgeClasses(player.overallScore)"
+                                                              x-text="getPlayerRating(player.id) ? getPlayerRating(player.id).toFixed(1) : player.overallScore"></span>
                                                         <span class="flex-1 truncate font-medium" x-text="player.name"></span>
                                                         {{-- Yellow card indicator --}}
                                                         <span x-show="isPlayerYellowCarded(player.id)"


### PR DESCRIPTION
Add four interconnected pillars to transform the live match from a passive animation into a strategic experience:

1. Narrative Events: Generate ~15-25 events per match (shots, saves, dangerous attacks, near misses, key passes) derived from xG, displayed as compact inline rows in the Events tab. Stored as JSON on game_matches to avoid DB bloat.

2. Live Stats Dashboard: Replace minimal Stats tab with rich accumulating stats (shots, shots on target, dangerous attacks, momentum indicator) computed client-side from revealed events.

3. Player Ratings: Show 1-10 match ratings per player using base ratings from simulation performance modifiers plus client-side event modifiers. Displayed in Lineups tab and tactical panel substitution picker.

4. Tactical Insights: Contextual hints (press fading, high line exploited, counter opportunity, player struggling/excellent, energy low) that auto-pause the match with a notification banner at key moments.

https://claude.ai/code/session_01CNj2xtMqwBhgY6w4Yxrt6x