### PR TITLE
Add granular access control for career and tournament modes

### DIFF
--- a/app/Http/Actions/JoinWaitlist.php
+++ b/app/Http/Actions/JoinWaitlist.php
@@ -14,6 +14,8 @@ class JoinWaitlist
         $validator = Validator::make($request->all(), [
             'name' => 'required|string|max:255',
             'email' => 'required|email:rfc,dns|max:255',
+            'wants_career' => 'sometimes|boolean',
+            'wants_tournament' => 'sometimes|boolean',
         ]);
 
         if ($validator->fails()) {
@@ -24,10 +26,17 @@ class JoinWaitlist
 
         $validated = $validator->validated();
         $validated['email'] = strtolower($validated['email']);
+        $validated['wants_career'] = $validated['wants_career'] ?? true;
+        $validated['wants_tournament'] = $validated['wants_tournament'] ?? true;
 
         $existing = WaitlistEntry::where('email', $validated['email'])->first();
 
         if ($existing) {
+            $existing->update([
+                'wants_career' => $validated['wants_career'],
+                'wants_tournament' => $validated['wants_tournament'],
+            ]);
+
             return response()->json([
                 'message' => __('waitlist.already_registered'),
             ], 200);

--- a/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -67,7 +67,8 @@ class RegisteredUserController extends Controller
             'name' => $request->name,
             'email' => $request->email,
             'password' => Hash::make($request->password),
-            'has_tournament_access' => true,
+            'has_career_access' => $invite->grants_career,
+            'has_tournament_access' => $invite->grants_tournament,
         ]);
 
         $invite->consume();

--- a/app/Models/InviteCode.php
+++ b/app/Models/InviteCode.php
@@ -13,6 +13,8 @@ use Illuminate\Database\Eloquent\Model;
  * @property bool $invite_sent
  * @property \Illuminate\Support\Carbon|null $invite_sent_at
  * @property \Illuminate\Support\Carbon|null $reminder_sent_at
+ * @property bool $grants_career
+ * @property bool $grants_tournament
  * @property \Illuminate\Support\Carbon|null $expires_at
  * @property \Illuminate\Support\Carbon|null $created_at
  * @property \Illuminate\Support\Carbon|null $updated_at
@@ -42,6 +44,8 @@ class InviteCode extends Model
         'invite_sent_at',
         'reminder_sent_at',
         'expires_at',
+        'grants_career',
+        'grants_tournament',
     ];
 
     protected function casts(): array
@@ -51,6 +55,8 @@ class InviteCode extends Model
             'invite_sent_at' => 'datetime',
             'reminder_sent_at' => 'datetime',
             'expires_at' => 'datetime',
+            'grants_career' => 'boolean',
+            'grants_tournament' => 'boolean',
             'max_uses' => 'integer',
             'times_used' => 'integer',
         ];

--- a/app/Models/WaitlistEntry.php
+++ b/app/Models/WaitlistEntry.php
@@ -9,6 +9,8 @@ use Illuminate\Database\Eloquent\Relations\HasOne;
  * @property int $id
  * @property string $name
  * @property string $email
+ * @property bool $wants_career
+ * @property bool $wants_tournament
  * @property \Illuminate\Support\Carbon|null $created_at
  * @property \Illuminate\Support\Carbon|null $updated_at
  * @property-read \App\Models\InviteCode|null $inviteCode
