### PR TITLE
Add counter-offer option for unsolicited and listed transfer bids

### DIFF
--- a/app/Http/Actions/NegotiateCounterOffer.php
+++ b/app/Http/Actions/NegotiateCounterOffer.php
@@ -1,0 +1,255 @@
+<?php
+
+namespace App\Http\Actions;
+
+use App\Models\Game;
+use App\Models\TransferOffer;
+use App\Modules\Notification\Services\NotificationService;
+use App\Modules\Transfer\Services\ContractService;
+use App\Modules\Transfer\Services\ScoutingService;
+use App\Modules\Transfer\Services\TransferService;
+use App\Support\Money;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
+
+class NegotiateCounterOffer
+{
+    private const MAX_ROUNDS = ContractService::MAX_NEGOTIATION_ROUNDS;
+
+    public function __construct(
+        private readonly TransferService $transferService,
+        private readonly ScoutingService $scoutingService,
+        private readonly NotificationService $notificationService,
+    ) {}
+
+    public function __invoke(Request $request, string $gameId, string $offerId): JsonResponse
+    {
+        $request->validate([
+            'action' => ['required', 'string', Rule::in(['start', 'counter', 'accept_counter', 'reject'])],
+        ]);
+
+        $game = Game::findOrFail($gameId);
+
+        $offer = TransferOffer::with(['gamePlayer.player', 'gamePlayer.team', 'offeringTeam'])
+            ->where('id', $offerId)
+            ->where('game_id', $gameId)
+            ->whereIn('offer_type', [TransferOffer::TYPE_UNSOLICITED, TransferOffer::TYPE_LISTED])
+            ->where('status', TransferOffer::STATUS_PENDING)
+            ->firstOrFail();
+
+        // Verify the player belongs to the user's team
+        if ($offer->gamePlayer->team_id !== $game->team_id) {
+            abort(403);
+        }
+
+        return match ($request->input('action')) {
+            'start' => $this->handleStart($game, $offer),
+            'counter' => $this->handleCounter($request, $game, $offer),
+            'accept_counter' => $this->handleAcceptCounter($game, $offer),
+            'reject' => $this->handleReject($game, $offer),
+            default => response()->json(['status' => 'error', 'message' => 'Invalid action'], 400),
+        };
+    }
+
+    private function handleStart(Game $game, TransferOffer $offer): JsonResponse
+    {
+        $player = $offer->gamePlayer;
+        $buyerName = $offer->offeringTeam->name;
+
+        // Extend expiry to prevent mid-negotiation timeout
+        if ($offer->expires_at && $offer->expires_at->diffInDays($game->current_date) < 5) {
+            $offer->update(['expires_at' => $game->current_date->addDays(5)]);
+        }
+
+        // Check for existing negotiation to resume
+        if ($offer->negotiation_round && $offer->asking_price && $offer->asking_price > $offer->transfer_fee) {
+            $suggestedCounter = $this->calculateMidpointInEuros($offer->transfer_fee, $offer->asking_price);
+
+            return response()->json([
+                'status' => 'ok',
+                'negotiation_status' => 'open',
+                'round' => $offer->negotiation_round,
+                'max_rounds' => self::MAX_ROUNDS,
+                'messages' => [
+                    $this->agentMessage('counter', [
+                        'text' => __('transfers.chat_buyer_counter_resume', [
+                            'team' => $buyerName,
+                            'fee' => Money::format($offer->transfer_fee),
+                        ]),
+                        'fee' => (int) ($offer->transfer_fee / 100),
+                    ], [
+                        'canAccept' => true,
+                        'suggestedFee' => $suggestedCounter,
+                    ]),
+                ],
+            ]);
+        }
+
+        // New negotiation — show AI's current bid
+        $suggestedCounter = (int) ($offer->transfer_fee / 100);
+
+        return response()->json([
+            'status' => 'ok',
+            'negotiation_status' => 'open',
+            'round' => 0,
+            'max_rounds' => self::MAX_ROUNDS,
+            'messages' => [
+                $this->agentMessage('demand', [
+                    'text' => __('transfers.chat_buyer_opening', [
+                        'team' => $buyerName,
+                        'fee' => Money::format($offer->transfer_fee),
+                        'player' => $player->name,
+                    ]),
+                    'fee' => (int) ($offer->transfer_fee / 100),
+                ], [
+                    'canAccept' => true,
+                    'suggestedFee' => $suggestedCounter,
+                ]),
+            ],
+        ]);
+    }
+
+    private function handleCounter(Request $request, Game $game, TransferOffer $offer): JsonResponse
+    {
+        $validated = $request->validate([
+            'bid' => ['required', 'integer', 'min:1'],
+        ]);
+
+        $userAskingCents = $validated['bid'] * 100;
+        $buyerName = $offer->offeringTeam->name;
+        $player = $offer->gamePlayer;
+
+        if ($userAskingCents <= $offer->transfer_fee) {
+            return response()->json([
+                'status' => 'error',
+                'message' => __('transfers.counter_must_be_higher'),
+            ], 422);
+        }
+
+        $result = $this->transferService->negotiateCounterOfferSync($game, $offer, $userAskingCents, $this->scoutingService);
+        $offer = $result['offer'];
+
+        return match ($result['result']) {
+            'accepted' => $this->completeSale($offer, $game, $player, $buyerName),
+            'countered' => response()->json([
+                'status' => 'ok',
+                'negotiation_status' => 'open',
+                'round' => $offer->negotiation_round,
+                'max_rounds' => self::MAX_ROUNDS,
+                'messages' => [
+                    $this->agentMessage('counter', [
+                        'text' => __('transfers.chat_buyer_counter', [
+                            'team' => $buyerName,
+                            'fee' => Money::format($offer->transfer_fee),
+                        ]),
+                        'fee' => (int) ($offer->transfer_fee / 100),
+                    ], [
+                        'canAccept' => true,
+                        'suggestedFee' => $this->calculateMidpointInEuros($offer->transfer_fee, $offer->asking_price),
+                    ]),
+                ],
+            ]),
+            default => response()->json([
+                'status' => 'ok',
+                'negotiation_status' => 'rejected',
+                'round' => $offer->negotiation_round,
+                'max_rounds' => self::MAX_ROUNDS,
+                'messages' => [
+                    $this->agentMessage('rejected', [
+                        'text' => __('transfers.chat_buyer_rejected', [
+                            'team' => $buyerName,
+                        ]),
+                    ]),
+                ],
+            ]),
+        };
+    }
+
+    private function handleAcceptCounter(Game $game, TransferOffer $offer): JsonResponse
+    {
+        $player = $offer->gamePlayer;
+        $buyerName = $offer->offeringTeam->name;
+
+        $completedImmediately = $this->transferService->acceptCounterOfferBid($offer);
+
+        if ($completedImmediately) {
+            $this->notificationService->notifyTransferComplete($game, $offer->refresh());
+        }
+
+        return response()->json([
+            'status' => 'ok',
+            'negotiation_status' => 'completed',
+            'round' => $offer->negotiation_round ?? 0,
+            'max_rounds' => self::MAX_ROUNDS,
+            'messages' => [
+                $this->agentMessage('accepted', [
+                    'text' => __('transfers.chat_buyer_deal_complete', [
+                        'player' => $player->name,
+                        'team' => $buyerName,
+                        'fee' => Money::format($offer->transfer_fee),
+                    ]),
+                    'fee' => (int) ($offer->transfer_fee / 100),
+                ]),
+            ],
+        ]);
+    }
+
+    private function completeSale(TransferOffer $offer, Game $game, $player, string $buyerName): JsonResponse
+    {
+        $completedImmediately = $this->transferService->acceptOffer($offer);
+
+        if ($completedImmediately) {
+            $this->notificationService->notifyTransferComplete($game, $offer->refresh());
+        }
+
+        return response()->json([
+            'status' => 'ok',
+            'negotiation_status' => 'completed',
+            'round' => $offer->negotiation_round ?? 0,
+            'max_rounds' => self::MAX_ROUNDS,
+            'messages' => [
+                $this->agentMessage('accepted', [
+                    'text' => __('transfers.chat_buyer_accepted', [
+                        'team' => $buyerName,
+                        'fee' => Money::format($offer->transfer_fee),
+                        'player' => $player->name,
+                    ]),
+                    'fee' => (int) ($offer->transfer_fee / 100),
+                ]),
+            ],
+        ]);
+    }
+
+    private function handleReject(Game $game, TransferOffer $offer): JsonResponse
+    {
+        $this->transferService->rejectOffer($offer);
+
+        return response()->json([
+            'status' => 'ok',
+            'negotiation_status' => 'rejected',
+            'messages' => [
+                $this->agentMessage('rejected', [
+                    'text' => __('transfers.chat_offer_rejected', [
+                        'player' => $offer->gamePlayer->name,
+                    ]),
+                ]),
+            ],
+        ]);
+    }
+
+    private function agentMessage(string $type, array $content, ?array $options = null): array
+    {
+        return [
+            'sender' => 'agent',
+            'type' => $type,
+            'content' => $content,
+            'options' => $options,
+        ];
+    }
+
+    private function calculateMidpointInEuros(int $centsA, int $centsB): int
+    {
+        return (int) (ceil(($centsA + $centsB) / 2 / 100 / 10000) * 10000);
+    }
+}

