### PR TITLE
Show tournament-specific loading messages in tournament mode games

### DIFF
--- a/app/Http/Views/ShowGame.php
+++ b/app/Http/Views/ShowGame.php
@@ -41,10 +41,11 @@ class ShowGame
                 ProcessSeasonTransition::dispatch($game->id);
                 $game->update(['season_transitioning_at' => now()]);
             }
+            $isTournament = $game->isTournamentMode();
             return view('game-loading', [
                 'game' => $game,
-                'title' => __('game.preparing_season'),
-                'message' => __('game.setup_loading_message'),
+                'title' => $isTournament ? __('game.preparing_tournament') : __('game.preparing_season'),
+                'message' => $isTournament ? __('game.setup_tournament_loading_message') : __('game.setup_loading_message'),
                 'showCrest' => true,
             ]);
         }

--- a/app/Http/Views/ShowNewSeason.php
+++ b/app/Http/Views/ShowNewSeason.php
@@ -29,10 +29,11 @@ class ShowNewSeason
             if ($game->created_at->lt(now()->subMinutes(2))) {
                 $game->redispatchSetupJob();
             }
+            $isTournament = $game->isTournamentMode();
             return view('game-loading', [
                 'game' => $game,
-                'title' => __('game.preparing_season'),
-                'message' => __('game.setup_loading_message'),
+                'title' => $isTournament ? __('game.preparing_tournament') : __('game.preparing_season'),
+                'message' => $isTournament ? __('game.setup_tournament_loading_message') : __('game.setup_loading_message'),
                 'showCrest' => true,
             ]);
         }

--- a/lang/en/game.php
+++ b/lang/en/game.php
@@ -230,6 +230,8 @@ return [
     // Setup loading
     'preparing_season' => 'Preparing your season...',
     'setup_loading_message' => 'We are setting up teams, players and competitions. This will only take a few seconds.',
+    'preparing_tournament' => 'Preparing the tournament...',
+    'setup_tournament_loading_message' => 'Loading national teams and players. This will only take a few seconds.',
     'processing_actions' => 'Processing...',
     'processing_career_actions' => 'Processing game actions...',
     'processing_career_actions_message' => 'Transfers, contracts, and other actions are being processed.',

--- a/lang/es/game.php
+++ b/lang/es/game.php
@@ -230,6 +230,8 @@ return [
     // Setup loading
     'preparing_season' => 'Preparando tu temporada...',
     'setup_loading_message' => 'Estamos configurando los equipos, jugadores y competiciones. Esto solo tomará unos segundos.',
+    'preparing_tournament' => 'Preparando el torneo...',
+    'setup_tournament_loading_message' => 'Cargando selecciones y jugadores. Esto solo tomará unos segundos.',
     'processing_actions' => 'Procesando...',
     'processing_career_actions' => 'Procesando acciones del juego...',
     'processing_career_actions_message' => 'Transferencias, contratos y otras acciones se están procesando.',


### PR DESCRIPTION
Career mode keeps "Preparando tu temporada..." while tournament mode
now shows "Preparando el torneo..." with appropriate descriptions.

https://claude.ai/code/session_01M3iD1imyWzQr99ur9LGu7o