### PR TITLE
Fix invite code access grant: career invites now grant tournament access

### DIFF
--- a/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -67,7 +67,7 @@ class RegisteredUserController extends Controller
             'name' => $request->name,
             'email' => $request->email,
             'password' => Hash::make($request->password),
-            'has_career_access' => true,
+            'has_tournament_access' => true,
         ]);
 
         $invite->consume();

--- a/tests/Feature/Auth/ActivationTest.php
+++ b/tests/Feature/Auth/ActivationTest.php
@@ -178,7 +178,7 @@ class ActivationTest extends TestCase
 
         $user = User::where('email', 'invited@example.com')->first();
         $this->assertNotNull($user->email_verified_at);
-        $this->assertTrue($user->has_career_access);
+        $this->assertTrue($user->has_tournament_access);
     }
 
     // --- Forgot password sends correct notification per state ---

--- a/tests/Feature/Auth/RegistrationTest.php
+++ b/tests/Feature/Auth/RegistrationTest.php
@@ -106,8 +106,8 @@ class RegistrationTest extends TestCase
         ]);
         $this->assertDatabaseHas('users', [
             'email' => 'beta@example.com',
-            'has_career_access' => true,
-            'has_tournament_access' => false,
+            'has_career_access' => false,
+            'has_tournament_access' => true,
         ]);
     }
 
@@ -163,7 +163,7 @@ class RegistrationTest extends TestCase
         ]);
     }
 
-    public function test_registration_with_valid_invite_grants_career_access(): void
+    public function test_registration_with_valid_invite_grants_tournament_access(): void
     {
         Notification::fake();
         config()->set('beta.enabled', false);
@@ -187,8 +187,8 @@ class RegistrationTest extends TestCase
         $response->assertRedirect(route('dashboard'));
         $this->assertDatabaseHas('users', [
             'email' => 'beta@example.com',
-            'has_career_access' => true,
-            'has_tournament_access' => false,
+            'has_career_access' => false,
+            'has_tournament_access' => true,
         ]);
         $this->assertDatabaseHas('invite_codes', [
             'code' => 'CAREER-INVITE',


### PR DESCRIPTION
## Summary
This PR corrects the access permission logic for invite code registration. Career mode invites were incorrectly granting `has_career_access` when they should grant `has_tournament_access` instead.

## Key Changes
- **RegisteredUserController**: Updated `storeCareerModeRegistration()` to set `has_tournament_access` instead of `has_career_access` when processing invite codes
- **RegistrationTest**: Updated test assertions to verify that beta users and invited users receive `has_tournament_access = true` and `has_career_access = false`
- **ActivationTest**: Updated assertion to verify `has_tournament_access` is set during career mode registration
- **Test naming**: Renamed `test_registration_with_valid_invite_grants_career_access()` to `test_registration_with_valid_invite_grants_tournament_access()` to accurately reflect the expected behavior

## Implementation Details
The changes ensure that when users register with a valid invite code (specifically career/tournament invites), they receive the correct feature access flag. This appears to be a correction of inverted logic where the wrong access type was being granted.

https://claude.ai/code/session_01A3K3nbQfQm8nSsJfXg9kLD