### PR TITLE
Exclude free agents from scout search results

### DIFF
--- a/app/Modules/Transfer/Services/ScoutSearchQueryBuilder.php
+++ b/app/Modules/Transfer/Services/ScoutSearchQueryBuilder.php
@@ -41,21 +41,6 @@ class ScoutSearchQueryBuilder
         return $query;
     }
 
-    /**
-     * Build the query for free agents matching scout filters.
-     */
-    public function buildFreeAgentQuery(Game $game, array $filters, array $positions): Builder
-    {
-        $query = GamePlayer::with(['player'])
-            ->where('game_id', $game->id)
-            ->whereNull('team_id')
-            ->whereIn('position', $positions);
-
-        $this->applyAgeFilter($query, $game, $filters);
-
-        return $query;
-    }
-
     private function applyScopeFilter(Builder $query, Game $game, array $filters): void
     {
         $scope = $filters['scope'] ?? ['domestic', 'international'];

--- a/app/Modules/Transfer/Services/ScoutingService.php
+++ b/app/Modules/Transfer/Services/ScoutingService.php
@@ -234,8 +234,6 @@ class ScoutingService
 
         $queryBuilder = app(ScoutSearchQueryBuilder::class);
         $candidates = $queryBuilder->buildCandidateQuery($game, $filters, $positions)->get();
-        $freeAgents = $queryBuilder->buildFreeAgentQuery($game, $filters, $positions)->get();
-        $candidates = $candidates->merge($freeAgents);
 
         if ($candidates->isEmpty()) {
             $report->update([


### PR DESCRIPTION
Remove free agent query and merge from ScoutingService::generateResults()
and delete the now-unused buildFreeAgentQuery() method from
ScoutSearchQueryBuilder. Scout searches now only return players belonging
to other teams.

https://claude.ai/code/session_01JEABbNwvWUdwsMYytD2YUP