### PR TITLE
Fix scouting filter logic for expiring contracts

### DIFF
--- a/app/Modules/Transfer/Services/ScoutingService.php
+++ b/app/Modules/Transfer/Services/ScoutingService.php
@@ -313,10 +313,15 @@ class ScoutingService
         }
 
         // Expiring contract filter (last year of contract)
+        $seasonEnd = $game->getSeasonEndDate();
         if (! empty($filters['expiring_contract'])) {
-            $seasonEnd = $game->getSeasonEndDate();
             $query->whereNotNull('contract_until')
                 ->where('contract_until', '<=', $seasonEnd);
+        } else {
+            $query->where(function ($q) use ($seasonEnd) {
+                $q->whereNull('contract_until')
+                    ->orWhere('contract_until', '>', $seasonEnd);
+            });
         }
 
         // Exclude players already on loan


### PR DESCRIPTION
## Summary
Fixed the contract expiration filter logic in the scouting service to properly handle both filtered and unfiltered states. Previously, the query only applied constraints when the expiring contract filter was active, but didn't explicitly exclude non-expiring contracts when the filter was disabled.

## Key Changes
- Moved `$seasonEnd` variable declaration outside the conditional block to make it available for both filter states
- Added an `else` clause to explicitly filter out players with non-expiring contracts (null or contracts extending beyond season end) when the expiring contract filter is not active
- This ensures the query correctly returns either expiring OR non-expiring contracts based on the filter state, rather than returning all players when the filter is disabled

## Implementation Details
The fix uses a nested query builder with `whereNull()` and `orWhere()` conditions to properly handle the exclusion logic when the filter is inactive, ensuring consistent and predictable query results regardless of filter state.

https://claude.ai/code/session_01D3S4dz9AAxmEDGups6gFF5