### PR TITLE
Fix live match lineup rendering and AI substitution edge cases

### DIFF
--- a/app/Http/Views/ShowLiveMatch.php
+++ b/app/Http/Views/ShowLiveMatch.php
@@ -136,6 +136,15 @@ class ShowLiveMatch
         // Batch load suspended player IDs for this competition
         $suspendedPlayerIds = PlayerSuspension::suspendedPlayerIdsForCompetition($playerMatch->competition_id);
 
+        $mapLineupPlayer = fn (GamePlayer $p) => [
+            'id' => $p->id,
+            'name' => $p->player->name ?? '',
+            'positionAbbr' => PositionMapper::toAbbreviation($p->position),
+            'positionGroup' => $p->position_group,
+            'positionSort' => LineupService::positionSortOrder($p->position),
+            'overallScore' => $p->overall_score,
+        ];
+
         // Bench players (all squad players NOT in the starting lineup, not suspended, not injured)
         $matchDate = $playerMatch->scheduled_date;
         $benchPlayers = GamePlayer::with('player')
@@ -171,19 +180,30 @@ class ShowLiveMatch
         $mapLineup = fn (array $ids) => GamePlayer::with('player')
             ->whereIn('id', $ids)
             ->get()
-            ->map(fn ($p) => [
-                'name' => $p->player->name ?? '',
-                'positionAbbr' => PositionMapper::toAbbreviation($p->position),
-                'positionGroup' => $p->position_group,
-                'positionSort' => LineupService::positionSortOrder($p->position),
-                'overallScore' => $p->overall_score,
-            ])
+            ->map($mapLineupPlayer)
+            ->sortBy('positionSort')
+            ->values()
+            ->all();
+
+        $buildBench = fn (string $teamId, array $lineupIds) => GamePlayer::with('player')
+            ->where('game_id', $gameId)
+            ->where('team_id', $teamId)
+            ->whereNotIn('id', $lineupIds)
+            ->whereNotIn('id', $suspendedPlayerIds)
+            ->where(function ($q) use ($matchDate) {
+                $q->whereNull('injury_until')
+                    ->orWhere('injury_until', '<', $matchDate);
+            })
+            ->get()
+            ->map($mapLineupPlayer)
             ->sortBy('positionSort')
             ->values()
             ->all();
 
         $homeLineupDisplay = $mapLineup($playerMatch->home_lineup ?? []);
         $awayLineupDisplay = $mapLineup($playerMatch->away_lineup ?? []);
+        $homeBenchDisplay = $buildBench($playerMatch->home_team_id, $playerMatch->home_lineup ?? []);
+        $awayBenchDisplay = $buildBench($playerMatch->away_team_id, $playerMatch->away_lineup ?? []);
 
         // User's current tactical setup
         $userFormation = $isUserHome
@@ -291,6 +311,8 @@ class ShowLiveMatch
             'mvpPlayerTeamId' => $playerMatch->mvpPlayer?->team_id,
             'homeLineupDisplay' => $homeLineupDisplay,
             'awayLineupDisplay' => $awayLineupDisplay,
+            'homeBenchDisplay' => $homeBenchDisplay,
+            'awayBenchDisplay' => $awayBenchDisplay,
             'homeFormation' => $playerMatch->home_formation ?? Formation::F_4_3_3->value,
             'awayFormation' => $playerMatch->away_formation ?? Formation::F_4_3_3->value,
             'formationSlots' => $formationSlots,

--- a/app/Modules/Lineup/Services/SubstitutionService.php
+++ b/app/Modules/Lineup/Services/SubstitutionService.php
@@ -162,6 +162,7 @@ class SubstitutionService
         Game $game,
         \Illuminate\Support\Collection $userLineup,
         array $substitutions,
