### PR TITLE
Prevent loaned players from being transferred

### DIFF
--- a/app/Http/Actions/AcceptTransferOffer.php
+++ b/app/Http/Actions/AcceptTransferOffer.php
@@ -29,7 +29,7 @@ class AcceptTransferOffer
             abort(403, 'You can only accept offers for your own players.');
         }
 
-        if ($offer->gamePlayer->isLoanedIn($game->team_id)) {
+        if ($offer->gamePlayer->isOnLoan()) {
             abort(403, 'Cannot accept offers for loaned players.');
         }
 

--- a/app/Http/Actions/ListPlayerForTransfer.php
+++ b/app/Http/Actions/ListPlayerForTransfer.php
@@ -22,7 +22,7 @@ class ListPlayerForTransfer
             ->where('team_id', $game->team_id)
             ->firstOrFail();
 
-        if ($player->isLoanedIn($game->team_id)) {
+        if ($player->isOnLoan()) {
             abort(403, 'Cannot list a loaned player for transfer.');
         }
 

--- a/app/Modules/Transfer/Services/TransferCompletionService.php
+++ b/app/Modules/Transfer/Services/TransferCompletionService.php
@@ -32,6 +32,13 @@ class TransferCompletionService
     public function completeOutgoingTransfer(TransferOffer $offer, Game $game): void
     {
         $player = $offer->gamePlayer;
+
+        // Safety: never sell a player who is on an active loan
+        if ($player->isOnLoan() && $offer->offer_type !== TransferOffer::TYPE_LOAN_OUT) {
+            $offer->update(['status' => TransferOffer::STATUS_REJECTED, 'resolved_at' => $game->current_date]);
+            return;
+        }
+
         $playerName = $player->player->name;
         $buyerName = $offer->offeringTeam->name;
         $isLoan = $offer->offer_type === TransferOffer::TYPE_LOAN_OUT;


### PR DESCRIPTION
## Summary
This PR adds validation to prevent players on active loans from being transferred or listed for transfer, ensuring loan agreements are respected during the transfer window.

## Key Changes
- **TransferCompletionService**: Added safety check to reject any outgoing transfer (except loan-out offers) for players currently on loan
- **AcceptTransferOffer**: Simplified loan validation to use the new `isOnLoan()` method instead of `isLoanedIn()`, making the check more general
- **ListPlayerForTransfer**: Updated to use `isOnLoan()` method to prevent listing loaned players for transfer

## Implementation Details
- The validation in `TransferCompletionService.completeOutgoingTransfer()` acts as a safety net, rejecting transfers and marking them as resolved
- Refactored loan checks to use a consistent `isOnLoan()` method across all transfer-related actions, improving code maintainability
- The check specifically allows loan-out offers to proceed (players can be loaned out even if on loan), while blocking all other transfer types

https://claude.ai/code/session_01EKgkNmYeuEQ55GFNX1LPtk