### PR TITLE
Extract TacticalConfig DTO, MatchEventRepository, and isNeutralVenue to eliminate duplication

### DIFF
--- a/app/Http/Views/ShowLineup.php
+++ b/app/Http/Views/ShowLineup.php
@@ -230,7 +230,7 @@ class ShowLineup
         $xgConfig = [
             'base_goals' => config('match_simulation.base_goals', 1.3),
             'skill_dominance' => config('match_simulation.skill_dominance', 2.0),
-            'home_advantage_goals' => $match->competition_id === 'WC2026'
+            'home_advantage_goals' => $match->isNeutralVenue()
                 ? 0.0
                 : config('match_simulation.home_advantage_goals', 0.15),
             'mentalities' => config('match_simulation.mentalities'),

--- a/app/Models/GameMatch.php
+++ b/app/Models/GameMatch.php
@@ -217,6 +217,11 @@ class GameMatch extends Model
         return $this->events()->whereIn('event_type', ['yellow_card', 'red_card']);
     }
 
+    public function isNeutralVenue(): bool
+    {
+        return $this->competition_id === 'WC2026';
+    }
+
     public function involvesTeam(string $teamId): bool
     {
         return $this->home_team_id === $teamId || $this->away_team_id === $teamId;

--- a/app/Modules/Match/DTOs/TacticalConfig.php
+++ b/app/Modules/Match/DTOs/TacticalConfig.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Modules\Match\DTOs;
+
+use App\Models\GameMatch;
+use App\Modules\Lineup\Enums\DefensiveLineHeight;
+use App\Modules\Lineup\Enums\Formation;
+use App\Modules\Lineup\Enums\Mentality;
+use App\Modules\Lineup\Enums\PlayingStyle;
+use App\Modules\Lineup\Enums\PressingIntensity;
+
+readonly class TacticalConfig
+{
+    public function __construct(
+        public Formation $homeFormation,
+        public Formation $awayFormation,
+        public Mentality $homeMentality,
+        public Mentality $awayMentality,
+        public PlayingStyle $homePlayingStyle,
+        public PlayingStyle $awayPlayingStyle,
+        public PressingIntensity $homePressing,
+        public PressingIntensity $awayPressing,
+        public DefensiveLineHeight $homeDefLine,
+        public DefensiveLineHeight $awayDefLine,
+    ) {}
+
+    public static function fromMatch(GameMatch $match): self
+    {
+        return new self(
+            homeFormation: Formation::tryFrom($match->home_formation) ?? Formation::F_4_3_3,
+            awayFormation: Formation::tryFrom($match->away_formation) ?? Formation::F_4_3_3,
+            homeMentality: Mentality::tryFrom($match->home_mentality ?? '') ?? Mentality::BALANCED,
+            awayMentality: Mentality::tryFrom($match->away_mentality ?? '') ?? Mentality::BALANCED,
+            homePlayingStyle: PlayingStyle::tryFrom($match->home_playing_style ?? '') ?? PlayingStyle::BALANCED,
+            awayPlayingStyle: PlayingStyle::tryFrom($match->away_playing_style ?? '') ?? PlayingStyle::BALANCED,
+            homePressing: PressingIntensity::tryFrom($match->home_pressing ?? '') ?? PressingIntensity::STANDARD,
+            awayPressing: PressingIntensity::tryFrom($match->away_pressing ?? '') ?? PressingIntensity::STANDARD,
+            homeDefLine: DefensiveLineHeight::tryFrom($match->home_defensive_line ?? '') ?? DefensiveLineHeight::NORMAL,
+            awayDefLine: DefensiveLineHeight::tryFrom($match->away_defensive_line ?? '') ?? DefensiveLineHeight::NORMAL,
+        );
+    }
+
+    public function neutralized(): self
+    {
+        return new self(
+            homeFormation: $this->homeFormation,
+            awayFormation: $this->awayFormation,
+            homeMentality: $this->homeMentality,
+            awayMentality: $this->awayMentality,
+            homePlayingStyle: PlayingStyle::BALANCED,
+            awayPlayingStyle: PlayingStyle::BALANCED,
+            homePressing: PressingIntensity::STANDARD,
+            awayPressing: PressingIntensity::STANDARD,
+            homeDefLine: DefensiveLineHeight::NORMAL,
+            awayDefLine: DefensiveLineHeight::NORMAL,
+        );
+    }
+}

--- a/app/Modules/Match/Services/AIMatchResolver.php
+++ b/app/Modules/Match/Services/AIMatchResolver.php
@@ -131,7 +131,7 @@ class AIMatchResolver
         $awayStrength = $this->calculateTeamStrength($awayXI);
 
         // Generate scoreline
-        $neutralVenue = $match->competition_id === 'WC2026';
+        $neutralVenue = $match->isNeutralVenue();
         [$homeXG, $awayXG] = $this->calculateExpectedGoals($homeStrength, $awayStrength, $neutralVenue);
         [$homeScore, $awayScore] = $this->dixonColesRandom($homeXG, $awayXG);
 

--- a/app/Modules/Match/Services/CupTieResolver.php
+++ b/app/Modules/Match/Services/CupTieResolver.php
@@ -74,7 +74,7 @@ class CupTieResolver
                 $awayTeam,
                 $homePlayers,
                 $awayPlayers,
-                neutralVenue: $match->competition_id === 'WC2026',
+                neutralVenue: $match->isNeutralVenue(),
             );
 
             $homeScoreEt = $extraTimeResult->homeScore;