--- a/app/Modules/Transfer/Services/ScoutingService.php
+++ b/app/Modules/Transfer/Services/ScoutingService.php
@@ -616,6 +616,64 @@ class ScoutingService
     }
 
     /**
+     * Evaluate the user's counter-offer from the AI buyer's perspective.
+     *
+     * Called when the user counters an unsolicited or listed offer with a higher asking price.
+     * The AI club evaluates whether to accept, counter, or walk away.
+     *
+     * @return array{result: string, counter_amount: int|null}
+     */
+    public function evaluateCounterOffer(TransferOffer $offer, int $userAskingPrice, Game $game): array
+    {
+        $player = $offer->gamePlayer;
+        $marketValue = $player->market_value_cents;
+
+        // Calculate AI club's squad value to determine budget ceiling
+        $offeringTeamSquadValue = GamePlayer::where('game_id', $game->id)
+            ->where('team_id', $offer->offering_team_id)
+            ->sum('market_value_cents');
+
+        // AI club's max willingness: min of squad-value ceiling and market-value ceiling
+        $squadValueCeiling = (int) ($offeringTeamSquadValue * 0.25);
+        $marketValueCeiling = (int) ($marketValue * 1.30);
+        $maxWillingness = min($squadValueCeiling, $marketValueCeiling);
+
+        // Ensure max willingness is at least the current offer
+        $maxWillingness = max($maxWillingness, $offer->transfer_fee);
+
+        if ($userAskingPrice <= (int) ($maxWillingness * 0.95)) {
+            return [
+                'result' => 'accepted',
+                'counter_amount' => null,
+            ];
+        }
+
+        if ($userAskingPrice <= (int) ($maxWillingness * 1.15)) {
+            // Counter with midpoint of user's ask and AI's current bid, rounded to nearest €100K
+            $counterAmount = (int) (($userAskingPrice + $offer->transfer_fee) / 2);
+            $counterAmount = (int) (round($counterAmount / 10_000_000) * 10_000_000);
+
+            // If rounding makes counter equal to or below the current bid, just accept
+            if ($counterAmount <= $offer->transfer_fee) {
+                return [
+                    'result' => 'accepted',
+                    'counter_amount' => null,
+                ];
+            }
+
+            return [
+                'result' => 'countered',
+                'counter_amount' => $counterAmount,
+            ];
+        }
+
+        return [
+            'result' => 'rejected',
+            'counter_amount' => null,
+        ];
+    }
+
+    /**
      * Check if player is a key player (top 3 by ability on their team).
      */
     private function isKeyPlayer(GamePlayer $player): bool

