### PR TITLE
Clean up orphaned generated players on game deletion

### DIFF
--- a/app/Console/Commands/CleanupOrphanedPlayers.php
+++ b/app/Console/Commands/CleanupOrphanedPlayers.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+
+class CleanupOrphanedPlayers extends Command
+{
+    protected $signature = 'app:cleanup-orphaned-players
+                            {--dry-run : Count orphaned players without deleting}
+                            {--chunk=1000 : Number of records to delete per batch}';
+
+    protected $description = 'Delete orphaned generated players that have no game_player references.';
+
+    public function handle(): int
+    {
+        $chunkSize = (int) $this->option('chunk');
+        $dryRun = $this->option('dry-run');
+
+        if ($dryRun) {
+            $count = $this->orphanedQuery()->count();
+            $this->info("[DRY RUN] Found {$count} orphaned generated player(s).");
+
+            return Command::SUCCESS;
+        }
+
+        $totalDeleted = 0;
+
+        do {
+            $ids = $this->orphanedQuery()
+                ->limit($chunkSize)
+                ->pluck('id')
+                ->all();
+
+            if (empty($ids)) {
+                break;
+            }
+
+            $deleted = DB::table('players')->whereIn('id', $ids)->delete();
+            $totalDeleted += $deleted;
+
+            $this->line("  Deleted {$deleted} orphaned player(s) ({$totalDeleted} total).");
+        } while (count($ids) === $chunkSize);
+
+        $this->info("Deleted {$totalDeleted} orphaned generated player(s).");
+
+        return Command::SUCCESS;
+    }
+
+    private function orphanedQuery()
+    {
+        return DB::table('players')
+            ->where('transfermarkt_id', 'like', 'gen-%')
+            ->whereNotExists(function ($query) {
+                $query->select(DB::raw(1))
+                    ->from('game_players')
+                    ->whereColumn('game_players.player_id', 'players.id');
+            });
+    }
+}

--- a/app/Jobs/DeleteGameJob.php
+++ b/app/Jobs/DeleteGameJob.php
@@ -34,12 +34,34 @@ class DeleteGameJob implements ShouldQueue
 
         Cache::forget("game_owner:{$this->gameId}");
 
+        // Collect generated player IDs before cascade removes game_players
+        $generatedPlayerIds = DB::table('game_players')
+            ->join('players', 'players.id', '=', 'game_players.player_id')
+            ->where('game_players.game_id', $this->gameId)
+            ->where('players.transfermarkt_id', 'like', 'gen-%')
+            ->pluck('game_players.player_id')
+            ->all();
+
         // Pre-delete the largest tables to avoid a single massive CASCADE transaction
         DB::table('match_events')->where('game_id', $this->gameId)->delete();
         DB::table('game_notifications')->where('game_id', $this->gameId)->delete();
         DB::table('game_matches')->where('game_id', $this->gameId)->delete();
 
-        // CASCADE handles the remaining small tables
+        // CASCADE handles the remaining small tables (including game_players)
         $game->delete();
+
+        // Clean up generated players that are now orphaned
+        if (! empty($generatedPlayerIds)) {
+            foreach (array_chunk($generatedPlayerIds, 500) as $chunk) {
+                DB::table('players')
+                    ->whereIn('id', $chunk)
+                    ->whereNotExists(function ($query) {
+                        $query->select(DB::raw(1))
+                            ->from('game_players')
+                            ->whereColumn('game_players.player_id', 'players.id');
+                    })
+                    ->delete();
+            }
+        }
     }
 }

--- a/routes/console.php
+++ b/routes/console.php
@@ -4,4 +4,5 @@ use Illuminate\Support\Facades\Schedule;
 
 Schedule::command('horizon:snapshot')->everyFiveMinutes();
 Schedule::command('app:cleanup-games')->dailyAt('04:00');
+Schedule::command('app:cleanup-orphaned-players')->weeklyOn(0, '05:00');
 // Schedule::command('beta:invite-waitlist '.config('beta.daily_invites'))->dailyAt('21:00');

