### PR TITLE
Remove formation and mentality stats from game stats dashboard

### DIFF
--- a/app/Http/Views/AdminGameStats.php
+++ b/app/Http/Views/AdminGameStats.php
@@ -11,8 +11,6 @@ class AdminGameStats
     {
         return view('admin.game-stats', [
             'teamPopularity' => $stats->getTeamPopularity(),
-            'formations' => $stats->getFormationPreferences(),
-            'mentalities' => $stats->getMentalityDistribution(),
             'seasonProgress' => $stats->getSeasonProgress(),
         ]);
     }

--- a/app/Modules/Analytics/Services/GameStatsService.php
+++ b/app/Modules/Analytics/Services/GameStatsService.php
@@ -18,40 +18,6 @@ class GameStatsService
             ->get();
     }
 
-    public function getFormationPreferences(): Collection
-    {
-        $caseExpr = "CASE
-                    WHEN games.team_id = game_matches.home_team_id THEN game_matches.home_formation
-                    WHEN games.team_id = game_matches.away_team_id THEN game_matches.away_formation
-                END";
-
-        return DB::table('game_matches')
-            ->join('games', 'game_matches.game_id', '=', 'games.id')
-            ->where('game_matches.played', true)
-            ->selectRaw("{$caseExpr} as formation, COUNT(*) as usage_count")
-            ->groupByRaw($caseExpr)
-            ->havingRaw("{$caseExpr} IS NOT NULL")
-            ->orderByDesc('usage_count')
-            ->get();
-    }
-
-    public function getMentalityDistribution(): Collection
-    {
-        $caseExpr = "CASE
-                    WHEN games.team_id = game_matches.home_team_id THEN game_matches.home_mentality
-                    WHEN games.team_id = game_matches.away_team_id THEN game_matches.away_mentality
-                END";
-
-        return DB::table('game_matches')
-            ->join('games', 'game_matches.game_id', '=', 'games.id')
-            ->where('game_matches.played', true)
-            ->selectRaw("{$caseExpr} as mentality, COUNT(*) as usage_count")
-            ->groupByRaw($caseExpr)
-            ->havingRaw("{$caseExpr} IS NOT NULL")
-            ->orderByDesc('usage_count')
-            ->get();
-    }
-
     public function getSeasonProgress(): Collection
     {
         return Game::selectRaw('season, COUNT(*) as count')

--- a/lang/en/admin.php
+++ b/lang/en/admin.php
@@ -98,8 +98,6 @@ return [
     'game_stats_title' => 'Game Stats',
     'game_stats_description' => 'Explore how players use the game',
     'team_popularity' => 'Team Popularity',
-    'formation_preferences' => 'Formation Preferences',
-    'mentality_distribution' => 'Mentality Distribution',
     'season_progress' => 'Season Progress',
     'no_data' => 'No data yet',
 

--- a/lang/es/admin.php
+++ b/lang/es/admin.php
@@ -98,8 +98,6 @@ return [
     'game_stats_title' => 'Estadísticas del Juego',
     'game_stats_description' => 'Descubre cómo juegan los usuarios',
     'team_popularity' => 'Popularidad de Equipos',
-    'formation_preferences' => 'Formaciones Preferidas',
-    'mentality_distribution' => 'Distribución de Mentalidad',
     'season_progress' => 'Progreso de Temporadas',
     'no_data' => 'Sin datos aún',
 

--- a/resources/views/admin/game-stats.blade.php
+++ b/resources/views/admin/game-stats.blade.php
@@ -3,7 +3,7 @@
         {{ __('admin.game_stats_title') }}
     </h1>
 
-    <div class="grid grid-cols-1 lg:grid-cols-2 gap-4 mb-4">
+    <div class="grid grid-cols-1 gap-4 mb-4">
         {{-- Team Popularity --}}
         <div class="bg-surface-800 border border-border-default rounded-xl p-5">
             <h2 class="font-heading text-sm font-bold uppercase tracking-wider text-text-primary mb-4">
@@ -32,72 +32,6 @@
                     @endforeach
                 </div>
             @endif
-        </div>
-
-        {{-- Formation & Mentality --}}
-        <div class="space-y-4">
-            {{-- Formation Preferences --}}
-            <div class="bg-surface-800 border border-border-default rounded-xl p-5">
-                <h2 class="font-heading text-sm font-bold uppercase tracking-wider text-text-primary mb-4">
-                    {{ __('admin.formation_preferences') }}
-                </h2>
-
-                @if($formations->isEmpty())
-                    <p class="text-sm text-text-muted">{{ __('admin.no_data') }}</p>
-                @else
-                    @php
-                        $maxFormation = $formations->max('usage_count');
-                        $totalFormation = $formations->sum('usage_count');
-                    @endphp
-                    <div class="space-y-2">
-                        @foreach($formations as $entry)
-                            <div class="flex items-center gap-3">
-                                <span class="text-sm text-text-primary w-16 shrink-0 font-mono">{{ $entry->formation }}</span>
-                                <div class="flex-1 h-5 bg-surface-700 rounded-sm overflow-hidden">
-                                    <div class="h-full bg-accent-blue/60 rounded-sm" style="width: {{ ($entry->usage_count / $maxFormation) * 100 }}%"></div>
-                                </div>
-                                <span class="text-xs text-text-muted shrink-0 w-12 text-right">{{ round(($entry->usage_count / $totalFormation) * 100) }}%</span>
-                            </div>
-                        @endforeach
-                    </div>
-                @endif
-            </div>
-
-            {{-- Mentality Distribution --}}
-            <div class="bg-surface-800 border border-border-default rounded-xl p-5">
-                <h2 class="font-heading text-sm font-bold uppercase tracking-wider text-text-primary mb-4">
-                    {{ __('admin.mentality_distribution') }}
-                </h2>
-
-                @if($mentalities->isEmpty())
-                    <p class="text-sm text-text-muted">{{ __('admin.no_data') }}</p>
-                @else
-                    @php
-                        $totalMentality = $mentalities->sum('usage_count');
-                        $mentalityColors = [
-                            'defensive' => 'bg-accent-blue/60',
-                            'balanced'  => 'bg-accent-gold/60',
-                            'attacking' => 'bg-accent-red/60',
-                        ];
-                        $mentalityLabels = [
-                            'defensive' => __('game.mentality_defensive'),
-                            'balanced'  => __('game.mentality_balanced'),
-                            'attacking' => __('game.mentality_attacking'),
-                        ];
-                    @endphp
-                    <div class="space-y-2">
-                        @foreach($mentalities as $entry)
-                            <div class="flex items-center gap-3">
-                                <span class="text-sm text-text-primary w-20 shrink-0">{{ $mentalityLabels[$entry->mentality] ?? ucfirst($entry->mentality) }}</span>
-                                <div class="flex-1 h-5 bg-surface-700 rounded-sm overflow-hidden">
-                                    <div class="h-full {{ $mentalityColors[$entry->mentality] ?? 'bg-accent-primary/60' }} rounded-sm" style="width: {{ ($entry->usage_count / $totalMentality) * 100 }}%"></div>
-                                </div>
-                                <span class="text-xs text-text-muted shrink-0 w-12 text-right">{{ round(($entry->usage_count / $totalMentality) * 100) }}%</span>
-                            </div>
-                        @endforeach
-                    </div>
-                @endif
-            </div>
         </div>
     </div>
 


### PR DESCRIPTION
## Summary
This PR removes the Formation Preferences and Mentality Distribution statistics sections from the admin game stats dashboard. These features are being deprecated as part of a dashboard simplification effort.

## Changes Made
- **View**: Removed the Formation & Mentality grid section from `admin/game-stats.blade.php`
  - Changed grid layout from 2-column to single-column
  - Deleted Formation Preferences card and its bar chart visualization
  - Deleted Mentality Distribution card and its color-coded bar chart visualization

- **Service**: Removed data retrieval methods from `GameStatsService`
  - Deleted `getFormationPreferences()` method
  - Deleted `getMentalityDistribution()` method

- **Controller**: Updated `AdminGameStats` view composer to remove data passing
  - Removed `formations` data binding
  - Removed `mentalities` data binding

- **Translations**: Cleaned up language files (English and Spanish)
  - Removed `formation_preferences` translation key
  - Removed `mentality_distribution` translation key

## Implementation Details
The removal is clean with no orphaned code or dependencies. The Team Popularity and Season Progress sections remain intact and functional. The grid layout automatically adjusts to single-column display without the Formation & Mentality section.

https://claude.ai/code/session_01UQFfEjJHBtnewJeeyoqgk8