### PR TITLE
Surface xG preview inline on lineup page and clean up code quality

### DIFF
--- a/app/Http/Views/ShowLineup.php
+++ b/app/Http/Views/ShowLineup.php
@@ -10,7 +10,6 @@ use App\Modules\Lineup\Enums\PlayingStyle;
 use App\Modules\Lineup\Enums\PressingIntensity;
 use App\Modules\Lineup\Services\LineupService;
 use App\Modules\Player\Services\InjuryService;
-use App\Models\TeamReputation;
 use App\Models\Game;
 use App\Support\PitchGrid;
 use App\Support\PositionSlotMapper;
@@ -125,7 +124,7 @@ class ShowLineup
         $userTeamAverage = $userBestXI['average'];
 
         // Get opponent scouting data (including predicted formation, mentality, and instructions)
-        $opponentData = $this->getOpponentData($gameId, $opponent->id, $matchDate, $competitionId, !$isHome, $userTeamAverage);
+        $opponentData = $this->lineupService->predictOpponentTactics($gameId, $opponent->id, $matchDate, $competitionId, !$isHome, $userTeamAverage);
 
         // Radar chart data for coach assistant
         $userRadar = $this->calculateRadarValues($userBestXI['players']);
@@ -315,56 +314,6 @@ class ShowLineup
                 'pitch_positions' => $p->pitch_positions,
             ])->values(),
         ]);
-    }
-
-    /**
-     * Get opponent scouting data, including predicted formation and mentality.
-     *
-     * @param bool $opponentIsHome Whether the opponent is the home team
-     * @param int $userTeamAverage The user's best XI average for relative strength comparison
-     */
-    private function getOpponentData(string $gameId, string $opponentTeamId, $matchDate, string $competitionId, bool $opponentIsHome, int $userTeamAverage): array
-    {
-        // Get opponent's available players and best XI
-        $availablePlayers = $this->lineupService->getAvailablePlayers($gameId, $opponentTeamId, $matchDate, $competitionId);
-
-        // Predict their formation based on squad composition
-        $predictedFormation = $this->lineupService->selectAIFormation($availablePlayers);
-
-        // Calculate their best XI average using the predicted formation
-        $bestXI = $this->lineupService->selectBestXI($availablePlayers, $predictedFormation);
-        $teamAverage = $this->lineupService->calculateTeamAverage($bestXI);
-
-        // Predict their mentality based on reputation and context
-        $opponentReputation = TeamReputation::resolveLevel($gameId, $opponentTeamId);
-        $predictedMentality = $this->lineupService->selectAIMentality(
-            $opponentReputation,
-            $opponentIsHome,
-            (float) $teamAverage,
-            (float) $userTeamAverage
-        );
-
-        // Predict their tactical instructions
-        [$predictedStyle, $predictedPressing, $predictedDefLine] = $this->lineupService->selectAIInstructions(
-            $opponentReputation,
-            $opponentIsHome,
-            (float) $teamAverage,
-            (float) $userTeamAverage
-        );
-
-        // Get recent form (last 5 matches) via CalendarService
-        $form = $this->calendarService->getTeamForm($gameId, $opponentTeamId);
-
-        return [
-            'teamAverage' => $teamAverage,
-            'form' => $form,
-            'formation' => $predictedFormation->value,
-            'mentality' => $predictedMentality->value,
-            'playingStyle' => $predictedStyle->value,
-            'pressing' => $predictedPressing->value,
-            'defensiveLine' => $predictedDefLine->value,
-            'bestXIPlayers' => $bestXI,
-        ];
     }
 
     /**

--- a/app/Modules/Lineup/Services/LineupService.php
+++ b/app/Modules/Lineup/Services/LineupService.php
@@ -9,9 +9,11 @@ use App\Modules\Lineup\Enums\PlayingStyle;
 use App\Modules\Lineup\Enums\PressingIntensity;
 use App\Models\Game;
 use App\Models\GameMatch;
-use App\Support\PositionMapper;
 use App\Models\GamePlayer;
 use App\Models\PlayerSuspension;
+use App\Models\TeamReputation;
+use App\Modules\Competition\Services\CalendarService;
+use App\Support\PositionMapper;
 use Carbon\Carbon;
 use Illuminate\Support\Collection;
 
@@ -19,6 +21,7 @@ class LineupService
 {
     public function __construct(
         private readonly FormationRecommender $formationRecommender,
+        private readonly CalendarService $calendarService,
     ) {}
 
     /**
@@ -335,7 +338,7 @@ class LineupService
         if ($isStronger && $isHome) {
             $style = $tier === 'cautious' ? PlayingStyle::BALANCED : PlayingStyle::POSSESSION;
         } elseif ($isWeaker && ! $isHome) {
-            $style = $tier === 'bold' ? PlayingStyle::COUNTER_ATTACK : PlayingStyle::COUNTER_ATTACK;
+            $style = PlayingStyle::COUNTER_ATTACK;
         } elseif ($isWeaker) {
             $style = PlayingStyle::COUNTER_ATTACK;
         } else {
@@ -829,5 +832,56 @@ class LineupService
         }
 
         return $lineup;
+    }
+
+    /**
+     * Predict opponent tactics for a match (formation, mentality, instructions).
+     *
+     * Used by both the lineup page and the dashboard next-match card.
+     *
+     * @return array{teamAverage: int, form: array, formation: string, mentality: string, playingStyle: string, pressing: string, defensiveLine: string, bestXIPlayers: Collection}
+     */
+    public function predictOpponentTactics(
+        string $gameId,
+        string $opponentTeamId,
+        Carbon $matchDate,
+        string $competitionId,
+        bool $opponentIsHome,
+        int $userTeamAverage,
+    ): array {
+        $availablePlayers = $this->getAvailablePlayers($gameId, $opponentTeamId, $matchDate, $competitionId);
+
+        $predictedFormation = $this->selectAIFormation($availablePlayers);
+
+        $bestXI = $this->selectBestXI($availablePlayers, $predictedFormation);
+        $teamAverage = $this->calculateTeamAverage($bestXI);
+
+        $opponentReputation = TeamReputation::resolveLevel($gameId, $opponentTeamId);
+        $predictedMentality = $this->selectAIMentality(
+            $opponentReputation,
+            $opponentIsHome,
+            $teamAverage,
+            $userTeamAverage
+        );
+
+        [$predictedStyle, $predictedPressing, $predictedDefLine] = $this->selectAIInstructions(
+            $opponentReputation,
+            $opponentIsHome,
+            $teamAverage,
+            $userTeamAverage
+        );
+
+        $form = $this->calendarService->getTeamForm($gameId, $opponentTeamId);
+
+        return [
+            'teamAverage' => $teamAverage,
+            'form' => $form,
+            'formation' => $predictedFormation->value,
+            'mentality' => $predictedMentality->value,
+            'playingStyle' => $predictedStyle->value,
+            'pressing' => $predictedPressing->value,
+            'defensiveLine' => $predictedDefLine->value,
+            'bestXIPlayers' => $bestXI,
+        ];
     }
 }

