### PR TITLE
Add LM/RM position filters to scout search

### DIFF
--- a/app/Support/PositionMapper.php
+++ b/app/Support/PositionMapper.php
@@ -196,6 +196,16 @@ class PositionMapper
     }
 
     /**
+     * Get all individual position filter options (code => translation key prefix).
+     *
+     * @return array<string, string>
+     */
+    public static function getFilterOptions(): array
+    {
+        return self::$filterToKey;
+    }
+
+    /**
      * Get all 13 canonical position names.
      *
      * @return string[]

--- a/lang/en/positions.php
+++ b/lang/en/positions.php
@@ -54,6 +54,6 @@ return [
 
     // Scout filter groups
     'any_defender' => 'Any Defender (CB, LB, RB)',
-    'any_midfielder' => 'Any Midfielder (DM, CM, AM)',
+    'any_midfielder' => 'Any Midfielder (DM, CM, AM, LM, RM)',
     'any_forward' => 'Any Forward (LW, RW, CF, SS)',
 ];

--- a/lang/es/positions.php
+++ b/lang/es/positions.php
@@ -54,6 +54,6 @@ return [
 
     // Scout filter groups
     'any_defender' => 'Cualquier Defensa (CT, LI, LD)',
-    'any_midfielder' => 'Cualquier Centrocampista (MCD, MC, MP)',
+    'any_midfielder' => 'Cualquier Centrocampista (MCD, MC, MP, MI, MD)',
     'any_forward' => 'Cualquier Delantero (EI, ED, DC, SD)',
 ];

--- a/resources/views/components/scout-search-modal.blade.php
+++ b/resources/views/components/scout-search-modal.blade.php
@@ -50,16 +50,9 @@
                         <x-select-input name="position" id="position" required class="w-full">
                             <option value="">{{ __('transfers.select_position') }}</option>
                             <optgroup label="{{ __('transfers.specific_positions') }}">
-                                <option value="GK">{{ __('positions.goalkeeper_label') }}</option>
-                                <option value="CB">{{ __('positions.centre_back_label') }}</option>
-                                <option value="LB">{{ __('positions.left_back_label') }}</option>
-                                <option value="RB">{{ __('positions.right_back_label') }}</option>
-                                <option value="DM">{{ __('positions.defensive_midfield_label') }}</option>
-                                <option value="CM">{{ __('positions.central_midfield_label') }}</option>
-                                <option value="AM">{{ __('positions.attacking_midfield_label') }}</option>
-                                <option value="LW">{{ __('positions.left_winger_label') }}</option>
-                                <option value="RW">{{ __('positions.right_winger_label') }}</option>
-                                <option value="CF">{{ __('positions.centre_forward_label') }}</option>
+                                @foreach(\App\Support\PositionMapper::getFilterOptions() as $code => $key)
+                                    <option value="{{ $code }}">{{ __("positions.{$key}_label") }}</option>
+                                @endforeach
                             </optgroup>
                             <optgroup label="{{ __('transfers.position_groups') }}">
                                 <option value="any_defender">{{ __('positions.any_defender') }}</option>


### PR DESCRIPTION
## Summary
- Add `getFilterOptions()` method to `PositionMapper` to expose all 13 position filter codes as a single source of truth
- Replace hardcoded `<option>` list in scout search modal with a dynamic `@foreach` loop from `PositionMapper`, so LM (MI) and RM (MD) — and SS (SD) — are now available as individual search filters
- Update "Any Midfielder" group labels in both `en` and `es` to mention LM/RM (MI/MD)

## Test plan
- [ ] Open scouting hub → new search → verify all 13 positions appear in the dropdown (including MI and MD in Spanish locale)
- [ ] Search specifically for MI (Left Midfield) → verify results return Left Midfield players
- [ ] Search specifically for MD (Right Midfield) → verify results return Right Midfield players
- [ ] Verify "Cualquier Centrocampista" group label now shows (MCD, MC, MP, MI, MD)
- [ ] Switch to English locale and verify equivalent labels

https://claude.ai/code/session_01PXoY9xT9KjrFjEUPZhH1p5