### PR TITLE
Add physical ability range display to scouting assessment

### DIFF
--- a/app/Http/Views/ShowScoutingHub.php
+++ b/app/Http/Views/ShowScoutingHub.php
@@ -94,6 +94,7 @@ class ShowScoutingHub
                 'onCooldown' => $existingOfferStatuses[$gp->id]['onCooldown'] ?? false,
                 // Locked by default — populated below if intel level warrants it
                 'techRange' => null,
+                'physRange' => null,
                 'formattedAskingPrice' => null,
                 'askingPrice' => null,
                 'canAffordFee' => false,
@@ -112,6 +113,7 @@ class ShowScoutingHub
             if ($entry->hasReportLevel()) {
                 $detail = $this->scoutingService->getPlayerScoutingDetail($gp, $game);
                 $playerData['techRange'] = $detail['tech_range'];
+                $playerData['physRange'] = $detail['phys_range'];
                 $playerData['formattedAskingPrice'] = $detail['formatted_asking_price'];
                 $playerData['askingPrice'] = $detail['asking_price'];
                 $playerData['canAffordFee'] = $detail['can_afford_fee'];

--- a/resources/views/scouting-hub.blade.php
+++ b/resources/views/scouting-hub.blade.php
@@ -383,6 +383,46 @@
                                                     {{-- Level 1+: Full scouting detail --}}
                                                     <template x-if="player.intelLevel >= 1">
                                                         <div class="bg-surface-800 rounded-lg p-4">
+                                                            {{-- Scouting Assessment: Ability ranges --}}
+                                                            <div class="mb-3">
+                                                                <h5 class="text-[10px] font-semibold text-text-muted uppercase tracking-wide mb-2">{{ __('transfers.scouting_assessment') }}</h5>
+                                                                <div class="space-y-1.5">
+                                                                    <div class="flex items-center justify-between gap-3">
+                                                                        <span class="text-xs text-text-muted w-16 shrink-0">{{ __('transfers.technical') }}</span>
+                                                                        <div class="flex items-center gap-1.5">
+                                                                            <span class="text-xs font-semibold tabular-nums text-text-body" x-text="player.techRange[0] + '-' + player.techRange[1]"></span>
+                                                                            <div class="w-10 h-1.5 bg-surface-600 rounded-full overflow-hidden shrink-0">
+                                                                                <div class="h-1.5 rounded-full fitness-bar"
+                                                                                    :class="{
+                                                                                        'bg-accent-green': Math.round((player.techRange[0] + player.techRange[1]) / 2) >= 80,
+                                                                                        'bg-lime-500': Math.round((player.techRange[0] + player.techRange[1]) / 2) >= 70 && Math.round((player.techRange[0] + player.techRange[1]) / 2) < 80,
+                                                                                        'bg-accent-gold': Math.round((player.techRange[0] + player.techRange[1]) / 2) >= 60 && Math.round((player.techRange[0] + player.techRange[1]) / 2) < 70,
+                                                                                        'bg-accent-orange': Math.round((player.techRange[0] + player.techRange[1]) / 2) < 60,
+                                                                                    }"
+                                                                                    :style="'width: ' + Math.min(100, Math.round((player.techRange[0] + player.techRange[1]) / 2) / 99 * 100) + '%'">
+                                                                                </div>
+                                                                            </div>
+                                                                        </div>
+                                                                    </div>
+                                                                    <div class="flex items-center justify-between gap-3">
+                                                                        <span class="text-xs text-text-muted w-16 shrink-0">{{ __('transfers.physical') }}</span>
+                                                                        <div class="flex items-center gap-1.5">
+                                                                            <span class="text-xs font-semibold tabular-nums text-text-body" x-text="player.physRange[0] + '-' + player.physRange[1]"></span>
+                                                                            <div class="w-10 h-1.5 bg-surface-600 rounded-full overflow-hidden shrink-0">
+                                                                                <div class="h-1.5 rounded-full fitness-bar"
+                                                                                    :class="{
+                                                                                        'bg-accent-green': Math.round((player.physRange[0] + player.physRange[1]) / 2) >= 80,
+                                                                                        'bg-lime-500': Math.round((player.physRange[0] + player.physRange[1]) / 2) >= 70 && Math.round((player.physRange[0] + player.physRange[1]) / 2) < 80,
+                                                                                        'bg-accent-gold': Math.round((player.physRange[0] + player.physRange[1]) / 2) >= 60 && Math.round((player.physRange[0] + player.physRange[1]) / 2) < 70,
+                                                                                        'bg-accent-orange': Math.round((player.physRange[0] + player.physRange[1]) / 2) < 60,
+                                                                                    }"
+                                                                                    :style="'width: ' + Math.min(100, Math.round((player.physRange[0] + player.physRange[1]) / 2) / 99 * 100) + '%'">
+                                                                                </div>
+                                                                            </div>
+                                                                        </div>
+                                                                    </div>
+                                                                </div>
+                                                            </div>
                                                             {{-- Financial summary --}}
                                                             <div class="flex flex-wrap gap-x-6 gap-y-1 text-xs mb-3">
                                                                 <div>


### PR DESCRIPTION
## Summary
This PR adds a physical ability range display to the scouting assessment section in the scouting hub, complementing the existing technical ability range visualization.

## Key Changes
- **Backend**: Added `physRange` field to player scouting data in `ShowScoutingHub` view class, populated from the scouting service's `phys_range` detail
- **Frontend**: Added a new physical ability range row in the scouting assessment section with:
  - Range display (min-max values)
  - Color-coded progress bar matching the technical ability bar styling (green ≥80, lime 70-79, gold 60-69, orange <60)
  - Consistent layout and spacing with the technical ability row

## Implementation Details
- The physical range display mirrors the technical range implementation, using the same color thresholds and visual styling
- Both ranges are calculated as the average of min-max values for the progress bar width
- The feature is only visible when `intelLevel >= 1`, consistent with other scouting details
- Uses existing translation keys for localization (`transfers.scouting_assessment`, `transfers.physical`)

https://claude.ai/code/session_01J1rrTsPrM9PsN46Qhbv6BJ