### PR TITLE
Add 1-match cooldown to renewal negotiations after player rejection

### DIFF
--- a/app/Http/Actions/NegotiateRenewal.php
+++ b/app/Http/Actions/NegotiateRenewal.php
@@ -80,8 +80,16 @@ class NegotiateRenewal
             ]);
         }
 
+        // Cooldown: must wait at least one matchday after a rejected negotiation
+        if (RenewalNegotiation::hasRenewalCooldown($player->id, $game->current_date)) {
+            return response()->json([
+                'status' => 'error',
+                'message' => __('transfers.renewal_cooldown'),
+            ], 422);
+        }
+
         // New negotiation — show player demand
-        if (!$player->canBeOfferedRenewal()) {
+        if (!$player->canBeOfferedRenewal(currentDate: $game->current_date)) {
             return response()->json([
                 'status' => 'error',
                 'message' => __('messages.cannot_renew'),

--- a/app/Http/Views/ShowOutgoingTransfers.php
+++ b/app/Http/Views/ShowOutgoingTransfers.php
@@ -108,17 +108,31 @@ class ShowOutgoingTransfers
         $renewalEligiblePlayers = $this->contractService->getPlayersEligibleForRenewal($game);
         $pendingRenewals = $this->contractService->getPlayersWithPendingRenewals($game);
 
-        // Declined renewals
+        // Declined renewals (club-declined only — player rejections use cooldown)
         $seasonEndDate = $game->getSeasonEndDate();
         $declinedRenewals = GamePlayer::with(['player', 'latestRenewalNegotiation'])
             ->where('game_id', $gameId)
             ->where('team_id', $game->team_id)
-            ->whereHas('latestRenewalNegotiation', fn ($q) => $q->whereIn('status', [
-                RenewalNegotiation::STATUS_PLAYER_REJECTED,
-                RenewalNegotiation::STATUS_CLUB_DECLINED,
-            ]))
+            ->whereHas('latestRenewalNegotiation', fn ($q) => $q->where('status', RenewalNegotiation::STATUS_CLUB_DECLINED))
             ->get()
             ->filter(fn (GamePlayer $p) => $p->isContractExpiring($seasonEndDate) && $p->hasDeclinedRenewal());
+
+        // Players on renewal cooldown (player rejected, waiting for next matchday)
+        $cooldownPlayerIds = RenewalNegotiation::where('game_id', $gameId)
+            ->where('status', RenewalNegotiation::STATUS_PLAYER_REJECTED)
+            ->where('rejected_at', '>=', $game->current_date)
+            ->pluck('game_player_id')
+            ->toArray();
+
+        $cooldownRenewals = collect();
+        if (!empty($cooldownPlayerIds)) {
+            $cooldownRenewals = GamePlayer::with(['player'])
+                ->where('game_id', $gameId)
+                ->where('team_id', $game->team_id)
+                ->whereIn('id', $cooldownPlayerIds)
+                ->get()
+                ->filter(fn (GamePlayer $p) => $p->isContractExpiring($seasonEndDate));
+        }
 
         return view('outgoing-transfers', [
             'game' => $game,
@@ -134,6 +148,7 @@ class ShowOutgoingTransfers
             'renewalEligiblePlayers' => $renewalEligiblePlayers,
             'pendingRenewals' => $pendingRenewals,
             'declinedRenewals' => $declinedRenewals,
+            'cooldownRenewals' => $cooldownRenewals,
             ...$this->headerService->getHeaderData($game),
         ]);
     }

--- a/app/Http/Views/ShowPlayerDetail.php
+++ b/app/Http/Views/ShowPlayerDetail.php
@@ -22,13 +22,18 @@ class ShowPlayerDetail
             ->where('team_id', $game->team_id)
             ->findOrFail($playerId);
 
-        $canRenew = $gamePlayer->canBeOfferedRenewal();
+        $canRenew = $gamePlayer->canBeOfferedRenewal(currentDate: $game->current_date);
         $renewalNegotiation = null;
+        $renewalCooldown = false;
 
         if ($game->isCareerMode() && $gamePlayer->isContractExpiring()) {
             $renewalNegotiation = RenewalNegotiation::where('game_player_id', $gamePlayer->id)
                 ->where('status', RenewalNegotiation::STATUS_PLAYER_COUNTERED)
                 ->first();
+
+            if (!$canRenew && !$renewalNegotiation) {
+                $renewalCooldown = RenewalNegotiation::hasRenewalCooldown($gamePlayer->id, $game->current_date);
+            }
         }
 
         // Release data
@@ -49,6 +54,7 @@ class ShowPlayerDetail
             'gamePlayer' => $gamePlayer,
             'canRenew' => $canRenew,
             'renewalNegotiation' => $renewalNegotiation,
+            'renewalCooldown' => $renewalCooldown,
             'canRelease' => $canRelease,
             'severance' => $severance,
         ]);

--- a/app/Models/GamePlayer.php
+++ b/app/Models/GamePlayer.php
@@ -278,11 +278,11 @@ class GamePlayer extends Model
     }
 
     /**
-     * Get the latest renewal negotiation (by creation date).
+     * Get the latest renewal negotiation.
      */
     public function latestRenewalNegotiation(): HasOne
     {
-        return $this->hasOne(RenewalNegotiation::class)->latest();
+        return $this->hasOne(RenewalNegotiation::class)->latest('id');
     }
 
     /**
@@ -310,6 +310,14 @@ class GamePlayer extends Model
         /** @var RenewalNegotiation|null $latest */
         $latest = $this->latestRenewalNegotiation()->first();
         return $latest !== null && $latest->isBlocking();
