### PR TITLE
Add search and pagination to admin users page

### DIFF
--- a/app/Http/Views/AdminUsers.php
+++ b/app/Http/Views/AdminUsers.php
@@ -10,12 +10,25 @@ class AdminUsers
 {
     public function __invoke(Request $request)
     {
-        $users = User::withCount('games')
-            ->orderBy('created_at', 'desc')
-            ->get();
+        $search = $request->query('search');
+
+        $query = User::withCount('games');
+
+        if ($search) {
+            $query->where(function ($q) use ($search) {
+                $searchLower = mb_strtolower($search);
+                $q->whereRaw('LOWER(name) LIKE ?', ["%{$searchLower}%"])
+                  ->orWhereRaw('LOWER(email) LIKE ?', ["%{$searchLower}%"]);
+            });
+        }
+
+        $users = $query->orderBy('created_at', 'desc')
+            ->paginate(50)
+            ->appends($request->query());
 
         return view('admin.users', [
             'users' => $users,
+            'search' => $search,
         ]);
     }
 }

--- a/lang/en/admin.php
+++ b/lang/en/admin.php
@@ -32,6 +32,8 @@ return [
     'grant_database_editing' => 'Grant Editor',
     'revoke_database_editing' => 'Revoke Editor',
     'current_user' => 'You',
+    'search_users_placeholder' => 'Search by name or email...',
+    'no_users_found' => 'No users found',
     'impersonating_banner' => 'You are impersonating :name (:email)',
     'stop_impersonating' => 'Stop impersonating',
 

--- a/lang/es/admin.php
+++ b/lang/es/admin.php
@@ -32,6 +32,8 @@ return [
     'grant_database_editing' => 'Dar Editor',
     'revoke_database_editing' => 'Quitar Editor',
     'current_user' => 'Tú',
+    'search_users_placeholder' => 'Buscar por nombre o email...',
+    'no_users_found' => 'No se encontraron usuarios',
     'impersonating_banner' => 'Estás suplantando a :name (:email)',
     'stop_impersonating' => 'Dejar de suplantar',
 

--- a/resources/views/admin/users.blade.php
+++ b/resources/views/admin/users.blade.php
@@ -3,6 +3,21 @@
         {{ __('admin.users_title') }}
     </h1>
 
+    <form method="GET" action="{{ route('admin.users') }}" class="mb-4">
+        <div class="relative max-w-xs">
+            <svg class="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-text-muted pointer-events-none" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+            </svg>
+            <input
+                type="text"
+                name="search"
+                value="{{ $search ?? '' }}"
+                placeholder="{{ __('admin.search_users_placeholder') }}"
+                class="w-full bg-surface-700 border border-border-default rounded-md text-xs text-text-primary placeholder-slate-500 pl-8 pr-3 py-1.5 focus:outline-hidden focus:border-accent-blue/50 min-h-[44px]"
+            />
+        </div>
+    </form>
+
     <div class="overflow-x-auto">
         <table class="min-w-full divide-y divide-border-default">
             <thead>
@@ -85,7 +100,19 @@
                         </td>
                     </tr>
                 @endforeach
+
+                @if($users->isEmpty())
+                    <tr>
+                        <td colspan="5" class="px-4 py-8 text-center text-sm text-text-muted">
+                            {{ __('admin.no_users_found') }}
+                        </td>
+                    </tr>
+                @endif
             </tbody>
         </table>
+    </div>
+
+    <div class="mt-6">
+        {{ $users->links() }}
     </div>
 </x-admin-layout>


### PR DESCRIPTION
## Summary
Enhanced the admin users management page with search functionality and pagination to improve usability when managing large numbers of users.

## Key Changes
- **Search functionality**: Added a search form that filters users by name or email (case-insensitive)
- **Pagination**: Implemented pagination with 50 users per page, replacing the previous single-page load of all users
- **Empty state**: Added a message displayed when no users match the search criteria
- **UI improvements**: Added a styled search input with icon and placeholder text
- **Localization**: Added English and Spanish translations for search placeholder and empty state messages

## Implementation Details
- Search uses case-insensitive `LIKE` queries on both `name` and `email` fields via `LOWER()` database functions
- Pagination preserves search query parameters when navigating between pages using `appends()`
- The search parameter is passed to the view to maintain the search value in the input field
- Search input uses Tailwind CSS styling consistent with the existing admin interface design

https://claude.ai/code/session_0167tXLS5Rrh6EYbtuBw2Tge