### PR TITLE
Fix infrastructure tiers resetting between seasons

### DIFF
--- a/app/Http/Views/ShowBudgetAllocation.php
+++ b/app/Http/Views/ShowBudgetAllocation.php
@@ -2,15 +2,14 @@
 
 namespace App\Http\Views;
 
-use App\Modules\Finance\Services\BudgetProjectionService;
 use App\Models\Game;
 use App\Models\GameInvestment;
-use App\Models\TeamReputation;
+use App\Modules\Finance\Services\BudgetAllocationService;
 
 class ShowBudgetAllocation
 {
     public function __construct(
-        private readonly BudgetProjectionService $projectionService,
+        private readonly BudgetAllocationService $budgetService,
     ) {}
 
     public function __invoke(string $gameId)
@@ -18,34 +17,11 @@ class ShowBudgetAllocation
         $game = Game::with('team')->findOrFail($gameId);
         abort_if($game->isTournamentMode(), 404);
 
-        // Access relationships after model is loaded (lazy loading works correctly)
-        $finances = $game->currentFinances;
-        if (!$finances) {
-            $finances = $this->projectionService->generateProjections($game);
-        }
-
-        $investment = $game->currentInvestment;
-
-        // Calculate available surplus
-        $availableSurplus = $finances->available_surplus ?? 0;
-
-        // Get current tiers (0-4 for each area), default based on club reputation
-        $tiers = $investment ? [
-            'youth_academy' => $investment->youth_academy_tier,
-            'medical' => $investment->medical_tier,
-            'scouting' => $investment->scouting_tier,
-            'facilities' => $investment->facilities_tier,
-        ] : GameInvestment::defaultTiersForReputation(
-            TeamReputation::resolveLevel($game->id, $game->team_id),
-            $availableSurplus,
-        );
+        $budgetData = $this->budgetService->prepareBudgetData($game);
 
         return view('budget-allocation', [
+            ...$budgetData,
             'game' => $game,
-            'finances' => $finances,
-            'investment' => $investment,
-            'availableSurplus' => $availableSurplus,
-            'tiers' => $tiers,
             'tierThresholds' => GameInvestment::TIER_THRESHOLDS,
             'isLocked' => false,
         ]);

--- a/app/Http/Views/ShowNewSeason.php
+++ b/app/Http/Views/ShowNewSeason.php
@@ -2,20 +2,19 @@
 
 namespace App\Http\Views;
 
-use App\Modules\Finance\Services\BudgetProjectionService;
+use App\Modules\Finance\Services\BudgetAllocationService;
 use App\Modules\Season\Services\SeasonGoalService;
 use App\Models\Competition;
 use App\Models\Game;
 use App\Models\GameInvestment;
 use App\Models\GamePlayer;
 use App\Models\SeasonArchive;
-use App\Models\TeamReputation;
 use App\Support\PositionMapper;
 
 class ShowNewSeason
 {
     public function __construct(
-        private readonly BudgetProjectionService $projectionService,
+        private readonly BudgetAllocationService $budgetService,
         private readonly SeasonGoalService $seasonGoalService,
     ) {}
 
@@ -48,26 +47,8 @@ class ShowNewSeason
             return redirect()->route('game.squad-selection', $gameId);
         }
 
-        // Ensure we have financial projections
-        $finances = $game->currentFinances;
-        if (!$finances) {
-            $finances = $this->projectionService->generateProjections($game);
-        }
-
-        $investment = $game->currentInvestment;
-        $availableSurplus = $finances->available_surplus ?? 0;
-
-        // Get current tiers (0-4 for each area), default based on club reputation
-        $reputationLevel = TeamReputation::resolveLevel($game->id, $game->team_id);
-        $tiers = $investment ? [
-            'youth_academy' => $investment->youth_academy_tier,
-            'medical' => $investment->medical_tier,
-            'scouting' => $investment->scouting_tier,
-            'facilities' => $investment->facilities_tier,
-        ] : GameInvestment::defaultTiersForReputation(
-            $reputationLevel,
-            $availableSurplus,
-        );
+        $budgetData = $this->budgetService->prepareBudgetData($game);
+        $reputationLevel = $budgetData['reputationLevel'];
 
         // Get season goal data
         $competition = Competition::find($game->competition_id);
@@ -90,16 +71,12 @@ class ShowNewSeason
         }
 
         return view('new-season', [
+            ...$budgetData,
             'game' => $game,
-            'finances' => $finances,
-            'investment' => $investment,
-            'availableSurplus' => $availableSurplus,
-            'tiers' => $tiers,
             'tierThresholds' => GameInvestment::TIER_THRESHOLDS,
             'seasonGoal' => $seasonGoal,
             'seasonGoalLabel' => $seasonGoalLabel,
             'seasonGoalTarget' => $seasonGoalTarget,
-            'reputationLevel' => $reputationLevel,
             'squadSnapshot' => $squadSnapshot,
             'offseasonRecap' => $offseasonRecap,
         ]);

