### PR TITLE
Allow goalkeeper repositioning and swapping with outfield players

### DIFF
--- a/app/Support/PitchGrid.php
+++ b/app/Support/PitchGrid.php
@@ -40,17 +40,24 @@ class PitchGrid
 
     /**
      * Check if a cell is valid for a slot.
-     * GK stays locked to its zone; outfield players can go anywhere on rows 1-13.
+     * GK can be at its own zone or any outfield cell (for swap scenarios).
+     * Outfield players can go anywhere on rows 1-13 or the GK cell (4,0).
      */
     public static function isValidCell(string $slotLabel, int $col, int $row): bool
     {
-        if ($slotLabel === 'GK') {
-            $zone = self::SLOT_ZONES['GK'];
-
-            return $col >= $zone[0] && $col <= $zone[1] && $row >= $zone[2] && $row <= $zone[3];
+        if ($col < 0 || $col >= self::GRID_COLS || $row < 0 || $row >= self::GRID_ROWS) {
+            return false;
         }
 
-        return $col >= 0 && $col < self::GRID_COLS && $row >= 1 && $row < self::GRID_ROWS;
+        if ($slotLabel === 'GK') {
+            $zone = self::SLOT_ZONES['GK'];
+            $inOwnZone = $col >= $zone[0] && $col <= $zone[1] && $row >= $zone[2] && $row <= $zone[3];
+
+            return $inOwnZone || $row >= 1;
+        }
+
+        // Outfield: rows 1-13 OR the GK cell (4,0) for swap scenarios
+        return $row >= 1 || ($col === 4 && $row === 0);
     }
 
     /**

--- a/resources/js/lineup.js
+++ b/resources/js/lineup.js
@@ -587,7 +587,6 @@ export default function lineupManager(config) {
          */
         selectForRepositioning(slotId) {
             const slot = this.currentSlots.find(s => s.id === slotId);
-            if (slot && slot.role === 'Goalkeeper') return;
             this.assigningSlotId = null;
             if (this.positioningSlotId === slotId) {
                 this.positioningSlotId = null;
@@ -609,11 +608,9 @@ export default function lineupManager(config) {
             const newPositions = { ...this.pitchPositions };
 
             if (occupying) {
-                // Don't swap with GK
-                if (occupying.role === 'Goalkeeper') return;
-
-                // Move occupying slot to dragged slot's old cell
+                // Move occupying slot to dragged slot's old cell (validate reverse direction)
                 const draggedCell = this.getSlotCell(slotId);
+                if (draggedCell && !this.isValidGridCell(occupying.label, draggedCell.col, draggedCell.row)) return;
                 if (draggedCell) {
                     newPositions[String(occupying.id)] = [draggedCell.col, draggedCell.row];
                 }
@@ -652,12 +649,17 @@ export default function lineupManager(config) {
 
             if (!this.isValidGridCell(slot.label, col, row)) return 'invalid';
 
-            // Occupied by GK = blocked; occupied by outfield = swappable (treat as valid)
+            // Occupied cells are swappable (treat as valid with appropriate color)
             const occupying = this._findSlotAtCell(col, row, activeSlotId);
-            if (occupying && occupying.role === 'Goalkeeper') return 'occupied';
+            if (occupying && occupying.role === 'Goalkeeper') return 'valid-gk';
 
-            // GK stays simple
-            if (slot.role === 'Goalkeeper') return 'valid';
+            // GK repositioning: show zone-colored hints for outfield cells
+            if (slot.role === 'Goalkeeper') {
+                if (row === 0) return 'valid';
+                if (row <= 4) return 'valid-def';
+                if (row <= 9) return 'valid-mid';
+                return 'valid-fwd';
+            }
 
             // Color outfield cells by zone for visual guidance
             if (row <= 4) return 'valid-def';
@@ -672,7 +674,6 @@ export default function lineupManager(config) {
          */
         startDrag(slotId, event) {
             const slot = this.currentSlots.find(s => s.id === slotId);
-            if (slot && slot.role === 'Goalkeeper') return;
 
             // Prevent default to avoid text selection and scroll on touch
             event.preventDefault();

--- a/resources/js/modules/pitch-renderer.js
+++ b/resources/js/modules/pitch-renderer.js
@@ -228,9 +228,14 @@ export function isValidGridCell(slotLabel, col, row, gridConfig) {
     if (slotLabel === 'GK') {
         const zone = gridConfig.zones['GK'];
         if (!zone) return false;
-        return col >= zone[0] && col <= zone[1] && row >= zone[2] && row <= zone[3];
+        const inOwnZone = col >= zone[0] && col <= zone[1] && row >= zone[2] && row <= zone[3];
+        return inOwnZone || (row >= 1 && col >= 0 && col < gridConfig.cols);
     }
-    return col >= 0 && col < gridConfig.cols && row >= 1 && row < gridConfig.rows;
+    // Outfield: rows 1-13 OR the GK cell (4,0)
+    if (col >= 0 && col < gridConfig.cols && row >= 1 && row < gridConfig.rows) {
+        return true;
+    }
+    return col === 4 && row === 0;
 }
 
 /**

--- a/resources/views/components/pitch-display.blade.php
+++ b/resources/views/components/pitch-display.blade.php
@@ -67,6 +67,7 @@
                                         'bg-blue-500/25': state === 'valid-def',
                                         'bg-emerald-500/25': state === 'valid-mid',
                                         'bg-red-500/25': state === 'valid-fwd',
+                                        'bg-amber-500/25': state === 'valid-gk',
                                         [getZoneColorClass('Goalkeeper')]: state === 'valid',
                                         'bg-surface-800/5': state === 'occupied',
                                         'bg-black/15': state === 'invalid',


### PR DESCRIPTION
## Summary
This PR removes restrictions that prevented goalkeepers from being repositioned on the pitch and enables swapping between goalkeepers and outfield players. Previously, goalkeepers were locked to their zone and couldn't be dragged or swapped. Now they can be repositioned to any valid outfield cell, and outfield players can occupy the goalkeeper cell for swap scenarios.

## Key Changes

- **Removed goalkeeper drag restrictions**: Deleted checks in `selectForRepositioning()` and `startDrag()` that prevented goalkeepers from being selected for repositioning
- **Enabled goalkeeper-outfield swaps**: Modified `completeRepositioning()` to allow swapping with goalkeepers instead of blocking the operation
- **Updated cell validation logic**: 
  - Goalkeepers can now occupy their own zone OR any outfield cell (rows 1+)
  - Outfield players can occupy rows 1-13 OR the goalkeeper cell (4,0) for swap scenarios
  - Applied consistently across `PitchGrid.php`, `pitch-renderer.js`, and validation checks
- **Enhanced visual feedback**: 
  - Added `valid-gk` state to indicate cells occupied by goalkeepers during drag operations
  - Goalkeepers now see zone-colored hints (defense/midfield/forward) when dragging to outfield cells
  - Added amber color styling for the `valid-gk` state in the pitch display

## Implementation Details

- Validation now checks grid bounds explicitly before zone checks
- Swap logic validates that the reverse direction (moving the occupying slot to the dragged slot's old position) is also valid
- Visual hints for goalkeeper repositioning use the same zone-coloring system as outfield players for consistency

https://claude.ai/code/session_0122AcG9PcyQdhd6W1HjTHXQ