### PR TITLE
Extract qualification logic from notification listener into ProgressResolvers

### DIFF
--- a/app/Modules/Competition/Contracts/ProgressResolver.php
+++ b/app/Modules/Competition/Contracts/ProgressResolver.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Modules\Competition\Contracts;
+
+use App\Models\GameStanding;
+use App\Modules\Competition\DTOs\QualificationOutcome;
+
+interface ProgressResolver
+{
+    /**
+     * Determine the qualification outcome for a team after a league/group phase completes.
+     *
+     * Returns null when no notification is needed (e.g., mid-table in a league with playoffs).
+     */
+    public function resolve(string $gameId, string $competitionId, GameStanding $standing): ?QualificationOutcome;
+}

--- a/app/Modules/Competition/DTOs/QualificationOutcome.php
+++ b/app/Modules/Competition/DTOs/QualificationOutcome.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Modules\Competition\DTOs;
+
+readonly class QualificationOutcome
+{
+    private function __construct(
+        public QualificationStatus $status,
+        public string $translationKey,
+        public array $translationParams = [],
+    ) {}
+
+    public static function advanced(string $translationKey, array $params = []): self
+    {
+        return new self(QualificationStatus::Advanced, $translationKey, $params);
+    }
+
+    public static function playoff(string $translationKey, array $params = []): self
+    {
+        return new self(QualificationStatus::Playoff, $translationKey, $params);
+    }
+
+    public static function eliminated(string $translationKey, array $params = []): self
+    {
+        return new self(QualificationStatus::Eliminated, $translationKey, $params);
+    }
+
+    public function isElimination(): bool
+    {
+        return $this->status === QualificationStatus::Eliminated;
+    }
+}

--- a/app/Modules/Competition/DTOs/QualificationStatus.php
+++ b/app/Modules/Competition/DTOs/QualificationStatus.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Modules\Competition\DTOs;
+
+enum QualificationStatus: string
+{
+    case Advanced = 'advanced';
+    case Playoff = 'playoff';
+    case Eliminated = 'eliminated';
+}

--- a/app/Modules/Competition/ProgressResolvers/CompetitionProgressResolverFactory.php
+++ b/app/Modules/Competition/ProgressResolvers/CompetitionProgressResolverFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Modules\Competition\ProgressResolvers;
+
+use App\Modules\Competition\Contracts\ProgressResolver;
+
+class CompetitionProgressResolverFactory
+{
+    /** @var array<string, ProgressResolver> */
+    private array $resolvers;
+
+    public function __construct(
+        SwissProgressResolver $swiss,
+        LeaguePlayoffProgressResolver $leaguePlayoff,
+        GroupStageProgressResolver $groupStage,
+    ) {
+        $this->resolvers = [
+            'swiss_format' => $swiss,
+            'league_with_playoff' => $leaguePlayoff,
+            'group_stage_cup' => $groupStage,
+        ];
+    }
+
+    public function forHandlerType(string $handlerType): ?ProgressResolver
+    {
+        return $this->resolvers[$handlerType] ?? null;
+    }
+}

--- a/app/Modules/Competition/ProgressResolvers/GroupStageProgressResolver.php
+++ b/app/Modules/Competition/ProgressResolvers/GroupStageProgressResolver.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Modules\Competition\ProgressResolvers;
+
+use App\Models\GameStanding;
+use App\Modules\Competition\Contracts\ProgressResolver;
+use App\Modules\Competition\DTOs\QualificationOutcome;
+use App\Modules\Competition\Services\WorldCupKnockoutGenerator;
+
+class GroupStageProgressResolver implements ProgressResolver
+{
+    public function __construct(
+        private readonly WorldCupKnockoutGenerator $knockoutGenerator,
+    ) {}
+
+    public function resolve(string $gameId, string $competitionId, GameStanding $standing): ?QualificationOutcome
+    {
+        $qualifiedTeams = $this->knockoutGenerator->getQualifiedTeams($gameId, $competitionId);
+
+        if (in_array($standing->team_id, $qualifiedTeams)) {
+            return QualificationOutcome::advanced(
+                'cup.group_stage_qualified',
+                ['group' => $standing->group_label],
+            );
+        }
+
+        return QualificationOutcome::eliminated(
+            'cup.group_stage_eliminated',
+            ['group' => $standing->group_label],
+        );
+    }
+}

--- a/app/Modules/Competition/ProgressResolvers/LeaguePlayoffProgressResolver.php
+++ b/app/Modules/Competition/ProgressResolvers/LeaguePlayoffProgressResolver.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Modules\Competition\ProgressResolvers;
+
+use App\Models\GameStanding;
+use App\Modules\Competition\Contracts\ProgressResolver;
+use App\Modules\Competition\DTOs\QualificationOutcome;
+use App\Modules\Competition\Playoffs\PlayoffGeneratorFactory;
+
+class LeaguePlayoffProgressResolver implements ProgressResolver
+{
+    public function __construct(
+        private readonly PlayoffGeneratorFactory $playoffFactory,
+    ) {}
+
+    public function resolve(string $gameId, string $competitionId, GameStanding $standing): ?QualificationOutcome
+    {
+        $generator = $this->playoffFactory->forCompetition($competitionId);
+
+        if (! $generator) {
+            return null;
+        }
+
+        if (in_array($standing->position, $generator->getDirectPromotionPositions())) {
+            return QualificationOutcome::advanced('cup.direct_promotion');
+        }
+
+        if (in_array($standing->position, $generator->getQualifyingPositions())) {
+            return QualificationOutcome::playoff('cup.promotion_playoff');
+        }
+
+        return null;
+    }
+}

