### PR TITLE
Exclude loaned players from expiring contract notifications

### DIFF
--- a/app/Modules/Match/Services/CareerActionProcessor.php
+++ b/app/Modules/Match/Services/CareerActionProcessor.php
@@ -170,6 +170,7 @@ class CareerActionProcessor
             ->whereDoesntHave('latestRenewalNegotiation', function ($q) {
                 $q->where('status', RenewalNegotiation::STATUS_CLUB_DECLINED);
             })
+            ->whereDoesntHave('activeLoan')
             ->get();
 
         if ($expiringPlayers->isEmpty()) {


### PR DESCRIPTION
## Summary
Updated the expiring contract check logic to exclude players who are currently on active loan from being processed for contract renewal notifications.

## Key Changes
- Added `whereDoesntHave('activeLoan')` filter to the expiring contracts query in `CareerActionProcessor::checkExpiringContracts()`
- This prevents loaned players from receiving contract expiration notifications, as their contracts are managed by their parent club, not the loaning club

## Implementation Details
The filter is applied alongside the existing exclusion for players with declined renewal negotiations, ensuring that only players actively available at their club are considered for contract renewal processing.

https://claude.ai/code/session_01NmQ18rnWbnmSxB3cfr39y2