### PR TITLE
Fix MaxAttemptsExceededException in season transition jobs

### DIFF
--- a/app/Http/Views/ShowGame.php
+++ b/app/Http/Views/ShowGame.php
@@ -37,6 +37,7 @@ class ShowGame
             // Re-dispatch if stuck for > 2 minutes
             if ($game->season_transitioning_at->lt(now()->subMinutes(2))) {
                 ProcessSeasonTransition::dispatch($game->id);
+                $game->update(['season_transitioning_at' => now()]);
             }
             return view('game-loading', [
                 'game' => $game,

--- a/app/Modules/Season/Jobs/ProcessSeasonTransition.php
+++ b/app/Modules/Season/Jobs/ProcessSeasonTransition.php
@@ -8,13 +8,14 @@ use App\Modules\Season\DTOs\SeasonTransitionData;
 use App\Modules\Season\Services\SeasonClosingPipeline;
 use App\Modules\Season\Services\SeasonSetupPipeline;
 use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Log;
 
-class ProcessSeasonTransition implements ShouldQueue
+class ProcessSeasonTransition implements ShouldQueue, ShouldBeUnique
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 
@@ -22,10 +23,17 @@ class ProcessSeasonTransition implements ShouldQueue
 
     public int $timeout = 300;
 
+    public int $uniqueFor = 600;
+
     public function __construct(
         public string $gameId,
     ) {
         $this->onQueue('setup');
+    }
+
+    public function uniqueId(): string
+    {
+        return $this->gameId;
     }
 
     public function handle(

--- a/config/queue.php
+++ b/config/queue.php
@@ -67,7 +67,7 @@ return [
             'driver' => 'redis',
             'connection' => env('REDIS_QUEUE_CONNECTION', 'default'),
             'queue' => env('REDIS_QUEUE', 'default'),
-            'retry_after' => (int) env('REDIS_QUEUE_RETRY_AFTER', 90),
+            'retry_after' => (int) env('REDIS_QUEUE_RETRY_AFTER', 600),
             'block_for' => null,
             'after_commit' => false,
         ],


### PR DESCRIPTION
The Redis queue retry_after (90s) was shorter than the job timeout (300s), causing Redis to re-queue the job while still running. A second worker would pick it up, exceed max attempts, and throw the exception — even though the original worker completed successfully.

- Bump Redis retry_after from 90s to 600s (exceeds 300s job timeout)
- Add ShouldBeUnique to ProcessSeasonTransition (keyed by gameId)
- Reset season_transitioning_at timer in ShowGame re-dispatch