### PR TITLE
Move pre-contract offers and loan requests to synchronous chat negotiation

### DIFF
--- a/app/Http/Actions/NegotiateLoan.php
+++ b/app/Http/Actions/NegotiateLoan.php
@@ -1,0 +1,334 @@
+<?php
+
+namespace App\Http\Actions;
+
+use App\Models\Game;
+use App\Models\GamePlayer;
+use App\Models\TransferOffer;
+use App\Modules\Notification\Services\NotificationService;
+use App\Modules\Transfer\Services\ContractService;
+use App\Modules\Transfer\Services\ScoutingService;
+use App\Modules\Transfer\Services\TransferService;
+use App\Support\Money;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
+
+class NegotiateLoan
+{
+    private const MAX_ROUNDS = ContractService::MAX_NEGOTIATION_ROUNDS;
+
+    public function __construct(
+        private readonly TransferService $transferService,
+        private readonly ScoutingService $scoutingService,
+        private readonly NotificationService $notificationService,
+    ) {}
+
+    public function __invoke(Request $request, string $gameId, string $playerId): JsonResponse
+    {
+        $request->validate([
+            'action' => ['required', 'string', Rule::in([
+                'start', 'offer', 'accept_counter',
+            ])],
+        ]);
+
+        $game = Game::findOrFail($gameId);
+
+        $player = GamePlayer::with(['player', 'game', 'team'])
+            ->where('game_id', $gameId)
+            ->findOrFail($playerId);
+
+        return match ($request->input('action')) {
+            'start' => $this->handleStart($game, $player),
+            'offer' => $this->handleOffer($request, $game, $player),
+            'accept_counter' => $this->handleAcceptCounter($game, $player),
+            default => response()->json(['status' => 'error', 'message' => 'Invalid action'], 400),
+        };
+    }
+
+    private function handleStart(Game $game, GamePlayer $player): JsonResponse
+    {
+        // Validate loan eligibility
+        if (!$player->team_id) {
+            return response()->json([
+                'status' => 'error',
+                'message' => __('messages.loan_not_available'),
+            ], 422);
+        }
+
+        if (ContractService::isSquadFull($game)) {
+            return response()->json([
+                'status' => 'error',
+                'message' => __('messages.squad_full'),
+            ], 422);
+        }
+
+        // Check for existing countered offer to resume
+        $existing = TransferOffer::where('game_id', $game->id)
+            ->where('game_player_id', $player->id)
+            ->where('offering_team_id', $game->team_id)
+            ->where('offer_type', TransferOffer::TYPE_LOAN_IN)
+            ->where('status', TransferOffer::STATUS_PENDING)
+            ->whereNotNull('negotiation_round')
+            ->where('asking_price', '>', 0)
+            ->first();
+
+        if ($existing && $existing->asking_price > $existing->transfer_fee) {
+            $disposition = $this->transferService->calculateLoanDisposition($player, $this->scoutingService);
+            $mood = $this->transferService->getLoanMoodIndicator($disposition);
+            $teamName = $player->team?->name ?? 'Unknown';
+
+            return response()->json([
+                'status' => 'ok',
+                'negotiation_status' => 'open',
+                'round' => $existing->negotiation_round,
+                'max_rounds' => self::MAX_ROUNDS,
+                'messages' => [
+                    $this->agentMessage('counter', [
+                        'text' => __('transfers.chat_loan_counter', [
+                            'team' => $teamName,
+                            'fee' => Money::format($existing->asking_price),
+                        ]),
+                        'fee' => (int) ($existing->asking_price / 100),
+                        'mood' => $mood,
+                    ], [
+                        'canAccept' => true,
+                        'suggestedFee' => $this->calculateMidpointInEuros($existing->transfer_fee, $existing->asking_price),
+                    ]),
+                ],
+            ]);
+        }
+
+        // Prevent duplicate pending offers
+        $hasPending = TransferOffer::where('game_id', $game->id)
+            ->where('game_player_id', $player->id)
+            ->where('offering_team_id', $game->team_id)
+            ->where('offer_type', TransferOffer::TYPE_LOAN_IN)
+            ->whereIn('status', [TransferOffer::STATUS_PENDING, TransferOffer::STATUS_AGREED])
+            ->exists();
+
+        if ($hasPending) {
+            return response()->json([
+                'status' => 'error',
+                'message' => __('transfers.already_bidding'),
+            ], 422);
+        }
+
+        // Evaluate loan feasibility
+        $evaluation = $this->scoutingService->evaluateLoanRequestSync($player, $game);
+        $teamName = $player->team?->name ?? 'Unknown';
+
+        if ($evaluation['result'] === 'rejected') {
+            $text = $evaluation['rejection_reason'] === 'key_player'
+                ? __('transfers.chat_loan_rejected_key_player', ['team' => $teamName, 'player' => $player->name])
+                : __('transfers.chat_loan_rejected_reputation', ['player' => $player->name]);
+
+            return response()->json([
+                'status' => 'ok',
+                'negotiation_status' => 'rejected',
+                'round' => 0,
+                'max_rounds' => self::MAX_ROUNDS,
+                'messages' => [
+                    $this->agentMessage('rejected', [
+                        'text' => $text,
+                    ]),
+                ],
+            ]);
+        }
+
+        $disposition = $evaluation['disposition'];
+        $mood = $this->transferService->getLoanMoodIndicator($disposition);
+
+        if ($evaluation['result'] === 'accepted') {
+            // Free loan — club agrees directly, create offer and complete
+            $offer = TransferOffer::create([
+                'game_id' => $game->id,
+                'game_player_id' => $player->id,
+                'offering_team_id' => $game->team_id,
+                'selling_team_id' => $player->team_id,
+                'offer_type' => TransferOffer::TYPE_LOAN_IN,
+                'direction' => TransferOffer::DIRECTION_INCOMING,
+                'transfer_fee' => 0,
+                'status' => TransferOffer::STATUS_PENDING,
+                'expires_at' => $game->current_date->addDays(30),
+                'game_date' => $game->current_date,
+                'negotiation_round' => 1,
+                'disposition' => $disposition,
+            ]);
+
+            $result = $this->transferService->completeSyncLoan($offer, $game);
+            $offer = $result['offer'];
+
+            $this->notificationService->notifyLoanRequestResult($game, $offer, 'accepted');
+
+            return response()->json([
+                'status' => 'ok',
+                'negotiation_status' => 'completed',
+                'round' => 0,
+                'max_rounds' => self::MAX_ROUNDS,
+                'messages' => [
+                    $this->agentMessage('accepted', [
+                        'text' => __('transfers.chat_loan_accepted_free', [
+                            'team' => $teamName,
+                            'player' => $player->name,
+                        ]),
+                        'mood' => $mood,
+                    ]),
+                ],
+            ]);
+        }
+
+        // Conditional — club demands a loan fee
+        $loanFee = $evaluation['loan_fee'];
+        $suggestedBid = (int) (round(($loanFee * 0.85) / 10_000_000) * 10_000_000);
+        $suggestedBidEuros = (int) ($suggestedBid / 100);
+
+        return response()->json([
+            'status' => 'ok',
+            'negotiation_status' => 'open',
+            'round' => 0,
+            'max_rounds' => self::MAX_ROUNDS,
+            'messages' => [
+                $this->agentMessage('demand', [
+                    'text' => __('transfers.chat_loan_demand', [
+                        'team' => $teamName,
+                        'player' => $player->name,
+                        'fee' => Money::format($loanFee),
+                    ]),
+                    'fee' => (int) ($loanFee / 100),
+                    'mood' => $mood,
+                ], [
+                    'canAccept' => false,
+                    'suggestedFee' => $suggestedBidEuros,
+                ]),
+            ],
+        ]);
+    }
+
+    private function handleOffer(Request $request, Game $game, GamePlayer $player): JsonResponse
+    {
+        $validated = $request->validate([
+            'bid' => ['required', 'integer', 'min:0'],
+        ]);
+
+        $bidCents = $validated['bid'] * 100;
+        $teamName = $player->team?->name ?? 'Unknown';
+
+        try {
+            $result = $this->transferService->negotiateLoanFeeSync($game, $player, $bidCents, $this->scoutingService);
+        } catch (\InvalidArgumentException $e) {
+            return response()->json([
+                'status' => 'error',
+                'message' => $e->getMessage(),
+            ], 422);
+        }
+
+        $offer = $result['offer'];
+
+        return match ($result['result']) {
+            'accepted' => $this->completeLoanNegotiation($offer, $game, $player),
+            'countered' => response()->json([
+                'status' => 'ok',
+                'negotiation_status' => 'open',
+                'round' => $offer->negotiation_round,
+                'max_rounds' => self::MAX_ROUNDS,
+                'messages' => [
+                    $this->agentMessage('counter', [
+                        'text' => __('transfers.chat_loan_counter', [
+                            'team' => $teamName,
+                            'fee' => Money::format($offer->asking_price),
+                        ]),
+                        'fee' => (int) ($offer->asking_price / 100),
+                        'mood' => $this->transferService->getLoanMoodIndicator(
+                            $this->transferService->calculateLoanDisposition($player, $this->scoutingService)
+                        ),
+                    ], [
+                        'canAccept' => true,
+                        'suggestedFee' => $this->calculateMidpointInEuros($offer->transfer_fee, $offer->asking_price),
+                    ]),
+                ],
+            ]),
+            default => response()->json([
+                'status' => 'ok',
+                'negotiation_status' => 'rejected',
+                'round' => $offer->negotiation_round,
+                'max_rounds' => self::MAX_ROUNDS,
+                'messages' => [
+                    $this->agentMessage('rejected', [
+                        'text' => __('transfers.chat_loan_rejected', [
+                            'team' => $teamName,
+                        ]),
+                    ]),
+                ],
+            ]),
+        };
+    }
+
+    private function handleAcceptCounter(Game $game, GamePlayer $player): JsonResponse
+    {
+        $offer = TransferOffer::where('game_id', $game->id)
+            ->where('game_player_id', $player->id)
+            ->where('offering_team_id', $game->team_id)
+            ->where('offer_type', TransferOffer::TYPE_LOAN_IN)
+            ->where('status', TransferOffer::STATUS_PENDING)
+            ->whereNotNull('negotiation_round')
+            ->first();
+
+        if (!$offer) {
+            return response()->json([
+                'status' => 'error',
+                'message' => __('messages.transfer_failed'),
+            ], 422);
+        }
+
+        try {
+            $result = $this->transferService->acceptLoanFeeCounter($game, $offer);
+        } catch (\InvalidArgumentException $e) {
+            return response()->json([
+                'status' => 'error',
+                'message' => $e->getMessage(),
+            ], 422);
+        }
+
+        return $this->completeLoanNegotiation($result['offer'], $game, $player);
+    }
+
+    private function completeLoanNegotiation(TransferOffer $offer, Game $game, GamePlayer $player): JsonResponse
+    {
+        $this->notificationService->notifyLoanRequestResult($game, $offer, 'accepted');
+
+        $completedNow = $offer->status === TransferOffer::STATUS_COMPLETED;
+        $text = $completedNow
+            ? __('transfers.chat_loan_completed', ['player' => $player->name])
+            : __('transfers.chat_loan_agreed', ['player' => $player->name]);
+
+        return response()->json([
+            'status' => 'ok',
+            'negotiation_status' => 'completed',
+            'round' => $offer->negotiation_round ?? 1,
+            'max_rounds' => self::MAX_ROUNDS,
+            'messages' => [
+                $this->agentMessage('accepted', [
+                    'text' => $text,
+                ]),
+            ],
+        ]);
+    }
+
+    // ── Helpers ──
+
+    private function agentMessage(string $type, array $content, ?array $options = null): array
+    {
+        return [
+            'sender' => 'agent',
+            'type' => $type,
+            'content' => $content,
+            'options' => $options,
+        ];
+    }
+
+    private function calculateMidpointInEuros(int $centsA, int $centsB): int
+    {
+        return (int) (ceil(($centsA + $centsB) / 2 / 100 / 10000) * 10000);
+    }
+}

