### PR TITLE
Fix: prevent transfer negotiations for loaned-in players

### DIFF
--- a/app/Http/Actions/AcceptTransferOffer.php
+++ b/app/Http/Actions/AcceptTransferOffer.php
@@ -29,6 +29,10 @@ class AcceptTransferOffer
             abort(403, 'You can only accept offers for your own players.');
         }
 
+        if ($offer->gamePlayer->isLoanedIn($game->team_id)) {
+            abort(403, 'Cannot accept offers for loaned players.');
+        }
+
         $playerName = $offer->gamePlayer->player->name;
         $team = $offer->offeringTeam;
         $fee = $offer->formatted_transfer_fee;

--- a/app/Http/Actions/ListPlayerForTransfer.php
+++ b/app/Http/Actions/ListPlayerForTransfer.php
@@ -22,6 +22,10 @@ class ListPlayerForTransfer
             ->where('team_id', $game->team_id)
             ->firstOrFail();
 
+        if ($player->isLoanedIn($game->team_id)) {
+            abort(403, 'Cannot list a loaned player for transfer.');
+        }
+
         // List the player
         $this->transferService->listPlayer($player);
 

--- a/app/Http/Actions/RejectTransferOffer.php
+++ b/app/Http/Actions/RejectTransferOffer.php
@@ -29,6 +29,10 @@ class RejectTransferOffer
             abort(403, 'You can only reject offers for your own players.');
         }
 
+        if ($offer->gamePlayer->isLoanedIn($game->team_id)) {
+            abort(403, 'Cannot reject offers for loaned players.');
+        }
+
         $team = $offer->offeringTeam;
 
         $this->transferService->rejectOffer($offer);

--- a/app/Modules/Transfer/Services/TransferService.php
+++ b/app/Modules/Transfer/Services/TransferService.php
@@ -108,6 +108,10 @@ class TransferService
      */
     public function listPlayer(GamePlayer $player): void
     {
+        if ($player->isOnLoan()) {
+            return;
+        }
+
         $player->update([
             'transfer_status' => GamePlayer::TRANSFER_STATUS_LISTED,
             'transfer_listed_at' => $player->game->current_date,
@@ -190,12 +194,14 @@ class TransferService
             $teamPlayers = $allPlayersGrouped->get($game->team_id, collect());
             $listedPlayers = $teamPlayers->filter(
                 fn ($p) => $p->transfer_status === GamePlayer::TRANSFER_STATUS_LISTED
+                    && !$p->isLoanedIn($game->team_id)
             );
         } else {
             $listedPlayers = GamePlayer::with('transferOffers')
                 ->where('game_id', $game->id)
                 ->where('team_id', $game->team_id)
                 ->where('transfer_status', GamePlayer::TRANSFER_STATUS_LISTED)
+                ->whereDoesntHave('activeLoan')
                 ->get();
         }
 
@@ -268,7 +274,8 @@ class TransferService
         if ($allPlayersGrouped !== null) {
             $teamPlayers = $allPlayersGrouped->get($game->team_id, collect());
             $starPlayers = $teamPlayers
-                ->filter(fn ($p) => $p->transfer_status === null)
+                ->filter(fn ($p) => $p->transfer_status === null
+                    && !$p->isLoanedIn($game->team_id))
                 ->sortByDesc('market_value_cents')
                 ->take(self::STAR_PLAYER_COUNT);
         } else {
@@ -276,6 +283,7 @@ class TransferService
                 ->where('game_id', $game->id)
                 ->where('team_id', $game->team_id)
                 ->whereNull('transfer_status')
+                ->whereDoesntHave('activeLoan')
                 ->orderByDesc('market_value_cents')
                 ->limit(self::STAR_PLAYER_COUNT)
                 ->get();
@@ -359,9 +367,13 @@ class TransferService
         if ($allPlayersGrouped !== null) {
             $teamPlayers = $allPlayersGrouped->get($game->team_id, collect());
             // Filter to players with expiring contracts who can receive offers
-            $expiringPlayers = $teamPlayers->filter(function ($player) use ($seasonEndDate) {
+            $expiringPlayers = $teamPlayers->filter(function ($player) use ($seasonEndDate, $game) {
                 // Check if contract is expiring
                 if (!$player->contract_until || !$player->contract_until->lte($seasonEndDate)) {
+                    return false;
+                }
+                // Skip loaned-in players — they belong to their parent club
+                if ($player->isLoanedIn($game->team_id)) {
                     return false;
                 }
                 // Retiring players won't sign pre-contracts
@@ -399,6 +411,7 @@ class TransferService
             $expiringPlayers = GamePlayer::with(['game', 'transferOffers', 'latestRenewalNegotiation', 'activeRenewalNegotiation'])
                 ->where('game_id', $game->id)
                 ->where('team_id', $game->team_id)
+                ->whereDoesntHave('activeLoan')
                 ->get()
                 ->filter(fn ($player) => $player->canReceivePreContractOffers($seasonEndDate));
         }


### PR DESCRIPTION
## Summary

- Users could list loaned-in players for transfer, receive AI-generated offers, and accept/reject those offers — even though they don't own the players (the parent club does)
- Added `isLoanedIn()` checks in `ListPlayerForTransfer`, `AcceptTransferOffer`, and `RejectTransferOffer` actions (abort 403)
- Added `whereDoesntHave('activeLoan')` / `isLoanedIn()` filters in `TransferService` to prevent AI offer generation (`generateOffersForListedPlayers`, `generateUnsolicitedOffers`, `generatePreContractOffers`) and listing (`listPlayer`) for loaned-in players

https://claude.ai/code/session_011AiDFALTftxBkSsZvZS9pT