### PR TITLE
Fix percentage calculation to use max of all step counts

### DIFF
--- a/app/Modules/Analytics/Services/ActivationFunnelService.php
+++ b/app/Modules/Analytics/Services/ActivationFunnelService.php
@@ -127,7 +127,7 @@ class ActivationFunnelService
 
     private function computePercentages(array &$steps): void
     {
-        $maxCount = max(1, $steps[0]['count']);
+        $maxCount = max(1, ...array_column($steps, 'count'));
 
         foreach ($steps as $i => &$step) {
             $step['percentage'] = $maxCount > 0 ? round(($step['count'] / $maxCount) * 100, 1) : 0;


### PR DESCRIPTION
## Summary
Fixed the percentage calculation in the activation funnel service to correctly compute percentages based on the maximum count across all steps, rather than only the first step.

## Key Changes
- Updated `computePercentages()` method to use `max(1, ...array_column($steps, 'count'))` instead of `max(1, $steps[0]['count'])`
- This ensures percentage calculations are relative to the highest count among all steps, not just the first one

## Implementation Details
The change uses the spread operator with `array_column()` to extract all 'count' values from the steps array and find the true maximum, providing more accurate percentage representations across the entire funnel.

https://claude.ai/code/session_018bHjgsxUCccmDrVAZ2EwvZ