--- a/app/Http/Actions/NegotiatePreContract.php
+++ b/app/Http/Actions/NegotiatePreContract.php
@@ -1,0 +1,300 @@
+<?php
+
+namespace App\Http\Actions;
+
+use App\Models\Game;
+use App\Models\GamePlayer;
+use App\Models\TransferOffer;
+use App\Modules\Notification\Services\NotificationService;
+use App\Modules\Transfer\Services\ContractService;
+use App\Modules\Transfer\Services\ScoutingService;
+use App\Support\Money;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
+
+class NegotiatePreContract
+{
+    private const MAX_ROUNDS = ContractService::MAX_NEGOTIATION_ROUNDS;
+
+    public function __construct(
+        private readonly ContractService $contractService,
+        private readonly ScoutingService $scoutingService,
+        private readonly NotificationService $notificationService,
+    ) {}
+
+    public function __invoke(Request $request, string $gameId, string $playerId): JsonResponse
+    {
+        $request->validate([
+            'action' => ['required', 'string', Rule::in([
+                'start', 'offer_terms', 'accept_terms_counter',
+            ])],
+        ]);
+
+        $game = Game::findOrFail($gameId);
+
+        $player = GamePlayer::with(['player', 'game', 'team'])
+            ->where('game_id', $gameId)
+            ->findOrFail($playerId);
+
+        return match ($request->input('action')) {
+            'start' => $this->handleStart($game, $player),
+            'offer_terms' => $this->handleOfferTerms($request, $game, $player),
+            'accept_terms_counter' => $this->handleAcceptTermsCounter($game, $player),
+            default => response()->json(['status' => 'error', 'message' => 'Invalid action'], 400),
+        };
+    }
+
+    private function handleStart(Game $game, GamePlayer $player): JsonResponse
+    {
+        // Validate pre-contract eligibility
+        if (!$game->isPreContractPeriod()) {
+            return response()->json([
+                'status' => 'error',
+                'message' => __('messages.pre_contract_not_available'),
+            ], 422);
+        }
+
+        $isExpiring = $player->contract_until && $player->contract_until <= $game->getSeasonEndDate();
+        if (!$isExpiring) {
+            return response()->json([
+                'status' => 'error',
+                'message' => __('messages.pre_contract_not_available'),
+            ], 422);
+        }
+
+        // Check for existing countered offer to resume
+        $existing = TransferOffer::where('game_id', $game->id)
+            ->where('game_player_id', $player->id)
+            ->where('offering_team_id', $game->team_id)
+            ->where('offer_type', TransferOffer::TYPE_PRE_CONTRACT)
+            ->where('status', TransferOffer::STATUS_PENDING)
+            ->where('terms_status', 'countered')
+            ->first();
+
+        if ($existing) {
+            $mood = $this->getWillingnessMood($player, $game);
+
+            return response()->json([
+                'status' => 'ok',
+                'negotiation_status' => 'terms_open',
+                'round' => $existing->terms_round,
+                'max_rounds' => self::MAX_ROUNDS,
+                'messages' => [
+                    $this->agentMessage('counter', [
+                        'text' => __('transfers.chat_pre_contract_counter', [
+                            'player' => $player->name,
+                            'wage' => Money::format($existing->wage_counter_offer),
+                            'years' => $existing->preferred_years,
+                        ]),
+                        'wage' => (int) ($existing->wage_counter_offer / 100),
+                        'years' => $existing->preferred_years,
+                        'mood' => $mood,
+                    ], [
+                        'canAccept' => true,
+                        'suggestedWage' => $this->calculateMidpointInEuros($existing->offered_wage, $existing->wage_counter_offer),
+                        'preferredYears' => $existing->preferred_years,
+                    ]),
+                ],
+            ]);
+        }
+
+        // Prevent duplicate pending/agreed offers
+        $hasPending = TransferOffer::where('game_id', $game->id)
+            ->where('game_player_id', $player->id)
+            ->where('offering_team_id', $game->team_id)
+            ->where('offer_type', TransferOffer::TYPE_PRE_CONTRACT)
+            ->whereIn('status', [TransferOffer::STATUS_PENDING, TransferOffer::STATUS_AGREED])
+            ->exists();
+
+        if ($hasPending) {
+            return response()->json([
+                'status' => 'error',
+                'message' => __('transfers.already_bidding'),
+            ], 422);
+        }
+
+        // Calculate wage demand (deterministic — no variance)
+        $demand = $this->contractService->calculatePreContractWageDemand($player, $this->scoutingService);
+        $mood = $this->getWillingnessMood($player, $game);
+        $demandInEuros = (int) ($demand['wage'] / 100);
+
+        return response()->json([
+            'status' => 'ok',
+            'negotiation_status' => 'terms_open',
+            'round' => 0,
+            'max_rounds' => self::MAX_ROUNDS,
+            'messages' => [
+                $this->agentMessage('demand', [
+                    'text' => __('transfers.chat_pre_contract_demand', [
+                        'player' => $player->name,
+                        'wage' => $demand['formattedWage'],
+                        'years' => $demand['contractYears'],
+                    ]),
+                    'wage' => $demandInEuros,
+                    'years' => $demand['contractYears'],
+                    'mood' => $mood,
+                ], [
+                    'canAccept' => false,
+                    'suggestedWage' => $demandInEuros,
+                    'preferredYears' => $demand['contractYears'],
+                ]),
+            ],
+        ]);
+    }
+
+    private function handleOfferTerms(Request $request, Game $game, GamePlayer $player): JsonResponse
+    {
+        $validated = $request->validate([
+            'wage' => ['required', 'integer', 'min:1'],
+            'years' => ['required', 'integer', 'min:1', 'max:5'],
+        ]);
+
+        // Find or create the pre-contract offer
+        $offer = TransferOffer::where('game_id', $game->id)
+            ->where('game_player_id', $player->id)
+            ->where('offering_team_id', $game->team_id)
+            ->where('offer_type', TransferOffer::TYPE_PRE_CONTRACT)
+            ->where('status', TransferOffer::STATUS_PENDING)
+            ->first();
+
+        if (!$offer) {
+            // Create on first round
+            $offer = TransferOffer::create([
+                'game_id' => $game->id,
+                'game_player_id' => $player->id,
+                'offering_team_id' => $game->team_id,
+                'selling_team_id' => $player->team_id,
+                'offer_type' => TransferOffer::TYPE_PRE_CONTRACT,
+                'direction' => TransferOffer::DIRECTION_INCOMING,
+                'transfer_fee' => 0,
+                'status' => TransferOffer::STATUS_PENDING,
+                'expires_at' => $game->current_date->addDays(TransferOffer::PRE_CONTRACT_OFFER_EXPIRY_DAYS),
+                'game_date' => $game->current_date,
+                'negotiation_round' => 1, // Mark as sync-negotiated
+            ]);
+        }
+
+        $offerWageCents = $validated['wage'] * 100;
+        $offeredYears = $validated['years'];
+
+        $result = $this->contractService->negotiatePreContractTermsSync(
+            $offer, $offerWageCents, $offeredYears, $game, $this->scoutingService
+        );
+
+        $offer = $result['offer'];
+
+        return match ($result['result']) {
+            'accepted' => $this->completePreContractNegotiation($offer, $game, $player),
+            'countered' => response()->json([
+                'status' => 'ok',
+                'negotiation_status' => 'terms_open',
+                'round' => $offer->terms_round,
+                'max_rounds' => self::MAX_ROUNDS,
+                'messages' => [
+                    $this->agentMessage('counter', [
+                        'text' => __('transfers.chat_pre_contract_counter', [
+                            'player' => $player->name,
+                            'wage' => Money::format($offer->wage_counter_offer),
+                            'years' => $offer->preferred_years,
+                        ]),
+                        'wage' => (int) ($offer->wage_counter_offer / 100),
+                        'years' => $offer->preferred_years,
+                        'mood' => $this->getWillingnessMood($player, $game),
+                    ], [
+                        'canAccept' => true,
+                        'suggestedWage' => $this->calculateMidpointInEuros($offer->offered_wage, $offer->wage_counter_offer),
+                        'preferredYears' => $offer->preferred_years,
+                    ]),
+                ],
+            ]),
+            default => response()->json([
+                'status' => 'ok',
+                'negotiation_status' => 'rejected',
+                'round' => $offer->terms_round,
+                'max_rounds' => self::MAX_ROUNDS,
+                'messages' => [
+                    $this->agentMessage('rejected', [
+                        'text' => __('transfers.chat_pre_contract_rejected', [
+                            'player' => $player->name,
+                        ]),
+                    ]),
+                ],
+            ]),
+        };
+    }
+
+    private function handleAcceptTermsCounter(Game $game, GamePlayer $player): JsonResponse
+    {
+        $offer = TransferOffer::where('game_id', $game->id)
+            ->where('game_player_id', $player->id)
+            ->where('offering_team_id', $game->team_id)
+            ->where('offer_type', TransferOffer::TYPE_PRE_CONTRACT)
+            ->where('status', TransferOffer::STATUS_PENDING)
+            ->where('terms_status', 'countered')
+            ->first();
+
+        if (!$offer) {
+            return response()->json([
+                'status' => 'error',
+                'message' => __('messages.transfer_failed'),
+            ], 422);
+        }
+
+        $this->contractService->acceptPreContractTermsCounter($offer);
+        $offer->refresh();
+
+        return $this->completePreContractNegotiation($offer, $game, $player);
+    }
+
+    private function completePreContractNegotiation(TransferOffer $offer, Game $game, GamePlayer $player): JsonResponse
+    {
+        $this->notificationService->notifyPreContractResult($game, $offer->refresh());
+
+        return response()->json([
+            'status' => 'ok',
+            'negotiation_status' => 'completed',
+            'round' => $offer->terms_round ?? 1,
+            'max_rounds' => self::MAX_ROUNDS,
+            'messages' => [
+                $this->agentMessage('accepted', [
+                    'text' => __('transfers.chat_pre_contract_accepted', [
+                        'player' => $player->name,
+                    ]),
+                ]),
+            ],
+        ]);
+    }
+
+    // ── Helpers ──
+
+    private function agentMessage(string $type, array $content, ?array $options = null): array
+    {
+        return [
+            'sender' => 'agent',
+            'type' => $type,
+            'content' => $content,
+            'options' => $options,
+        ];
+    }
+
+    private function calculateMidpointInEuros(int $centsA, int $centsB): int
+    {
+        return (int) (ceil(($centsA + $centsB) / 2 / 100 / 10000) * 10000);
+    }
+
+    /**
+     * Build the mood indicator from the scout willingness score,
+     * so the negotiation modal matches the scout report.
+     */
+    private function getWillingnessMood(GamePlayer $player, Game $game): array
+    {
+        $willingness = $this->scoutingService->calculateWillingness($player, $game);
+
+        return match ($willingness['label']) {
+            'very_interested', 'open' => ['label' => __('transfers.mood_willing_sign'), 'color' => 'green'],
+            'undecided' => ['label' => __('transfers.mood_open_sign'), 'color' => 'amber'],
+            default => ['label' => __('transfers.mood_reluctant_sign'), 'color' => 'red'],
+        };
+    }
+}

