### PR TITLE
Add transfer market feature: AI teams list players for sale during windows

### DIFF
--- a/app/Http/Actions/NegotiateTransfer.php
+++ b/app/Http/Actions/NegotiateTransfer.php
@@ -147,7 +147,7 @@ class NegotiateTransfer
         }
 
         // New negotiation — show asking price
-        $askingPrice = $this->scoutingService->calculateAskingPrice($player);
+        $askingPrice = $this->scoutingService->calculateAskingPrice($player, $game->current_date);
         $disposition = $this->transferService->calculateClubDisposition($player, $this->scoutingService);
         $mood = $this->transferService->getClubMoodIndicator($disposition);
         $teamName = $player->team?->name ?? 'Unknown';

--- a/app/Http/Views/ShowTransferMarket.php
+++ b/app/Http/Views/ShowTransferMarket.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Views;
+
+use App\Models\Game;
+use App\Modules\Transfer\Services\TransferHeaderService;
+use App\Modules\Transfer\Services\TransferMarketService;
+use Illuminate\Http\Request;
+
+class ShowTransferMarket
+{
+    public function __construct(
+        private readonly TransferMarketService $transferMarketService,
+        private readonly TransferHeaderService $headerService,
+    ) {}
+
+    public function __invoke(Request $request, string $gameId)
+    {
+        $game = Game::findOrFail($gameId);
+
+        $isTransferWindow = $game->isTransferWindowOpen();
+        $listings = $isTransferWindow
+            ? $this->transferMarketService->getMarketListings($game)
+            : collect();
+
+        $headerData = $this->headerService->getHeaderData($game);
+
+        $availableBudget = $game->currentInvestment?->transfer_budget ?? 0;
+
+        return view('transfer-market', [
+            'game' => $game,
+            'listings' => $listings,
+            'isTransferWindow' => $isTransferWindow,
+            'availableBudget' => $availableBudget,
+        ] + $headerData);
+    }
+}

--- a/app/Http/Views/ShowTransferMarket.php
+++ b/app/Http/Views/ShowTransferMarket.php
@@ -19,9 +19,7 @@ class ShowTransferMarket
         $game = Game::findOrFail($gameId);
 
         $isTransferWindow = $game->isTransferWindowOpen();
-        $listings = $isTransferWindow
-            ? $this->transferMarketService->getMarketListings($game)
-            : collect();
+        $listings = $this->transferMarketService->getMarketListings($game);
 
         $headerData = $this->headerService->getHeaderData($game);
 

--- a/app/Modules/Match/Services/CareerActionProcessor.php
+++ b/app/Modules/Match/Services/CareerActionProcessor.php
@@ -13,6 +13,7 @@ use App\Modules\Transfer\Enums\TransferWindowType;
 use App\Modules\Transfer\Services\AITransferMarketService;
 use App\Modules\Transfer\Services\LoanService;
 use App\Modules\Transfer\Services\ScoutingService;
+use App\Modules\Transfer\Services\TransferMarketService;
 use App\Modules\Transfer\Services\TransferService;
 
 class CareerActionProcessor
@@ -28,6 +29,7 @@ class CareerActionProcessor
         private readonly YouthAcademyService $youthAcademyService,
         private readonly NotificationService $notificationService,
         private readonly AITransferMarketService $aiTransferMarketService,
+        private readonly TransferMarketService $transferMarketService,
     ) {}
 
     public function process(Game $game): void
@@ -206,6 +208,8 @@ class CareerActionProcessor
         }
 
         $this->aiTransferMarketService->processTransferBatch($game, $windowType->value);
+
+        $this->transferMarketService->refreshListings($game);
     }
 
 }

--- a/app/Modules/Match/Services/CareerActionProcessor.php
+++ b/app/Modules/Match/Services/CareerActionProcessor.php
@@ -201,15 +201,18 @@ class CareerActionProcessor
 
     private function processAITransferBatch(Game $game): void
     {
-        $windowType = TransferWindowType::fromDate($game->current_date);
+        // The user-facing market is refreshed year-round so players can be
+        // bought at any time. Bids accepted out-of-window are stored as
+        // STATUS_AGREED and flushed when the next window opens.
+        $this->transferMarketService->refreshListings($game);
 
+        // AI-to-AI transfer activity only runs while a window is open.
+        $windowType = TransferWindowType::fromDate($game->current_date);
         if (! $windowType) {
             return;
         }
 
         $this->aiTransferMarketService->processTransferBatch($game, $windowType->value);
-
-        $this->transferMarketService->refreshListings($game);
     }
 
 }

--- a/app/Modules/Transfer/Listeners/ProcessTransferWindowClose.php
+++ b/app/Modules/Transfer/Listeners/ProcessTransferWindowClose.php
@@ -6,13 +6,11 @@ use App\Models\GameNotification;
 use App\Modules\Match\Events\GameDateAdvanced;
 use App\Modules\Transfer\Enums\TransferWindowType;
 use App\Modules\Transfer\Services\AITransferMarketService;
-use App\Modules\Transfer\Services\TransferMarketService;
 
 class ProcessTransferWindowClose
 {
     public function __construct(
         private readonly AITransferMarketService $aiTransferMarketService,
-        private readonly TransferMarketService $transferMarketService,
     ) {}
 
     public function handle(GameDateAdvanced $event): void
@@ -40,7 +38,5 @@ class ProcessTransferWindowClose
         }
 
         $this->aiTransferMarketService->processWindowClose($game, $previousWindow->value);
-
-        $this->transferMarketService->clearListings($game);
     }
 }

--- a/app/Modules/Transfer/Listeners/ProcessTransferWindowClose.php
+++ b/app/Modules/Transfer/Listeners/ProcessTransferWindowClose.php
@@ -6,11 +6,13 @@ use App\Models\GameNotification;
 use App\Modules\Match\Events\GameDateAdvanced;
 use App\Modules\Transfer\Enums\TransferWindowType;
 use App\Modules\Transfer\Services\AITransferMarketService;
+use App\Modules\Transfer\Services\TransferMarketService;
 
 class ProcessTransferWindowClose
 {
     public function __construct(
         private readonly AITransferMarketService $aiTransferMarketService,
+        private readonly TransferMarketService $transferMarketService,
     ) {}
 
     public function handle(GameDateAdvanced $event): void
@@ -38,5 +40,7 @@ class ProcessTransferWindowClose
         }
 
         $this->aiTransferMarketService->processWindowClose($game, $previousWindow->value);
+
+        $this->transferMarketService->clearListings($game);
     }
 }

--- a/app/Modules/Transfer/Services/AITransferMarketService.php
+++ b/app/Modules/Transfer/Services/AITransferMarketService.php
@@ -705,6 +705,18 @@ class AITransferMarketService
             $score += 3;
         }
 
+        // Contract situation: short contracts = must sell or lose for free
+        if ($player->contract_until) {
+            $yearsLeft = $currentDate->diffInYears($player->contract_until);
+            if ($yearsLeft <= 1) {
+                $score += 6;
+            } elseif ($yearsLeft <= 2) {
+                $score += 3;
+            } elseif ($yearsLeft >= 4) {
+                $score -= 2;
+            }
+        }
+
         // Random variance
         $score += mt_rand(0, 2);
 
@@ -757,6 +769,16 @@ class AITransferMarketService
         $surplus = $groupCount - (self::IDEAL_GROUP_COUNTS[$group] ?? 4);
         if ($surplus > 0) {
             $score += min(4, $surplus * 2);
+        }
+
+        // Contract situation: short contracts = must sell
+        if ($player->contract_until) {
+            $yearsLeft = $currentDate->diffInYears($player->contract_until);
+            if ($yearsLeft <= 1) {
+                $score += 6;
+            } elseif ($yearsLeft <= 2) {
+                $score += 3;
+            }
         }
 
         // Random variance

--- a/app/Modules/Transfer/Services/AITransferMarketService.php
+++ b/app/Modules/Transfer/Services/AITransferMarketService.php
@@ -603,6 +603,7 @@ class AITransferMarketService
             $teamAvg = $teamAverages[$teamId] ?? 55;
             $teamRepIndex = $this->getReputationIndex($teamId, $teamReputations);
             $teamGroupCounts = $groupCounts->get($teamId, collect());
