### PR TITLE
Fix injury auto-substitution bypassing the 5-sub limit

### DIFF
--- a/app/Modules/Match/Services/MatchResimulationService.php
+++ b/app/Modules/Match/Services/MatchResimulationService.php
@@ -121,7 +121,15 @@ class MatchResimulationService
             }
         }
 
-        // 8. Re-simulate the remainder
+        // 8. Count existing substitutions per team to enforce the limit
+        $userSubCount = count($allSubstitutions);
+        $opponentSubCount = collect($match->substitutions ?? [])
+            ->filter(fn ($s) => $s['team_id'] !== $game->team_id)
+            ->count();
+        $homeExistingSubs = $isUserHome ? $userSubCount : $opponentSubCount;
+        $awayExistingSubs = $isUserHome ? $opponentSubCount : $userSubCount;
+
+        // 9. Re-simulate the remainder
         $remainderOutput = $this->matchSimulator->simulateRemainder(
             $match->homeTeam,
             $match->awayTeam,
@@ -145,17 +153,19 @@ class MatchResimulationService
             $awayDefLine,
             $homeBenchPlayers,
             $awayBenchPlayers,
+            homeExistingSubstitutions: $homeExistingSubs,
+            awayExistingSubstitutions: $awayExistingSubs,
         );
 
-        // 9. Calculate new final score
+        // 10. Calculate new final score
         $remainderResult = $remainderOutput->result;
         $newHomeScore = $scoreAtMinute['home'] + $remainderResult->homeScore;
         $newAwayScore = $scoreAtMinute['away'] + $remainderResult->awayScore;
 
-        // 10. Apply the new remainder events
+        // 11. Apply the new remainder events
         $this->applyNewEvents($match, $game, $remainderResult, $competitionId);
 
-        // 11. Update match score and possession
+        // 12. Update match score and possession
         // Note: Score-dependent side effects (standings, cup ties, GK stats, prize money)
         // are NOT handled here. They are deferred to FinalizeMatch, which applies them
         // once after the user finishes the live match. This eliminates the need for

--- a/app/Modules/Match/Services/MatchSimulator.php
+++ b/app/Modules/Match/Services/MatchSimulator.php
@@ -10,6 +10,7 @@ use App\Modules\Lineup\Enums\Formation;
 use App\Modules\Lineup\Enums\Mentality;
 use App\Modules\Lineup\Enums\PlayingStyle;
 use App\Modules\Lineup\Enums\PressingIntensity;
+use App\Modules\Lineup\Services\SubstitutionService;
 use App\Models\Game;
 use App\Models\GamePlayer;
 use App\Models\Team;
@@ -755,6 +756,8 @@ class MatchSimulator
         ?Collection $homeBenchPlayers = null,
         ?Collection $awayBenchPlayers = null,
         string $matchSeed = '',
+        int $homeExistingSubstitutions = 0,
+        int $awayExistingSubstitutions = 0,
     ): MatchSimulationOutput {
         $this->matchPerformance = [];
 
@@ -837,11 +840,14 @@ class MatchSimulator
             // so team strength reflects the replacement player
             $injuryMaxMinute = 85;
             $lineupChanged = false;
+            $maxSubs = $fromMinute > 90
+                ? SubstitutionService::MAX_ET_SUBSTITUTIONS
+                : SubstitutionService::MAX_SUBSTITUTIONS;
 
             if (! in_array($homeTeam->id, $existingInjuryTeamIds) && $fromMinute + 1 <= $injuryMaxMinute) {
                 $homeInjuryEvents = $this->generateInjuryEventsInRange($homeTeam->id, $homePlayersForInjury, $fromMinute + 1, $injuryMaxMinute, $game);
                 $events = $events->merge($homeInjuryEvents);
-                if ($homeInjuryEvents->isNotEmpty() && $homeBenchPlayers !== null && $homeBenchPlayers->isNotEmpty()) {
+                if ($homeInjuryEvents->isNotEmpty() && $homeBenchPlayers !== null && $homeBenchPlayers->isNotEmpty() && $homeExistingSubstitutions < $maxSubs) {
                     [$subEvents, $homePlayers, $homeBenchPlayers] = $this->processInjurySubstitution(
                         $homeTeam->id, $homeInjuryEvents, $homePlayers, $homeBenchPlayers
                     );
@@ -854,7 +860,7 @@ class MatchSimulator
             if (! in_array($awayTeam->id, $existingInjuryTeamIds) && $fromMinute + 1 <= $injuryMaxMinute) {
                 $awayInjuryEvents = $this->generateInjuryEventsInRange($awayTeam->id, $awayPlayersForInjury, $fromMinute + 1, $injuryMaxMinute, $game);
                 $events = $events->merge($awayInjuryEvents);
-                if ($awayInjuryEvents->isNotEmpty() && $awayBenchPlayers !== null && $awayBenchPlayers->isNotEmpty()) {
+                if ($awayInjuryEvents->isNotEmpty() && $awayBenchPlayers !== null && $awayBenchPlayers->isNotEmpty() && $awayExistingSubstitutions < $maxSubs) {
                     [$subEvents, $awayPlayers, $awayBenchPlayers] = $this->processInjurySubstitution(
                         $awayTeam->id, $awayInjuryEvents, $awayPlayers, $awayBenchPlayers
                     );


### PR DESCRIPTION
## Summary

- When a player got injured after all 5 substitutions were used, `processInjurySubstitution()` would still create an automatic 6th substitution, violating substitution rules
- Added `homeExistingSubstitutions` and `awayExistingSubstitutions` parameters to `simulateRemainder()` to track how many subs each team has already used
- `MatchResimulationService` now computes per-team substitution counts (from user subs + opponent auto-subs) and passes them through
- The injury auto-sub is now skipped when the team has already reached `MAX_SUBSTITUTIONS` (5) or `MAX_ET_SUBSTITUTIONS` (6) in extra time

## Test plan

- [ ] Verify existing tests pass (no regressions)
- [ ] Play a live match, make all 5 substitutions, then confirm that if a player gets injured afterward, no 6th substitution is created
- [ ] Verify that injury auto-subs still work correctly when the team has fewer than 5 substitutions
- [ ] Verify extra time allows up to 6 substitutions (including injury auto-subs)

https://claude.ai/code/session_017e6T4BKaupEf9ZPjUQbtHF