### PR TITLE
Fix transfer offer expiration timing for forward-looking game date

### DIFF
--- a/app/Http/Actions/NegotiateCounterOffer.php
+++ b/app/Http/Actions/NegotiateCounterOffer.php
@@ -58,8 +58,8 @@ class NegotiateCounterOffer
         $buyerName = $offer->offeringTeam->name;
 
         // Extend expiry to prevent mid-negotiation timeout
-        if ($offer->expires_at && $offer->expires_at->diffInDays($game->current_date) < 5) {
-            $offer->update(['expires_at' => $game->current_date->addDays(5)]);
+        if ($offer->expires_at && $offer->expires_at->diffInDays($game->current_date) < 14) {
+            $offer->update(['expires_at' => $game->current_date->addDays(14)]);
         }
 
         // Check for existing negotiation to resume

--- a/app/Modules/Match/Services/CareerActionProcessor.php
+++ b/app/Modules/Match/Services/CareerActionProcessor.php
@@ -114,7 +114,7 @@ class CareerActionProcessor
             ->where('status', TransferOffer::STATUS_PENDING)
             ->whereHas('gamePlayer', fn ($q) => $q->where('team_id', $game->team_id))
             ->where('expires_at', '>', $currentDate)
-            ->where('expires_at', '<=', $currentDate->copy()->addDays(2))
+            ->where('expires_at', '<=', $currentDate->copy()->addDays(7))
             ->get();
 
         if ($expiringOffers->isEmpty()) {

--- a/app/Modules/Transfer/Services/TransferService.php
+++ b/app/Modules/Transfer/Services/TransferService.php
@@ -49,8 +49,8 @@ class TransferService
     /**
      * Offer expiry in days.
      */
-    private const LISTED_OFFER_EXPIRY_DAYS = 7;
-    private const UNSOLICITED_OFFER_EXPIRY_DAYS = 5;
+    private const LISTED_OFFER_EXPIRY_DAYS = 14;
+    private const UNSOLICITED_OFFER_EXPIRY_DAYS = 14;
 
     /**
      * Chance of unsolicited offer per star player per matchday.

--- a/tests/Feature/CounterOfferTest.php
+++ b/tests/Feature/CounterOfferTest.php
@@ -74,7 +74,7 @@ class CounterOfferTest extends TestCase
             'direction' => TransferOffer::DIRECTION_OUTGOING,
             'transfer_fee' => 11_000_000_00, // €11M
             'status' => TransferOffer::STATUS_PENDING,
-            'expires_at' => '2025-08-06',
+            'expires_at' => '2025-08-15',
             'game_date' => '2025-08-01',
         ]);
     }
@@ -275,8 +275,8 @@ class CounterOfferTest extends TestCase
         );
 
         $this->offer->refresh();
-        // Should be extended to 5 days from current_date
-        $this->assertEquals('2025-08-06', $this->offer->expires_at->format('Y-m-d'));
+        // Should be extended to 14 days from current_date
+        $this->assertEquals('2025-08-15', $this->offer->expires_at->format('Y-m-d'));
     }
 
     public function test_cannot_counter_other_users_player(): void


### PR DESCRIPTION
Offers expired between matchdays because the 5-day (unsolicited) and
7-day (listed) expiry windows were shorter than the typical 7-day gap
between league matches. Increased both to 14 days so users get at least
2 matchdays to react. Also widened the expiry warning window (2→7 days)
and counter-offer extension logic to match.

https://claude.ai/code/session_017yiY7DMkEd36MXv2h6gVJ3