--- a/app/Modules/Competition/ProgressResolvers/SwissProgressResolver.php
+++ b/app/Modules/Competition/ProgressResolvers/SwissProgressResolver.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Modules\Competition\ProgressResolvers;
+
+use App\Models\GameStanding;
+use App\Modules\Competition\Contracts\ProgressResolver;
+use App\Modules\Competition\DTOs\QualificationOutcome;
+
+class SwissProgressResolver implements ProgressResolver
+{
+    private const DIRECT_KNOCKOUT_MAX_POSITION = 8;
+    private const PLAYOFF_MAX_POSITION = 24;
+
+    public function resolve(string $gameId, string $competitionId, GameStanding $standing): ?QualificationOutcome
+    {
+        if ($standing->position <= self::DIRECT_KNOCKOUT_MAX_POSITION) {
+            return QualificationOutcome::advanced('cup.swiss_direct_r16');
+        }
+
+        if ($standing->position <= self::PLAYOFF_MAX_POSITION) {
+            return QualificationOutcome::playoff('cup.swiss_knockout_playoff');
+        }
+
+        return QualificationOutcome::eliminated('cup.swiss_eliminated');
+    }
+}

--- a/app/Modules/Notification/Listeners/SendCompetitionProgressNotifications.php
+++ b/app/Modules/Notification/Listeners/SendCompetitionProgressNotifications.php
@@ -2,9 +2,9 @@
 
 namespace App\Modules\Notification\Listeners;
 
+use App\Modules\Competition\ProgressResolvers\CompetitionProgressResolverFactory;
 use App\Modules\Match\Events\MatchFinalized;
 use App\Modules\Notification\Services\NotificationService;
-use App\Models\Competition;
 use App\Models\GameMatch;
 use App\Models\GameStanding;
 
@@ -18,6 +18,7 @@ class SendCompetitionProgressNotifications
 {
     public function __construct(
         private readonly NotificationService $notificationService,
+        private readonly CompetitionProgressResolverFactory $progressResolverFactory,
     ) {}
 
     public function handle(MatchFinalized $event): void
@@ -54,60 +55,27 @@ class SendCompetitionProgressNotifications
             return;
         }
 
-        match ($competition->handler_type) {
-            'swiss_format' => $this->notifySwissCompletion($event, $competition, $standing),
-            'league_with_playoff' => $this->notifyLeaguePlayoffCompletion($event, $competition, $standing),
-            'group_stage_cup' => $this->notifyGroupStageCompletion($event, $competition, $standing),
-            default => null,
-        };
-    }
+        $resolver = $this->progressResolverFactory->forHandlerType($competition->handler_type);
 
-    private function notifySwissCompletion(MatchFinalized $event, Competition $competition, GameStanding $standing): void
-    {
-        if ($standing->position <= 8) {
-            $this->notificationService->notifyCompetitionAdvancement(
-                $event->game, $competition->id, $competition->name,
-                __('cup.swiss_direct_r16'),
-            );
-        } elseif ($standing->position <= 24) {
-            $this->notificationService->notifyCompetitionAdvancement(
-                $event->game, $competition->id, $competition->name,
-                __('cup.swiss_knockout_playoff'),
+        if (! $resolver) {
+            return;
+        }
+
+        $outcome = $resolver->resolve($event->game->id, $competition->id, $standing);
+
+        if (! $outcome) {
+            return;
+        }
+
+        $message = __($outcome->translationKey, $outcome->translationParams);
+
+        if ($outcome->isElimination()) {
+            $this->notificationService->notifyCompetitionElimination(
+                $event->game, $competition->id, $competition->name, $message,
             );
         } else {
-            $this->notificationService->notifyCompetitionElimination(
-                $event->game, $competition->id, $competition->name,
-                __('cup.swiss_eliminated'),
-            );
-        }
-    }
-
-    private function notifyLeaguePlayoffCompletion(MatchFinalized $event, Competition $competition, GameStanding $standing): void
-    {
-        if ($standing->position <= 2) {
             $this->notificationService->notifyCompetitionAdvancement(
-                $event->game, $competition->id, $competition->name,
-                __('cup.direct_promotion'),
-            );
-        } elseif ($standing->position <= 6) {
-            $this->notificationService->notifyCompetitionAdvancement(
-                $event->game, $competition->id, $competition->name,
-                __('cup.promotion_playoff'),
-            );
-        }
-    }
-
-    private function notifyGroupStageCompletion(MatchFinalized $event, Competition $competition, GameStanding $standing): void
-    {
-        if ($standing->position <= 2) {
-            $this->notificationService->notifyCompetitionAdvancement(
-                $event->game, $competition->id, $competition->name,
-                __('cup.group_stage_qualified', ['group' => $standing->group_label]),
-            );
-        } else {
-            $this->notificationService->notifyCompetitionElimination(
-                $event->game, $competition->id, $competition->name,
-                __('cup.group_stage_eliminated', ['group' => $standing->group_label]),
+                $event->game, $competition->id, $competition->name, $message,
             );
         }
     }


### PR DESCRIPTION
The SendCompetitionProgressNotifications listener had hardcoded position thresholds for each competition type, duplicating qualification logic that belongs in the Competition module. Each resolver now delegates to existing services (PlayoffGenerator, WorldCupKnockoutGenerator) while the listener becomes a thin dispatcher. This also fixes a bug where World Cup best third-place teams received elimination notifications.