### PR TITLE
Fix transfer actions crossing game boundaries

### DIFF
--- a/app/Http/Actions/RequestLoan.php
+++ b/app/Http/Actions/RequestLoan.php
@@ -2,10 +2,10 @@
 
 namespace App\Http\Actions;
 
-use App\Modules\Transfer\Services\ContractService;
-use App\Modules\Transfer\Services\LoanService;
 use App\Models\Game;
 use App\Models\GamePlayer;
+use App\Modules\Transfer\Services\ContractService;
+use App\Modules\Transfer\Services\LoanService;
 use Illuminate\Http\Request;
 
 class RequestLoan
@@ -17,7 +17,9 @@ class RequestLoan
     public function __invoke(Request $request, string $gameId, string $playerId)
     {
         $game = Game::with(['team', 'finances'])->findOrFail($gameId);
-        $player = GamePlayer::with(['player', 'team'])->findOrFail($playerId);
+        $player = GamePlayer::with(['player', 'team'])
+            ->where('game_id', $gameId)
+            ->findOrFail($playerId);
 
         // Determine if this is loan-in (from scouting) or loan-out (from squad)
         $isLoanOut = $player->team_id === $game->team_id;

--- a/app/Http/Actions/SignFreeAgent.php
+++ b/app/Http/Actions/SignFreeAgent.php
@@ -21,7 +21,9 @@ class SignFreeAgent
     public function __invoke(Request $request, string $gameId, string $playerId)
     {
         $game = Game::findOrFail($gameId);
-        $player = GamePlayer::with('player')->findOrFail($playerId);
+        $player = GamePlayer::with('player')
+            ->where('game_id', $gameId)
+            ->findOrFail($playerId);
 
         // Must be a free agent
         if ($player->team_id !== null) {

--- a/app/Http/Actions/SubmitPreContractOffer.php
+++ b/app/Http/Actions/SubmitPreContractOffer.php
@@ -16,7 +16,9 @@ class SubmitPreContractOffer
     public function __invoke(Request $request, string $gameId, string $playerId)
     {
         $game = Game::findOrFail($gameId);
-        $player = GamePlayer::with(['player', 'team'])->findOrFail($playerId);
+        $player = GamePlayer::with(['player', 'team'])
+            ->where('game_id', $gameId)
+            ->findOrFail($playerId);
 
         $validated = $request->validate([
             'offered_wage' => 'required|integer|min:0',

--- a/app/Modules/Transfer/Services/LoanService.php
+++ b/app/Modules/Transfer/Services/LoanService.php
@@ -20,6 +20,7 @@ use Illuminate\Support\Collection;
 class LoanService
 {
     private const SEARCH_EXPIRY_DAYS = 21;
+
     private const MATCH_PROBABILITY = 50; // % chance per matchday
 
     /**
@@ -108,6 +109,7 @@ class LoanService
                         'destination' => $destination,
                         'windowOpen' => $game->isTransferWindowOpen(),
                     ];
+
                     continue;
                 }
             }
@@ -158,10 +160,10 @@ class LoanService
                 'score' => $this->scoreLoanDestination($game, $player, $team, $positionCounts, $teamReputations),
             ];
         })
-        ->filter(fn ($item) => $item['score'] >= 20)
-        ->sortByDesc('score')
-        ->take(5)
-        ->values();
+            ->filter(fn ($item) => $item['score'] >= 20)
+            ->sortByDesc('score')
+            ->take(5)
+            ->values();
 
         if ($scored->isEmpty()) {
             return null;
@@ -272,7 +274,7 @@ class LoanService
     /**
      * Pre-load position group counts for multiple teams in a single query.
      *
-     * @return array<string, array<string, int>>  [teamId => [positionGroup => count]]
+     * @return array<string, array<string, int>> [teamId => [positionGroup => count]]
      */
     private function getPositionCountsByTeam(Game $game, array $teamIds): array
     {
@@ -323,7 +325,7 @@ class LoanService
      */
     private function isSearchExpired(GamePlayer $player, Carbon $currentDate): bool
     {
-        if (!$player->transfer_listed_at) {
+        if (! $player->transfer_listed_at) {
             return true;
         }
 
@@ -408,6 +410,10 @@ class LoanService
      */
     public function requestLoanIn(Game $game, GamePlayer $player): TransferOffer
     {
+        if ($player->game_id !== $game->id) {
+            throw new \InvalidArgumentException('Player does not belong to this game.');
+        }
+
         if ($player->team_id === null) {
             throw new \InvalidArgumentException('Cannot loan a free agent — no parent team.');
         }
@@ -508,6 +514,7 @@ class LoanService
         // Safety net: reject if squad is full
         if (ContractService::isSquadFull($game)) {
             $offer->update(['status' => TransferOffer::STATUS_REJECTED, 'resolved_at' => $game->current_date]);
+
             return;
         }
 
@@ -516,6 +523,7 @@ class LoanService
 
         if ($parentTeamId === null) {
             $offer->update(['status' => TransferOffer::STATUS_REJECTED, 'resolved_at' => $game->current_date]);
+
             return;
         }
 
@@ -619,6 +627,7 @@ class LoanService
     {
         if ($game->isTransferWindowOpen()) {
             $this->completeLoanIn($offer, $game);
+
             return ['result' => 'accepted', 'offer' => $offer->fresh()];
         }
 
@@ -626,6 +635,7 @@ class LoanService
             'status' => TransferOffer::STATUS_AGREED,
             'resolved_at' => $game->current_date,
         ]);
+
         return ['result' => 'accepted', 'offer' => $offer->fresh()];
     }
 
@@ -645,5 +655,4 @@ class LoanService
 
         return ['label' => __('transfers.mood_reluctant_loan'), 'color' => 'red'];
     }
-
 }

--- a/app/Modules/Transfer/Services/TransferService.php
+++ b/app/Modules/Transfer/Services/TransferService.php
@@ -2,12 +2,6 @@
 
 namespace App\Modules\Transfer\Services;
 
-use App\Modules\Player\PlayerAge;
-use App\Modules\Transfer\Enums\TransferWindowType;
-use App\Modules\Transfer\Services\ContractService;
-use App\Modules\Transfer\Services\LoanService;
-use App\Modules\Transfer\Services\ScoutingService;
-use App\Support\Money;
 use App\Models\ClubProfile;
 use App\Models\Competition;
 use App\Models\Game;
@@ -17,6 +11,9 @@ use App\Models\ShortlistedPlayer;
 use App\Models\Team;
 use App\Models\TeamReputation;
 use App\Models\TransferOffer;
+use App\Modules\Player\PlayerAge;
+use App\Modules\Transfer\Enums\TransferWindowType;
+use App\Support\Money;
 use Carbon\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
@@ -32,24 +29,28 @@ class TransferService
      * Discount range for listed players (buyer has leverage).
      */
     private const LISTED_PRICE_MIN = 0.85;
+
     private const LISTED_PRICE_MAX = 0.95;
 
     /**
      * Premium range for unsolicited offers (tempting the seller).
      */
     private const UNSOLICITED_PRICE_MIN = 1.00;
+
     private const UNSOLICITED_PRICE_MAX = 1.20;
 
     /**
      * Age adjustments for transfer pricing.
      */
     private const AGE_PREMIUM_YOUNG = 1.10;  // Young talent premium
+
     private const AGE_DECLINE_PENALTY_PER_YEAR = 0.05;  // 5% per year
 
     /**
      * Offer expiry in days.
      */
     private const LISTED_OFFER_EXPIRY_DAYS = 14;
+
     private const UNSOLICITED_OFFER_EXPIRY_DAYS = 14;
 
     /**
@@ -79,11 +80,11 @@ class TransferService
      * [min_market_value_cents => chance]
      */
     private const PRE_CONTRACT_OFFER_CHANCE_BY_VALUE = [
-        5_000_000_000  => 0.35, // €50M+ → 35%
-        2_000_000_000  => 0.25, // €20M+ → 25%
-        1_000_000_000  => 0.20, // €10M+ → 20%
-        500_000_000    => 0.15, // €5M+  → 15%
-        0              => 0.10, // < €5M → 10%
+        5_000_000_000 => 0.35, // €50M+ → 35%
+        2_000_000_000 => 0.25, // €20M+ → 25%
+        1_000_000_000 => 0.20, // €10M+ → 20%
+        500_000_000 => 0.15, // €5M+  → 15%
+        0 => 0.10, // < €5M → 10%
     ];
 
     /**
@@ -96,11 +97,11 @@ class TransferService
      * to be interested, keyed by reputation tier.
      */
     private const MIN_TIER_BY_REPUTATION = [
-        ClubProfile::REPUTATION_LOCAL        => 1,
-        ClubProfile::REPUTATION_MODEST       => 1,
-        ClubProfile::REPUTATION_ESTABLISHED  => 2,
-        ClubProfile::REPUTATION_CONTINENTAL  => 3,
-        ClubProfile::REPUTATION_ELITE        => 4,
+        ClubProfile::REPUTATION_LOCAL => 1,
+        ClubProfile::REPUTATION_MODEST => 1,
+        ClubProfile::REPUTATION_ESTABLISHED => 2,
+        ClubProfile::REPUTATION_CONTINENTAL => 3,
+        ClubProfile::REPUTATION_ELITE => 4,
     ];
 
     /**
@@ -141,7 +142,7 @@ class TransferService
      * Generate offers for all listed players.
      * Called on each matchday advance.
      *
-     * @param Collection|null $allPlayersGrouped Pre-loaded players grouped by team_id (optional, for N+1 optimization)
+     * @param  Collection|null  $allPlayersGrouped  Pre-loaded players grouped by team_id (optional, for N+1 optimization)
      */
     public function generateOffersForListedPlayers(Game $game, $allPlayersGrouped = null, ?array $buyerPool = null): Collection
     {
@@ -152,7 +153,7 @@ class TransferService
             $teamPlayers = $allPlayersGrouped->get($game->team_id, collect());
             $listedPlayers = $teamPlayers->filter(
                 fn ($p) => $p->transfer_status === GamePlayer::TRANSFER_STATUS_LISTED
-                    && !$p->isLoanedIn($game->team_id)
+                    && ! $p->isLoanedIn($game->team_id)
             );
         } else {
             $listedPlayers = GamePlayer::with('transferOffers')
@@ -199,7 +200,7 @@ class TransferService
                     ->toArray();
 
                 $availableBuyers = $buyers->filter(
-                    fn ($team) => !in_array($team->id, $existingOfferTeamIds)
+                    fn ($team) => ! in_array($team->id, $existingOfferTeamIds)
                 );
 
                 if ($availableBuyers->isNotEmpty()) {
@@ -221,7 +222,7 @@ class TransferService
      * Generate unsolicited offers for star players.
      * Called on each matchday advance.
      *
-     * @param Collection|null $allPlayersGrouped Pre-loaded players grouped by team_id (optional, for N+1 optimization)
+     * @param  Collection|null  $allPlayersGrouped  Pre-loaded players grouped by team_id (optional, for N+1 optimization)
      * @param  array{leagueTeams: Collection, squadValues: Collection}|null  $buyerPool  Pre-loaded pool from loadBuyerPool()
      */
     public function generateUnsolicitedOffers(Game $game, $allPlayersGrouped = null, ?array $buyerPool = null): Collection
@@ -233,7 +234,7 @@ class TransferService
             $teamPlayers = $allPlayersGrouped->get($game->team_id, collect());
             $starPlayers = $teamPlayers
                 ->filter(fn ($p) => $p->transfer_status === null
-                    && !$p->isLoanedIn($game->team_id))
+                    && ! $p->isLoanedIn($game->team_id))
                 ->sortByDesc('market_value_cents')
                 ->take(self::STAR_PLAYER_COUNT);
         } else {
@@ -301,7 +302,7 @@ class TransferService
      * Generate pre-contract offers for players with expiring contracts.
      * Called on each matchday advance (typically from January onwards).
      *
-     * @param Collection|null $allPlayersGrouped Pre-loaded players grouped by team_id (optional, for N+1 optimization)
+     * @param  Collection|null  $allPlayersGrouped  Pre-loaded players grouped by team_id (optional, for N+1 optimization)
      * @param  array{leagueTeams: Collection, squadValues: Collection}|null  $buyerPool  Pre-loaded pool from loadBuyerPool()
      */
     public function generatePreContractOffers(Game $game, $allPlayersGrouped = null, ?array $buyerPool = null): Collection
@@ -310,7 +311,7 @@ class TransferService
 
         // Only generate pre-contract offers from January through May
         // Players can sign pre-contracts 6 months before their contract expires (June 30)
-        if (!$game->current_date) {
+        if (! $game->current_date) {
             return $offers;
         }
 
@@ -327,7 +328,7 @@ class TransferService
             // Filter to players with expiring contracts who can receive offers
             $expiringPlayers = $teamPlayers->filter(function ($player) use ($seasonEndDate, $game) {
                 // Check if contract is expiring
-                if (!$player->contract_until || !$player->contract_until->lte($seasonEndDate)) {
+                if (! $player->contract_until || ! $player->contract_until->lte($seasonEndDate)) {
                     return false;
                 }
                 // Skip loaned-in players — they belong to their parent club
@@ -543,17 +544,20 @@ class TransferService
         // current contract is still valid until June regardless of window status.
         if ($offer->isPreContract()) {
             $offer->update(['status' => TransferOffer::STATUS_AGREED, 'resolved_at' => $game->current_date]);
+
             return false;
         }
 
         // If transfer window is open, complete immediately
         if ($game->isTransferWindowOpen()) {
             $this->completeTransfer($offer, $game);
+
             return true;
         }
 
         // Otherwise, mark as agreed (waiting for next transfer window)
         $offer->update(['status' => TransferOffer::STATUS_AGREED, 'resolved_at' => $game->current_date]);
+
         return false;
     }
 
@@ -868,8 +872,8 @@ class TransferService
     /**
      * Pick a random item from a collection using weighted probabilities.
      *
-     * @param Collection $items Collection of items (must have 'id' property)
-     * @param array<string, float> $weights Item ID => weight
+     * @param  Collection  $items  Collection of items (must have 'id' property)
+     * @param  array<string, float>  $weights  Item ID => weight
      */
     private function weightedRandom(Collection $items, array $weights): mixed
     {
@@ -938,6 +942,10 @@ class TransferService
      */
     public function signFreeAgent(Game $game, GamePlayer $player, int $wageDemand): TransferOffer
     {
+        if ($player->game_id !== $game->id) {
+            throw new \InvalidArgumentException('Player does not belong to this game.');
+        }
+
         $seasonYear = (int) $game->season;
         $contractYears = $player->age($game->current_date) >= 32 ? 1 : mt_rand(2, 3);
         $newContractEnd = Carbon::createFromDate($seasonYear + $contractYears + 1, 6, 30);
@@ -996,6 +1004,7 @@ class TransferService
         if ($game->isTransferWindowOpen()) {
             if ($offer->offer_type === TransferOffer::TYPE_LOAN_IN) {
                 $this->loanService->completeLoanIn($offer, $game);
+
                 return true;
             }
 
@@ -1004,6 +1013,7 @@ class TransferService
 
         // Otherwise, mark as agreed (waiting for next transfer window)
         $offer->update(['status' => TransferOffer::STATUS_AGREED, 'resolved_at' => $game->current_date]);
+
         return false;
     }
 
@@ -1036,12 +1046,16 @@ class TransferService
      */
     public function submitPreContractOffer(Game $game, GamePlayer $player, int $offeredWageCents): TransferOffer
     {
-        if (!$game->isPreContractPeriod()) {
+        if ($player->game_id !== $game->id) {
+            throw new \InvalidArgumentException('Player does not belong to this game.');
+        }
+
+        if (! $game->isPreContractPeriod()) {
             throw new \InvalidArgumentException(__('messages.pre_contract_not_available'));
         }
 
         $seasonEnd = $game->getSeasonEndDate();
-        if (!$player->contract_until || !$player->contract_until->lte($seasonEnd)) {
+        if (! $player->contract_until || ! $player->contract_until->lte($seasonEnd)) {
             throw new \InvalidArgumentException(__('messages.player_not_expiring'));
         }
 
@@ -1148,6 +1162,7 @@ class TransferService
                 'asking_price' => $evaluation['asking_price'],
                 'resolved_at' => $game->current_date,
             ]);
+
             return ['result' => 'accepted', 'offer' => $offer->fresh()];
         }
 
@@ -1155,6 +1170,7 @@ class TransferService
             $offer->update([
                 'asking_price' => $evaluation['counter_amount'],
             ]);
+
             return ['result' => 'countered', 'offer' => $offer->fresh()];
         }
 
@@ -1164,6 +1180,7 @@ class TransferService
             'asking_price' => $evaluation['asking_price'],
             'resolved_at' => $game->current_date,
         ]);
+
         return ['result' => 'rejected', 'offer' => $offer->fresh()];
     }
 
@@ -1172,7 +1189,7 @@ class TransferService
      */
     public function acceptTransferFeeCounter(Game $game, TransferOffer $offer): TransferOffer
     {
-        if (!$offer->isPending() || !$offer->isSyncNegotiated() || !$offer->asking_price || $offer->asking_price <= $offer->transfer_fee) {
+        if (! $offer->isPending() || ! $offer->isSyncNegotiated() || ! $offer->asking_price || $offer->asking_price <= $offer->transfer_fee) {
             throw new \InvalidArgumentException(__('messages.transfer_failed'));
         }
 
@@ -1218,6 +1235,7 @@ class TransferService
             $offer->update([
                 'transfer_fee' => $userAskingCents,
             ]);
+
             return ['result' => 'accepted', 'offer' => $offer->fresh()];
         }
 
@@ -1225,6 +1243,7 @@ class TransferService
             $offer->update([
                 'transfer_fee' => $evaluation['counter_amount'],
             ]);
+
             return ['result' => 'countered', 'offer' => $offer->fresh()];
         }
 
@@ -1233,6 +1252,7 @@ class TransferService
             'status' => TransferOffer::STATUS_REJECTED,
             'resolved_at' => $game->current_date,
         ]);
+
         return ['result' => 'rejected', 'offer' => $offer->fresh()];
     }
 

--- a/database/migrations/2026_03_31_100000_enforce_transfer_offer_game_player_scope.php
+++ b/database/migrations/2026_03_31_100000_enforce_transfer_offer_game_player_scope.php
@@ -1,0 +1,53 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    private const GAME_PLAYERS_COMPOSITE_UNIQUE = 'game_players_id_game_id_unique_idx';
+
+    private const TRANSFER_OFFERS_GAME_PLAYER_GAME_INDEX = 'transfer_offers_game_player_game_idx';
+
+    private const TRANSFER_OFFERS_GAME_PLAYER_GAME_FOREIGN = 'transfer_offers_game_player_game_foreign';
+
+    public function up(): void
+    {
+        $hasInconsistentOffers = DB::table('transfer_offers')
+            ->join('game_players', 'game_players.id', '=', 'transfer_offers.game_player_id')
+            ->whereColumn('game_players.game_id', '!=', 'transfer_offers.game_id')
+            ->exists();
+
+        if ($hasInconsistentOffers) {
+            throw new RuntimeException('Cannot enforce transfer offer game scope: inconsistent transfer offers already exist.');
+        }
+
+        Schema::table('game_players', function (Blueprint $table) {
+            $table->unique(['id', 'game_id'], self::GAME_PLAYERS_COMPOSITE_UNIQUE);
+        });
+
+        Schema::table('transfer_offers', function (Blueprint $table) {
+            $table->dropForeign(['game_player_id']);
+            $table->index(['game_player_id', 'game_id'], self::TRANSFER_OFFERS_GAME_PLAYER_GAME_INDEX);
+            $table->foreign(['game_player_id', 'game_id'], self::TRANSFER_OFFERS_GAME_PLAYER_GAME_FOREIGN)
+                ->references(['id', 'game_id'])
+                ->on('game_players')
+                ->cascadeOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('transfer_offers', function (Blueprint $table) {
+            $table->dropForeign(self::TRANSFER_OFFERS_GAME_PLAYER_GAME_FOREIGN);
+            $table->dropIndex(self::TRANSFER_OFFERS_GAME_PLAYER_GAME_INDEX);
+            $table->foreign('game_player_id')->references('id')->on('game_players')->cascadeOnDelete();
+        });
+
+        Schema::table('game_players', function (Blueprint $table) {
+            $table->dropUnique(self::GAME_PLAYERS_COMPOSITE_UNIQUE);
+        });
+    }
+};

--- a/tests/Feature/TransferGameIsolationTest.php
+++ b/tests/Feature/TransferGameIsolationTest.php
@@ -1,0 +1,163 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Competition;
+use App\Models\Game;
+use App\Models\GamePlayer;
+use App\Models\Team;
+use App\Models\User;
+use App\Modules\Transfer\Services\LoanService;
+use App\Modules\Transfer\Services\TransferService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class TransferGameIsolationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private TransferService $transferService;
+
+    private LoanService $loanService;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->transferService = app(TransferService::class);
+        $this->loanService = app(LoanService::class);
+    }
+
+    public function test_sign_free_agent_route_cannot_target_player_from_another_game(): void
+    {
+        [$user, $game] = $this->createOwnedGame();
+        [, $otherGame] = $this->createOwnedGame();
+
+        $freeAgent = GamePlayer::factory()->forGame($otherGame)->create([
+            'team_id' => null,
+        ]);
+
+        $this->actingAs($user)
+            ->post(route('game.scouting.sign-free-agent', [
+                'gameId' => $game->id,
+                'playerId' => $freeAgent->id,
+            ]))
+            ->assertNotFound();
+
+        $this->assertDatabaseCount('transfer_offers', 0);
+        $this->assertNull($freeAgent->fresh()->team_id);
+    }
+
+    public function test_request_loan_route_cannot_target_player_from_another_game(): void
+    {
+        [$user, $game] = $this->createOwnedGame();
+        [, $otherGame] = $this->createOwnedGame();
+
+        $loanTarget = GamePlayer::factory()->forGame($otherGame)->create();
+
+        $this->actingAs($user)
+            ->post(route('game.scouting.loan', [
+                'gameId' => $game->id,
+                'playerId' => $loanTarget->id,
+            ]))
+            ->assertNotFound();
+
+        $this->assertDatabaseCount('transfer_offers', 0);
+        $this->assertSame($otherGame->id, $loanTarget->fresh()->game_id);
+    }
+
+    public function test_pre_contract_route_cannot_target_player_from_another_game(): void
+    {
+        [$user, $game] = $this->createOwnedGame([
+            'current_date' => '2025-01-15',
+            'season' => '2025',
+        ]);
+        [, $otherGame] = $this->createOwnedGame([
+            'current_date' => '2025-01-15',
+            'season' => '2025',
+        ]);
+
+        $expiringPlayer = GamePlayer::factory()->forGame($otherGame)->create([
+            'contract_until' => '2025-06-30',
+        ]);
+
+        $this->actingAs($user)
+            ->post(route('game.scouting.pre-contract', [
+                'gameId' => $game->id,
+                'playerId' => $expiringPlayer->id,
+            ]), [
+                'offered_wage' => 150000,
+            ])
+            ->assertNotFound();
+
+        $this->assertDatabaseCount('transfer_offers', 0);
+        $this->assertSame($otherGame->id, $expiringPlayer->fresh()->game_id);
+    }
+
+    public function test_sign_free_agent_service_rejects_player_from_another_game(): void
+    {
+        [, $game] = $this->createOwnedGame([
+            'current_date' => '2025-01-15',
+            'season' => '2025',
+        ]);
+        [, $otherGame] = $this->createOwnedGame([
+            'current_date' => '2025-01-15',
+            'season' => '2025',
+        ]);
+
+        $freeAgent = GamePlayer::factory()->forGame($otherGame)->create([
+            'team_id' => null,
+        ]);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Player does not belong to this game.');
+        $this->transferService->signFreeAgent($game, $freeAgent, 100000);
+    }
+
+    public function test_submit_pre_contract_service_rejects_player_from_another_game(): void
+    {
+        [, $game] = $this->createOwnedGame([
+            'current_date' => '2025-01-15',
+            'season' => '2025',
+        ]);
+        [, $otherGame] = $this->createOwnedGame([
+            'current_date' => '2025-01-15',
+            'season' => '2025',
+        ]);
+
+        $player = GamePlayer::factory()->forGame($otherGame)->create([
+            'contract_until' => '2025-06-30',
+        ]);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Player does not belong to this game.');
+        $this->transferService->submitPreContractOffer($game, $player, 100000);
+    }
+
+    public function test_request_loan_service_rejects_player_from_another_game(): void
+    {
+        [, $game] = $this->createOwnedGame();
+        [, $otherGame] = $this->createOwnedGame();
+
+        $player = GamePlayer::factory()->forGame($otherGame)->create();
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Player does not belong to this game.');
+        $this->loanService->requestLoanIn($game, $player);
+    }
+
+    private function createOwnedGame(array $attributes = []): array
+    {
+        $competition = Competition::factory()->league()->create();
+        $user = User::factory()->create();
+        $team = Team::factory()->create();
+
+        $game = Game::factory()->create(array_merge([
+            'user_id' => $user->id,
+            'team_id' => $team->id,
+            'competition_id' => $competition->id,
+        ], $attributes));
+
+        return [$user, $game];
+    }
+}


### PR DESCRIPTION
## Summary

This PR fixes a save-isolation bug in transfer actions where some endpoints loaded `GamePlayer` records by global UUID instead of scoping them to the current `game_id`.

## What changed

* scope `SignFreeAgent`, `RequestLoan`, and `SubmitPreContractOffer` player lookups to the active game
* add defensive service-level guards so transfer and loan flows reject players from a different save even if a caller bypasses the HTTP layer
* enforce the same invariant in the database with a composite foreign key from `transfer_offers` to `(game_player_id, game_id)`
* add regression coverage to ensure transfer actions cannot target players from another game

## Why

There was a save-boundary bug in a few market flows:

* the request route was tied to one game, but the `playerId` could still be resolved globally
* that meant a malformed or leaked UUID could create transfer state in one save while pointing at a `GamePlayer` from another save
* in the worst case, that could corrupt transfer offers or mutate player state across otherwise independent careers

## Testing

* added feature tests covering cross-game free-agent, loan, and pre-contract requests
* added service-level regression tests for cross-game transfer guards
* ran `php artisan test tests/Feature/TransferGameIsolationTest.php`
* ran `php artisan test tests/Feature/PreContractBalanceTest.php`
* ran `php artisan test tests/Unit/FreeAgentReputationGateTest.php`