### PR TITLE
Fix transfer prices rounding to zero for low-value players

### DIFF
--- a/app/Modules/Transfer/Services/ScoutingService.php
+++ b/app/Modules/Transfer/Services/ScoutingService.php
@@ -320,8 +320,7 @@ class ScoutingService
         $totalMultiplier = min($importanceMultiplier * $contractModifier * $ageModifier, 1.5);
         $askingPrice = $base * $totalMultiplier;
 
-        // Round to nearest €100K (in cents)
-        return (int) (round($askingPrice / 10_000_000) * 10_000_000);
+        return Money::roundPrice((int) $askingPrice);
     }
 
     /**
@@ -445,7 +444,7 @@ class ScoutingService
 
         if ($ratio >= $counterThreshold) {
             $counterAmount = (int) (($bidAmount + $ceiling) / 2);
-            $counterAmount = (int) (round($counterAmount / 10_000_000) * 10_000_000);
+            $counterAmount = Money::roundPrice($counterAmount);
 
             // If rounding makes counter equal to bid, just accept the bid
             if ($counterAmount <= $bidAmount) {
@@ -507,9 +506,9 @@ class ScoutingService
         }
 
         if ($userAskingPrice <= (int) ($maxWillingness * 1.15)) {
-            // Counter with midpoint of user's ask and AI's current bid, rounded to nearest €100K
+            // Counter with midpoint of user's ask and AI's current bid
             $counterAmount = (int) (($userAskingPrice + $offer->transfer_fee) / 2);
-            $counterAmount = (int) (round($counterAmount / 10_000_000) * 10_000_000);
+            $counterAmount = Money::roundPrice($counterAmount);
 
             // If rounding makes counter equal to or below the current bid, just accept
             if ($counterAmount <= $offer->transfer_fee) {
@@ -669,8 +668,7 @@ class ScoutingService
             deterministic: true,
         );
 
-        // Round to nearest 100K (cents)
-        return (int) (round($wage / 10_000_000) * 10_000_000);
+        return Money::roundPrice($wage);
     }
 
     /**
@@ -682,8 +680,7 @@ class ScoutingService
         $baseWage = $this->calculateWageDemand($player);
         $premium = $this->getFreeAgentWagePremium($player->market_value_cents);
 
-        // Round to nearest 100K (cents)
-        return (int) (round(($baseWage * $premium) / 10_000_000) * 10_000_000);
+        return Money::roundPrice((int) ($baseWage * $premium));
     }
 
     /**

--- a/app/Modules/Transfer/Services/TransferService.php
+++ b/app/Modules/Transfer/Services/TransferService.php
@@ -6,6 +6,7 @@ use App\Modules\Player\PlayerAge;
 use App\Modules\Transfer\Services\ContractService;
 use App\Modules\Transfer\Services\LoanService;
 use App\Modules\Transfer\Services\ScoutingService;
+use App\Support\Money;
 use App\Models\ClubProfile;
 use App\Models\Competition;
 use App\Models\Game;
@@ -678,8 +679,7 @@ class TransferService
 
         $finalPrice = (int) ($baseValue * $typeModifier * $ageModifier);
 
-        // Round to nearest 100K (cents)
-        return (int) (round($finalPrice / 10_000_000) * 10_000_000);
+        return Money::roundPrice($finalPrice);
     }
 
     /**

--- a/app/Support/Money.php
+++ b/app/Support/Money.php
@@ -46,6 +46,29 @@ class Money
     }
 
     /**
+     * Round a price in cents to the nearest "nice" increment.
+     *
+     * Uses tiered granularity so small values don't round down to zero:
+     *   >= €1M   → round to nearest €100K
+     *   >= €100K → round to nearest €50K
+     *   otherwise → round to nearest €10K
+     *
+     * @param int $cents Amount in cents
+     * @return int Rounded amount in cents
+     */
+    public static function roundPrice(int $cents): int
+    {
+        if ($cents >= 100_000_000) {      // >= €1M
+            return (int) (round($cents / 10_000_000) * 10_000_000);
+        }
+        if ($cents >= 10_000_000) {       // >= €100K
+            return (int) (round($cents / 5_000_000) * 5_000_000);
+        }
+
+        return (int) (round($cents / 1_000_000) * 1_000_000); // round to €10K
+    }
+
+    /**
      * Parse a market value string like "€10M" or "500k" into cents.
      *
      * @param string|null $value e.g., "€10M", "€500K", "250000"

--- a/resources/js/negotiation-chat.js
+++ b/resources/js/negotiation-chat.js
@@ -56,9 +56,13 @@ export default function negotiationChat() {
 
         get wageStep() {
             if (this.mode === 'transfer_fee' || this.phase === 'counter_offer') {
-                return this.offerWage >= 10000000 ? 1000000 : 100000;
+                if (this.offerWage >= 10000000) return 1000000;  // >= €10M: €1M steps
+                if (this.offerWage >= 1000000) return 100000;    // >= €1M: €100K steps
+                return 50000;                                     // < €1M: €50K steps
             }
-            return this.offerWage >= 1000000 ? 100000 : 10000;
+            if (this.offerWage >= 1000000) return 100000;
+            if (this.offerWage >= 100000) return 10000;
+            return 5000;
         },
 
         get wageDisplay() {


### PR DESCRIPTION
All transfer/wage prices were rounded to the nearest €100K, causing
values under €50K to round down to €0. This made low-value players
show "€ 0" for both market value and asking price in negotiations.

Introduced Money::roundPrice() with tiered granularity (€100K for
values >= €1M, €50K for >= €100K, €10K otherwise) and updated all
six rounding call sites. Also adjusted JS wage stepper to use finer
increments for low-value transfers.

https://claude.ai/code/session_01WfBTbqv1S3RV2kUUtmDwUx