### PR TITLE
Add bulk invite button to admin waitlist page

### DIFF
--- a/app/Console/Commands/InviteFromWaitlist.php
+++ b/app/Console/Commands/InviteFromWaitlist.php
@@ -2,6 +2,7 @@
 
 namespace App\Console\Commands;
 
+use App\Jobs\ProcessBulkWaitlistInvites;
 use App\Models\WaitlistEntry;
 use App\Services\BetaInviteService;
 use Illuminate\Console\Command;
@@ -76,40 +77,34 @@ class InviteFromWaitlist extends Command
             return self::FAILURE;
         }
 
-        $entries = WaitlistEntry::whereDoesntHave('inviteCode')
-            ->inRandomOrder()
-            ->limit($count)
-            ->get();
+        $pending = WaitlistEntry::whereDoesntHave('inviteCode')->count();
 
-        if ($entries->isEmpty()) {
+        if ($pending === 0) {
             $this->info('No pending waitlist entries to invite.');
 
             return self::SUCCESS;
         }
 
-        $dryRun = $this->option('dry-run');
-        $sent = 0;
+        $count = min($count, $pending);
 
-        foreach ($entries as $entry) {
-            if ($dryRun) {
+        if ($this->option('dry-run')) {
+            $entries = WaitlistEntry::whereDoesntHave('inviteCode')
+                ->inRandomOrder()
+                ->limit($count)
+                ->get();
+
+            foreach ($entries as $entry) {
                 $this->line("  [dry-run] Would invite: {$entry->name} <{$entry->email}>");
-                $sent++;
-
-                continue;
             }
 
-            $this->inviteService->invite($entry, $this->option('expires'));
-            $this->info("  Invited: {$entry->name} <{$entry->email}>");
-            $sent++;
+            $this->newLine();
+            $this->info("Would invite: {$entries->count()} of {$pending} waitlist entries.");
 
-            if ($sent < $entries->count()) {
-                sleep(1);
-            }
+            return self::SUCCESS;
         }
 
-        $this->newLine();
-        $action = $dryRun ? 'Would invite' : 'Invited';
-        $this->info("{$action}: {$sent} of {$entries->count()} waitlist entries.");
+        ProcessBulkWaitlistInvites::dispatch($count);
+        $this->info("Dispatched job to invite {$count} waitlist entries.");
 
         return self::SUCCESS;
     }

--- a/app/Http/Actions/SendBulkWaitlistInvites.php
+++ b/app/Http/Actions/SendBulkWaitlistInvites.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Actions;
+
+use App\Jobs\ProcessBulkWaitlistInvites;
+use App\Models\WaitlistEntry;
+use Illuminate\Http\Request;
+
+class SendBulkWaitlistInvites
+{
+    public function __invoke(Request $request)
+    {
+        if (! config('beta.enabled')) {
+            return back()->with('error', __('admin.waitlist_beta_disabled'));
+        }
+
+        $pending = WaitlistEntry::whereDoesntHave('inviteCode')->count();
+
+        if ($pending === 0) {
+            return back()->with('error', __('admin.waitlist_no_pending'));
+        }
+
+        $count = min(50, $pending);
+
+        ProcessBulkWaitlistInvites::dispatch($count);
+
+        return back()->with('success', __('admin.waitlist_bulk_invite_started', ['count' => $count]));
+    }
+}

--- a/app/Jobs/ProcessBulkWaitlistInvites.php
+++ b/app/Jobs/ProcessBulkWaitlistInvites.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\WaitlistEntry;
+use App\Services\BetaInviteService;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+class ProcessBulkWaitlistInvites implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public int $timeout = 300;
+
+    public function __construct(
+        private readonly int $count,
+    ) {
+        $this->onQueue('mail');
+    }
+
+    public function handle(BetaInviteService $inviteService): void
+    {
+        $entries = WaitlistEntry::whereDoesntHave('inviteCode')
+            ->inRandomOrder()
+            ->limit($this->count)
+            ->get();
+
+        $sent = 0;
+
+        foreach ($entries as $entry) {
+            $inviteService->invite($entry);
+            $sent++;
+
+            if ($sent < $entries->count()) {
+                sleep(1);
+            }
+        }
+    }
+}

--- a/lang/en/admin.php
+++ b/lang/en/admin.php
@@ -87,6 +87,10 @@ return [
     'waitlist_status_pending' => 'Pending',
     'waitlist_status_invited' => 'Invited',
     'waitlist_status_registered' => 'Registered',
+    'waitlist_bulk_invite' => 'Send 50 invitations',
+    'waitlist_bulk_invite_started' => 'Sending :count invitations in the background...',
+    'waitlist_bulk_invite_confirm' => 'This will send up to 50 invitations. Continue?',
+    'waitlist_no_pending' => 'No pending waitlist entries to invite.',
     'search_waitlist_placeholder' => 'Search by name or email...',
 
     // Game stats

--- a/lang/es/admin.php
+++ b/lang/es/admin.php
@@ -87,6 +87,10 @@ return [
     'waitlist_status_pending' => 'Pendiente',
     'waitlist_status_invited' => 'Invitado',
     'waitlist_status_registered' => 'Registrado',
+    'waitlist_bulk_invite' => 'Enviar 50 invitaciones',
+    'waitlist_bulk_invite_started' => 'Enviando :count invitaciones en segundo plano...',
+    'waitlist_bulk_invite_confirm' => 'Se enviarán hasta 50 invitaciones. ¿Continuar?',
+    'waitlist_no_pending' => 'No hay entradas pendientes en la lista de espera.',
     'search_waitlist_placeholder' => 'Buscar por nombre o email...',
 
     // Game stats

--- a/resources/views/admin/waitlist.blade.php
+++ b/resources/views/admin/waitlist.blade.php
@@ -25,6 +25,20 @@
         </div>
     </div>
 
+    @if($pending > 0 && config('beta.enabled'))
+        <form method="POST" action="{{ route('admin.bulk-waitlist-invite') }}" class="mb-4">
+            @csrf
+            <x-ghost-button
+                type="submit"
+                color="green"
+                size="xs"
+                x-on:click.prevent="if (confirm(@js(__('admin.waitlist_bulk_invite_confirm')))) $el.closest('form').submit()"
+            >
+                {{ __('admin.waitlist_bulk_invite') }}
+            </x-ghost-button>
+        </form>
+    @endif
+
     <form method="GET" action="{{ route('admin.waitlist') }}" class="mb-4">
         <div class="relative max-w-xs">
             <svg class="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-text-muted pointer-events-none" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/routes/web.php
+++ b/routes/web.php
@@ -12,6 +12,7 @@ use App\Http\Actions\StopImpersonation;
 use App\Http\Actions\ToggleCareerAccess;
 use App\Http\Actions\ToggleDatabaseEditing;
 use App\Http\Actions\ToggleTournamentAccess;
+use App\Http\Actions\SendBulkWaitlistInvites;
 use App\Http\Actions\SendWaitlistInvite;
 use App\Http\Views\AdminActivation;
 use App\Http\Views\AdminDashboard;
@@ -262,6 +263,7 @@ Route::middleware('auth')->prefix('admin')->name('admin.')->group(function () {
         Route::get('/game-stats', AdminGameStats::class)->name('game-stats');
         Route::get('/waitlist', AdminWaitlist::class)->name('waitlist');
         Route::post('/waitlist/{waitlistEntry}/invite', SendWaitlistInvite::class)->name('send-waitlist-invite');
+        Route::post('/waitlist/bulk-invite', SendBulkWaitlistInvites::class)->name('bulk-waitlist-invite');
         Route::post('/impersonate/{userId}', StartImpersonation::class)->name('impersonate');
         Route::post('/users/{userId}/toggle-career', ToggleCareerAccess::class)->name('toggle-career');
         Route::post('/users/{userId}/toggle-tournament', ToggleTournamentAccess::class)->name('toggle-tournament');


### PR DESCRIPTION
Dispatches a queued job to send up to 50 invitations with 1s delay between each email to respect provider rate limits. Refactors the artisan command to reuse the same job, avoiding logic duplication.