--- a/app/Modules/Transfer/Services/ContractService.php
+++ b/app/Modules/Transfer/Services/ContractService.php
@@ -80,7 +80,7 @@ class ContractService
      * @param int|null $age Player's age (null defaults to prime-age calculation)
      * @return int Annual wage in cents
      */
-    public function calculateAnnualWage(int $marketValueCents, int $minimumWageCents, ?int $age = null): int
+    public function calculateAnnualWage(int $marketValueCents, int $minimumWageCents, ?int $age = null, bool $deterministic = false): int
     {
         // Get wage percentage based on market value tier
         $percentage = $this->getWagePercentage($marketValueCents);
@@ -92,12 +92,14 @@ class ContractService
         $ageModifier = $this->getAgeWageModifier($age);
         $baseWage = (int) ($baseWage * $ageModifier);
 
-        // Apply ±10% variance for squad diversity
-        $variance = 0.90 + (mt_rand(0, 2000) / 10000); // 0.90 to 1.10
-        $wage = (int) ($baseWage * $variance);
+        if (!$deterministic) {
+            // Apply ±10% variance for squad diversity
+            $variance = 0.90 + (mt_rand(0, 2000) / 10000); // 0.90 to 1.10
+            $baseWage = (int) ($baseWage * $variance);
+        }
 
         // Round to nearest €10k (1_000_000 cents)
-        $wage = (int) (round($wage / 1_000_000) * 1_000_000);
+        $wage = (int) (round($baseWage / 1_000_000) * 1_000_000);
 
         // Enforce minimum wage
         return max($wage, $minimumWageCents);
@@ -1126,6 +1128,161 @@ class ContractService
             'offered_wage' => $offer->wage_counter_offer,
             'offered_years' => $offer->preferred_years,
             'terms_status' => 'accepted',
+        ]);
+
+        return $offer->fresh();
+    }
+
+    // =========================================
+    // PRE-CONTRACT PERSONAL TERMS NEGOTIATION
+    // =========================================
+
+    /**
+     * Calculate a player's disposition for a pre-contract (willingness to sign).
+     * Higher base than transfer — player is running out of contract, more motivated.
+     */
+    public function calculatePreContractDisposition(GamePlayer $player, Game $buyingClubGame, int $round = 1, ?ScoutingService $scoutingService = null): float
+    {
+        $disposition = 0.60;
+
+        // Morale
+        $morale = $player->morale;
+        if ($morale >= 70) {
+            $disposition += 0.10;
+        } elseif ($morale < 40) {
+            $disposition -= 0.05;
+        }
+
+        // Age (older = wants security)
+        $age = $player->age($player->game->current_date);
+        if ($age >= 32) {
+            $disposition += 0.12;
+        } elseif ($age <= 23) {
+            $disposition -= 0.05;
+        }
+
+        // Round penalty
+        if ($round === 2) {
+            $disposition -= 0.05;
+        } elseif ($round >= 3) {
+            $disposition -= 0.10;
+        }
+
+        // Apply reputation gap modifier (same scale the scout willingness uses)
+        if ($scoutingService && $buyingClubGame->team) {
+            $reputationModifier = $scoutingService->calculateReputationModifier($buyingClubGame->team, $player);
+            $disposition *= $reputationModifier;
+        }
+
+        return max(0.10, min(0.95, $disposition));
+    }
+
+    /**
+     * Calculate the wage demand for a pre-contract signing.
+     *
+     * @return array{wage: int, contractYears: int, formattedWage: string}
+     */
+    public function calculatePreContractWageDemand(GamePlayer $player, ScoutingService $scoutingService): array
+    {
+        $wage = $scoutingService->calculatePreContractWageDemand($player);
+        $age = $player->age($player->game->current_date);
+
+        $contractYears = $age >= 33 ? 1 : ($age >= 30 ? 2 : 3);
+
+        return [
+            'wage' => $wage,
+            'contractYears' => $contractYears,
+            'formattedWage' => Money::format($wage),
+        ];
+    }
+
+    /**
+     * Synchronous personal terms negotiation for pre-contracts.
+     *
+     * @return array{result: string, offer: TransferOffer}
+     */
+    public function negotiatePreContractTermsSync(TransferOffer $offer, int $offerWageCents, int $offeredYears, Game $buyingClubGame, ScoutingService $scoutingService): array
+    {
+        $player = $offer->gamePlayer;
+
+        if ($offer->terms_status === 'countered') {
+            // Continue from counter
+            $offer->update([
+                'terms_round' => min(($offer->terms_round ?? 1) + 1, self::MAX_NEGOTIATION_ROUNDS),
+                'offered_wage' => $offerWageCents,
+                'offered_years' => $offeredYears,
+                'wage_counter_offer' => null,
+            ]);
+        } else {
+            // New terms negotiation
+            $demand = $this->calculatePreContractWageDemand($player, $scoutingService);
+            $offer->update([
+                'terms_status' => 'pending',
+                'terms_round' => 1,
+                'player_demand' => $demand['wage'],
+                'preferred_years' => $demand['contractYears'],
+                'offered_wage' => $offerWageCents,
+                'offered_years' => $offeredYears,
+            ]);
+        }
+
+        // Evaluate
+        $disposition = $this->calculatePreContractDisposition($player, $buyingClubGame, $offer->terms_round, $scoutingService);
+        $offer->update(['terms_disposition' => $disposition]);
+
+        $flexibility = $disposition * 0.30;
+        $minimumAcceptable = (int) ($offer->player_demand * (1.0 - $flexibility));
+
+        $yearsModifier = $this->calculateYearsModifier($offer->offered_years, $offer->preferred_years);
+        $effectiveOffer = (int) ($offer->offered_wage * $yearsModifier);
+
+        if ($effectiveOffer >= $minimumAcceptable) {
+            $offer->update([
+                'terms_status' => 'accepted',
+                'status' => TransferOffer::STATUS_AGREED,
+                'resolved_at' => $offer->game->current_date,
+            ]);
+            return ['result' => 'accepted', 'offer' => $offer->fresh()];
+        }
+
+        // Check if close enough for counter
+        $counterThreshold = (int) ($minimumAcceptable * 0.85);
+
+        if ($effectiveOffer >= $counterThreshold && $offer->terms_round < self::MAX_NEGOTIATION_ROUNDS) {
+            $counterWage = (int) (($minimumAcceptable + $offer->player_demand) / 2);
+            $counterWage = (int) (round($counterWage / 10_000_000) * 10_000_000);
+
+            $offer->update([
+                'terms_status' => 'countered',
+                'wage_counter_offer' => $counterWage,
+            ]);
+            return ['result' => 'countered', 'offer' => $offer->fresh()];
+        }
+
+        // Rejected
+        $offer->update([
+            'terms_status' => 'rejected',
+            'status' => TransferOffer::STATUS_REJECTED,
+            'resolved_at' => $offer->game->current_date,
+        ]);
+        return ['result' => 'rejected', 'offer' => $offer->fresh()];
+    }
+
+    /**
+     * Accept the player's counter-offer on pre-contract personal terms.
+     */
+    public function acceptPreContractTermsCounter(TransferOffer $offer): TransferOffer
+    {
+        if ($offer->terms_status !== 'countered') {
+            throw new \InvalidArgumentException(__('messages.transfer_failed'));
+        }
+
+        $offer->update([
+            'offered_wage' => $offer->wage_counter_offer,
+            'offered_years' => $offer->preferred_years,
+            'terms_status' => 'accepted',
+            'status' => TransferOffer::STATUS_AGREED,
+            'resolved_at' => $offer->game->current_date,
         ]);
 
         return $offer->fresh();

--- a/app/Modules/Transfer/Services/ScoutingService.php
+++ b/app/Modules/Transfer/Services/ScoutingService.php
@@ -736,6 +736,72 @@ class ScoutingService
     }
 
     // =========================================
