### PR TITLE
Add missing indexes on nullOnDelete foreign key columns

### DIFF
--- a/database/migrations/2026_03_24_000000_add_missing_indexes_on_nullable_foreign_keys.php
+++ b/database/migrations/2026_03_24_000000_add_missing_indexes_on_nullable_foreign_keys.php
@@ -1,0 +1,56 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('game_matches', function (Blueprint $table) {
+            $table->index('mvp_player_id');
+            $table->index('cup_tie_id');
+        });
+
+        Schema::table('game_transfers', function (Blueprint $table) {
+            $table->index('from_team_id');
+        });
+
+        Schema::table('financial_transactions', function (Blueprint $table) {
+            $table->index('related_player_id');
+        });
+
+        Schema::table('teams', function (Blueprint $table) {
+            $table->index('parent_team_id');
+        });
+
+        Schema::table('activation_events', function (Blueprint $table) {
+            $table->index('game_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('game_matches', function (Blueprint $table) {
+            $table->dropIndex(['mvp_player_id']);
+            $table->dropIndex(['cup_tie_id']);
+        });
+
+        Schema::table('game_transfers', function (Blueprint $table) {
+            $table->dropIndex(['from_team_id']);
+        });
+
+        Schema::table('financial_transactions', function (Blueprint $table) {
+            $table->dropIndex(['related_player_id']);
+        });
+
+        Schema::table('teams', function (Blueprint $table) {
+            $table->dropIndex(['parent_team_id']);
+        });
+
+        Schema::table('activation_events', function (Blueprint $table) {
+            $table->dropIndex(['game_id']);
+        });
+    }
+};


### PR DESCRIPTION
## Summary

- **Root cause:** Deleting rows from referenced tables (e.g. `games`) triggers `ON DELETE SET NULL` cascades. Without indexes on the FK columns, PostgreSQL performs full sequential table scans to find rows to nullify — effectively hanging on large tables like `game_matches`.
- Adds indexes to 6 unindexed `nullOnDelete()` foreign key columns: `game_matches.mvp_player_id`, `game_matches.cup_tie_id`, `game_transfers.from_team_id`, `financial_transactions.related_player_id`, `teams.parent_team_id`, `activation_events.game_id`

## Test plan

- [ ] Run `php artisan migrate` — migration applies cleanly
- [ ] Run `php artisan test` — no regressions
- [ ] Verify DELETE on `games` table completes promptly in PostgreSQL

https://claude.ai/code/session_01WtARYtNrs6WqMebF3zCdtu