### PR TITLE
Fix auto-assignment placing players in suboptimal slots

### DIFF
--- a/app/Modules/Lineup/Services/FormationRecommender.php
+++ b/app/Modules/Lineup/Services/FormationRecommender.php
@@ -18,8 +18,58 @@ class FormationRecommender
         $assigned = [];
         $usedPlayerIds = [];
 
-        // Sort slots by specificity (GK first, then positions with fewer compatible players)
-        $sortedSlots = collect($slots)->sortBy(function ($slot) {
+        // Pass 0: Reserve natural position fits first (compatibility 100)
+        // This prevents suboptimal cascading where a natural RW takes an RW slot,
+        // forcing an RM into CM instead of the now-vacant RW.
+        $sortedByRating = $players->sortByDesc(function ($player) {
+            return $player->overall_score ?? $player['overallScore'] ?? $player['overall_score'];
+        });
+
+        foreach ($sortedByRating as $player) {
+            $playerId = $player->id ?? $player['id'];
+            if (in_array($playerId, $usedPlayerIds)) {
+                continue;
+            }
+
+            $position = $player->position ?? $player['position'];
+            $overallScore = $player->overall_score ?? $player['overallScore'] ?? $player['overall_score'];
+
+            // Find an empty slot where this player has natural compatibility (100)
+            foreach ($slots as &$slot) {
+                $slotId = $slot['id'];
+                $alreadyFilled = collect($assigned)->contains(fn ($a) => $a['slot']['id'] === $slotId && $a['player'] !== null);
+                if ($alreadyFilled) {
+                    continue;
+                }
+
+                $compatibility = PositionSlotMapper::getCompatibilityScore($position, $slot['label']);
+                if ($compatibility === 100) {
+                    $effectiveRating = PositionSlotMapper::getEffectiveRating($overallScore, $position, $slot['label']);
+                    $assigned[] = [
+                        'slot' => $slot,
+                        'player' => [
+                            'id' => $playerId,
+                            'name' => $player->name ?? $player['name'],
+                            'position' => $position,
+                            'overallScore' => $overallScore,
+                            'compatibility' => $compatibility,
+                            'effectiveRating' => $effectiveRating,
+                        ],
+                        'compatibility' => $compatibility,
+                        'effectiveRating' => $effectiveRating,
+                    ];
+                    $usedPlayerIds[] = $playerId;
+                    break;
+                }
+            }
+            unset($slot);
+        }
+
+        // Sort remaining slots by specificity (GK first, then positions with fewer compatible players)
+        $assignedSlotIds = collect($assigned)->pluck('slot.id')->all();
+        $sortedSlots = collect($slots)->filter(function ($slot) use ($assignedSlotIds) {
+            return ! in_array($slot['id'], $assignedSlotIds);
+        })->sortBy(function ($slot) {
             $compatibleCount = count(PositionSlotMapper::getCompatiblePositions($slot['label']));
             // GK has priority (only 1 compatible position)
             if ($slot['label'] === 'GK') return 0;

--- a/resources/js/modules/slot-assignment.js
+++ b/resources/js/modules/slot-assignment.js
@@ -32,8 +32,29 @@ export function assignPlayersToSlots(slots, players, slotCompatibility, manualAs
     const unassignedPlayers = players.filter(p => !assigned.has(p.id));
 
     if (emptySlots.length > 0 && unassignedPlayers.length > 0) {
+        // Pass 0: Reserve natural position fits first (compatibility 100)
+        // This prevents suboptimal cascading where a natural RW takes an RW slot,
+        // forcing an RM into CM instead of the now-vacant RW.
+        const naturalCandidates = [...unassignedPlayers]
+            .filter(p => !assigned.has(p.id))
+            .sort((a, b) => b.overallScore - a.overallScore);
+
+        naturalCandidates.forEach(player => {
+            if (assigned.has(player.id)) return;
+            const naturalSlot = slots.find(s =>
+                !s.player &&
+                (slotCompatibility[s.label]?.[player.position] ?? 0) === 100
+            );
+            if (naturalSlot) {
+                naturalSlot.player = { ...player, compatibility: 100 };
+                naturalSlot.compatibility = 100;
+                assigned.add(player.id);
+            }
+        });
+
         const rolePriority = { 'Goalkeeper': 0, 'Forward': 1, 'Defender': 2, 'Midfielder': 3 };
-        const sortedEmpty = [...emptySlots].sort((a, b) => {
+        const remainingEmpty = slots.filter(s => !s.player);
+        const sortedEmpty = [...remainingEmpty].sort((a, b) => {
             const aPriority = rolePriority[a.role] ?? 99;
             const bPriority = rolePriority[b.role] ?? 99;
             if (aPriority !== bPriority) return aPriority - bPriority;


### PR DESCRIPTION
Add a natural position reservation pass before the weighted assignment algorithm. Players are first matched to their natural slot (compatibility 100), sorted by overall score to break ties. This prevents greedy cascading where e.g. an RM ends up in CM (compat 50) because the RW slot was already taken by a natural RW.