### PR TITLE
Replace approximate match count with exact date for injury display

### DIFF
--- a/app/Http/Views/ShowLineup.php
+++ b/app/Http/Views/ShowLineup.php
@@ -9,7 +9,7 @@ use App\Modules\Lineup\Enums\Mentality;
 use App\Modules\Lineup\Enums\PlayingStyle;
 use App\Modules\Lineup\Enums\PressingIntensity;
 use App\Modules\Lineup\Services\LineupService;
-use App\Modules\Player\Services\InjuryService;
+
 use App\Models\Game;
 use App\Support\PitchGrid;
 use App\Support\PositionSlotMapper;
@@ -249,9 +249,6 @@ class ShowLineup
         $gridConfig = PitchGrid::getGridConfig();
         $currentPitchPositions = $game->tactics?->default_pitch_positions;
 
-        // Pre-compute matches missed for injured players
-        $matchesMissedMap = InjuryService::getMatchesMissedMap($gameId, $game->team_id, $matchDate, $allPlayers);
-
         return view('lineup', [
             'game' => $game,
             'match' => $match,
@@ -299,7 +296,7 @@ class ShowLineup
             'currentPitchPositions' => $currentPitchPositions,
             'userRadar' => $userRadar,
             'opponentRadar' => $opponentRadar,
-            'matchesMissedMap' => $matchesMissedMap,
+
             'tacticalPresets' => $game->tacticalPresets,
             'presetsConfig' => $game->tacticalPresets->map(fn ($p) => [
                 'id' => $p->id,

--- a/app/Models/GamePlayer.php
+++ b/app/Models/GamePlayer.php
@@ -628,8 +628,6 @@ class GamePlayer extends Model
     public function getUnavailabilityReason(
         ?Carbon $gameDate = null,
         ?string $competitionId = null,
-        ?int $matchesMissed = null,
-        bool $matchesMissedApproximate = false,
     ): ?string {
         if ($competitionId !== null && $this->isSuspendedInCompetition($competitionId)) {
             $remaining = $this->getSuspensionMatchesRemaining($competitionId);
@@ -640,12 +638,12 @@ class GamePlayer extends Model
             $translationKey = InjuryService::INJURY_TRANSLATION_MAP[$this->injury_type] ?? null;
             $injuryName = $translationKey ? __($translationKey) : __('squad.injured_generic');
 
-            if ($matchesMissed !== null && $matchesMissed > 0) {
-                $matchesStr = $matchesMissedApproximate
-                    ? trans_choice('squad.injury_matches_approx', $matchesMissed, ['count' => $matchesMissed])
-                    : trans_choice('squad.injury_matches', $matchesMissed, ['count' => $matchesMissed]);
+            if ($this->injury_until) {
+                $returnDate = __('squad.injury_return_date', [
+                    'date' => $this->injury_until->translatedFormat('j M Y'),
+                ]);
 
-                return "$injuryName ($matchesStr)";
+                return "$injuryName ($returnDate)";
             }
 
             return $injuryName;

--- a/app/Modules/Notification/Services/NotificationService.php
+++ b/app/Modules/Notification/Services/NotificationService.php
@@ -5,7 +5,7 @@ namespace App\Modules\Notification\Services;
 use App\Models\Game;
 use App\Models\GameNotification;
 use App\Models\GamePlayer;
-use App\Modules\Player\Services\InjuryService;
+
 use App\Models\ScoutReport;
 use App\Models\ShortlistedPlayer;
 use App\Models\Team;
@@ -128,32 +128,19 @@ class NotificationService
         $translatedInjury = $this->translateInjuryType($injuryType);
         $translatedLocation = __('notifications.injury_location_'.($duringMatch ? 'match' : 'training'));
 
-        // Compute matches missed if injury_until is set
-        $messageKey = 'notifications.player_injured_message';
-        $matchesMissed = 0;
-
-        if ($player->injury_until) {
-            // Use the day after current_date so the match where the injury occurred
-            // is excluded from the "missed" count (the player already played that match).
-            $data = InjuryService::getMatchesMissed($game->id, $player->team_id, $game->current_date->copy()->addDay(), $player->injury_until);
-            $matchesMissed = $data['count'];
-
-            if ($matchesMissed > 0) {
-                $messageKey = $data['approx']
-                    ? 'notifications.player_injured_message_matches_approx'
-                    : 'notifications.player_injured_message_matches';
-            }
-        }
+        $messageKey = $player->injury_until
+            ? 'notifications.player_injured_message_with_date'
+            : 'notifications.player_injured_message';
 
         return $this->create(
             game: $game,
             type: GameNotification::TYPE_PLAYER_INJURED,
             title: __('notifications.player_injured_title', ['player' => $player->name]),
-            message: trans_choice($messageKey, $matchesMissed, [
+            message: __($messageKey, [
                 'player' => $player->name,
                 'injury' => $translatedInjury,
                 'location' => $translatedLocation,
-                'matches' => $matchesMissed,
+                'date' => $player->injury_until?->translatedFormat('j M Y'),
             ]),
             priority: GameNotification::PRIORITY_CRITICAL,
             metadata: [

--- a/app/Modules/Player/Services/InjuryService.php
+++ b/app/Modules/Player/Services/InjuryService.php
@@ -557,29 +557,6 @@ class InjuryService
     }
 
     /**
-     * Build a map of matches missed for injured players in a collection.
-     *
-     * @return array<string, array{count: int, approx: bool}>  Keyed by player ID
-     */
-    public static function getMatchesMissedMap(string $gameId, string $teamId, Carbon $referenceDate, Collection $players): array
-    {
-        $upcomingMatchDates = self::getUpcomingMatchDates($gameId, $teamId, $referenceDate);
-        $lastScheduledDate = $upcomingMatchDates->last();
-
-        $map = [];
-        foreach ($players as $player) {
-            if ($player->isInjured($referenceDate) && $player->injury_until) {
-                $map[$player->id] = [
-                    'count' => $upcomingMatchDates->filter(fn ($d) => $d->lte($player->injury_until))->count(),
-                    'approx' => $lastScheduledDate && $player->injury_until->gt($lastScheduledDate),
-                ];
-            }
-        }
-
-        return $map;
-    }
-
-    /**
      * Get matches missed for a single injured player.
      *
      * @return array{count: int, approx: bool}

--- a/app/Modules/Squad/Services/SquadService.php
+++ b/app/Modules/Squad/Services/SquadService.php
@@ -7,7 +7,7 @@ use App\Models\Game;
 use App\Models\GameMatch;
 use App\Models\GamePlayer;
 use App\Modules\Player\PlayerAge;
-use App\Modules\Player\Services\InjuryService;
+
 use App\Modules\Player\Services\PlayerDevelopmentService;
 use App\Modules\Transfer\Services\ContractService;
 use App\Support\PositionSlotMapper;
@@ -35,21 +35,15 @@ class SquadService
         $matchDate = $nextMatch?->scheduled_date ?? $game->current_date;
         $competitionId = $nextMatch?->competition_id;
 
-        // Pre-compute matches missed for injured players
-        $matchesMissedMap = InjuryService::getMatchesMissedMap($gameId, $game->team_id, $game->current_date, $allPlayers);
-
         // Enrich each player with computed data and count age distribution in a single pass
         $youngCount = 0;
         $primeCount = 0;
         $veteranCount = 0;
 
-        $allPlayers->each(function (GamePlayer $player) use ($game, $seasonEndDate, $matchDate, $competitionId, $matchesMissedMap, &$youngCount, &$primeCount, &$veteranCount) {
+        $allPlayers->each(function (GamePlayer $player) use ($game, $seasonEndDate, $matchDate, $competitionId, &$youngCount, &$primeCount, &$veteranCount) {
             // Availability
-            $matchData = $matchesMissedMap[$player->id] ?? null;
             $player->setAttribute('is_unavailable', !$player->isAvailable($matchDate, $competitionId));
-            $player->setAttribute('unavailability_reason', $player->getUnavailabilityReason(
-                $matchDate, $competitionId, $matchData['count'] ?? null, $matchData['approx'] ?? false,
-            ));
+            $player->setAttribute('unavailability_reason', $player->getUnavailabilityReason($matchDate, $competitionId));
 
             // Development projection
             $age = $player->age($game->current_date);

--- a/lang/en/notifications.php
+++ b/lang/en/notifications.php
@@ -22,8 +22,7 @@ return [
     // Player injuries
     'player_injured_title' => ':player injured',
     'player_injured_message' => ':player has suffered :injury :location.',
-    'player_injured_message_matches' => ':player has suffered :injury :location and will miss :matches match.|:player has suffered :injury :location and will miss :matches matches.',
-    'player_injured_message_matches_approx' => ':player has suffered :injury :location and will miss :matches+ match.|:player has suffered :injury :location and will miss :matches+ matches.',
+    'player_injured_message_with_date' => ':player has suffered :injury :location. Out until :date.',
     'injury_location_match' => 'during the match',
     'injury_location_training' => 'during training',
 

--- a/lang/en/squad.php
+++ b/lang/en/squad.php
@@ -114,8 +114,7 @@ return [
     // Unavailability reasons
     'suspended_matches' => 'Suspended (:count match)|Suspended (:count matches)',
     'injured_generic' => 'Injured',
-    'injury_matches' => ':count match|:count matches',
-    'injury_matches_approx' => ':count+ match|:count+ matches',
+    'injury_return_date' => 'out until :date',
 
     // Injury types
     'injury_muscle_fatigue' => 'Muscle fatigue',

--- a/lang/es/notifications.php
+++ b/lang/es/notifications.php
@@ -22,8 +22,7 @@ return [
     // Player injuries
     'player_injured_title' => ':player lesionado',
     'player_injured_message' => ':player ha sufrido :injury :location.',
-    'player_injured_message_matches' => ':player ha sufrido :injury :location y se perderá :matches partido.|:player ha sufrido :injury :location y se perderá :matches partidos.',
-    'player_injured_message_matches_approx' => ':player ha sufrido :injury :location y se perderá :matches+ partido.|:player ha sufrido :injury :location y se perderá :matches+ partidos.',
+    'player_injured_message_with_date' => ':player ha sufrido :injury :location. Baja hasta el :date.',
     'injury_location_match' => 'durante el partido',
     'injury_location_training' => 'durante el entrenamiento',
 

--- a/lang/es/squad.php
+++ b/lang/es/squad.php
@@ -114,8 +114,7 @@ return [
     // Unavailability reasons
     'suspended_matches' => 'Sancionado (:count partido)|Sancionado (:count partidos)',
     'injured_generic' => 'Lesionado',
-    'injury_matches' => ':count partido|:count partidos',
-    'injury_matches_approx' => ':count+ partido|:count+ partidos',
+    'injury_return_date' => 'baja hasta :date',
 
     // Injury types
     'injury_muscle_fatigue' => 'Fatiga muscular',

--- a/resources/views/lineup.blade.php
+++ b/resources/views/lineup.blade.php
@@ -269,12 +269,9 @@
                                         @foreach($group['players'] as $player)
                                             @php
                                                 $isUnavailable = !$player->isAvailable($matchDate, $competitionId);
-                                                $matchData = $matchesMissedMap[$player->id] ?? null;
                                                 $unavailabilityReason = $player->getUnavailabilityReason(
                                                     $matchDate,
                                                     $competitionId,
-                                                    $matchData['count'] ?? null,
-                                                    $matchData['approx'] ?? false,
                                                 );
                                                 $posGroup = \App\Support\PositionMapper::getPositionGroup($player->position);
                                             @endphp


### PR DESCRIPTION
Show "baja hasta 11 dic 2025" / "out until 11 Dec 2025" instead of the confusing "2+ partidos" format that users didn't understand.