+    // SYNCHRONOUS LOAN EVALUATION
+    // =========================================
+
+    /**
+     * Deterministic loan request evaluation for sync negotiation.
+     * Returns result, asking loan fee, mood, and rejection reason.
+     *
+     * @return array{result: string, loan_fee: int, disposition: float, rejection_reason: ?string}
+     */
+    public function evaluateLoanRequestSync(GamePlayer $player, Game $game): array
+    {
+        $teamName = $player->team?->name ?? 'Unknown';
+
+        // Reputation gate
+        $reputationModifier = $this->calculateReputationModifier($game->team, $player);
+        if ($reputationModifier < 0.50) {
+            return [
+                'result' => 'rejected',
+                'loan_fee' => 0,
+                'disposition' => 0.10,
+                'rejection_reason' => 'reputation',
+            ];
+        }
+
+        $importance = $this->calculatePlayerImportance($player);
+
+        // Key player — outright rejection
+        if ($importance > 0.70) {
+            return [
+                'result' => 'rejected',
+                'loan_fee' => 0,
+                'disposition' => 0.15,
+                'rejection_reason' => 'key_player',
+            ];
+        }
+
+        // Calculate disposition for mood indicator
+        $disposition = 0.50;
+        $disposition += (1.0 - $importance) * 0.30; // Less important = more willing
+        $disposition += ($reputationModifier - 0.50) * 0.20; // Higher rep = more willing
+        $disposition = max(0.10, min(0.95, $disposition));
+
+        // Fringe player — free loan
+        if ($importance < 0.30) {
+            return [
+                'result' => 'accepted',
+                'loan_fee' => 0,
+                'disposition' => $disposition,
+                'rejection_reason' => null,
+            ];
+        }
+
+        // Mid-range player (0.30-0.70) — demand a loan fee
+        $feeRate = 0.05 + ($importance * 0.05); // 5-10% of market value
+        $loanFee = (int) ($player->market_value_cents * $feeRate);
+        $loanFee = (int) (round($loanFee / 10_000_000) * 10_000_000); // Round to €100K
+
+        return [
+            'result' => 'conditional',
+            'loan_fee' => max($loanFee, 10_000_000), // Minimum €100K
+            'disposition' => $disposition,
+            'rejection_reason' => null,
+        ];
+    }
+
+    // =========================================
     // WAGE DEMAND
     // =========================================
 