+            $importanceMap = $this->buildImportanceMap($players);
 
             $eligible = $players->filter(
                 fn (GamePlayer $p) => ! $p->retiring_at_season && ! isset($alreadyTransferredSet[$p->id])
@@ -617,12 +618,18 @@ class AITransferMarketService
 
             // Score clearing and upgrade candidates separately
             $clearingCandidates = $eligible
-                ->map(fn ($p) => $this->scoreClearingCandidate($p, $teamAvg, $teamGroupCounts, $currentDate))
+                ->map(fn ($p) => $this->scoreClearingCandidate(
+                    $p, $teamAvg, $teamGroupCounts, $currentDate,
+                    $importanceMap[$p->id] ?? 0.5
+                ))
                 ->filter()
                 ->sortByDesc('score');
 
             $upgradeCandidates = $eligible
-                ->map(fn ($p) => $this->scoreUpgradeCandidate($p, $teamAvg, $teamRepIndex, $teamGroupCounts, $currentDate))
+                ->map(fn ($p) => $this->scoreUpgradeCandidate(
+                    $p, $teamAvg, $teamRepIndex, $teamGroupCounts, $currentDate,
+                    $importanceMap[$p->id] ?? 0.5
+                ))
                 ->filter()
                 ->sortByDesc('score');
 
@@ -670,14 +677,30 @@ class AITransferMarketService
     /**
      * Score a player as a squad clearing candidate (surplus/backup player).
      */
-    private function scoreClearingCandidate(GamePlayer $player, int $teamAvg, Collection $teamGroupCounts, Carbon $currentDate): ?array
-    {
+    private function scoreClearingCandidate(
+        GamePlayer $player,
+        int $teamAvg,
+        Collection $teamGroupCounts,
+        Carbon $currentDate,
+        float $importance,
+    ): ?array {
         $ability = $this->getPlayerAbility($player);
         $group = $this->getPositionGroup($player->position);
         $groupCount = $teamGroupCounts->get($group, 0);
 
         // Never sell below minimum depth
         if ($groupCount <= (self::MIN_GROUP_COUNTS[$group] ?? 2)) {
+            return null;
+        }
+
+        $yearsLeft = $player->contract_until
+            ? (int) $currentDate->diffInYears($player->contract_until)
+            : 0;
+
+        // Core players aren't "cleared" — clearing dumps surplus, not starters.
+        // Only exception: renewal has failed (contract <= 1 year) and the club
+        // is forced to recoup something rather than lose the player for free.
+        if ($importance >= 0.60 && $yearsLeft > 1) {
             return null;
         }
 
@@ -705,13 +728,15 @@ class AITransferMarketService
             $score += 3;
         }
 
-        // Contract situation: short contracts = must sell or lose for free
+        // Contract bonus — short contracts push clubs to list, but the pull is
+        // scaled down for important players because clubs renew them first.
+        // Long contracts slightly discourage clearing regardless of role.
         if ($player->contract_until) {
-            $yearsLeft = $currentDate->diffInYears($player->contract_until);
+            $scale = 1.0 - ($importance * 0.75); // core ~0.25x, fringe ~1.0x
             if ($yearsLeft <= 1) {
-                $score += 6;
+                $score += (int) round(6 * $scale);
             } elseif ($yearsLeft <= 2) {
-                $score += 3;
+                $score += (int) round(3 * $scale);
             } elseif ($yearsLeft >= 4) {
                 $score -= 2;
             }
@@ -730,13 +755,14 @@ class AITransferMarketService
     /**
      * Score a player as a talent upgrade candidate (quality player attractive to bigger clubs).
      */
-    private function scoreUpgradeCandidate(GamePlayer $player, int $teamAvg, int $teamRepIndex, Collection $teamGroupCounts, Carbon $currentDate): ?array
-    {
-        // Elite clubs have no higher-reputation domestic buyer
-        if ($teamRepIndex <= 0) {
-            return null;
-        }
-
+    private function scoreUpgradeCandidate(
+        GamePlayer $player,
+        int $teamAvg,
+        int $teamRepIndex,
+        Collection $teamGroupCounts,
+        Carbon $currentDate,
+        float $importance,
+    ): ?array {
         $ability = $this->getPlayerAbility($player);
         $group = $this->getPositionGroup($player->position);
         $groupCount = $teamGroupCounts->get($group, 0);
@@ -748,6 +774,18 @@ class AITransferMarketService
 
         // Must be at or above team average — this is a quality player
         if ($ability < $teamAvg) {
+            return null;
+        }
+
+        $yearsLeft = $player->contract_until
+            ? (int) $currentDate->diffInYears($player->contract_until)
+            : 0;
+
+        // Elite and continental clubs don't sell core players upward — there's
+        // no larger domestic buyer. They only let a star go when renewal has
+        // failed and the contract is running out.
+        // (This service uses an inverted scale: 2=elite, 3=continental.)
+        if ($importance >= 0.60 && $teamRepIndex <= 3 && $yearsLeft > 1) {
             return null;
         }
 
@@ -771,13 +809,13 @@ class AITransferMarketService
             $score += min(4, $surplus * 2);
         }
 
-        // Contract situation: short contracts = must sell
+        // Contract bonus, scaled by importance (see scoreClearingCandidate).
         if ($player->contract_until) {
-            $yearsLeft = $currentDate->diffInYears($player->contract_until);
+            $scale = 1.0 - ($importance * 0.75);
             if ($yearsLeft <= 1) {
-                $score += 6;
+                $score += (int) round(6 * $scale);
             } elseif ($yearsLeft <= 2) {
-                $score += 3;
+                $score += (int) round(3 * $scale);
             }
         }
 
@@ -789,6 +827,31 @@ class AITransferMarketService
         }
 
         return ['player' => $player, 'score' => $score];
+    }
+
+    /**
+     * Build a player_id → importance map for a team's roster.
+     *
+     * Importance is the player's rank within his squad by overall ability,
+     * mapped to a 0.0 (worst) .. 1.0 (best) scale. This identifies the core
+     * players (roughly the top 11 by rank, importance >= 0.60 in a 25-player
+     * squad) so scoring can protect them from being listed casually.
+     *
+     * @return array<string, float>
+     */
+    private function buildImportanceMap(Collection $players): array
+    {
+        $sorted = $players
+            ->sortByDesc(fn (GamePlayer $p) => $this->getPlayerAbility($p))
+            ->values();
+
+        $total = $sorted->count();
+        $map = [];
+        foreach ($sorted as $rank => $player) {
+            $map[$player->id] = 1.0 - ($rank / max($total - 1, 1));
+        }
+
+        return $map;
     }
 
     /**

--- a/app/Modules/Transfer/Services/ScoutingService.php
+++ b/app/Modules/Transfer/Services/ScoutingService.php
@@ -10,6 +10,7 @@ use App\Models\Team;
 use App\Models\TransferOffer;
 use App\Support\Money;
 use App\Support\PositionMapper;
+use Carbon\Carbon;
 use Illuminate\Support\Collection;
 use App\Modules\Player\PlayerAge;
 use App\Modules\Transfer\Enums\NegotiationScenario;
@@ -258,7 +259,7 @@ class ScoutingService
     /**
      * Calculate the AI's asking price for a player.
      */
-    public function calculateAskingPrice(GamePlayer $player): int
+    public function calculateAskingPrice(GamePlayer $player, Carbon $currentDate): int
     {
         $base = $player->market_value_cents;
         $importance = $this->calculatePlayerImportance($player);
@@ -267,7 +268,7 @@ class ScoutingService
         // it has leverage to refuse bids. As the contract runs down that
         // leverage decays — an expiring star is worth about what a buyer
         // would pay for any player they can pick up free next window.
-        $leverage = $this->getContractLeverage($player);
+        $leverage = $this->getContractLeverage($player, $currentDate);
         $effectiveImportance = $importance * $leverage;
 
         // Importance multiplier: 0.8x for worst (or no leverage), 1.0x for
@@ -275,10 +276,10 @@ class ScoutingService
         $importanceMultiplier = 0.8 + ($effectiveImportance * 0.4);
 
         // Contract modifier (fee discount from less time remaining)
-        $contractModifier = $this->getContractModifier($player);
+        $contractModifier = $this->getContractModifier($player, $currentDate);
 
         // Age modifier
-        $ageModifier = $this->getAgeModifier($player->age($player->game->current_date));
+        $ageModifier = $this->getAgeModifier($player->age($currentDate));
 
         $totalMultiplier = $importanceMultiplier * $contractModifier * $ageModifier;
 
@@ -312,13 +313,13 @@ class ScoutingService
      * expiring end there is no premium because the buyer can simply wait and
      * sign free.
      */
-    private function getContractLeverage(GamePlayer $player): float
+    private function getContractLeverage(GamePlayer $player, Carbon $currentDate): float
     {
         if (! $player->contract_until) {
             return 0.0;
         }
 
-        $yearsLeft = $player->game->current_date->diffInYears($player->contract_until);
+        $yearsLeft = $currentDate->diffInYears($player->contract_until);
 
         if ($yearsLeft >= 4) {
             return 1.0;
@@ -339,14 +340,13 @@ class ScoutingService
     /**
      * Get contract years modifier for asking price.
      */
-    private function getContractModifier(GamePlayer $player): float
+    private function getContractModifier(GamePlayer $player, Carbon $currentDate): float
     {
         if (! $player->contract_until) {
             return 0.5;
         }
 
-        $game = $player->game;
-        $yearsLeft = $game->current_date->diffInYears($player->contract_until);
+        $yearsLeft = $currentDate->diffInYears($player->contract_until);
 
         if ($yearsLeft >= 4) {
             return 1.2;
@@ -393,7 +393,8 @@ class ScoutingService
      */
     public function evaluateBid(GamePlayer $player, int $bidAmount, ?Game $game = null, ?int $previousCounter = null): array
     {
-        $askingPrice = $this->calculateAskingPrice($player);
+        $currentDate = $game?->current_date ?? $player->game->current_date;
+        $askingPrice = $this->calculateAskingPrice($player, $currentDate);
 
         // Use the previous counter as ceiling so the club never raises their demand
         $ceiling = ($previousCounter !== null && $previousCounter < $askingPrice)
@@ -596,7 +597,7 @@ class ScoutingService
     public function getPlayerScoutingDetail(GamePlayer $player, Game $game): array
     {
         $isFreeAgent = $player->team_id === null;
-        $askingPrice = $isFreeAgent ? 0 : $this->calculateAskingPrice($player);
+        $askingPrice = $isFreeAgent ? 0 : $this->calculateAskingPrice($player, $game->current_date);
         $transferDemand = $this->contractService->calculateWageDemand($player, NegotiationScenario::TRANSFER);
         $wageDemand = $transferDemand['wage'];
         $importance = $isFreeAgent ? 0.0 : $this->calculatePlayerImportance($player);

--- a/app/Modules/Transfer/Services/ScoutingService.php
+++ b/app/Modules/Transfer/Services/ScoutingService.php
@@ -263,10 +263,18 @@ class ScoutingService
         $base = $player->market_value_cents;
         $importance = $this->calculatePlayerImportance($player);
 
-        // Importance multiplier: 0.8x for worst, 1.0x for average, 1.2x for best
-        $importanceMultiplier = 0.8 + ($importance * 0.4);
+        // Contract leverage: a club can only charge an importance premium if
+        // it has leverage to refuse bids. As the contract runs down that
+        // leverage decays — an expiring star is worth about what a buyer
+        // would pay for any player they can pick up free next window.
+        $leverage = $this->getContractLeverage($player);
+        $effectiveImportance = $importance * $leverage;
 
-        // Contract modifier
+        // Importance multiplier: 0.8x for worst (or no leverage), 1.0x for
+        // average, 1.2x for the club's best player on a long contract.
+        $importanceMultiplier = 0.8 + ($effectiveImportance * 0.4);
+
+        // Contract modifier (fee discount from less time remaining)
         $contractModifier = $this->getContractModifier($player);
 
         // Age modifier
@@ -274,9 +282,10 @@ class ScoutingService
 
         $totalMultiplier = $importanceMultiplier * $contractModifier * $ageModifier;
 
-        // Important players: team is reluctant to sell, never ask below market value.
-        // Low-importance players can be discounted down to 0.75x.
-        $floor = $importance >= 0.5 ? 1.0 : 0.75;
+        // Important players with contract leverage: team is reluctant to sell,
+        // never ask below market value. Players without leverage (expiring)
+        // or with low importance can be discounted down to 0.75x.
+        $floor = $effectiveImportance >= 0.5 ? 1.0 : 0.75;
         $totalMultiplier = min(max($totalMultiplier, $floor), 1.5);
 
         $askingPrice = $base * $totalMultiplier;
@@ -293,6 +302,38 @@ class ScoutingService
     public function calculatePlayerImportance(GamePlayer $player, ?Collection $teammates = null): float
     {
         return $this->dispositionService->playerImportance($player, $teammates);
+    }
+
+    /**
+     * Get the contract leverage factor (0.0 to 1.0).
+     *
+     * A club can only charge an importance premium if it has leverage to
+     * refuse bids. As the contract runs down that leverage decays — at the
+     * expiring end there is no premium because the buyer can simply wait and
+     * sign free.
+     */
+    private function getContractLeverage(GamePlayer $player): float
+    {
+        if (! $player->contract_until) {
+            return 0.0;
+        }
+
+        $yearsLeft = $player->game->current_date->diffInYears($player->contract_until);
+
+        if ($yearsLeft >= 4) {
+            return 1.0;
+        }
+        if ($yearsLeft >= 3) {
+            return 0.85;
+        }
+        if ($yearsLeft >= 2) {
+            return 0.65;
+        }
+        if ($yearsLeft >= 1) {
+            return 0.30;
+        }
+
+        return 0.0; // Expiring
     }
 
     /**

--- a/app/Modules/Transfer/Services/TransferMarketService.php
+++ b/app/Modules/Transfer/Services/TransferMarketService.php
@@ -2,11 +2,9 @@
 
 namespace App\Modules\Transfer\Services;
 
-use App\Models\ClubProfile;
 use App\Models\Game;
 use App\Models\GamePlayer;
 use App\Models\GameTransfer;
-use App\Models\TeamReputation;
 use App\Models\TransferListing;
 use App\Modules\Player\PlayerAge;
 use Carbon\Carbon;
@@ -27,15 +25,8 @@ class TransferMarketService
     /** Listings expire after this many days */
     private const LISTING_EXPIRY_DAYS = 30;
 
-    /** Ideal squad depth per position group — never list below this */
+    /** Minimum squad depth per position group — never list below this */
     private const MIN_GROUP_COUNTS = [
-        'Goalkeeper' => 3,
-        'Defender' => 6,
-        'Midfielder' => 6,
-        'Forward' => 4,
-    ];
-
-    private const IDEAL_GROUP_COUNTS = [
         'Goalkeeper' => 3,
         'Defender' => 6,
         'Midfielder' => 6,
@@ -45,8 +36,8 @@ class TransferMarketService
     /** Minimum squad size below which a team will not list */
     private const MIN_SQUAD_SIZE = 20;
 
-    /** Percentage chance each listing is a clearing type (vs upgrade) */
-    private const CLEARING_CHANCE = 65;
+    /** Max listings contributed by any single AI team per refresh */
+    private const MAX_PICKS_PER_TEAM = 3;
 
     public function __construct(
         private readonly ScoutingService $scoutingService,
@@ -82,7 +73,10 @@ class TransferMarketService
         // Load context
         $teamRosters = $this->loadAIRosters($game);
         $teamAverages = $teamRosters->map(fn ($players) => $this->calculateTeamAverage($players));
-        $teamReputations = TeamReputation::resolveLevels($game->id, $teamRosters->keys()->toArray());
+        $groupCounts = $teamRosters->map(function ($players) {
+            return $players->groupBy(fn (GamePlayer $p) => $p->position_group)
+                ->map->count();
+        });
 
         // Players already listed or transferred this season
         $alreadyListedIds = TransferListing::where('game_id', $game->id)
@@ -98,28 +92,20 @@ class TransferMarketService
 
         $excludedIds = $alreadyListedIds + $alreadyTransferredIds;
 
-        $groupCounts = $teamRosters->map(function ($players) {
-            return $players->groupBy(fn ($p) => $this->getPositionGroup($p->position))
-                ->map->count();
-        });
-
-        // Build candidate sell offers using the same scoring as AITransferMarketService
         $candidates = $this->buildListingCandidates(
             $teamRosters,
             $teamAverages,
-            $teamReputations,
             $groupCounts,
             $excludedIds,
             $game->current_date,
         );
 
-        // Take up to available slots, shuffle for variety
+        // Shuffle for cross-team variety, then take available slots
         $selected = $candidates->shuffle()->take($slotsAvailable);
 
-        // Create listings
         foreach ($selected as $candidate) {
             $player = $candidate['player'];
-            $askingPrice = $this->scoutingService->calculateAskingPrice($player);
+            $askingPrice = $this->scoutingService->calculateAskingPrice($player, $game->current_date);
 
             TransferListing::create([
                 'game_id' => $game->id,
@@ -145,43 +131,28 @@ class TransferMarketService
     }
 
     /**
-     * Get market listings for the view, optionally filtered by position group.
+     * Get active market listings for the view.
      */
-    public function getMarketListings(Game $game, ?string $positionFilter = null): Collection
+    public function getMarketListings(Game $game): Collection
     {
-        $query = TransferListing::with(['gamePlayer.player', 'gamePlayer.team'])
+        return TransferListing::with(['gamePlayer.player', 'gamePlayer.team'])
             ->where('game_id', $game->id)
             ->where('team_id', '!=', $game->team_id)
             ->where('status', TransferListing::STATUS_LISTED)
-            ->whereNotNull('asking_price');
-
-        if ($positionFilter && $positionFilter !== 'all') {
-            $query->whereHas('gamePlayer', function ($q) use ($positionFilter) {
-                $positions = match ($positionFilter) {
-                    'gk' => ['Goalkeeper'],
-                    'def' => ['Centre-Back', 'Left-Back', 'Right-Back'],
-                    'mid' => ['Defensive Midfield', 'Central Midfield', 'Attacking Midfield', 'Left Midfield', 'Right Midfield'],
-                    'fwd' => ['Left Winger', 'Right Winger', 'Centre-Forward', 'Second Striker'],
-                    default => [],
-                };
-                if (!empty($positions)) {
-                    $q->whereIn('position', $positions);
-                }
-            });
-        }
-
-        return $query->orderByDesc('asking_price')->get();
+            ->whereNotNull('asking_price')
+            ->orderByDesc('asking_price')
+            ->get();
     }
 
     // ── Private helpers ─────────────────────────────────────────────────
 
     /**
-     * Build candidate listings from AI team rosters.
+     * Score each eligible player from each team and return up to
+     * MAX_PICKS_PER_TEAM candidates per team.
      */
     private function buildListingCandidates(
         Collection $teamRosters,
         Collection $teamAverages,
-        Collection $teamReputations,
         Collection $groupCounts,
         array $excludedIds,
         Carbon $currentDate,
@@ -195,71 +166,57 @@ class TransferMarketService
 
             $teamAvg = $teamAverages[$teamId] ?? 55;
             $teamGroupCounts = $groupCounts->get($teamId, collect());
-            $importanceMap = $this->buildImportanceMap($players);
-            $teamRepIndex = ClubProfile::getReputationTierIndex(
-                $teamReputations->get($teamId) ?? ClubProfile::REPUTATION_LOCAL
-            );
 
-            $eligible = $players->filter(
-                fn (GamePlayer $p) => !$p->retiring_at_season && !isset($excludedIds[$p->id])
-            );
+            // Top 11 players by ability ≈ core XI. Used as a hard filter so
+            // clubs don't put their starters on the open market.
+            $coreIds = $players
+                ->sortByDesc(fn (GamePlayer $p) => $this->getPlayerAbility($p))
+                ->take(11)
+                ->pluck('id')
+                ->flip()
+                ->all();
 
-            // Score candidates
-            $clearingCandidates = $eligible
-                ->map(fn ($p) => $this->scoreClearingCandidate(
-                    $p, $teamAvg, $teamGroupCounts, $currentDate,
-                    $importanceMap[$p->id] ?? 0.5
+            $teamPicks = $players
+                ->filter(fn (GamePlayer $p) => !$p->retiring_at_season && !isset($excludedIds[$p->id]))
+                ->map(fn (GamePlayer $p) => $this->scoreListable(
+                    $p,
+                    $teamAvg,
+                    $teamGroupCounts,
+                    $currentDate,
+                    isset($coreIds[$p->id]),
                 ))
-                ->filter();
+                ->filter()
+                ->sortByDesc('score')
+                ->take(self::MAX_PICKS_PER_TEAM)
+                ->values();
 
-            $upgradeCandidates = $eligible
-                ->map(fn ($p) => $this->scoreUpgradeCandidate(
-                    $p, $teamAvg, $teamGroupCounts, $currentDate,
-                    $importanceMap[$p->id] ?? 0.5, $teamRepIndex
-                ))
-                ->filter();
-
-            // Pick 1-3 per team
-            $teamPicks = mt_rand(1, 3);
-            $usedIds = [];
-
-            for ($i = 0; $i < $teamPicks; $i++) {
-                $isClearing = mt_rand(1, 100) <= self::CLEARING_CHANCE;
-                $pool = $isClearing ? $clearingCandidates : $upgradeCandidates;
-                $candidate = $pool->sortByDesc('score')
-                    ->first(fn ($c) => !isset($usedIds[$c['player']->id]));
-
-                // Fallback to other pool
-                if (!$candidate) {
-                    $pool = $isClearing ? $upgradeCandidates : $clearingCandidates;
-                    $candidate = $pool->sortByDesc('score')
-                        ->first(fn ($c) => !isset($usedIds[$c['player']->id]));
-                }
-
-                if (!$candidate) {
-                    break;
-                }
-
-                $usedIds[$candidate['player']->id] = true;
-                $candidates->push($candidate);
-            }
+            $candidates = $candidates->concat($teamPicks);
         }
 
         return $candidates;
     }
 
-    private function scoreClearingCandidate(
+    /**
+     * Score a player as a listing candidate. Returns null if unlistable.
+     *
+     * One scoring pool: both "clearing surplus depth" and "selling a player
+     * above team average" earn score here. Core players (top-11 by ability)
+     * are protected unless their contract is running out.
+     *
+     * @return array{player: GamePlayer, score: int}|null
+     */
+    private function scoreListable(
         GamePlayer $player,
         int $teamAvg,
         Collection $teamGroupCounts,
         Carbon $currentDate,
-        float $importance,
+        bool $isCorePlayer,
     ): ?array {
-        $ability = $this->getPlayerAbility($player);
-        $group = $this->getPositionGroup($player->position);
+        $group = $player->position_group;
+        $groupFloor = self::MIN_GROUP_COUNTS[$group] ?? 4;
         $groupCount = $teamGroupCounts->get($group, 0);
 
-        if ($groupCount <= (self::MIN_GROUP_COUNTS[$group] ?? 2)) {
+        if ($groupCount <= $groupFloor) {
             return null;
         }
 
@@ -267,48 +224,51 @@ class TransferMarketService
             ? (int) $currentDate->diffInYears($player->contract_until)
             : 0;
 
-        // Core players aren't "cleared" — clearing dumps surplus, not starters.
-        // Only exception: renewal has failed (contract <= 1 year) and the club
-        // is forced to recoup something rather than lose the player for free.
-        if ($importance >= 0.60 && $yearsLeft > 1) {
+        // Protect starters unless their contract is running down — a club
+        // will only sell a core player when renewal has failed and free
+        // departure is the alternative.
+        if ($isCorePlayer && $yearsLeft > 1) {
             return null;
         }
 
+        $ability = $this->getPlayerAbility($player);
         $score = 0;
 
-        $surplus = $groupCount - (self::IDEAL_GROUP_COUNTS[$group] ?? 4);
+        // Surplus at position
+        $surplus = $groupCount - $groupFloor;
         if ($surplus > 0) {
-            $score += $surplus * 3;
+            $score += min(5, $surplus * 2);
         }
 
-        $abilityGap = $teamAvg - $ability;
-        if ($abilityGap > 15) {
+        // Ability gap vs team average — both directions are a listing signal.
+        // Below average ⇒ clearing weak depth. Above average ⇒ selling upward.
+        $gap = abs($ability - $teamAvg);
+        if ($gap > 15) {
             $score += 5;
-        } elseif ($abilityGap > 5) {
+        } elseif ($gap > 5) {
             $score += 3;
-        } elseif ($abilityGap > 0) {
+        } elseif ($gap > 0) {
             $score += 1;
         }
 
-        $age = $player->age($currentDate);
-        if ($age >= PlayerAge::PRIME_END) {
+        // Past-prime age is a classic clearing signal
+        if ($player->age($currentDate) >= PlayerAge::PRIME_END) {
             $score += 3;
         }
 
-        // Contract bonus — short contracts push clubs to list, but the pull is
-        // scaled down for important players because clubs renew them first.
-        // Long contracts slightly discourage clearing regardless of role.
+        // Contract leverage: short contracts push clubs to list; long
+        // contracts slightly discourage listing.
         if ($player->contract_until) {
-            $scale = 1.0 - ($importance * 0.75); // core ~0.25x, fringe ~1.0x
             if ($yearsLeft <= 1) {
-                $score += (int) round(6 * $scale);
+                $score += 6;
             } elseif ($yearsLeft <= 2) {
-                $score += (int) round(3 * $scale);
+                $score += 3;
             } elseif ($yearsLeft >= 4) {
                 $score -= 2;
             }
         }
 
+        // Jitter so identical profiles don't always order the same way
         $score += mt_rand(0, 2);
 
         if ($score < 3) {
@@ -316,98 +276,6 @@ class TransferMarketService
         }
 
         return ['player' => $player, 'score' => $score];
-    }
-
-    private function scoreUpgradeCandidate(
-        GamePlayer $player,
-        int $teamAvg,
-        Collection $teamGroupCounts,
-        Carbon $currentDate,
-        float $importance,
-        int $teamRepIndex,
-    ): ?array {
-        $ability = $this->getPlayerAbility($player);
-        $group = $this->getPositionGroup($player->position);
-        $groupCount = $teamGroupCounts->get($group, 0);
-
-        if ($groupCount <= (self::MIN_GROUP_COUNTS[$group] ?? 2)) {
-            return null;
-        }
-
-        if ($ability < $teamAvg) {
-            return null;
-        }
-
-        $yearsLeft = $player->contract_until
-            ? (int) $currentDate->diffInYears($player->contract_until)
-            : 0;
-
-        // Elite and continental clubs don't sell core players upward — there's
-        // no larger domestic buyer to sell to. They only let a star go when
-        // renewal has failed and the contract is running out.
-        if ($importance >= 0.60 && $teamRepIndex >= 3 && $yearsLeft > 1) {
-            return null;
-        }
-
-        $score = 0;
-
-        $abilityGap = $ability - $teamAvg;
-        $score += min(5, (int) ($abilityGap / 3));
-
-        $age = $player->age($currentDate);
-        if ($age >= PlayerAge::YOUNG_END && $age <= PlayerAge::primePhaseAge(0.5)) {
-            $score += 3;
-        } elseif ($age >= PlayerAge::ACADEMY_END && $age < PlayerAge::YOUNG_END) {
-            $score += 1;
-        }
-
-        $surplus = $groupCount - (self::IDEAL_GROUP_COUNTS[$group] ?? 4);
-        if ($surplus > 0) {
-            $score += min(4, $surplus * 2);
-        }
-
-        // Contract bonus, scaled by importance (see scoreClearingCandidate).
-        if ($player->contract_until) {
-            $scale = 1.0 - ($importance * 0.75);
-            if ($yearsLeft <= 1) {
-                $score += (int) round(6 * $scale);
-            } elseif ($yearsLeft <= 2) {
-                $score += (int) round(3 * $scale);
-            }
-        }
-
-        $score += mt_rand(0, 2);
-
-        if ($score < 3) {
-            return null;
-        }
-
-        return ['player' => $player, 'score' => $score];
-    }
-
-    /**
-     * Build a player_id → importance map for a team's roster.
-     *
-     * Importance is the player's rank within his squad by overall ability,
-     * mapped to a 0.0 (worst) .. 1.0 (best) scale. This identifies the core
-     * players (the ~top 11 by rank, importance >= 0.60 in a 25-player squad)
-     * so the scoring can protect them from being listed casually.
-     *
-     * @return array<string, float>
-     */
-    private function buildImportanceMap(Collection $players): array
-    {
-        $sorted = $players
-            ->sortByDesc(fn (GamePlayer $p) => $this->getPlayerAbility($p))
-            ->values();
-
-        $total = $sorted->count();
-        $map = [];
-        foreach ($sorted as $rank => $player) {
-            $map[$player->id] = 1.0 - ($rank / max($total - 1, 1));
-        }
-
-        return $map;
     }
 
     private function loadAIRosters(Game $game): Collection
@@ -442,17 +310,5 @@ class TransferMarketService
         $phys = $player->game_physical_ability ?? 50;
 
         return (int) round(($tech + $phys) / 2);
-    }
-
-    private function getPositionGroup(string $position): string
-    {
-        return match ($position) {
-            'Goalkeeper' => 'Goalkeeper',
-            'Centre-Back', 'Left-Back', 'Right-Back' => 'Defender',
-            'Defensive Midfield', 'Central Midfield', 'Attacking Midfield',
-            'Left Midfield', 'Right Midfield' => 'Midfielder',
-            'Left Winger', 'Right Winger', 'Centre-Forward', 'Second Striker' => 'Forward',
-            default => 'Midfielder',
-        };
     }
 }

--- a/app/Modules/Transfer/Services/TransferMarketService.php
+++ b/app/Modules/Transfer/Services/TransferMarketService.php
@@ -269,6 +269,18 @@ class TransferMarketService
             $score += 3;
         }
 
+        // Contract situation: short contracts = must sell or lose for free
+        if ($player->contract_until) {
+            $yearsLeft = $currentDate->diffInYears($player->contract_until);
+            if ($yearsLeft <= 1) {
+                $score += 6;
+            } elseif ($yearsLeft <= 2) {
+                $score += 3;
+            } elseif ($yearsLeft >= 4) {
+                $score -= 2;
+            }
+        }
+
         $score += mt_rand(0, 2);
 
         if ($score < 3) {
@@ -307,6 +319,16 @@ class TransferMarketService
         $surplus = $groupCount - (self::IDEAL_GROUP_COUNTS[$group] ?? 4);
         if ($surplus > 0) {
             $score += min(4, $surplus * 2);
+        }
+
+        // Contract situation: short contracts = must sell
+        if ($player->contract_until) {
+            $yearsLeft = $currentDate->diffInYears($player->contract_until);
+            if ($yearsLeft <= 1) {
+                $score += 6;
+            } elseif ($yearsLeft <= 2) {
+                $score += 3;
+            }
         }
 
         $score += mt_rand(0, 2);

--- a/app/Modules/Transfer/Services/TransferMarketService.php
+++ b/app/Modules/Transfer/Services/TransferMarketService.php
@@ -6,11 +6,9 @@ use App\Models\ClubProfile;
 use App\Models\Game;
 use App\Models\GamePlayer;
 use App\Models\GameTransfer;
-use App\Models\Team;
 use App\Models\TeamReputation;
 use App\Models\TransferListing;
 use App\Modules\Player\PlayerAge;
-use App\Support\Money;
 use Carbon\Carbon;
 use Illuminate\Support\Collection;
 
@@ -109,6 +107,7 @@ class TransferMarketService
         $candidates = $this->buildListingCandidates(
             $teamRosters,
             $teamAverages,
+            $teamReputations,
             $groupCounts,
             $excludedIds,
             $game->current_date,
@@ -182,6 +181,7 @@ class TransferMarketService
     private function buildListingCandidates(
         Collection $teamRosters,
         Collection $teamAverages,
+        Collection $teamReputations,
         Collection $groupCounts,
         array $excludedIds,
         Carbon $currentDate,
@@ -195,6 +195,10 @@ class TransferMarketService
 
             $teamAvg = $teamAverages[$teamId] ?? 55;
             $teamGroupCounts = $groupCounts->get($teamId, collect());
+            $importanceMap = $this->buildImportanceMap($players);
+            $teamRepIndex = ClubProfile::getReputationTierIndex(
+                $teamReputations->get($teamId) ?? ClubProfile::REPUTATION_LOCAL
+            );
 
             $eligible = $players->filter(
                 fn (GamePlayer $p) => !$p->retiring_at_season && !isset($excludedIds[$p->id])
@@ -202,11 +206,17 @@ class TransferMarketService
 
             // Score candidates
             $clearingCandidates = $eligible
-                ->map(fn ($p) => $this->scoreClearingCandidate($p, $teamAvg, $teamGroupCounts, $currentDate))
+                ->map(fn ($p) => $this->scoreClearingCandidate(
+                    $p, $teamAvg, $teamGroupCounts, $currentDate,
+                    $importanceMap[$p->id] ?? 0.5
+                ))
                 ->filter();
 
             $upgradeCandidates = $eligible
-                ->map(fn ($p) => $this->scoreUpgradeCandidate($p, $teamAvg, $teamGroupCounts, $currentDate))
+                ->map(fn ($p) => $this->scoreUpgradeCandidate(
+                    $p, $teamAvg, $teamGroupCounts, $currentDate,
+                    $importanceMap[$p->id] ?? 0.5, $teamRepIndex
+                ))
                 ->filter();
 
             // Pick 1-3 per team
@@ -238,13 +248,29 @@ class TransferMarketService
         return $candidates;
     }
 
-    private function scoreClearingCandidate(GamePlayer $player, int $teamAvg, Collection $teamGroupCounts, Carbon $currentDate): ?array
-    {
+    private function scoreClearingCandidate(
+        GamePlayer $player,
+        int $teamAvg,
+        Collection $teamGroupCounts,
+        Carbon $currentDate,
+        float $importance,
+    ): ?array {
         $ability = $this->getPlayerAbility($player);
         $group = $this->getPositionGroup($player->position);
         $groupCount = $teamGroupCounts->get($group, 0);
 
         if ($groupCount <= (self::MIN_GROUP_COUNTS[$group] ?? 2)) {
+            return null;
+        }
+
+        $yearsLeft = $player->contract_until
+            ? (int) $currentDate->diffInYears($player->contract_until)
+            : 0;
+
+        // Core players aren't "cleared" — clearing dumps surplus, not starters.
+        // Only exception: renewal has failed (contract <= 1 year) and the club
+        // is forced to recoup something rather than lose the player for free.
+        if ($importance >= 0.60 && $yearsLeft > 1) {
             return null;
         }
 
@@ -269,13 +295,15 @@ class TransferMarketService
             $score += 3;
         }
 
-        // Contract situation: short contracts = must sell or lose for free
+        // Contract bonus — short contracts push clubs to list, but the pull is
+        // scaled down for important players because clubs renew them first.
+        // Long contracts slightly discourage clearing regardless of role.
         if ($player->contract_until) {
-            $yearsLeft = $currentDate->diffInYears($player->contract_until);
+            $scale = 1.0 - ($importance * 0.75); // core ~0.25x, fringe ~1.0x
             if ($yearsLeft <= 1) {
-                $score += 6;
+                $score += (int) round(6 * $scale);
             } elseif ($yearsLeft <= 2) {
-                $score += 3;
+                $score += (int) round(3 * $scale);
             } elseif ($yearsLeft >= 4) {
                 $score -= 2;
             }
@@ -290,8 +318,14 @@ class TransferMarketService
         return ['player' => $player, 'score' => $score];
     }
 
-    private function scoreUpgradeCandidate(GamePlayer $player, int $teamAvg, Collection $teamGroupCounts, Carbon $currentDate): ?array
-    {
+    private function scoreUpgradeCandidate(
+        GamePlayer $player,
+        int $teamAvg,
+        Collection $teamGroupCounts,
+        Carbon $currentDate,
+        float $importance,
+        int $teamRepIndex,
+    ): ?array {
         $ability = $this->getPlayerAbility($player);
         $group = $this->getPositionGroup($player->position);
         $groupCount = $teamGroupCounts->get($group, 0);
@@ -301,6 +335,17 @@ class TransferMarketService
         }
 
         if ($ability < $teamAvg) {
+            return null;
+        }
+
+        $yearsLeft = $player->contract_until
+            ? (int) $currentDate->diffInYears($player->contract_until)
+            : 0;
+
+        // Elite and continental clubs don't sell core players upward — there's
+        // no larger domestic buyer to sell to. They only let a star go when
+        // renewal has failed and the contract is running out.
+        if ($importance >= 0.60 && $teamRepIndex >= 3 && $yearsLeft > 1) {
             return null;
         }
 
@@ -321,13 +366,13 @@ class TransferMarketService
             $score += min(4, $surplus * 2);
         }
 
-        // Contract situation: short contracts = must sell
+        // Contract bonus, scaled by importance (see scoreClearingCandidate).
         if ($player->contract_until) {
-            $yearsLeft = $currentDate->diffInYears($player->contract_until);
+            $scale = 1.0 - ($importance * 0.75);
             if ($yearsLeft <= 1) {
-                $score += 6;
+                $score += (int) round(6 * $scale);
             } elseif ($yearsLeft <= 2) {
-                $score += 3;
+                $score += (int) round(3 * $scale);
             }
         }
 
@@ -338,6 +383,31 @@ class TransferMarketService
         }
 
         return ['player' => $player, 'score' => $score];
+    }
+
+    /**
+     * Build a player_id → importance map for a team's roster.
+     *
+     * Importance is the player's rank within his squad by overall ability,
+     * mapped to a 0.0 (worst) .. 1.0 (best) scale. This identifies the core
+     * players (the ~top 11 by rank, importance >= 0.60 in a 25-player squad)
+     * so the scoring can protect them from being listed casually.
+     *
+     * @return array<string, float>
+     */
+    private function buildImportanceMap(Collection $players): array
+    {
+        $sorted = $players
+            ->sortByDesc(fn (GamePlayer $p) => $this->getPlayerAbility($p))
+            ->values();
+
+        $total = $sorted->count();
+        $map = [];
+        foreach ($sorted as $rank => $player) {
+            $map[$player->id] = 1.0 - ($rank / max($total - 1, 1));
+        }
+
+        return $map;
     }
 
     private function loadAIRosters(Game $game): Collection

--- a/app/Modules/Transfer/Services/TransferMarketService.php
+++ b/app/Modules/Transfer/Services/TransferMarketService.php
@@ -6,6 +6,7 @@ use App\Models\Game;
 use App\Models\GamePlayer;
 use App\Models\GameTransfer;
 use App\Models\TransferListing;
+use App\Models\TransferOffer;
 use App\Modules\Player\PlayerAge;
 use Carbon\Carbon;
 use Illuminate\Support\Collection;
@@ -21,6 +22,13 @@ class TransferMarketService
 {
     /** Maximum number of AI listings active at any time */
     private const MAX_LISTINGS = 50;
+
+    /**
+     * Soft-fill threshold: refresh only tops up new listings when the
+     * current count drops below this, giving the market stable browsing
+     * between natural churn events instead of replacing listings daily.
+     */
+    private const SOFT_FILL_THRESHOLD = 30;
 
     /** Listings expire after this many days */
     private const LISTING_EXPIRY_DAYS = 30;
@@ -44,9 +52,11 @@ class TransferMarketService
     ) {}
 
     /**
-     * Refresh AI market listings. Called each matchday during transfer windows.
+     * Refresh AI market listings. Called every matchday, year-round.
      *
-     * Removes expired listings, then generates new ones up to MAX_LISTINGS.
+     * Always removes expired listings. Only tops up new listings when the
+     * active count drops below SOFT_FILL_THRESHOLD, so the market is stable
+     * between natural churn events instead of replacing rows daily.
      */
     public function refreshListings(Game $game): void
     {
@@ -65,10 +75,12 @@ class TransferMarketService
             ->whereNotNull('asking_price')
             ->count();
 
-        $slotsAvailable = self::MAX_LISTINGS - $currentCount;
-        if ($slotsAvailable <= 0) {
+        // Soft-fill: only top up when the market has noticeably decayed
+        if ($currentCount >= self::SOFT_FILL_THRESHOLD) {
             return;
         }
+
+        $slotsAvailable = self::MAX_LISTINGS - $currentCount;
 
         // Load context
         $teamRosters = $this->loadAIRosters($game);
@@ -119,27 +131,25 @@ class TransferMarketService
     }
 
     /**
-     * Clear all AI listings when the transfer window closes.
-     */
-    public function clearListings(Game $game): void
-    {
-        TransferListing::where('game_id', $game->id)
-            ->where('team_id', '!=', $game->team_id)
-            ->where('status', TransferListing::STATUS_LISTED)
-            ->whereNotNull('asking_price')
-            ->delete();
-    }
-
-    /**
      * Get active market listings for the view.
+     *
+     * Excludes players for whom the user already has an agreed offer
+     * waiting on a window — otherwise the user would see "available" rows
+     * for players they've already bought.
      */
     public function getMarketListings(Game $game): Collection
     {
+        $alreadyAgreedIds = TransferOffer::where('game_id', $game->id)
+            ->where('offering_team_id', $game->team_id)
+            ->where('status', TransferOffer::STATUS_AGREED)
+            ->pluck('game_player_id');
+
         return TransferListing::with(['gamePlayer.player', 'gamePlayer.team'])
             ->where('game_id', $game->id)
             ->where('team_id', '!=', $game->team_id)
             ->where('status', TransferListing::STATUS_LISTED)
             ->whereNotNull('asking_price')
+            ->whereNotIn('game_player_id', $alreadyAgreedIds)
             ->orderByDesc('asking_price')
             ->get();
     }

--- a/app/Modules/Transfer/Services/TransferMarketService.php
+++ b/app/Modules/Transfer/Services/TransferMarketService.php
@@ -1,0 +1,366 @@
+<?php
+
+namespace App\Modules\Transfer\Services;
+
+use App\Models\ClubProfile;
+use App\Models\Game;
+use App\Models\GamePlayer;
+use App\Models\GameTransfer;
+use App\Models\Team;
+use App\Models\TeamReputation;
+use App\Models\TransferListing;
+use App\Modules\Player\PlayerAge;
+use App\Support\Money;
+use Carbon\Carbon;
+use Illuminate\Support\Collection;
+
+/**
+ * Manages AI-generated transfer market listings.
+ *
+ * AI teams list players for sale on the public market during transfer windows.
+ * The user can browse these listings and bid on players via the existing
+ * negotiation flow.
+ */
+class TransferMarketService
+{
+    /** Maximum number of AI listings active at any time */
+    private const MAX_LISTINGS = 50;
+
+    /** Listings expire after this many days */
+    private const LISTING_EXPIRY_DAYS = 30;
+
+    /** Ideal squad depth per position group — never list below this */
+    private const MIN_GROUP_COUNTS = [
+        'Goalkeeper' => 3,
+        'Defender' => 6,
+        'Midfielder' => 6,
+        'Forward' => 4,
+    ];
+
+    private const IDEAL_GROUP_COUNTS = [
+        'Goalkeeper' => 3,
+        'Defender' => 6,
+        'Midfielder' => 6,
+        'Forward' => 4,
+    ];
+
+    /** Minimum squad size below which a team will not list */
+    private const MIN_SQUAD_SIZE = 20;
+
+    /** Percentage chance each listing is a clearing type (vs upgrade) */
+    private const CLEARING_CHANCE = 65;
+
+    public function __construct(
+        private readonly ScoutingService $scoutingService,
+    ) {}
+
+    /**
+     * Refresh AI market listings. Called each matchday during transfer windows.
+     *
+     * Removes expired listings, then generates new ones up to MAX_LISTINGS.
+     */
+    public function refreshListings(Game $game): void
+    {
+        // Remove expired listings
+        TransferListing::where('game_id', $game->id)
+            ->where('team_id', '!=', $game->team_id)
+            ->where('status', TransferListing::STATUS_LISTED)
+            ->whereNotNull('asking_price')
+            ->where('listed_at', '<', $game->current_date->copy()->subDays(self::LISTING_EXPIRY_DAYS))
+            ->delete();
+
+        // Count current AI listings
+        $currentCount = TransferListing::where('game_id', $game->id)
+            ->where('team_id', '!=', $game->team_id)
+            ->where('status', TransferListing::STATUS_LISTED)
+            ->whereNotNull('asking_price')
+            ->count();
+
+        $slotsAvailable = self::MAX_LISTINGS - $currentCount;
+        if ($slotsAvailable <= 0) {
+            return;
+        }
+
+        // Load context
+        $teamRosters = $this->loadAIRosters($game);
+        $teamAverages = $teamRosters->map(fn ($players) => $this->calculateTeamAverage($players));
+        $teamReputations = TeamReputation::resolveLevels($game->id, $teamRosters->keys()->toArray());
+
+        // Players already listed or transferred this season
+        $alreadyListedIds = TransferListing::where('game_id', $game->id)
+            ->pluck('game_player_id')
+            ->flip()
+            ->all();
+
+        $alreadyTransferredIds = GameTransfer::where('game_id', $game->id)
+            ->where('season', $game->season)
+            ->pluck('game_player_id')
+            ->flip()
+            ->all();
+
+        $excludedIds = $alreadyListedIds + $alreadyTransferredIds;
+
+        $groupCounts = $teamRosters->map(function ($players) {
+            return $players->groupBy(fn ($p) => $this->getPositionGroup($p->position))
+                ->map->count();
+        });
+
+        // Build candidate sell offers using the same scoring as AITransferMarketService
+        $candidates = $this->buildListingCandidates(
+            $teamRosters,
+            $teamAverages,
+            $groupCounts,
+            $excludedIds,
+            $game->current_date,
+        );
+
+        // Take up to available slots, shuffle for variety
+        $selected = $candidates->shuffle()->take($slotsAvailable);
+
+        // Create listings
+        foreach ($selected as $candidate) {
+            $player = $candidate['player'];
+            $askingPrice = $this->scoutingService->calculateAskingPrice($player);
+
+            TransferListing::create([
+                'game_id' => $game->id,
+                'game_player_id' => $player->id,
+                'team_id' => $player->team_id,
+                'status' => TransferListing::STATUS_LISTED,
+                'listed_at' => $game->current_date,
+                'asking_price' => $askingPrice,
+            ]);
+        }
+    }
+
+    /**
+     * Clear all AI listings when the transfer window closes.
+     */
+    public function clearListings(Game $game): void
+    {
+        TransferListing::where('game_id', $game->id)
+            ->where('team_id', '!=', $game->team_id)
+            ->where('status', TransferListing::STATUS_LISTED)
+            ->whereNotNull('asking_price')
+            ->delete();
+    }
+
+    /**
+     * Get market listings for the view, optionally filtered by position group.
+     */
+    public function getMarketListings(Game $game, ?string $positionFilter = null): Collection
+    {
+        $query = TransferListing::with(['gamePlayer.player', 'gamePlayer.team'])
+            ->where('game_id', $game->id)
+            ->where('team_id', '!=', $game->team_id)
+            ->where('status', TransferListing::STATUS_LISTED)
+            ->whereNotNull('asking_price');
+
+        if ($positionFilter && $positionFilter !== 'all') {
+            $query->whereHas('gamePlayer', function ($q) use ($positionFilter) {
+                $positions = match ($positionFilter) {
+                    'gk' => ['Goalkeeper'],
+                    'def' => ['Centre-Back', 'Left-Back', 'Right-Back'],
+                    'mid' => ['Defensive Midfield', 'Central Midfield', 'Attacking Midfield', 'Left Midfield', 'Right Midfield'],
+                    'fwd' => ['Left Winger', 'Right Winger', 'Centre-Forward', 'Second Striker'],
+                    default => [],
+                };
+                if (!empty($positions)) {
+                    $q->whereIn('position', $positions);
+                }
+            });
+        }
+
+        return $query->orderByDesc('asking_price')->get();
+    }
+
+    // ── Private helpers ─────────────────────────────────────────────────
+
+    /**
+     * Build candidate listings from AI team rosters.
+     */
+    private function buildListingCandidates(
+        Collection $teamRosters,
+        Collection $teamAverages,
+        Collection $groupCounts,
+        array $excludedIds,
+        Carbon $currentDate,
+    ): Collection {
+        $candidates = collect();
+
+        foreach ($teamRosters as $teamId => $players) {
+            if ($players->count() <= self::MIN_SQUAD_SIZE) {
+                continue;
+            }
+
+            $teamAvg = $teamAverages[$teamId] ?? 55;
+            $teamGroupCounts = $groupCounts->get($teamId, collect());
+
+            $eligible = $players->filter(
+                fn (GamePlayer $p) => !$p->retiring_at_season && !isset($excludedIds[$p->id])
+            );
+
+            // Score candidates
+            $clearingCandidates = $eligible
+                ->map(fn ($p) => $this->scoreClearingCandidate($p, $teamAvg, $teamGroupCounts, $currentDate))
+                ->filter();
+
+            $upgradeCandidates = $eligible
+                ->map(fn ($p) => $this->scoreUpgradeCandidate($p, $teamAvg, $teamGroupCounts, $currentDate))
+                ->filter();
+
+            // Pick 1-3 per team
+            $teamPicks = mt_rand(1, 3);
+            $usedIds = [];
+
+            for ($i = 0; $i < $teamPicks; $i++) {
+                $isClearing = mt_rand(1, 100) <= self::CLEARING_CHANCE;
+                $pool = $isClearing ? $clearingCandidates : $upgradeCandidates;
+                $candidate = $pool->sortByDesc('score')
+                    ->first(fn ($c) => !isset($usedIds[$c['player']->id]));
+
+                // Fallback to other pool
+                if (!$candidate) {
+                    $pool = $isClearing ? $upgradeCandidates : $clearingCandidates;
+                    $candidate = $pool->sortByDesc('score')
+                        ->first(fn ($c) => !isset($usedIds[$c['player']->id]));
+                }
+
+                if (!$candidate) {
+                    break;
+                }
+
+                $usedIds[$candidate['player']->id] = true;
+                $candidates->push($candidate);
+            }
+        }
+
+        return $candidates;
+    }
+
+    private function scoreClearingCandidate(GamePlayer $player, int $teamAvg, Collection $teamGroupCounts, Carbon $currentDate): ?array
+    {
+        $ability = $this->getPlayerAbility($player);
+        $group = $this->getPositionGroup($player->position);
+        $groupCount = $teamGroupCounts->get($group, 0);
+
+        if ($groupCount <= (self::MIN_GROUP_COUNTS[$group] ?? 2)) {
+            return null;
+        }
+
+        $score = 0;
+
+        $surplus = $groupCount - (self::IDEAL_GROUP_COUNTS[$group] ?? 4);
+        if ($surplus > 0) {
+            $score += $surplus * 3;
+        }
+
+        $abilityGap = $teamAvg - $ability;
+        if ($abilityGap > 15) {
+            $score += 5;
+        } elseif ($abilityGap > 5) {
+            $score += 3;
+        } elseif ($abilityGap > 0) {
+            $score += 1;
+        }
+
+        $age = $player->age($currentDate);
+        if ($age >= PlayerAge::PRIME_END) {
+            $score += 3;
+        }
+
+        $score += mt_rand(0, 2);
+
+        if ($score < 3) {
+            return null;
+        }
+
+        return ['player' => $player, 'score' => $score];
+    }
+
+    private function scoreUpgradeCandidate(GamePlayer $player, int $teamAvg, Collection $teamGroupCounts, Carbon $currentDate): ?array
+    {
+        $ability = $this->getPlayerAbility($player);
+        $group = $this->getPositionGroup($player->position);
+        $groupCount = $teamGroupCounts->get($group, 0);
+
+        if ($groupCount <= (self::MIN_GROUP_COUNTS[$group] ?? 2)) {
+            return null;
+        }
+
+        if ($ability < $teamAvg) {
+            return null;
+        }
+
+        $score = 0;
+
+        $abilityGap = $ability - $teamAvg;
+        $score += min(5, (int) ($abilityGap / 3));
+
+        $age = $player->age($currentDate);
+        if ($age >= PlayerAge::YOUNG_END && $age <= PlayerAge::primePhaseAge(0.5)) {
+            $score += 3;
+        } elseif ($age >= PlayerAge::ACADEMY_END && $age < PlayerAge::YOUNG_END) {
+            $score += 1;
+        }
+
+        $surplus = $groupCount - (self::IDEAL_GROUP_COUNTS[$group] ?? 4);
+        if ($surplus > 0) {
+            $score += min(4, $surplus * 2);
+        }
+
+        $score += mt_rand(0, 2);
+
+        if ($score < 3) {
+            return null;
+        }
+
+        return ['player' => $player, 'score' => $score];
+    }
+
+    private function loadAIRosters(Game $game): Collection
+    {
+        return GamePlayer::with(['player:id,date_of_birth'])
+            ->select([
+                'id', 'game_id', 'player_id', 'team_id', 'position',
+                'market_value_cents', 'game_technical_ability', 'game_physical_ability',
+                'retiring_at_season', 'contract_until', 'annual_wage',
+            ])
+            ->where('game_id', $game->id)
+            ->whereNotNull('team_id')
+            ->where('team_id', '!=', $game->team_id)
+            ->get()
+            ->groupBy('team_id');
+    }
+
+    private function calculateTeamAverage(Collection $players): int
+    {
+        if ($players->isEmpty()) {
+            return 55;
+        }
+
+        $total = $players->sum(fn (GamePlayer $p) => $this->getPlayerAbility($p));
+
+        return (int) round($total / $players->count());
+    }
+
+    private function getPlayerAbility(GamePlayer $player): int
+    {
+        $tech = $player->game_technical_ability ?? 50;
+        $phys = $player->game_physical_ability ?? 50;
+
+        return (int) round(($tech + $phys) / 2);
+    }
+
+    private function getPositionGroup(string $position): string
+    {
+        return match ($position) {
+            'Goalkeeper' => 'Goalkeeper',
+            'Centre-Back', 'Left-Back', 'Right-Back' => 'Defender',
+            'Defensive Midfield', 'Central Midfield', 'Attacking Midfield',
+            'Left Midfield', 'Right Midfield' => 'Midfielder',
+            'Left Winger', 'Right Winger', 'Centre-Forward', 'Second Striker' => 'Forward',
+            default => 'Midfielder',
+        };
+    }
+}

--- a/lang/en/transfers.php
+++ b/lang/en/transfers.php
@@ -405,4 +405,11 @@ return [
     'mood_willing_loan' => 'Willing to loan',
     'mood_open_loan' => 'Open to loan',
     'mood_reluctant_loan' => 'Reluctant to loan',
+
+    // Transfer market
+    'market_tab' => 'Market',
+    'market_closed' => 'The transfer market opens during transfer windows.',
+    'market_empty' => 'No players currently listed on the market.',
+    'market_bid' => 'Bid',
+    'market_asking_price' => 'Asking Price',
 ];

--- a/lang/en/transfers.php
+++ b/lang/en/transfers.php
@@ -413,4 +413,5 @@ return [
     'market_empty' => 'No players currently listed on the market.',
     'market_bid' => 'Bid',
     'market_asking_price' => 'Asking Price',
+    'market_window_closed_notice' => 'The transfer window is closed. You can still negotiate with clubs — any agreed signings will join your team when the next window opens.',
 ];

--- a/lang/en/transfers.php
+++ b/lang/en/transfers.php
@@ -276,6 +276,7 @@ return [
     'explore_midfielders' => 'Midfielders',
     'explore_forwards' => 'Forwards',
     'explore_age' => 'Age',
+    'explore_rating' => 'Rating',
     'explore_value' => 'Value',
     'explore_free_agents' => 'Free Agents',
     'explore_free_agents_hint' => 'Browse available free agents. Free agents can be signed at any time, even outside transfer windows.',

--- a/lang/es/transfers.php
+++ b/lang/es/transfers.php
@@ -281,6 +281,7 @@ return [
     'explore_midfielders' => 'Centrocampistas',
     'explore_forwards' => 'Delanteros',
     'explore_age' => 'Edad',
+    'explore_rating' => 'Nota',
     'explore_value' => 'Valor',
     'explore_free_agents' => 'Agentes Libres',
     'explore_free_agents_hint' => 'Explora agentes libres disponibles. Los agentes libres se pueden fichar en cualquier momento, incluso fuera de las ventanas de fichajes.',

--- a/lang/es/transfers.php
+++ b/lang/es/transfers.php
@@ -410,4 +410,11 @@ return [
     'mood_willing_loan' => 'Dispuesto a ceder',
     'mood_open_loan' => 'Abierto a cesión',
     'mood_reluctant_loan' => 'Reticente a ceder',
+
+    // Transfer market
+    'market_tab' => 'Mercado',
+    'market_closed' => 'El mercado de fichajes abre durante las ventanas de traspasos.',
+    'market_empty' => 'No hay jugadores en el mercado actualmente.',
+    'market_bid' => 'Pujar',
+    'market_asking_price' => 'Precio de Salida',
 ];

--- a/lang/es/transfers.php
+++ b/lang/es/transfers.php
@@ -418,4 +418,5 @@ return [
     'market_empty' => 'No hay jugadores en el mercado actualmente.',
     'market_bid' => 'Pujar',
     'market_asking_price' => 'Precio de Salida',
+    'market_window_closed_notice' => 'La ventana de fichajes está cerrada. Puedes seguir negociando con los clubes — los acuerdos se incorporarán a tu equipo cuando se abra la próxima ventana.',
 ];

--- a/resources/views/components/bottom-tab-bar.blade.php
+++ b/resources/views/components/bottom-tab-bar.blade.php
@@ -9,7 +9,7 @@
     $dashboardActive = $currentRoute === 'show-game';
     $squadActive = Str::startsWith($currentRoute, 'game.squad');
     $lineupActive = $currentRoute === 'game.lineup';
-    $transfersActive = in_array($currentRoute, ['game.transfers', 'game.transfers.outgoing', 'game.scouting', 'game.explore', 'game.transfer-activity']);
+    $transfersActive = in_array($currentRoute, ['game.transfers', 'game.transfers.outgoing', 'game.scouting', 'game.explore', 'game.transfer-activity', 'game.transfers.market']);
     $moreActive = in_array($currentRoute, ['game.finances', 'game.calendar', 'game.competition']);
 
 @endphp

--- a/resources/views/components/explore-player-row.blade.php
+++ b/resources/views/components/explore-player-row.blade.php
@@ -85,7 +85,9 @@ $canNegotiateFreeAgent = $isFreeAgent && !$isOwnTeam;
     @if($showOvr)
     {{-- OVR --}}
     <td class="py-2 pr-3 hidden md:table-cell text-center">
-        <x-rating-badge :value="$player->overall_score" size="sm" />
+        <div class="flex justify-center">
+            <x-rating-badge :value="$player->overall_score" size="sm" />
+        </div>
     </td>
     @endif
     {{-- Market value --}}

--- a/resources/views/components/explore-player-row.blade.php
+++ b/resources/views/components/explore-player-row.blade.php
@@ -3,6 +3,9 @@
     'game',
     'showTeam' => false,
     'isOwnTeam' => false,
+    'showOvr' => false,
+    'askingPrice' => null,
+    'teamPlacement' => 'column', // 'column' | 'inline'
 ])
 
 @php
@@ -20,11 +23,18 @@ $canNegotiateFreeAgent = $isFreeAgent && !$isOwnTeam;
     </td>
     {{-- Name + nationality + mobile details --}}
     <td class="py-2 pr-3">
-        <div class="flex items-center gap-2">
+        <div class="flex items-center gap-2 min-w-0">
             @if($player->nationality_flag['code'] ?? null)
             <img src="{{ Storage::disk('assets')->url('flags/' . $player->nationality_flag['code'] . '.svg') }}" class="w-4 h-3 rounded-xs shadow-xs shrink-0" title="{{ $player->nationality_flag['name'] }}">
             @endif
             <span class="font-medium text-text-primary truncate">{{ $player->name }}</span>
+            @if($teamPlacement === 'inline' && $showTeam && $player->team)
+            <span class="hidden md:inline-flex items-center gap-1 text-xs text-text-muted min-w-0 shrink">
+                <span class="text-text-muted/60">&middot;</span>
+                <img src="{{ $player->team->image }}" alt="{{ $player->team->name }}" class="w-4 h-4 shrink-0 object-contain">
+                <span class="truncate">{{ $player->team->name }}</span>
+            </span>
+            @endif
             @if(!$showTeam && $player->is_loaned_in)
             <span class="text-[10px] bg-violet-500/10 text-violet-400 px-1.5 py-0.5 rounded-sm font-medium shrink-0">{{ __('transfers.loans') }}</span>
             @endif
@@ -43,13 +53,21 @@ $canNegotiateFreeAgent = $isFreeAgent && !$isOwnTeam;
             <span>{{ $player->age($game->current_date) }} {{ __('app.years') }}</span>
             <span>&middot;</span>
             <span>{{ \App\Support\Money::format($player->market_value_cents) }}</span>
+            @if($showOvr)
+                <span>&middot;</span>
+                <span>OVR {{ $player->overall_score }}</span>
+            @endif
+            @if($askingPrice !== null)
+                <span>&middot;</span>
+                <span class="font-medium text-text-primary">{{ \App\Support\Money::format($askingPrice) }}</span>
+            @endif
             @if(!$showTeam)
                 <span>&middot;</span>
                 <span>{{ $player->contract_until?->year ?? '—' }}</span>
             @endif
         </div>
     </td>
-    @if($showTeam)
+    @if($showTeam && $teamPlacement === 'column')
     {{-- Team --}}
     <td class="py-2 pr-3 hidden md:table-cell">
         @if($player->team)
@@ -64,8 +82,18 @@ $canNegotiateFreeAgent = $isFreeAgent && !$isOwnTeam;
     @endif
     {{-- Age --}}
     <td class="py-2 pr-3 hidden md:table-cell text-center text-text-secondary tabular-nums">{{ $player->age($game->current_date) }}</td>
+    @if($showOvr)
+    {{-- OVR --}}
+    <td class="py-2 pr-3 hidden md:table-cell text-center">
+        <x-rating-badge :value="$player->overall_score" size="sm" />
+    </td>
+    @endif
     {{-- Market value --}}
     <td class="py-2 pr-3 hidden md:table-cell text-text-secondary tabular-nums">{{ \App\Support\Money::format($player->market_value_cents) }}</td>
+    @if($askingPrice !== null)
+    {{-- Asking price --}}
+    <td class="py-2 pr-3 hidden md:table-cell text-right font-semibold text-text-primary tabular-nums">{{ \App\Support\Money::format($askingPrice) }}</td>
+    @endif
     @if(!$showTeam)
     {{-- Contract --}}
     <td class="py-2 pr-3 hidden md:table-cell text-center text-text-muted tabular-nums">{{ $player->contract_until?->year ?? '—' }}</td>

--- a/resources/views/components/rating-badge.blade.php
+++ b/resources/views/components/rating-badge.blade.php
@@ -10,7 +10,7 @@
     };
 
     $sizeClasses = match($size) {
-        'sm' => 'w-7 h-7 rounded-md text-[10px]',
+        'sm' => 'w-7 h-7 rounded-md text-xs',
         'lg' => 'w-12 h-12 rounded-lg text-lg',
         default => 'w-9 h-9 rounded-lg text-sm',
     };

--- a/resources/views/explore.blade.php
+++ b/resources/views/explore.blade.php
@@ -21,6 +21,7 @@
                         ['href' => route('game.transfers.outgoing', $game->id), 'label' => __('transfers.outgoing'), 'active' => false, 'badge' => $salidaBadgeCount > 0 ? $salidaBadgeCount : null],
                         ['href' => route('game.scouting', $game->id), 'label' => __('transfers.scouting_tab'), 'active' => false],
                         ['href' => route('game.explore', $game->id), 'label' => __('transfers.explore_tab'), 'active' => true],
+                        ['href' => route('game.transfers.market', $game->id), 'label' => __('transfers.market_tab'), 'active' => false],
                     ]" />
 
                     {{-- Explorer Content --}}

--- a/resources/views/incoming-transfers.blade.php
+++ b/resources/views/incoming-transfers.blade.php
@@ -23,6 +23,7 @@
                             ['href' => route('game.transfers.outgoing', $game->id), 'label' => __('transfers.outgoing'), 'active' => false, 'badge' => $salidaBadgeCount > 0 ? $salidaBadgeCount : null],
                             ['href' => route('game.scouting', $game->id), 'label' => __('transfers.scouting_tab'), 'active' => false],
                             ['href' => route('game.explore', $game->id), 'label' => __('transfers.explore_tab'), 'active' => false],
+                            ['href' => route('game.transfers.market', $game->id), 'label' => __('transfers.market_tab'), 'active' => false],
                         ]">
                             <x-ghost-button color="slate" @click="helpOpen = !helpOpen" class="gap-2">
                                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="w-4 h-4 text-text-secondary shrink-0">

--- a/resources/views/outgoing-transfers.blade.php
+++ b/resources/views/outgoing-transfers.blade.php
@@ -26,6 +26,7 @@
                             ['href' => route('game.transfers.outgoing', $game->id), 'label' => __('transfers.outgoing'), 'active' => true, 'badge' => $salidaBadge > 0 ? $salidaBadge : null],
                             ['href' => route('game.scouting', $game->id), 'label' => __('transfers.scouting_tab'), 'active' => false],
                             ['href' => route('game.explore', $game->id), 'label' => __('transfers.explore_tab'), 'active' => false],
+                            ['href' => route('game.transfers.market', $game->id), 'label' => __('transfers.market_tab'), 'active' => false],
                         ]">
                             <x-ghost-button color="slate" @click="helpOpen = !helpOpen" class="gap-2">
                                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="w-4 h-4 text-text-secondary shrink-0">

--- a/resources/views/partials/live-match/penalty-picker.blade.php
+++ b/resources/views/partials/live-match/penalty-picker.blade.php
@@ -53,7 +53,7 @@
                                   :class="getPositionBadgeColor(kicker.positionGroup)"
                                   x-text="kicker.positionAbbr"></span>
                             <span class="text-sm font-semibold text-text-primary flex-1 truncate" x-text="kicker.name"></span>
-                            <span class="rating-badge w-7 h-7 rounded-md text-[10px] flex items-center justify-center shrink-0"
+                            <span class="rating-badge w-7 h-7 rounded-md text-xs flex items-center justify-center shrink-0"
                                   :class="getRatingBadgeClass(kicker.overallScore)">
                                 <span class="font-heading font-bold" x-text="kicker.overallScore"></span>
                             </span>
@@ -86,7 +86,7 @@
                                   :class="getPositionBadgeColor(player.positionGroup)"
                                   x-text="player.positionAbbr"></span>
                             <span class="text-sm text-text-primary flex-1 truncate" x-text="player.name"></span>
-                            <span class="rating-badge w-7 h-7 rounded-md text-[10px] flex items-center justify-center shrink-0"
+                            <span class="rating-badge w-7 h-7 rounded-md text-xs flex items-center justify-center shrink-0"
                                   :class="getRatingBadgeClass(player.overallScore)">
                                 <span class="font-heading font-bold" x-text="player.overallScore"></span>
                             </span>

--- a/resources/views/scouting-hub.blade.php
+++ b/resources/views/scouting-hub.blade.php
@@ -23,6 +23,7 @@
                             ['href' => route('game.transfers.outgoing', $game->id), 'label' => __('transfers.outgoing'), 'active' => false, 'badge' => $salidaBadgeCount > 0 ? $salidaBadgeCount : null],
                             ['href' => route('game.scouting', $game->id), 'label' => __('transfers.scouting_tab'), 'active' => true],
                             ['href' => route('game.explore', $game->id), 'label' => __('transfers.explore_tab'), 'active' => false],
+                            ['href' => route('game.transfers.market', $game->id), 'label' => __('transfers.market_tab'), 'active' => false],
                         ]">
                             <x-ghost-button color="slate" @click="helpOpen = !helpOpen" class="gap-2">
                                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="w-4 h-4 text-text-secondary shrink-0">

--- a/resources/views/squad-registration.blade.php
+++ b/resources/views/squad-registration.blade.php
@@ -158,7 +158,7 @@
                                         <span class="text-sm font-medium text-text-primary truncate flex-1 min-w-0" x-text="getPlayer({{ $i }}).name"></span>
                                         <span class="text-xs text-text-muted tabular-nums shrink-0" x-text="getPlayer({{ $i }}).age + ' {{ __('squad.years_abbr') }}'"></span>
 
-                                        <div class="rating-badge w-7 h-7 rounded-md text-[10px] flex items-center justify-center shrink-0"
+                                        <div class="rating-badge w-7 h-7 rounded-md text-xs flex items-center justify-center shrink-0"
                                              :class="ratingBadgeClass(getPlayer({{ $i }}).overall)">
                                             <span class="font-heading font-bold" x-text="getPlayer({{ $i }}).overall"></span>
                                         </div>
@@ -221,7 +221,7 @@
                                     <span class="text-sm font-medium text-text-primary truncate flex-1 min-w-0" x-text="players[entry.id].name"></span>
                                     <span class="text-xs text-text-muted tabular-nums shrink-0" x-text="players[entry.id].age + ' {{ __('squad.years_abbr') }}'"></span>
 
-                                    <div class="rating-badge w-7 h-7 rounded-md text-[10px] flex items-center justify-center shrink-0"
+                                    <div class="rating-badge w-7 h-7 rounded-md text-xs flex items-center justify-center shrink-0"
                                          :class="ratingBadgeClass(players[entry.id].overall)">
                                         <span class="font-heading font-bold" x-text="players[entry.id].overall"></span>
                                     </div>
@@ -274,7 +274,7 @@
                                     <span class="text-sm font-medium text-text-primary truncate flex-1 min-w-0" x-text="players[playerId].name"></span>
                                     <span class="text-xs text-text-muted tabular-nums shrink-0" x-text="players[playerId].age + ' {{ __('squad.years_abbr') }}'"></span>
 
-                                    <div class="rating-badge w-7 h-7 rounded-md text-[10px] flex items-center justify-center shrink-0"
+                                    <div class="rating-badge w-7 h-7 rounded-md text-xs flex items-center justify-center shrink-0"
                                          :class="ratingBadgeClass(players[playerId].overall)">
                                         <span class="font-heading font-bold" x-text="players[playerId].overall"></span>
                                     </div>

--- a/resources/views/transfer-market.blade.php
+++ b/resources/views/transfer-market.blade.php
@@ -25,7 +25,7 @@
             ['href' => route('game.transfers.market', $game->id), 'label' => __('transfers.market_tab'), 'active' => true],
         ]" />
 
-        <div class="mt-6" x-data="{ posFilter: 'all' }">
+        <div class="mt-6">
             @if(!$isTransferWindow)
                 {{-- Window closed state --}}
                 <div class="bg-surface-800 border border-border-default rounded-xl p-8 text-center">
@@ -43,192 +43,32 @@
                     <p class="text-text-secondary text-sm">{{ __('transfers.market_empty') }}</p>
                 </div>
             @else
-                {{-- Position filter pills --}}
-                <div class="flex flex-wrap gap-2 mb-4">
-                    @foreach([
-                        'all' => __('transfers.explore_filter_all'),
-                        'gk' => __('squad.goalkeepers'),
-                        'def' => __('squad.defenders'),
-                        'mid' => __('squad.midfielders'),
-                        'fwd' => __('squad.forwards'),
-                    ] as $filterKey => $filterLabel)
-                        <button
-                            @click="posFilter = '{{ $filterKey }}'"
-                            :class="posFilter === '{{ $filterKey }}'
-                                ? 'bg-accent-blue/15 text-accent-blue border-accent-blue/30'
-                                : 'bg-surface-800 text-text-secondary border-border-default hover:bg-surface-700'"
-                            class="px-3 py-1.5 text-xs font-medium rounded-full border transition-colors"
-                        >
-                            {{ $filterLabel }}
-                        </button>
-                    @endforeach
-                </div>
-
-                {{-- Budget info --}}
-                <div class="mb-4 text-xs text-text-secondary">
-                    {{ __('transfers.budget_available') }}: <span class="font-semibold text-text-primary">{{ \App\Support\Money::format($availableBudget) }}</span>
-                </div>
-
-                {{-- Desktop table --}}
-                <div class="hidden md:block overflow-x-auto">
+                <div class="overflow-x-auto">
                     <table class="w-full text-sm">
                         <thead>
-                            <tr class="border-b border-border-default text-text-muted text-xs uppercase tracking-wider">
-                                <th class="text-left py-3 px-3 font-medium">{{ __('transfers.transfer_activity_player') }}</th>
-                                <th class="text-center py-3 px-2 font-medium">{{ __('transfers.transfer_activity_position') }}</th>
-                                <th class="text-center py-3 px-2 font-medium">{{ __('transfers.transfer_activity_age') }}</th>
-                                <th class="text-center py-3 px-2 font-medium">OVR</th>
-                                <th class="text-right py-3 px-2 font-medium">{{ __('transfers.market_value') }}</th>
-                                <th class="text-right py-3 px-2 font-medium">{{ __('transfers.market_asking_price') }}</th>
-                                <th class="text-left py-3 px-3 font-medium">{{ __('transfers.explore_search_team') }}</th>
-                                <th class="text-right py-3 px-3 font-medium"></th>
+                            <tr class="text-left border-b border-border-default">
+                                <th class="py-2.5 pl-4 w-12"></th>
+                                <th class="py-2.5 text-[10px] text-text-muted uppercase tracking-wider"></th>
+                                <th class="py-2.5 text-[10px] text-text-muted uppercase tracking-wider text-center hidden md:table-cell">{{ __('transfers.explore_age') }}</th>
+                                <th class="py-2.5 text-[10px] text-text-muted uppercase tracking-wider text-center hidden md:table-cell">OVR</th>
+                                <th class="py-2.5 text-[10px] text-text-muted uppercase tracking-wider hidden md:table-cell">{{ __('transfers.explore_value') }}</th>
+                                <th class="py-2.5 text-[10px] text-text-muted uppercase tracking-wider text-right hidden md:table-cell">{{ __('transfers.market_asking_price') }}</th>
+                                <th class="py-2.5 w-10"></th>
+                                <th class="py-2.5 pr-4 w-10"></th>
                             </tr>
                         </thead>
                         <tbody>
                             @foreach($listings as $listing)
-                                @php
-                                    $gp = $listing->gamePlayer;
-                                    $posGroup = strtolower(match($gp->position_group) {
-                                        'Goalkeeper' => 'gk',
-                                        'Defender' => 'def',
-                                        'Midfielder' => 'mid',
-                                        'Forward' => 'fwd',
-                                        default => 'mid',
-                                    });
-                                    $posDisp = $gp->position_display;
-                                    $playerInfo = \Illuminate\Support\Js::from([
-                                        'age' => $gp->age($game->current_date),
-                                        'position' => $posDisp['abbreviation'],
-                                        'positionBg' => $posDisp['bg'],
-                                        'positionText' => $posDisp['text'],
-                                        'marketValue' => $gp->formatted_market_value,
-                                        'contractYear' => $gp->contract_expiry_year,
-                                    ]);
-                                @endphp
-                                <tr x-show="posFilter === 'all' || posFilter === '{{ $posGroup }}'"
-                                    class="border-b border-border-default/50 hover:bg-surface-700/50 transition-colors">
-                                    {{-- Player name --}}
-                                    <td class="py-3 px-3">
-                                        <span class="font-medium text-text-primary">{{ $gp->name }}</span>
-                                    </td>
-
-                                    {{-- Position --}}
-                                    <td class="py-3 px-2 text-center">
-                                        <x-position-badge :position="$gp->position" size="sm" />
-                                    </td>
-
-                                    {{-- Age --}}
-                                    <td class="py-3 px-2 text-center text-text-secondary">{{ $gp->age($game->current_date) }}</td>
-
-                                    {{-- OVR --}}
-                                    <td class="py-3 px-2 text-center">
-                                        <x-rating-badge :value="$gp->overall_score" size="sm" />
-                                    </td>
-
-                                    {{-- Market Value --}}
-                                    <td class="py-3 px-2 text-right text-text-secondary">{{ $gp->formatted_market_value }}</td>
-
-                                    {{-- Asking Price --}}
-                                    <td class="py-3 px-2 text-right font-medium text-text-primary">{{ \App\Support\Money::format($listing->asking_price) }}</td>
-
-                                    {{-- Team --}}
-                                    <td class="py-3 px-3">
-                                        @if($gp->team)
-                                            <div class="flex items-center gap-1.5">
-                                                <x-team-crest :team="$gp->team" class="w-4 h-4 shrink-0" />
-                                                <span class="text-text-secondary truncate">{{ $gp->team->name }}</span>
-                                            </div>
-                                        @endif
-                                    </td>
-
-                                    {{-- Bid button --}}
-                                    <td class="py-3 px-3 text-right">
-                                        @if($availableBudget > 0)
-                                            <x-primary-button size="xs"
-                                                @click="$dispatch('open-negotiation', {
-                                                    playerName: {{ \Illuminate\Support\Js::from($gp->name) }},
-                                                    negotiateUrl: {{ \Illuminate\Support\Js::from(route('game.negotiate.transfer', [$game->id, $gp->id])) }},
-                                                    mode: 'transfer_fee',
-                                                    phase: 'club_fee',
-                                                    chatTitle: {{ \Illuminate\Support\Js::from(__('transfers.chat_transfer_title')) }},
-                                                    playerInfo: {{ $playerInfo }}
-                                                })">
-                                                {{ __('transfers.market_bid') }}
-                                            </x-primary-button>
-                                        @endif
-                                    </td>
-                                </tr>
+                                <x-explore-player-row
+                                    :player="$listing->gamePlayer"
+                                    :game="$game"
+                                    :show-team="true"
+                                    team-placement="inline"
+                                    :show-ovr="true"
+                                    :asking-price="$listing->asking_price" />
                             @endforeach
                         </tbody>
                     </table>
-                </div>
-
-                {{-- Mobile cards --}}
-                <div class="md:hidden space-y-3">
-                    @foreach($listings as $listing)
-                        @php
-                            $gp = $listing->gamePlayer;
-                            $posGroup = strtolower(match($gp->position_group) {
-                                'Goalkeeper' => 'gk',
-                                'Defender' => 'def',
-                                'Midfielder' => 'mid',
-                                'Forward' => 'fwd',
-                                default => 'mid',
-                            });
-                            $posDisp = $gp->position_display;
-                            $playerInfo = \Illuminate\Support\Js::from([
-                                'age' => $gp->age($game->current_date),
-                                'position' => $posDisp['abbreviation'],
-                                'positionBg' => $posDisp['bg'],
-                                'positionText' => $posDisp['text'],
-                                'marketValue' => $gp->formatted_market_value,
-                                'contractYear' => $gp->contract_expiry_year,
-                            ]);
-                        @endphp
-                        <div x-show="posFilter === 'all' || posFilter === '{{ $posGroup }}'"
-                             class="bg-surface-800 border border-border-default rounded-xl p-4">
-                            <div class="flex items-center justify-between mb-3">
-                                <div class="flex items-center gap-2 min-w-0">
-                                    <x-position-badge :position="$gp->position" size="sm" />
-                                    <span class="font-medium text-text-primary truncate">{{ $gp->name }}</span>
-                                </div>
-                                <x-rating-badge :value="$gp->overall_score" size="sm" />
-                            </div>
-
-                            <div class="grid grid-cols-2 gap-x-4 gap-y-1 text-xs mb-3">
-                                <div class="flex justify-between">
-                                    <span class="text-text-muted">{{ __('transfers.transfer_activity_age') }}</span>
-                                    <span class="text-text-secondary">{{ $gp->age($game->current_date) }}</span>
-                                </div>
-                                <div class="flex justify-between">
-                                    <span class="text-text-muted">{{ __('transfers.explore_search_team') }}</span>
-                                    <span class="text-text-secondary truncate ml-1">{{ $gp->team?->name }}</span>
-                                </div>
-                                <div class="flex justify-between">
-                                    <span class="text-text-muted">{{ __('transfers.market_value') }}</span>
-                                    <span class="text-text-secondary">{{ $gp->formatted_market_value }}</span>
-                                </div>
-                                <div class="flex justify-between">
-                                    <span class="text-text-muted">{{ __('transfers.market_asking_price') }}</span>
-                                    <span class="font-medium text-text-primary">{{ \App\Support\Money::format($listing->asking_price) }}</span>
-                                </div>
-                            </div>
-
-                            @if($availableBudget > 0)
-                                <x-primary-button size="xs" class="w-full justify-center"
-                                    @click="$dispatch('open-negotiation', {
-                                        playerName: {{ \Illuminate\Support\Js::from($gp->name) }},
-                                        negotiateUrl: {{ \Illuminate\Support\Js::from(route('game.negotiate.transfer', [$game->id, $gp->id])) }},
-                                        mode: 'transfer_fee',
-                                        phase: 'club_fee',
-                                        chatTitle: {{ \Illuminate\Support\Js::from(__('transfers.chat_transfer_title')) }},
-                                        playerInfo: {{ $playerInfo }}
-                                    })">
-                                    {{ __('transfers.market_bid') }}
-                                </x-primary-button>
-                            @endif
-                        </div>
-                    @endforeach
                 </div>
             @endif
         </div>

--- a/resources/views/transfer-market.blade.php
+++ b/resources/views/transfer-market.blade.php
@@ -1,0 +1,238 @@
+@php /** @var App\Models\Game $game */ @endphp
+
+<x-app-layout>
+    <x-slot name="header">
+        <x-game-header :game="$game" :next-match="$game->next_match"></x-game-header>
+    </x-slot>
+
+    <div class="max-w-7xl mx-auto px-4 pb-8">
+        <div class="mt-6 mb-6">
+            <h2 class="font-heading text-2xl lg:text-3xl font-bold uppercase tracking-wide text-text-primary">{{ __('app.transfers') }}</h2>
+        </div>
+
+        {{-- Flash Messages --}}
+        <x-flash-message type="success" :message="session('success')" class="mb-4" />
+        <x-flash-message type="error" :message="session('error')" class="mb-4" />
+
+        @include('partials.transfers-header')
+
+        {{-- Tab Navigation --}}
+        <x-section-nav :items="[
+            ['href' => route('game.transfers', $game->id), 'label' => __('transfers.incoming'), 'active' => false],
+            ['href' => route('game.transfers.outgoing', $game->id), 'label' => __('transfers.outgoing'), 'active' => false, 'badge' => $salidaBadgeCount > 0 ? $salidaBadgeCount : null],
+            ['href' => route('game.scouting', $game->id), 'label' => __('transfers.scouting_tab'), 'active' => false],
+            ['href' => route('game.explore', $game->id), 'label' => __('transfers.explore_tab'), 'active' => false],
+            ['href' => route('game.transfers.market', $game->id), 'label' => __('transfers.market_tab'), 'active' => true],
+        ]" />
+
+        <div class="mt-6" x-data="{ posFilter: 'all' }">
+            @if(!$isTransferWindow)
+                {{-- Window closed state --}}
+                <div class="bg-surface-800 border border-border-default rounded-xl p-8 text-center">
+                    <svg class="w-12 h-12 mx-auto text-text-muted mb-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M16.5 10.5V6.75a4.5 4.5 0 1 0-9 0v3.75m-.75 11.25h10.5a2.25 2.25 0 0 0 2.25-2.25v-6.75a2.25 2.25 0 0 0-2.25-2.25H6.75a2.25 2.25 0 0 0-2.25 2.25v6.75a2.25 2.25 0 0 0 2.25 2.25Z"/>
+                    </svg>
+                    <p class="text-text-secondary text-sm">{{ __('transfers.market_closed') }}</p>
+                </div>
+            @elseif($listings->isEmpty())
+                {{-- No listings --}}
+                <div class="bg-surface-800 border border-border-default rounded-xl p-8 text-center">
+                    <svg class="w-12 h-12 mx-auto text-text-muted mb-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M15.75 10.5V6a3.75 3.75 0 1 0-7.5 0v4.5m11.356-1.993 1.263 12c.07.665-.45 1.243-1.119 1.243H4.25a1.125 1.125 0 0 1-1.12-1.243l1.264-12A1.125 1.125 0 0 1 5.513 7.5h12.974c.576 0 1.059.435 1.119 1.007ZM8.625 10.5a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Zm7.5 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Z"/>
+                    </svg>
+                    <p class="text-text-secondary text-sm">{{ __('transfers.market_empty') }}</p>
+                </div>
+            @else
+                {{-- Position filter pills --}}
+                <div class="flex flex-wrap gap-2 mb-4">
+                    @foreach([
+                        'all' => __('transfers.explore_filter_all'),
+                        'gk' => __('squad.goalkeepers'),
+                        'def' => __('squad.defenders'),
+                        'mid' => __('squad.midfielders'),
+                        'fwd' => __('squad.forwards'),
+                    ] as $filterKey => $filterLabel)
+                        <button
+                            @click="posFilter = '{{ $filterKey }}'"
+                            :class="posFilter === '{{ $filterKey }}'
+                                ? 'bg-accent-blue/15 text-accent-blue border-accent-blue/30'
+                                : 'bg-surface-800 text-text-secondary border-border-default hover:bg-surface-700'"
+                            class="px-3 py-1.5 text-xs font-medium rounded-full border transition-colors"
+                        >
+                            {{ $filterLabel }}
+                        </button>
+                    @endforeach
+                </div>
+
+                {{-- Budget info --}}
+                <div class="mb-4 text-xs text-text-secondary">
+                    {{ __('transfers.budget_available') }}: <span class="font-semibold text-text-primary">{{ \App\Support\Money::format($availableBudget) }}</span>
+                </div>
+
+                {{-- Desktop table --}}
+                <div class="hidden md:block overflow-x-auto">
+                    <table class="w-full text-sm">
+                        <thead>
+                            <tr class="border-b border-border-default text-text-muted text-xs uppercase tracking-wider">
+                                <th class="text-left py-3 px-3 font-medium">{{ __('transfers.transfer_activity_player') }}</th>
+                                <th class="text-center py-3 px-2 font-medium">{{ __('transfers.transfer_activity_position') }}</th>
+                                <th class="text-center py-3 px-2 font-medium">{{ __('transfers.transfer_activity_age') }}</th>
+                                <th class="text-center py-3 px-2 font-medium">OVR</th>
+                                <th class="text-right py-3 px-2 font-medium">{{ __('transfers.market_value') }}</th>
+                                <th class="text-right py-3 px-2 font-medium">{{ __('transfers.market_asking_price') }}</th>
+                                <th class="text-left py-3 px-3 font-medium">{{ __('transfers.explore_search_team') }}</th>
+                                <th class="text-right py-3 px-3 font-medium"></th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @foreach($listings as $listing)
+                                @php
+                                    $gp = $listing->gamePlayer;
+                                    $posGroup = strtolower(match($gp->position_group) {
+                                        'Goalkeeper' => 'gk',
+                                        'Defender' => 'def',
+                                        'Midfielder' => 'mid',
+                                        'Forward' => 'fwd',
+                                        default => 'mid',
+                                    });
+                                    $posDisp = $gp->position_display;
+                                    $playerInfo = \Illuminate\Support\Js::from([
+                                        'age' => $gp->age($game->current_date),
+                                        'position' => $posDisp['abbreviation'],
+                                        'positionBg' => $posDisp['bg'],
+                                        'positionText' => $posDisp['text'],
+                                        'marketValue' => $gp->formatted_market_value,
+                                        'contractYear' => $gp->contract_expiry_year,
+                                    ]);
+                                @endphp
+                                <tr x-show="posFilter === 'all' || posFilter === '{{ $posGroup }}'"
+                                    class="border-b border-border-default/50 hover:bg-surface-700/50 transition-colors">
+                                    {{-- Player name --}}
+                                    <td class="py-3 px-3">
+                                        <span class="font-medium text-text-primary">{{ $gp->name }}</span>
+                                    </td>
+
+                                    {{-- Position --}}
+                                    <td class="py-3 px-2 text-center">
+                                        <x-position-badge :position="$gp->position" size="sm" />
+                                    </td>
+
+                                    {{-- Age --}}
+                                    <td class="py-3 px-2 text-center text-text-secondary">{{ $gp->age($game->current_date) }}</td>
+
+                                    {{-- OVR --}}
+                                    <td class="py-3 px-2 text-center">
+                                        <x-rating-badge :value="$gp->overall_score" size="sm" />
+                                    </td>
+
+                                    {{-- Market Value --}}
+                                    <td class="py-3 px-2 text-right text-text-secondary">{{ $gp->formatted_market_value }}</td>
+
+                                    {{-- Asking Price --}}
+                                    <td class="py-3 px-2 text-right font-medium text-text-primary">{{ \App\Support\Money::format($listing->asking_price) }}</td>
+
+                                    {{-- Team --}}
+                                    <td class="py-3 px-3">
+                                        @if($gp->team)
+                                            <div class="flex items-center gap-1.5">
+                                                <x-team-crest :team="$gp->team" class="w-4 h-4 shrink-0" />
+                                                <span class="text-text-secondary truncate">{{ $gp->team->name }}</span>
+                                            </div>
+                                        @endif
+                                    </td>
+
+                                    {{-- Bid button --}}
+                                    <td class="py-3 px-3 text-right">
+                                        @if($availableBudget > 0)
+                                            <x-primary-button size="xs"
+                                                @click="$dispatch('open-negotiation', {
+                                                    playerName: {{ \Illuminate\Support\Js::from($gp->name) }},
+                                                    negotiateUrl: {{ \Illuminate\Support\Js::from(route('game.negotiate.transfer', [$game->id, $gp->id])) }},
+                                                    mode: 'transfer_fee',
+                                                    phase: 'club_fee',
+                                                    chatTitle: {{ \Illuminate\Support\Js::from(__('transfers.chat_transfer_title')) }},
+                                                    playerInfo: {{ $playerInfo }}
+                                                })">
+                                                {{ __('transfers.market_bid') }}
+                                            </x-primary-button>
+                                        @endif
+                                    </td>
+                                </tr>
+                            @endforeach
+                        </tbody>
+                    </table>
+                </div>
+
+                {{-- Mobile cards --}}
+                <div class="md:hidden space-y-3">
+                    @foreach($listings as $listing)
+                        @php
+                            $gp = $listing->gamePlayer;
+                            $posGroup = strtolower(match($gp->position_group) {
+                                'Goalkeeper' => 'gk',
+                                'Defender' => 'def',
+                                'Midfielder' => 'mid',
+                                'Forward' => 'fwd',
+                                default => 'mid',
+                            });
+                            $posDisp = $gp->position_display;
+                            $playerInfo = \Illuminate\Support\Js::from([
+                                'age' => $gp->age($game->current_date),
+                                'position' => $posDisp['abbreviation'],
+                                'positionBg' => $posDisp['bg'],
+                                'positionText' => $posDisp['text'],
+                                'marketValue' => $gp->formatted_market_value,
+                                'contractYear' => $gp->contract_expiry_year,
+                            ]);
+                        @endphp
+                        <div x-show="posFilter === 'all' || posFilter === '{{ $posGroup }}'"
+                             class="bg-surface-800 border border-border-default rounded-xl p-4">
+                            <div class="flex items-center justify-between mb-3">
+                                <div class="flex items-center gap-2 min-w-0">
+                                    <x-position-badge :position="$gp->position" size="sm" />
+                                    <span class="font-medium text-text-primary truncate">{{ $gp->name }}</span>
+                                </div>
+                                <x-rating-badge :value="$gp->overall_score" size="sm" />
+                            </div>
+
+                            <div class="grid grid-cols-2 gap-x-4 gap-y-1 text-xs mb-3">
+                                <div class="flex justify-between">
+                                    <span class="text-text-muted">{{ __('transfers.transfer_activity_age') }}</span>
+                                    <span class="text-text-secondary">{{ $gp->age($game->current_date) }}</span>
+                                </div>
+                                <div class="flex justify-between">
+                                    <span class="text-text-muted">{{ __('transfers.explore_search_team') }}</span>
+                                    <span class="text-text-secondary truncate ml-1">{{ $gp->team?->name }}</span>
+                                </div>
+                                <div class="flex justify-between">
+                                    <span class="text-text-muted">{{ __('transfers.market_value') }}</span>
+                                    <span class="text-text-secondary">{{ $gp->formatted_market_value }}</span>
+                                </div>
+                                <div class="flex justify-between">
+                                    <span class="text-text-muted">{{ __('transfers.market_asking_price') }}</span>
+                                    <span class="font-medium text-text-primary">{{ \App\Support\Money::format($listing->asking_price) }}</span>
+                                </div>
+                            </div>
+
+                            @if($availableBudget > 0)
+                                <x-primary-button size="xs" class="w-full justify-center"
+                                    @click="$dispatch('open-negotiation', {
+                                        playerName: {{ \Illuminate\Support\Js::from($gp->name) }},
+                                        negotiateUrl: {{ \Illuminate\Support\Js::from(route('game.negotiate.transfer', [$game->id, $gp->id])) }},
+                                        mode: 'transfer_fee',
+                                        phase: 'club_fee',
+                                        chatTitle: {{ \Illuminate\Support\Js::from(__('transfers.chat_transfer_title')) }},
+                                        playerInfo: {{ $playerInfo }}
+                                    })">
+                                    {{ __('transfers.market_bid') }}
+                                </x-primary-button>
+                            @endif
+                        </div>
+                    @endforeach
+                </div>
+            @endif
+        </div>
+    </div>
+
+    <x-negotiation-chat-modal />
+</x-app-layout>

--- a/resources/views/transfer-market.blade.php
+++ b/resources/views/transfer-market.blade.php
@@ -27,14 +27,16 @@
 
         <div class="mt-6">
             @if(!$isTransferWindow)
-                {{-- Window closed state --}}
-                <div class="bg-surface-800 border border-border-default rounded-xl p-8 text-center">
-                    <svg class="w-12 h-12 mx-auto text-text-muted mb-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M16.5 10.5V6.75a4.5 4.5 0 1 0-9 0v3.75m-.75 11.25h10.5a2.25 2.25 0 0 0 2.25-2.25v-6.75a2.25 2.25 0 0 0-2.25-2.25H6.75a2.25 2.25 0 0 0-2.25 2.25v6.75a2.25 2.25 0 0 0 2.25 2.25Z"/>
+                {{-- Window closed banner — listings remain browseable; agreed bids complete on next window open --}}
+                <div class="mb-4 flex items-center gap-3 px-4 py-3 bg-accent-blue/10 border border-accent-blue/20 rounded-lg text-sm text-accent-blue">
+                    <svg class="w-5 h-5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
                     </svg>
-                    <p class="text-text-secondary text-sm">{{ __('transfers.market_closed') }}</p>
+                    <span>{{ __('transfers.market_window_closed_notice') }}</span>
                 </div>
-            @elseif($listings->isEmpty())
+            @endif
+
+            @if($listings->isEmpty())
                 {{-- No listings --}}
                 <div class="bg-surface-800 border border-border-default rounded-xl p-8 text-center">
                     <svg class="w-12 h-12 mx-auto text-text-muted mb-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/resources/views/transfer-market.blade.php
+++ b/resources/views/transfer-market.blade.php
@@ -50,7 +50,7 @@
                                 <th class="py-2.5 pl-4 w-12"></th>
                                 <th class="py-2.5 text-[10px] text-text-muted uppercase tracking-wider"></th>
                                 <th class="py-2.5 text-[10px] text-text-muted uppercase tracking-wider text-center hidden md:table-cell">{{ __('transfers.explore_age') }}</th>
-                                <th class="py-2.5 text-[10px] text-text-muted uppercase tracking-wider text-center hidden md:table-cell">OVR</th>
+                                <th class="py-2.5 text-[10px] text-text-muted uppercase tracking-wider text-center hidden md:table-cell">{{ __('transfers.explore_rating') }}</th>
                                 <th class="py-2.5 text-[10px] text-text-muted uppercase tracking-wider hidden md:table-cell">{{ __('transfers.explore_value') }}</th>
                                 <th class="py-2.5 text-[10px] text-text-muted uppercase tracking-wider text-right hidden md:table-cell">{{ __('transfers.market_asking_price') }}</th>
                                 <th class="py-2.5 w-10"></th>

--- a/routes/web.php
+++ b/routes/web.php
@@ -108,6 +108,7 @@ use App\Http\Views\ShowPlayerDetail;
 use App\Http\Views\ShowSquad;
 use App\Http\Views\ShowTransferActivity;
 use App\Http\Views\ShowOutgoingTransfers;
+use App\Http\Views\ShowTransferMarket;
 use App\Http\Views\ShowLeaderboard;
 use App\Http\Views\ShowManagerProfile;
 use App\Http\Views\ShowTeamLeaderboard;
@@ -162,6 +163,7 @@ Route::middleware('auth')->group(function () {
         Route::get('/game/{gameId}/finances', ShowFinances::class)->name('game.finances');
         Route::get('/game/{gameId}/transfers', ShowIncomingTransfers::class)->name('game.transfers');
         Route::get('/game/{gameId}/transfers/outgoing', ShowOutgoingTransfers::class)->name('game.transfers.outgoing');
+        Route::get('/game/{gameId}/transfers/market', ShowTransferMarket::class)->name('game.transfers.market');
         Route::get('/game/{gameId}/transfer-activity', ShowTransferActivity::class)->name('game.transfer-activity');
         Route::get('/game/{gameId}/calendar', ShowCalendar::class)->name('game.calendar');
         Route::get('/game/{gameId}/competition/{competitionId}', ShowCompetition::class)->name('game.competition');

--- a/tests/Feature/PreContractBalanceTest.php
+++ b/tests/Feature/PreContractBalanceTest.php
@@ -277,7 +277,7 @@ class PreContractBalanceTest extends TestCase
         );
 
         // Low bid — should be rejected on price, not reputation
-        $askingPrice = $this->scoutingService->calculateAskingPrice($player);
+        $askingPrice = $this->scoutingService->calculateAskingPrice($player, $game->current_date);
         $bidAmount = (int) ($askingPrice * 0.5);
 
         $result = $this->scoutingService->evaluateBid($player, $bidAmount, $game);
@@ -294,7 +294,7 @@ class PreContractBalanceTest extends TestCase
         );
 
         // Offer above asking price — reputation gate should NOT apply
-        $askingPrice = $this->scoutingService->calculateAskingPrice($player);
+        $askingPrice = $this->scoutingService->calculateAskingPrice($player, $game->current_date);
         $bidAmount = (int) ($askingPrice * 1.5);
 
         for ($i = 0; $i < 50; $i++) {


### PR DESCRIPTION
Adds a browsable "Market" tab under Transfers where AI teams list players for sale. Users can browse listings and bid directly via the existing negotiation flow, without needing to scout first.

- TransferMarketService: generates AI listings each matchday using the same scoring logic as AITransferMarketService (clearing + upgrade candidates), calculates asking prices via ScoutingService, expires stale listings after 30 days, caps at 50 active listings, clears all on window close
- ShowTransferMarket view + transfer-market.blade.php: responsive desktop table + mobile cards, position filter pills (Alpine.js), bid button dispatches open-negotiation event to existing negotiation modal
- Hooked into CareerActionProcessor (refreshListings each matchday) and ProcessTransferWindowClose listener (clearListings on close)
- Market tab added to section-nav on all 4 existing transfer pages + bottom tab bar active state
- Translations added (en + es): market_tab, market_closed, market_empty, market_bid, market_asking_price

https://claude.ai/code/session_01FQXacU2TfB2M6Eyv61RBi5