### PR TITLE
Exclude cup-filler and national teams from transfer market

### DIFF
--- a/app/Models/Team.php
+++ b/app/Models/Team.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Models\Competition;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Support\Facades\Storage;
@@ -71,6 +72,17 @@ class Team extends Model
     public function scopeWorldCupEligible(Builder $query): Builder
     {
         return $query->where('type', 'national')->whereNotNull('fifa_code');
+    }
+
+    /**
+     * Exclude national teams and cup-only teams (e.g. Primera RFEF filler)
+     * from transfer market queries.
+     */
+    public function scopeTransferMarketEligible(Builder $query): Builder
+    {
+        return $query
+            ->where('type', '!=', 'national')
+            ->whereHas('competitions', fn (Builder $q) => $q->where('role', '!=', Competition::ROLE_DOMESTIC_CUP));
     }
 
     public function competitions(): BelongsToMany

--- a/app/Modules/Transfer/Services/AITransferMarketService.php
+++ b/app/Modules/Transfer/Services/AITransferMarketService.php
@@ -297,8 +297,8 @@ class AITransferMarketService
         $teamSizeDeltas = $teamRosters->map(fn () => 0);
 
         // Foreign teams for cross-border transfers
-        $foreignTeams = Team::where('country', '!=', $game->country)
-            ->where('type', 'club')
+        $foreignTeams = Team::transferMarketEligible()
+            ->where('country', '!=', $game->country)
             ->whereNotIn('id', $teamRosters->keys())
             ->inRandomOrder()
             ->limit(40)

--- a/app/Modules/Transfer/Services/LoanService.php
+++ b/app/Modules/Transfer/Services/LoanService.php
@@ -130,7 +130,8 @@ class LoanService
      */
     private function findBestDestination(Game $game, GamePlayer $player): ?Team
     {
-        $teams = Team::with(['clubProfile', 'competitions'])
+        $teams = Team::transferMarketEligible()
+            ->with(['clubProfile', 'competitions'])
             ->whereHas('competitions', function ($q) {
                 $q->where('scope', Competition::SCOPE_DOMESTIC)
                     ->where('type', 'league');

--- a/app/Modules/Transfer/Services/ScoutSearchQueryBuilder.php
+++ b/app/Modules/Transfer/Services/ScoutSearchQueryBuilder.php
@@ -66,9 +66,10 @@ class ScoutSearchQueryBuilder
         $teamCountry = $game->country;
         $scopeCompetitionIds = Competition::where('country', in_array('domestic', $scope) ? '=' : '!=', $teamCountry)
             ->pluck('id');
-        $scopeTeamIds = Team::whereHas('competitions', function ($q) use ($scopeCompetitionIds) {
-            $q->whereIn('competitions.id', $scopeCompetitionIds);
-        })->pluck('id');
+        $scopeTeamIds = Team::transferMarketEligible()
+            ->whereHas('competitions', function ($q) use ($scopeCompetitionIds) {
+                $q->whereIn('competitions.id', $scopeCompetitionIds);
+            })->pluck('id');
         $query->whereIn('team_id', $scopeTeamIds);
     }
 

--- a/app/Modules/Transfer/Services/TransferService.php
+++ b/app/Modules/Transfer/Services/TransferService.php
@@ -698,10 +698,11 @@ class TransferService
      */
     public function loadBuyerPool(Game $game): array
     {
-        $leagueTeamIds = Team::whereHas('competitions', function ($query) {
-            $query->where('scope', Competition::SCOPE_DOMESTIC)
-                ->where('type', 'league');
-        })->where('id', '!=', $game->team_id)->pluck('id')->toArray();
+        $leagueTeamIds = Team::transferMarketEligible()
+            ->whereHas('competitions', function ($query) {
+                $query->where('scope', Competition::SCOPE_DOMESTIC)
+                    ->where('type', 'league');
+            })->where('id', '!=', $game->team_id)->pluck('id')->toArray();
 
         $squadValues = $this->getSquadValues($game, $leagueTeamIds);
         $leagueTeams = Team::whereIn('id', $leagueTeamIds)->get()->keyBy('id');
@@ -750,10 +751,11 @@ class TransferService
         $game = $player->game;
 
         // Get all teams in domestic leagues (both playable and foreign), excluding player's team
-        $leagueTeamIds = Team::whereHas('competitions', function ($query) {
-            $query->where('scope', Competition::SCOPE_DOMESTIC)
-                ->where('type', 'league');
-        })->where('id', '!=', $playerTeamId)->pluck('id')->toArray();
+        $leagueTeamIds = Team::transferMarketEligible()
+            ->whereHas('competitions', function ($query) {
+                $query->where('scope', Competition::SCOPE_DOMESTIC)
+                    ->where('type', 'league');
+            })->where('id', '!=', $playerTeamId)->pluck('id')->toArray();
 
         $squadValues = $this->getSquadValues($game, $leagueTeamIds);
 


### PR DESCRIPTION
Add Team::transferMarketEligible() scope that filters out national teams
(type != 'national') and cup-only teams (must have at least one
non-domestic-cup competition). Apply across all transfer market code
paths: buyer pool, loan destinations, scout search, and AI transfers.

https://claude.ai/code/session_016rcHx3cQizWEHG71RNKNmz