### PR TITLE
Fix pending action not clearing after squad registration save

### DIFF
--- a/app/Http/Actions/SaveSquadRegistration.php
+++ b/app/Http/Actions/SaveSquadRegistration.php
@@ -33,9 +33,7 @@ class SaveSquadRegistration
             return back()->with('error', $e->getMessage());
         }
 
-        if (! $game->isTransferWindowOpen()) {
-            $game->removePendingAction('squad_registration');
-        }
+        $game->removePendingAction('squad_registration');
 
         return back()->with('success', __('squad.registration_saved'));
     }


### PR DESCRIPTION
The pending action was only removed when the transfer window was closed,
but during season transition the action gets created while the window is
open. This trapped users in a loop where saving never cleared the action.

Always remove the pending action after a successful save. The
EnforceSquadRegistration listener will re-add it at window close if
conflicts still exist.

https://claude.ai/code/session_015XhaMzmdDtU67Bk67ZpGPd