+    }
+
+    /**
+     * Check if player has a renewal negotiation cooldown active.
+     */
+    public function hasRenewalCooldown($currentDate): bool
+    {
+        return RenewalNegotiation::hasRenewalCooldown($this->id, $currentDate);
     }
 
     /**
@@ -489,7 +497,7 @@ class GamePlayer extends Model
      *
      * @param Carbon|null $seasonEndDate The season end date. If null, calculated from game.
      */
-    public function canBeOfferedRenewal(?Carbon $seasonEndDate = null): bool
+    public function canBeOfferedRenewal(?Carbon $seasonEndDate = null, ?Carbon $currentDate = null): bool
     {
         if (!$this->isContractExpiring($seasonEndDate)) {
             return false;
@@ -515,8 +523,13 @@ class GamePlayer extends Model
             return false;
         }
 
-        // Renewal explicitly declined or rejected
+        // Renewal explicitly declined by club
         if ($this->hasDeclinedRenewal()) {
+            return false;
+        }
+
+        // Cooldown after player rejection (wait one matchday)
+        if ($currentDate && $this->hasRenewalCooldown($currentDate)) {
             return false;
         }
 

--- a/app/Models/RenewalNegotiation.php
+++ b/app/Models/RenewalNegotiation.php
@@ -20,8 +20,6 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  * @property int|null $counter_offer
  * @property int|null $contract_years
  * @property float|null $disposition
- * @property \Illuminate\Support\Carbon|null $created_at
- * @property \Illuminate\Support\Carbon|null $updated_at
  * @property-read \App\Models\Game $game
  * @property-read \App\Models\GamePlayer $gamePlayer
  * @property-read string $formatted_counter_offer
@@ -32,7 +30,6 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  * @method static \Illuminate\Database\Eloquent\Builder<static>|RenewalNegotiation query()
  * @method static \Illuminate\Database\Eloquent\Builder<static>|RenewalNegotiation whereContractYears($value)
  * @method static \Illuminate\Database\Eloquent\Builder<static>|RenewalNegotiation whereCounterOffer($value)
- * @method static \Illuminate\Database\Eloquent\Builder<static>|RenewalNegotiation whereCreatedAt($value)
  * @method static \Illuminate\Database\Eloquent\Builder<static>|RenewalNegotiation whereDisposition($value)
  * @method static \Illuminate\Database\Eloquent\Builder<static>|RenewalNegotiation whereGameId($value)
  * @method static \Illuminate\Database\Eloquent\Builder<static>|RenewalNegotiation whereGamePlayerId($value)
@@ -42,13 +39,14 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  * @method static \Illuminate\Database\Eloquent\Builder<static>|RenewalNegotiation wherePreferredYears($value)
  * @method static \Illuminate\Database\Eloquent\Builder<static>|RenewalNegotiation whereRound($value)
  * @method static \Illuminate\Database\Eloquent\Builder<static>|RenewalNegotiation whereStatus($value)
- * @method static \Illuminate\Database\Eloquent\Builder<static>|RenewalNegotiation whereUpdatedAt($value)
  * @method static \Illuminate\Database\Eloquent\Builder<static>|RenewalNegotiation whereUserOffer($value)
  * @mixin \Eloquent
  */
 class RenewalNegotiation extends Model
 {
     use HasUuids;
+
+    public $timestamps = false;
 
     public const STATUS_OFFER_PENDING = 'offer_pending';
     public const STATUS_PLAYER_COUNTERED = 'player_countered';
@@ -70,6 +68,7 @@ class RenewalNegotiation extends Model
         'counter_offer',
         'contract_years',
         'disposition',
+        'rejected_at',
     ];
 
     protected $casts = [
@@ -81,6 +80,7 @@ class RenewalNegotiation extends Model
         'counter_offer' => 'integer',
         'contract_years' => 'integer',
         'disposition' => 'float',
+        'rejected_at' => 'date',
     ];
 
     public function game(): BelongsTo
@@ -120,7 +120,19 @@ class RenewalNegotiation extends Model
 
     public function isBlocking(): bool
     {
-        return in_array($this->status, [self::STATUS_PLAYER_REJECTED, self::STATUS_CLUB_DECLINED]);
+        return $this->status === self::STATUS_CLUB_DECLINED;
+    }
+
+    /**
+     * Check if a renewal negotiation cooldown is active for a player.
+     * After a rejected negotiation, the user must wait at least one matchday before retrying.
+     */
+    public static function hasRenewalCooldown(string $gamePlayerId, $currentDate): bool
+    {
+        return static::where('game_player_id', $gamePlayerId)
+            ->where('status', self::STATUS_PLAYER_REJECTED)
+            ->where('rejected_at', '>=', $currentDate)
+            ->exists();
     }
 
     public function isTerminal(): bool

--- a/app/Modules/Transfer/Services/ContractService.php
+++ b/app/Modules/Transfer/Services/ContractService.php
@@ -335,7 +335,7 @@ class ContractService
             ->where('game_id', $game->id)
             ->where('team_id', $game->team_id)
             ->get()
-            ->filter(fn ($player) => $player->canBeOfferedRenewal($seasonEndDate))
+            ->filter(fn ($player) => $player->canBeOfferedRenewal($seasonEndDate, $game->current_date))
             ->sortBy('contract_until');
     }
 