--- a/tests/Feature/CleanupOrphanedPlayersTest.php
+++ b/tests/Feature/CleanupOrphanedPlayersTest.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Competition;
+use App\Models\Game;
+use App\Models\GamePlayer;
+use App\Models\Player;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+class CleanupOrphanedPlayersTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function createOrphanedGeneratedPlayer(): Player
+    {
+        return Player::create([
+            'id' => Str::uuid()->toString(),
+            'transfermarkt_id' => 'gen-'.Str::uuid()->toString(),
+            'name' => 'Orphaned Generated',
+            'nationality' => ['Spain'],
+            'date_of_birth' => '2000-01-01',
+            'technical_ability' => 60,
+            'physical_ability' => 60,
+        ]);
+    }
+
+    private function createOrphanedRealPlayer(): Player
+    {
+        return Player::create([
+            'id' => Str::uuid()->toString(),
+            'transfermarkt_id' => '99999',
+            'name' => 'Orphaned Real',
+            'nationality' => ['Spain'],
+            'date_of_birth' => '1995-01-01',
+            'technical_ability' => 80,
+            'physical_ability' => 75,
+        ]);
+    }
+
+    private function createActiveGeneratedPlayer(): Player
+    {
+        $user = User::factory()->create();
+        $team = Team::factory()->create();
+        Competition::factory()->league()->create(['id' => 'ESP1']);
+
+        $game = Game::factory()->create([
+            'user_id' => $user->id,
+            'team_id' => $team->id,
+            'competition_id' => 'ESP1',
+            'season' => '2024',
+        ]);
+
+        $player = Player::create([
+            'id' => Str::uuid()->toString(),
+            'transfermarkt_id' => 'gen-'.Str::uuid()->toString(),
+            'name' => 'Active Generated',
+            'nationality' => ['Spain'],
+            'date_of_birth' => '2000-01-01',
+            'technical_ability' => 60,
+            'physical_ability' => 60,
+        ]);
+
+        GamePlayer::create([
+            'id' => Str::uuid()->toString(),
+            'game_id' => $game->id,
+            'player_id' => $player->id,
+            'team_id' => $team->id,
+            'position' => 'Centre-Back',
+            'market_value_cents' => 1_000_000_00,
+            'contract_until' => '2027-06-30',
+            'annual_wage' => 500_000_00,
+            'fitness' => 90,
+            'morale' => 70,
+            'durability' => 80,
+            'game_technical_ability' => 60,
+            'game_physical_ability' => 60,
+            'potential' => 70,
+            'potential_low' => 65,
+            'potential_high' => 75,
+            'season_appearances' => 0,
+            'tier' => 3,
+            'number' => 5,
+        ]);
+
+        return $player;
+    }
+
+    public function test_deletes_orphaned_generated_players(): void
+    {
+        $orphan = $this->createOrphanedGeneratedPlayer();
+
+        $this->artisan('app:cleanup-orphaned-players')
+            ->expectsOutputToContain('Deleted 1 orphaned generated player(s)')
+            ->assertExitCode(0);
+
+        $this->assertDatabaseMissing('players', ['id' => $orphan->id]);
+    }
+
+    public function test_preserves_generated_players_with_active_references(): void
+    {
+        $activePlayer = $this->createActiveGeneratedPlayer();
+
+        $this->artisan('app:cleanup-orphaned-players')
+            ->assertExitCode(0);
+
+        $this->assertDatabaseHas('players', ['id' => $activePlayer->id]);
+    }
+
+    public function test_preserves_real_players_even_if_orphaned(): void
+    {
+        $realPlayer = $this->createOrphanedRealPlayer();
+
+        $this->artisan('app:cleanup-orphaned-players')
+            ->assertExitCode(0);
+
+        $this->assertDatabaseHas('players', ['id' => $realPlayer->id]);
+    }
+
+    public function test_dry_run_reports_count_without_deleting(): void
+    {
+        $orphan1 = $this->createOrphanedGeneratedPlayer();
+        $orphan2 = $this->createOrphanedGeneratedPlayer();
+
+        $this->artisan('app:cleanup-orphaned-players', ['--dry-run' => true])
+            ->expectsOutputToContain('[DRY RUN] Found 2 orphaned generated player(s)')
+            ->assertExitCode(0);
+
+        $this->assertDatabaseHas('players', ['id' => $orphan1->id]);
+        $this->assertDatabaseHas('players', ['id' => $orphan2->id]);
+    }
+}

