### PR TITLE
Remove legacy suspended_until_matchday column from game_players

### DIFF
--- a/app/Models/GamePlayer.php
+++ b/app/Models/GamePlayer.php
@@ -28,7 +28,6 @@ use Illuminate\Database\Eloquent\Relations\HasOne;
  * @property int $morale
  * @property \Illuminate\Support\Carbon|null $injury_until
  * @property string|null $injury_type
- * @property int|null $suspended_until_matchday
  * @property int $appearances
  * @property int $goals
  * @property int $own_goals
@@ -115,7 +114,6 @@ use Illuminate\Database\Eloquent\Relations\HasOne;
  * @method static \Illuminate\Database\Eloquent\Builder<static>|GamePlayer whereRedCards($value)
  * @method static \Illuminate\Database\Eloquent\Builder<static>|GamePlayer whereRetiringAtSeason($value)
  * @method static \Illuminate\Database\Eloquent\Builder<static>|GamePlayer whereSeasonAppearances($value)
- * @method static \Illuminate\Database\Eloquent\Builder<static>|GamePlayer whereSuspendedUntilMatchday($value)
  * @method static \Illuminate\Database\Eloquent\Builder<static>|GamePlayer whereTeamId($value)
  * @method static \Illuminate\Database\Eloquent\Builder<static>|GamePlayer whereTransferListedAt($value)
  * @method static \Illuminate\Database\Eloquent\Builder<static>|GamePlayer whereTransferStatus($value)
@@ -145,7 +143,6 @@ class GamePlayer extends Model
         'durability',
         'injury_until',
         'injury_type',
-        'suspended_until_matchday',
         'appearances',
         'goals',
         'own_goals',
@@ -176,7 +173,6 @@ class GamePlayer extends Model
         'morale' => 'integer',
         'durability' => 'integer',
         'injury_until' => 'date',
-        'suspended_until_matchday' => 'integer',
         'appearances' => 'integer',
         'goals' => 'integer',
         'own_goals' => 'integer',

--- a/app/Modules/Season/Processors/StatsResetProcessor.php
+++ b/app/Modules/Season/Processors/StatsResetProcessor.php
@@ -38,7 +38,6 @@ class StatsResetProcessor implements SeasonProcessor
             'goals_conceded' => 0,
             'clean_sheets' => 0,
             'season_appearances' => 0,
-            'suspended_until_matchday' => null,
             'injury_until' => null,
             'injury_type' => null,
             'fitness' => 80,

--- a/database/migrations/2026_04_05_061424_drop_suspended_until_matchday_from_game_players.php
+++ b/database/migrations/2026_04_05_061424_drop_suspended_until_matchday_from_game_players.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('game_players', function (Blueprint $table) {
+            $table->dropColumn('suspended_until_matchday');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('game_players', function (Blueprint $table) {
+            $table->unsignedInteger('suspended_until_matchday')->nullable();
+        });
+    }
+};


### PR DESCRIPTION
This column was superseded by the player_suspensions table which handles
per-competition suspension tracking. The old column was never read by any
business logic — only nulled during season reset.

https://claude.ai/code/session_01SodTdUHNhTsQesHhDhrgfo