### PR TITLE
Fix pre-contract transfers lost during season transition

### DIFF
--- a/app/Modules/Transfer/Services/TransferService.php
+++ b/app/Modules/Transfer/Services/TransferService.php
@@ -2,8 +2,6 @@
 
 namespace App\Modules\Transfer\Services;
 
-use App\Models\GameNotification;
-use App\Modules\Notification\Services\NotificationService;
 use App\Modules\Player\PlayerAge;
 use App\Modules\Transfer\Services\ContractService;
 use App\Modules\Transfer\Services\ScoutingService;
@@ -1260,17 +1258,6 @@ class TransferService
         // Safety net: reject if squad is full (skipped for season-close pre-contracts)
         if (!$skipSquadCheck && ContractService::isSquadFull($game)) {
             $offer->update(['status' => TransferOffer::STATUS_REJECTED, 'resolved_at' => $game->current_date]);
-
-            $playerName = $offer->gamePlayer->player->name ?? $offer->gamePlayer->name;
-            app(NotificationService::class)->create(
-                game: $game,
-                type: GameNotification::TYPE_TRANSFER_COMPLETE,
-                title: __('messages.pre_contract_rejected_squad_full', ['player' => $playerName]),
-                message: __('messages.pre_contract_rejected_squad_full_detail', ['player' => $playerName, 'max' => ContractService::MAX_SQUAD_SIZE]),
-                priority: GameNotification::PRIORITY_WARNING,
-                metadata: ['offer_id' => $offer->id, 'player_id' => $offer->game_player_id],
-            );
-
             return;
         }
 

--- a/lang/en/messages.php
+++ b/lang/en/messages.php
@@ -97,8 +97,6 @@ return [
 
     // Squad cap
     'squad_full' => 'Your squad already has the maximum of :max players. Release or sell a player first.',
-    'pre_contract_rejected_squad_full' => 'Signing cancelled: :player',
-    'pre_contract_rejected_squad_full_detail' => 'The pre-contract for :player was cancelled because your squad already has :max players.',
     'squad_trim_required' => 'Your squad has :count players. You must release at least :excess to meet the :max-player limit.',
     'cannot_loan_free_agent' => 'Cannot loan a free agent. Sign them directly instead.',
 

--- a/lang/es/messages.php
+++ b/lang/es/messages.php
@@ -97,8 +97,6 @@ return [
 
     // Squad cap
     'squad_full' => 'Tu plantilla ya tiene el máximo de :max jugadores. Libera o vende un jugador primero.',
-    'pre_contract_rejected_squad_full' => 'Fichaje cancelado: :player',
-    'pre_contract_rejected_squad_full_detail' => 'El precontrato de :player ha sido cancelado porque tu plantilla ya tiene :max jugadores.',
     'squad_trim_required' => 'Tu plantilla tiene :count jugadores. Debes liberar al menos :excess para cumplir el límite de :max jugadores.',
     'cannot_loan_free_agent' => 'No se puede ceder a un jugador libre. Fíchalo directamente.',
 


### PR DESCRIPTION
## Summary

**Season-close pre-contract transfers lost:**
- **Fix processor ordering bug**: `PreContractTransferProcessor` and `ContractExpirationProcessor` both had priority 5. Due to stable sort, pre-contract signings were checked against a squad that still included expiring-contract players, causing silent rejection when squad was at 30. Changed `ContractExpirationProcessor` priority to 4 so expired contracts are cleared first.
- **Pre-contract signings always arrive**: Season-close pre-contracts now skip the squad-full check entirely. The user committed to these deals — they should decide who to release via the existing `SquadCapEnforcementProcessor` trim flow.
- **Prevent race condition**: `ContractExpirationProcessor` now excludes user players with agreed outgoing pre-contracts from deletion, so `PreContractTransferProcessor` can still process their departure to the new team.

**Mid-season transfers showing false success when squad is full:**
- `acceptIncomingOffer` returned `true` (meaning "window was open") even when `completeIncomingTransfer` silently rejected the transfer due to squad being full. The user saw a success notification and "transfer complete" chat message, but no player arrived and no money was deducted.
- Fix: `completeIncomingTransfer` now returns `bool` indicating actual success. `acceptIncomingOffer` propagates the result. `NegotiateTransfer` checks for rejection and shows the squad-full error in the negotiation chat.

## Test plan

- [x] `php artisan test --filter=PreContractProcessorOrderingTest` — verifies pipeline ordering
- [x] `php artisan test --filter=PreContract` — existing pre-contract tests still pass
- [ ] Manual: simulate a season with 30-player squad, expiring contracts, and pre-contract signings → verify all signings arrive and squad trim is triggered
- [ ] Manual: try to sign a player mid-season with a full 30-player squad → verify negotiation chat shows squad-full error instead of false success

https://claude.ai/code/session_01KzQgtgfWoFWXpfd1XqWtT9