### PR TITLE
Simplify suspension notifications using PlayerSuspension model

### DIFF
--- a/app/Modules/Notification/Listeners/SendMatchNotifications.php
+++ b/app/Modules/Notification/Listeners/SendMatchNotifications.php
@@ -3,7 +3,6 @@
 namespace App\Modules\Notification\Listeners;
 
 use App\Modules\Match\Events\MatchFinalized;
-use App\Modules\Squad\Services\EligibilityService;
 use App\Modules\Notification\Services\NotificationService;
 use App\Models\GamePlayer;
 use App\Models\MatchEvent;
@@ -13,7 +12,6 @@ class SendMatchNotifications
 {
     public function __construct(
         private readonly NotificationService $notificationService,
-        private readonly EligibilityService $eligibilityService,
     ) {}
 
     public function handle(MatchFinalized $event): void
@@ -57,13 +55,17 @@ class SendMatchNotifications
 
     private function notifyRedCard(MatchFinalized $event, GamePlayer $player, MatchEvent $matchEvent): void
     {
-        $isSecondYellow = $matchEvent->metadata['second_yellow'] ?? false;
-        $suspensionMatches = $isSecondYellow ? 1 : 1;
+        $competitionId = $event->competition->id ?? $event->match->competition_id;
+        $suspension = PlayerSuspension::forPlayerInCompetition($player->id, $competitionId);
+
+        if (! $suspension || $suspension->matches_remaining <= 0) {
+            return;
+        }
 
         $this->notificationService->notifySuspension(
             $event->game,
             $player,
-            $suspensionMatches,
+            $suspension->matches_remaining,
             __('notifications.reason_red_card'),
             $event->competition->name,
         );
@@ -80,18 +82,18 @@ class SendMatchNotifications
     private function notifyYellowCardAccumulation(MatchFinalized $event, GamePlayer $player): void
     {
         $competitionId = $event->competition->id ?? $event->match->competition_id;
-        $handlerType = $event->competition->handler_type ?? 'league';
-        $competitionYellows = PlayerSuspension::getYellowCards($player->id, $competitionId);
-        $suspension = $this->eligibilityService->checkYellowCardAccumulation($competitionYellows, $handlerType);
+        $suspension = PlayerSuspension::forPlayerInCompetition($player->id, $competitionId);
 
-        if ($suspension) {
-            $this->notificationService->notifySuspension(
-                $event->game,
-                $player,
-                $suspension,
-                __('notifications.reason_yellow_accumulation'),
-                $event->competition->name,
-            );
+        if (! $suspension || $suspension->matches_remaining <= 0) {
+            return;
         }
+
+        $this->notificationService->notifySuspension(
+            $event->game,
+            $player,
+            $suspension->matches_remaining,
+            __('notifications.reason_yellow_accumulation'),
+            $event->competition->name,
+        );
     }
 }


### PR DESCRIPTION
## Summary
Refactored the `SendMatchNotifications` listener to simplify suspension notification logic by leveraging the `PlayerSuspension` model directly, removing dependency on the `EligibilityService`.

## Key Changes
- Removed `EligibilityService` dependency and its import
- Updated `notifyRedCard()` to query `PlayerSuspension` directly instead of calculating suspension matches manually
- Updated `notifyYellowCardAccumulation()` to use `PlayerSuspension::forPlayerInCompetition()` instead of calling `EligibilityService::checkYellowCardAccumulation()`
- Added early return guards in both methods to skip notifications when no active suspension exists (`matches_remaining <= 0`)
- Simplified suspension match calculation by using `$suspension->matches_remaining` directly

## Implementation Details
- Both notification methods now follow the same pattern: fetch suspension record, validate it exists and has remaining matches, then notify
- Removed unnecessary metadata parsing and hardcoded suspension logic from `notifyRedCard()`
- Removed competition handler type logic from `notifyYellowCardAccumulation()` as it's now encapsulated in the `PlayerSuspension` model
- The refactoring improves code maintainability by centralizing suspension logic in the model layer

https://claude.ai/code/session_0196Y7FrgkFcV2B4DDwy15vP