--- a/resources/views/lineup.blade.php
+++ b/resources/views/lineup.blade.php
@@ -410,6 +410,39 @@
                                 </div>
                             @endif
 
+                            {{-- Inline xG Preview (reactive) --}}
+                            <template x-if="xgPreview">
+                                <div class="mt-3 bg-surface-700/50 border border-border-strong rounded-lg p-3">
+                                    <div class="text-[10px] font-semibold text-text-secondary uppercase tracking-wide mb-2 text-center">{{ __('game.xg_preview') }}</div>
+                                    <div class="flex items-center justify-between gap-3">
+                                        <div class="flex-1 text-center">
+                                            <div class="text-2xl font-bold tabular-nums"
+                                                 :class="xgPreview.userXG > xgPreview.opponentXG ? 'text-accent-green' : (xgPreview.userXG < xgPreview.opponentXG ? 'text-accent-red' : 'text-text-primary')"
+                                                 x-text="xgPreview.userXG.toFixed(2)"></div>
+                                            <div class="text-[10px] text-text-muted mt-0.5">{{ __('game.xg_your_team') }}</div>
+                                        </div>
+                                        <div class="text-text-secondary text-xs font-medium shrink-0">xG</div>
+                                        <div class="flex-1 text-center">
+                                            <div class="text-2xl font-bold tabular-nums"
+                                                 :class="xgPreview.opponentXG > xgPreview.userXG ? 'text-accent-red' : (xgPreview.opponentXG < xgPreview.userXG ? 'text-accent-green' : 'text-text-primary')"
+                                                 x-text="xgPreview.opponentXG.toFixed(2)"></div>
+                                            <div class="text-[10px] text-text-muted mt-0.5">{{ __('game.xg_opponent') }}</div>
+                                        </div>
+                                    </div>
+                                    <div class="mt-2">
+                                        <div class="flex h-1.5 rounded-full overflow-hidden gap-0.5">
+                                            <div class="h-full rounded-l-full transition-all duration-300"
+                                                 :class="xgPreview.userXG >= xgPreview.opponentXG ? 'bg-accent-green' : 'bg-accent-red'"
+                                                 :style="'width: ' + ((xgPreview.userXG + xgPreview.opponentXG) > 0 ? (xgPreview.userXG / (xgPreview.userXG + xgPreview.opponentXG) * 100) : 50) + '%'"></div>
+                                            <div class="h-full rounded-r-full transition-all duration-300"
+                                                 :class="xgPreview.opponentXG >= xgPreview.userXG ? 'bg-accent-red' : 'bg-accent-green'"
+                                                 :style="'width: ' + ((xgPreview.userXG + xgPreview.opponentXG) > 0 ? (xgPreview.opponentXG / (xgPreview.userXG + xgPreview.opponentXG) * 100) : 50) + '%'"></div>
+                                        </div>
+                                    </div>
+                                    <p class="text-[10px] text-text-secondary mt-2 text-center leading-relaxed">{{ __('game.xg_explanation') }}</p>
+                                </div>
+                            </template>
+
                             <x-ghost-button type="button" @click="$dispatch('open-modal', 'coach-assistant')" size="xs" class="w-full mt-3">
                                 {{ __('squad.coach_full_report') }} &rarr;
                             </x-ghost-button>

