### PR TITLE
Add season summary image download feature

### DIFF
--- a/lang/en/season.php
+++ b/lang/en/season.php
@@ -160,4 +160,5 @@ return [
     'play_again' => 'Play Again',
     'copied_to_clipboard' => 'Copied!',
     'your_squad_stats' => 'Your Squad Stats',
+    'download_season' => 'Download season',
 ];

--- a/lang/es/season.php
+++ b/lang/es/season.php
@@ -160,4 +160,5 @@ return [
     'play_again' => 'Jugar de nuevo',
     'copied_to_clipboard' => '¡Copiado!',
     'your_squad_stats' => 'Estadísticas de tu plantilla',
+    'download_season' => 'Descargar temporada',
 ];

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -8,6 +8,7 @@ import lineupManager from './lineup';
 import negotiationChat from './negotiation-chat';
 import squadSelection from './squad-selection';
 import tournamentSummary from './tournament-summary';
+import seasonSummary from './season-summary';
 
 Alpine.plugin(Collapse);
 Alpine.plugin(Tooltip);
@@ -17,6 +18,7 @@ Alpine.data('lineupManager', lineupManager);
 Alpine.data('negotiationChat', negotiationChat);
 Alpine.data('squadSelection', squadSelection);
 Alpine.data('tournamentSummary', tournamentSummary);
+Alpine.data('seasonSummary', seasonSummary);
 
 window.Alpine = Alpine;
 

--- a/resources/js/modules/canvas-image.js
+++ b/resources/js/modules/canvas-image.js
@@ -1,6 +1,6 @@
 /**
  * Shared Canvas drawing primitives for generating downloadable PNG images.
- * Used by squad-selection.js and tournament-end.blade.php.
+ * Used by squad-selection.js, tournament-summary.js, and season-summary.js.
  */
 
 const DEFAULT_WIDTH = 800;
@@ -75,12 +75,63 @@ export function drawSectionLabel(ctx, text, x, y) {
     ctx.fillText(text.toUpperCase(), x, y);
 }
 
