### PR TITLE
Soft-block transfers when player price exceeds budget

### DIFF
--- a/app/Http/Actions/NegotiateTransfer.php
+++ b/app/Http/Actions/NegotiateTransfer.php
@@ -5,6 +5,7 @@ namespace App\Http\Actions;
 use App\Models\Game;
 use App\Models\GamePlayer;
 use App\Models\TransferOffer;
+use App\Modules\Finance\Services\BudgetLoanService;
 use App\Modules\Notification\Services\NotificationService;
 use App\Modules\Transfer\Services\ContractService;
 use App\Modules\Transfer\Services\ScoutingService;
@@ -23,6 +24,7 @@ class NegotiateTransfer
         private readonly ContractService $contractService,
         private readonly ScoutingService $scoutingService,
         private readonly NotificationService $notificationService,
+        private readonly BudgetLoanService $budgetLoanService,
     ) {}
 
     public function __invoke(Request $request, string $gameId, string $playerId): JsonResponse
@@ -74,6 +76,9 @@ class NegotiateTransfer
                 'negotiation_status' => 'open',
                 'round' => $existing->negotiation_round,
                 'max_rounds' => self::MAX_ROUNDS,
+                'available_budget' => (int) (($this->transferService->availableBudget($game) + $existing->transfer_fee) / 100),
+                'budget_loan_available' => $this->budgetLoanService->canRequestLoan($game),
+                'budget_loan_url' => route('game.finances', $game->id),
                 'messages' => [
                     $this->agentMessage('counter', [
                         'text' => __('transfers.chat_club_counter_resume', [
@@ -153,6 +158,9 @@ class NegotiateTransfer
             'negotiation_status' => 'open',
             'round' => 0,
             'max_rounds' => self::MAX_ROUNDS,
+            'available_budget' => (int) ($this->transferService->availableBudget($game) / 100),
+            'budget_loan_available' => $this->budgetLoanService->canRequestLoan($game),
+            'budget_loan_url' => route('game.finances', $game->id),
             'messages' => [
                 $this->agentMessage('demand', [
                     'text' => __('transfers.chat_club_demand', [
@@ -212,6 +220,7 @@ class NegotiateTransfer
                 'negotiation_status' => 'open',
                 'round' => $offer->negotiation_round,
                 'max_rounds' => self::MAX_ROUNDS,
+                'available_budget' => (int) (($this->transferService->availableBudget($game) + $offer->transfer_fee) / 100),
                 'messages' => [
                     $this->agentMessage('counter', [
                         'text' => __('transfers.chat_club_counter', [

--- a/app/Http/Views/ShowScoutingHub.php
+++ b/app/Http/Views/ShowScoutingHub.php
@@ -98,6 +98,7 @@ class ShowScoutingHub
                 'askingPrice' => null,
                 'canAffordFee' => false,
                 'canAffordLoan' => false,
+                'availableBudget' => 0,
                 'wageDemand' => null,
                 'formattedWageDemand' => null,
                 'bidEuros' => 0,
@@ -115,6 +116,7 @@ class ShowScoutingHub
                 $playerData['askingPrice'] = $detail['asking_price'];
                 $playerData['canAffordFee'] = $detail['can_afford_fee'];
                 $playerData['canAffordLoan'] = $detail['can_afford_loan'];
+                $playerData['availableBudget'] = (int) ($detail['available_budget'] / 100);
                 $playerData['wageDemand'] = $detail['wage_demand'];
                 $playerData['formattedWageDemand'] = $detail['formatted_wage_demand'];
                 $playerData['bidEuros'] = (int) ($detail['asking_price'] / 100);

--- a/app/Modules/Transfer/Services/ScoutingService.php
+++ b/app/Modules/Transfer/Services/ScoutingService.php
@@ -984,6 +984,7 @@ class ScoutingService
             'importance' => $importance,
             'can_afford_fee' => $canAffordFee,
             'can_afford_loan' => $canAffordLoan,
+            'available_budget' => $availableBudget,
             'transfer_budget' => $investment->transfer_budget ?? 0,
             'formatted_transfer_budget' => $investment ? $investment->formatted_transfer_budget : '€ 0',
             'tech_range' => [max(1, $techAbility - $fuzz), min(99, $techAbility + $fuzz)],

--- a/lang/en/transfers.php
+++ b/lang/en/transfers.php
@@ -136,6 +136,10 @@ return [
     'loan_cost_salary' => 'Loan cost (salary)',
     'asking_price' => 'Asking price',
     'request_loan' => 'Request Loan',
+    'budget_cap_warning' => 'Your bid is limited by your available transfer budget.',
+    'budget_available' => 'Available budget',
+    'request_budget_loan' => 'Request a budget loan',
+    'budget_limited_hint' => 'Your budget is below the asking price. You can still negotiate or request a budget loan.',
 
     // Bid evaluation responses
     'bid_accepted' => ':team has accepted your bid.',

--- a/lang/es/transfers.php
+++ b/lang/es/transfers.php
@@ -137,6 +137,10 @@ return [
     'loan_cost_salary' => 'Coste cesión (salario)',
     'asking_price' => 'Precio pedido',
     'request_loan' => 'Solicitar Cesión',
+    'budget_cap_warning' => 'Tu oferta está limitada por tu presupuesto de fichajes disponible.',
+    'budget_available' => 'Presupuesto disponible',
+    'request_budget_loan' => 'Solicitar préstamo presupuestario',
+    'budget_limited_hint' => 'Tu presupuesto está por debajo del precio de venta. Aún puedes negociar o solicitar un préstamo presupuestario.',
 
     // Bid evaluation responses
     'bid_accepted' => ':team ha aceptado tu oferta.',

--- a/resources/js/negotiation-chat.js
+++ b/resources/js/negotiation-chat.js
@@ -25,6 +25,11 @@ export default function negotiationChat() {
         offerWage: 0,
         offerYears: 3,
 
+        // Budget cap state (transfer fee mode)
+        availableBudget: 0,
+        budgetLoanAvailable: false,
+        budgetLoanUrl: '',
+
         // Stepper hold state
         _holdTimer: null,
         _holdInterval: null,
@@ -44,6 +49,10 @@ export default function negotiationChat() {
             return !this.loading && !this.isTerminal && this.offerWage > 0;
         },
 
+        get isBudgetConstrained() {
+            return this.mode === 'transfer_fee' && this.availableBudget > 0 && this.offerWage >= this.availableBudget;
+        },
+
         get wageStep() {
             if (this.mode === 'transfer_fee' || this.phase === 'counter_offer') {
                 return this.offerWage >= 10000000 ? 1000000 : 100000;
@@ -56,7 +65,12 @@ export default function negotiationChat() {
         },
 
         incrementWage() {
-            this.offerWage += this.wageStep;
+            const newValue = this.offerWage + this.wageStep;
+            if (this.mode === 'transfer_fee' && this.availableBudget > 0 && newValue > this.availableBudget) {
+                this.offerWage = this.availableBudget;
+                return;
+            }
+            this.offerWage = newValue;
         },
 
         decrementWage() {
@@ -87,6 +101,9 @@ export default function negotiationChat() {
             this.negotiationStatus = null;
             this.offerWage = 0;
             this.offerYears = 3;
+            this.availableBudget = 0;
+            this.budgetLoanAvailable = false;
+            this.budgetLoanUrl = '';
             this.round = 0;
             this.open = true;
 
@@ -95,6 +112,9 @@ export default function negotiationChat() {
                 this.negotiationStatus = data.negotiation_status;
                 this.round = data.round || 0;
                 this.maxRounds = data.max_rounds || 3;
+                if (data.available_budget !== undefined) this.availableBudget = data.available_budget;
+                if (data.budget_loan_available !== undefined) this.budgetLoanAvailable = data.budget_loan_available;
+                if (data.budget_loan_url) this.budgetLoanUrl = data.budget_loan_url;
                 this.appendMessages(data.messages);
 
                 // Fee already agreed from a previous session — go straight to personal terms
@@ -146,6 +166,7 @@ export default function negotiationChat() {
                 if (data) {
                     this.negotiationStatus = data.negotiation_status;
                     this.round = data.round || this.round;
+                    if (data.available_budget !== undefined) this.availableBudget = data.available_budget;
                     this.appendMessages(data.messages);
 
                     // Handle fee agreed → transition to personal terms (transfers only)
@@ -389,7 +410,13 @@ export default function negotiationChat() {
         prefillFromOptions() {
             const lastMsg = this.messages[this.messages.length - 1];
             if (lastMsg?.options?.suggestedWage) this.offerWage = lastMsg.options.suggestedWage;
-            if (lastMsg?.options?.suggestedFee) this.offerWage = lastMsg.options.suggestedFee;
+            if (lastMsg?.options?.suggestedFee) {
+                let fee = lastMsg.options.suggestedFee;
+                if (this.mode === 'transfer_fee' && this.availableBudget > 0 && fee > this.availableBudget) {
+                    fee = this.availableBudget;
+                }
+                this.offerWage = fee;
+            }
             if (lastMsg?.options?.preferredYears) this.offerYears = lastMsg.options.preferredYears;
         },
 

--- a/resources/views/components/negotiation-chat-modal.blade.php
+++ b/resources/views/components/negotiation-chat-modal.blade.php
@@ -269,6 +269,31 @@
                 </template>
             </div>
 
+            {{-- Budget constraint banner --}}
+            <div x-show="mode === 'transfer_fee' && availableBudget > 0 && !isTerminal && negotiationStatus !== 'fee_agreed' && availableBudget < (messages[0]?.content?.fee || 0)"
+                 x-cloak class="shrink-0 border-t border-border-strong px-5 py-2.5">
+                <div class="rounded-lg bg-accent-gold/10 border border-accent-gold/20 px-3 py-2">
+                    <div class="flex items-start gap-2">
+                        <svg class="w-4 h-4 text-accent-gold shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L4.072 16.5c-.77.833.192 2.5 1.732 2.5z"/>
+                        </svg>
+                        <div class="min-w-0">
+                            <p class="text-xs text-accent-gold font-medium">{{ __('transfers.budget_cap_warning') }}</p>
+                            <p class="text-xs text-text-muted mt-0.5">
+                                {{ __('transfers.budget_available') }}: <span class="text-text-body font-semibold" x-text="'€ ' + new Intl.NumberFormat('es-ES').format(availableBudget)"></span>
+                            </p>
+                            <template x-if="budgetLoanAvailable">
+                                <a :href="budgetLoanUrl" target="_blank"
+                                   class="inline-flex items-center gap-1 mt-1 text-xs text-accent-blue hover:underline font-medium">
+                                    {{ __('transfers.request_budget_loan') }}
+                                    <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"/></svg>
+                                </a>
+                            </template>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
             {{-- Input area: Transfer fee / loan fee mode --}}
             <div class="shrink-0 border-t border-border-strong px-5 py-3 space-y-2.5" x-show="mode === 'transfer_fee' && !isTerminal && !loading && negotiationStatus !== 'fee_agreed'">
                 <div class="flex items-end gap-2">

--- a/resources/views/partials/scout-report-results.blade.php
+++ b/resources/views/partials/scout-report-results.blade.php
@@ -49,6 +49,7 @@
                     $formattedWageDemand = $detail['formatted_wage_demand'] ?? '-';
                     $canAffordFee = $detail['can_afford_fee'] ?? false;
                     $canAffordLoan = $detail['can_afford_loan'] ?? false;
+                    $availableBudget = (int) (($detail['available_budget'] ?? 0) / 100);
                     $onCooldown = $detail['on_cooldown'] ?? false;
                     $techRange = $detail['tech_range'] ?? [0, 0];
                     $physRange = $detail['phys_range'] ?? [0, 0];
@@ -217,7 +218,7 @@
                                                 })">
                                                 {{ __('transfers.negotiate_pre_contract') }}
                                             </x-primary-button>
-                                        @elseif(!$canAffordFee && !$canAffordLoan)
+                                        @elseif($availableBudget <= 0 && !$canAffordLoan)
                                             <div>
                                                 <div class="text-xs text-accent-red font-medium">
                                                     {{ __('transfers.loan_fee_exceeds_budget') }}
@@ -225,37 +226,6 @@
                                                 <div class="text-xs text-text-muted mt-1">
                                                     {{ __('transfers.loan_cost_salary') }}: <span class="text-text-body font-medium">{{ $formattedWageDemand }}{{ __('squad.per_year') }}</span>
                                                 </div>
-                                            </div>
-                                        @elseif(!$canAffordFee && $canAffordLoan)
-                                            @php
-                                                $posDisp = $player->position_display;
-                                                $scoutPlayerInfo = \Illuminate\Support\Js::from([
-                                                    'age' => $player->age($game->current_date),
-                                                    'position' => $posDisp['abbreviation'],
-                                                    'positionBg' => $posDisp['bg'],
-                                                    'positionText' => $posDisp['text'],
-                                                    'marketValue' => $player->formatted_market_value,
-                                                    'contractYear' => $player->contract_expiry_year,
-                                                ]);
-                                            @endphp
-                                            <div class="flex flex-col gap-2">
-                                                <div class="text-xs text-accent-gold font-medium">
-                                                    {{ __('transfers.transfer_fee_exceeds_budget_loan_available') }}
-                                                </div>
-                                                <div class="text-xs text-text-muted">
-                                                    {{ __('transfers.loan_cost_salary') }}: <span class="text-text-body font-medium">{{ $formattedWageDemand }}{{ __('squad.per_year') }}</span>
-                                                </div>
-                                                <x-secondary-button size="xs"
-                                                    @click="$dispatch('open-negotiation', {
-                                                        playerName: {{ \Illuminate\Support\Js::from($player->name) }},
-                                                        negotiateUrl: {{ \Illuminate\Support\Js::from(route('game.negotiate.loan', [$game->id, $player->id])) }},
-                                                        mode: 'loan',
-                                                        phase: 'club_fee',
-                                                        chatTitle: {{ \Illuminate\Support\Js::from(__('transfers.chat_loan_title')) }},
-                                                        playerInfo: {{ $scoutPlayerInfo }}
-                                                    })">
-                                                    {{ __('transfers.request_loan') }}
-                                                </x-secondary-button>
                                             </div>
                                         @else
                                             @php
@@ -269,31 +239,40 @@
                                                     'contractYear' => $player->contract_expiry_year,
                                                 ]);
                                             @endphp
-                                            <div class="flex flex-col sm:flex-row gap-2">
-                                                {{-- Transfer Negotiate --}}
-                                                <x-primary-button size="xs"
-                                                    @click="$dispatch('open-negotiation', {
-                                                        playerName: {{ \Illuminate\Support\Js::from($player->name) }},
-                                                        negotiateUrl: {{ \Illuminate\Support\Js::from(route('game.negotiate.transfer', [$game->id, $player->id])) }},
-                                                        mode: 'transfer_fee',
-                                                        phase: 'club_fee',
-                                                        chatTitle: {{ \Illuminate\Support\Js::from(__('transfers.chat_transfer_title')) }},
-                                                        playerInfo: {{ $scoutPlayerInfo }}
-                                                    })">
-                                                    {{ __('transfers.negotiate') }}
-                                                </x-primary-button>
-                                                {{-- Loan Request --}}
-                                                <x-secondary-button size="xs"
-                                                    @click="$dispatch('open-negotiation', {
-                                                        playerName: {{ \Illuminate\Support\Js::from($player->name) }},
-                                                        negotiateUrl: {{ \Illuminate\Support\Js::from(route('game.negotiate.loan', [$game->id, $player->id])) }},
-                                                        mode: 'loan',
-                                                        phase: 'club_fee',
-                                                        chatTitle: {{ \Illuminate\Support\Js::from(__('transfers.chat_loan_title')) }},
-                                                        playerInfo: {{ $scoutPlayerInfo }}
-                                                    })">
-                                                    {{ __('transfers.request_loan') }}
-                                                </x-secondary-button>
+                                            <div class="flex flex-col gap-2">
+                                                @if(!$canAffordFee)
+                                                    <div class="text-xs text-accent-gold font-medium">
+                                                        {{ __('transfers.budget_limited_hint') }}
+                                                    </div>
+                                                @endif
+                                                <div class="flex flex-col sm:flex-row gap-2">
+                                                    @if($availableBudget > 0)
+                                                        {{-- Transfer Negotiate --}}
+                                                        <x-primary-button size="xs"
+                                                            @click="$dispatch('open-negotiation', {
+                                                                playerName: {{ \Illuminate\Support\Js::from($player->name) }},
+                                                                negotiateUrl: {{ \Illuminate\Support\Js::from(route('game.negotiate.transfer', [$game->id, $player->id])) }},
+                                                                mode: 'transfer_fee',
+                                                                phase: 'club_fee',
+                                                                chatTitle: {{ \Illuminate\Support\Js::from(__('transfers.chat_transfer_title')) }},
+                                                                playerInfo: {{ $scoutPlayerInfo }}
+                                                            })">
+                                                            {{ __('transfers.negotiate') }}
+                                                        </x-primary-button>
+                                                    @endif
+                                                    {{-- Loan Request --}}
+                                                    <x-secondary-button size="xs"
+                                                        @click="$dispatch('open-negotiation', {
+                                                            playerName: {{ \Illuminate\Support\Js::from($player->name) }},
+                                                            negotiateUrl: {{ \Illuminate\Support\Js::from(route('game.negotiate.loan', [$game->id, $player->id])) }},
+                                                            mode: 'loan',
+                                                            phase: 'club_fee',
+                                                            chatTitle: {{ \Illuminate\Support\Js::from(__('transfers.chat_loan_title')) }},
+                                                            playerInfo: {{ $scoutPlayerInfo }}
+                                                        })">
+                                                        {{ __('transfers.request_loan') }}
+                                                    </x-secondary-button>
+                                                </div>
                                             </div>
                                         @endif
                                     </div>

--- a/resources/views/scouting-hub.blade.php
+++ b/resources/views/scouting-hub.blade.php
@@ -480,8 +480,8 @@
                                                                 </x-primary-button>
                                                             </template>
 
-                                                            {{-- Action: Can't afford transfer or loan --}}
-                                                            <template x-if="!player.isFreeAgent && !player.hasExistingOffer && !player.onCooldown && !(player.isExpiring && isPreContractPeriod) && !player.canAffordFee && !player.canAffordLoan">
+                                                            {{-- Action: Budget is zero and can't afford loan — fully blocked --}}
+                                                            <template x-if="!player.isFreeAgent && !player.hasExistingOffer && !player.onCooldown && !(player.isExpiring && isPreContractPeriod) && player.availableBudget <= 0 && !player.canAffordLoan">
                                                                 <div>
                                                                     <div class="text-xs text-accent-red font-medium">
                                                                         {{ __('transfers.loan_fee_exceeds_budget') }}
@@ -492,54 +492,40 @@
                                                                 </div>
                                                             </template>
 
-                                                            {{-- Action: Can't afford transfer, but can afford loan --}}
-                                                            <template x-if="!player.isFreeAgent && !player.hasExistingOffer && !player.onCooldown && !(player.isExpiring && isPreContractPeriod) && !player.canAffordFee && player.canAffordLoan">
+                                                            {{-- Action: Negotiate + Loan (soft block: always show when budget > 0 or can afford loan) --}}
+                                                            <template x-if="!player.isFreeAgent && !player.hasExistingOffer && !player.onCooldown && !(player.isExpiring && isPreContractPeriod) && (player.availableBudget > 0 || player.canAffordLoan)">
                                                                 <div class="flex flex-col gap-2">
-                                                                    <div class="text-xs text-accent-gold font-medium">
-                                                                        {{ __('transfers.transfer_fee_exceeds_budget_loan_available') }}
+                                                                    <template x-if="!player.canAffordFee">
+                                                                        <div class="text-xs text-accent-gold font-medium">
+                                                                            {{ __('transfers.budget_limited_hint') }}
+                                                                        </div>
+                                                                    </template>
+                                                                    <div class="flex flex-col sm:flex-row gap-2">
+                                                                        <template x-if="player.availableBudget > 0">
+                                                                            <x-primary-button size="xs"
+                                                                                @click="$dispatch('open-negotiation', {
+                                                                                    playerName: player.name,
+                                                                                    negotiateUrl: negotiateRoute(player.id),
+                                                                                    mode: 'transfer_fee',
+                                                                                    phase: 'club_fee',
+                                                                                    chatTitle: {{ \Illuminate\Support\Js::from(__('transfers.chat_transfer_title')) }},
+                                                                                    playerInfo: { age: player.age, position: player.positionAbbr, positionBg: player.positionBg, positionText: player.positionText, marketValue: player.formattedMarketValue, contractYear: player.contractYear }
+                                                                                })">
+                                                                                {{ __('transfers.negotiate') }}
+                                                                            </x-primary-button>
+                                                                        </template>
+                                                                        <x-secondary-button size="xs"
+                                                                            @click="$dispatch('open-negotiation', {
+                                                                                playerName: player.name,
+                                                                                negotiateUrl: loanRoute(player.id),
+                                                                                mode: 'loan',
+                                                                                phase: 'club_fee',
+                                                                                chatTitle: {{ \Illuminate\Support\Js::from(__('transfers.chat_loan_title')) }},
+                                                                                playerInfo: { age: player.age, position: player.positionAbbr, positionBg: player.positionBg, positionText: player.positionText, marketValue: player.formattedMarketValue, contractYear: player.contractYear }
+                                                                            })">
+                                                                            {{ __('transfers.request_loan') }}
+                                                                        </x-secondary-button>
                                                                     </div>
-                                                                    <div class="text-xs text-text-muted">
-                                                                        {{ __('transfers.loan_cost_salary') }}: <span class="text-text-body font-medium" x-text="player.formattedWageDemand + '{{ __('squad.per_year') }}'"></span>
-                                                                    </div>
-                                                                    <x-secondary-button size="xs"
-                                                                        @click="$dispatch('open-negotiation', {
-                                                                            playerName: player.name,
-                                                                            negotiateUrl: loanRoute(player.id),
-                                                                            mode: 'loan',
-                                                                            phase: 'club_fee',
-                                                                            chatTitle: {{ \Illuminate\Support\Js::from(__('transfers.chat_loan_title')) }},
-                                                                            playerInfo: { age: player.age, position: player.positionAbbr, positionBg: player.positionBg, positionText: player.positionText, marketValue: player.formattedMarketValue, contractYear: player.contractYear }
-                                                                        })">
-                                                                        {{ __('transfers.request_loan') }}
-                                                                    </x-secondary-button>
-                                                                </div>
-                                                            </template>
-
-                                                            {{-- Action: Negotiate + Loan --}}
-                                                            <template x-if="!player.isFreeAgent && !player.hasExistingOffer && !player.onCooldown && !(player.isExpiring && isPreContractPeriod) && player.canAffordFee">
-                                                                <div class="flex flex-col sm:flex-row gap-2">
-                                                                    <x-primary-button size="xs"
-                                                                        @click="$dispatch('open-negotiation', {
-                                                                            playerName: player.name,
-                                                                            negotiateUrl: negotiateRoute(player.id),
-                                                                            mode: 'transfer_fee',
-                                                                            phase: 'club_fee',
-                                                                            chatTitle: {{ \Illuminate\Support\Js::from(__('transfers.chat_transfer_title')) }},
-                                                                            playerInfo: { age: player.age, position: player.positionAbbr, positionBg: player.positionBg, positionText: player.positionText, marketValue: player.formattedMarketValue, contractYear: player.contractYear }
-                                                                        })">
-                                                                        {{ __('transfers.negotiate') }}
-                                                                    </x-primary-button>
-                                                                    <x-secondary-button size="xs"
-                                                                        @click="$dispatch('open-negotiation', {
-                                                                            playerName: player.name,
-                                                                            negotiateUrl: loanRoute(player.id),
-                                                                            mode: 'loan',
-                                                                            phase: 'club_fee',
-                                                                            chatTitle: {{ \Illuminate\Support\Js::from(__('transfers.chat_loan_title')) }},
-                                                                            playerInfo: { age: player.age, position: player.positionAbbr, positionBg: player.positionBg, positionText: player.positionText, marketValue: player.formattedMarketValue, contractYear: player.contractYear }
-                                                                        })">
-                                                                        {{ __('transfers.request_loan') }}
-                                                                    </x-secondary-button>
                                                                 </div>
                                                             </template>
                                                         </div>


### PR DESCRIPTION
## Summary

- **Replaces the hard block** (hidden Negotiate button) with a soft block that allows negotiations to start even when a player's asking price exceeds the transfer budget
- **Caps the maximum bid** at the user's available transfer budget via the stepper input
- **Adds a budget warning banner** inside the negotiation modal showing the budget constraint and a link to request a budget loan

## How it works

When a player's asking price > available budget:
- The Negotiate button now **always appears** (previously hidden)
- A gold hint text appears in the scouting card: "Your budget is below the asking price. You can still negotiate or request a budget loan."
- Inside the negotiation modal, the bid stepper is capped at the available budget
- A gold warning banner shows "Your bid is limited by your available transfer budget" with the exact amount and a link to the finances page to request a budget loan

**Hard block preserved only when budget = €0** — if the user has zero available budget AND can't afford a loan, the existing red block message remains since there's nothing to negotiate with.

## Changes

| File | Change |
|------|--------|
| `ScoutingService` | Exposes `available_budget` in scouting detail data |
| `ShowScoutingHub` | Passes `availableBudget` to Alpine player data |
| `NegotiateTransfer` | Returns `available_budget`, `budget_loan_available`, `budget_loan_url` in start/offer responses |
| `negotiation-chat.js` | Caps `incrementWage()` at budget, clamps prefilled suggestions, adds `isBudgetConstrained` computed |
| `negotiation-chat-modal` | Budget warning banner with loan CTA link |
| `scouting-hub` | Collapsed 3 template branches → 2 (soft block) |
| `scout-report-results` | Same conditional simplification |
| `lang/en+es/transfers` | 4 new translation keys each |

## Test plan

- [ ] Find a player whose asking price > your transfer budget → Negotiate button should appear
- [ ] Open negotiation → bid stepper should cap at available budget
- [ ] Verify budget warning banner appears with correct amount and loan link
- [ ] Click loan link → opens finances page in new tab
- [ ] Request a budget loan → return to scouting → verify increased bid cap
- [ ] Test with budget = €0 → verify hard block still shows
- [ ] Test with budget > asking price → verify no warning banner, stepper uncapped
- [ ] Test both scouting hub (shortlist) and scout report results views
- [ ] Verify server rejects bids over budget (safety net)

https://claude.ai/code/session_013kJsmuyyBUJx9YfpBdVPzn