@@ -565,6 +565,7 @@ class ContractService
         }
 
         $updateData['status'] = RenewalNegotiation::STATUS_PLAYER_REJECTED;
+        $updateData['rejected_at'] = $player->game->current_date;
         $negotiation->fill($updateData)->save();
 
         return 'rejected';

--- a/database/migrations/2026_03_30_200000_add_rejected_at_to_renewal_negotiations_table.php
+++ b/database/migrations/2026_03_30_200000_add_rejected_at_to_renewal_negotiations_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('renewal_negotiations', function (Blueprint $table) {
+            $table->date('rejected_at')->nullable()->after('disposition');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('renewal_negotiations', function (Blueprint $table) {
+            $table->dropColumn('rejected_at');
+        });
+    }
+};

--- a/database/migrations/2026_03_31_000001_drop_timestamps_from_renewal_negotiations_table.php
+++ b/database/migrations/2026_03_31_000001_drop_timestamps_from_renewal_negotiations_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('renewal_negotiations', function (Blueprint $table) {
+            $table->dropColumn(['created_at', 'updated_at']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('renewal_negotiations', function (Blueprint $table) {
+            $table->timestamps();
+        });
+    }
+};

--- a/lang/en/transfers.php
+++ b/lang/en/transfers.php
@@ -125,6 +125,8 @@ return [
     'already_bidding' => 'You already have a bid for this player',
     'negotiation_cooldown' => 'Negotiations with this player broke down recently. Wait until the next matchday to try again.',
     'negotiation_cooldown_short' => 'Wait until next matchday',
+    'renewal_cooldown' => 'This player rejected your renewal offer recently. Wait until the next matchday to try again.',
+    'renewal_cooldown_short' => 'Wait until next matchday',
     'scouting_assessment' => 'Scouting Assessment',
     'financial_details' => 'Financial Details',
     'estimated_asking_price' => 'Estimated Asking Price',

--- a/lang/es/transfers.php
+++ b/lang/es/transfers.php
@@ -126,6 +126,8 @@ return [
     'already_bidding' => 'Ya tienes una oferta por este jugador',
     'negotiation_cooldown' => 'Las negociaciones con este jugador se rompieron recientemente. Espera a la siguiente jornada para intentarlo de nuevo.',
     'negotiation_cooldown_short' => 'Espera a la próxima jornada',
+    'renewal_cooldown' => 'Este jugador rechazó tu oferta de renovación recientemente. Espera a la siguiente jornada para intentarlo de nuevo.',
+    'renewal_cooldown_short' => 'Espera a la próxima jornada',
     'scouting_assessment' => 'Evaluación del Ojeador',
     'financial_details' => 'Detalles Financieros',
     'estimated_asking_price' => 'Precio de Venta Estimado',

--- a/resources/views/outgoing-transfers.blade.php
+++ b/resources/views/outgoing-transfers.blade.php
@@ -458,10 +458,10 @@
                         <div class="space-y-6">
 
                             {{-- EXPIRING CONTRACTS --}}
-                            @if($renewalEligiblePlayers->isNotEmpty())
+                            @if($renewalEligiblePlayers->isNotEmpty() || $cooldownRenewals->isNotEmpty())
                             <x-section-card :title="__('transfers.expiring_contracts_section')">
                                 <x-slot name="badge">
-                                    <span class="text-xs text-text-secondary">({{ $renewalEligiblePlayers->count() }})</span>
+                                    <span class="text-xs text-text-secondary">({{ $renewalEligiblePlayers->count() + $cooldownRenewals->count() }})</span>
                                 </x-slot>
                                 <div class="overflow-x-auto">
                                     <table class="w-full text-sm">
@@ -505,6 +505,24 @@
                                                     @if($hasPendingOffer)
                                                         <div class="text-xs text-accent-gold">{{ __('squad.has_pre_contract_offers') }}</div>
                                                     @endif
+                                                </div>
+                                            </td>
+                                            <td class="py-2.5 text-center text-text-secondary tabular-nums hidden md:table-cell">{{ $player->age($game->current_date) }}</td>
+                                            <td class="py-2.5 text-center text-text-secondary tabular-nums hidden md:table-cell pr-4">{{ $player->formatted_wage }}</td>
+                                        </tr>
+                                        @endforeach
+                                        @foreach($cooldownRenewals as $player)
+                                        <tr class="border-t border-border-default opacity-60">
+                                            <td class="py-2.5 pl-4 text-center">
+                                                <x-position-badge :position="$player->position" size="sm" />
+                                            </td>
+                                            <td class="py-2.5 pl-2 pr-3">
+                                                <div>
+                                                    <span class="font-medium text-text-primary truncate">{{ $player->player->name }}</span>
+                                                    <div class="inline-flex items-center gap-1 text-xs text-text-muted">
+                                                        <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
+                                                        {{ __('transfers.renewal_cooldown_short') }}
+                                                    </div>
                                                 </div>
                                             </td>
                                             <td class="py-2.5 text-center text-text-secondary tabular-nums hidden md:table-cell">{{ $player->age($game->current_date) }}</td>

--- a/resources/views/partials/player-detail.blade.php
+++ b/resources/views/partials/player-detail.blade.php
@@ -198,7 +198,7 @@
 </div>
 
 {{-- Actions --}}
-@if($showActions || $canRenew || $renewalNegotiation)
+@if($showActions || $canRenew || $renewalNegotiation || $renewalCooldown)
     <div class="px-5 py-4 border-t border-border-default flex flex-wrap items-center gap-2">
         @if(!$isListed && $canManage)
             <form method="POST" action="{{ route('game.transfers.list', [$game->id, $gamePlayer->id]) }}">
@@ -295,6 +295,11 @@
                 <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" /></svg>
                 {{ $renewalNegotiation?->isCountered() ? __('transfers.chat_continue') : __('squad.renew') }}
             </x-action-button>
+        @elseif($renewalCooldown)
+            <div class="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded-lg bg-surface-700 text-text-muted border border-border-default min-h-[44px]">
+                <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
+                {{ __('transfers.renewal_cooldown_short') }}
+            </div>
         @endif
     </div>
 @endif


### PR DESCRIPTION
Instead of permanently hiding the renewal button when a player rejects, show a cooldown indicator and allow retrying after the next matchday. Club-declined renewals keep existing "Reconsider" behavior unchanged.