### PR TITLE
Add Squad Registration page for career mode

### DIFF
--- a/app/Http/Actions/SaveSquadRegistration.php
+++ b/app/Http/Actions/SaveSquadRegistration.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Actions;
+
+use App\Models\Game;
+use App\Modules\Squad\Services\RegistrationException;
+use App\Modules\Squad\Services\SquadRegistrationService;
+use Illuminate\Http\Request;
+
+class SaveSquadRegistration
+{
+    public function __construct(
+        private readonly SquadRegistrationService $registrationService,
+    ) {}
+
+    public function __invoke(Request $request, string $gameId)
+    {
+        $game = Game::findOrFail($gameId);
+
+        $validated = $request->validate([
+            'assignments' => 'present|array|max:99',
+            'assignments.*.player_id' => 'required|string',
+            'assignments.*.number' => 'required|integer|min:1|max:99',
+        ]);
+
+        try {
+            $this->registrationService->save($game, collect($validated['assignments'] ?? []));
+        } catch (RegistrationException $e) {
+            return back()->with('error', $e->getMessage());
+        }
+
+        return back()->with('success', __('squad.registration_saved'));
+    }
+}

--- a/app/Http/Views/ShowSquadRegistration.php
+++ b/app/Http/Views/ShowSquadRegistration.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Http\Views;
+
+use App\Models\Game;
+use App\Models\GamePlayer;
+use App\Support\PositionMapper;
+
+class ShowSquadRegistration
+{
+    public function __invoke(string $gameId)
+    {
+        $game = Game::with('team')->findOrFail($gameId);
+
+        if (! $game->isCareerMode()) {
+            return redirect()->route('game.squad', $gameId);
+        }
+
+        $gamePlayers = GamePlayer::where('game_id', $gameId)
+            ->where('team_id', $game->team_id)
+            ->with('player')
+            ->get();
+
+        $players = [];
+        $slots = array_fill(1, 25, null);
+        $academyPlayers = [];
+        $unregistered = [];
+
+        foreach ($gamePlayers as $gp) {
+            $dto = [
+                'id' => $gp->id,
+                'name' => $gp->player->name,
+                'position' => $gp->position,
+                'position_group' => $gp->position_group,
+                'position_abbreviation' => PositionMapper::toAbbreviation($gp->position),
+                'overall' => $gp->overall_score,
+                'age' => $gp->age($game->current_date),
+            ];
+
+            $players[$gp->id] = $dto;
+
+            if ($gp->number !== null && $gp->number >= 1 && $gp->number <= 25) {
+                $slots[$gp->number] = $gp->id;
+            } elseif ($gp->number !== null && $gp->number >= 26 && $gp->number <= 99) {
+                $academyPlayers[] = ['id' => $gp->id, 'number' => $gp->number];
+            } else {
+                $unregistered[] = $gp->id;
+            }
+        }
+
+        return view('squad-registration', [
+            'game' => $game,
+            'players' => $players,
+            'slots' => $slots,
+            'academyPlayers' => $academyPlayers,
+            'unregistered' => $unregistered,
+        ]);
+    }
+}

--- a/app/Modules/Squad/Services/RegistrationException.php
+++ b/app/Modules/Squad/Services/RegistrationException.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Modules\Squad\Services;
+
+use RuntimeException;
+
+class RegistrationException extends RuntimeException
+{
+    public static function duplicateNumber(): self
+    {
+        return new self(__('squad.number_taken'));
+    }
+
+    public static function invalidPlayers(): self
+    {
+        return new self(__('squad.invalid_selection'));
+    }
+
+    public static function academyAgeLimit(): self
+    {
+        return new self(__('squad.academy_age_limit'));
+    }
+}

