### PR TITLE
Fix goalkeeper injuries being too frequent and out-of-position GK having no match impact

### DIFF
--- a/app/Modules/Match/Services/MatchSimulator.php
+++ b/app/Modules/Match/Services/MatchSimulator.php
@@ -408,6 +408,27 @@ class MatchSimulator
     }
 
     /**
+     * Calculate opponent xG multiplier based on goalkeeper quality.
+     *
+     * Returns a multiplier >= 1.0 applied to the OPPONENT's expected goals.
+     * A natural goalkeeper returns 1.0 (no change). A team with no natural
+     * goalkeeper (e.g. a centre-back in goal) returns a penalty multiplier
+     * that increases the opponent's scoring chances.
+     */
+    private function calculateGoalkeeperModifier(Collection $lineup): float
+    {
+        $hasNaturalGK = $lineup->contains(fn ($player) => $player->position === 'Goalkeeper');
+
+        if ($hasNaturalGK) {
+            return 1.0;
+        }
+
+        $penalty = config('match_simulation.goalkeeper.missing_gk_xg_penalty', 0.25);
+
+        return 1.0 + $penalty;
+    }
+
+    /**
      * Get the highest physical ability among forward players in a lineup.
      * Used to check if opponent forwards can nullify a high defensive line.
      */
@@ -808,6 +829,10 @@ class MatchSimulator
         $homeExpectedGoals += $this->calculateStrikerBonus($homePlayers) * $matchFraction;
         $awayExpectedGoals += $this->calculateStrikerBonus($awayPlayers) * $matchFraction;
 
+        // Goalkeeper quality: missing/out-of-position GK increases opponent xG
+        $awayExpectedGoals *= $this->calculateGoalkeeperModifier($homePlayers);
+        $homeExpectedGoals *= $this->calculateGoalkeeperModifier($awayPlayers);
+
         $homeScore = $this->poissonRandom($homeExpectedGoals);
         $awayScore = $this->poissonRandom($awayExpectedGoals);
 
@@ -895,6 +920,9 @@ class MatchSimulator
 
                 $homeExpectedGoals += $this->calculateStrikerBonus($homePlayers) * $matchFraction;
                 $awayExpectedGoals += $this->calculateStrikerBonus($awayPlayers) * $matchFraction;
+
+                $awayExpectedGoals *= $this->calculateGoalkeeperModifier($homePlayers);
+                $homeExpectedGoals *= $this->calculateGoalkeeperModifier($awayPlayers);
 
                 $homeScore = $this->poissonRandom($homeExpectedGoals);
                 $awayScore = $this->poissonRandom($awayExpectedGoals);
@@ -1033,6 +1061,9 @@ class MatchSimulator
         $homeXG1 += $this->calculateStrikerBonus($homePlayers) * $fraction1;
         $awayXG1 += $this->calculateStrikerBonus($awayPlayers) * $fraction1;
 
+        $awayXG1 *= $this->calculateGoalkeeperModifier($homePlayers);
+        $homeXG1 *= $this->calculateGoalkeeperModifier($awayPlayers);
+
         $homeScore1 = $this->poissonRandom($homeXG1);
         $awayScore1 = $this->poissonRandom($awayXG1);
 
@@ -1091,6 +1122,9 @@ class MatchSimulator
 
         $homeXG2 += $this->calculateStrikerBonus($homePlayers2) * $fraction2;
         $awayXG2 += $this->calculateStrikerBonus($awayPlayers2) * $fraction2;
+
+        $awayXG2 *= $this->calculateGoalkeeperModifier($homePlayers2);
+        $homeXG2 *= $this->calculateGoalkeeperModifier($awayPlayers2);
 
         $homeScore2 = $this->poissonRandom($homeXG2);
         $awayScore2 = $this->poissonRandom($awayXG2);
@@ -1475,6 +1509,10 @@ class MatchSimulator
             $etEffectiveMinute,
             $homePlayers, $awayPlayers,
         );
+
+        // Goalkeeper quality
+        $awayExpectedGoals *= $this->calculateGoalkeeperModifier($homePlayers);
+        $homeExpectedGoals *= $this->calculateGoalkeeperModifier($awayPlayers);
 
         $homeScore = $this->poissonRandom($homeExpectedGoals);
         $awayScore = $this->poissonRandom($awayExpectedGoals);

--- a/app/Modules/Player/Services/InjuryService.php
+++ b/app/Modules/Player/Services/InjuryService.php
@@ -23,6 +23,14 @@ class InjuryService
     private const TRAINING_INJURY_CHANCE = 1.05;
 
     /**
+     * Goalkeepers face far fewer physical duels and run significantly less
+     * than outfield players, so their injury risk is much lower.
+     */
+    private const GK_MATCH_INJURY_MULTIPLIER = 0.3;
+
+    private const GK_TRAINING_INJURY_MULTIPLIER = 0.5;
+
+    /**
      * Medical tier multipliers for injury prevention.
      * Higher tier = lower injury chance.
      */
@@ -73,12 +81,12 @@ class InjuryService
         // Minor (1-2 weeks) - Very common
         'Muscle fatigue' => [
             'weeks' => [1, 1],
-            'positions' => ['MF', 'FW', 'DF'],
+            'positions' => ['MF', 'FW', 'DF', 'GK'],
             'weight' => 30,
         ],
         'Muscle strain' => [
             'weeks' => [1, 2],
-            'positions' => ['MF', 'FW', 'DF'],
+            'positions' => ['MF', 'FW', 'DF', 'GK'],
             'weight' => 25,
         ],
         // Medium (2-4 weeks) - Common
