### PR TITLE
Optimize DeleteGameJob to prevent timeouts on large games

### DIFF
--- a/app/Jobs/DeleteGameJob.php
+++ b/app/Jobs/DeleteGameJob.php
@@ -8,10 +8,15 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
 
 class DeleteGameJob implements ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable;
+
+    public int $timeout = 300;
+
+    public int $tries = 3;
 
     public function __construct(
         public string $gameId,
@@ -29,6 +34,12 @@ class DeleteGameJob implements ShouldQueue
 
         Cache::forget("game_owner:{$this->gameId}");
 
+        // Pre-delete the largest tables to avoid a single massive CASCADE transaction
+        DB::table('match_events')->where('game_id', $this->gameId)->delete();
+        DB::table('game_notifications')->where('game_id', $this->gameId)->delete();
+        DB::table('game_matches')->where('game_id', $this->gameId)->delete();
+
+        // CASCADE handles the remaining small tables
         $game->delete();
     }
 }


### PR DESCRIPTION
Pre-delete the three largest child tables (match_events,
game_notifications, game_matches) before calling $game->delete(),
breaking one massive CASCADE transaction into smaller operations.
CASCADE still handles the remaining ~20 small tables.

Also adds timeout (300s) and retry (3 attempts) configuration.

https://claude.ai/code/session_01MGtZA6TQ3v7gCCxLSmuhi6