### PR TITLE
Fix goalkeeper positioning when red card triggers substitution

### DIFF
--- a/resources/js/live-match.js
+++ b/resources/js/live-match.js
@@ -913,6 +913,28 @@ export default function liveMatch(config) {
                 }
             }
 
+            // Post-process: ensure a non-red-carded Goalkeeper occupies the GK slot.
+            // When a GK is sent off and a reserve GK is subbed in, the algorithm places
+            // the sent-off GK in the GK slot (natural fit) and the reserve GK in the
+            // outfield slot. Swap them so the active GK is shown in goal.
+            const redCarded = this.redCardedPlayerIds;
+            const gkSlot = assignments.find(s => s.role === 'Goalkeeper');
+            if (gkSlot?.player && redCarded.includes(gkSlot.player.id)) {
+                const reserveGkSlot = assignments.find(s =>
+                    s !== gkSlot &&
+                    s.player &&
+                    s.player.position === 'Goalkeeper' &&
+                    !redCarded.includes(s.player.id)
+                );
+                if (reserveGkSlot) {
+                    const temp = gkSlot.player;
+                    gkSlot.player = reserveGkSlot.player;
+                    reserveGkSlot.player = temp;
+                    gkSlot.compatibility = this.slotCompatibility[gkSlot.label]?.[gkSlot.player.position] ?? 0;
+                    reserveGkSlot.compatibility = this.slotCompatibility[reserveGkSlot.label]?.[reserveGkSlot.player.position] ?? 0;
+                }
+            }
+
             return assignments;
         },
 


### PR DESCRIPTION
## Summary
This change fixes a lineup assignment issue where a red-carded goalkeeper was incorrectly placed in the goalkeeper slot instead of the substitute goalkeeper who replaced them.

## Key Changes
- Added post-processing logic to detect when a red-carded goalkeeper occupies the GK slot
- Automatically swaps the red-carded goalkeeper with an available reserve goalkeeper
- Updates compatibility scores for both slots after the swap to reflect the new player assignments

## Implementation Details
The fix works by:
1. Checking if the assigned goalkeeper has been red-carded
2. Finding an alternative non-red-carded goalkeeper in the outfield slots
3. Swapping their positions so the active goalkeeper is shown in goal
4. Recalculating slot compatibility scores based on the new player-slot pairings

This ensures the correct goalkeeper is displayed in the lineup when a substitution occurs due to a red card.

https://claude.ai/code/session_01CoBeEGzrSVddoKB7ZgtBS1