@@ -169,7 +169,7 @@ class CupTieResolver
                 $awayTeam,
                 $homePlayers,
                 $awayPlayers,
-                neutralVenue: $secondLeg->competition_id === 'WC2026',
+                neutralVenue: $secondLeg->isNeutralVenue(),
             );
 
             $homeScoreEt = $extraTimeResult->homeScore;

--- a/app/Modules/Match/Services/ExtraTimeAndPenaltyService.php
+++ b/app/Modules/Match/Services/ExtraTimeAndPenaltyService.php
@@ -8,17 +8,15 @@ use App\Models\GameMatch;
 use App\Models\GamePlayer;
 use App\Models\MatchEvent;
 use App\Modules\Match\DTOs\ExtraTimeProcessResult;
-use App\Modules\Match\DTOs\MatchEventData;
 use App\Modules\Match\DTOs\PenaltyProcessResult;
-use App\Modules\Lineup\Enums\Formation;
-use App\Modules\Lineup\Enums\Mentality;
+use App\Modules\Match\DTOs\TacticalConfig;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Str;
 
 class ExtraTimeAndPenaltyService
 {
     public function __construct(
         private readonly MatchSimulator $matchSimulator,
+        private readonly MatchEventRepository $matchEventRepository,
     ) {}
 
     /**
@@ -41,11 +39,7 @@ class ExtraTimeAndPenaltyService
             }
         }
 
-        // Read formation/mentality from match record
-        $homeFormation = Formation::tryFrom($match->home_formation) ?? Formation::F_4_3_3;
-        $awayFormation = Formation::tryFrom($match->away_formation) ?? Formation::F_4_3_3;
-        $homeMentality = Mentality::tryFrom($match->home_mentality ?? '') ?? Mentality::BALANCED;
-        $awayMentality = Mentality::tryFrom($match->away_mentality ?? '') ?? Mentality::BALANCED;
+        $tc = TacticalConfig::fromMatch($match);
 
         $extraTimeResult = $this->matchSimulator->simulateExtraTime(
             $match->homeTeam,
@@ -54,11 +48,17 @@ class ExtraTimeAndPenaltyService
             $awayPlayers,
             $homeEntryMinutes,
             $awayEntryMinutes,
-            homeFormation: $homeFormation,
-            awayFormation: $awayFormation,
-            homeMentality: $homeMentality,
-            awayMentality: $awayMentality,
-            neutralVenue: $match->competition_id === 'WC2026',
+            homeFormation: $tc->homeFormation,
+            awayFormation: $tc->awayFormation,
+            homeMentality: $tc->homeMentality,
+            awayMentality: $tc->awayMentality,
+            homePlayingStyle: $tc->homePlayingStyle,
+            awayPlayingStyle: $tc->awayPlayingStyle,
+            homePressing: $tc->homePressing,
+            awayPressing: $tc->awayPressing,
+            homeDefLine: $tc->homeDefLine,
+            awayDefLine: $tc->awayDefLine,
+            neutralVenue: $match->isNeutralVenue(),
         );
 
         $match->update([
@@ -184,27 +184,11 @@ class ExtraTimeAndPenaltyService
      */
     private function storeExtraTimeEvents(GameMatch $match, Game $game, Collection $events): Collection
     {
-        $now = now();
+        $ids = $this->matchEventRepository->bulkInsert($events, $game->id, $match->id);
 
-        $rows = $events->map(fn (MatchEventData $e) => [
-            'id' => Str::uuid()->toString(),
-            'game_id' => $game->id,
-            'game_match_id' => $match->id,
-            'game_player_id' => $e->gamePlayerId,
-            'team_id' => $e->teamId,
-            'minute' => $e->minute,
-            'event_type' => $e->type,
-            'metadata' => $e->metadata ? json_encode($e->metadata) : null,
-            'created_at' => $now,
-        ])->all();
-
-        if (empty($rows)) {
+        if (empty($ids)) {
             return collect();
         }
-
-        MatchEvent::insert($rows);
-
-        $ids = array_column($rows, 'id');
 
         return MatchEvent::with('gamePlayer.player')
             ->whereIn('id', $ids)

--- a/app/Modules/Match/Services/FullMatchSimulationService.php
+++ b/app/Modules/Match/Services/FullMatchSimulationService.php
@@ -5,14 +5,10 @@ namespace App\Modules\Match\Services;
 use App\Models\Game;
 use App\Models\GameMatch;
 use App\Models\TeamReputation;
-use App\Modules\Lineup\Enums\DefensiveLineHeight;
-use App\Modules\Lineup\Enums\Formation;
-use App\Modules\Lineup\Enums\Mentality;
-use App\Modules\Lineup\Enums\PlayingStyle;
-use App\Modules\Lineup\Enums\PressingIntensity;
 use App\Modules\Lineup\Services\LineupService;
 use App\Modules\Match\DTOs\MatchEventData;
 use App\Modules\Match\DTOs\MatchResult;
+use App\Modules\Match\DTOs\TacticalConfig;
 use App\Modules\Notification\Services\NotificationService;
 use Illuminate\Support\Collection;
 
@@ -120,28 +116,9 @@ class FullMatchSimulationService
         $homeBenchPlayers = $isUserHome ? null : $this->getBenchPlayers($match, $allPlayers, 'home', $game);
         $awayBenchPlayers = ($isUserMatch && ! $isUserHome) ? null : $this->getBenchPlayers($match, $allPlayers, 'away', $game);
 
-        $homeFormation = Formation::tryFrom($match->home_formation) ?? Formation::F_4_3_3;
-        $awayFormation = Formation::tryFrom($match->away_formation) ?? Formation::F_4_3_3;
-        $homeMentality = Mentality::tryFrom($match->home_mentality ?? '') ?? Mentality::BALANCED;
-        $awayMentality = Mentality::tryFrom($match->away_mentality ?? '') ?? Mentality::BALANCED;
-
-        $homePlayingStyle = PlayingStyle::tryFrom($match->home_playing_style ?? '') ?? PlayingStyle::BALANCED;
-        $awayPlayingStyle = PlayingStyle::tryFrom($match->away_playing_style ?? '') ?? PlayingStyle::BALANCED;
-        $homePressing = PressingIntensity::tryFrom($match->home_pressing ?? '') ?? PressingIntensity::STANDARD;
-        $awayPressing = PressingIntensity::tryFrom($match->away_pressing ?? '') ?? PressingIntensity::STANDARD;
-        $homeDefLine = DefensiveLineHeight::tryFrom($match->home_defensive_line ?? '') ?? DefensiveLineHeight::NORMAL;
-        $awayDefLine = DefensiveLineHeight::tryFrom($match->away_defensive_line ?? '') ?? DefensiveLineHeight::NORMAL;
-
-        // Neutralize tactical instructions for AI-vs-AI matches — these only
-        // add meaningful complexity for user-involved matches. Formation and
-        // mentality still apply to differentiate AI teams.
+        $tc = TacticalConfig::fromMatch($match);
         if (! $isUserMatch) {
-            $homePlayingStyle = PlayingStyle::BALANCED;
-            $awayPlayingStyle = PlayingStyle::BALANCED;
-            $homePressing = PressingIntensity::STANDARD;
-            $awayPressing = PressingIntensity::STANDARD;
-            $homeDefLine = DefensiveLineHeight::NORMAL;
-            $awayDefLine = DefensiveLineHeight::NORMAL;
+            $tc = $tc->neutralized();
         }
 
         $output = $this->matchSimulator->simulate(
@@ -149,21 +126,21 @@ class FullMatchSimulationService
             $match->awayTeam,
             $homePlayers,
             $awayPlayers,
-            $homeFormation,
-            $awayFormation,
-            $homeMentality,
-            $awayMentality,
+            $tc->homeFormation,
+            $tc->awayFormation,
+            $tc->homeMentality,
+            $tc->awayMentality,
             $game,
-            $homePlayingStyle,
-            $awayPlayingStyle,
-            $homePressing,
-            $awayPressing,
-            $homeDefLine,
-            $awayDefLine,
+            $tc->homePlayingStyle,
+            $tc->awayPlayingStyle,
+            $tc->homePressing,
+            $tc->awayPressing,
+            $tc->homeDefLine,
+            $tc->awayDefLine,
             $homeBenchPlayers,
             $awayBenchPlayers,
             matchSeed: $match->id,
-            neutralVenue: $match->competition_id === 'WC2026',
+            neutralVenue: $match->isNeutralVenue(),
         );
 
         $result = $output->result;

--- a/app/Modules/Match/Services/MatchEventRepository.php
+++ b/app/Modules/Match/Services/MatchEventRepository.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Modules\Match\Services;
+
+use App\Models\MatchEvent;
+use App\Modules\Match\DTOs\MatchEventData;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
+
+class MatchEventRepository
+{
+    /**
+     * Map MatchEventData objects to database rows and bulk insert.
+     *
+     * @param  Collection<MatchEventData>  $events
+     * @return array<string>  Inserted row IDs
+     */
+    public function bulkInsert(Collection $events, string $gameId, string $matchId, int $chunkSize = 50): array
+    {
+        $now = now();
+
+        $rows = $events->map(fn (MatchEventData $e) => [
+            'id' => Str::uuid()->toString(),
+            'game_id' => $gameId,
+            'game_match_id' => $matchId,
+            'game_player_id' => $e->gamePlayerId,
+            'team_id' => $e->teamId,
+            'minute' => $e->minute,
+            'event_type' => $e->type,
+            'metadata' => $e->metadata ? json_encode($e->metadata) : null,
+            'created_at' => $now,
+        ])->all();
+
+        foreach (array_chunk($rows, $chunkSize) as $chunk) {
+            MatchEvent::insert($chunk);
+        }
+
+        return array_column($rows, 'id');
+    }
+}

--- a/app/Modules/Match/Services/MatchResimulationService.php
+++ b/app/Modules/Match/Services/MatchResimulationService.php
@@ -5,11 +5,7 @@ namespace App\Modules\Match\Services;
 use App\Modules\Match\DTOs\MatchEventData;
 use App\Modules\Match\DTOs\MatchResult;
 use App\Modules\Match\DTOs\ResimulationResult;
-use App\Modules\Lineup\Enums\DefensiveLineHeight;
-use App\Modules\Lineup\Enums\Formation;
-use App\Modules\Lineup\Enums\Mentality;
-use App\Modules\Lineup\Enums\PlayingStyle;
-use App\Modules\Lineup\Enums\PressingIntensity;
+use App\Modules\Match\DTOs\TacticalConfig;
 use App\Models\Game;
 use App\Models\GameMatch;
 use App\Models\GamePlayer;
@@ -18,7 +14,6 @@ use App\Models\PlayerSuspension;
 use Carbon\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Str;
 use App\Modules\Squad\Services\EligibilityService;
 
 class MatchResimulationService
@@ -26,6 +21,7 @@ class MatchResimulationService
     public function __construct(
         private readonly MatchSimulator $matchSimulator,
         private readonly EligibilityService $eligibilityService,
+        private readonly MatchEventRepository $matchEventRepository,
     ) {}
 
     /**
@@ -72,17 +68,7 @@ class MatchResimulationService
         $scoreAtMinute = $this->calculateScoreAtMinute($match);
 
         // 4. Read formation/mentality/instructions from match record (already updated by caller)
-        $homeFormation = Formation::tryFrom($match->home_formation) ?? Formation::F_4_3_3;
-        $awayFormation = Formation::tryFrom($match->away_formation) ?? Formation::F_4_3_3;
-        $homeMentality = Mentality::tryFrom($match->home_mentality ?? '') ?? Mentality::BALANCED;
-        $awayMentality = Mentality::tryFrom($match->away_mentality ?? '') ?? Mentality::BALANCED;
-
-        $homePlayingStyle = PlayingStyle::tryFrom($match->home_playing_style ?? '') ?? PlayingStyle::BALANCED;
-        $awayPlayingStyle = PlayingStyle::tryFrom($match->away_playing_style ?? '') ?? PlayingStyle::BALANCED;
-        $homePressing = PressingIntensity::tryFrom($match->home_pressing ?? '') ?? PressingIntensity::STANDARD;
-        $awayPressing = PressingIntensity::tryFrom($match->away_pressing ?? '') ?? PressingIntensity::STANDARD;
-        $homeDefLine = DefensiveLineHeight::tryFrom($match->home_defensive_line ?? '') ?? DefensiveLineHeight::NORMAL;
-        $awayDefLine = DefensiveLineHeight::tryFrom($match->away_defensive_line ?? '') ?? DefensiveLineHeight::NORMAL;
+        $tc = TacticalConfig::fromMatch($match);
 
         // 5. Exclude red-carded and substituted-out players
         $unavailablePlayerIds = MatchEvent::where('game_match_id', $match->id)
@@ -167,22 +153,22 @@ class MatchResimulationService
                 $match->awayTeam,
                 $homePlayers,
                 $awayPlayers,
-                $homeFormation,
-                $awayFormation,
-                $homeMentality,
-                $awayMentality,
+                $tc->homeFormation,
+                $tc->awayFormation,
+                $tc->homeMentality,
+                $tc->awayMentality,
                 $minute,
                 $game,
                 $existingInjuryTeamIds,
                 $existingYellowPlayerIds,
                 $homeEntryMinutes,
                 $awayEntryMinutes,
-                $homePlayingStyle,
-                $awayPlayingStyle,
-                $homePressing,
-                $awayPressing,
-                $homeDefLine,
-                $awayDefLine,
+                $tc->homePlayingStyle,
+                $tc->awayPlayingStyle,
+                $tc->homePressing,
+                $tc->awayPressing,
+                $tc->homeDefLine,
+                $tc->awayDefLine,
                 $homeBenchPlayers,
                 $awayBenchPlayers,
                 homeExistingSubstitutions: $homeExistingSubs,
@@ -199,27 +185,27 @@ class MatchResimulationService
                 $match->awayTeam,
                 $homePlayers,
                 $awayPlayers,
-                $homeFormation,
-                $awayFormation,
-                $homeMentality,
-                $awayMentality,
+                $tc->homeFormation,
+                $tc->awayFormation,
+                $tc->homeMentality,
+                $tc->awayMentality,
                 $minute,
                 $game,
                 $existingInjuryTeamIds,
                 $existingYellowPlayerIds,
                 $homeEntryMinutes,
                 $awayEntryMinutes,
-                $homePlayingStyle,
-                $awayPlayingStyle,
-                $homePressing,
-                $awayPressing,
-                $homeDefLine,
-                $awayDefLine,
+                $tc->homePlayingStyle,
+                $tc->awayPlayingStyle,
+                $tc->homePressing,
+                $tc->awayPressing,
+                $tc->homeDefLine,
+                $tc->awayDefLine,
                 $homeBenchPlayers,
                 $awayBenchPlayers,
                 homeExistingSubstitutions: $homeExistingSubs,
                 awayExistingSubstitutions: $awayExistingSubs,
-                neutralVenue: $match->competition_id === 'WC2026',
+                neutralVenue: $match->isNeutralVenue(),
             );
         }
 
@@ -277,17 +263,7 @@ class MatchResimulationService
             $scoreAtMinute = $this->calculateScoreAtMinute($match, 90);
 
             // 4. Read formation/mentality/instructions from match record
-            $homeFormation = Formation::tryFrom($match->home_formation) ?? Formation::F_4_3_3;
-            $awayFormation = Formation::tryFrom($match->away_formation) ?? Formation::F_4_3_3;
-            $homeMentality = Mentality::tryFrom($match->home_mentality ?? '') ?? Mentality::BALANCED;
-            $awayMentality = Mentality::tryFrom($match->away_mentality ?? '') ?? Mentality::BALANCED;
-
-            $homePlayingStyle = PlayingStyle::tryFrom($match->home_playing_style ?? '') ?? PlayingStyle::BALANCED;
-            $awayPlayingStyle = PlayingStyle::tryFrom($match->away_playing_style ?? '') ?? PlayingStyle::BALANCED;
-            $homePressing = PressingIntensity::tryFrom($match->home_pressing ?? '') ?? PressingIntensity::STANDARD;
-            $awayPressing = PressingIntensity::tryFrom($match->away_pressing ?? '') ?? PressingIntensity::STANDARD;
-            $homeDefLine = DefensiveLineHeight::tryFrom($match->home_defensive_line ?? '') ?? DefensiveLineHeight::NORMAL;
-            $awayDefLine = DefensiveLineHeight::tryFrom($match->away_defensive_line ?? '') ?? DefensiveLineHeight::NORMAL;
+            $tc = TacticalConfig::fromMatch($match);
 
             // 5. Exclude red-carded and substituted-out players
             $unavailablePlayerIds = MatchEvent::where('game_match_id', $match->id)
@@ -320,17 +296,17 @@ class MatchResimulationService
                 $homeEntryMinutes,
                 $awayEntryMinutes,
                 fromMinute: $minute,
-                homeFormation: $homeFormation,
-                awayFormation: $awayFormation,
-                homeMentality: $homeMentality,
-                awayMentality: $awayMentality,
-                homePlayingStyle: $homePlayingStyle,
-                awayPlayingStyle: $awayPlayingStyle,
-                homePressing: $homePressing,
-                awayPressing: $awayPressing,
-                homeDefLine: $homeDefLine,
-                awayDefLine: $awayDefLine,
-                neutralVenue: $match->competition_id === 'WC2026',
+                homeFormation: $tc->homeFormation,
+                awayFormation: $tc->awayFormation,
+                homeMentality: $tc->homeMentality,
+                awayMentality: $tc->awayMentality,
+                homePlayingStyle: $tc->homePlayingStyle,
+                awayPlayingStyle: $tc->awayPlayingStyle,
+                homePressing: $tc->homePressing,
+                awayPressing: $tc->awayPressing,
+                homeDefLine: $tc->homeDefLine,
+                awayDefLine: $tc->awayDefLine,
+                neutralVenue: $match->isNeutralVenue(),
             );
 
             // 8. Calculate new ET score
@@ -536,27 +512,11 @@ class MatchResimulationService
      */
     private function applyNewEvents(GameMatch $match, Game $game, MatchResult $result, string $competitionId): void
     {
-        $now = now();
         $events = $result->events;
         $competition = \App\Models\Competition::find($competitionId);
         $handlerType = $competition->handler_type ?? 'league';
 
-        // Bulk insert match events
-        $rows = $events->map(fn (MatchEventData $e) => [
-            'id' => Str::uuid()->toString(),
-            'game_id' => $game->id,
-            'game_match_id' => $match->id,
-            'game_player_id' => $e->gamePlayerId,
-            'team_id' => $e->teamId,
-            'minute' => $e->minute,
-            'event_type' => $e->type,
-            'metadata' => $e->metadata ? json_encode($e->metadata) : null,
-            'created_at' => $now,
-        ])->all();
-
-        foreach (array_chunk($rows, 50) as $chunk) {
-            MatchEvent::insert($chunk);
-        }
+        $this->matchEventRepository->bulkInsert($events, $game->id, $match->id);
 
         // Update player stats
         $statIncrements = [];


### PR DESCRIPTION
Reduces code duplication across FullMatchSimulationService, MatchResimulationService, and ExtraTimeAndPenaltyService by extracting three shared abstractions:

- TacticalConfig DTO: centralizes the 10-line tactical config reading block (formation, mentality, playing style, pressing, defensive line) that was duplicated in 4 places. Includes neutralized() for AI-vs-AI instruction simplification.
- MatchEventRepository: extracts the identical MatchEventData-to-row mapping and bulk insert logic shared between MatchResimulationService and ExtraTimeAndPenaltyService.
- GameMatch::isNeutralVenue(): replaces 6 scattered competition_id === 'WC2026' checks.

Also fixes a bug where ExtraTimeAndPenaltyService::processExtraTime() silently ignored the user's playing style, pressing intensity, and defensive line settings during extra time (only formation and mentality were being passed to the simulator).