### PR TITLE
fix(lineup): allow replacing tactical presets at 3-slot limit (#590)

### DIFF
--- a/lang/en/squad.php
+++ b/lang/en/squad.php
@@ -346,6 +346,11 @@ return [
     'preset_apply_now' => 'Use this tactic for the next match',
     'save_and_confirm' => 'Save & confirm',
     'preset_delete_confirm' => 'Delete this saved tactic?',
+    'preset_save_mode_legend' => 'Save as',
+    'preset_save_as_new' => 'New saved tactic',
+    'preset_replace_existing' => 'Replace an existing tactic',
+    'preset_choose_slot' => 'Which tactic to replace',
+    'preset_replace_required_hint' => 'You already have three saved tactics. Choose one to replace with your current board.',
 
     // Number
     'number' => 'Number',

--- a/lang/es/squad.php
+++ b/lang/es/squad.php
@@ -346,6 +346,11 @@ return [
     'preset_apply_now' => 'Usar esta táctica en el próximo partido',
     'save_and_confirm' => 'Guardar y confirmar',
     'preset_delete_confirm' => '¿Eliminar esta táctica guardada?',
+    'preset_save_mode_legend' => 'Guardar como',
+    'preset_save_as_new' => 'Nueva táctica guardada',
+    'preset_replace_existing' => 'Sustituir una táctica existente',
+    'preset_choose_slot' => 'Qué táctica sustituir',
+    'preset_replace_required_hint' => 'Ya tienes tres tácticas guardadas. Elige cuál sustituir por la alineación actual.',
 
     // Dorsales
     'number' => 'Dorsal',

--- a/resources/views/lineup.blade.php
+++ b/resources/views/lineup.blade.php
@@ -126,7 +126,7 @@
                     <div class="border-t border-border-default"></div>
 
                     {{-- Saved tactical presets --}}
-                    <div class="flex items-center gap-2 overflow-x-auto scrollbar-hide" x-show="presets.length > 0 || {{ $tacticalPresets->count() < 3 ? 'true' : 'false' }}">
+                    <div class="flex items-center gap-2 overflow-x-auto scrollbar-hide">
                         <span class="text-[10px] text-text-muted uppercase tracking-wider shrink-0">{{ __('squad.presets') }}</span>
                         <div class="flex gap-1.5">
                             <template x-for="preset in presets" :key="preset.id">
@@ -156,15 +156,13 @@
                                     </button>
                                 </div>
                             </template>
-                            @if($tacticalPresets->count() < 3)
-                                <button type="button"
-                                    @click="$dispatch('open-modal', 'save-preset')"
-                                    x-bind:disabled="selectedCount !== 11"
-                                    class="flex items-center gap-1 px-2.5 py-1.5 rounded-md border border-dashed border-border-default text-sm text-text-muted hover:text-text-body hover:border-border-strong transition-colors shrink-0 min-h-[36px] disabled:opacity-40 disabled:cursor-not-allowed">
-                                    <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" /></svg>
-                                    {{ __('squad.save_preset') }}
-                                </button>
-                            @endif
+                            <button type="button"
+                                @click="$dispatch('open-modal', 'save-preset')"
+                                x-bind:disabled="selectedCount !== 11"
+                                class="flex items-center gap-1 px-2.5 py-1.5 rounded-md border border-dashed border-border-default text-sm text-text-muted hover:text-text-body hover:border-border-strong transition-colors shrink-0 min-h-[36px] disabled:opacity-40 disabled:cursor-not-allowed">
+                                <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" /></svg>
+                                {{ __('squad.save_preset') }}
+                            </button>
                         </div>
                     </div>
 
@@ -500,11 +498,87 @@
         {{-- Save Tactical Preset Modal --}}
         <x-modal name="save-preset" maxWidth="sm">
         <form method="POST" action="{{ route('game.tactical-presets.save', $game->id) }}"
-              x-data="{ presetName: '', applyNow: false }"
+              x-data="{
+                presetList: @js($presetsConfig),
+                presetName: '',
+                applyNow: false,
+                savePresetMode: 'new',
+                replacePresetId: '',
+                initPresetModal() {
+                    const ps = this.presetList;
+                    if (!ps.length) {
+                        this.savePresetMode = 'new';
+                        this.replacePresetId = '';
+                        this.presetName = '';
+                        return;
+                    }
+                    if (ps.length >= 3) {
+                        this.savePresetMode = 'replace';
+                        this.replacePresetId = ps[0].id;
+                    } else {
+                        this.savePresetMode = 'new';
+                        this.replacePresetId = '';
+                    }
+                    this.syncPresetNameFromTarget();
+                },
+                syncPresetNameFromTarget() {
+                    if (this.savePresetMode !== 'replace' || !this.replacePresetId) {
+                        return;
+                    }
+                    const p = this.presetList.find(x => x.id === this.replacePresetId);
+                    if (p) {
+                        this.presetName = p.name;
+                    }
+                },
+                get presetSubmitDisabled() {
+                    if (!this.presetName.trim()) {
+                        return true;
+                    }
+                    if (this.presetList.length >= 3) {
+                        return this.savePresetMode !== 'replace' || !this.replacePresetId;
+                    }
+                    if (this.savePresetMode === 'replace') {
+                        return !this.replacePresetId;
+                    }
+                    return false;
+                },
+              }"
+              x-on:open-modal.window="if ($event.detail === 'save-preset') initPresetModal()"
               @submit="_isSaving = true">
             @csrf
             <div class="p-5">
                 <h3 class="text-lg font-semibold text-text-primary mb-4">{{ __('squad.save_preset') }}</h3>
+
+                <template x-if="presetList.length > 0">
+                    <div class="mb-4 space-y-2">
+                        <p class="text-xs text-text-muted" x-show="presetList.length >= 3">{{ __('squad.preset_replace_required_hint') }}</p>
+                        <template x-if="presetList.length < 3">
+                            <fieldset class="space-y-2">
+                                <legend class="text-sm text-text-secondary mb-1">{{ __('squad.preset_save_mode_legend') }}</legend>
+                                <label class="flex items-center gap-2 cursor-pointer select-none">
+                                    <input type="radio" name="save_preset_mode_ui" value="new" x-model="savePresetMode"
+                                        class="border-border-strong bg-surface-700 text-accent-blue focus:ring-accent-blue focus:ring-offset-0">
+                                    <span class="text-sm text-text-body">{{ __('squad.preset_save_as_new') }}</span>
+                                </label>
+                                <label class="flex items-center gap-2 cursor-pointer select-none">
+                                    <input type="radio" name="save_preset_mode_ui" value="replace" x-model="savePresetMode"
+                                        @change="replacePresetId = presetList[0]?.id || ''; syncPresetNameFromTarget()"
+                                        class="border-border-strong bg-surface-700 text-accent-blue focus:ring-accent-blue focus:ring-offset-0">
+                                    <span class="text-sm text-text-body">{{ __('squad.preset_replace_existing') }}</span>
+                                </label>
+                            </fieldset>
+                        </template>
+                        <div x-show="savePresetMode === 'replace' || presetList.length >= 3">
+                            <label for="preset-replace-target" class="block text-sm text-text-secondary mb-1.5">{{ __('squad.preset_choose_slot') }}</label>
+                            <select id="preset-replace-target" x-model="replacePresetId" @change="syncPresetNameFromTarget()"
+                                class="w-full px-3 py-2 bg-surface-700 border border-border-strong rounded-lg text-sm text-text-body focus:outline-none focus:ring-2 focus:ring-accent-blue focus:border-transparent">
+                                <template x-for="p in presetList" :key="'opt-' + p.id">
+                                    <option :value="p.id" x-text="p.name + ' (' + p.formation + ')'"></option>
+                                </template>
+                            </select>
+                        </div>
+                    </div>
+                </template>
 
                 <div class="mb-4">
                     <label for="preset-name" class="block text-sm text-text-secondary mb-1.5">{{ __('squad.preset_name') }}</label>
@@ -513,6 +587,10 @@
                         placeholder="{{ __('squad.preset_name_placeholder') }}"
                         maxlength="30" required autofocus>
                 </div>
+
+                <template x-if="savePresetMode === 'replace' && replacePresetId">
+                    <input type="hidden" name="preset_id" :value="replacePresetId">
+                </template>
 
                 <label class="flex items-center gap-2 mb-4 cursor-pointer select-none">
                     <input type="checkbox" name="apply_now" value="1" x-model="applyNow"
@@ -538,7 +616,7 @@
                     <x-secondary-button type="button" @click="$dispatch('close-modal', 'save-preset')">
                         {{ __('app.cancel') }}
                     </x-secondary-button>
-                    <x-primary-button type="submit" color="blue" x-bind:disabled="!presetName.trim()">
+                    <x-primary-button type="submit" color="blue" x-bind:disabled="presetSubmitDisabled">
                         <span x-text="applyNow ? '{{ __('squad.save_and_confirm') }}' : '{{ __('app.confirm') }}'"></span>
                     </x-primary-button>
                 </div>

--- a/tests/Feature/SaveTacticalPresetTest.php
+++ b/tests/Feature/SaveTacticalPresetTest.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Competition;
+use App\Models\Game;
+use App\Models\GamePlayer;
+use App\Models\GameTacticalPreset;
+use App\Models\Player;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Http\Middleware\ValidateCsrfToken;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+class SaveTacticalPresetTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+
+    private Game $game;
+
+    private Team $team;
+
+    /** @var list<string> */
+    private array $elevenPlayerIds;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->withoutMiddleware(ValidateCsrfToken::class);
+
+        $this->user = User::factory()->create();
+        $this->team = Team::factory()->create();
+        Competition::factory()->league()->create(['id' => 'ESP1']);
+
+        $this->game = Game::factory()->create([
+            'user_id' => $this->user->id,
+            'team_id' => $this->team->id,
+            'competition_id' => 'ESP1',
+            'season' => '2025',
+            'current_date' => '2025-09-01',
+        ]);
+
+        $this->elevenPlayerIds = [];
+        for ($i = 0; $i < 11; $i++) {
+            $player = Player::factory()->create();
+            $gp = GamePlayer::factory()->create([
+                'game_id' => $this->game->id,
+                'player_id' => $player->id,
+                'team_id' => $this->team->id,
+                'position' => $i === 0 ? 'Goalkeeper' : 'Central Midfield',
+            ]);
+            $this->elevenPlayerIds[] = $gp->id;
+        }
+    }
+
+    public function test_post_with_preset_id_updates_existing_preset(): void
+    {
+        $preset = $this->createPreset('Slot A', '4-3-3', 1);
+
+        $response = $this->actingAs($this->user)->post(
+            route('game.tactical-presets.save', $this->game->id),
+            $this->presetPayload([
+                'name' => 'Renamed A',
+                'formation' => '4-4-2',
+                'preset_id' => $preset->id,
+            ])
+        );
+
+        $response->assertRedirect(route('game.lineup', $this->game->id));
+        $response->assertSessionHas('success');
+
+        $preset->refresh();
+        $this->assertSame('Renamed A', $preset->name);
+        $this->assertSame('4-4-2', $preset->formation);
+    }
+
+    public function test_post_without_preset_id_fails_when_three_presets_exist(): void
+    {
+        $this->createPreset('One', '4-3-3', 1);
+        $this->createPreset('Two', '4-3-3', 2);
+        $this->createPreset('Three', '4-3-3', 3);
+
+        $response = $this->actingAs($this->user)->post(
+            route('game.tactical-presets.save', $this->game->id),
+            $this->presetPayload([
+                'name' => 'Fourth',
+            ])
+        );
+
+        $response->assertRedirect(route('game.lineup', $this->game->id));
+        $response->assertSessionHasErrors();
+
+        $this->assertSame(3, GameTacticalPreset::where('game_id', $this->game->id)->count());
+    }
+
+    private function createPreset(string $name, string $formation, int $sortOrder): GameTacticalPreset
+    {
+        return GameTacticalPreset::create([
+            'id' => (string) Str::uuid(),
+            'game_id' => $this->game->id,
+            'name' => $name,
+            'sort_order' => $sortOrder,
+            'formation' => $formation,
+            'lineup' => $this->elevenPlayerIds,
+            'slot_assignments' => null,
+            'pitch_positions' => null,
+            'mentality' => 'balanced',
+            'playing_style' => 'balanced',
+            'pressing' => 'standard',
+            'defensive_line' => 'normal',
+        ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     * @return array<string, mixed>
+     */
+    private function presetPayload(array $overrides = []): array
+    {
+        return array_merge([
+            'name' => 'My Tactic',
+            'formation' => '4-3-3',
+            'lineup' => $this->elevenPlayerIds,
+            'slot_assignments' => 'null',
+            'pitch_positions' => 'null',
+            'mentality' => 'balanced',
+            'playing_style' => 'balanced',
+            'pressing' => 'standard',
+            'defensive_line' => 'normal',
+        ], $overrides);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes **#590**: with **3 tactical presets** saved, users could not overwrite a slot from the lineup screen.

## Root cause

- **Backend** (`SaveTacticalPreset`): updating an existing preset when `preset_id` is present already worked; the “max 3” guard applies only to **new** presets.
- **UI** (`lineup.blade.php`): the “Save tactic” control was hidden when there were already 3 presets, and the save modal never sent `preset_id`, so every attempt used the **create** path and hit the limit.

## Changes

- Show “Save tactic” whenever 11 players are selected, including when 3 presets exist.
- Save modal: choose **new preset** vs **replace existing** (with a preset picker); with 3 presets, **replace only**, plus a short hint.
- Submit `preset_id` only in replace mode (conditional hidden input).
- **i18n**: new `squad.*` strings in `lang/en` and `lang/es`.
- **Tests** (`SaveTacticalPresetTest`): POST with `preset_id` updates the preset; POST without `preset_id` when 3 presets exist still returns the limit error (existing server behaviour).

Closes #590