-export function drawBrandFooter(ctx, width, y) {
+/**
+ * Draw a team header block: crest + name + optional subtitle line.
+ * Returns the new y position after the header (including divider).
+ */
+export async function drawTeamHeader(ctx, { crestUrl, name, subtitle, subtitleColor, padding, width, y }) {
+    const crestHeight = 52;
+    const crestWidth = 52;
+    const crest = await drawTeamCrest(ctx, crestUrl, padding, y, crestWidth, crestHeight);
+
+    const textX = crest.loaded ? padding + crestWidth + 16 : padding;
+    drawTeamName(ctx, name, textX, y + 22);
+
+    if (subtitle) {
+        ctx.fillStyle = subtitleColor || COLORS.muted;
+        ctx.font = '700 12px Inter, sans-serif';
+        ctx.fillText(subtitle.toUpperCase(), textX, y + 44);
+    }
+
+    y += crestHeight + 24;
+    drawDivider(ctx, padding, width - padding, y);
+    y += 24;
+    return y;
+}
+
+/**
+ * Draw a centered stats row with columns of value + label.
+ * Each stat: { label: string, value: string|number, color: string }.
+ * Returns the new y position after the row (including bottom divider).
+ */
+export function drawStatsRow(ctx, stats, { padding, contentWidth, y }) {
+    const colWidth = contentWidth / stats.length;
+    for (let i = 0; i < stats.length; i++) {
+        const cx = padding + colWidth * i + colWidth / 2;
+
+        ctx.fillStyle = stats[i].color;
+        ctx.font = 'bold 22px Inter, sans-serif';
+        const valText = String(stats[i].value);
+        ctx.fillText(valText, cx - ctx.measureText(valText).width / 2, y + 4);
+
+        ctx.fillStyle = COLORS.muted;
+        ctx.font = '600 9px Inter, sans-serif';
+        const lblText = stats[i].label.toUpperCase();
+        ctx.fillText(lblText, cx - ctx.measureText(lblText).width / 2, y + 20);
+    }
+    y += 40;
+
+    drawDivider(ctx, padding, padding + contentWidth, y);
+    y += 20;
+    return y;
+}
+
+export function drawBrandFooter(ctx, width, y, { tagline = 'Juega a ser seleccionador en virtuafc.com' } = {}) {
     const padding = DEFAULT_PADDING;
 
-    y += 4;
+    y += 16;
     drawDivider(ctx, padding, width - padding, y);
-    y += 28;
+    y += 16;
 
     // Virtua FC badge — compensate skew to visually center
     const badgeText = 'Virtua FC';
@@ -98,12 +149,11 @@ export function drawBrandFooter(ctx, width, y) {
     ctx.fillText(badgeText, badgeX + 8, y + 16);
     ctx.restore();
 
-    y += badgeHeight + 12;
+    y += badgeHeight + 18;
 
     // Tagline
     ctx.fillStyle = COLORS.muted;
     ctx.font = '400 11px Inter, sans-serif';
-    const tagline = 'Juega a ser seleccionador en virtuafc.com';
     const tagWidth = ctx.measureText(tagline).width;
     ctx.fillText(tagline, (width - tagWidth) / 2, y);
 

--- a/resources/js/season-summary.js
+++ b/resources/js/season-summary.js
@@ -1,0 +1,147 @@
+import {
+    createCanvasContext,
+    fillBackground,
+    drawTeamHeader,
+    drawStatsRow,
+    drawDivider,
+    drawSectionLabel,
+    drawBrandFooter,
+    trimAndDownload,
+} from './modules/canvas-image';
+
+export default function seasonSummary(config) {
+    return {
+        teamName: config.teamName,
+        teamCrestUrl: config.teamCrestUrl,
+        subtitle: config.subtitle,
+        subtitleColor: config.subtitleColor,
+        record: config.record,
+        highlights: config.highlights,
+        homeRecord: config.homeRecord,
+        awayRecord: config.awayRecord,
+        otherCompetitions: config.otherCompetitions,
+        labels: config.labels,
+
+        async downloadSeasonImage() {
+            const { canvas, ctx, width, padding, contentWidth } = createCanvasContext(800, 1400);
+            fillBackground(ctx, width, 1400);
+
+            await document.fonts.ready;
+
+            let y = padding;
+
+            // Team header
+            y = await drawTeamHeader(ctx, {
+                crestUrl: this.teamCrestUrl,
+                name: this.teamName,
+                subtitle: this.subtitle,
+                subtitleColor: this.subtitleColor,
+                padding, width, y,
+            });
+
+            // Stats row: P / W / D / L / GF / GA / GD / Pts
+            const gd = this.record.gf - this.record.ga;
+            y = drawStatsRow(ctx, [
+                { label: this.labels.played, value: this.record.played, color: '#ffffff' },
+                { label: this.labels.won, value: this.record.won, color: '#22c55e' },
+                { label: this.labels.drawn, value: this.record.drawn, color: '#94a3b8' },
+                { label: this.labels.lost, value: this.record.lost, color: '#ef4444' },
+                { label: this.labels.gf, value: this.record.gf, color: '#ffffff' },
+                { label: this.labels.ga, value: this.record.ga, color: '#ffffff' },
+                { label: this.labels.gd, value: (gd >= 0 ? '+' : '') + gd, color: gd >= 0 ? '#22c55e' : '#ef4444' },
+                { label: this.labels.pts, value: this.record.pts, color: '#f59e0b' },
+            ], { padding, contentWidth, y });
+
+            // Team highlights (top scorer, assister, appearances, MVP)
+            if (this.highlights.length > 0) {
+                drawSectionLabel(ctx, this.labels.teamHighlights, padding, y);
+                y += 18;
+
+                for (const h of this.highlights) {
+                    ctx.fillStyle = '#e2e8f0';
+                    ctx.font = '400 14px Inter, sans-serif';
+                    ctx.fillText(h.playerName, padding, y);
+
+                    // Value + label on the right
+                    ctx.fillStyle = '#cbd5e1';
+                    ctx.font = '600 13px Inter, sans-serif';
+                    const valText = String(h.value);
+                    const rightEdge = width - padding;
+                    const valWidth = ctx.measureText(valText).width;
+
+                    ctx.fillStyle = '#64748b';
+                    ctx.font = '600 10px Inter, sans-serif';
+                    const lblText = h.label.toUpperCase();
+                    const lblWidth = ctx.measureText(lblText).width;
+                    ctx.fillText(lblText, rightEdge - lblWidth, y);
+
+                    ctx.fillStyle = '#cbd5e1';
+                    ctx.font = '600 13px Inter, sans-serif';
+                    ctx.fillText(valText, rightEdge - lblWidth - valWidth - 6, y);
+
+                    y += 22;
+                }
+                y += 14;
+
+                drawDivider(ctx, padding, width - padding, y);
+                y += 14;
+            }
+
+            // Home / Away records
+            y += 8;
+            drawSectionLabel(ctx, this.labels.homeRecord, padding, y);
+            drawSectionLabel(ctx, this.labels.awayRecord, padding + contentWidth / 2, y);
+            y += 18;
+
+            const drawRecord = (record, x) => {
+                const items = [
+                    { value: record.w, color: '#22c55e', label: this.labels.won },
+                    { value: record.d, color: '#94a3b8', label: this.labels.drawn },
+                    { value: record.l, color: '#ef4444', label: this.labels.lost },
+                ];
+                let offsetX = x;
+                for (const item of items) {
+                    ctx.fillStyle = item.color;
+                    ctx.font = 'bold 20px Inter, sans-serif';
+                    const vText = String(item.value);
+                    ctx.fillText(vText, offsetX, y + 2);
+                    offsetX += ctx.measureText(vText).width + 3;
+
+                    ctx.fillStyle = '#64748b';
+                    ctx.font = '600 10px Inter, sans-serif';
+                    ctx.fillText(item.label, offsetX, y + 2);
+                    offsetX += ctx.measureText(item.label).width + 12;
+                }
+            };
+
+            drawRecord(this.homeRecord, padding);
+            drawRecord(this.awayRecord, padding + contentWidth / 2);
+            y += 20;
+
+            // Other competitions
+            if (this.otherCompetitions.length > 0) {
+                drawDivider(ctx, padding, width - padding, y);
+                y += 20;
+
+                drawSectionLabel(ctx, this.labels.otherCompetitions, padding, y);
+                y += 18;
+
+                for (const comp of this.otherCompetitions) {
+                    ctx.fillStyle = '#e2e8f0';
+                    ctx.font = '600 14px Inter, sans-serif';
+                    ctx.fillText(comp.name, padding, y);
+
+                    ctx.fillStyle = comp.isChampion ? '#f59e0b' : '#94a3b8';
+                    ctx.font = '400 13px Inter, sans-serif';
+                    const resultText = comp.result;
+                    ctx.fillText(resultText, width - padding - ctx.measureText(resultText).width, y);
+
+                    y += 22;
+                }
+            }
+
+            y = drawBrandFooter(ctx, width, y, { tagline: 'Dirige a tu club en virtuafc.com' });
+            trimAndDownload(canvas, y, this.teamName.replace(/[^a-zA-Z0-9]/g, '_') + '_season.png');
+        },
+    };
+}

--- a/resources/js/squad-selection.js
+++ b/resources/js/squad-selection.js
@@ -1,9 +1,7 @@
 import {
     createCanvasContext,
     fillBackground,
-    drawTeamCrest,
-    drawTeamName,
-    drawDivider,
+    drawTeamHeader,
     drawSectionLabel,
     drawBrandFooter,
     trimAndDownload,
@@ -60,16 +58,12 @@ export default function squadSelection(config) {
             await document.fonts.ready;
 
             let y = padding;
-            const crestHeight = 48;
-            const crestWidth = 64; // 4:3 flag ratio
-            const crest = await drawTeamCrest(ctx, this.teamCrestUrl, padding, y, crestWidth, crestHeight);
-            const nameX = crest.loaded ? padding + crestWidth + 16 : padding;
-            const nameY = crest.loaded ? y + crestHeight / 2 + 8 : y + 24;
-            drawTeamName(ctx, this.teamName, nameX, nameY);
-
-            y += crestHeight + 32;
-            drawDivider(ctx, padding, width - padding, y);
-            y += 24;
+            y = await drawTeamHeader(ctx, {
+                crestUrl: this.teamCrestUrl,
+                name: this.teamName,
+                padding, width, y,
+            });
+            y += 4; // extra spacing before squad list
 
             const groups = ['goalkeepers', 'defenders', 'midfielders', 'forwards'];
             for (const group of groups) {

--- a/resources/js/tournament-summary.js
+++ b/resources/js/tournament-summary.js
@@ -1,9 +1,8 @@
 import {
     createCanvasContext,
     fillBackground,
-    drawTeamCrest,
-    drawTeamName,
-    drawDivider,
+    drawTeamHeader,
+    drawStatsRow,
     drawSectionLabel,
     drawBrandFooter,
     trimAndDownload,
@@ -27,25 +26,19 @@ export default function tournamentSummary(config) {
             await document.fonts.ready;
 
             let y = padding;
-            const crestHeight = 52;
-            const crestWidth = 69; // 4:3 flag ratio
-            const crest = await drawTeamCrest(ctx, this.teamCrestUrl, padding, y, crestWidth, crestHeight);
 
-            const textX = crest.loaded ? padding + crestWidth + 16 : padding;
-            drawTeamName(ctx, this.teamName, textX, y + 22);
-
-            // Result badge
-            ctx.fillStyle = this.isChampion ? '#f59e0b' : '#94a3b8';
-            ctx.font = '700 12px Inter, sans-serif';
-            ctx.fillText(this.resultLabel.toUpperCase(), textX, y + 44);
-
-            y += crestHeight + 28;
-            drawDivider(ctx, padding, width - padding, y);
-            y += 20;
+            // Team header
+            y = await drawTeamHeader(ctx, {
+                crestUrl: this.teamCrestUrl,
+                name: this.teamName,
+                subtitle: this.resultLabel,
+                subtitleColor: this.isChampion ? '#f59e0b' : '#94a3b8',
+                padding, width, y,
+            });
 
             // Stats row
             const gd = this.record.goalsFor - this.record.goalsAgainst;
-            const stats = [
+            y = drawStatsRow(ctx, [
                 { label: this.statLabels.played, value: this.record.played, color: '#ffffff' },
                 { label: this.statLabels.won, value: this.record.won, color: '#22c55e' },
                 { label: this.statLabels.drawn, value: this.record.drawn, color: '#94a3b8' },
@@ -53,26 +46,7 @@ export default function tournamentSummary(config) {
                 { label: this.statLabels.gf, value: this.record.goalsFor, color: '#ffffff' },
                 { label: this.statLabels.ga, value: this.record.goalsAgainst, color: '#ffffff' },
                 { label: this.statLabels.gd, value: (gd >= 0 ? '+' : '') + gd, color: gd >= 0 ? '#22c55e' : '#ef4444' },
-            ];
-
-            const colWidth = contentWidth / stats.length;
-            for (let i = 0; i < stats.length; i++) {
-                const cx = padding + colWidth * i + colWidth / 2;
-
-                ctx.fillStyle = stats[i].color;
-                ctx.font = 'bold 22px Inter, sans-serif';
-                const valText = String(stats[i].value);
-                ctx.fillText(valText, cx - ctx.measureText(valText).width / 2, y + 4);
-
-                ctx.fillStyle = '#64748b';
-                ctx.font = '600 9px Inter, sans-serif';
-                const lblText = stats[i].label.toUpperCase();
-                ctx.fillText(lblText, cx - ctx.measureText(lblText).width / 2, y + 20);
-            }
-            y += 40;
-
-            drawDivider(ctx, padding, width - padding, y);
-            y += 20;
+            ], { padding, contentWidth, y });
 
             // Column headers for squad
             const nameColX = padding;
@@ -119,7 +93,7 @@ export default function tournamentSummary(config) {
 
                     y += 20;
                 }
-                y += 10;
+                y += 4;
             }
 
             y = drawBrandFooter(ctx, width, y);

--- a/resources/views/season-end.blade.php
+++ b/resources/views/season-end.blade.php
@@ -39,7 +39,64 @@ $getZoneClass = function($position) use ($standingsZones, $borderColorMap) {
 @endphp
 
 <x-app-layout :hide-footer="true">
-<div class="min-h-screen py-6 md:py-8">
+@php
+    $seasonHighlights = collect([
+        $teamTopScorer && $teamTopScorer->goals > 0 ? ['label' => __('season.goals'), 'playerName' => $teamTopScorer->player->name, 'value' => $teamTopScorer->goals] : null,
+        $teamTopAssister && $teamTopAssister->assists > 0 ? ['label' => __('season.assists'), 'playerName' => $teamTopAssister->player->name, 'value' => $teamTopAssister->assists] : null,
+        $teamMostAppearances && $teamMostAppearances->appearances > 0 ? ['label' => __('season.appearances'), 'playerName' => $teamMostAppearances->player->name, 'value' => $teamMostAppearances->appearances] : null,
+        $teamMvpLeader ? ['label' => __('season.mvp_awards'), 'playerName' => $teamMvpLeader->gamePlayer->player->name, 'value' => $teamMvpLeader->count] : null,
+    ])->filter()->values()->toArray();
+
+    $otherComps = collect($otherCompetitionResults)->map(function ($result) {
+        $comp = $result['competition'];
+        if ($result['wonCompetition']) {
+            $resultText = __('season.champion_label');
+        } elseif ($result['roundName']) {
+            $resultText = __($result['roundName']);
+        } else {
+            $resultText = '';
+        }
+        return ['name' => __($comp->name), 'result' => $resultText, 'isChampion' => $result['wonCompetition']];
+    })->toArray();
+
+    $positionLabel = $playerStanding
+        ? $playerStanding->position . 'º'
+        : '';
+    $seasonSubtitle = $game->formatted_season . ' · ' . $positionLabel;
+@endphp
+<div class="min-h-screen py-6 md:py-8" x-data="seasonSummary({
+    teamName: @js($game->team->name),
+    teamCrestUrl: @js($game->team->image),
+    subtitle: @js($seasonSubtitle),
+    subtitleColor: @js($isChampion ? '#f59e0b' : '#94a3b8'),
+    record: @js([
+        'played' => $playerStanding?->played ?? 0,
+        'won' => $playerStanding?->won ?? 0,
+        'drawn' => $playerStanding?->drawn ?? 0,
+        'lost' => $playerStanding?->lost ?? 0,
+        'gf' => $playerStanding?->goals_for ?? 0,
+        'ga' => $playerStanding?->goals_against ?? 0,
+        'pts' => $playerStanding?->points ?? 0,
+    ]),
+    highlights: @js($seasonHighlights),
+    homeRecord: @js($homeRecord),
+    awayRecord: @js($awayRecord),
+    otherCompetitions: @js($otherComps),
+    labels: @js([
+        'played' => __('season.played_abbr'),
+        'won' => __('season.won'),
+        'drawn' => __('season.drawn'),
+        'lost' => __('season.lost'),
+        'gf' => __('season.goals_for'),
+        'ga' => __('season.goals_against'),
+        'gd' => __('season.goal_diff_abbr'),
+        'pts' => __('season.pts_abbr'),
+        'teamHighlights' => __('season.team_in_numbers'),
+        'homeRecord' => __('season.home_record'),
+        'awayRecord' => __('season.away_record'),
+        'otherCompetitions' => __('season.your_other_competitions'),
+    ]),
+})">
     <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
 
         {{-- ============================================================ --}}
@@ -595,7 +652,15 @@ $getZoneClass = function($position) use ($standingsZones, $borderColorMap) {
         {{-- CTA: Start New Season                                         --}}
         {{-- ============================================================ --}}
 
-        <div class="text-center py-6 md:py-10">
+        <div class="flex flex-col sm:flex-row items-center justify-center gap-3 py-6 md:py-10">
+            <x-secondary-button
+                type="button"
+                @click="downloadSeasonImage()"
+                class="px-6 py-4 text-base"
+            >
+                <svg class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5M16.5 12 12 16.5m0 0L7.5 12m4.5 4.5V3"/></svg>
+                <span class="ml-1.5">{{ __('season.download_season') }}</span>
+            </x-secondary-button>
             @if(config('beta.allow_new_season'))
             <form method="post" action="{{ route('game.start-new-season', $game->id) }}" x-data="{ loading: false }" @submit="loading = true">
                 @csrf


### PR DESCRIPTION
## Summary
This PR adds the ability for users to download a shareable PNG image summarizing their completed season, including team stats, player highlights, home/away records, and other competition results.

## Key Changes

- **New module**: `resources/js/season-summary.js` - Main component that generates and downloads season summary images with team header, statistics, highlights, and competition results
- **Canvas utilities**: Added `drawTeamHeader()` and `drawStatsRow()` helper functions to `resources/js/modules/canvas-image.js` for reusable UI components
- **Refactored existing code**: Updated `tournament-summary.js` and `squad-selection.js` to use the new `drawTeamHeader()` function, reducing code duplication
- **UI integration**: Added download button to `resources/views/season-end.blade.php` with Alpine.js data binding to pass season data to the summary component
- **Localization**: Added `download_season` translation strings in English and Spanish language files

## Implementation Details

- The season summary image includes:
  - Team crest, name, season, and league position
  - Core statistics (Played, Won, Drawn, Lost, Goals For/Against, Goal Difference, Points)
  - Team highlights (top scorer, assister, most appearances, MVP awards)
  - Home and away record breakdowns
  - Other competition results with champion status indicator
  - Brand footer
  
- Reusable canvas drawing functions promote consistency across different summary image types (squad selection, tournament, and season)
- Data is passed from Blade template to JavaScript via Alpine.js `x-data` attribute, with proper localization of labels

https://claude.ai/code/session_01QJMgSNzkXwNARmNfChymXj