### PR TITLE
Make current_date forward-looking (set to upcoming match date before simulation)

### DIFF
--- a/app/Models/Game.php
+++ b/app/Models/Game.php
@@ -522,10 +522,9 @@ class Game extends Model
      * Winter transfer window: January 1 - January 31
      * Mid-season transfer period.
      *
-     * Also accounts for the gap between the last December match and the first
-     * January match: current_date only advances when matches are played, so
-     * when it's still December but the next match is in January, the calendar
-     * has progressed past January 1st and the window should be open.
+     * current_date is forward-looking (set to the upcoming match date before
+     * simulation), so it naturally advances to January when the next match
+     * is in January — no December peek-ahead needed.
      */
     public function isWinterWindowOpen(): bool
     {
@@ -533,18 +532,7 @@ class Game extends Model
             return false;
         }
 
-        if ($this->current_date->month === 1) {
-            return true;
-        }
-
-        if ($this->current_date->month === 12) {
-            $nextMatch = $this->next_match;
-            if ($nextMatch && $nextMatch->scheduled_date->month === 1) {
-                return true;
-            }
-        }
-
-        return false;
+        return $this->current_date->month === 1;
     }
 
     /**
@@ -572,8 +560,6 @@ class Game extends Model
     /**
      * Check if we've just entered the winter window (January 1).
      * Used to trigger one-time events like wage payments.
-     *
-     * Also accounts for the December→January gap (see isWinterWindowOpen).
      */
     public function isStartOfWinterWindow(): bool
     {
@@ -581,20 +567,7 @@ class Game extends Model
             return false;
         }
 
-        // First week of January
-        if ($this->current_date->month === 1 && $this->current_date->day <= 7) {
-            return true;
-        }
-
-        // December→January gap: next match is in early January
-        if ($this->current_date->month === 12) {
-            $nextMatch = $this->next_match;
-            if ($nextMatch && $nextMatch->scheduled_date->month === 1 && $nextMatch->scheduled_date->day <= 7) {
-                return true;
-            }
-        }
-
-        return false;
+        return $this->current_date->month === 1 && $this->current_date->day <= 7;
     }
 
     /**
@@ -680,8 +653,6 @@ class Game extends Model
     /**
      * Check if we're in the pre-contract offer period (January through May).
      * Players in their last year of contract can be approached for a free transfer.
-     *
-     * Also accounts for the December→January gap (see isWinterWindowOpen).
      */
     public function isPreContractPeriod(): bool
     {
@@ -691,18 +662,7 @@ class Game extends Model
 
         $month = $this->current_date->month;
 
-        if ($month >= 1 && $month <= 5) {
-            return true;
-        }
-
-        if ($month === 12) {
-            $nextMatch = $this->next_match;
-            if ($nextMatch && $nextMatch->scheduled_date->month === 1) {
-                return true;
-            }
-        }
-
-        return false;
+        return $month >= 1 && $month <= 5;
     }
 
     // ==========================================
