### PR TITLE
Fix season transition stuck due to WC template number conflicts

### DIFF
--- a/app/Modules/Season/Jobs/SetupNewGame.php
+++ b/app/Modules/Season/Jobs/SetupNewGame.php
@@ -378,6 +378,9 @@ class SetupNewGame implements ShouldQueue
 
         DB::table('game_player_templates')
             ->where('season', $this->season)
+            ->whereNotIn('team_id', function ($query) {
+                $query->select('id')->from('teams')->where('type', 'national');
+            })
             ->orderBy('player_id')
             ->chunk(500, function ($templates) use ($gameId, &$seenPlayerIds) {
                 $rows = [];

--- a/app/Modules/Season/Services/GamePlayerTemplateService.php
+++ b/app/Modules/Season/Services/GamePlayerTemplateService.php
@@ -92,6 +92,7 @@ class GamePlayerTemplateService
             foreach ($data['players'] as $playerData) {
                 $row = $this->prepareTemplateRow($season, $team->id, $playerData, 0, $allPlayers);
                 if ($row && !isset($processedPlayerIds[$row['player_id']])) {
+                    $row['number'] = null; // WC templates must not store squad numbers
                     $rows[] = $row;
                     $processedPlayerIds[$row['player_id']] = true;
                 }


### PR DESCRIPTION
## Summary

- After 95f26f5, `SeedWorldCupData.generatePlayerTemplates()` inserts WC national team templates into the shared `game_player_templates` table with squad numbers from JSON rosters
- Career mode `SetupNewGame` queries all templates for the season, picking up WC templates and importing national team players with numbers that violate the `game_players_squad_number_unique` constraint
- **Fix 1:** Null out numbers in WC templates (`GamePlayerTemplateService::generateForWorldCup`)
- **Fix 2:** Exclude national team templates from career mode template query (`SetupNewGame::initializeGamePlayersFromTemplates`)

## Test plan

- [ ] Verify existing `SetupNewGame` and `SeasonTransition` tests pass
- [ ] Run `app:seed-world-cup-data` and confirm WC templates have `number = NULL`
- [ ] Create a career game and confirm no national team players in `game_players`
- [ ] Complete a season transition without unique constraint errors

https://claude.ai/code/session_01LU3wo3pcB1Rdy84Xr8ZygV