### PR TITLE
Fix local seeded default user activation and mode access

### DIFF
--- a/app/Console/Commands/SeedReferenceData.php
+++ b/app/Console/Commands/SeedReferenceData.php
@@ -233,13 +233,19 @@ class SeedReferenceData extends Command
 
     private function createDefaultUser(): void
     {
-        User::firstOrCreate(
+        $user = User::firstOrCreate(
             ['email' => 'test@test.com'],
             [
                 'name' => 'Test User',
                 'password' => Hash::make('password'),
             ]
         );
+
+        $user->forceFill([
+            'email_verified_at' => $user->email_verified_at ?? now(),
+            'has_career_access' => true,
+            'has_tournament_access' => true,
+        ])->save();
 
         $this->line("Default user: test@test.com / password");
     }


### PR DESCRIPTION
## Summary (dev mode)

This updates the local default user created by `app:seed-reference-data` even when `test@test.com` already exists.

It now ensures the seeded local user is:
- email verified
- granted career access
- granted tournament access

## Why

By default, the app does not allow login because the email is not verified. That meant the local seeded user could exist but still be blocked from signing in.d

There is a second issue after login: if the user does not have either `has_career_access` or `has_tournament_access`, they cannot choose a playable mode. In practice that leaves the local default user in a broken state, because the app signs in successfully but cannot proceed to a valid game flow.

`firstOrCreate()` only applies the default attributes when the record is created. If `test@test.com` already existed from a previous seed, it could keep stale values and miss verification or mode access flags.