@@ -752,6 +818,7 @@ class ScoutingService
             $player->market_value_cents,
             $minimumWage,
             $player->age($player->game->current_date),
+            deterministic: true,
         );
 
         // Round to nearest 100K (cents)
@@ -1092,13 +1159,26 @@ class ScoutingService
             $score += 5; // Young players seeking opportunities
         }
 
-        // Reputation gap penalty: players are reluctant to move to lower-rep clubs
+        // Reputation gap: penalize moving down, reward moving up
         $reputationModifier = $this->calculateReputationModifier($game->team, $player);
         if ($reputationModifier < 1.0) {
-            // Scale the score down proportionally to the reputation gap
-            // e.g. modifier 0.75 (1 tier gap) → score * 0.75
-            // e.g. modifier 0.20 (3 tier gap) → score * 0.20
+            // Moving down: scale the score down proportionally to the reputation gap
             $score = (int) ($score * $reputationModifier);
+        } elseif ($player->team_id) {
+            // Moving up: bonus based on how many tiers above the buying club is
+            $sourceReputation = TeamReputation::resolveLevel($player->game_id, $player->team_id);
+            $offeringReputation = TeamReputation::resolveLevel($player->game_id, $game->team_id);
+            $sourceIndex = ClubProfile::getReputationTierIndex($sourceReputation);
+            $offeringIndex = ClubProfile::getReputationTierIndex($offeringReputation);
+            $upwardGap = $offeringIndex - $sourceIndex;
+
+            if ($upwardGap >= 3) {
+                $score += 30; // Dream move (e.g. local → elite)
+            } elseif ($upwardGap === 2) {
+                $score += 20; // Big step up
+            } elseif ($upwardGap === 1) {
+                $score += 10; // Step up
+            }
         }
 
         $score = min(100, max(0, $score + rand(-5, 5)));

--- a/app/Modules/Transfer/Services/TransferService.php
+++ b/app/Modules/Transfer/Services/TransferService.php
@@ -1593,6 +1593,199 @@ class TransferService
         return $this->acceptOffer($offer);
     }
 