+        int $minute,
     ): array {
         $isUserHome = $match->isHomeTeam($game->team_id);
 
@@ -176,8 +177,9 @@ class SubstitutionService
 
         // Apply opponent substitutions from match record (auto-subs from initial simulation)
         // so that injured/subbed-out players are excluded and their replacements are included.
+        // Only apply substitutions that have already happened by the resimulation minute.
         foreach ($match->substitutions ?? [] as $sub) {
-            if ($sub['team_id'] === $opponentTeamId) {
+            if ($sub['team_id'] === $opponentTeamId && ($sub['minute'] ?? 0) <= $minute) {
                 $opponentLineupIds = array_values(array_filter(
                     $opponentLineupIds,
                     fn ($id) => $id !== $sub['player_out_id']

--- a/app/Modules/Lineup/Services/TacticalChangeService.php
+++ b/app/Modules/Lineup/Services/TacticalChangeService.php
@@ -88,7 +88,7 @@ class TacticalChangeService
 
         // Build active lineup and load teams for resimulation
         $userLineup = $this->substitutionService->buildActiveLineup($match, $game->team_id, $allSubs);
-        $teams = $this->substitutionService->loadTeamsForResimulation($match, $game, $userLineup, $allSubs);
+        $teams = $this->substitutionService->loadTeamsForResimulation($match, $game, $userLineup, $allSubs, $minute);
         ['homePlayers' => $homePlayers, 'awayPlayers' => $awayPlayers, 'homeBench' => $homeBench, 'awayBench' => $awayBench] = $teams;
 
         // Capture effective tactical values before re-simulation

--- a/app/Modules/Match/Services/AISubstitutionService.php
+++ b/app/Modules/Match/Services/AISubstitutionService.php
@@ -122,6 +122,7 @@ class AISubstitutionService
      * @param  int  $subsInWindow  How many subs to make in this window
      * @param  int  $goalDifference  Positive = winning, negative = losing
      * @param  array<string>  $yellowCardPlayerIds  Players on a yellow card
+     * @param  array<string, int>  $entryMinutes  Minute each player entered the pitch
      * @param  float  $tacticalDrainMultiplier  Energy drain multiplier from tactics
      * @param  Carbon  $currentDate  Game's current date (for age calculations)
      * @return array<array{player_out: GamePlayer, player_in: GamePlayer}>
@@ -133,6 +134,7 @@ class AISubstitutionService
         int $subsInWindow,
         int $goalDifference,
         array $yellowCardPlayerIds,
+        array $entryMinutes,
         float $tacticalDrainMultiplier,
         Carbon $currentDate,
     ): array {
@@ -146,6 +148,7 @@ class AISubstitutionService
         $substitutions = [];
         $availableBench = $bench->values();
         $currentLineup = $lineup->values();
+        $currentEntryMinutes = $entryMinutes;
 
         for ($i = 0; $i < $subsInWindow; $i++) {
             if ($availableBench->isEmpty()) {
@@ -154,7 +157,7 @@ class AISubstitutionService
 
             // Score each lineup player for substitution urgency
             $candidates = $this->scoreSubstitutionUrgency(
-                $currentLineup, $windowMinute, $yellowCardPlayerIds,
+                $currentLineup, $windowMinute, $yellowCardPlayerIds, $currentEntryMinutes,
                 $energyThreshold, $yellowCardWeight, $tacticalDrainMultiplier,
                 $currentDate,
             );
@@ -181,6 +184,8 @@ class AISubstitutionService
             $currentLineup = $currentLineup->reject(fn ($p) => $p->id === $playerOut->id)
                 ->push($playerIn)->values();
             $availableBench = $availableBench->reject(fn ($p) => $p->id === $playerIn->id)->values();
+            unset($currentEntryMinutes[$playerOut->id]);
+            $currentEntryMinutes[$playerIn->id] = $windowMinute;
 
             // Remove subbed-out player from yellow card list (no longer on pitch)
             $yellowCardPlayerIds = array_values(array_filter(
@@ -201,6 +206,7 @@ class AISubstitutionService
         Collection $lineup,
         int $minute,
         array $yellowCardPlayerIds,
+        array $entryMinutes,
         float $energyThreshold,
         float $yellowCardWeight,
         float $tacticalDrainMultiplier,
@@ -208,13 +214,14 @@ class AISubstitutionService
     ): Collection {
         return $lineup
             ->filter(fn (GamePlayer $p) => $p->position !== 'Goalkeeper')
-            ->map(function (GamePlayer $player) use ($minute, $yellowCardPlayerIds, $energyThreshold, $yellowCardWeight, $tacticalDrainMultiplier, $currentDate) {
+            ->map(function (GamePlayer $player) use ($minute, $yellowCardPlayerIds, $entryMinutes, $energyThreshold, $yellowCardWeight, $tacticalDrainMultiplier, $currentDate) {
+                $minuteEntered = $entryMinutes[$player->id] ?? 0;
                 $energy = EnergyCalculator::energyAtMinute(
                     $player->physical_ability,
                     $player->age($currentDate),
                     false,
                     $minute,
-                    0, // started from minute 0
+                    $minuteEntered,
                     $tacticalDrainMultiplier,
                 );
 
@@ -224,6 +231,17 @@ class AISubstitutionService
                 // Bonus urgency when below energy threshold
                 if ($energy < $energyThreshold) {
                     $urgency += 0.2;
+                }
+
+                // Recently-entered players should be very unlikely to be hooked
+                // again straight away, but not completely forbidden.
+                $recentSubWindow = (int) ($this->config['recent_sub_protection_minutes'] ?? 12);
+                $recentSubPenalty = (float) ($this->config['recent_sub_max_penalty'] ?? 0.35);
+                if ($minuteEntered > 0 && $recentSubWindow > 0) {
+                    $minutesSinceEntry = max(0, $minute - $minuteEntered);
+                    if ($minutesSinceEntry < $recentSubWindow) {
+                        $urgency -= $recentSubPenalty * (($recentSubWindow - $minutesSinceEntry) / $recentSubWindow);
+                    }
                 }
 
                 // Yellow card risk

--- a/app/Modules/Match/Services/MatchSimulator.php
+++ b/app/Modules/Match/Services/MatchSimulator.php
@@ -448,7 +448,7 @@ class MatchSimulator
         $subs = $this->aiSubstitutionService->chooseSubstitutions(
             $players, $benchPlayers,
             $splitMinute, $subsInWindow, $goalDifference,
-            $yellowCardPlayerIds, $tacticalDrain, $currentDate,
+            $yellowCardPlayerIds, $entryMinutes, $tacticalDrain, $currentDate,
         );
 
         if (count($subs) > 0) {
@@ -2293,10 +2293,6 @@ class MatchSimulator
             ];
             $homeIdx++;
 
-            if ($this->hasPenaltyShootoutWinner($homeScore, $awayScore, $i + 1, $i, $maxRounds)) {
-                break;
-            }
-
             $awayKicker = $awayKickers[$awayIdx % count($awayKickers)];
             $awayScored = $this->penaltyScored($awayKicker, $homeGk);
             if ($awayScored) {
@@ -2311,7 +2307,12 @@ class MatchSimulator
             ];
             $awayIdx++;
 
-            if ($this->hasPenaltyShootoutWinner($homeScore, $awayScore, $i + 1, $i + 1, $maxRounds)) {
+            // Check if one team has mathematically won
+            $remainingRounds = $maxRounds - $round;
+            if ($homeScore > $awayScore + $remainingRounds) {
+                break;
+            }
+            if ($awayScore > $homeScore + $remainingRounds) {
                 break;
             }
 
@@ -2368,23 +2369,6 @@ class MatchSimulator
             'awayScore' => $awayScore,
             'kicks' => $kicks,
         ];
-    }
-
-    /**
-     * Check whether a penalty shootout is already decided after the latest kick.
-     */
-    private function hasPenaltyShootoutWinner(
-        int $homeScore,
-        int $awayScore,
-        int $homeTaken,
-        int $awayTaken,
-        int $maxRounds = 5,
-    ): bool {
-        $homeRemaining = max(0, $maxRounds - $homeTaken);
-        $awayRemaining = max(0, $maxRounds - $awayTaken);
-
-        return $homeScore > $awayScore + $awayRemaining
-            || $awayScore > $homeScore + $homeRemaining;
     }
 
     /**

--- a/config/match_simulation.php
+++ b/config/match_simulation.php
@@ -358,6 +358,8 @@ return [
         'energy_threshold' => 40,           // energy below this = strong sub candidate
         'yellow_card_weight' => 0.30,       // extra urgency score for yellowed players
         'losing_attack_bias' => 0.70,       // probability of preferring attackers when losing
+        'recent_sub_protection_minutes' => 12, // newly-entered players get a strong temporary penalty
+        'recent_sub_max_penalty' => 0.35,   // max urgency penalty applied right after entering
     ],
 
 ];

--- a/tests/Feature/SuspensionDeferralTest.php
+++ b/tests/Feature/SuspensionDeferralTest.php
@@ -402,7 +402,7 @@ class SuspensionDeferralTest extends TestCase
         $userLineup = GamePlayer::with('player')->whereIn('id', $lineup)->get();
 
         $service = app(SubstitutionService::class);
-        $result = $service->loadTeamsForResimulation($match, $this->game, $userLineup, []);
+        $result = $service->loadTeamsForResimulation($match, $this->game, $userLineup, [], 60);
 
         // Suspended player should NOT be in the user's bench
         $homeBenchIds = $result['homeBench']->pluck('id')->toArray();
@@ -490,6 +490,62 @@ class SuspensionDeferralTest extends TestCase
             $suspension->matches_remaining,
             'Copa suspension should NOT be served when the team only played a La Liga match'
         );
+    }
+
+    public function test_resimulation_excludes_future_opponent_auto_substitutions(): void
+    {
+        $this->createSquad($this->playerTeam);
+        $this->createSquad($this->opponentTeam);
+
+        $userLineup = GamePlayer::where('game_id', $this->game->id)
+            ->where('team_id', $this->playerTeam->id)
+            ->limit(11)
+            ->get();
+
+        $opponentLineup = GamePlayer::where('game_id', $this->game->id)
+            ->where('team_id', $this->opponentTeam->id)
+            ->limit(11)
+            ->get();
+
+        $starterToRemove = $opponentLineup->first();
+        $futureSub = GamePlayer::factory()
+            ->forGame($this->game)
+            ->forTeam($this->opponentTeam)
+            ->create(['position' => 'Centre-Forward']);
+
+        $match = GameMatch::factory()->create([
+            'game_id' => $this->game->id,
+            'competition_id' => $this->competition->id,
+            'round_number' => 1,
+            'home_team_id' => $this->playerTeam->id,
+            'away_team_id' => $this->opponentTeam->id,
+            'scheduled_date' => Carbon::parse('2024-08-16'),
+            'played' => true,
+            'home_lineup' => $userLineup->pluck('id')->toArray(),
+            'away_lineup' => $opponentLineup->pluck('id')->toArray(),
+            'substitutions' => [[
+                'team_id' => $this->opponentTeam->id,
+                'player_out_id' => $starterToRemove->id,
+                'player_in_id' => $futureSub->id,
+                'minute' => 76,
+                'auto' => true,
+            ]],
+        ]);
+
+        $result = app(SubstitutionService::class)->loadTeamsForResimulation(
+            $match,
+            $this->game,
+            $userLineup,
+            [],
+            60,
+        );
+
+        $awayPlayerIds = $result['awayPlayers']->pluck('id')->toArray();
+        $awayBenchIds = $result['awayBench']->pluck('id')->toArray();
+
+        $this->assertContains($starterToRemove->id, $awayPlayerIds);
+        $this->assertNotContains($futureSub->id, $awayPlayerIds);
+        $this->assertContains($futureSub->id, $awayBenchIds);
     }
 
     public function test_same_competition_suspension_is_served(): void

--- a/tests/Unit/AISubstitutionServiceTest.php
+++ b/tests/Unit/AISubstitutionServiceTest.php
@@ -113,7 +113,7 @@ class AISubstitutionServiceTest extends TestCase
 
         for ($i = 0; $i < 20; $i++) {
             $subs = $this->service->chooseSubstitutions(
-                $lineup, $bench, 70, 3, 0, [], 1.0, $game->current_date,
+                $lineup, $bench, 70, 3, 0, [], [], 1.0, $game->current_date,
             );
 
             foreach ($subs as $sub) {
@@ -134,7 +134,7 @@ class AISubstitutionServiceTest extends TestCase
         $bench = $this->createBenchPlayers($game, $team, 5, 75);
 
         $subs = $this->service->chooseSubstitutions(
-            $lineup, $bench, 70, 2, 0, [], 1.0, $game->current_date,
+            $lineup, $bench, 70, 2, 0, [], [], 1.0, $game->current_date,
         );
 
         $this->assertCount(2, $subs);
@@ -158,7 +158,7 @@ class AISubstitutionServiceTest extends TestCase
         $bench = collect([$benchPlayer]);
 
         $subs = $this->service->chooseSubstitutions(
-            $lineup, $bench, 70, 3, 0, [], 1.0, $game->current_date,
+            $lineup, $bench, 70, 3, 0, [], [], 1.0, $game->current_date,
         );
 
         $this->assertCount(1, $subs, 'Cannot make more subs than bench players available');
@@ -209,7 +209,7 @@ class AISubstitutionServiceTest extends TestCase
 
         for ($i = 0; $i < $iterations; $i++) {
             $subs = $this->service->chooseSubstitutions(
-                $lineup, $bench, 80, 1, 0, [], 1.0, $game->current_date,
+                $lineup, $bench, 80, 1, 0, [], [], 1.0, $game->current_date,
             );
 
             if ($subs[0]['player_out']->id === $tiredPlayer->id) {
@@ -234,7 +234,7 @@ class AISubstitutionServiceTest extends TestCase
         $bench = $this->createBenchPlayers($game, $team, 5, 75);
 
         $subs = $this->service->chooseSubstitutions(
-            $lineup, $bench, 70, 3, 0, [], 1.0, $game->current_date,
+            $lineup, $bench, 70, 3, 0, [], [], 1.0, $game->current_date,
         );
 
         $outIds = array_map(fn ($s) => $s['player_out']->id, $subs);
@@ -242,5 +242,155 @@ class AISubstitutionServiceTest extends TestCase
 
         $this->assertCount(count($outIds), array_unique($outIds), 'Each player should only be subbed out once');
         $this->assertCount(count($inIds), array_unique($inIds), 'Each bench player should only be brought on once');
+    }
+
+    public function test_choose_substitutions_discourages_hooking_recent_substitute(): void
+    {
+        $game = Game::factory()->create(['current_date' => '2025-10-01']);
+        $team = Team::factory()->create();
+
+        $lineup = collect();
+        $lineup->push(GamePlayer::factory()->forGame($game)->forTeam($team)->create([
+            'position' => 'Goalkeeper',
+            'game_technical_ability' => 70,
+            'game_physical_ability' => 70,
+            'fitness' => 95,
+            'morale' => 80,
+        ])->setRelation('game', $game));
+
+        for ($i = 0; $i < 8; $i++) {
+            $positions = ['Centre-Back', 'Centre-Back', 'Left-Back', 'Right-Back', 'Central Midfield', 'Central Midfield', 'Defensive Midfield', 'Right Winger'];
+            $lineup->push(GamePlayer::factory()->forGame($game)->forTeam($team)->create([
+                'position' => $positions[$i],
+                'game_technical_ability' => 70,
+                'game_physical_ability' => 90,
+                'fitness' => 95,
+                'morale' => 80,
+            ])->setRelation('game', $game));
+        }
+
+        $starter = GamePlayer::factory()->forGame($game)->forTeam($team)->create([
+            'position' => 'Left Winger',
+            'game_technical_ability' => 70,
+            'game_physical_ability' => 30,
+            'fitness' => 95,
+            'morale' => 80,
+        ]);
+        $starter->setRelation('game', $game);
+        $lineup->push($starter);
+
+        $recentSub = GamePlayer::factory()->forGame($game)->forTeam($team)->create([
+            'position' => 'Centre-Forward',
+            'game_technical_ability' => 70,
+            'game_physical_ability' => 30,
+            'fitness' => 95,
+            'morale' => 80,
+        ]);
+        $recentSub->setRelation('game', $game);
+        $lineup->push($recentSub);
+
+        $bench = collect([
+            GamePlayer::factory()->forGame($game)->forTeam($team)->create([
+                'position' => 'Centre-Forward',
+                'game_technical_ability' => 75,
+                'game_physical_ability' => 75,
+                'fitness' => 95,
+                'morale' => 80,
+            ])->setRelation('game', $game),
+        ]);
+
+        $recentSubbedOut = 0;
+        $starterSubbedOut = 0;
+
+        for ($i = 0; $i < 20; $i++) {
+            $subs = $this->service->chooseSubstitutions(
+                $lineup,
+                $bench,
+                75,
+                1,
+                0,
+                [],
+                [$recentSub->id => 70],
+                1.0,
+                $game->current_date,
+            );
+
+            if ($subs[0]['player_out']->id === $recentSub->id) {
+                $recentSubbedOut++;
+            }
+            if ($subs[0]['player_out']->id === $starter->id) {
+                $starterSubbedOut++;
+            }
+        }
+
+        $this->assertSame(0, $recentSubbedOut, 'Recently-entered players should not be the preferred sub-out option immediately');
+        $this->assertSame(20, $starterSubbedOut, 'A genuinely tired starter should be preferred over a recent substitute');
+    }
+
+    public function test_choose_substitutions_does_not_hook_player_added_earlier_in_same_window(): void
+    {
+        $game = Game::factory()->create(['current_date' => '2025-10-01']);
+        $team = Team::factory()->create();
+
+        $lineup = collect([
+            GamePlayer::factory()->forGame($game)->forTeam($team)->create([
+                'position' => 'Goalkeeper',
+                'game_technical_ability' => 70,
+                'game_physical_ability' => 70,
+                'fitness' => 95,
+                'morale' => 80,
+            ])->setRelation('game', $game),
+        ]);
+
+        foreach ([
+            'Centre-Back', 'Centre-Back', 'Left-Back', 'Right-Back',
+            'Central Midfield', 'Central Midfield', 'Defensive Midfield',
+            'Left Winger', 'Right Winger', 'Centre-Forward',
+        ] as $position) {
+            $lineup->push(GamePlayer::factory()->forGame($game)->forTeam($team)->create([
+                'position' => $position,
+                'game_technical_ability' => 70,
+                'game_physical_ability' => 30,
+                'fitness' => 95,
+                'morale' => 80,
+            ])->setRelation('game', $game));
+        }
+
+        $bench = collect([
+            GamePlayer::factory()->forGame($game)->forTeam($team)->create([
+                'position' => 'Defensive Midfield',
+                'game_technical_ability' => 75,
+                'game_physical_ability' => 75,
+                'fitness' => 95,
+                'morale' => 80,
+            ])->setRelation('game', $game),
+            GamePlayer::factory()->forGame($game)->forTeam($team)->create([
+                'position' => 'Central Midfield',
+                'game_technical_ability' => 74,
+                'game_physical_ability' => 74,
+                'fitness' => 95,
+                'morale' => 80,
+            ])->setRelation('game', $game),
+        ]);
+
+        $subs = $this->service->chooseSubstitutions(
+            $lineup,
+            $bench,
+            69,
+            2,
+            0,
+            [],
+            [],
+            1.0,
+            $game->current_date,
+        );
+
+        $this->assertCount(2, $subs);
+        $subbedInIds = array_map(fn ($sub) => $sub['player_in']->id, $subs);
+        $subbedOutIds = array_map(fn ($sub) => $sub['player_out']->id, $subs);
+
+        foreach ($subbedInIds as $subbedInId) {
+            $this->assertNotContains($subbedInId, $subbedOutIds, 'A player brought on in this window should not be hooked in the same window');
+        }
     }
 }


### PR DESCRIPTION
## Summary

This PR fixes a set of live match issues around lineup rendering, resimulation, and AI substitutions.

## What changed

- prevent resimulation from applying future opponent auto-substitutions before they actually happen
- fix cases where match events could be assigned to players who were not actually on the pitch yet
- improve the live match `lineups` tab to show starters, bench players, substitutions, cards, and injuries more clearly
- make AI substitutions use each player's real entry minute when evaluating fatigue
- discourage the AI from immediately subbing off a recently introduced player
- prevent the AI from bringing a player on and taking him off again in the same substitution window

## Why

There were a few related problems in live matches:

- stale resimulated lineups could treat future opponent substitutions as already active
- that could lead to impossible match events, such as goals or cards being assigned to players who had not entered the match yet
- lineup UI did not reflect bench usage and player status clearly enough
- AI substitution logic could overvalue removing newly introduced players because it treated them as if they had played since minute 0
- in some cases, the AI could create unrealistic same-window substitution chains

## Testing

- added regression coverage for opponent resimulation with future auto-subs
- added unit tests for recent-substitute handling
- added unit tests to prevent same-window `in -> out` AI substitutions

## Preview
<img width="694" height="770" alt="Screenshot 2026-03-31 at 13 32 17" src="https://github.com/user-attachments/assets/243b957a-bf3f-495a-afa6-183efab72f64" />
