### PR TITLE
Fix player sanctions not applied across competitions

### DIFF
--- a/app/Modules/Lineup/Services/LineupService.php
+++ b/app/Modules/Lineup/Services/LineupService.php
@@ -547,10 +547,10 @@ class LineupService
      * AI teams get squad-fitted formations, reputation-driven mentality, and fitness rotation.
      *
      * @param Collection|null $allPlayersGrouped Pre-loaded players grouped by team_id (optional, for N+1 optimization)
-     * @param array $suspendedPlayerIds Array of player IDs who are suspended (optional, for N+1 optimization)
+     * @param array $suspendedByCompetition Map of competition_id => [player_ids] who are suspended (optional, for N+1 optimization)
      * @param Collection|null $clubProfiles Pre-loaded ClubProfiles keyed by team_id (optional, for AI mentality)
      */
-    public function ensureLineupsForMatches($matches, Game $game, $allPlayersGrouped = null, array $suspendedPlayerIds = [], $clubProfiles = null): void
+    public function ensureLineupsForMatches($matches, Game $game, $allPlayersGrouped = null, array $suspendedByCompetition = [], $clubProfiles = null): void
     {
         $tactics = $game->tactics;
         $playerFormation = $tactics?->default_formation
@@ -565,6 +565,7 @@ class LineupService
         foreach ($matches as $match) {
             $matchDate = $match->scheduled_date;
             $competitionId = $match->competition_id;
+            $suspendedPlayerIds = $suspendedByCompetition[$competitionId] ?? [];
 
             $this->ensureTeamLineup(
                 $match,

--- a/app/Modules/Match/Services/MatchResultProcessor.php
+++ b/app/Modules/Match/Services/MatchResultProcessor.php
@@ -78,7 +78,7 @@ class MatchResultProcessor
                 $preLoadedPlayerIds = array_values(array_diff($preLoadedPlayerIds, $deferredPlayerIds));
             }
         }
-        $this->batchServeSuspensions($matches, $matchResults, $preLoadedPlayerIds);
+        $this->batchServeSuspensions($matches, $matchResults, $preLoadedPlayerIds, $allPlayers);
 
         // 4. Bulk insert all match events across all matches
         $this->bulkInsertMatchEvents($gameId, $matchResults);
@@ -174,13 +174,14 @@ class MatchResultProcessor
 
     /**
      * Serve suspensions for all matches in the batch.
-     * Decrements matches_remaining for suspended players on teams that played.
+     * Decrements matches_remaining for suspended players whose team actually
+     * played a match in the competition the suspension belongs to.
      *
      * @param  array  $preLoadedPlayerIds  Eligible player IDs (deferred match teams already excluded by caller)
+     * @param  \Illuminate\Support\Collection|null  $allPlayers  Players grouped by team_id (for team lookup)
      */
-    private function batchServeSuspensions($matches, array $matchResults, array $preLoadedPlayerIds): void
+    private function batchServeSuspensions($matches, array $matchResults, array $preLoadedPlayerIds, $allPlayers = null): void
     {
-        // Group matches by competition
         $competitionIds = [];
         foreach ($matchResults as $result) {
             $competitionIds[$result['competitionId']] = true;
@@ -190,12 +191,58 @@ class MatchResultProcessor
             return;
         }
 
-        // Use direct whereIn on pre-loaded player IDs instead of whereHas subquery
-        $suspensionIds = PlayerSuspension::whereIn('competition_id', array_keys($competitionIds))
+        // Build a map of which competitions each team played in this batch.
+        // Uses match result data (homeTeamId/awayTeamId) when available,
+        // falls back to the GameMatch models for backward compatibility.
+        $teamCompetitions = []; // [team_id => [competition_id => true]]
+        foreach ($matchResults as $result) {
+            $homeTeamId = $result['homeTeamId'] ?? null;
+            $awayTeamId = $result['awayTeamId'] ?? null;
+
+            if (! $homeTeamId || ! $awayTeamId) {
+                $match = $matches->get($result['matchId']);
+                $homeTeamId = $homeTeamId ?? $match?->home_team_id;
+                $awayTeamId = $awayTeamId ?? $match?->away_team_id;
+            }
+
+            if ($homeTeamId) {
+                $teamCompetitions[$homeTeamId][$result['competitionId']] = true;
+            }
+            if ($awayTeamId) {
+                $teamCompetitions[$awayTeamId][$result['competitionId']] = true;
+            }
+        }
+
+        // Build player → team mapping from pre-loaded data
+        $playerTeamMap = []; // [player_id => team_id]
+        if ($allPlayers) {
+            foreach ($allPlayers as $teamId => $teamPlayers) {
+                foreach ($teamPlayers as $player) {
+                    if (in_array($player->id, $preLoadedPlayerIds)) {
+                        $playerTeamMap[$player->id] = $teamId;
+                    }
+                }
+            }
+        }
+
+        // Load suspensions with player and competition info for filtering
+        $suspensions = PlayerSuspension::whereIn('competition_id', array_keys($competitionIds))
             ->where('matches_remaining', '>', 0)
             ->whereIn('game_player_id', $preLoadedPlayerIds)
-            ->pluck('id')
-            ->all();
+            ->get(['id', 'game_player_id', 'competition_id']);
+
+        // Filter: only serve if the player's team played in this specific competition.
+        // When team mapping is unavailable, fall back to serving (preserving old behavior).
+        $suspensionIds = [];
+        foreach ($suspensions as $suspension) {
+            $teamId = $playerTeamMap[$suspension->game_player_id] ?? null;
+            if (! $teamId || empty($teamCompetitions)) {
+                // Fallback: no team data available, serve as before
+                $suspensionIds[] = $suspension->id;
+            } elseif (isset($teamCompetitions[$teamId][$suspension->competition_id])) {
+                $suspensionIds[] = $suspension->id;
+            }
+        }
 
         if (! empty($suspensionIds)) {
             PlayerSuspension::whereIn('id', $suspensionIds)->decrement('matches_remaining');

--- a/app/Modules/Match/Services/MatchdayOrchestrator.php
+++ b/app/Modules/Match/Services/MatchdayOrchestrator.php
@@ -181,16 +181,18 @@ class MatchdayOrchestrator
         $allPlayers = $allPlayers->groupBy('team_id');
 
         $competitionIds = $matches->pluck('competition_id')->unique()->toArray();
-        $suspendedPlayerIds = PlayerSuspension::whereIn('competition_id', $competitionIds)
+        $suspendedByCompetition = PlayerSuspension::whereIn('competition_id', $competitionIds)
             ->where('matches_remaining', '>', 0)
-            ->pluck('game_player_id')
+            ->get(['game_player_id', 'competition_id'])
+            ->groupBy('competition_id')
+            ->map(fn ($group) => $group->pluck('game_player_id')->toArray())
             ->toArray();
 
         $clubProfiles = TeamReputation::where('game_id', $game->id)
             ->whereIn('team_id', $teamIds)->get()->keyBy('team_id');
 
         // --- Ensure lineups ---
-        $this->lineupService->ensureLineupsForMatches($matches, $game, $allPlayers, $suspendedPlayerIds, $clubProfiles);
+        $this->lineupService->ensureLineupsForMatches($matches, $game, $allPlayers, $suspendedByCompetition, $clubProfiles);
 
         // --- Check for forfeit (user's team has < 7 available players) ---
         // $playerMatch was already resolved above (line 158) — reuse it after filtering

--- a/tests/Feature/SuspensionDeferralTest.php
+++ b/tests/Feature/SuspensionDeferralTest.php
@@ -414,6 +414,137 @@ class SuspensionDeferralTest extends TestCase
         );
     }
 
+    public function test_cross_competition_suspension_not_served_when_team_plays_different_competition(): void
+    {
+        // Setup: two competitions on the same date
+        $copa = Competition::factory()->knockoutCup()->create([
+            'id' => 'ESPCUP',
+            'name' => 'Copa del Rey',
+        ]);
+
+        $this->createSquad($this->playerTeam);
+        $this->createSquad($this->opponentTeam);
+
+        $aiTeamA = Team::factory()->create(['name' => 'AI Team A']);
+        $aiTeamB = Team::factory()->create(['name' => 'AI Team B']);
+        $this->createSquad($aiTeamA);
+        $this->createSquad($aiTeamB);
+
+        // AI Team A has a Copa suspension
+        $suspendedPlayer = GamePlayer::where('game_id', $this->game->id)
+            ->where('team_id', $aiTeamA->id)
+            ->where('position', 'Centre-Forward')
+            ->first();
+
+        PlayerSuspension::create([
+            'game_player_id' => $suspendedPlayer->id,
+            'competition_id' => $copa->id,
+            'matches_remaining' => 1,
+            'yellow_cards' => 3,
+        ]);
+
+        // La Liga match: player's team vs AI Team A
+        GameMatch::factory()->create([
+            'game_id' => $this->game->id,
+            'competition_id' => $this->competition->id,
+            'round_number' => 1,
+            'home_team_id' => $this->playerTeam->id,
+            'away_team_id' => $aiTeamA->id,
+            'scheduled_date' => Carbon::parse('2024-08-16'),
+        ]);
+
+        // Copa match on the same date: AI Team B vs opponent (AI Team A NOT playing Copa)
+        $aiTeamB->competitions()->attach($copa->id, ['season' => '2024']);
+        $this->opponentTeam->competitions()->attach($copa->id, ['season' => '2024']);
+
+        GameMatch::factory()->create([
+            'game_id' => $this->game->id,
+            'competition_id' => $copa->id,
+            'round_number' => 1,
+            'home_team_id' => $aiTeamB->id,
+            'away_team_id' => $this->opponentTeam->id,
+            'scheduled_date' => Carbon::parse('2024-08-16'),
+        ]);
+
+        $this->createStandings();
+
+        // Advance matchday
+        $action = app(AdvanceMatchday::class);
+        $action($this->game->id);
+
+        // Finalize
+        $this->game->refresh();
+        if ($this->game->pending_finalization_match_id) {
+            $match = GameMatch::find($this->game->pending_finalization_match_id);
+            app(MatchFinalizationService::class)->finalize($match, $this->game);
+        }
+
+        // AI Team A's Copa suspension should NOT have been served
+        // (they played La Liga, not Copa)
+        $suspension = PlayerSuspension::where('game_player_id', $suspendedPlayer->id)
+            ->where('competition_id', $copa->id)
+            ->first();
+
+        $this->assertNotNull($suspension);
+        $this->assertEquals(
+            1,
+            $suspension->matches_remaining,
+            'Copa suspension should NOT be served when the team only played a La Liga match'
+        );
+    }
+
+    public function test_same_competition_suspension_is_served(): void
+    {
+        $this->createSquad($this->playerTeam);
+        $this->createSquad($this->opponentTeam);
+
+        // Player team has a La Liga suspension
+        $suspendedPlayer = GamePlayer::factory()
+            ->forGame($this->game)
+            ->forTeam($this->opponentTeam)
+            ->create(['position' => 'Right Winger']);
+
+        PlayerSuspension::create([
+            'game_player_id' => $suspendedPlayer->id,
+            'competition_id' => $this->competition->id,
+            'matches_remaining' => 1,
+            'yellow_cards' => 5,
+        ]);
+
+        // La Liga match
+        GameMatch::factory()->create([
+            'game_id' => $this->game->id,
+            'competition_id' => $this->competition->id,
+            'round_number' => 1,
+            'home_team_id' => $this->playerTeam->id,
+            'away_team_id' => $this->opponentTeam->id,
+            'scheduled_date' => Carbon::parse('2024-08-16'),
+        ]);
+
+        $this->createStandings();
+
+        // Advance matchday
+        $action = app(AdvanceMatchday::class);
+        $action($this->game->id);
+
+        // Finalize
+        $this->game->refresh();
+        $match = GameMatch::find($this->game->pending_finalization_match_id);
+        app(MatchFinalizationService::class)->finalize($match, $this->game);
+
+        // La Liga suspension SHOULD be served (team played La Liga)
+        $suspension = PlayerSuspension::where('game_player_id', $suspendedPlayer->id)
+            ->where('competition_id', $this->competition->id)
+            ->first();
+
+        $this->assertNotNull($suspension);
+        $this->assertEquals(
+            0,
+            $suspension->matches_remaining,
+            'La Liga suspension should be served when team played a La Liga match'
+        );
+    }
+
     private function createStandings(): void
     {
         foreach ([$this->playerTeam, $this->opponentTeam] as $team) {


### PR DESCRIPTION
batchServeSuspensions was serving suspensions for all players in the
batch regardless of whether their team actually played in the competition
they were suspended in. When a batch contained matches from multiple
competitions (e.g. La Liga + Copa del Rey on the same date), a player's
Copa suspension could be consumed when their team only played La Liga.

Also fix ensureLineupsForMatches which pooled suspended player IDs across
all competitions, over-restrictively excluding players from lineups in
competitions where they weren't suspended.

Changes:
- batchServeSuspensions now builds a team→competitions map and only
  serves suspensions when the player's team played in that competition
- MatchdayOrchestrator passes competition-scoped suspension data instead
  of a flat array
- ensureLineupsForMatches resolves suspension IDs per match competition
- Add tests for cross-competition suspension isolation

https://claude.ai/code/session_01WNCmLnupFXYas35p4zoVbv