### PR TITLE
Fix: end penalty shootouts once the result is mathematically decided

### DIFF
--- a/app/Modules/Match/Services/MatchSimulator.php
+++ b/app/Modules/Match/Services/MatchSimulator.php
@@ -2293,6 +2293,10 @@ class MatchSimulator
             ];
             $homeIdx++;
 
+            if ($this->hasPenaltyShootoutWinner($homeScore, $awayScore, $i + 1, $i, $maxRounds)) {
+                break;
+            }
+
             $awayKicker = $awayKickers[$awayIdx % count($awayKickers)];
             $awayScored = $this->penaltyScored($awayKicker, $homeGk);
             if ($awayScored) {
@@ -2307,12 +2311,7 @@ class MatchSimulator
             ];
             $awayIdx++;
 
-            // Check if one team has mathematically won
-            $remainingRounds = $maxRounds - $round;
-            if ($homeScore > $awayScore + $remainingRounds) {
-                break;
-            }
-            if ($awayScore > $homeScore + $remainingRounds) {
+            if ($this->hasPenaltyShootoutWinner($homeScore, $awayScore, $i + 1, $i + 1, $maxRounds)) {
                 break;
             }
 
@@ -2369,6 +2368,23 @@ class MatchSimulator
             'awayScore' => $awayScore,
             'kicks' => $kicks,
         ];
+    }
+
+    /**
+     * Check whether a penalty shootout is already decided after the latest kick.
+     */
+    private function hasPenaltyShootoutWinner(
+        int $homeScore,
+        int $awayScore,
+        int $homeTaken,
+        int $awayTaken,
+        int $maxRounds = 5,
+    ): bool {
+        $homeRemaining = max(0, $maxRounds - $homeTaken);
+        $awayRemaining = max(0, $maxRounds - $awayTaken);
+
+        return $homeScore > $awayScore + $awayRemaining
+            || $awayScore > $homeScore + $homeRemaining;
     }
 
     /**

--- a/tests/Unit/PenaltyShootoutTest.php
+++ b/tests/Unit/PenaltyShootoutTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Modules\Match\Services\MatchSimulator;
+use ReflectionMethod;
+use Tests\TestCase;
+
+class PenaltyShootoutTest extends TestCase
+{
+    private MatchSimulator $simulator;
+
+    private ReflectionMethod $hasPenaltyShootoutWinner;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->simulator = new MatchSimulator;
+        $this->hasPenaltyShootoutWinner = new ReflectionMethod(MatchSimulator::class, 'hasPenaltyShootoutWinner');
+    }
+
+    public function test_shootout_can_end_before_last_away_kick_when_result_is_decided(): void
+    {
+        $resolved = $this->hasPenaltyShootoutWinner->invoke(
+            $this->simulator,
+            4,
+            2,
+            5,
+            4,
+            5,
+        );
+
+        $this->assertTrue($resolved);
+    }
+
+    public function test_shootout_continues_when_trailing_team_can_still_equalise(): void
+    {
+        $resolved = $this->hasPenaltyShootoutWinner->invoke(
+            $this->simulator,
+            3,
+            2,
+            4,
+            4,
+            5,
+        );
+
+        $this->assertFalse($resolved);
+    }
+
+    public function test_shootout_can_end_immediately_after_home_kick_in_round_five(): void
+    {
+        $resolved = $this->hasPenaltyShootoutWinner->invoke(
+            $this->simulator,
+            5,
+            3,
+            5,
+            4,
+            5,
+        );
+
+        $this->assertTrue($resolved);
+    }
+}


### PR DESCRIPTION
## Summary

This fixes penalty shootouts so they stop as soon as one team has already won mathematically.

## What changed

- check whether the shootout is already decided after each kick
- stop the sequence immediately instead of always playing the full five kicks per team
- add regression tests for early endings and normal continuation cases

## Why

The simulator could keep taking penalties even when the trailing team no longer had enough kicks left to equalise. That produced impossible shootout flows, like the losing team still taking a final penalty after the winner was already decided.