### PR TITLE
Fix unable to make 5 substitutions in a single window

### DIFF
--- a/resources/js/modules/substitution-manager.js
+++ b/resources/js/modules/substitution-manager.js
@@ -58,7 +58,7 @@ export function createSubstitutionManager(ctx) {
     }
 
     function getCanAddMoreToPending() {
-        return getCanSubstitute() && ctx().pendingSubs.length < getSubsRemaining();
+        return getSubsRemaining() > 1;
     }
 
     // Lineup players considering both confirmed subs AND pending subs in this window

--- a/resources/views/partials/live-match/tactical-panel.blade.php
+++ b/resources/views/partials/live-match/tactical-panel.blade.php
@@ -469,7 +469,7 @@
                     <div class="ml-auto flex items-center gap-2">
                         {{-- Add another sub button (only when a complete selection is ready and more subs available) --}}
                         <x-secondary-button
-                            x-show="!showingConfirmation && selectedPlayerOut && selectedPlayerIn && canAddMoreToPending && subsRemaining > 1"
+                            x-show="!showingConfirmation && selectedPlayerOut && selectedPlayerIn && canAddMoreToPending"
                             @click="addPendingSub()"
                             class="gap-1.5 !bg-teal-600 !border-teal-500 !text-white hover:!bg-teal-500"
                         >


### PR DESCRIPTION
## Summary

- Fix `getCanAddMoreToPending()` in `substitution-manager.js` which double-counted `pendingSubs.length` — `getSubsRemaining()` already subtracts it, so `pendingSubs.length < getSubsRemaining()` became false at 3 pending subs (3 < 2), preventing users from queuing more than 3 subs in a single window
- Replace with `getSubsRemaining() > 1` which correctly allows queuing up to 4 pending subs (the 5th is the current selection applied on confirm)
- Remove redundant `subsRemaining > 1` condition from the "Add another" button template

## Test plan

- [ ] Start a live match, open tactical panel during first half or halftime
- [ ] Queue 5 substitutions using "Add another" — all 5 should be queueable in a single window
- [ ] Apply all — should succeed as 1 window with 5 subs
- [ ] Verify the tab counter shows `5/5 · 1/3`
- [ ] Verify extra time knockout allows 6 subs / 4 windows
- [ ] Verify that after using all 5 subs, the "All subs used" message appears

https://claude.ai/code/session_012BxztVvEHvVXmdzoARWq7N