### PR TITLE
Add morale indicator to player lineup display

### DIFF
--- a/resources/views/lineup.blade.php
+++ b/resources/views/lineup.blade.php
@@ -305,6 +305,7 @@
                                                                 </div>
                                                                 <span class="text-[8px] text-text-faint">{{ $player->fitness }}%</span>
                                                             </div>
+                                                            <x-morale-indicator :value="$player->morale" class="shrink-0" />
                                                             @endif
                                                         </div>
                                                     </div>


### PR DESCRIPTION
## Summary
Added a morale indicator component to the player lineup view to display player morale status alongside existing fitness information.

## Key Changes
- Integrated `x-morale-indicator` component into the player card display in the lineup view
- The morale indicator is positioned after the fitness percentage and uses the player's morale value
- Applied `shrink-0` utility class to prevent the indicator from shrinking in flex layouts

## Implementation Details
- The morale indicator is conditionally rendered within the existing player information section
- Uses the `$player->morale` attribute as the indicator value
- Maintains consistent styling with the existing player card layout

https://claude.ai/code/session_01UmbBEsTkzKvUCPSgTeQgYR