--- a/app/Modules/Squad/Services/SquadRegistrationService.php
+++ b/app/Modules/Squad/Services/SquadRegistrationService.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace App\Modules\Squad\Services;
+
+use App\Models\Game;
+use App\Models\GamePlayer;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+
+class SquadRegistrationService
+{
+    /**
+     * Validate and save squad registration assignments.
+     *
+     * @param  Collection<int, array{player_id: string, number: int}>  $assignments
+     * @throws \App\Modules\Squad\Exceptions\RegistrationException
+     */
+    public function save(Game $game, Collection $assignments): void
+    {
+        $this->validateNoDuplicateNumbers($assignments);
+        $this->validatePlayersExist($game, $assignments);
+        $this->validateAcademyAgeLimit($game, $assignments);
+
+        DB::transaction(function () use ($game, $assignments) {
+            GamePlayer::where('game_id', $game->id)
+                ->where('team_id', $game->team_id)
+                ->update(['number' => null]);
+
+            foreach ($assignments as $assignment) {
+                GamePlayer::where('game_id', $game->id)
+                    ->where('team_id', $game->team_id)
+                    ->where('id', $assignment['player_id'])
+                    ->update(['number' => $assignment['number']]);
+            }
+        });
+    }
+
+    private function validateNoDuplicateNumbers(Collection $assignments): void
+    {
+        $numbers = $assignments->pluck('number');
+
+        if ($numbers->count() !== $numbers->unique()->count()) {
+            throw RegistrationException::duplicateNumber();
+        }
+    }
+
+    private function validatePlayersExist(Game $game, Collection $assignments): void
+    {
+        $playerIds = $assignments->pluck('player_id');
+
+        $validCount = GamePlayer::where('game_id', $game->id)
+            ->where('team_id', $game->team_id)
+            ->whereIn('id', $playerIds)
+            ->count();
+
+        if ($validCount !== $playerIds->count()) {
+            throw RegistrationException::invalidPlayers();
+        }
+    }
+
+    private function validateAcademyAgeLimit(Game $game, Collection $assignments): void
+    {
+        $academyAssignments = $assignments->filter(fn ($a) => $a['number'] > 25);
+
+        if ($academyAssignments->isEmpty()) {
+            return;
+        }
+
+        $academyPlayerIds = $academyAssignments->pluck('player_id');
+
+        $overageCount = GamePlayer::where('game_id', $game->id)
+            ->where('team_id', $game->team_id)
+            ->whereIn('id', $academyPlayerIds)
+            ->whereHas('player', function ($q) use ($game) {
+                $q->where('date_of_birth', '<=', $game->current_date->subYears(23));
+            })
+            ->count();
+
+        if ($overageCount > 0) {
+            throw RegistrationException::academyAgeLimit();
+        }
+    }
+}

--- a/lang/en/squad.php
+++ b/lang/en/squad.php
@@ -349,4 +349,21 @@ return [
 
     // Number
     'number' => 'Number',
+
+    // Squad registration
+    'registration' => 'Registration',
+    'registration_title' => 'Squad Registration',
+    'registration_subtitle' => 'Assign shirt numbers for the season',
+    'first_team_slots' => 'First Team (1-25)',
+    'academy_slots' => 'Academy (26-99)',
+    'unregistered_players' => 'Unregistered',
+    'empty_slot' => 'Empty',
+    'save_registration' => 'Save',
+    'registration_saved' => 'Squad registration saved',
+    'registered_count' => ':count registered',
+    'academy_age_limit' => 'Only players under 23 can be registered with academy numbers (26-99)',
+    'registration_rules_title' => 'Registration Rules',
+    'registration_rule_first_team' => 'First team players are assigned shirt numbers 1 to 25.',
+    'registration_rule_academy' => 'Academy numbers (26-99) are reserved for players under 23 years old.',
+    'registration_rule_unregistered' => 'Unregistered players cannot be selected for matchday squads.',
 ];

--- a/lang/es/squad.php
+++ b/lang/es/squad.php
@@ -349,4 +349,21 @@ return [
 
     // Dorsales
     'number' => 'Dorsal',
+
+    // Inscripción de plantilla
+    'registration' => 'Inscripción',
+    'registration_title' => 'Inscripción de Plantilla',
+    'registration_subtitle' => 'Asigna dorsales para la temporada',
+    'first_team_slots' => 'Primer Equipo (1-25)',
+    'academy_slots' => 'Cantera (26-99)',
+    'unregistered_players' => 'No inscritos',
+    'empty_slot' => 'Vacío',
+    'save_registration' => 'Guardar',
+    'registration_saved' => 'Inscripción guardada',
+    'registered_count' => ':count inscritos',
+    'academy_age_limit' => 'Solo jugadores menores de 23 años pueden inscribirse con dorsal de cantera (26-99)',
+    'registration_rules_title' => 'Reglas de Inscripción',
+    'registration_rule_first_team' => 'Los jugadores del primer equipo llevan dorsales del 1 al 25.',
+    'registration_rule_academy' => 'Los dorsales de cantera (26-99) están reservados para jugadores menores de 23 años.',
+    'registration_rule_unregistered' => 'Los jugadores no inscritos no pueden ser convocados para los partidos.',
 ];

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -9,6 +9,7 @@ import negotiationChat from './negotiation-chat';
 import squadSelection from './squad-selection';
 import tournamentSummary from './tournament-summary';
 import seasonSummary from './season-summary';
+import squadRegistration from './squad-registration';
 
 Alpine.plugin(Collapse);
 Alpine.plugin(Tooltip);
@@ -17,6 +18,7 @@ Alpine.data('liveMatch', liveMatch);
 Alpine.data('lineupManager', lineupManager);
 Alpine.data('negotiationChat', negotiationChat);
 Alpine.data('squadSelection', squadSelection);
