### PR TITLE
Remove beta feedback request cronjob and related code

### DIFF
--- a/routes/console.php
+++ b/routes/console.php
@@ -4,5 +4,4 @@ use Illuminate\Support\Facades\Schedule;
 
 Schedule::command('horizon:snapshot')->everyFiveMinutes();
 Schedule::command('app:cleanup-games')->dailyAt('04:00');
-Schedule::command('beta:send-invite-reminders')->dailyAt('10:00');
 // Schedule::command('beta:invite-waitlist '.config('beta.daily_invites'))->dailyAt('21:00');


### PR DESCRIPTION
The hourly cronjob that sent feedback emails 24h after beta invite is no longer needed.
Removes the command, job, mailable, email template, translation keys,
and the feedback_requested_at column from users.

https://claude.ai/code/session_01CxEKE8ZVSBv75M9NAx5UiN