### PR TITLE
Clear checkpoint fields after initial game setup completes

### DIFF
--- a/app/Modules/Season/Jobs/SetupNewGame.php
+++ b/app/Modules/Season/Jobs/SetupNewGame.php
@@ -114,7 +114,11 @@ class SetupNewGame implements ShouldQueue
             }
 
             // Mark setup as complete
-            Game::where('id', $this->gameId)->update(['setup_completed_at' => now()]);
+            Game::where('id', $this->gameId)->update([
+                'setup_completed_at' => now(),
+                'season_transition_step' => null,
+                'season_transition_data' => null,
+            ]);
 
             // Record activation event
             app(\App\Modules\Season\Services\ActivationTracker::class)


### PR DESCRIPTION
## Summary

- `SetupNewGame` runs the setup pipeline which checkpoints `season_transition_step` and `season_transition_data` after each processor, but never clears them once setup finishes. This leaves residual data on the game record (e.g. `season_transition_step: 7`) that makes it look like the game is stuck mid-transition when it actually completed successfully.
- Now clears both fields alongside setting `setup_completed_at`.

## Test plan

- [ ] Create a new career mode game and verify `season_transition_step` and `season_transition_data` are null after setup completes
- [ ] Create a new tournament mode game and verify the same (tournament uses `SetupTournamentGame` which doesn't checkpoint, so unaffected)
- [ ] Verify existing season transitions still work correctly (they clear these fields independently in `ProcessSeasonTransition`)

https://claude.ai/code/session_01C3ckxQW1R2TwfYRPcnkmvh