### PR TITLE
Fix live match results tab always showing 0-0

### DIFF
--- a/app/Modules/Match/Services/MatchdayOrchestrator.php
+++ b/app/Modules/Match/Services/MatchdayOrchestrator.php
@@ -71,8 +71,8 @@ class MatchdayOrchestrator
                     fn ($m) => $m->involvesTeam($game->team_id)
                 );
 
-                // When the player's match is in the batch, only simulate their match
-                // — sibling AI matches are deferred to background processing
+                // When the player's match is in the batch, simulate it fully
+                // — sibling AI matches are resolved via fast AI resolver
                 $result = $this->processBatch($game, $batch, $batchHasPlayerMatch);
 
                 if ($result['playerMatch']) {

--- a/app/Modules/Match/Services/MatchdayOrchestrator.php
+++ b/app/Modules/Match/Services/MatchdayOrchestrator.php
@@ -136,13 +136,7 @@ class MatchdayOrchestrator
         $matchday = $batch['matchday'];
         $currentDate = $batch['currentDate'];
 
-        // When playerMatchOnly is true, filter batch to only the player's match
-        // (sibling AI matches in the same batch are deferred to background processing)
         $playerMatch = $matches->first(fn ($m) => $m->involvesTeam($game->team_id));
-        if ($playerMatchOnly && $playerMatch) {
-            $matches = collect([$playerMatch]);
-            $handlers = array_intersect_key($handlers, [$playerMatch->competition_id => true]);
-        }
 
         // Determine if this is a pure AI-only batch eligible for fast resolution
         $isAIOnlyBatch = ! $playerMatch && config('match_simulation.ai_resolver_enabled', false);
@@ -197,15 +191,27 @@ class MatchdayOrchestrator
             ->map(fn ($group) => $group->pluck('game_player_id')->toArray())
             ->toArray();
 
-        if ($isAIOnlyBatch) {
+        if ($playerMatchOnly && $playerMatch) {
+            // --- Mixed batch: full simulation for player, fast AI for siblings ---
+            $siblingMatches = $matches->reject(fn ($m) => $m->id === $playerMatch->id);
+
+            $resolution = $this->fullMatchSimulation->resolveMatches(
+                collect([$playerMatch]), $game, $allPlayers, $suspendedByCompetition
+            );
+            $matchResults = $resolution['matchResults'];
+            $playerMatch = $resolution['playerMatch'];
+
+            if ($siblingMatches->isNotEmpty()) {
+                $siblingResults = $this->aiMatchResolver->resolveMatches(
+                    $siblingMatches, $allPlayers, $game, $suspendedByCompetition
+                );
+                $matchResults = array_merge($matchResults, $siblingResults);
+            }
+        } elseif ($isAIOnlyBatch) {
             // --- Fast AI resolution path ---
-            // Skips: FormationRecommender, full LineupService, MatchSimulator,
-            // AISubstitutionService, EnergyCalculator, tactical instruction selection.
-            // The AIMatchResolver handles lineup selection (with rotation) and
-            // statistical result generation in a single lightweight pass.
             $matchResults = $this->aiMatchResolver->resolveMatches($matches, $allPlayers, $game, $suspendedByCompetition);
         } else {
-            // --- Full simulation path (player-involved batches) ---
+            // --- Full simulation path ---
             $resolution = $this->fullMatchSimulation->resolveMatches($matches, $game, $allPlayers, $suspendedByCompetition);
             $matchResults = $resolution['matchResults'];
             $playerMatch = $resolution['playerMatch'];

--- a/tests/Feature/AdvanceMatchdayTest.php
+++ b/tests/Feature/AdvanceMatchdayTest.php
@@ -347,7 +347,8 @@ class AdvanceMatchdayTest extends TestCase
 
         $this->assertEquals('live_match', $result->type);
 
-        // Player's match should be played, AI match should NOT (deferred to background)
+        // Both matches should be played — sibling AI matches in the same batch
+        // are now resolved synchronously via AIMatchResolver
         $this->assertDatabaseHas('game_matches', [
             'game_id' => $this->game->id,
             'home_team_id' => $this->playerTeam->id,
@@ -356,7 +357,7 @@ class AdvanceMatchdayTest extends TestCase
         $this->assertDatabaseHas('game_matches', [
             'game_id' => $this->game->id,
             'home_team_id' => $team3->id,
-            'played' => false,
+            'played' => true,
         ]);
 
         // remaining_batches_processing_at flag should be set
@@ -381,25 +382,19 @@ class AdvanceMatchdayTest extends TestCase
 
         $this->assertEquals('live_match', $result->type);
 
-        // AI match not yet played
-        $this->assertDatabaseHas('game_matches', [
-            'game_id' => $this->game->id,
-            'home_team_id' => $team3->id,
-            'played' => false,
-        ]);
-
-        // Now manually call processRemainingBatches (simulating the job running)
-        Queue::fake([]); // Stop faking so career actions can dispatch if needed
-        $this->game->refresh();
-        $orchestrator = app(MatchdayOrchestrator::class);
-        $orchestrator->processRemainingBatches($this->game, 0);
-
-        // AI match should now be played
+        // AI sibling match already played synchronously via AIMatchResolver
         $this->assertDatabaseHas('game_matches', [
             'game_id' => $this->game->id,
             'home_team_id' => $team3->id,
             'played' => true,
         ]);
+
+        // Now manually call processRemainingBatches (simulating the job running)
+        // — no remaining matches, but flag should still be cleared
+        Queue::fake([]); // Stop faking so career actions can dispatch if needed
+        $this->game->refresh();
+        $orchestrator = app(MatchdayOrchestrator::class);
+        $orchestrator->processRemainingBatches($this->game, 0);
 
         // Flag should be cleared
         $this->game->refresh();


### PR DESCRIPTION
Sibling AI matches in the same batch were deferred to a background job, so their scores weren't available when the live match page loaded.

Now they are resolved synchronously via AIMatchResolver before returning the live match, so the results tab can progressively reveal their scores.