+    // =========================================
+    // SYNCHRONOUS LOAN FEE NEGOTIATION
+    // =========================================
+
+    /**
+     * Synchronous loan fee negotiation. Creates or continues a negotiation,
+     * evaluates the bid immediately, and returns the result.
+     *
+     * @return array{result: string, offer: TransferOffer}
+     */
+    public function negotiateLoanFeeSync(Game $game, GamePlayer $player, int $bidCents, ScoutingService $scoutingService): array
+    {
+        // Check for existing countered offer to resume
+        $existing = TransferOffer::where('game_id', $game->id)
+            ->where('game_player_id', $player->id)
+            ->where('offering_team_id', $game->team_id)
+            ->where('offer_type', TransferOffer::TYPE_LOAN_IN)
+            ->where('status', TransferOffer::STATUS_PENDING)
+            ->whereNotNull('negotiation_round')
+            ->where('asking_price', '>', 0)
+            ->first();
+
+        if ($existing) {
+            // Resume: update bid, increment round
+            if ($bidCents > $this->availableBudget($game) + $existing->transfer_fee) {
+                throw new \InvalidArgumentException(__('messages.bid_exceeds_budget'));
+            }
+
+            $existing->update([
+                'transfer_fee' => $bidCents,
+                'negotiation_round' => min($existing->negotiation_round + 1, ContractService::MAX_NEGOTIATION_ROUNDS),
+            ]);
+            $offer = $existing;
+        } else {
+            // New negotiation: create offer and mark as sync
+            if ($bidCents > $this->availableBudget($game)) {
+                throw new \InvalidArgumentException(__('messages.bid_exceeds_budget'));
+            }
+
+            $existingBid = TransferOffer::where('game_id', $game->id)
+                ->where('game_player_id', $player->id)
+                ->where('offering_team_id', $game->team_id)
+                ->where('offer_type', TransferOffer::TYPE_LOAN_IN)
+                ->where('status', TransferOffer::STATUS_PENDING)
+                ->exists();
+
+            if ($existingBid) {
+                throw new \InvalidArgumentException(__('transfers.already_bidding'));
+            }
+
+            $offer = TransferOffer::create([
+                'game_id' => $game->id,
+                'game_player_id' => $player->id,
+                'offering_team_id' => $game->team_id,
+                'selling_team_id' => $player->team_id,
+                'offer_type' => TransferOffer::TYPE_LOAN_IN,
+                'direction' => TransferOffer::DIRECTION_INCOMING,
+                'transfer_fee' => $bidCents,
+                'status' => TransferOffer::STATUS_PENDING,
+                'expires_at' => $game->current_date->addDays(30),
+                'game_date' => $game->current_date,
+                'negotiation_round' => 1,
+                'disposition' => $this->calculateLoanDisposition($player, $scoutingService),
+            ]);
+        }
+
+        // Evaluate: compare bid to asking price
+        $evaluation = $scoutingService->evaluateLoanRequestSync($player, $game);
+        $askingFee = $evaluation['loan_fee'];
+
+        if ($offer->transfer_fee >= $askingFee) {
+            // Accepted
+            $offer->update([
+                'status' => TransferOffer::STATUS_PENDING,
+                'asking_price' => $askingFee,
+                'resolved_at' => $game->current_date,
+            ]);
+
+            // Complete the loan
+            return $this->completeSyncLoan($offer, $game);
+        }
+
+        // Check if close enough for counter (within 70% of asking)
+        $counterThreshold = (int) ($askingFee * 0.70);
+
+        if ($offer->transfer_fee >= $counterThreshold && $offer->negotiation_round < ContractService::MAX_NEGOTIATION_ROUNDS) {
+            $counterFee = (int) (($offer->transfer_fee + $askingFee) / 2);
+            $counterFee = (int) (round($counterFee / 10_000_000) * 10_000_000);
+
+            $offer->update([
+                'asking_price' => $counterFee,
+            ]);
+            return ['result' => 'countered', 'offer' => $offer->fresh()];
+        }
+
+        // Rejected
+        $offer->update([
+            'status' => TransferOffer::STATUS_REJECTED,
+            'asking_price' => $askingFee,
+            'resolved_at' => $game->current_date,
+        ]);
+        return ['result' => 'rejected', 'offer' => $offer->fresh()];
+    }
+
+    /**
+     * Accept a club's counter-offer on a loan fee.
+     */
+    public function acceptLoanFeeCounter(Game $game, TransferOffer $offer): array
+    {
+        if (!$offer->isPending() || !$offer->isSyncNegotiated() || !$offer->asking_price || $offer->asking_price <= $offer->transfer_fee) {
+            throw new \InvalidArgumentException(__('messages.transfer_failed'));
+        }
+
+        $counterAmount = $offer->asking_price;
+        $available = $this->availableBudget($game) + $offer->transfer_fee;
+
+        if ($counterAmount > $available) {
+            throw new \InvalidArgumentException(__('messages.bid_exceeds_budget'));
+        }
+
+        $offer->update([
+            'transfer_fee' => $counterAmount,
+            'resolved_at' => $game->current_date,
+        ]);
+
+        return $this->completeSyncLoan($offer, $game);
+    }
+
+    /**
+     * Complete a sync-negotiated loan. Calls completeLoanIn if window open,
+     * otherwise marks as agreed.
+     *
+     * @return array{result: string, offer: TransferOffer}
+     */
+    public function completeSyncLoan(TransferOffer $offer, Game $game): array
+    {
+        if ($game->isTransferWindowOpen()) {
+            $this->completeLoanIn($offer, $game);
+            return ['result' => 'accepted', 'offer' => $offer->fresh()];
+        }
+
+        $offer->update([
+            'status' => TransferOffer::STATUS_AGREED,
+            'resolved_at' => $game->current_date,
+        ]);
+        return ['result' => 'accepted', 'offer' => $offer->fresh()];
+    }
+
+    /**
+     * Calculate club's disposition for a loan request.
+     * Similar to sale disposition but more willing (loan is temporary).
+     */
+    public function calculateLoanDisposition(GamePlayer $player, ScoutingService $scoutingService): float
+    {
+        $disposition = 0.55;
+
+        $importance = $scoutingService->calculatePlayerImportance($player);
+        if ($importance >= 0.85) {
+            $disposition -= 0.25;
+        } elseif ($importance >= 0.60) {
+            $disposition -= 0.10;
+        } elseif ($importance <= 0.30) {
+            $disposition += 0.15;
+        }
+
+        // Age (young players more likely to be loaned for development)
+        $age = $player->age($player->game->current_date);
+        if ($age <= 23) {
+            $disposition += 0.10;
+        } elseif ($age >= 30) {
+            $disposition += 0.05;
+        }
+
+        return max(0.10, min(0.95, $disposition));
+    }
+
+    /**
+     * Get mood indicator for loan disposition.
+     *
+     * @return array{label: string, color: string}
+     */
+    public function getLoanMoodIndicator(float $disposition): array
+    {
+        if ($disposition >= 0.65) {
+            return ['label' => __('transfers.mood_willing_loan'), 'color' => 'green'];
+        }
+        if ($disposition >= 0.40) {
+            return ['label' => __('transfers.mood_open_loan'), 'color' => 'amber'];
+        }
+
+        return ['label' => __('transfers.mood_reluctant_loan'), 'color' => 'red'];
+    }
+
     /**
      * Calculate selling club's disposition (willingness to sell).
      * Higher = more willing.

--- a/lang/en/transfers.php
+++ b/lang/en/transfers.php
@@ -352,4 +352,28 @@ return [
     'chat_buyer_rejected' => ':team has withdrawn their interest. The deal is off.',
     'chat_buyer_deal_complete' => 'Sale agreed! :player will join :team for :fee.',
     'chat_offer_rejected' => 'You have rejected the offer for :player. The player is not for sale.',
+
+    // Pre-contract negotiation chat
+    'chat_pre_contract_title' => 'Pre-Contract Negotiation',
+    'chat_pre_contract_demand' => ':player\'s agent wants :wage/year for :years years to sign a pre-contract.',
+    'chat_pre_contract_counter' => ':player\'s agent insists on :wage/year for :years years.',
+    'chat_pre_contract_accepted' => ':player has agreed to a pre-contract! He will join your club in the summer.',
+    'chat_pre_contract_rejected' => ':player\'s agent has walked away. No pre-contract agreement.',
+    'chat_pre_contract_deal' => 'Pre-contract agreed',
+    'negotiate_pre_contract' => 'Pre-Contract',
+
+    // Loan negotiation chat
+    'chat_loan_title' => 'Loan Negotiation',
+    'chat_loan_demand' => ':team would loan :player for a fee of :fee.',
+    'chat_loan_counter' => ':team insists on a loan fee of :fee.',
+    'chat_loan_accepted_free' => ':team is happy to loan :player at no cost. Welcome aboard!',
+    'chat_loan_completed' => ':player has joined on loan until the end of the season!',
+    'chat_loan_agreed' => ':player\'s loan has been agreed. The move will complete when the transfer window opens.',
+    'chat_loan_rejected' => ':team has rejected the loan request. Negotiations have broken down.',
+    'chat_loan_rejected_key_player' => ':team has rejected the request. :player is a key player for them.',
+    'chat_loan_rejected_reputation' => ':player is not interested in joining your club on loan.',
+    'chat_loan_deal' => 'Loan agreed',
+    'mood_willing_loan' => 'Willing to loan',
+    'mood_open_loan' => 'Open to loan',
+    'mood_reluctant_loan' => 'Reluctant to loan',
 ];

--- a/lang/es/transfers.php
+++ b/lang/es/transfers.php
@@ -357,4 +357,28 @@ return [
     'chat_buyer_rejected' => ':team ha retirado su interés. La negociación ha fracasado.',
     'chat_buyer_deal_complete' => '¡Venta acordada! :player se unirá a :team por :fee.',
     'chat_offer_rejected' => 'Has rechazado la oferta por :player. El jugador no está en venta.',
+
+    // Pre-contract negotiation chat
+    'chat_pre_contract_title' => 'Negociación de Pre-Contrato',
+    'chat_pre_contract_demand' => 'El agente de :player pide :wage/año durante :years años para firmar un pre-contrato.',
+    'chat_pre_contract_counter' => 'El agente de :player insiste en :wage/año durante :years años.',
+    'chat_pre_contract_accepted' => '¡:player ha aceptado un pre-contrato! Se unirá a tu club en verano.',
+    'chat_pre_contract_rejected' => 'El agente de :player se ha marchado. No hay acuerdo de pre-contrato.',
+    'chat_pre_contract_deal' => 'Pre-contrato acordado',
+    'negotiate_pre_contract' => 'Pre-Contrato',
+
+    // Loan negotiation chat
+    'chat_loan_title' => 'Negociación de Cesión',
+    'chat_loan_demand' => ':team cedería a :player por una tarifa de :fee.',
+    'chat_loan_counter' => ':team insiste en una tarifa de cesión de :fee.',
+    'chat_loan_accepted_free' => '¡:team acepta ceder a :player sin coste! ¡Bienvenido!',
+    'chat_loan_completed' => '¡:player se ha unido en cesión hasta final de temporada!',
+    'chat_loan_agreed' => 'La cesión de :player ha sido acordada. El traspaso se completará cuando abra la ventana de fichajes.',
+    'chat_loan_rejected' => ':team ha rechazado la solicitud de cesión. Las negociaciones se han roto.',
+    'chat_loan_rejected_key_player' => ':team ha rechazado la solicitud. :player es un jugador clave para ellos.',
+    'chat_loan_rejected_reputation' => ':player no está interesado en unirse a tu club en cesión.',
+    'chat_loan_deal' => 'Cesión acordada',
+    'mood_willing_loan' => 'Dispuesto a ceder',
+    'mood_open_loan' => 'Abierto a cesión',
+    'mood_reluctant_loan' => 'Reticente a ceder',
 ];

--- a/resources/js/negotiation-chat.js
+++ b/resources/js/negotiation-chat.js
@@ -8,7 +8,7 @@ export default function negotiationChat() {
         round: 0,
         maxRounds: 3,
 
-        // Mode: 'renewal' | 'transfer_fee' | 'personal_terms'
+        // Mode: 'renewal' | 'transfer_fee' | 'personal_terms' | 'pre_contract' | 'loan'
         mode: 'renewal',
         // Phase: null (renewal) | 'club_fee' | 'personal_terms' | 'counter_offer'
         phase: null,
@@ -40,7 +40,7 @@ export default function negotiationChat() {
         },
 
         get wageStep() {
-            if (this.mode === 'transfer_fee' || this.phase === 'counter_offer') {
+            if (this.mode === 'transfer_fee' || this.mode === 'loan' || this.phase === 'counter_offer') {
                 return this.offerWage >= 10000000 ? 1000000 : 100000;
             }
             return this.offerWage >= 1000000 ? 100000 : 10000;
@@ -124,7 +124,7 @@ export default function negotiationChat() {
                     this.prefillFromOptions();
                 }
                 this.loading = false;
-            } else if (this.phase === 'club_fee') {
+            } else if (this.phase === 'club_fee' || this.mode === 'loan') {
                 // Show user's bid as a message
                 this.messages.push({
                     sender: 'user',
@@ -142,7 +142,7 @@ export default function negotiationChat() {
                     this.round = data.round || this.round;
                     this.appendMessages(data.messages);
 
-                    // Handle fee agreed → transition to personal terms
+                    // Handle fee agreed → transition to personal terms (transfers only)
                     if (data.negotiation_status === 'fee_agreed') {
                         await this.transitionToPersonalTerms();
                     } else {
@@ -150,7 +150,7 @@ export default function negotiationChat() {
                     }
                 }
                 this.loading = false;
-            } else if (this.phase === 'personal_terms') {
+            } else if (this.phase === 'personal_terms' || this.mode === 'pre_contract') {
                 // Show user's wage/years offer
                 this.messages.push({
                     sender: 'user',
@@ -221,19 +221,19 @@ export default function negotiationChat() {
                     this.negotiationStatus = data.negotiation_status;
                     this.appendMessages(data.messages);
                 }
-            } else if (this.phase === 'personal_terms') {
+            } else if (this.phase === 'personal_terms' || this.mode === 'pre_contract') {
                 const data = await this.sendAction('accept_terms_counter');
                 if (data) {
                     this.negotiationStatus = data.negotiation_status;
                     this.appendMessages(data.messages);
                 }
-            } else if (this.phase === 'club_fee') {
+            } else if (this.phase === 'club_fee' || this.mode === 'loan') {
                 const data = await this.sendAction('accept_counter');
                 if (data) {
                     this.negotiationStatus = data.negotiation_status;
                     this.appendMessages(data.messages);
 
-                    // Handle fee agreed → transition to personal terms
+                    // Handle fee agreed → transition to personal terms (transfers only)
                     if (data.negotiation_status === 'fee_agreed') {
                         await this.transitionToPersonalTerms();
                     }

--- a/resources/views/components/negotiation-chat-modal.blade.php
+++ b/resources/views/components/negotiation-chat-modal.blade.php
@@ -153,7 +153,13 @@
                                     <template x-if="mode === 'renewal'">
                                         <span>{{ __('transfers.chat_renewal_agreed') }}</span>
                                     </template>
-                                    <template x-if="mode !== 'renewal' && negotiationStatus === 'completed'">
+                                    <template x-if="negotiationStatus === 'completed' && mode === 'pre_contract'">
+                                        <span>{{ __('transfers.chat_pre_contract_deal') }}</span>
+                                    </template>
+                                    <template x-if="negotiationStatus === 'completed' && mode === 'loan'">
+                                        <span>{{ __('transfers.chat_loan_deal') }}</span>
+                                    </template>
+                                    <template x-if="mode !== 'renewal' && negotiationStatus === 'completed' && mode !== 'pre_contract' && mode !== 'loan'">
                                         <span>{{ __('transfers.chat_deal_agreed') }}</span>
                                     </template>
                                     <template x-if="mode !== 'renewal' && negotiationStatus !== 'completed'">
@@ -193,8 +199,8 @@
                 </template>
             </div>
 
-            {{-- Input area: Transfer fee mode --}}
-            <div class="shrink-0 border-t border-border-strong px-5 py-3 space-y-2.5" x-show="mode === 'transfer_fee' && !isTerminal && !loading && negotiationStatus !== 'fee_agreed'">
+            {{-- Input area: Transfer fee / loan fee mode --}}
+            <div class="shrink-0 border-t border-border-strong px-5 py-3 space-y-2.5" x-show="(mode === 'transfer_fee' || mode === 'loan') && !isTerminal && !loading && negotiationStatus !== 'fee_agreed'">
                 <div class="flex items-end gap-2">
                     <div class="flex-1 min-w-0">
                         <label class="text-[10px] text-text-muted uppercase tracking-wider block mb-1">{{ __('transfers.chat_your_bid') }}</label>
@@ -230,8 +236,8 @@
                 </button>
             </div>
 
-            {{-- Input area: Wage + years mode (renewal and personal terms) --}}
-            <div class="shrink-0 border-t border-border-strong px-5 py-3 space-y-2.5" x-show="(mode === 'renewal' || mode === 'personal_terms') && !isTerminal && !loading">
+            {{-- Input area: Wage + years mode (renewal, personal terms, and pre-contract) --}}
+            <div class="shrink-0 border-t border-border-strong px-5 py-3 space-y-2.5" x-show="(mode === 'renewal' || mode === 'personal_terms' || mode === 'pre_contract') && !isTerminal && !loading">
                 <div class="flex items-end gap-2">
                     {{-- Wage stepper --}}
                     <div class="flex-1 min-w-0">

--- a/resources/views/partials/scout-report-results.blade.php
+++ b/resources/views/partials/scout-report-results.blade.php
@@ -187,18 +187,17 @@
                                                 {{ __('transfers.transfer_agreed') }}
                                             </div>
                                         @elseif($isExpiring && $isPreContractPeriod)
-                                            {{-- Pre-contract offer form --}}
-                                            @php $preContractWage = $detail['pre_contract_wage_demand'] ?? $wageDemand; @endphp
-                                            <form method="POST" action="{{ route('game.scouting.pre-contract', [$game->id, $player->id]) }}" class="space-y-2">
-                                                @csrf
-                                                <label class="block text-xs font-medium text-text-secondary">{{ __('transfers.offered_wage_euros') }}</label>
-                                                <div class="flex items-center gap-2">
-                                                    <x-money-input name="offered_wage" :value="(int)($preContractWage / 100)" :min="0" size="sm" />
-                                                    <x-primary-button color="green" size="xs">
-                                                        {{ __('transfers.submit_pre_contract') }}
-                                                    </x-primary-button>
-                                                </div>
-                                            </form>
+                                            {{-- Pre-contract negotiation --}}
+                                            <x-primary-button size="xs" color="green"
+                                                @click="$dispatch('open-negotiation', {
+                                                    playerName: {{ \Illuminate\Support\Js::from($player->name) }},
+                                                    negotiateUrl: {{ \Illuminate\Support\Js::from(route('game.negotiate.pre-contract', [$game->id, $player->id])) }},
+                                                    mode: 'pre_contract',
+                                                    phase: 'personal_terms',
+                                                    chatTitle: {{ \Illuminate\Support\Js::from(__('transfers.chat_pre_contract_title')) }}
+                                                })">
+                                                {{ __('transfers.negotiate_pre_contract') }}
+                                            </x-primary-button>
                                         @elseif(!$canAffordFee)
                                             <div class="text-xs text-accent-red font-medium">
                                                 {{ __('transfers.transfer_fee_exceeds_budget') }}
@@ -217,12 +216,16 @@
                                                     {{ __('transfers.negotiate') }}
                                                 </x-primary-button>
                                                 {{-- Loan Request --}}
-                                                <form method="POST" action="{{ route('game.scouting.loan', [$game->id, $player->id]) }}">
-                                                    @csrf
-                                                    <x-secondary-button type="submit" size="xs">
-                                                        {{ __('transfers.request_loan') }}
-                                                    </x-secondary-button>
-                                                </form>
+                                                <x-secondary-button size="xs"
+                                                    @click="$dispatch('open-negotiation', {
+                                                        playerName: {{ \Illuminate\Support\Js::from($player->name) }},
+                                                        negotiateUrl: {{ \Illuminate\Support\Js::from(route('game.negotiate.loan', [$game->id, $player->id])) }},
+                                                        mode: 'loan',
+                                                        phase: 'club_fee',
+                                                        chatTitle: {{ \Illuminate\Support\Js::from(__('transfers.chat_loan_title')) }}
+                                                    })">
+                                                    {{ __('transfers.request_loan') }}
+                                                </x-secondary-button>
                                             </div>
                                         @endif
                                     </div>

--- a/resources/views/scouting-hub.blade.php
+++ b/resources/views/scouting-hub.blade.php
@@ -178,8 +178,8 @@
                                     this.confirmRemoveId = null;
                                 },
                                 negotiateRoute(id) { return '{{ route('game.negotiate.transfer', [$game->id, '__ID__']) }}'.replace('__ID__', id); },
-                                loanRoute(id) { return '{{ route('game.scouting.loan', [$game->id, '__ID__']) }}'.replace('__ID__', id); },
-                                preContractRoute(id) { return '{{ route('game.scouting.pre-contract', [$game->id, '__ID__']) }}'.replace('__ID__', id); },
+                                loanRoute(id) { return '{{ route('game.negotiate.loan', [$game->id, '__ID__']) }}'.replace('__ID__', id); },
+                                preContractRoute(id) { return '{{ route('game.negotiate.pre-contract', [$game->id, '__ID__']) }}'.replace('__ID__', id); },
                                 signFreeAgentRoute(id) { return '{{ route('game.scouting.sign-free-agent', [$game->id, '__ID__']) }}'.replace('__ID__', id); },
                             }" @shortlist-toggled.window="handleToggle($event.detail)">
 
@@ -459,30 +459,16 @@
 
                                                             {{-- Action: Pre-contract --}}
                                                             <template x-if="!player.isFreeAgent && !player.hasExistingOffer && player.isExpiring && isPreContractPeriod">
-                                                                <form :action="preContractRoute(player.id)" method="POST" class="space-y-2">
-                                                                    <input type="hidden" name="_token" :value="csrfToken">
-                                                                    <label class="block text-xs font-medium text-text-secondary">{{ __('transfers.offered_wage_euros') }}</label>
-                                                                    <div class="flex items-center gap-2" x-data="{
-                                                                        holdTimer: null, holdInterval: null,
-                                                                        get step() { return player.wageEuros >= 1000000 ? 100000 : 10000 },
-                                                                        get display() { return '€ ' + new Intl.NumberFormat('es-ES').format(player.wageEuros) },
-                                                                        get atMin() { return player.wageEuros <= 0 },
-                                                                        increment() { player.wageEuros += this.step },
-                                                                        decrement() { player.wageEuros = Math.max(player.wageEuros - this.step, 0) },
-                                                                        startHold(fn) { fn(); this.holdTimer = setTimeout(() => { this.holdInterval = setInterval(() => fn(), 80) }, 400) },
-                                                                        stopHold() { clearTimeout(this.holdTimer); clearInterval(this.holdInterval) }
-                                                                    }">
-                                                                        <div class="inline-flex items-stretch border border-border-strong rounded-lg overflow-hidden h-[36px]">
-                                                                            <input type="hidden" name="offered_wage" :value="player.wageEuros">
-                                                                            <button type="button" :disabled="atMin" :class="atMin ? 'opacity-40 cursor-not-allowed' : 'hover:bg-surface-700 active:bg-surface-600'" class="min-h-[32px] sm:min-h-0 min-w-[32px] text-sm flex items-center justify-center bg-surface-700/50 text-text-body font-bold select-none transition-colors" @mousedown.prevent="startHold(() => decrement())" @mouseup="stopHold()" @mouseleave="stopHold()" @touchstart.prevent="startHold(() => decrement())" @touchend="stopHold()">&minus;</button>
-                                                                            <input type="text" readonly :value="display" class="min-h-[32px] sm:min-h-0 w-28 text-xs text-center font-semibold text-text-primary bg-surface-800 border-x border-y-0 border-border-strong outline-hidden cursor-default focus:outline-hidden focus:ring-0 focus:border-border-strong">
-                                                                            <button type="button" class="min-h-[32px] sm:min-h-0 min-w-[32px] text-sm flex items-center justify-center bg-surface-700/50 hover:bg-surface-700 active:bg-surface-600 text-text-body font-bold select-none transition-colors" @mousedown.prevent="startHold(() => increment())" @mouseup="stopHold()" @mouseleave="stopHold()" @touchstart.prevent="startHold(() => increment())" @touchend="stopHold()">+</button>
-                                                                        </div>
-                                                                        <x-primary-button color="green" size="xs">
-                                                                            {{ __('transfers.submit_pre_contract') }}
-                                                                        </x-primary-button>
-                                                                    </div>
-                                                                </form>
+                                                                <x-primary-button size="xs" color="green"
+                                                                    @click="$dispatch('open-negotiation', {
+                                                                        playerName: player.name,
+                                                                        negotiateUrl: preContractRoute(player.id),
+                                                                        mode: 'pre_contract',
+                                                                        phase: 'personal_terms',
+                                                                        chatTitle: {{ \Illuminate\Support\Js::from(__('transfers.chat_pre_contract_title')) }}
+                                                                    })">
+                                                                    {{ __('transfers.negotiate_pre_contract') }}
+                                                                </x-primary-button>
                                                             </template>
 
                                                             {{-- Action: Can't afford --}}
@@ -501,16 +487,20 @@
                                                                             negotiateUrl: negotiateRoute(player.id),
                                                                             mode: 'transfer_fee',
                                                                             phase: 'club_fee',
-                                                                            chatTitle: '{{ __('transfers.chat_transfer_title') }}'
+                                                                            chatTitle: {{ \Illuminate\Support\Js::from(__('transfers.chat_transfer_title')) }}
                                                                         })">
                                                                         {{ __('transfers.negotiate') }}
                                                                     </x-primary-button>
-                                                                    <form :action="loanRoute(player.id)" method="POST">
-                                                                        <input type="hidden" name="_token" :value="csrfToken">
-                                                                        <x-secondary-button type="submit" size="xs">
-                                                                            {{ __('transfers.request_loan') }}
-                                                                        </x-secondary-button>
-                                                                    </form>
+                                                                    <x-secondary-button size="xs"
+                                                                        @click="$dispatch('open-negotiation', {
+                                                                            playerName: player.name,
+                                                                            negotiateUrl: loanRoute(player.id),
+                                                                            mode: 'loan',
+                                                                            phase: 'club_fee',
+                                                                            chatTitle: {{ \Illuminate\Support\Js::from(__('transfers.chat_loan_title')) }}
+                                                                        })">
+                                                                        {{ __('transfers.request_loan') }}
+                                                                    </x-secondary-button>
                                                                 </div>
                                                             </template>
                                                         </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -43,6 +43,8 @@ use App\Http\Actions\ProcessPenalties;
 use App\Http\Actions\InitGame;
 use App\Http\Actions\ListPlayerForTransfer;
 use App\Http\Actions\NegotiateCounterOffer;
+use App\Http\Actions\NegotiateLoan;
+use App\Http\Actions\NegotiatePreContract;
 use App\Http\Actions\NegotiateRenewal;
 use App\Http\Actions\NegotiateTransfer;
 use App\Http\Actions\ReleasePlayer;
@@ -169,6 +171,8 @@ Route::middleware('auth')->group(function () {
         Route::post('/game/{gameId}/negotiate/renewal/{playerId}', NegotiateRenewal::class)->name('game.negotiate.renewal');
         Route::post('/game/{gameId}/negotiate/transfer/{playerId}', NegotiateTransfer::class)->name('game.negotiate.transfer');
         Route::post('/game/{gameId}/negotiate/counter-offer/{offerId}', NegotiateCounterOffer::class)->name('game.negotiate.counter-offer');
+        Route::post('/game/{gameId}/negotiate/pre-contract/{playerId}', NegotiatePreContract::class)->name('game.negotiate.pre-contract');
+        Route::post('/game/{gameId}/negotiate/loan/{playerId}', NegotiateLoan::class)->name('game.negotiate.loan');
         Route::post('/game/{gameId}/transfers/decline-renewal/{playerId}', DeclineRenewal::class)->name('game.transfers.decline-renewal');
         Route::post('/game/{gameId}/transfers/reconsider-renewal/{playerId}', ReconsiderRenewal::class)->name('game.transfers.reconsider-renewal');
         Route::post('/game/{gameId}/squad/release/{playerId}', ReleasePlayer::class)->name('game.squad.release');


### PR DESCRIPTION
Pre-contracts now open a single-phase personal terms chat (wage + years) instead of a form submission with async matchday resolution. Loans now open a club fee negotiation chat with deterministic evaluation: key players are rejected, fringe players are loaned free, and mid-range players have a negotiable loan fee.

Both reuse the existing negotiation-chat modal component with new modes ('pre_contract' and 'loan'). Async resolution code is untouched and naturally skips sync-negotiated offers.