### PR TITLE
Filter out national teams without slugs in tournament stats

### DIFF
--- a/app/Modules/Manager/Services/NationalTeamStatsService.php
+++ b/app/Modules/Manager/Services/NationalTeamStatsService.php
@@ -16,6 +16,7 @@ class NationalTeamStatsService
         return Team::query()
             ->join('tournament_summaries', 'teams.id', '=', 'tournament_summaries.team_id')
             ->where('teams.type', 'national')
+            ->whereNotNull('teams.slug')
             ->groupBy('teams.id')
             ->selectRaw('teams.*, COUNT(*) as tournaments_count')
             ->orderByDesc('tournaments_count')


### PR DESCRIPTION
## Summary
Added a filter to exclude national teams without slugs from the tournament statistics query in `NationalTeamStatsService`.

## Key Changes
- Added `whereNotNull('teams.slug')` condition to the `getTeamsWithTournamentCounts()` query to ensure only teams with valid slugs are included in the results

## Implementation Details
This change prevents teams with null slug values from appearing in the national team tournament statistics, which likely improves data quality and prevents potential issues with slug-dependent functionality downstream. The filter is applied at the database query level for optimal performance.

https://claude.ai/code/session_01GsPrqsMZSARKqRatwkcomH