@@ -26,7 +28,15 @@ class WaitlistEntry extends Model
 {
     protected $table = 'waitlist';
 
-    protected $fillable = ['name', 'email'];
+    protected $fillable = ['name', 'email', 'wants_career', 'wants_tournament'];
+
+    protected function casts(): array
+    {
+        return [
+            'wants_career' => 'boolean',
+            'wants_tournament' => 'boolean',
+        ];
+    }
 
     public function setEmailAttribute(string $value): void
     {

--- a/app/Services/BetaInviteService.php
+++ b/app/Services/BetaInviteService.php
@@ -10,13 +10,19 @@ use Illuminate\Support\Str;
 
 class BetaInviteService
 {
-    public function invite(WaitlistEntry $entry, ?string $expiresAt = null): InviteCode
-    {
+    public function invite(
+        WaitlistEntry $entry,
+        ?string $expiresAt = null,
+        bool $grantsCareer = false,
+        bool $grantsTournament = true,
+    ): InviteCode {
         $invite = InviteCode::create([
             'code' => $this->generateCode(),
             'email' => strtolower($entry->email),
             'max_uses' => 1,
             'expires_at' => $expiresAt,
+            'grants_career' => $grantsCareer,
+            'grants_tournament' => $grantsTournament,
         ]);
 
         Mail::to($entry->email)->send(new BetaInvite($invite));

--- a/database/migrations/2026_03_27_000000_add_mode_columns_to_waitlist_table.php
+++ b/database/migrations/2026_03_27_000000_add_mode_columns_to_waitlist_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('waitlist', function (Blueprint $table) {
+            $table->boolean('wants_career')->default(true);
+            $table->boolean('wants_tournament')->default(true);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('waitlist', function (Blueprint $table) {
+            $table->dropColumn(['wants_career', 'wants_tournament']);
+        });
+    }
+};

--- a/database/migrations/2026_03_27_000001_add_grant_columns_to_invite_codes_table.php
+++ b/database/migrations/2026_03_27_000001_add_grant_columns_to_invite_codes_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('invite_codes', function (Blueprint $table) {
+            $table->boolean('grants_career')->default(false);
+            $table->boolean('grants_tournament')->default(true);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('invite_codes', function (Blueprint $table) {
+            $table->dropColumn(['grants_career', 'grants_tournament']);
+        });
+    }
+};

--- a/lang/en/admin.php
+++ b/lang/en/admin.php
@@ -91,6 +91,9 @@ return [
     'waitlist_bulk_invite_started' => 'Sending :count invitations in the background...',
     'waitlist_bulk_invite_confirm' => 'This will send up to 50 invitations. Continue?',
     'waitlist_no_pending' => 'No pending waitlist entries to invite.',
+    'waitlist_mode' => 'Mode',
+    'waitlist_mode_career' => 'Career',
+    'waitlist_mode_tournament' => 'Tournament',
     'search_waitlist_placeholder' => 'Search by name or email...',
 
     // Game stats

--- a/lang/es/admin.php
+++ b/lang/es/admin.php
@@ -91,6 +91,9 @@ return [
     'waitlist_bulk_invite_started' => 'Enviando :count invitaciones en segundo plano...',
     'waitlist_bulk_invite_confirm' => 'Se enviarán hasta 50 invitaciones. ¿Continuar?',
     'waitlist_no_pending' => 'No hay entradas pendientes en la lista de espera.',
+    'waitlist_mode' => 'Modo',
+    'waitlist_mode_career' => 'Carrera',
+    'waitlist_mode_tournament' => 'Torneo',
     'search_waitlist_placeholder' => 'Buscar por nombre o email...',
 
     // Game stats

--- a/resources/views/admin/waitlist.blade.php
+++ b/resources/views/admin/waitlist.blade.php
@@ -60,6 +60,7 @@
                 <tr>
                     <th class="px-4 py-3 text-left text-[10px] text-text-muted uppercase tracking-wider">{{ __('admin.user') }}</th>
                     <th class="px-4 py-3 text-left text-[10px] text-text-muted uppercase tracking-wider hidden md:table-cell">{{ __('admin.email') }}</th>
+                    <th class="px-4 py-3 text-left text-[10px] text-text-muted uppercase tracking-wider hidden md:table-cell">{{ __('admin.waitlist_mode') }}</th>
                     <th class="px-4 py-3 text-left text-[10px] text-text-muted uppercase tracking-wider">{{ __('admin.waitlist_status') }}</th>
                     <th class="px-4 py-3 text-left text-[10px] text-text-muted uppercase tracking-wider hidden md:table-cell">{{ __('admin.waitlist_signed_up') }}</th>
                     <th class="px-4 py-3 text-right text-[10px] text-text-muted uppercase tracking-wider">{{ __('admin.actions') }}</th>
@@ -73,6 +74,20 @@
                             <div class="text-xs text-text-muted md:hidden">{{ $entry->email }}</div>
                         </td>
                         <td class="px-4 py-3 text-sm text-text-muted hidden md:table-cell">{{ $entry->email }}</td>
+                        <td class="px-4 py-3 text-sm hidden md:table-cell">
+                            <div class="flex gap-1">
+                                @if($entry->wants_career)
+                                    <span class="inline-flex items-center rounded-full bg-accent-blue/10 px-2 py-0.5 text-[10px] font-medium text-accent-blue ring-1 ring-inset ring-accent-blue/20">
+                                        {{ __('admin.waitlist_mode_career') }}
+                                    </span>
+                                @endif
+                                @if($entry->wants_tournament)
+                                    <span class="inline-flex items-center rounded-full bg-accent-green/10 px-2 py-0.5 text-[10px] font-medium text-accent-green ring-1 ring-inset ring-accent-green/20">
+                                        {{ __('admin.waitlist_mode_tournament') }}
+                                    </span>
+                                @endif
+                            </div>
+                        </td>
                         <td class="px-4 py-3 text-sm">
                             @if(! $entry->inviteCode)
                                 <span class="inline-flex items-center rounded-full bg-accent-gold/10 px-2 py-0.5 text-xs font-medium text-accent-gold ring-1 ring-inset ring-accent-gold/20">
@@ -104,7 +119,7 @@
 
                 @if($entries->isEmpty())
                     <tr>
-                        <td colspan="5" class="px-4 py-8 text-center text-sm text-text-muted">
+                        <td colspan="6" class="px-4 py-8 text-center text-sm text-text-muted">
                             {{ __('admin.no_results') }}
                         </td>
                     </tr>

--- a/tests/Feature/Auth/RegistrationTest.php
+++ b/tests/Feature/Auth/RegistrationTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature\Auth;
 
 use App\Models\InviteCode;
 use App\Models\User;
+use App\Models\WaitlistEntry;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Notification;
 use Tests\TestCase;
@@ -139,6 +140,98 @@ class RegistrationTest extends TestCase
         $this->assertDatabaseHas('invite_codes', [
             'code' => 'EMAIL-LOCKED',
             'times_used' => 0,
+        ]);
+    }
+
+    // --- Invite code grant flags ---
+
+    public function test_invite_granting_both_modes_gives_full_access(): void
+    {
+        Notification::fake();
+        config()->set('beta.enabled', true);
+
+        InviteCode::create([
+            'code' => 'BOTH-MODES',
+            'email' => 'both@example.com',
+            'max_uses' => 1,
+            'times_used' => 0,
+            'grants_career' => true,
+            'grants_tournament' => true,
+        ]);
+
+        $response = $this->post(route('register.career-mode', ['invite' => 'BOTH-MODES']), [
+            'name' => 'Both Modes',
+            'email' => 'both@example.com',
+            'password' => 'my-new-password',
+            'password_confirmation' => 'my-new-password',
+            'invite_code' => 'BOTH-MODES',
+        ]);
+
+        $this->assertAuthenticated();
+        $this->assertDatabaseHas('users', [
+            'email' => 'both@example.com',
+            'has_career_access' => true,
+            'has_tournament_access' => true,
+        ]);
+    }
+
+    public function test_invite_granting_career_only_gives_career_access(): void
+    {
+        Notification::fake();
+        config()->set('beta.enabled', true);
+
+        InviteCode::create([
+            'code' => 'CAREER-ONLY',
+            'email' => 'career@example.com',
+            'max_uses' => 1,
+            'times_used' => 0,
+            'grants_career' => true,
+            'grants_tournament' => false,
+        ]);
+
+        $this->post(route('register.career-mode', ['invite' => 'CAREER-ONLY']), [
+            'name' => 'Career Only',
+            'email' => 'career@example.com',
+            'password' => 'my-new-password',
+            'password_confirmation' => 'my-new-password',
+            'invite_code' => 'CAREER-ONLY',
+        ]);
+
+        $this->assertAuthenticated();
+        $this->assertDatabaseHas('users', [
+            'email' => 'career@example.com',
+            'has_career_access' => true,
+            'has_tournament_access' => false,
+        ]);
+    }
+
+    public function test_invite_granting_tournament_only_gives_tournament_access(): void
+    {
+        Notification::fake();
+        config()->set('beta.enabled', true);
+
+        InviteCode::create([
+            'code' => 'TOURN-ONLY',
+            'email' => 'tourn@example.com',
+            'max_uses' => 1,
+            'times_used' => 0,
+            'grants_career' => false,
+            'grants_tournament' => true,
+        ]);
+
+        $this->post(route('register.career-mode', ['invite' => 'TOURN-ONLY']), [
+            'name' => 'Tournament Only',
+            'email' => 'tourn@example.com',
+            'password' => 'my-new-password',
+            'password_confirmation' => 'my-new-password',
+            'invite_code' => 'TOURN-ONLY',
+        ]);
+
+        $this->assertAuthenticated();
+        $this->assertDatabaseHas('users', [
+            'email' => 'tourn@example.com',
+            'has_career_access' => false,
+            'has_tournament_access' => true,
         ]);
     }
 


### PR DESCRIPTION
## Summary
This PR introduces granular access control for career and tournament modes, allowing invite codes and waitlist entries to specify which features users should have access to upon registration.

## Key Changes

- **Invite Code Grant Flags**: Added `grants_career` and `grants_tournament` boolean columns to the `invite_codes` table to control which features an invite code grants access to
- **Waitlist Mode Preferences**: Added `wants_career` and `wants_tournament` boolean columns to the `waitlist` table to track user preferences when joining the waitlist
- **Registration Logic**: Updated `RegisteredUserController` to respect the grant flags from invite codes when creating user accounts, replacing the hardcoded `has_tournament_access = true` behavior
- **Waitlist UI**: Enhanced the admin waitlist view to display mode preferences as badges, showing which features each waitlist entry is interested in
- **Service Layer**: Updated `BetaInviteService` to accept and persist grant flags when creating invite codes
- **Waitlist Action**: Modified `JoinWaitlist` action to accept and store mode preferences, with sensible defaults (both modes enabled)
- **Model Updates**: Updated `WaitlistEntry` and `InviteCode` models with proper fillable attributes and boolean casts
- **Translations**: Added English and Spanish translations for the new "Mode" column and mode labels in the admin interface
- **Tests**: Added comprehensive test coverage for invite codes granting different combinations of access (both modes, career only, tournament only)

## Implementation Details

- Invite codes default to `grants_career = false` and `grants_tournament = true` to maintain backward compatibility
- Waitlist entries default to `wants_career = true` and `wants_tournament = true` to capture interest in all features
- When a user registers with an invite code, their access flags are set based on the invite code's grant flags, not hardcoded values
- The admin waitlist view now displays mode preferences as color-coded badges for better visibility

https://claude.ai/code/session_01C9ZAhFPwKyxrr1SJfL8AvR