--- a/app/Models/Game.php
+++ b/app/Models/Game.php
@@ -404,6 +404,22 @@ class Game extends Model
         return $this->hasOne(GameInvestment::class)->where('season', $this->season);
     }
 
+    /**
+     * Get the investment record from the previous season, if any.
+     */
+    public function previousSeasonInvestment(): ?GameInvestment
+    {
+        $previousSeason = (int) $this->season - 1;
+
+        if ($previousSeason < 1) {
+            return null;
+        }
+
+        return GameInvestment::where('game_id', $this->id)
+            ->where('season', $previousSeason)
+            ->first();
+    }
+
     public function loans(): HasMany
     {
         return $this->hasMany(Loan::class);

--- a/app/Modules/Finance/Services/BudgetAllocationService.php
+++ b/app/Modules/Finance/Services/BudgetAllocationService.php
@@ -4,9 +4,66 @@ namespace App\Modules\Finance\Services;
 
 use App\Models\Game;
 use App\Models\GameInvestment;
+use App\Models\TeamReputation;
 
 class BudgetAllocationService
 {
+    public function __construct(
+        private readonly BudgetProjectionService $projectionService,
+    ) {}
+
+    /**
+     * Prepare budget allocation data for display (finances, tiers, minimums).
+     *
+     * @return array{finances: \App\Models\GameFinances, investment: ?GameInvestment, availableSurplus: int, tiers: array, minTiers: array, reputationLevel: string}
+     */
+    public function prepareBudgetData(Game $game): array
+    {
+        $finances = $game->currentFinances;
+        if (!$finances) {
+            $finances = $this->projectionService->generateProjections($game);
+        }
+
+        $investment = $game->currentInvestment;
+        $availableSurplus = $finances->available_surplus ?? 0;
+        $reputationLevel = TeamReputation::resolveLevel($game->id, $game->team_id);
+        $previousInvestment = $game->previousSeasonInvestment();
+
+        if ($investment) {
+            $tiers = [
+                'youth_academy' => $investment->youth_academy_tier,
+                'medical' => $investment->medical_tier,
+                'scouting' => $investment->scouting_tier,
+                'facilities' => $investment->facilities_tier,
+            ];
+        } elseif ($previousInvestment) {
+            $tiers = [
+                'youth_academy' => $previousInvestment->youth_academy_tier,
+                'medical' => $previousInvestment->medical_tier,
+                'scouting' => $previousInvestment->scouting_tier,
+                'facilities' => $previousInvestment->facilities_tier,
+            ];
+        } else {
+            $tiers = GameInvestment::defaultTiersForReputation($reputationLevel, $availableSurplus);
+        }
+
+        $minTiers = $previousInvestment ? [
+            'youth_academy' => $previousInvestment->youth_academy_tier,
+            'medical' => $previousInvestment->medical_tier,
+            'scouting' => $previousInvestment->scouting_tier,
+            'facilities' => $previousInvestment->facilities_tier,
+        ] : ['youth_academy' => 1, 'medical' => 1, 'scouting' => 1, 'facilities' => 1];
+
+        return [
+            'finances' => $finances,
+            'investment' => $investment,
+            'availableSurplus' => $availableSurplus,
+            'tiers' => $tiers,
+            'minTiers' => $minTiers,
+            'reputationLevel' => $reputationLevel,
+        ];
+    }
+
     /**
      * Allocate budget from validated euro amounts.
      *
@@ -38,6 +95,18 @@ class BudgetAllocationService
 
         if ($youthTier < 1 || $medicalTier < 1 || $scoutingTier < 1 || $facilitiesTier < 1) {
             throw new \InvalidArgumentException('messages.budget_minimum_tier');
+        }
+
+        // Infrastructure tiers are permanent — cannot drop below previous season's levels
+        $previousInvestment = $game->previousSeasonInvestment();
+        if ($previousInvestment) {
+            if ($youthTier < $previousInvestment->youth_academy_tier
+                || $medicalTier < $previousInvestment->medical_tier
+                || $scoutingTier < $previousInvestment->scouting_tier
+                || $facilitiesTier < $previousInvestment->facilities_tier
+            ) {
+                throw new \InvalidArgumentException('messages.budget_tier_below_previous');
+            }
         }
 
         return GameInvestment::updateOrCreate(

--- a/lang/en/messages.php
+++ b/lang/en/messages.php
@@ -66,6 +66,7 @@ return [
     // Season messages
     'budget_exceeds_surplus' => 'Total allocation exceeds available surplus.',
     'budget_minimum_tier' => 'All infrastructure areas must be at least Tier 1.',
+    'budget_tier_below_previous' => 'Infrastructure tiers cannot be reduced below the previous season\'s levels.',
 
     // Infrastructure upgrades
     'infrastructure_upgraded' => ':area upgraded to Tier :tier.',

--- a/lang/es/messages.php
+++ b/lang/es/messages.php
@@ -66,6 +66,7 @@ return [
     // Season messages
     'budget_exceeds_surplus' => 'La asignación total supera el superávit disponible.',
     'budget_minimum_tier' => 'Todas las áreas de infraestructura deben ser al menos Nivel 1.',
+    'budget_tier_below_previous' => 'Los niveles de infraestructura no pueden reducirse por debajo de los de la temporada anterior.',
 
     // Infrastructure upgrades
     'infrastructure_upgraded' => ':area mejorada a Nivel :tier.',

--- a/resources/views/budget-allocation.blade.php
+++ b/resources/views/budget-allocation.blade.php
@@ -48,6 +48,7 @@
             <x-budget-allocation
                 :available-surplus="$availableSurplus"
                 :tiers="$tiers"
+                :min-tiers="$minTiers"
                 :tier-thresholds="$tierThresholds"
                 :is-locked="$isLocked"
                 :form-action="route('game.budget.save', $game->id)"

--- a/resources/views/components/budget-allocation.blade.php
+++ b/resources/views/components/budget-allocation.blade.php
@@ -2,6 +2,7 @@
     'availableSurplus',
     'tiers',
     'tierThresholds',
+    'minTiers' => ['youth_academy' => 1, 'medical' => 1, 'scouting' => 1, 'facilities' => 1],
     'isLocked' => false,
     'formAction',
     'submitLabel' => null,
@@ -15,6 +16,7 @@ $submitLabel = $submitLabel ?? __('finances.confirm_budget_allocation');
 <div x-data="{
     availableSurplus: {{ $availableSurplus }},
     thresholds: {{ json_encode($tierThresholds) }},
+    minTiers: @js($minTiers),
     youth_academy_tier: {{ $tiers['youth_academy'] }},
     medical_tier: {{ $tiers['medical'] }},
     scouting_tier: {{ $tiers['scouting'] }},
@@ -43,7 +45,10 @@ $submitLabel = $submitLabel ?? __('finances.confirm_budget_allocation');
     },
 
     get meetsMinimumRequirements() {
-        return this.youth_academy_tier >= 1 && this.medical_tier >= 1 && this.scouting_tier >= 1 && this.facilities_tier >= 1;
+        return this.youth_academy_tier >= this.minTiers.youth_academy
+            && this.medical_tier >= this.minTiers.medical
+            && this.scouting_tier >= this.minTiers.scouting
+            && this.facilities_tier >= this.minTiers.facilities;
     },
 
     formatMoney(cents) {
@@ -108,7 +113,7 @@ $submitLabel = $submitLabel ?? __('finances.confirm_budget_allocation');
                 <div class="tier-range">
                     <div class="track"></div>
                     <div class="track-fill" :style="'width:' + (youth_academy_tier / 4 * 100) + '%'"></div>
-                    <input type="range" x-model="youth_academy_tier" min="0" max="4" step="1" {{ $isLocked ? 'disabled' : '' }}>
+                    <input type="range" x-model="youth_academy_tier" :min="minTiers.youth_academy" max="4" step="1" {{ $isLocked ? 'disabled' : '' }}>
                 </div>
                 <div class="flex justify-between text-[10px] text-text-faint mt-1">
                     <span>T0</span><span>T1</span><span>T2</span><span>T3</span><span>T4</span>
@@ -133,7 +138,7 @@ $submitLabel = $submitLabel ?? __('finances.confirm_budget_allocation');
                 <div class="tier-range">
                     <div class="track"></div>
                     <div class="track-fill" :style="'width:' + (medical_tier / 4 * 100) + '%'"></div>
-                    <input type="range" x-model="medical_tier" min="0" max="4" step="1" {{ $isLocked ? 'disabled' : '' }}>
+                    <input type="range" x-model="medical_tier" :min="minTiers.medical" max="4" step="1" {{ $isLocked ? 'disabled' : '' }}>
                 </div>
                 <div class="flex justify-between text-[10px] text-text-faint mt-1">
                     <span>T0</span><span>T1</span><span>T2</span><span>T3</span><span>T4</span>
@@ -158,7 +163,7 @@ $submitLabel = $submitLabel ?? __('finances.confirm_budget_allocation');
                 <div class="tier-range">
                     <div class="track"></div>
                     <div class="track-fill" :style="'width:' + (scouting_tier / 4 * 100) + '%'"></div>
-                    <input type="range" x-model="scouting_tier" min="0" max="4" step="1" {{ $isLocked ? 'disabled' : '' }}>
+                    <input type="range" x-model="scouting_tier" :min="minTiers.scouting" max="4" step="1" {{ $isLocked ? 'disabled' : '' }}>
                 </div>
                 <div class="flex justify-between text-[10px] text-text-faint mt-1">
                     <span>T0</span><span>T1</span><span>T2</span><span>T3</span><span>T4</span>
@@ -183,7 +188,7 @@ $submitLabel = $submitLabel ?? __('finances.confirm_budget_allocation');
                 <div class="tier-range">
                     <div class="track"></div>
                     <div class="track-fill" :style="'width:' + (facilities_tier / 4 * 100) + '%'"></div>
-                    <input type="range" x-model="facilities_tier" min="0" max="4" step="1" {{ $isLocked ? 'disabled' : '' }}>
+                    <input type="range" x-model="facilities_tier" :min="minTiers.facilities" max="4" step="1" {{ $isLocked ? 'disabled' : '' }}>
                 </div>
                 <div class="flex justify-between text-[10px] text-text-faint mt-1">
                     <span>T0</span><span>T1</span><span>T2</span><span>T3</span><span>T4</span>

--- a/resources/views/new-season.blade.php
+++ b/resources/views/new-season.blade.php
@@ -243,6 +243,7 @@
                 <x-budget-allocation
                     :available-surplus="$availableSurplus"
                     :tiers="$tiers"
+                    :min-tiers="$minTiers"
                     :tier-thresholds="$tierThresholds"
                     :form-action="route('game.new-season.complete', $game->id)"
                     :submit-label="__('game.begin_season')"


### PR DESCRIPTION
## Summary

- **Bug:** Infrastructure investment tiers (youth academy, medical, scouting, facilities) reset to reputation-based defaults every new season, even if the player had maxed them to tier 4
- **Root cause:** `ShowNewSeason` and `ShowBudgetAllocation` check `$game->currentInvestment` which is null for the new season (no record yet), then fall back to `defaultTiersForReputation()` — completely ignoring previous season's tiers
- **Fix:** Carry forward previous season's tiers as defaults and enforce them as a permanent floor — infrastructure improvements cannot degrade

## Changes (9 files)

- `Game::previousSeasonInvestment()` — new helper to fetch previous season's investment record
- `ShowNewSeason` / `ShowBudgetAllocation` — use previous season's tiers as defaults instead of reputation-based defaults
- `BudgetAllocationService` — server-side enforcement that tiers cannot drop below previous season's levels
- Budget allocation Blade component — `minTiers` prop constrains range slider minimums
- Translation keys added in both `en` and `es`

## Test plan

- [x] All 324 existing tests pass
- [ ] Start a game, complete season 1 with max infrastructure, advance to season 2 — tiers should show as 4/4/4/4
- [ ] Verify sliders cannot go below previous season's tiers
- [ ] Verify mid-season budget allocation page also respects tier floors
- [ ] Season 1 (no previous investment) still uses reputation-based defaults correctly

https://claude.ai/code/session_01PsdcNy7Dd2XxWVTZ8Zw5UP