### PR TITLE
Enhance red card mechanics with natural strength reduction and reactive AI subs

### DIFF
--- a/app/Modules/Match/Services/AISubstitutionService.php
+++ b/app/Modules/Match/Services/AISubstitutionService.php
@@ -4,7 +4,6 @@ namespace App\Modules\Match\Services;
 
 use App\Models\GamePlayer;
 use App\Modules\Lineup\Services\SubstitutionService;
-use App\Modules\Match\Services\EnergyCalculator;
 use App\Support\PositionMapper;
 use Carbon\Carbon;
 use Illuminate\Support\Collection;

--- a/app/Modules/Match/Services/MatchSimulator.php
+++ b/app/Modules/Match/Services/MatchSimulator.php
@@ -505,21 +505,19 @@ class MatchSimulator
 
         $maxSubs = SubstitutionService::MAX_SUBSTITUTIONS;
         $maxWindows = SubstitutionService::MAX_WINDOWS;
-        $reactiveChance = config('match_simulation.ai_substitutions.red_card_reactive_chance', 70);
-        $reactiveMaxMinute = config('match_simulation.ai_substitutions.red_card_reactive_max_minute', 80);
 
         foreach ($redCards as $redCard) {
             $subMinute = $redCard->minute + 2;
 
             if ($redCard->teamId === $homeTeamId) {
                 $this->applyRedCardTeamReactiveSub(
-                    $redCard, $subMinute, $reactiveMaxMinute, $reactiveChance, $maxSubs, $maxWindows,
+                    $redCard, $subMinute, $maxSubs, $maxWindows,
                     $homeTeamId, $homePlayers, $homeBench, $homeEntryMinutes,
                     $homeSubsUsed, $homeWindowsUsed, $allEvents,
                 );
             } else {
                 $this->applyRedCardTeamReactiveSub(
-                    $redCard, $subMinute, $reactiveMaxMinute, $reactiveChance, $maxSubs, $maxWindows,
+                    $redCard, $subMinute, $maxSubs, $maxWindows,
                     $awayTeamId, $awayPlayers, $awayBench, $awayEntryMinutes,
                     $awaySubsUsed, $awayWindowsUsed, $allEvents,
                 );
@@ -533,8 +531,6 @@ class MatchSimulator
     private function applyRedCardTeamReactiveSub(
         MatchEventData $redCard,
         int $subMinute,
-        int $maxMinute,
-        int $chance,
         int $maxSubs,
         int $maxWindows,
         string $teamId,
@@ -545,10 +541,8 @@ class MatchSimulator
         int &$windowsUsed,
         Collection $allEvents,
     ): void {
-        if ($redCard->minute > $maxMinute
-            || $subsUsed >= $maxSubs || $windowsUsed >= $maxWindows
+        if ($subsUsed >= $maxSubs || $windowsUsed >= $maxWindows
             || $bench === null || $bench->isEmpty()
-            || rand(1, 100) > $chance
         ) {
             return;
         }

--- a/config/match_simulation.php
+++ b/config/match_simulation.php
@@ -336,10 +336,6 @@ return [
         'energy_threshold' => 40,           // energy below this = strong sub candidate
         'yellow_card_weight' => 0.30,       // extra urgency score for yellowed players
         'losing_attack_bias' => 0.70,       // probability of preferring attackers when losing
-
-        // Reactive substitutions after red cards
-        'red_card_reactive_chance' => 70,              // % chance the 10-man team makes a tactical sub
-        'red_card_reactive_max_minute' => 80,          // no reactive subs after this minute
     ],
 
 ];

--- a/tests/Unit/RedCardSimulationTest.php
+++ b/tests/Unit/RedCardSimulationTest.php
@@ -382,8 +382,6 @@ class RedCardSimulationTest extends TestCase
         $homeBench = $this->createBenchPlayers($game, $homeTeam, 7, 70);
         $awayBench = $this->createBenchPlayers($game, $awayTeam, 7, 70);
 
-        // Force red card reactive chance to 100% for deterministic testing
-        config(['match_simulation.ai_substitutions.red_card_reactive_chance' => 100]);
         // Increase direct red card chance so we get one reliably
         config(['match_simulation.direct_red_chance' => 50]);
 


### PR DESCRIPTION
- **Natural strength impact**: Changed calculateTeamStrength() to divide by 11 (fixed squad size) instead of $lineup->count(), so removing a sent-off player naturally reduces team strength and xG — no artificial modifiers needed
- **Reactive AI substitutions**: When a goalkeeper or defender is sent off, the AI immediately brings on a replacement from the bench, sacrificing a random forward or midfielder
- **Removed artificial xG modifiers**: Deleted the entire red_card_impact config section (base_attack_modifier, base_defense_modifier, position_modifiers) that previously applied arbitrary xG boosts/penalties — the strength reduction now emerges organically from the missing player