### PR TITLE
Fix squad availability using wrong date and missing competition ID

### DIFF
--- a/app/Modules/Squad/Services/SquadService.php
+++ b/app/Modules/Squad/Services/SquadService.php
@@ -31,7 +31,9 @@ class SquadService
             ->get();
 
         $seasonEndDate = $game->getSeasonEndDate();
-        $nextMatchday = $game->current_matchday + 1;
+        $nextMatch = $game->next_match;
+        $matchDate = $nextMatch?->scheduled_date ?? $game->current_date;
+        $competitionId = $nextMatch?->competition_id;
 
         // Pre-compute matches missed for injured players
         $matchesMissedMap = InjuryService::getMatchesMissedMap($gameId, $game->team_id, $game->current_date, $allPlayers);
@@ -41,12 +43,12 @@ class SquadService
         $primeCount = 0;
         $veteranCount = 0;
 
-        $allPlayers->each(function (GamePlayer $player) use ($game, $seasonEndDate, $nextMatchday, $matchesMissedMap, &$youngCount, &$primeCount, &$veteranCount) {
+        $allPlayers->each(function (GamePlayer $player) use ($game, $seasonEndDate, $matchDate, $competitionId, $matchesMissedMap, &$youngCount, &$primeCount, &$veteranCount) {
             // Availability
             $matchData = $matchesMissedMap[$player->id] ?? null;
-            $player->setAttribute('is_unavailable', !$player->isAvailable($game->current_date, $nextMatchday));
+            $player->setAttribute('is_unavailable', !$player->isAvailable($matchDate, $competitionId));
             $player->setAttribute('unavailability_reason', $player->getUnavailabilityReason(
-                $game->current_date, $nextMatchday, $matchData['count'] ?? null, $matchData['approx'] ?? false,
+                $matchDate, $competitionId, $matchData['count'] ?? null, $matchData['approx'] ?? false,
             ));
 
             // Development projection


### PR DESCRIPTION
The squad list was passing `$nextMatchday` (an integer) as the `$competitionId` parameter and checking injuries against `current_date` instead of the next match's `scheduled_date`. This caused players to appear injured in the squad but available in the lineup when their recovery date fell between the two dates, and silently broke suspension checks entirely.