### PR TITLE
Exclude players with agreed pre-contracts and declined renewals from contract expiry checks

### DIFF
--- a/app/Modules/Match/Services/CareerActionProcessor.php
+++ b/app/Modules/Match/Services/CareerActionProcessor.php
@@ -5,6 +5,7 @@ namespace App\Modules\Match\Services;
 use App\Models\Game;
 use App\Models\GameNotification;
 use App\Models\GamePlayer;
+use App\Models\RenewalNegotiation;
 use App\Models\TransferOffer;
 use App\Modules\Academy\Services\YouthAcademyService;
 use App\Modules\Notification\Services\NotificationService;
@@ -152,6 +153,13 @@ class CareerActionProcessor
             ->whereNull('pending_annual_wage') // not already renewed
             ->where('contract_until', '<=', $sixMonthsOut)
             ->where('contract_until', '>', $currentDate)
+            ->whereDoesntHave('transferOffers', function ($q) {
+                $q->where('status', TransferOffer::STATUS_AGREED)
+                    ->where('offer_type', TransferOffer::TYPE_PRE_CONTRACT);
+            })
+            ->whereDoesntHave('latestRenewalNegotiation', function ($q) {
+                $q->where('status', RenewalNegotiation::STATUS_CLUB_DECLINED);
+            })
             ->get();
 
         if ($expiringPlayers->isEmpty()) {


### PR DESCRIPTION
## Summary
Updated the contract expiry check logic to exclude players who have agreed pre-contract transfer offers or have declined renewal negotiations, preventing unnecessary contract renewal notifications for players who are already in advanced transfer or negotiation processes.

## Key Changes
- Added filtering to exclude players with agreed pre-contract transfer offers from the expiring contracts query
- Added filtering to exclude players with declined renewal negotiations from the expiring contracts query
- Imported `RenewalNegotiation` model to support the new filtering logic

## Implementation Details
The `checkExpiringContracts()` method now uses two additional `whereDoesntHave()` constraints:
1. Filters out players with transfer offers that have `STATUS_AGREED` status and `TYPE_PRE_CONTRACT` offer type
2. Filters out players whose latest renewal negotiation has `STATUS_CLUB_DECLINED` status

This prevents the system from initiating contract renewal processes for players who are already committed to transfers or have had their renewal offers rejected by the club.

https://claude.ai/code/session_01RrBWxrFE7N66SP2XQxVwWW