--- a/tests/Feature/DeleteGameJobTest.php
+++ b/tests/Feature/DeleteGameJobTest.php
@@ -1,0 +1,180 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Jobs\DeleteGameJob;
+use App\Models\Competition;
+use App\Models\Game;
+use App\Models\GamePlayer;
+use App\Models\Player;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+class DeleteGameJobTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function createGameWithTeam(): array
+    {
+        $user = User::factory()->create();
+        $team = Team::factory()->create();
+        Competition::factory()->league()->create(['id' => 'ESP1']);
+
+        $game = Game::factory()->create([
+            'user_id' => $user->id,
+            'team_id' => $team->id,
+            'competition_id' => 'ESP1',
+            'season' => '2024',
+        ]);
+
+        return [$game, $team];
+    }
+
+    private function createGeneratedPlayer(Game $game, Team $team): Player
+    {
+        $player = Player::create([
+            'id' => Str::uuid()->toString(),
+            'transfermarkt_id' => 'gen-'.Str::uuid()->toString(),
+            'name' => 'Test Generated',
+            'nationality' => ['Spain'],
+            'date_of_birth' => '2000-01-01',
+            'technical_ability' => 60,
+            'physical_ability' => 60,
+        ]);
+
+        GamePlayer::create([
+            'id' => Str::uuid()->toString(),
+            'game_id' => $game->id,
+            'player_id' => $player->id,
+            'team_id' => $team->id,
+            'position' => 'Centre-Back',
+            'market_value_cents' => 1_000_000_00,
+            'contract_until' => '2027-06-30',
+            'annual_wage' => 500_000_00,
+            'fitness' => 90,
+            'morale' => 70,
+            'durability' => 80,
+            'game_technical_ability' => 60,
+            'game_physical_ability' => 60,
+            'potential' => 70,
+            'potential_low' => 65,
+            'potential_high' => 75,
+            'season_appearances' => 0,
+            'tier' => 3,
+            'number' => 5,
+        ]);
+
+        return $player;
+    }
+
+    private function createRealPlayer(Game $game, Team $team): Player
+    {
+        $player = Player::create([
+            'id' => Str::uuid()->toString(),
+            'transfermarkt_id' => '12345',
+            'name' => 'Real Player',
+            'nationality' => ['Spain'],
+            'date_of_birth' => '1995-03-10',
+            'technical_ability' => 80,
+            'physical_ability' => 75,
+        ]);
+
+        GamePlayer::create([
+            'id' => Str::uuid()->toString(),
+            'game_id' => $game->id,
+            'player_id' => $player->id,
+            'team_id' => $team->id,
+            'position' => 'Attacking Midfield',
+            'market_value_cents' => 20_000_000_00,
+            'contract_until' => '2028-06-30',
+            'annual_wage' => 5_000_000_00,
+            'fitness' => 95,
+            'morale' => 80,
+            'durability' => 85,
+            'game_technical_ability' => 80,
+            'game_physical_ability' => 75,
+            'potential' => 85,
+            'potential_low' => 80,
+            'potential_high' => 90,
+            'season_appearances' => 0,
+            'tier' => 1,
+            'number' => 10,
+        ]);
+
+        return $player;
+    }
+
+    public function test_deleting_game_removes_orphaned_generated_players(): void
+    {
+        [$game, $team] = $this->createGameWithTeam();
+        $generatedPlayer = $this->createGeneratedPlayer($game, $team);
+
+        (new DeleteGameJob($game->id))->handle();
+
+        $this->assertDatabaseMissing('games', ['id' => $game->id]);
+        $this->assertDatabaseMissing('game_players', ['game_id' => $game->id]);
+        $this->assertDatabaseMissing('players', ['id' => $generatedPlayer->id]);
+    }
+
+    public function test_deleting_game_does_not_remove_real_players(): void
+    {
+        [$game, $team] = $this->createGameWithTeam();
+        $realPlayer = $this->createRealPlayer($game, $team);
+
+        (new DeleteGameJob($game->id))->handle();
+
+        $this->assertDatabaseMissing('games', ['id' => $game->id]);
+        $this->assertDatabaseHas('players', ['id' => $realPlayer->id]);
+    }
+
+    public function test_deleting_game_does_not_remove_generated_players_referenced_by_other_games(): void
+    {
+        [$game1, $team] = $this->createGameWithTeam();
+        $generatedPlayer = $this->createGeneratedPlayer($game1, $team);
+
+        // Create a second game referencing the same generated player
+        $user2 = User::factory()->create();
+        $game2 = Game::factory()->create([
+            'user_id' => $user2->id,
+            'team_id' => $team->id,
+            'competition_id' => 'ESP1',
+            'season' => '2024',
+        ]);
+
+        GamePlayer::create([
+            'id' => Str::uuid()->toString(),
+            'game_id' => $game2->id,
+            'player_id' => $generatedPlayer->id,
+            'team_id' => $team->id,
+            'position' => 'Centre-Back',
+            'market_value_cents' => 1_000_000_00,
+            'contract_until' => '2027-06-30',
+            'annual_wage' => 500_000_00,
+            'fitness' => 90,
+            'morale' => 70,
+            'durability' => 80,
+            'game_technical_ability' => 60,
+            'game_physical_ability' => 60,
+            'potential' => 70,
+            'potential_low' => 65,
+            'potential_high' => 75,
+            'season_appearances' => 0,
+            'tier' => 3,
+            'number' => 5,
+        ]);
+
+        // Delete only game1
+        (new DeleteGameJob($game1->id))->handle();
+
+        $this->assertDatabaseMissing('games', ['id' => $game1->id]);
+        // Player should still exist because game2 references it
+        $this->assertDatabaseHas('players', ['id' => $generatedPlayer->id]);
+        $this->assertDatabaseHas('game_players', [
+            'game_id' => $game2->id,
+            'player_id' => $generatedPlayer->id,
+        ]);
+    }
+}


### PR DESCRIPTION
Generated players (transfermarkt_id LIKE 'gen-%') were never cleaned up
when games were deleted, causing unbounded accumulation in the players
table. This adds cleanup in DeleteGameJob (inline, after cascade) and a
new app:cleanup-orphaned-players command for backlog purging, scheduled
weekly as a safety net.

https://claude.ai/code/session_017a8eg1C4KG815Sc3agNJKz