### PR TITLE
Optimize heavy season transition processors with chunked queries

### DIFF
--- a/app/Modules/Season/Processors/PlayerDevelopmentProcessor.php
+++ b/app/Modules/Season/Processors/PlayerDevelopmentProcessor.php
@@ -29,58 +29,58 @@ class PlayerDevelopmentProcessor implements SeasonProcessor
 
     public function process(Game $game, SeasonTransitionData $data): SeasonTransitionData
     {
-        // Process development for ALL players in the game
-        $players = GamePlayer::with(['player', 'game'])
-            ->where('game_id', $game->id)
-            ->get();
-
         $allChanges = [];
         $upsertRows = [];
 
-        foreach ($players as $player) {
-            $change = $this->developmentService->calculateDevelopment($player);
+        // Process development in chunks to bound memory usage
+        GamePlayer::with(['player', 'game'])
+            ->where('game_id', $game->id)
+            ->chunk(200, function ($chunk) use (&$allChanges, &$upsertRows, $game) {
+                foreach ($chunk as $player) {
+                    $change = $this->developmentService->calculateDevelopment($player);
 
-            $previousAbility = (int) round(($change['techBefore'] + $change['physBefore']) / 2);
-            $previousMarketValue = $player->market_value_cents ?? 0;
+                    $previousAbility = (int) round(($change['techBefore'] + $change['physBefore']) / 2);
+                    $previousMarketValue = $player->market_value_cents ?? 0;
 
-            // Recalculate market value for ALL players (even if ability didn't change,
-            // age increased by 1 which affects value)
-            $newAbility = (int) round(($change['techAfter'] + $change['physAfter']) / 2);
-            $newMarketValue = $this->valuationService->abilityToMarketValue(
-                $newAbility,
-                $player->age($game->current_date),
-                $previousAbility
-            );
+                    // Recalculate market value for ALL players (even if ability didn't change,
+                    // age increased by 1 which affects value)
+                    $newAbility = (int) round(($change['techAfter'] + $change['physAfter']) / 2);
+                    $newMarketValue = $this->valuationService->abilityToMarketValue(
+                        $newAbility,
+                        $player->age($game->current_date),
+                        $previousAbility
+                    );
 
-            // Collect row for batch upsert (includes abilities + market value in one operation)
-            $upsertRows[] = [
-                'id' => $player->id,
-                'game_id' => $player->game_id,
-                'player_id' => $player->player_id,
-                'team_id' => $player->team_id,
-                'position' => $player->position,
-                'game_technical_ability' => $change['techAfter'],
-                'game_physical_ability' => $change['physAfter'],
-                'market_value_cents' => $newMarketValue,
-            ];
+                    // Collect row for batch upsert (includes abilities + market value in one operation)
+                    $upsertRows[] = [
+                        'id' => $player->id,
+                        'game_id' => $player->game_id,
+                        'player_id' => $player->player_id,
+                        'team_id' => $player->team_id,
+                        'position' => $player->position,
+                        'game_technical_ability' => $change['techAfter'],
+                        'game_physical_ability' => $change['physAfter'],
+                        'market_value_cents' => $newMarketValue,
+                    ];
 
-            if ($change['techChange'] !== 0 || $change['physChange'] !== 0 || $newMarketValue !== $previousMarketValue) {
-                $allChanges[] = [
-                    'playerId' => $player->id,
-                    'playerName' => $player->name,
-                    'teamId' => $player->team_id,
-                    'age' => $player->age($game->current_date),
-                    'techBefore' => $change['techBefore'],
-                    'techAfter' => $change['techAfter'],
-                    'physBefore' => $change['physBefore'],
-                    'physAfter' => $change['physAfter'],
-                    'overallBefore' => $previousAbility,
-                    'overallAfter' => $newAbility,
-                    'marketValueBefore' => $previousMarketValue,
-                    'marketValueAfter' => $newMarketValue,
-                ];
-            }
-        }
+                    if ($change['techChange'] !== 0 || $change['physChange'] !== 0 || $newMarketValue !== $previousMarketValue) {
+                        $allChanges[] = [
+                            'playerId' => $player->id,
+                            'playerName' => $player->name,
+                            'teamId' => $player->team_id,
+                            'age' => $player->age($game->current_date),
+                            'techBefore' => $change['techBefore'],
+                            'techAfter' => $change['techAfter'],
+                            'physBefore' => $change['physBefore'],
+                            'physAfter' => $change['physAfter'],
+                            'overallBefore' => $previousAbility,
+                            'overallAfter' => $newAbility,
+                            'marketValueBefore' => $previousMarketValue,
+                            'marketValueAfter' => $newMarketValue,
+                        ];
+                    }
+                }
+            });
 
         // Batch upsert all development changes + market values in one query
         if (!empty($upsertRows)) {

--- a/app/Modules/Season/Processors/SeasonArchiveProcessor.php
+++ b/app/Modules/Season/Processors/SeasonArchiveProcessor.php
@@ -150,28 +150,32 @@ class SeasonArchiveProcessor implements SeasonProcessor
      */
     private function capturePlayerStats(Game $game): array
     {
-        return GamePlayer::with('player')
+        $stats = [];
+
+        GamePlayer::with('player')
             ->where('game_id', $game->id)
             ->whereNotNull('team_id')
-            ->get()
-            ->map(function ($player) {
-                return [
-                    'player_id' => $player->id,
-                    'reference_player_id' => $player->player_id,
-                    'name' => $player->name,
-                    'team_id' => $player->team_id,
-                    'position' => $player->position,
-                    'appearances' => $player->appearances,
-                    'goals' => $player->goals,
-                    'assists' => $player->assists,
-                    'own_goals' => $player->own_goals,
-                    'yellow_cards' => $player->yellow_cards,
-                    'red_cards' => $player->red_cards,
-                    'goals_conceded' => $player->goals_conceded,
-                    'clean_sheets' => $player->clean_sheets,
-                ];
-            })
-            ->toArray();
+            ->chunk(200, function ($chunk) use (&$stats) {
+                foreach ($chunk as $player) {
+                    $stats[] = [
+                        'player_id' => $player->id,
+                        'reference_player_id' => $player->player_id,
+                        'name' => $player->name,
+                        'team_id' => $player->team_id,
+                        'position' => $player->position,
+                        'appearances' => $player->appearances,
+                        'goals' => $player->goals,
+                        'assists' => $player->assists,
+                        'own_goals' => $player->own_goals,
+                        'yellow_cards' => $player->yellow_cards,
+                        'red_cards' => $player->red_cards,
+                        'goals_conceded' => $player->goals_conceded,
+                        'clean_sheets' => $player->clean_sheets,
+                    ];
+                }
+            });
+
+        return $stats;
     }
 
     /**
@@ -274,26 +278,30 @@ class SeasonArchiveProcessor implements SeasonProcessor
      */
     private function captureMatchResults(Game $game): array
     {
-        return GameMatch::where('game_id', $game->id)
+        $results = [];
+
+        GameMatch::where('game_id', $game->id)
             ->where('played', true)
-            ->get()
-            ->map(function ($match) {
-                return [
-                    'home_team_id' => $match->home_team_id,
-                    'away_team_id' => $match->away_team_id,
-                    'home_score' => $match->home_score,
-                    'away_score' => $match->away_score,
-                    'is_extra_time' => $match->is_extra_time,
-                    'home_score_et' => $match->home_score_et,
-                    'away_score_et' => $match->away_score_et,
-                    'home_score_penalties' => $match->home_score_penalties,
-                    'away_score_penalties' => $match->away_score_penalties,
-                    'competition_id' => $match->competition_id,
-                    'round_number' => $match->round_number,
-                    'date' => $match->scheduled_date->toDateString(),
-                ];
-            })
-            ->toArray();
+            ->chunk(200, function ($chunk) use (&$results) {
+                foreach ($chunk as $match) {
+                    $results[] = [
+                        'home_team_id' => $match->home_team_id,
+                        'away_team_id' => $match->away_team_id,
+                        'home_score' => $match->home_score,
+                        'away_score' => $match->away_score,
+                        'is_extra_time' => $match->is_extra_time,
+                        'home_score_et' => $match->home_score_et,
+                        'away_score_et' => $match->away_score_et,
+                        'home_score_penalties' => $match->home_score_penalties,
+                        'away_score_penalties' => $match->away_score_penalties,
+                        'competition_id' => $match->competition_id,
+                        'round_number' => $match->round_number,
+                        'date' => $match->scheduled_date->toDateString(),
+                    ];
+                }
+            });
+
+        return $results;
     }
 
     /**
@@ -329,20 +337,24 @@ class SeasonArchiveProcessor implements SeasonProcessor
      */
     private function captureTransferActivity(Game $game): array
     {
-        return GameTransfer::where('game_id', $game->id)
+        $activity = [];
+
+        GameTransfer::where('game_id', $game->id)
             ->where('season', $game->season)
-            ->get()
-            ->map(function ($transfer) {
-                return [
-                    'game_player_id' => $transfer->game_player_id,
-                    'from_team_id' => $transfer->from_team_id,
-                    'to_team_id' => $transfer->to_team_id,
-                    'transfer_fee' => $transfer->transfer_fee,
-                    'type' => $transfer->type,
-                    'window' => $transfer->window,
-                ];
-            })
-            ->toArray();
+            ->chunk(200, function ($chunk) use (&$activity) {
+                foreach ($chunk as $transfer) {
+                    $activity[] = [
+                        'game_player_id' => $transfer->game_player_id,
+                        'from_team_id' => $transfer->from_team_id,
+                        'to_team_id' => $transfer->to_team_id,
+                        'transfer_fee' => $transfer->transfer_fee,
+                        'type' => $transfer->type,
+                        'window' => $transfer->window,
+                    ];
+                }
+            });
+
+        return $activity;
     }
 
     /**

--- a/app/Modules/Season/Processors/SquadReplenishmentProcessor.php
+++ b/app/Modules/Season/Processors/SquadReplenishmentProcessor.php
@@ -134,14 +134,17 @@ class SquadReplenishmentProcessor implements SeasonProcessor
         $bulkMeta = [];
         $releaseIds = [];
 
-        // Get all AI team rosters (grouped by team, excluding free agents)
-        $teamRosters = GamePlayer::where('game_id', $game->id)
+        // Get AI team IDs, then process one team at a time to bound memory
+        $aiTeamIds = GamePlayer::where('game_id', $game->id)
             ->whereNotNull('team_id')
             ->where('team_id', '!=', $game->team_id)
-            ->get()
-            ->groupBy('team_id');
+            ->distinct()
+            ->pluck('team_id');
 
-        foreach ($teamRosters as $teamId => $players) {
+        foreach ($aiTeamIds as $teamId) {
+            $players = GamePlayer::where('game_id', $game->id)
+                ->where('team_id', $teamId)
+                ->get();
             $teamAvgAbility = $this->calculateTeamAverageAbility($players);
             $positionCounts = $players->groupBy('position')->map->count();
 
@@ -476,9 +479,8 @@ class SquadReplenishmentProcessor implements SeasonProcessor
             ->whereHas('player', function ($q) use ($game) {
                 $q->where('date_of_birth', '<=', $game->current_date->copy()->subYears(30));
             })
-            ->get()
-            ->sortBy(fn ($p) => ($p->game_technical_ability + $p->game_physical_ability) / 2)
-            ->take($count)
+            ->orderByRaw('(COALESCE(game_technical_ability, 0) + COALESCE(game_physical_ability, 0)) ASC')
+            ->limit($count)
             ->pluck('id')
             ->toArray();
     }


### PR DESCRIPTION
Reduce memory pressure during season transitions by avoiding loading entire collections into memory at once:

- SquadReplenishmentProcessor: query per team instead of loading all AI rosters; push sort to database in getOldestWeakestIds
- SeasonArchiveProcessor: chunk capturePlayerStats, captureMatchResults, and captureTransferActivity (200 per chunk)
- PlayerDevelopmentProcessor: chunk player loading (200 per chunk)