+Alpine.data('squadRegistration', squadRegistration);
 Alpine.data('tournamentSummary', tournamentSummary);
 Alpine.data('seasonSummary', seasonSummary);
 

--- a/resources/js/squad-registration.js
+++ b/resources/js/squad-registration.js
@@ -1,0 +1,362 @@
+export default function squadRegistration(config) {
+    return {
+        players: config.players,
+        slots: config.slots,
+        academyPlayers: config.academyPlayers,
+
+        // Drag state
+        dragPlayerId: null,
+        dragSourceSlot: null, // number for first-team slot, 'academy' for academy, null for unregistered
+        dropTargetSlot: null,
+
+        // Touch drag state
+        touchActive: false,
+        touchTimer: null,
+        touchClone: null,
+        touchStartX: 0,
+        touchStartY: 0,
+
+        get unregisteredIds() {
+            const assigned = new Set(Object.values(this.slots).filter(Boolean));
+            for (const ap of this.academyPlayers) {
+                assigned.add(ap.id);
+            }
+            return Object.keys(this.players).filter(id => !assigned.has(id));
+        },
+
+        get registeredCount() {
+            return Object.values(this.slots).filter(Boolean).length + this.academyPlayers.length;
+        },
+
+        get firstTeamCount() {
+            let count = 0;
+            for (let i = 1; i <= 25; i++) {
+                if (this.slots[i]) count++;
+            }
+            return count;
+        },
+
+        sortedUnregistered() {
+            return this.unregisteredIds.slice().sort((a, b) => {
+                const pa = this.players[a];
+                const pb = this.players[b];
+                const groupOrder = { Goalkeeper: 0, Defender: 1, Midfielder: 2, Forward: 3 };
+                const ga = groupOrder[pa.position_group] ?? 9;
+                const gb = groupOrder[pb.position_group] ?? 9;
+                if (ga !== gb) return ga - gb;
+                return pb.overall - pa.overall;
+            });
+        },
+
+        getPlayer(slotNumber) {
+            const id = this.slots[slotNumber];
+            return id ? this.players[id] : null;
+        },
+
+        // --- Academy helpers ---
+
+        allTakenNumbers() {
+            const taken = new Set();
+            for (let i = 1; i <= 25; i++) {
+                if (this.slots[i]) taken.add(i);
+            }
+            for (const ap of this.academyPlayers) {
+                taken.add(ap.number);
+            }
+            return taken;
+        },
+
+        nextAvailableAcademyNumber() {
+            const taken = this.allTakenNumbers();
+            for (let n = 26; n <= 99; n++) {
+                if (!taken.has(n)) return n;
+            }
+            return 26;
+        },
+
+        canBeAcademy(playerId) {
+            return this.players[playerId].age < 23;
+        },
+
+        addToAcademy(playerId) {
+            if (!this.canBeAcademy(playerId)) return;
+            // Remove from first-team slot if there
+            for (let i = 1; i <= 25; i++) {
+                if (this.slots[i] === playerId) {
+                    this.slots[i] = null;
+                    break;
+                }
+            }
+            // Don't add if already in academy
+            if (this.academyPlayers.some(ap => ap.id === playerId)) return;
+            this.academyPlayers.push({ id: playerId, number: this.nextAvailableAcademyNumber() });
+        },
+
+        removeFromAcademy(playerId) {
+            this.academyPlayers = this.academyPlayers.filter(ap => ap.id !== playerId);
+        },
+
+        isAcademyNumberValid(number, playerId) {
+            if (number < 26 || number > 99) return false;
+            // Check against other academy players
+            for (const ap of this.academyPlayers) {
+                if (ap.id !== playerId && ap.number === number) return false;
+            }
+            // Check against first-team slots (shouldn't overlap but be safe)
+            for (let i = 1; i <= 25; i++) {
+                if (this.slots[i] && i === number) return false;
+            }
+            return true;
+        },
+
+        updateAcademyNumber(playerId, rawValue) {
+            const number = parseInt(rawValue, 10);
+            if (isNaN(number)) return;
+            const entry = this.academyPlayers.find(ap => ap.id === playerId);
+            if (entry) entry.number = number;
+        },
+
+        // --- Style helpers ---
+
+        positionBadgeClass(group) {
+            return {
+                'bg-amber-500': group === 'Goalkeeper',
+                'bg-blue-600': group === 'Defender',
+                'bg-emerald-600': group === 'Midfielder',
+                'bg-red-600': group === 'Forward',
+            };
+        },
+
+        ratingBadgeClass(value) {
+            if (value >= 80) return 'rating-elite';
+            if (value >= 70) return 'rating-good';
+            if (value >= 60) return 'rating-average';
+            if (value >= 50) return 'rating-below';
+            return 'rating-poor';
+        },
+
+        // --- HTML5 Drag and Drop ---
+
+        onDragStart(event, playerId, sourceSlot) {
+            this.dragPlayerId = playerId;
+            this.dragSourceSlot = sourceSlot;
+            event.dataTransfer.effectAllowed = 'move';
+            event.dataTransfer.setData('text/plain', playerId);
+            event.target.classList.add('opacity-50');
+        },
+
+        onDragEnd(event) {
+            event.target.classList.remove('opacity-50');
+            this.dragPlayerId = null;
+            this.dragSourceSlot = null;
+            this.dropTargetSlot = null;
+        },
+
+        onDragOverSlot(event, slotNumber) {
+            event.preventDefault();
+            event.dataTransfer.dropEffect = 'move';
+            this.dropTargetSlot = slotNumber;
+        },
+
+        onDragOverUnregistered(event) {
+            event.preventDefault();
+            event.dataTransfer.dropEffect = 'move';
+            this.dropTargetSlot = 'unregistered';
+        },
+
+        onDragOverAcademy(event) {
+            event.preventDefault();
+            event.dataTransfer.dropEffect = 'move';
+            this.dropTargetSlot = 'academy';
+        },
+
+        onDragLeave() {
+            this.dropTargetSlot = null;
+        },
+
+        onDropSlot(event, targetSlot) {
+            event.preventDefault();
+            this.dropTargetSlot = null;
+            if (!this.dragPlayerId) return;
+
+            // Remove from academy if dragging from there
+            if (this.dragSourceSlot === 'academy') {
+                this.removeFromAcademy(this.dragPlayerId);
+            }
+
+            const targetOccupant = this.slots[targetSlot];
+
+            if (typeof this.dragSourceSlot === 'number') {
+                // Dragging from another first-team slot — swap
+                this.slots[targetSlot] = this.dragPlayerId;
+                this.slots[this.dragSourceSlot] = targetOccupant;
+            } else {
+                // Dragging from unregistered or academy
+                this.slots[targetSlot] = this.dragPlayerId;
+            }
+
+            this.dragPlayerId = null;
+            this.dragSourceSlot = null;
+        },
+
+        onDropUnregistered(event) {
+            event.preventDefault();
+            this.dropTargetSlot = null;
+            if (!this.dragPlayerId) return;
+
+            if (typeof this.dragSourceSlot === 'number') {
+                this.slots[this.dragSourceSlot] = null;
+            } else if (this.dragSourceSlot === 'academy') {
+                this.removeFromAcademy(this.dragPlayerId);
+            }
+
+            this.dragPlayerId = null;
+            this.dragSourceSlot = null;
+        },
+
+        onDropAcademy(event) {
+            event.preventDefault();
+            this.dropTargetSlot = null;
+            if (!this.dragPlayerId) return;
+
+            // Remove from first-team slot if needed
+            if (typeof this.dragSourceSlot === 'number') {
+                this.slots[this.dragSourceSlot] = null;
+            }
+
+            // Add to academy (addToAcademy handles dedup)
+            this.addToAcademy(this.dragPlayerId);
+
+            this.dragPlayerId = null;
+            this.dragSourceSlot = null;
+        },
+
+        removeFromSlot(slotNumber) {
+            this.slots[slotNumber] = null;
+        },
+
+        assignToNextSlot(playerId) {
+            for (let i = 1; i <= 25; i++) {
+                if (!this.slots[i]) {
+                    this.slots[i] = playerId;
+                    return;
+                }
+            }
+        },
+
+        // --- Touch support ---
+
+        onTouchStart(event, playerId, sourceSlot) {
+            this.touchStartX = event.touches[0].clientX;
+            this.touchStartY = event.touches[0].clientY;
+
+            this.touchTimer = setTimeout(() => {
+                this.touchActive = true;
+                this.dragPlayerId = playerId;
+                this.dragSourceSlot = sourceSlot;
+
+                const el = event.target.closest('[data-draggable]');
+                if (!el) return;
+
+                const rect = el.getBoundingClientRect();
+                const clone = el.cloneNode(true);
+                clone.style.position = 'fixed';
+                clone.style.width = rect.width + 'px';
+                clone.style.top = (event.touches[0].clientY - rect.height / 2) + 'px';
+                clone.style.left = (event.touches[0].clientX - rect.width / 2) + 'px';
+                clone.style.opacity = '0.85';
+                clone.style.zIndex = '9999';
+                clone.style.pointerEvents = 'none';
+                clone.style.transform = 'scale(1.05)';
+                clone.style.transition = 'transform 0.1s';
+                clone.classList.add('touch-drag-clone');
+                document.body.appendChild(clone);
+                this.touchClone = clone;
+
+                if (navigator.vibrate) navigator.vibrate(30);
+            }, 200);
+        },
+
+        onTouchMove(event) {
+            if (!this.touchActive) {
+                const dx = event.touches[0].clientX - this.touchStartX;
+                const dy = event.touches[0].clientY - this.touchStartY;
+                if (Math.abs(dx) > 10 || Math.abs(dy) > 10) {
+                    clearTimeout(this.touchTimer);
+                }
+                return;
+            }
+
+            event.preventDefault();
+            const touch = event.touches[0];
+
+            if (this.touchClone) {
+                const rect = this.touchClone.getBoundingClientRect();
+                this.touchClone.style.top = (touch.clientY - rect.height / 2) + 'px';
+                this.touchClone.style.left = (touch.clientX - rect.width / 2) + 'px';
+            }
+
+            if (this.touchClone) this.touchClone.style.display = 'none';
+            const target = document.elementFromPoint(touch.clientX, touch.clientY);
+            if (this.touchClone) this.touchClone.style.display = '';
+
+            if (target) {
+                const slotEl = target.closest('[data-slot]');
+                const unregEl = target.closest('[data-unregistered-zone]');
+                const acadEl = target.closest('[data-academy-zone]');
+                if (slotEl) {
+                    this.dropTargetSlot = parseInt(slotEl.dataset.slot);
+                } else if (acadEl) {
+                    this.dropTargetSlot = 'academy';
+                } else if (unregEl) {
+                    this.dropTargetSlot = 'unregistered';
+                } else {
+                    this.dropTargetSlot = null;
+                }
+            }
+        },
+
+        onTouchEnd() {
+            clearTimeout(this.touchTimer);
+
+            if (!this.touchActive) {
+                this.touchActive = false;
+                return;
+            }
+
+            if (this.touchClone) {
+                this.touchClone.remove();
+                this.touchClone = null;
+            }
+
+            if (this.dropTargetSlot === 'unregistered') {
+                if (typeof this.dragSourceSlot === 'number') {
+                    this.slots[this.dragSourceSlot] = null;
+                } else if (this.dragSourceSlot === 'academy') {
+                    this.removeFromAcademy(this.dragPlayerId);
+                }
+            } else if (this.dropTargetSlot === 'academy') {
+                if (typeof this.dragSourceSlot === 'number') {
+                    this.slots[this.dragSourceSlot] = null;
+                }
+                this.addToAcademy(this.dragPlayerId);
+            } else if (typeof this.dropTargetSlot === 'number') {
+                if (this.dragSourceSlot === 'academy') {
+                    this.removeFromAcademy(this.dragPlayerId);
+                }
+                const targetOccupant = this.slots[this.dropTargetSlot];
+                if (typeof this.dragSourceSlot === 'number') {
+                    this.slots[this.dropTargetSlot] = this.dragPlayerId;
+                    this.slots[this.dragSourceSlot] = targetOccupant;
+                } else {
+                    this.slots[this.dropTargetSlot] = this.dragPlayerId;
+                }
+            }
+
+            this.touchActive = false;
+            this.dragPlayerId = null;
+            this.dragSourceSlot = null;
+            this.dropTargetSlot = null;
+        },
+    };
+}