--- a/app/Modules/Transfer/Services/TransferService.php
+++ b/app/Modules/Transfer/Services/TransferService.php
@@ -1540,6 +1540,59 @@ class TransferService
         return $offer->fresh();
     }
 
+    // =========================================
+    // SYNCHRONOUS COUNTER-OFFER NEGOTIATION
+    // =========================================
+
+    /**
+     * Handle user counter-offering an unsolicited or listed bid.
+     *
+     * The user demands a higher price for their player. The AI buying club
+     * evaluates whether to raise their bid, counter, or walk away.
+     *
+     * @return array{result: string, offer: TransferOffer}
+     */
+    public function negotiateCounterOfferSync(Game $game, TransferOffer $offer, int $userAskingCents, ScoutingService $scoutingService): array
+    {
+        // Increment negotiation round
+        $offer->update([
+            'asking_price' => $userAskingCents,
+            'negotiation_round' => ($offer->negotiation_round ?? 0) + 1,
+        ]);
+
+        $evaluation = $scoutingService->evaluateCounterOffer($offer, $userAskingCents, $game);
+
+        if ($evaluation['result'] === 'accepted') {
+            $offer->update([
+                'transfer_fee' => $userAskingCents,
+            ]);
+            return ['result' => 'accepted', 'offer' => $offer->fresh()];
+        }
+
+        if ($evaluation['result'] === 'countered' && $offer->negotiation_round < ContractService::MAX_NEGOTIATION_ROUNDS) {
+            $offer->update([
+                'transfer_fee' => $evaluation['counter_amount'],
+            ]);
+            return ['result' => 'countered', 'offer' => $offer->fresh()];
+        }
+
+        // Rejected (or countered but at max rounds)
+        $offer->update([
+            'status' => TransferOffer::STATUS_REJECTED,
+            'resolved_at' => $game->current_date,
+        ]);
+        return ['result' => 'rejected', 'offer' => $offer->fresh()];
+    }
+
+    /**
+     * User accepts the AI buyer's latest counter-bid.
+     * Completes the sale via the standard acceptOffer flow.
+     */
+    public function acceptCounterOfferBid(TransferOffer $offer): bool
+    {
+        return $this->acceptOffer($offer);
+    }
+
     /**
      * Calculate selling club's disposition (willingness to sell).
      * Higher = more willing.

--- a/lang/en/transfers.php
+++ b/lang/en/transfers.php
@@ -311,7 +311,9 @@ return [
     'chat_agent_accepted' => ':player has agreed to :wage/year for :years years. Deal done!',
     'chat_agent_rejected' => ':player\'s agent has left the table. Negotiations have broken down.',
     'chat_accept' => 'Accept',
+    'chat_reject' => 'Reject',
     'chat_user_accepts' => 'Deal!',
+    'chat_user_rejects' => 'Not for sale',
     'chat_deal_agreed' => 'Contract agreed',
     'chat_club_agreement' => 'Club agreement reached',
     'chat_renewal_agreed' => 'Renewal agreed',
@@ -339,4 +341,15 @@ return [
     'chat_player_counter_transfer' => ':player\'s agent insists on :wage/year for :years years.',
     'chat_transfer_complete' => ':player has signed! Welcome to the team.',
     'chat_terms_rejected' => ':player\'s agent has walked away. The deal is off.',
+
+    // Counter-offer negotiation (user selling)
+    'counter_offer_title' => 'Counter-offer',
+    'counter_must_be_higher' => 'Your asking price must be higher than the current offer.',
+    'chat_buyer_opening' => ':team has offered :fee for :player. What is your asking price?',
+    'chat_buyer_counter' => ':team raises their offer to :fee.',
+    'chat_buyer_counter_resume' => ':team\'s latest offer is :fee.',
+    'chat_buyer_accepted' => ':team accepts your price of :fee for :player!',
+    'chat_buyer_rejected' => ':team has withdrawn their interest. The deal is off.',
+    'chat_buyer_deal_complete' => 'Sale agreed! :player will join :team for :fee.',
+    'chat_offer_rejected' => 'You have rejected the offer for :player. The player is not for sale.',
 ];

--- a/lang/es/transfers.php
+++ b/lang/es/transfers.php
@@ -316,7 +316,9 @@ return [
     'chat_agent_accepted' => ':player ha aceptado :wage/año por :years años. ¡Hecho!',
     'chat_agent_rejected' => 'El agente de :player ha abandonado la mesa. La negociación ha fracasado.',
     'chat_accept' => 'Aceptar',
+    'chat_reject' => 'Rechazar',
     'chat_user_accepts' => '¡Trato!',
+    'chat_user_rejects' => 'No está en venta',
     'chat_deal_agreed' => 'Fichaje acordado',
     'chat_club_agreement' => 'Acuerdo entre clubes',
     'chat_renewal_agreed' => 'Renovación acordada',
@@ -344,4 +346,15 @@ return [
     'chat_player_counter_transfer' => 'El agente de :player insiste en :wage/año durante :years años.',
     'chat_transfer_complete' => '¡:player ha firmado! Bienvenido al equipo.',
     'chat_terms_rejected' => 'El agente de :player se ha marchado. El acuerdo se ha roto.',
+
+    // Counter-offer negotiation (user selling)
+    'counter_offer_title' => 'Contraoferta',
+    'counter_must_be_higher' => 'Tu precio debe ser superior a la oferta actual.',
+    'chat_buyer_opening' => ':team ha ofrecido :fee por :player. ¿Cuál es tu precio?',
+    'chat_buyer_counter' => ':team sube su oferta a :fee.',
+    'chat_buyer_counter_resume' => 'La última oferta de :team es :fee.',
+    'chat_buyer_accepted' => '¡:team acepta tu precio de :fee por :player!',
+    'chat_buyer_rejected' => ':team ha retirado su interés. La negociación ha fracasado.',
+    'chat_buyer_deal_complete' => '¡Venta acordada! :player se unirá a :team por :fee.',
+    'chat_offer_rejected' => 'Has rechazado la oferta por :player. El jugador no está en venta.',
 ];

--- a/resources/js/negotiation-chat.js
+++ b/resources/js/negotiation-chat.js
@@ -10,7 +10,7 @@ export default function negotiationChat() {
 
         // Mode: 'renewal' | 'transfer_fee' | 'personal_terms'
         mode: 'renewal',
-        // Phase: null (renewal) | 'club_fee' | 'personal_terms'
+        // Phase: null (renewal) | 'club_fee' | 'personal_terms' | 'counter_offer'
         phase: null,
 
         // Player info (set on open)
@@ -40,7 +40,7 @@ export default function negotiationChat() {
         },
 
         get wageStep() {
-            if (this.mode === 'transfer_fee') {
+            if (this.mode === 'transfer_fee' || this.phase === 'counter_offer') {
                 return this.offerWage >= 10000000 ? 1000000 : 100000;
             }
             return this.offerWage >= 1000000 ? 100000 : 10000;
@@ -104,7 +104,27 @@ export default function negotiationChat() {
         async submitOffer() {
             if (!this.canSubmit) return;
 
-            if (this.phase === 'club_fee') {
+            if (this.phase === 'counter_offer') {
+                // Counter-offer: user is seller demanding a higher price
+                this.messages.push({
+                    sender: 'user',
+                    type: 'bid',
+                    content: { fee: this.offerWage },
+                    options: null,
+                });
+                this.clearLastOptions();
+                this.loading = true;
+                await this.delay(400 + Math.random() * 300);
+
+                const data = await this.sendAction('counter', { bid: this.offerWage });
+                if (data) {
+                    this.negotiationStatus = data.negotiation_status;
+                    this.round = data.round || this.round;
+                    this.appendMessages(data.messages);
+                    this.prefillFromOptions();
+                }
+                this.loading = false;
+            } else if (this.phase === 'club_fee') {
                 // Show user's bid as a message
                 this.messages.push({
                     sender: 'user',
@@ -194,7 +214,14 @@ export default function negotiationChat() {
             this.loading = true;
             await this.delay(300);
 
-            if (this.phase === 'personal_terms') {
+            if (this.phase === 'counter_offer') {
+                // Counter-offer: user accepts AI buyer's latest bid
+                const data = await this.sendAction('accept_counter');
+                if (data) {
+                    this.negotiationStatus = data.negotiation_status;
+                    this.appendMessages(data.messages);
+                }
+            } else if (this.phase === 'personal_terms') {
                 const data = await this.sendAction('accept_terms_counter');
                 if (data) {
                     this.negotiationStatus = data.negotiation_status;
@@ -218,6 +245,28 @@ export default function negotiationChat() {
                     this.negotiationStatus = data.negotiation_status;
                     this.appendMessages(data.messages);
                 }
+            }
+            this.loading = false;
+        },
+
+        async rejectOffer() {
+            if (this.loading || this.isTerminal) return;
+
+            this.messages.push({
+                sender: 'user',
+                type: 'reject',
+                content: { text: '' },
+                options: null,
+            });
+            this.clearLastOptions();
+
+            this.loading = true;
+            await this.delay(300);
+
+            const data = await this.sendAction('reject');
+            if (data) {
+                this.negotiationStatus = data.negotiation_status;
+                this.appendMessages(data.messages);
             }
             this.loading = false;
         },

--- a/resources/views/components/negotiation-chat-modal.blade.php
+++ b/resources/views/components/negotiation-chat-modal.blade.php
@@ -73,13 +73,19 @@
                                                 x-text="msg.content.mood.label"></span>
                                         </div>
                                     </template>
-                                    {{-- Accept counter-offer --}}
+                                    {{-- Accept / Reject counter-offer --}}
                                     <template x-if="msg.options?.canAccept">
-                                        <div class="pt-1">
+                                        <div class="pt-1 flex gap-2">
                                             <button type="button" @click="acceptCounter()"
                                                 class="px-3 py-1.5 text-xs font-semibold rounded-lg bg-accent-green/15 text-accent-green hover:bg-accent-green/25 transition-colors min-h-[36px]">
                                                 {{ __('transfers.chat_accept') }}
                                             </button>
+                                            <template x-if="phase === 'counter_offer'">
+                                                <button type="button" @click="rejectOffer()"
+                                                    class="px-3 py-1.5 text-xs font-semibold rounded-lg bg-accent-red/15 text-accent-red hover:bg-accent-red/25 transition-colors min-h-[36px]">
+                                                    {{ __('transfers.chat_reject') }}
+                                                </button>
+                                            </template>
                                         </div>
                                     </template>
                                 </div>
@@ -108,6 +114,12 @@
                                     <template x-if="msg.type === 'accept'">
                                         <div class="bg-accent-green/15 rounded-xl rounded-tr-sm px-3.5 py-2.5 text-sm text-accent-green font-medium">
                                             {{ __('transfers.chat_user_accepts') }}
+                                        </div>
+                                    </template>
+                                    {{-- User rejects offer --}}
+                                    <template x-if="msg.type === 'reject'">
+                                        <div class="bg-accent-red/15 rounded-xl rounded-tr-sm px-3.5 py-2.5 text-sm text-accent-red font-medium">
+                                            {{ __('transfers.chat_user_rejects') }}
                                         </div>
                                     </template>
                                 </div>

--- a/resources/views/components/player-detail-modal.blade.php
+++ b/resources/views/components/player-detail-modal.blade.php
@@ -23,5 +23,4 @@
         {{-- Server-rendered content --}}
         <div x-show="!loading" x-html="content"></div>
     </x-modal>
-    <x-negotiation-chat-modal />
 </div>

--- a/resources/views/outgoing-transfers.blade.php
+++ b/resources/views/outgoing-transfers.blade.php
@@ -106,7 +106,7 @@
 
                             {{-- UNSOLICITED OFFERS — red accent --}}
                             @if($unsolicitedOffers->isNotEmpty())
-                            <div class="border-l-4 border-l-accent-red pl-5">
+                            <div x-data class="border-l-4 border-l-accent-red pl-5">
                                 <h4 class="font-semibold text-lg text-text-primary mb-1">{{ __('transfers.unsolicited_offers') }}</h4>
                                 <p class="text-sm text-text-muted mb-3">{{ __('transfers.unsolicited_offers_help') }}</p>
                                 <div class="space-y-3">
@@ -130,27 +130,19 @@
                                                     <div class="text-xl font-bold text-accent-green">{{ $offer->formatted_transfer_fee }}</div>
                                                     <div class="text-xs text-text-muted">{{ __('transfers.expires_in_days', ['days' => $offer->days_until_expiry]) }}</div>
                                                 </div>
-                                                <div class="flex gap-2">
-                                                    <form method="post" action="{{ route('game.transfers.accept', [$game->id, $offer->id]) }}">
-                                                        @csrf
-                                                        <x-primary-button color="green">{{ __('app.accept') }}</x-primary-button>
-                                                    </form>
-                                                    @php $offeredPlayer = $renewalEligiblePlayers->firstWhere('id', $offer->game_player_id); @endphp
-                                                    @if($offeredPlayer)
-                                                        <x-action-button color="green" type="button"
-                                                            @click="$dispatch('open-negotiation', {
-                                                                playerName: @js($offeredPlayer->name),
-                                                                negotiateUrl: @js(route('game.negotiate.renewal', [$game->id, $offeredPlayer->id]))
-                                                            })">
-                                                            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" /></svg>
-                                                            {{ __('squad.renew') }}
-                                                        </x-action-button>
-                                                    @else
-                                                    <form method="post" action="{{ route('game.transfers.reject', [$game->id, $offer->id]) }}">
-                                                        @csrf
-                                                        <x-secondary-button type="submit">{{ __('app.reject') }}</x-secondary-button>
-                                                    </form>
-                                                    @endif
+                                                <div class="flex flex-wrap gap-2">
+                                                    @php
+                                                        $counterOfferDetail = \Illuminate\Support\Js::from([
+                                                            'playerName' => $offer->gamePlayer->player->name,
+                                                            'negotiateUrl' => route('game.negotiate.counter-offer', [$game->id, $offer->id]),
+                                                            'mode' => 'transfer_fee',
+                                                            'phase' => 'counter_offer',
+                                                            'chatTitle' => __('transfers.counter_offer_title'),
+                                                        ]);
+                                                    @endphp
+                                                    <x-primary-button type="button" x-on:click="$dispatch('open-negotiation', {{ $counterOfferDetail }})">
+                                                        {{ __('transfers.negotiate') }}
+                                                    </x-primary-button>
                                                 </div>
                                             </div>
                                         </div>
@@ -162,7 +154,7 @@
 
                             {{-- PRE-CONTRACT OFFERS — red accent --}}
                             @if($preContractOffers->isNotEmpty())
-                            <div class="border-l-4 border-l-accent-red pl-5">
+                            <div x-data class="border-l-4 border-l-accent-red pl-5">
                                 <h4 class="font-semibold text-lg text-text-primary mb-1">{{ __('transfers.pre_contract_offers_received') }}</h4>
                                 <p class="text-sm text-text-muted mb-3">{{ __('transfers.pre_contract_offers_help') }}</p>
                                 <div class="space-y-3">
@@ -190,11 +182,13 @@
                                                     </form>
                                                     @php $offeredPlayer = $renewalEligiblePlayers->firstWhere('id', $offer->game_player_id); @endphp
                                                     @if($offeredPlayer)
-                                                        <x-action-button color="green" type="button"
-                                                            @click="$dispatch('open-negotiation', {
-                                                                playerName: @js($offeredPlayer->name),
-                                                                negotiateUrl: @js(route('game.negotiate.renewal', [$game->id, $offeredPlayer->id]))
-                                                            })">
+                                                        @php
+                                                            $renewalDetail = \Illuminate\Support\Js::from([
+                                                                'playerName' => $offeredPlayer->name,
+                                                                'negotiateUrl' => route('game.negotiate.renewal', [$game->id, $offeredPlayer->id]),
+                                                            ]);
+                                                        @endphp
+                                                        <x-action-button color="green" type="button" x-on:click="$dispatch('open-negotiation', {{ $renewalDetail }})">
                                                             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" /></svg>
                                                             {{ __('squad.renew') }}
                                                         </x-action-button>
@@ -215,7 +209,7 @@
 
                             {{-- OFFERS FOR LISTED PLAYERS — gold accent --}}
                             @if($listedOffers->isNotEmpty())
-                            <div class="border-l-4 border-l-accent-gold pl-5">
+                            <div x-data class="border-l-4 border-l-accent-gold pl-5">
                                 <h4 class="font-semibold text-lg text-text-primary mb-1">{{ __('transfers.offers_received') }}</h4>
                                 <p class="text-sm text-text-muted mb-3">{{ __('transfers.offers_received_help') }}</p>
                                 <div class="space-y-3">
@@ -239,15 +233,19 @@
                                                     <div class="text-xl font-bold text-accent-green">{{ $offer->formatted_transfer_fee }}</div>
                                                     <div class="text-xs text-text-muted">{{ __('transfers.expires_in_days', ['days' => $offer->days_until_expiry]) }}</div>
                                                 </div>
-                                                <div class="flex gap-2">
-                                                    <form method="post" action="{{ route('game.transfers.accept', [$game->id, $offer->id]) }}">
-                                                        @csrf
-                                                        <x-primary-button color="green">{{ __('app.accept') }}</x-primary-button>
-                                                    </form>
-                                                    <form method="post" action="{{ route('game.transfers.reject', [$game->id, $offer->id]) }}">
-                                                        @csrf
-                                                        <x-secondary-button type="submit">{{ __('app.reject') }}</x-secondary-button>
-                                                    </form>
+                                                <div class="flex flex-wrap gap-2">
+                                                    @php
+                                                        $counterOfferDetail = \Illuminate\Support\Js::from([
+                                                            'playerName' => $offer->gamePlayer->player->name,
+                                                            'negotiateUrl' => route('game.negotiate.counter-offer', [$game->id, $offer->id]),
+                                                            'mode' => 'transfer_fee',
+                                                            'phase' => 'counter_offer',
+                                                            'chatTitle' => __('transfers.counter_offer_title'),
+                                                        ]);
+                                                    @endphp
+                                                    <x-primary-button type="button" x-on:click="$dispatch('open-negotiation', {{ $counterOfferDetail }})">
+                                                        {{ __('transfers.negotiate') }}
+                                                    </x-primary-button>
                                                 </div>
                                             </div>
                                         </div>
@@ -561,4 +559,5 @@
     </div>
 
     <x-player-detail-modal />
+    <x-negotiation-chat-modal />
 </x-app-layout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -42,6 +42,7 @@ use App\Http\Actions\ProcessExtraTime;
 use App\Http\Actions\ProcessPenalties;
 use App\Http\Actions\InitGame;
 use App\Http\Actions\ListPlayerForTransfer;
+use App\Http\Actions\NegotiateCounterOffer;
 use App\Http\Actions\NegotiateRenewal;
 use App\Http\Actions\NegotiateTransfer;
 use App\Http\Actions\ReleasePlayer;
@@ -167,6 +168,7 @@ Route::middleware('auth')->group(function () {
         Route::post('/game/{gameId}/transfers/withdraw/{offerId}', WithdrawTransferOffer::class)->name('game.transfers.withdraw');
         Route::post('/game/{gameId}/negotiate/renewal/{playerId}', NegotiateRenewal::class)->name('game.negotiate.renewal');
         Route::post('/game/{gameId}/negotiate/transfer/{playerId}', NegotiateTransfer::class)->name('game.negotiate.transfer');
+        Route::post('/game/{gameId}/negotiate/counter-offer/{offerId}', NegotiateCounterOffer::class)->name('game.negotiate.counter-offer');
         Route::post('/game/{gameId}/transfers/decline-renewal/{playerId}', DeclineRenewal::class)->name('game.transfers.decline-renewal');
         Route::post('/game/{gameId}/transfers/reconsider-renewal/{playerId}', ReconsiderRenewal::class)->name('game.transfers.reconsider-renewal');
         Route::post('/game/{gameId}/squad/release/{playerId}', ReleasePlayer::class)->name('game.squad.release');

--- a/tests/Feature/CounterOfferTest.php
+++ b/tests/Feature/CounterOfferTest.php
@@ -1,0 +1,300 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Competition;
+use App\Models\Game;
+use App\Models\GamePlayer;
+use App\Models\Player;
+use App\Models\Team;
+use App\Models\TransferOffer;
+use App\Models\User;
+use App\Modules\Transfer\Services\ContractService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class CounterOfferTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+    private Team $userTeam;
+    private Team $buyerTeam;
+    private Competition $competition;
+    private Game $game;
+    private GamePlayer $gamePlayer;
+    private TransferOffer $offer;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = User::factory()->create();
+        $this->userTeam = Team::factory()->create(['name' => 'User Team']);
+        $this->buyerTeam = Team::factory()->create(['name' => 'Buyer Team']);
+
+        $this->competition = Competition::factory()->league()->create([
+            'id' => 'ESP1',
+            'name' => 'LaLiga',
+        ]);
+
+        // Summer window (August) so transfers complete immediately
+        $this->game = Game::factory()->create([
+            'user_id' => $this->user->id,
+            'team_id' => $this->userTeam->id,
+            'competition_id' => $this->competition->id,
+            'current_date' => '2025-08-01',
+        ]);
+
+        $player = Player::factory()->create(['date_of_birth' => '1998-01-01']);
+
+        $this->gamePlayer = GamePlayer::factory()->create([
+            'game_id' => $this->game->id,
+            'player_id' => $player->id,
+            'team_id' => $this->userTeam->id,
+            'market_value_cents' => 10_000_000_00, // €10M
+            'contract_until' => '2027-06-30',
+        ]);
+
+        // Create buyer team players to give them squad value (€100M total)
+        for ($i = 0; $i < 10; $i++) {
+            GamePlayer::factory()->create([
+                'game_id' => $this->game->id,
+                'team_id' => $this->buyerTeam->id,
+                'market_value_cents' => 10_000_000_00, // €10M each = €100M total
+            ]);
+        }
+
+        // Create the unsolicited offer at €11M (1.1x market value)
+        $this->offer = TransferOffer::create([
+            'game_id' => $this->game->id,
+            'game_player_id' => $this->gamePlayer->id,
+            'offering_team_id' => $this->buyerTeam->id,
+            'offer_type' => TransferOffer::TYPE_UNSOLICITED,
+            'direction' => TransferOffer::DIRECTION_OUTGOING,
+            'transfer_fee' => 11_000_000_00, // €11M
+            'status' => TransferOffer::STATUS_PENDING,
+            'expires_at' => '2025-08-06',
+            'game_date' => '2025-08-01',
+        ]);
+    }
+
+    public function test_start_returns_buyer_opening_message(): void
+    {
+        $response = $this->actingAs($this->user)->postJson(
+            route('game.negotiate.counter-offer', [$this->game->id, $this->offer->id]),
+            ['action' => 'start']
+        );
+
+        $response->assertOk();
+        $response->assertJsonPath('negotiation_status', 'open');
+        $response->assertJsonPath('round', 0);
+        $this->assertNotEmpty($response->json('messages'));
+    }
+
+    public function test_counter_accepted_when_asking_within_willingness(): void
+    {
+        // Buyer squad value = €100M, so max willingness = min(€25M, €13M) = €13M
+        // 95% of €13M = €12.35M. Ask for €12M → should be accepted
+        $this->actingAs($this->user)->postJson(
+            route('game.negotiate.counter-offer', [$this->game->id, $this->offer->id]),
+            ['action' => 'start']
+        );
+
+        $response = $this->actingAs($this->user)->postJson(
+            route('game.negotiate.counter-offer', [$this->game->id, $this->offer->id]),
+            ['action' => 'counter', 'bid' => 12_000_000] // €12M in euros
+        );
+
+        $response->assertOk();
+        $response->assertJsonPath('negotiation_status', 'completed');
+    }
+
+    public function test_counter_rejected_when_asking_far_above_willingness(): void
+    {
+        // Buyer max willingness = €13M. 115% of €13M = €14.95M. Ask for €30M → rejected
+        $this->actingAs($this->user)->postJson(
+            route('game.negotiate.counter-offer', [$this->game->id, $this->offer->id]),
+            ['action' => 'start']
+        );
+
+        $response = $this->actingAs($this->user)->postJson(
+            route('game.negotiate.counter-offer', [$this->game->id, $this->offer->id]),
+            ['action' => 'counter', 'bid' => 30_000_000] // €30M in euros
+        );
+
+        $response->assertOk();
+        $response->assertJsonPath('negotiation_status', 'rejected');
+
+        $this->offer->refresh();
+        $this->assertEquals(TransferOffer::STATUS_REJECTED, $this->offer->status);
+    }
+
+    public function test_counter_results_in_ai_counter_when_moderately_above(): void
+    {
+        // Max willingness = €13M. Ask for €14M (between 95% and 115% of €13M) → countered
+        $this->actingAs($this->user)->postJson(
+            route('game.negotiate.counter-offer', [$this->game->id, $this->offer->id]),
+            ['action' => 'start']
+        );
+
+        $response = $this->actingAs($this->user)->postJson(
+            route('game.negotiate.counter-offer', [$this->game->id, $this->offer->id]),
+            ['action' => 'counter', 'bid' => 14_000_000] // €14M
+        );
+
+        $response->assertOk();
+        $response->assertJsonPath('negotiation_status', 'open');
+
+        $this->offer->refresh();
+        $this->assertEquals(1, $this->offer->negotiation_round);
+        $this->assertGreaterThan(11_000_000_00, $this->offer->transfer_fee); // AI raised their bid
+    }
+
+    public function test_accept_counter_completes_sale(): void
+    {
+        // Start and get a counter, then accept it
+        $this->actingAs($this->user)->postJson(
+            route('game.negotiate.counter-offer', [$this->game->id, $this->offer->id]),
+            ['action' => 'start']
+        );
+
+        // Force a counter state
+        $this->offer->update([
+            'negotiation_round' => 1,
+            'transfer_fee' => 12_500_000_00,
+            'asking_price' => 14_000_000_00,
+        ]);
+
+        $response = $this->actingAs($this->user)->postJson(
+            route('game.negotiate.counter-offer', [$this->game->id, $this->offer->id]),
+            ['action' => 'accept_counter']
+        );
+
+        $response->assertOk();
+        $response->assertJsonPath('negotiation_status', 'completed');
+
+        $this->offer->refresh();
+        // Should be completed (window is open in August)
+        $this->assertEquals(TransferOffer::STATUS_COMPLETED, $this->offer->status);
+    }
+
+    public function test_counter_must_be_higher_than_current_bid(): void
+    {
+        $this->actingAs($this->user)->postJson(
+            route('game.negotiate.counter-offer', [$this->game->id, $this->offer->id]),
+            ['action' => 'start']
+        );
+
+        $response = $this->actingAs($this->user)->postJson(
+            route('game.negotiate.counter-offer', [$this->game->id, $this->offer->id]),
+            ['action' => 'counter', 'bid' => 10_000_000] // €10M < €11M current offer
+        );
+
+        $response->assertStatus(422);
+    }
+
+    public function test_cannot_counter_non_unsolicited_offer(): void
+    {
+        $this->offer->update(['offer_type' => TransferOffer::TYPE_USER_BID]);
+
+        $response = $this->actingAs($this->user)->postJson(
+            route('game.negotiate.counter-offer', [$this->game->id, $this->offer->id]),
+            ['action' => 'start']
+        );
+
+        $response->assertStatus(404);
+    }
+
+    public function test_cannot_counter_expired_offer(): void
+    {
+        $this->offer->update(['status' => TransferOffer::STATUS_EXPIRED]);
+
+        $response = $this->actingAs($this->user)->postJson(
+            route('game.negotiate.counter-offer', [$this->game->id, $this->offer->id]),
+            ['action' => 'start']
+        );
+
+        $response->assertStatus(404);
+    }
+
+    public function test_resume_mid_negotiation(): void
+    {
+        // Set up a mid-negotiation state
+        $this->offer->update([
+            'negotiation_round' => 1,
+            'transfer_fee' => 12_000_000_00,
+            'asking_price' => 14_000_000_00,
+        ]);
+
+        $response = $this->actingAs($this->user)->postJson(
+            route('game.negotiate.counter-offer', [$this->game->id, $this->offer->id]),
+            ['action' => 'start']
+        );
+
+        $response->assertOk();
+        $response->assertJsonPath('negotiation_status', 'open');
+        $response->assertJsonPath('round', 1);
+
+        // Should show the AI's current bid in the resume message
+        $messages = $response->json('messages');
+        $this->assertNotEmpty($messages);
+        $this->assertEquals('counter', $messages[0]['type']);
+    }
+
+    public function test_negotiation_capped_at_max_rounds(): void
+    {
+        $maxRounds = ContractService::MAX_NEGOTIATION_ROUNDS;
+
+        // Set up at max rounds - 1
+        $this->offer->update([
+            'negotiation_round' => $maxRounds - 1,
+            'transfer_fee' => 12_000_000_00,
+            'asking_price' => 14_000_000_00,
+        ]);
+
+        // One more counter should trigger rejection if not accepted
+        $response = $this->actingAs($this->user)->postJson(
+            route('game.negotiate.counter-offer', [$this->game->id, $this->offer->id]),
+            ['action' => 'counter', 'bid' => 14_000_000]
+        );
+
+        $response->assertOk();
+        // At max rounds, even a counter-eligible bid should be rejected
+        $this->assertContains($response->json('negotiation_status'), ['completed', 'rejected']);
+    }
+
+    public function test_expiry_extended_on_start(): void
+    {
+        // Set expiry to tomorrow
+        $this->offer->update(['expires_at' => '2025-08-02']);
+
+        $this->actingAs($this->user)->postJson(
+            route('game.negotiate.counter-offer', [$this->game->id, $this->offer->id]),
+            ['action' => 'start']
+        );
+
+        $this->offer->refresh();
+        // Should be extended to 5 days from current_date
+        $this->assertEquals('2025-08-06', $this->offer->expires_at->format('Y-m-d'));
+    }
+
+    public function test_cannot_counter_other_users_player(): void
+    {
+        $otherUser = User::factory()->create();
+        $otherTeam = Team::factory()->create();
+        $otherGame = Game::factory()->create([
+            'user_id' => $otherUser->id,
+            'team_id' => $otherTeam->id,
+            'competition_id' => $this->competition->id,
+        ]);
+
+        $response = $this->actingAs($otherUser)->postJson(
+            route('game.negotiate.counter-offer', [$this->game->id, $this->offer->id]),
+            ['action' => 'start']
+        );
+
+        // Should fail because the player doesn't belong to the other user's team
+        $this->assertContains($response->status(), [403, 404]);
+    }
+}


### PR DESCRIPTION
Users can now negotiate a higher price when receiving unsolicited or listed bids, instead of only accepting or rejecting. Opens the existing negotiation chat modal where the AI buyer evaluates counter-offers based on squad value ceiling and market value thresholds.