@@ -89,7 +97,7 @@ class InjuryService
         ],
         'Ankle sprain' => [
             'weeks' => [2, 4],
-            'positions' => ['MF', 'DF', 'FW'],
+            'positions' => ['MF', 'DF', 'FW', 'GK'],
             'weight' => 16,
         ],
         'Groin strain' => [
@@ -180,13 +188,19 @@ class InjuryService
         $congestionMultiplier = $this->getCongestionMultiplier($lastMatchDate, $currentMatchDate);
         $medicalMultiplier = $this->getMedicalInjuryMultiplier($game);
 
+        // Goalkeepers face much lower injury risk
+        $positionMultiplier = $this->getPositionGroup($player->position) === 'GK'
+            ? self::GK_MATCH_INJURY_MULTIPLIER
+            : 1.0;
+
         // Calculate final probability
         $finalProbability = $baseProbability
             * $durabilityMultiplier
             * $ageMultiplier
             * $fitnessMultiplier
             * $congestionMultiplier
-            * $medicalMultiplier;
+            * $medicalMultiplier
+            * $positionMultiplier;
 
         // Cap at reasonable maximum
         return min($finalProbability, 35.0);
@@ -225,6 +239,7 @@ class InjuryService
 
     /**
      * Select an injury type based on player's position.
+     * Only injury types that include the player's position group are eligible.
      */
     private function selectInjuryType(GamePlayer $player): string
     {
@@ -232,14 +247,9 @@ class InjuryService
         $weightedTypes = [];
 
         foreach (self::INJURY_TYPES as $type => $config) {
-            $weight = $config['weight'];
-
-            // Increase weight if this injury is common for the player's position
             if (in_array($positionGroup, $config['positions'])) {
-                $weight *= 2;
+                $weightedTypes[$type] = $config['weight'];
             }
-
-            $weightedTypes[$type] = $weight;
         }
 
         return $this->weightedRandomSelect($weightedTypes);
@@ -484,11 +494,16 @@ class InjuryService
         $fitnessMultiplier = $this->getFitnessMultiplier($player->fitness);
         $medicalMultiplier = $this->getMedicalInjuryMultiplier($game);
 
+        $positionMultiplier = $this->getPositionGroup($player->position) === 'GK'
+            ? self::GK_TRAINING_INJURY_MULTIPLIER
+            : 1.0;
+
         $finalProbability = $baseProbability
             * $durabilityMultiplier
             * $ageMultiplier
             * $fitnessMultiplier
-            * $medicalMultiplier;
+            * $medicalMultiplier
+            * $positionMultiplier;
 
         return min($finalProbability, 25.0);
     }
@@ -511,7 +526,10 @@ class InjuryService
      */
     private function generateTrainingInjury(GamePlayer $player, ?Game $game = null): array
     {
-        $injuryType = $this->weightedRandomSelect(self::TRAINING_INJURY_WEIGHTS);
+        $weights = $this->getTrainingInjuryWeightsForPosition(
+            $this->getPositionGroup($player->position)
+        );
+        $injuryType = $this->weightedRandomSelect($weights);
         $weeksOut = $this->calculateInjuryDuration($injuryType, $player, $game);
 
         return [
@@ -519,6 +537,23 @@ class InjuryService
             'type' => $injuryType,
             'weeks' => $weeksOut,
         ];
+    }
+
+    /**
+     * Filter training injury weights to only include types matching the player's position.
+     */
+    private function getTrainingInjuryWeightsForPosition(string $positionGroup): array
+    {
+        $filtered = [];
+
+        foreach (self::TRAINING_INJURY_WEIGHTS as $type => $weight) {
+            if (isset(self::INJURY_TYPES[$type]) && in_array($positionGroup, self::INJURY_TYPES[$type]['positions'])) {
+                $filtered[$type] = $weight;
+            }
+        }
+
+        // Fallback to all training weights if nothing matches (shouldn't happen)
+        return $filtered ?: self::TRAINING_INJURY_WEIGHTS;
     }
 
     /**

--- a/config/match_simulation.php
+++ b/config/match_simulation.php
@@ -332,4 +332,18 @@ return [
         'defense_modifier' => 1.15,     // 15% boost in opponent xG when facing 10 men
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Goalkeeper Quality
+    |--------------------------------------------------------------------------
+    |
+    | When a team has no natural goalkeeper in their lineup (e.g. an outfield
+    | player in the GK slot), the opponent's xG is increased. This reflects
+    | the massive defensive disadvantage of playing without a proper keeper.
+    |
+    */
+    'goalkeeper' => [
+        'missing_gk_xg_penalty' => 0.25,   // opponent xG multiplied by (1 + this) when no natural GK
+    ],
+
 ];


### PR DESCRIPTION
Injury system changes:
- Add 0.3x match / 0.5x training injury multiplier for goalkeepers
- Filter injury types by position (GKs can only get muscle fatigue, muscle
  strain, ankle sprain, knee contusion)
- Filter training injury types by position as well

Match engine changes:
- Add calculateGoalkeeperModifier() that increases opponent xG by 25% when
  no natural goalkeeper is in the lineup
- Apply modifier in simulateRemainder, red card split, and extra time

https://claude.ai/code/session_01FUSzZYsm7oaKYVwDuQuW8J