--- a/resources/views/partials/lineup-coach-panel.blade.php
+++ b/resources/views/partials/lineup-coach-panel.blade.php
@@ -45,47 +45,6 @@
         </div>
     @endif
 
-    {{-- xG Preview --}}
-    <template x-if="xgPreview">
-        <div class="bg-surface-700/50 border border-border-strong rounded-lg p-3 mb-3">
-            <div class="text-[10px] font-semibold text-text-secondary uppercase tracking-wide mb-2 text-center">{{ __('game.xg_preview') }}</div>
-            <div class="flex items-center justify-between gap-3">
-                {{-- User xG --}}
-                <div class="flex-1 text-center">
-                    <div class="text-2xl font-bold tabular-nums"
-                         :class="xgPreview.userXG > xgPreview.opponentXG ? 'text-accent-green' : (xgPreview.userXG < xgPreview.opponentXG ? 'text-accent-red' : 'text-text-primary')"
-                         x-text="xgPreview.userXG.toFixed(2)"></div>
-                    <div class="text-[10px] text-text-muted mt-0.5">{{ __('game.xg_your_team') }}</div>
-                </div>
-
-                {{-- Divider --}}
-                <div class="text-text-secondary text-xs font-medium shrink-0">xG</div>
-
-                {{-- Opponent xG --}}
-                <div class="flex-1 text-center">
-                    <div class="text-2xl font-bold tabular-nums"
-                         :class="xgPreview.opponentXG > xgPreview.userXG ? 'text-accent-red' : (xgPreview.opponentXG < xgPreview.userXG ? 'text-accent-green' : 'text-text-primary')"
-                         x-text="xgPreview.opponentXG.toFixed(2)"></div>
-                    <div class="text-[10px] text-text-muted mt-0.5">{{ __('game.xg_opponent') }}</div>
-                </div>
-            </div>
-
-            {{-- xG Difference Bar --}}
-            <div class="mt-2">
-                <div class="flex h-1.5 rounded-full overflow-hidden gap-0.5">
-                    <div class="h-full rounded-l-full transition-all duration-300"
-                         :class="xgPreview.userXG >= xgPreview.opponentXG ? 'bg-accent-green' : 'bg-accent-red'"
-                         :style="'width: ' + (xgPreview.userXG / (xgPreview.userXG + xgPreview.opponentXG) * 100) + '%'"></div>
-                    <div class="h-full rounded-r-full transition-all duration-300"
-                         :class="xgPreview.opponentXG >= xgPreview.userXG ? 'bg-accent-red' : 'bg-accent-green'"
-                         :style="'width: ' + (xgPreview.opponentXG / (xgPreview.userXG + xgPreview.opponentXG) * 100) + '%'"></div>
-                </div>
-            </div>
-
-            <p class="text-[10px] text-text-secondary mt-2 text-center leading-relaxed">{{ __('game.xg_explanation') }}</p>
-        </div>
-    </template>
-
     {{-- Form (symmetrical) --}}
     <div class="flex items-center justify-between gap-2 mb-3">
         {{-- User Form --}}


### PR DESCRIPTION
Move xG preview widget from coach modal to inline lineup panel for better visibility. Extract opponent tactics prediction into reusable LineupService::predictOpponentTactics() method. Fix division-by-zero in xG bar, dead-code ternary in AI instructions, and remove passthrough wrapper method.