### PR TITLE
Fix World Cup knockout round advancement and tournament result labels

### DIFF
--- a/app/Modules/Competition/Services/WorldCupKnockoutGenerator.php
+++ b/app/Modules/Competition/Services/WorldCupKnockoutGenerator.php
@@ -101,6 +101,10 @@ class WorldCupKnockoutGenerator
      */
     public function generateMatchups(Game $game, string $competitionId, int $round): array
     {
+        // Clear the completed ties cache so we pick up ties resolved in
+        // the current request (e.g. batch-resolved R16 ties before generating QF).
+        $this->completedTiesCache = [];
+
         if ($round === self::ROUND_OF_32) {
             return $this->generateRoundOf32($game, $competitionId);
         }

--- a/app/Modules/Report/Services/CompetitionSummaryService.php
+++ b/app/Modules/Report/Services/CompetitionSummaryService.php
@@ -11,6 +11,7 @@ use App\Models\GamePlayer;
 use App\Models\GameStanding;
 use App\Models\MatchEvent;
 use App\Models\Team;
+use App\Modules\Competition\Services\WorldCupKnockoutGenerator;
 use Illuminate\Support\Collection;
 
 class CompetitionSummaryService
@@ -116,9 +117,15 @@ class CompetitionSummaryService
             return 'group_stage';
         }
 
-        $maxRound = $allTies->max('round_number');
+        // Exclude the third-place match from progression calculations — it's a
+        // side-match between SF losers, not part of the main bracket path.
+        $progressionTies = $allTies->reject(fn ($tie) =>
+            $tie->round_number === WorldCupKnockoutGenerator::ROUND_THIRD_PLACE
+        );
 
-        $finalTie = $allTies->where('round_number', $maxRound)->first();
+        $maxRound = $progressionTies->max('round_number');
+
+        $finalTie = $progressionTies->where('round_number', $maxRound)->first();
         if ($finalTie && $finalTie->winner_id === $teamId) {
             return 'champion';
         }
@@ -127,7 +134,17 @@ class CompetitionSummaryService
             return 'runner_up';
         }
 
-        $teamTies = $allTies->filter(fn ($tie) =>
+        // Check if team played the third-place match
+        $thirdPlaceTie = $allTies->first(fn ($tie) =>
+            $tie->round_number === WorldCupKnockoutGenerator::ROUND_THIRD_PLACE
+            && ($tie->home_team_id === $teamId || $tie->away_team_id === $teamId)
+        );
+
+        if ($thirdPlaceTie) {
+            return $thirdPlaceTie->winner_id === $teamId ? 'third_place' : 'semi_finalist';
+        }
+
+        $teamTies = $progressionTies->filter(fn ($tie) =>
             $tie->home_team_id === $teamId || $tie->away_team_id === $teamId
         );
 
@@ -136,7 +153,12 @@ class CompetitionSummaryService
         }
 
         $highestRound = $teamTies->max('round_number');
-        $roundsFromFinal = $maxRound - $highestRound;
+
+        // Count distinct progression rounds above the team's highest round.
+        // This avoids raw round-number arithmetic which breaks when there's
+        // a gap (e.g. WC third-place match at round 5 between SF=4 and Final=6).
+        $progressionRounds = $progressionTies->pluck('round_number')->unique();
+        $roundsFromFinal = $progressionRounds->filter(fn ($r) => $r > $highestRound)->count();
 
         return match (true) {
             $roundsFromFinal === 0 => 'runner_up',

--- a/app/Modules/Report/Services/TournamentSnapshotService.php
+++ b/app/Modules/Report/Services/TournamentSnapshotService.php
@@ -239,8 +239,9 @@ class TournamentSnapshotService
     public static function computeResultPoints(string $resultLabel): int
     {
         return match ($resultLabel) {
-            'champion' => 6,
-            'runner_up' => 5,
+            'champion' => 7,
+            'runner_up' => 6,
+            'third_place' => 5,
             'semi_finalist' => 4,
             'quarter_finalist' => 3,
             'round_of_16' => 2,
@@ -251,8 +252,9 @@ class TournamentSnapshotService
     public static function resultLabelFromPoints(int $points): string
     {
         return match ($points) {
-            6 => 'champion',
-            5 => 'runner_up',
+            7 => 'champion',
+            6 => 'runner_up',
+            5 => 'third_place',
             4 => 'semi_finalist',
             3 => 'quarter_finalist',
             2 => 'round_of_16',


### PR DESCRIPTION
Clear the completed ties cache before generating new knockout matchups, fixing a stale cache bug where batch-resolved ties (e.g. R16) were invisible when generating the next round (QF), halting the tournament.

Fix tournament result labels by excluding the third-place match (round 5) from progression calculations and counting distinct rounds instead of raw round-number differences. Add third_place as a distinct result tier with its own points value, and migrate existing data to the new scale.