@@ -764,9 +724,8 @@ class Game extends Model
                 ];
             }
             if ($this->isWinterWindowOpen()) {
-                $closeYear = $month === 12 ? $year + 1 : $year;
                 $boundaries[] = [
-                    'date' => Carbon::createFromDate($closeYear, 2, 1),
+                    'date' => Carbon::createFromDate($year, 2, 1),
                     'action' => 'closes',
                     'window' => __('app.winter_window'),
                 ];

--- a/app/Modules/Match/Services/MatchResultProcessor.php
+++ b/app/Modules/Match/Services/MatchResultProcessor.php
@@ -30,22 +30,11 @@ class MatchResultProcessor
      *
      * @param  string|null  $deferMatchId  Match ID to skip standings and GK stats for (deferred to finalization)
      */
-    public function processAll(string $gameId, int $matchday, string $currentDate, array $matchResults, ?string $deferMatchId = null, $allPlayers = null): void
+    public function processAll(string $gameId, array $matchResults, ?string $deferMatchId = null, $allPlayers = null): void
     {
-        // Load game once for previous date capture and date guard
         $game = Game::find($gameId);
 
-        // 1. Update game state (replaces onMatchdayAdvanced projector)
-        // Only advance current_date forward — background batch processing must not
-        // regress the date that was already set by the player's batch.
-        $newDate = Carbon::parse($currentDate);
-        $updateData = ['current_matchday' => $matchday];
-        if (! $game->current_date || $newDate->gte($game->current_date)) {
-            $updateData['current_date'] = $newDate->toDateString();
-        }
-        Game::where('id', $gameId)->update($updateData);
-
-        // 2. Bulk update match records (scores + played)
+        // 1. Bulk update match records (scores + played)
         $this->bulkUpdateMatchScores($matchResults);
 
         // Reload game with post-update state for the rest of the method
@@ -57,7 +46,7 @@ class MatchResultProcessor
         $competitionIds = collect($matchResults)->pluck('competitionId')->unique();
         $competitions = Competition::whereIn('id', $competitionIds)->get()->keyBy('id');
 
-        // 3. Serve suspensions for all matches (batch, using pre-loaded player IDs)
+        // 2. Serve suspensions for all matches (batch, using pre-loaded player IDs)
         // Exclude players from the deferred match's teams — their suspensions
         // will be served during finalization, so they remain ineligible for
         // substitution while the user plays the live match.
@@ -77,26 +66,26 @@ class MatchResultProcessor
         }
         $this->batchServeSuspensions($matches, $matchResults, $preLoadedPlayerIds, $allPlayers);
 
-        // 4. Bulk insert all match events across all matches
+        // 3. Bulk insert all match events across all matches
         $this->bulkInsertMatchEvents($gameId, $matchResults);
 
-        // 5. Batch process player stats across all matches
+        // 4. Batch process player stats across all matches
         $this->batchProcessPlayerStats($game, $matchResults, $matches, $competitions, $deferMatchId, $allPlayers);
 
-        // 6. Bulk update appearances across all matches (including auto-subbed-in players)
+        // 5. Bulk update appearances across all matches (including auto-subbed-in players)
         $this->bulkUpdateAppearances($matches, $matchResults);
 
         // 6b. Record auto-substitutions in match substitutions JSON
         $this->recordAutoSubstitutions($matches, $matchResults);
 
-        // 7. Batch update conditions (exclude deferred match — finalization handles it)
+        // 6. Batch update conditions (exclude deferred match — finalization handles it)
         $conditionMatches = $deferMatchId ? $matches->except($deferMatchId) : $matches;
         $conditionResults = $deferMatchId
             ? array_filter($matchResults, fn ($r) => $r['matchId'] !== $deferMatchId)
             : $matchResults;
         $this->batchUpdateConditions($conditionMatches, $conditionResults, $allPlayers ?? collect());
 
-        // 8. Batch update goalkeeper stats (skip deferred match)
+        // 7. Batch update goalkeeper stats (skip deferred match)
         $gkResults = $deferMatchId
             ? array_filter($matchResults, fn ($r) => $r['matchId'] !== $deferMatchId)
             : $matchResults;
@@ -105,7 +94,7 @@ class MatchResultProcessor
             : $matches;
         $this->batchUpdateGoalkeeperStats($gkMatches, $gkResults, $allPlayers);
 
-        // 9. Update standings per league in bulk (skip deferred match)
+        // 8. Update standings per league in bulk (skip deferred match)
         $leagueResultsByCompetition = [];
         foreach ($matchResults as $result) {
             if ($result['matchId'] === $deferMatchId) {

--- a/app/Modules/Match/Services/MatchdayOrchestrator.php
+++ b/app/Modules/Match/Services/MatchdayOrchestrator.php
@@ -142,6 +142,19 @@ class MatchdayOrchestrator
         $matchday = $batch['matchday'];
         $currentDate = $batch['currentDate'];
 
+        // Advance current_date and current_matchday to the upcoming match BEFORE
+        // simulation. This ensures calendar-dependent logic (transfer windows,
+        // offer expiry) sees the correct date. Only advance forward to prevent
+        // background batches from regressing a date already set by the player's batch.
+        $newDate = Carbon::parse($currentDate);
+        $updateData = ['current_matchday' => $matchday];
+        if (! $game->current_date || $newDate->gte($game->current_date)) {
+            $updateData['current_date'] = $newDate->toDateString();
+            $game->current_date = $newDate;
+        }
+        Game::where('id', $game->id)->update($updateData);
+        $game->current_matchday = $matchday;
+
         // When playerMatchOnly is true, filter batch to only the player's match
         // (sibling AI matches in the same batch are deferred to background processing)
         $playerMatch = $matches->first(fn ($m) => $m->involvesTeam($game->team_id));
@@ -241,7 +254,7 @@ class MatchdayOrchestrator
         $deferMatchId = $playerMatch?->id;
 
         // --- Process results ---
-        $this->matchResultProcessor->processAll($game->id, $matchday, $currentDate, $matchResults, $deferMatchId, $allPlayers);
+        $this->matchResultProcessor->processAll($game->id, $matchResults, $deferMatchId, $allPlayers);
 
         // --- Recalculate positions ---
         $this->recalculateLeaguePositions($game->id, $matches);

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -56,7 +56,7 @@
                             @if($game->current_date)
                                 <dd class="mt-2 mb-2">
                                     <span class="inline-flex items-center rounded-full bg-accent-green/10 px-2 py-1 text-xs font-medium text-accent-green ring-1 ring-inset ring-green-600/20">
-                                        {{ __('game.matchday_n', ['number' => $game->current_matchday + 1]) }} - {{ $game->current_date->format('d/m/Y') }}
+                                        {{ __('game.matchday_n', ['number' => $game->current_matchday]) }} - {{ $game->current_date->format('d/m/Y') }}
                                     </span>
                                 </dd>
                             @endif

--- a/tests/Feature/PreseasonSuspensionTest.php
+++ b/tests/Feature/PreseasonSuspensionTest.php
@@ -102,8 +102,6 @@ class PreseasonSuspensionTest extends TestCase
         $processor = app(MatchResultProcessor::class);
         $processor->processAll(
             $this->game->id,
-            1,
-            '2024-07-16',
             [$matchResult],
         );
 
@@ -234,8 +232,6 @@ class PreseasonSuspensionTest extends TestCase
         $processor = app(MatchResultProcessor::class);
         $processor->processAll(
             $this->game->id,
-            1,
-            '2024-07-16',
             [$matchResult],
         );
 


### PR DESCRIPTION
current_date previously had inconsistent semantics: initialization set it
forward-looking (July 1, first match date) but runtime set it to the last
played match date. This caused the December gap problem (winter window never
opened because current_date stayed in December) and required peek-ahead
workarounds.

Now current_date and current_matchday are advanced in the orchestrator BEFORE
simulation, making them consistently represent the upcoming match. This
eliminates the December peek-ahead workarounds in isWinterWindowOpen(),
isStartOfWinterWindow(), isPreContractPeriod(), and getWindowCountdown(),
and removes the dashboard's matchday +1 display offset.

https://claude.ai/code/session_01Ev9z9SfXJ9BqFaxL2RwX7q