--- a/resources/views/squad-registration.blade.php
+++ b/resources/views/squad-registration.blade.php
@@ -1,0 +1,241 @@
+@php
+    /** @var App\Models\Game $game */
+    /** @var array $players */
+    /** @var array $slots */
+    /** @var array $academyPlayers */
+    /** @var array $unregistered */
+@endphp
+
+<x-app-layout :hide-footer="true">
+    <div x-data="squadRegistration({
+        players: @js($players),
+        slots: @js($slots),
+        academyPlayers: @js($academyPlayers),
+    })" class="min-h-screen pb-28">
+        <div class="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-6 md:py-8">
+
+            {{-- Header --}}
+            <div class="text-center mb-6 md:mb-8">
+                <x-team-crest :team="$game->team" class="w-16 h-16 md:w-20 md:h-20 mx-auto mb-3 md:mb-4" />
+                <h1 class="font-heading text-2xl md:text-3xl font-bold uppercase tracking-wide text-text-primary">{{ __('squad.registration_title') }}</h1>
+                <p class="text-sm text-text-muted">{{ __('squad.registration_subtitle') }}</p>
+            </div>
+
+            {{-- Flash Messages --}}
+            <x-flash-message type="success" :message="session('success')" class="mb-4" />
+            <x-flash-message type="error" :message="session('error')" class="mb-4" />
+
+            {{-- Rules --}}
+            <div class="mb-6 bg-surface-800 border border-border-default rounded-xl px-5 py-4">
+                <div class="flex items-center gap-2 mb-2">
+                    <svg class="w-4 h-4 text-accent-blue shrink-0" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M11.25 11.25l.041-.02a.75.75 0 011.063.852l-.708 2.836a.75.75 0 001.063.853l.041-.021M21 12a9 9 0 11-18 0 9 9 0 0118 0zm-9-3.75h.008v.008H12V8.25z"/></svg>
+                    <h3 class="text-sm font-semibold text-text-primary">{{ __('squad.registration_rules_title') }}</h3>
+                </div>
+                <ul class="text-xs text-text-muted space-y-1 ml-6 list-disc">
+                    <li>{{ __('squad.registration_rule_first_team') }}</li>
+                    <li>{{ __('squad.registration_rule_academy') }}</li>
+                    <li>{{ __('squad.registration_rule_unregistered') }}</li>
+                </ul>
+            </div>
+
+            {{-- Two-column layout --}}
+            <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
+
+                {{-- ===== LEFT PANEL: Registered Players ===== --}}
+                <div>
+                    {{-- First Team (1-25) --}}
+                    <x-section-card :title="__('squad.first_team_slots')">
+                        <x-slot name="badge">
+                            <span class="text-xs text-text-muted"><span x-text="firstTeamCount" class="font-semibold text-text-body"></span>/25</span>
+                        </x-slot>
+                        <div class="divide-y divide-border-default">
+                            @for($i = 1; $i <= 25; $i++)
+                            <div data-slot="{{ $i }}"
+                                 @dragover.prevent="onDragOverSlot($event, {{ $i }})"
+                                 @dragleave="onDragLeave()"
+                                 @drop="onDropSlot($event, {{ $i }})"
+                                 class="flex items-center gap-3 px-4 py-2.5 min-h-[52px] transition-colors"
+                                 :class="dropTargetSlot === {{ $i }} ? 'bg-accent-blue/10 border-l-2 border-l-accent-blue' : 'border-l-2 border-l-transparent'">
+
+                                <span class="w-8 text-center text-sm font-bold tabular-nums text-text-secondary shrink-0">{{ $i }}</span>
+
+                                <template x-if="getPlayer({{ $i }})">
+                                    <div class="flex items-center gap-3 flex-1 min-w-0 cursor-grab active:cursor-grabbing"
+                                         draggable="true"
+                                         data-draggable
+                                         @dragstart="onDragStart($event, slots[{{ $i }}], {{ $i }})"
+                                         @dragend="onDragEnd($event)"
+                                         @touchstart="onTouchStart($event, slots[{{ $i }}], {{ $i }})"
+                                         @touchmove="onTouchMove($event)"
+                                         @touchend="onTouchEnd()">
+
+                                        <span class="inline-flex items-center justify-center w-5 h-5 text-[10px] font-semibold text-white -skew-x-12"
+                                              :class="positionBadgeClass(getPlayer({{ $i }}).position_group)">
+                                            <span class="skew-x-12" x-text="getPlayer({{ $i }}).position_abbreviation"></span>
+                                        </span>
+
+                                        <span class="text-sm font-medium text-text-primary truncate flex-1 min-w-0" x-text="getPlayer({{ $i }}).name"></span>
+                                        <span class="text-xs text-text-muted tabular-nums shrink-0" x-text="getPlayer({{ $i }}).age + ' {{ __('squad.years_abbr') }}'"></span>
+
+                                        <div class="rating-badge w-7 h-7 rounded-md text-[10px] flex items-center justify-center shrink-0"
+                                             :class="ratingBadgeClass(getPlayer({{ $i }}).overall)">
+                                            <span class="font-heading font-bold" x-text="getPlayer({{ $i }}).overall"></span>
+                                        </div>
+                                        <button type="button" @click.stop="removeFromSlot({{ $i }})" class="p-1 text-text-faint hover:text-accent-red transition-colors shrink-0">
+                                            <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/></svg>
+                                        </button>
+                                    </div>
+                                </template>
+                                <template x-if="!getPlayer({{ $i }})">
+                                    <span class="text-xs text-text-faint italic">{{ __('squad.empty_slot') }}</span>
+                                </template>
+                            </div>
+                            @endfor
+                        </div>
+                    </x-section-card>
+
+                    {{-- Academy (26-99) --}}
+                    <x-section-card :title="__('squad.academy_slots')" class="mt-4">
+                        <x-slot name="badge">
+                            <span class="text-xs text-text-muted"><span x-text="academyPlayers.length" class="font-semibold text-text-body"></span></span>
+                        </x-slot>
+                        <div data-academy-zone
+                             @dragover.prevent="onDragOverAcademy($event)"
+                             @dragleave="onDragLeave()"
+                             @drop="onDropAcademy($event)"
+                             class="divide-y divide-border-default min-h-[52px] transition-colors"
+                             :class="dropTargetSlot === 'academy' ? 'bg-accent-blue/5' : ''">
+
+                            <template x-for="(entry, index) in academyPlayers" :key="entry.id">
+                                <div class="flex items-center gap-3 px-4 py-2.5 min-h-[52px] cursor-grab active:cursor-grabbing"
+                                     draggable="true"
+                                     data-draggable
+                                     @dragstart="onDragStart($event, entry.id, 'academy')"
+                                     @dragend="onDragEnd($event)"
+                                     @touchstart="onTouchStart($event, entry.id, 'academy')"
+                                     @touchmove="onTouchMove($event)"
+                                     @touchend="onTouchEnd()">
+
+                                    {{-- Editable number input --}}
+                                    <input type="number" min="26" max="99"
+                                           :value="entry.number"
+                                           @input.stop="updateAcademyNumber(entry.id, $event.target.value)"
+                                           @click.stop
+                                           class="w-12 h-8 text-sm font-bold text-center bg-surface-700 border rounded-sm tabular-nums focus:ring-2 focus:ring-accent-blue focus:border-accent-blue [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+                                           :class="isAcademyNumberValid(entry.number, entry.id) ? 'border-border-strong' : 'border-red-500 bg-accent-red/10'">
+
+                                    <span class="inline-flex items-center justify-center w-5 h-5 text-[10px] font-semibold text-white -skew-x-12"
+                                          :class="positionBadgeClass(players[entry.id].position_group)">
+                                        <span class="skew-x-12" x-text="players[entry.id].position_abbreviation"></span>
+                                    </span>
+
+                                    <span class="text-sm font-medium text-text-primary truncate flex-1 min-w-0" x-text="players[entry.id].name"></span>
+                                    <span class="text-xs text-text-muted tabular-nums shrink-0" x-text="players[entry.id].age + ' {{ __('squad.years_abbr') }}'"></span>
+
+                                    <div class="rating-badge w-7 h-7 rounded-md text-[10px] flex items-center justify-center shrink-0"
+                                         :class="ratingBadgeClass(players[entry.id].overall)">
+                                        <span class="font-heading font-bold" x-text="players[entry.id].overall"></span>
+                                    </div>
+                                    <button type="button" @click.stop="removeFromAcademy(entry.id)" class="p-1 text-text-faint hover:text-accent-red transition-colors shrink-0">
+                                        <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/></svg>
+                                    </button>
+                                </div>
+                            </template>
+
+                            {{-- Empty state --}}
+                            <div x-show="academyPlayers.length === 0" class="px-4 py-6 text-center">
+                                <p class="text-xs text-text-faint italic">{{ __('squad.drag_to_assign') }}</p>
+                            </div>
+                        </div>
+                    </x-section-card>
+                </div>
+
+                {{-- ===== RIGHT PANEL: Unregistered Players ===== --}}
+                <div class="lg:sticky lg:top-4 lg:self-start">
+                    <x-section-card :title="__('squad.unregistered_players')">
+                        <x-slot name="badge">
+                            <span class="text-xs text-text-muted" x-text="unregisteredIds.length + ' {{ __('squad.players_count') }}'"></span>
+                        </x-slot>
+
+                        <div data-unregistered-zone
+                             @dragover.prevent="onDragOverUnregistered($event)"
+                             @dragleave="onDragLeave()"
+                             @drop="onDropUnregistered($event)"
+                             class="divide-y divide-border-default min-h-[200px] transition-colors lg:max-h-[70vh] lg:overflow-y-auto"
+                             :class="dropTargetSlot === 'unregistered' ? 'bg-accent-blue/5' : ''">
+
+                            <template x-for="playerId in sortedUnregistered()" :key="playerId">
+                                <div class="flex items-center gap-3 px-4 py-2.5 min-h-[52px] cursor-grab active:cursor-grabbing hover:bg-surface-700/50 transition-colors"
+                                     draggable="true"
+                                     data-draggable
+                                     @dragstart="onDragStart($event, playerId, null)"
+                                     @dragend="onDragEnd($event)"
+                                     @touchstart="onTouchStart($event, playerId, null)"
+                                     @touchmove="onTouchMove($event)"
+                                     @touchend="onTouchEnd()">
+
+                                    <span class="inline-flex items-center justify-center w-5 h-5 text-[10px] font-semibold text-white -skew-x-12"
+                                          :class="positionBadgeClass(players[playerId].position_group)">
+                                        <span class="skew-x-12" x-text="players[playerId].position_abbreviation"></span>
+                                    </span>
+
+                                    <span class="text-sm font-medium text-text-primary truncate flex-1 min-w-0" x-text="players[playerId].name"></span>
+                                    <span class="text-xs text-text-muted tabular-nums shrink-0" x-text="players[playerId].age + ' {{ __('squad.years_abbr') }}'"></span>
+
+                                    <div class="rating-badge w-7 h-7 rounded-md text-[10px] flex items-center justify-center shrink-0"
+                                         :class="ratingBadgeClass(players[playerId].overall)">
+                                        <span class="font-heading font-bold" x-text="players[playerId].overall"></span>
+                                    </div>
+                                    <button type="button" @click.stop="assignToNextSlot(playerId)" class="p-1 text-text-faint hover:text-accent-green transition-colors shrink-0" title="{{ __('squad.first_team') }}">
+                                        <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15"/></svg>
+                                    </button>
+                                </div>
+                            </template>
+
+                            <div x-show="sortedUnregistered().length === 0" class="px-4 py-8 text-center">
+                                <p class="text-sm text-text-faint">{{ __('squad.no_players_match_filter') }}</p>
+                            </div>
+                        </div>
+                    </x-section-card>
+                </div>
+            </div>
+        </div>
+
+        {{-- Sticky Bottom Bar --}}
+        <div class="fixed bottom-0 left-0 right-0 bg-surface-800/95 backdrop-blur-xs border-t border-border-strong shadow-lg z-30">
+            <div class="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-3 md:py-4">
+                <div class="flex items-center gap-3 md:gap-4">
+                    <div class="flex-1 text-sm text-text-muted">
+                        <span class="font-bold transition-colors"
+                              :class="registeredCount > 0 ? 'text-text-body' : 'text-text-secondary'"
+                              x-text="registeredCount"></span>
+                        <span>{{ __('squad.registered_count', ['count' => '']) }}</span>
+                    </div>
+
+                    <form method="POST" action="{{ route('game.squad.registration.save', $game->id) }}">
+                        @csrf
+                        {{-- First team slots --}}
+                        <template x-for="n in 25" :key="'slot-' + n">
+                            <template x-if="slots[n]">
+                                <div>
+                                    <input type="hidden" :name="'assignments[' + (n - 1) + '][player_id]'" :value="slots[n]">
+                                    <input type="hidden" :name="'assignments[' + (n - 1) + '][number]'" :value="n">
+                                </div>
+                            </template>
+                        </template>
+                        {{-- Academy players --}}
+                        <template x-for="(entry, index) in academyPlayers" :key="'acad-' + entry.id">
+                            <div>
+                                <input type="hidden" :name="'assignments[' + (25 + index) + '][player_id]'" :value="entry.id">
+                                <input type="hidden" :name="'assignments[' + (25 + index) + '][number]'" :value="entry.number">
+                            </div>
+                        </template>
+                        <x-primary-button color="emerald">
+                            {{ __('squad.save_registration') }}
+                        </x-primary-button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -58,7 +58,9 @@ use App\Http\Actions\SaveLineup;
 use App\Http\Actions\SaveTacticalPreset;
 use App\Http\Actions\DeleteTacticalPreset;
 
