### PR TITLE
Generate sale offers for listed players outside transfer windows

### DIFF
--- a/app/Modules/Match/Services/CareerActionProcessor.php
+++ b/app/Modules/Match/Services/CareerActionProcessor.php
@@ -17,6 +17,10 @@ use App\Modules\Transfer\Services\TransferService;
 
 class CareerActionProcessor
 {
+    private const LISTED_OFFER_CHANCE_IN_WINDOW = 40;
+
+    private const LISTED_OFFER_CHANCE_OUTSIDE_WINDOW = 15;
+
     public function __construct(
         private readonly TransferService $transferService,
         private readonly ScoutingService $scoutingService,
@@ -41,11 +45,19 @@ class CareerActionProcessor
             }
         }
 
-        // Generate transfer offers (can happen anytime, but more during windows)
+        // Generate offers for listed players (always, with reduced chance outside window)
+        $listedOfferChance = $game->isTransferWindowOpen()
+            ? self::LISTED_OFFER_CHANCE_IN_WINDOW
+            : self::LISTED_OFFER_CHANCE_OUTSIDE_WINDOW;
+        $listedOffers = $this->transferService->generateOffersForListedPlayers($game, buyerPool: $buyerPool, offerChance: $listedOfferChance);
+        foreach ($listedOffers as $offer) {
+            $this->notificationService->notifyTransferOffer($game, $offer);
+        }
+
+        // Unsolicited offers only during open windows
         if ($game->isTransferWindowOpen()) {
-            $listedOffers = $this->transferService->generateOffersForListedPlayers($game, buyerPool: $buyerPool);
             $unsolicitedOffers = $this->transferService->generateUnsolicitedOffers($game, buyerPool: $buyerPool);
-            foreach ($listedOffers->merge($unsolicitedOffers) as $offer) {
+            foreach ($unsolicitedOffers as $offer) {
                 $this->notificationService->notifyTransferOffer($game, $offer);
             }
         }

--- a/app/Modules/Transfer/Services/TransferService.php
+++ b/app/Modules/Transfer/Services/TransferService.php
@@ -143,7 +143,7 @@ class TransferService
      *
      * @param Collection|null $allPlayersGrouped Pre-loaded players grouped by team_id (optional, for N+1 optimization)
      */
-    public function generateOffersForListedPlayers(Game $game, $allPlayersGrouped = null, ?array $buyerPool = null): Collection
+    public function generateOffersForListedPlayers(Game $game, $allPlayersGrouped = null, ?array $buyerPool = null, int $offerChance = 40): Collection
     {
         $offers = collect();
 
@@ -188,8 +188,7 @@ class TransferService
                 continue;
             }
 
-            // 40% chance of receiving a new offer each matchday
-            if (rand(1, 100) <= 40) {
+            if (rand(1, 100) <= $offerChance) {
                 ['buyers' => $buyers, 'squadValues' => $squadValues] = $this->getEligibleBuyersWithSquadValues($player, $buyerPool);
 
                 // Exclude teams that already made offers

--- a/docs/game-systems/transfer-market.md
+++ b/docs/game-systems/transfer-market.md
@@ -25,7 +25,7 @@ Transfers complete immediately if the window is open, otherwise they're marked "
 
 ## Selling
 
-- **Listed players** receive offers each matchday with a configurable probability (max 3 pending).
+- **Listed players** receive offers each matchday (max 3 pending). Offers arrive year-round: 40% chance per matchday during transfer windows, 15% outside windows. Offers accepted outside a window are deferred (`agreed`) and complete when the next window opens.
 - **Unsolicited offers** target the team's best players with a small daily chance.
 - Both offer types apply age-based adjustments and randomized pricing around market value.
 


### PR DESCRIPTION
Listed players now receive AI offers year-round instead of only during
open transfer windows. Offer probability is reduced outside windows
(15% vs 40% per matchday). Accepted offers outside windows are deferred
as agreed and complete when the next window opens (existing behavior).
Unsolicited/poaching offers remain window-only.

https://claude.ai/code/session_012oiW6GctpeJjFwuCtczW1k