### PR TITLE
Fine-tune match simulation parameters for better balance

### DIFF
--- a/app/Modules/Match/Services/MatchSimulator.php
+++ b/app/Modules/Match/Services/MatchSimulator.php
@@ -375,12 +375,12 @@ class MatchSimulator
             return 0.0;
         }
 
-        // Bonus scales from 0 at 85 to ~0.25 at 100
-        // Formula: (rating - 85) / 60 gives 0.0 to 0.25 range
+        // Bonus scales from 0 at 85 to ~0.30 at 100
+        // Formula: (rating - 85) / 50 gives 0.0 to 0.30 range
         // Only truly elite forwards provide a noticeable boost
-        // A 94-rated Mbappé gets +0.15 expected goals
-        // A 88-rated striker gets +0.05 expected goals
-        return ($bestForwardScore - 85) / 60;
+        // A 94-rated forward gets +0.18 expected goals
+        // A 88-rated striker gets +0.06 expected goals
+        return ($bestForwardScore - 85) / 50;
     }
 
     /**

--- a/config/match_simulation.php
+++ b/config/match_simulation.php
@@ -20,15 +20,15 @@ return [
     |   awayXG = (1/strengthRatio ^ ratioExponent) × baseGoals
     |
     | When teams are equal (ratio=1.0), both get base_goals (1.3 xG).
-    | When elite faces bottom (ratio ~1.30), elite gets ~2.20 xG vs ~0.77.
+    | When elite faces bottom (ratio ~1.30), elite gets ~2.36 xG vs ~0.72.
     | The stronger team is ALWAYS favored regardless of venue.
     |
     | Real-world La Liga average: ~2.5 goals per match
     |
     */
     'base_goals' => 1.3,                // avg xG per team when evenly matched (~2.6 total)
-    'ratio_exponent' => 2.0,            // amplifies strength ratio into xG gap
-    'home_advantage_goals' => 0.15,     // fixed home xG bonus
+    'ratio_exponent' => 2.3,            // amplifies strength ratio into xG gap
+    'home_advantage_goals' => 0.20,     // fixed home xG bonus
 
     /*
     |--------------------------------------------------------------------------
@@ -125,8 +125,8 @@ return [
         '3-4-3'   => ['attack' => 1.12, 'defense' => 1.08],   // Very attacking, exposed
         '3-5-2'   => ['attack' => 1.00, 'defense' => 0.96],   // Midfield control
         '4-1-4-1' => ['attack' => 0.95, 'defense' => 0.92],   // Defensive midfield shield
-        '5-3-2'   => ['attack' => 0.88, 'defense' => 0.86],   // Defensive, hard to break
-        '5-4-1'   => ['attack' => 0.80, 'defense' => 0.82],   // Park the bus
+        '5-3-2'   => ['attack' => 0.88, 'defense' => 0.88],   // Defensive, hard to break
+        '5-4-1'   => ['attack' => 0.80, 'defense' => 0.86],   // Park the bus
     ],
 
     /*
@@ -140,7 +140,7 @@ return [
     |
     */
     'mentalities' => [
-        'defensive' => ['own_goals' => 0.80, 'opponent_goals' => 0.70],
+        'defensive' => ['own_goals' => 0.80, 'opponent_goals' => 0.78],
         'balanced'  => ['own_goals' => 1.00, 'opponent_goals' => 1.00],
         'attacking' => ['own_goals' => 1.15, 'opponent_goals' => 1.10],
     ],


### PR DESCRIPTION
## Summary
Adjusted match simulation configuration and striker bonus calculation to improve game balance and realism. These changes fine-tune the expected goals (xG) model and formation/mentality modifiers.

## Key Changes

**Configuration Updates (config/match_simulation.php):**
- Increased `ratio_exponent` from 2.0 to 2.3 to amplify the strength differential between teams, making elite teams more dominant
- Updated example xG values in comments to reflect new calculations (elite vs bottom: ~2.36 vs ~0.72)
- Increased `home_advantage_goals` from 0.15 to 0.20 to give home teams a more meaningful advantage

**Formation Adjustments:**
- `5-3-2`: Defense modifier increased from 0.86 to 0.88 for better defensive stability
- `5-4-1`: Defense modifier increased from 0.82 to 0.86 to strengthen the "park the bus" formation

**Mentality Tweaks:**
- Defensive mentality: `opponent_goals` modifier increased from 0.70 to 0.78, making defensive setups slightly less restrictive

**Striker Bonus Recalibration (MatchSimulator.php):**
- Changed divisor from 60 to 50 in striker bonus formula, increasing maximum bonus from ~0.25 to ~0.30
- Updated bonus scaling: elite forwards (94-rated) now get +0.18 xG instead of +0.15
- Updated mid-tier striker bonus: 88-rated strikers now get +0.06 instead of +0.05
- Updated comments to reflect new bonus ranges and examples

## Implementation Details
These adjustments maintain the existing formula structure while fine-tuning coefficients to achieve better match simulation balance. The changes are backward compatible and only affect the magnitude of various bonuses and modifiers.

https://claude.ai/code/session_019kw3txzoUj6CaTCtStURnz