+use App\Http\Actions\SaveSquadRegistration;
 use App\Http\Actions\SaveSquadSelection;
+use App\Http\Views\ShowSquadRegistration;
 use App\Http\Views\ShowSquadSelection;
 use App\Http\Actions\SubmitScoutSearch;
 use App\Http\Actions\SubmitPreContractOffer;
@@ -147,6 +149,8 @@ Route::middleware('auth')->group(function () {
         Route::get('/game/{gameId}', ShowGame::class)->name('show-game');
         Route::get('/game/{gameId}/squad', ShowSquad::class)->name('game.squad');
         Route::get('/game/{gameId}/squad/academy', ShowAcademy::class)->name('game.squad.academy');
+        Route::get('/game/{gameId}/squad/registration', ShowSquadRegistration::class)->name('game.squad.registration');
+        Route::post('/game/{gameId}/squad/registration', SaveSquadRegistration::class)->name('game.squad.registration.save');
         Route::get('/game/{gameId}/player/{playerId}/detail', ShowPlayerDetail::class)->name('game.player.detail');
         Route::get('/game/{gameId}/academy/{playerId}/detail', ShowAcademyPlayerDetail::class)->name('game.academy.detail');
         Route::post('/game/{gameId}/academy/{playerId}/promote', PromoteAcademyPlayer::class)->name('game.academy.promote');


### PR DESCRIPTION
Introduces a new blocking-step page where users assign shirt numbers via drag-and-drop. First team gets fixed slots 1-25, academy players (under 23 only) get editable numbers 26-99. Includes touch support, inline validation, and server-side age enforcement via SquadRegistrationService.