### PR TITLE
Fix squad number assignment to include jersey number 1

### DIFF
--- a/app/Modules/Squad/Services/SquadNumberService.php
+++ b/app/Modules/Squad/Services/SquadNumberService.php
@@ -59,13 +59,13 @@ class SquadNumberService
         if ($isYoung) {
             // Under-23: try preferred numbers in 1-25, then any 1-25, then 26-99
             return $this->preferredNumber($player->position, $takenNumbers, 1, self::FIRST_TEAM_MAX)
-                ?? $this->firstAvailable(2, self::FIRST_TEAM_MAX, $takenNumbers)
+                ?? $this->firstAvailable(1, self::FIRST_TEAM_MAX, $takenNumbers)
                 ?? $this->firstAvailable(self::FIRST_TEAM_MAX + 1, 99, $takenNumbers);
         }
 
         // Over-23: try preferred numbers, then any free 1-25
         $number = $this->preferredNumber($player->position, $takenNumbers, 1, self::FIRST_TEAM_MAX)
-            ?? $this->firstAvailable(2, self::FIRST_TEAM_MAX, $takenNumbers);
+            ?? $this->firstAvailable(1, self::FIRST_TEAM_MAX, $takenNumbers);
 
         if ($number !== null) {
             return $number;
@@ -185,11 +185,13 @@ class SquadNumberService
         $resolvableOver23 = $over23NeedSlot->take($over23NeedingCount - $unresolvable);
         foreach ($resolvableOver23 as $player) {
             $number = $this->preferredNumber($player->position, $usedFirstTeam, 1, self::FIRST_TEAM_MAX)
-                ?? $this->firstAvailable(2, self::FIRST_TEAM_MAX, $usedFirstTeam);
+                ?? $this->firstAvailable(1, self::FIRST_TEAM_MAX, $usedFirstTeam);
 
             if ($number !== null) {
                 $updates[$player->id] = $number;
                 $usedFirstTeam->put($number, true);
+            } elseif ($player->number !== null) {
+                $updates[$player->id] = null;
             }
         }
 
@@ -211,7 +213,7 @@ class SquadNumberService
         // Unregistered under-23: try first-team with position prefs, then academy
         foreach ($under23NeedSlot as $player) {
             $number = $this->preferredNumber($player->position, $usedFirstTeam, 1, self::FIRST_TEAM_MAX)
-                ?? $this->firstAvailable(2, self::FIRST_TEAM_MAX, $usedFirstTeam);
+                ?? $this->firstAvailable(1, self::FIRST_TEAM_MAX, $usedFirstTeam);
 
             if ($number !== null) {
                 $updates[$player->id] = $number;


### PR DESCRIPTION
## Summary
Fixed squad number assignment logic to correctly include jersey number 1 in the available first-team number range (1-25) for both young and senior players.

## Key Changes
- Changed `firstAvailable(2, ...)` to `firstAvailable(1, ...)` in three locations within the squad number assignment service
  - `assignNumberForNewPlayer()` method for under-23 players
  - `assignNumberForNewPlayer()` method for over-23 players
  - `reassignNumbers()` method for both over-23 and under-23 players
- Added logic to clear squad numbers (set to null) for over-23 players who cannot be assigned a number in the first-team range during reassignment

## Implementation Details
The changes ensure that jersey number 1 is properly considered as an available option when assigning squad numbers, rather than starting the search from number 2. This affects the fallback logic when preferred numbers are unavailable. Additionally, the reassignment process now explicitly handles cases where a player cannot be accommodated in the first-team range by clearing their existing number assignment.

https://claude.ai/code/session_013BZETYPqeYPv9DgtbMj6mt