### PR TITLE
Split team popularity into club and national team stats

### DIFF
--- a/app/Http/Views/AdminGameStats.php
+++ b/app/Http/Views/AdminGameStats.php
@@ -10,7 +10,8 @@ class AdminGameStats
     public function __invoke(Request $request, GameStatsService $stats)
     {
         return view('admin.game-stats', [
-            'teamPopularity' => $stats->getTeamPopularity(),
+            'clubPopularity' => $stats->getClubPopularity(),
+            'nationalTeamPopularity' => $stats->getNationalTeamPopularity(),
             'seasonProgress' => $stats->getSeasonProgress(),
         ]);
     }

--- a/app/Modules/Analytics/Services/GameStatsService.php
+++ b/app/Modules/Analytics/Services/GameStatsService.php
@@ -8,12 +8,24 @@ use Illuminate\Support\Facades\DB;
 
 class GameStatsService
 {
-    public function getTeamPopularity(int $limit = 15): Collection
+    public function getClubPopularity(int $limit = 15): Collection
     {
         return Game::select('team_id', DB::raw('COUNT(*) as picks'))
+            ->whereHas('team', fn ($q) => $q->where('type', '!=', 'national'))
             ->groupBy('team_id')
             ->orderByDesc('picks')
-            ->with('team:id,name,image')
+            ->with('team:id,name,image,type,country')
+            ->limit($limit)
+            ->get();
+    }
+
+    public function getNationalTeamPopularity(int $limit = 15): Collection
+    {
+        return Game::select('team_id', DB::raw('COUNT(*) as picks'))
+            ->whereHas('team', fn ($q) => $q->where('type', 'national'))
+            ->groupBy('team_id')
+            ->orderByDesc('picks')
+            ->with('team:id,name,image,type,country')
             ->limit($limit)
             ->get();
     }

--- a/lang/en/admin.php
+++ b/lang/en/admin.php
@@ -100,7 +100,8 @@ return [
     'nav_game_stats' => 'Game Stats',
     'game_stats_title' => 'Game Stats',
     'game_stats_description' => 'Explore how players use the game',
-    'team_popularity' => 'Team Popularity',
+    'club_popularity' => 'Club Popularity',
+    'national_team_popularity' => 'National Team Popularity',
     'season_progress' => 'Season Progress',
     'no_data' => 'No data yet',
 

--- a/lang/es/admin.php
+++ b/lang/es/admin.php
@@ -100,7 +100,8 @@ return [
     'nav_game_stats' => 'Estadísticas',
     'game_stats_title' => 'Estadísticas del Juego',
     'game_stats_description' => 'Descubre cómo juegan los usuarios',
-    'team_popularity' => 'Popularidad de Equipos',
+    'club_popularity' => 'Popularidad de Clubes',
+    'national_team_popularity' => 'Popularidad de Selecciones',
     'season_progress' => 'Progreso de Temporadas',
     'no_data' => 'Sin datos aún',
 

--- a/resources/views/admin/game-stats.blade.php
+++ b/resources/views/admin/game-stats.blade.php
@@ -3,23 +3,53 @@
         {{ __('admin.game_stats_title') }}
     </h1>
 
-    <div class="grid grid-cols-1 gap-4 mb-4">
-        {{-- Team Popularity --}}
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
+        {{-- Club Popularity --}}
         <div class="bg-surface-800 border border-border-default rounded-xl p-5">
             <h2 class="font-heading text-sm font-bold uppercase tracking-wider text-text-primary mb-4">
-                {{ __('admin.team_popularity') }}
+                {{ __('admin.club_popularity') }}
             </h2>
 
-            @if($teamPopularity->isEmpty())
+            @if($clubPopularity->isEmpty())
                 <p class="text-sm text-text-muted">{{ __('admin.no_data') }}</p>
             @else
-                @php $maxPicks = $teamPopularity->max('picks'); @endphp
+                @php $maxPicks = $clubPopularity->max('picks'); @endphp
                 <div class="space-y-2">
-                    @foreach($teamPopularity as $index => $entry)
+                    @foreach($clubPopularity as $index => $entry)
                         <div class="flex items-center gap-3">
                             <span class="text-xs text-text-muted w-5 text-right shrink-0">{{ $index + 1 }}</span>
-                            @if($entry->team?->image)
-                                <img src="{{ $entry->team->image }}" alt="" class="w-5 h-5 shrink-0">
+                            @if($entry->team)
+                                <x-team-crest :team="$entry->team" class="w-5 h-5 shrink-0" />
+                            @else
+                                <div class="w-5 h-5 shrink-0 rounded bg-surface-700"></div>
+                            @endif
+                            <span class="text-sm text-text-primary truncate w-28 shrink-0">{{ $entry->team?->name ?? '—' }}</span>
+                            <div class="flex-1 h-5 bg-surface-700 rounded-sm overflow-hidden">
+                                <div class="h-full bg-accent-blue/60 rounded-sm" style="width: {{ ($entry->picks / $maxPicks) * 100 }}%"></div>
+                            </div>
+                            <span class="text-xs text-text-muted shrink-0 w-12 text-right">{{ $entry->picks }}</span>
+                        </div>
+                    @endforeach
+                </div>
+            @endif
+        </div>
+
+        {{-- National Team Popularity --}}
+        <div class="bg-surface-800 border border-border-default rounded-xl p-5">
+            <h2 class="font-heading text-sm font-bold uppercase tracking-wider text-text-primary mb-4">
+                {{ __('admin.national_team_popularity') }}
+            </h2>
+
+            @if($nationalTeamPopularity->isEmpty())
+                <p class="text-sm text-text-muted">{{ __('admin.no_data') }}</p>
+            @else
+                @php $maxPicks = $nationalTeamPopularity->max('picks'); @endphp
+                <div class="space-y-2">
+                    @foreach($nationalTeamPopularity as $index => $entry)
+                        <div class="flex items-center gap-3">
+                            <span class="text-xs text-text-muted w-5 text-right shrink-0">{{ $index + 1 }}</span>
+                            @if($entry->team)
+                                <x-team-crest :team="$entry->team" class="w-5 h-5 shrink-0" />
                             @else
                                 <div class="w-5 h-5 shrink-0 rounded bg-surface-700"></div>
                             @endif


### PR DESCRIPTION
## Summary
Refactored the game stats dashboard to separately track and display popularity metrics for club teams and national teams, providing more granular insights into player preferences.

## Key Changes
- **Service Layer**: Split `getTeamPopularity()` into two methods:
  - `getClubPopularity()` - filters teams where `type != 'national'`
  - `getNationalTeamPopularity()` - filters teams where `type = 'national'`
  - Both methods now include `type` and `country` in team relations for better data context

- **View Controller**: Updated `AdminGameStats` to pass both `clubPopularity` and `nationalTeamPopularity` data to the view

- **UI/Template**: 
  - Changed grid layout from single column to responsive 2-column layout (`md:grid-cols-2`)
  - Split the single popularity card into two separate cards side-by-side
  - Replaced direct image rendering with `x-team-crest` component for consistent team logo display
  - Added fallback UI (gray box) when team image is unavailable

- **Localization**: Updated English and Spanish language files to reflect the terminology change:
  - `team_popularity` → `club_popularity` and `national_team_popularity`
  - Spanish: "Popularidad de Equipos" → "Popularidad de Clubes" and "Popularidad de Selecciones"

## Implementation Details
- The filtering is done at the database query level using `whereHas()` for optimal performance
- Both queries maintain the same sorting and limiting logic (top 15 by picks)
- The UI maintains visual consistency with existing design patterns while providing better data organization

https://claude.ai/code/session_014ji4cA8iNWZNhSvBKUz9gQ