### PR TITLE
Skip live match animation on page refresh

### DIFF
--- a/app/Http/Views/ShowLiveMatch.php
+++ b/app/Http/Views/ShowLiveMatch.php
@@ -39,6 +39,14 @@ class ShowLiveMatch
             return redirect()->route('show-game', $gameId);
         }
 
+        // Track whether the live animation has already been seen for this match.
+        // First visit sets the flag and plays the animation; refreshes skip to full_time.
+        $sessionKey = "live_match_animated:{$matchId}";
+        $animationSeen = session()->has($sessionKey);
+        if (! $animationSeen) {
+            session()->put($sessionKey, true);
+        }
+
         // Determine if this is a knockout match (cup tie) that could go to ET
         $isKnockout = $playerMatch->cup_tie_id !== null;
         $extraTimeData = null;
@@ -361,6 +369,7 @@ class ShowLiveMatch
             'slotAssignments' => $playerMatch->{"{$prefix}_slot_assignments"}
                 ?? $game->tactics?->default_slot_assignments ?? [],
             'narrativeTemplates' => $narrativeTemplates,
+            'animationSeen' => $animationSeen,
         ]);
     }
 

--- a/app/Modules/Match/Services/MatchFinalizationService.php
+++ b/app/Modules/Match/Services/MatchFinalizationService.php
@@ -51,6 +51,7 @@ class MatchFinalizationService
         // 4. Clear the pending flag before dispatching events (prevents re-entry
         // from the finalizePendingMatch safety net if advance() runs concurrently)
         $game->update(['pending_finalization_match_id' => null]);
+        session()->forget("live_match_animated:{$match->id}");
 
         // 5. Dispatch MatchFinalized for standings, GK stats, and notifications
         MatchFinalized::dispatch($match, $game, $competition);

--- a/resources/js/live-match.js
+++ b/resources/js/live-match.js
@@ -107,6 +107,10 @@ export default function liveMatch(config) {
         knockoutRoundNumber: config.knockoutRoundNumber || null,
         knockoutRoundName: config.knockoutRoundName || '',
 
+        // Animation state (server-side flag to skip animation on page refresh)
+        matchId: config.matchId || '',
+        animationSeen: config.animationSeen || false,
+
         // MVP
         mvpPlayerName: config.mvpPlayerName || null,
         mvpPlayerTeamId: config.mvpPlayerTeamId || null,
@@ -285,14 +289,139 @@ export default function liveMatch(config) {
             };
             document.addEventListener('visibilitychange', this._onVisibilityChange);
 
-            // Generate client-side atmosphere events (shots, fouls) and narratives
-            this._injectAtmosphere();
-            if (this.preloadedExtraTimeData) {
-                this._injectETAtmosphere();
+            // On page refresh, try to restore cached events so the feed is
+            // identical to what the user saw during the live simulation.
+            if (this.animationSeen && this._restoreEventsFromCache()) {
+                this.skipToFullTimeImmediate();
+            } else {
+                // Generate client-side atmosphere events (shots, fouls) and narratives
+                this._injectAtmosphere();
+                if (this.preloadedExtraTimeData) {
+                    this._injectETAtmosphere();
+                }
+
+                if (this.animationSeen) {
+                    // Cache miss on refresh — synthesize fresh (rare edge case)
+                    this.skipToFullTimeImmediate();
+                } else {
+                    this.startSimulation();
+                }
+            }
+        },
+
+        /**
+         * Cold-start the component directly into full_time state without any
+         * animation. Used on page refresh so the user sees the final result
+         * immediately instead of replaying the live experience.
+         */
+        skipToFullTimeImmediate() {
+            // Synthesize any missing goal events so the event list is complete
+            this.events = this.synthesizeGoalsIfNeeded(this.events);
+
+            // Reveal all regular-time events and track substitutions
+            for (let i = 0; i < this.events.length; i++) {
+                const event = this.events[i];
+                this.revealedEvents.unshift(event);
+                this.lastRevealedIndex = i;
+
+                if (event.type === 'substitution' && event.teamId === this.userTeamId) {
+                    this.substitutionsMade.push({
+                        playerOutId: event.gamePlayerId,
+                        playerInId: event.metadata?.player_in_id ?? '',
+                        minute: event.minute,
+                        playerOutName: event.playerName ?? '',
+                        playerInName: event.playerInName ?? '',
+                    });
+                    const playerInId = event.metadata?.player_in_id;
+                    if (playerInId) {
+                        const benchPlayer = this.benchPlayers.find(p => p.id === playerInId);
+                        if (benchPlayer) benchPlayer.minuteEntered = event.minute;
+                    }
+                }
             }
 
-            // Start the match simulation (synthesize goals + kickoff delay)
-            this.startSimulation();
+            // Set regular-time scores
+            this.homeScore = this.finalHomeScore;
+            this.awayScore = this.finalAwayScore;
+
+            // Handle extra time if preloaded (ET already simulated before refresh)
+            if (this.preloadedExtraTimeData) {
+                for (let i = 0; i < this.extraTimeEvents.length; i++) {
+                    const event = this.extraTimeEvents[i];
+                    this.revealedEvents.unshift(event);
+                    this.lastRevealedETIndex = i;
+
+                    if (event.type === 'substitution' && event.teamId === this.userTeamId) {
+                        this.substitutionsMade.push({
+                            playerOutId: event.gamePlayerId,
+                            playerInId: event.metadata?.player_in_id ?? '',
+                            minute: event.minute,
+                            playerOutName: event.playerName ?? '',
+                            playerInName: event.playerInName ?? '',
+                        });
+                    }
+                }
+                this.homeScore = this.finalHomeScore + this.etHomeScore;
+                this.awayScore = this.finalAwayScore + this.etAwayScore;
+                this.currentMinute = 120;
+            } else {
+                this.currentMinute = 90;
+            }
+
+            // Set other match scores to final values
+            for (let i = 0; i < this.otherMatches.length; i++) {
+                this.otherMatchScores[i] = {
+                    homeScore: this.otherMatches[i].homeScore,
+                    awayScore: this.otherMatches[i].awayScore,
+                };
+            }
+
+            // Set final possession (no oscillation)
+            this.homePossession = this._basePossession;
+            this.awayPossession = 100 - this._basePossession;
+
+            // Set phase to full_time and calculate player ratings
+            this.phase = 'full_time';
+            this.recalculatePlayerRatings();
+        },
+
+        /**
+         * Cache the current events arrays to localStorage so page refreshes
+         * show the exact same event feed the user saw during live simulation.
+         */
+        _cacheEvents() {
+            if (!this.matchId) return;
+            try {
+                const payload = {
+                    events: this.events,
+                    extraTimeEvents: this.extraTimeEvents,
+                };
+                localStorage.setItem(`live_match_events:${this.matchId}`, JSON.stringify(payload));
+            } catch (_) { /* quota exceeded — silently skip */ }
+        },
+
+        /**
+         * Restore cached events from localStorage. Returns true if cache was
+         * found and applied, false otherwise.
+         */
+        _restoreEventsFromCache() {
+            if (!this.matchId) return false;
+            try {
+                const raw = localStorage.getItem(`live_match_events:${this.matchId}`);
+                if (!raw) return false;
+                const cached = JSON.parse(raw);
+                if (cached.events) this.events = cached.events;
+                if (cached.extraTimeEvents) this.extraTimeEvents = cached.extraTimeEvents;
+                return true;
+            } catch (_) { return false; }
+        },
+
+        /**
+         * Remove the cached events entry for this match.
+         */
+        _clearEventsCache() {
+            if (!this.matchId) return;
+            localStorage.removeItem(`live_match_events:${this.matchId}`);
         },
 
         // =====================================================================

--- a/resources/js/modules/match-simulation.js
+++ b/resources/js/modules/match-simulation.js
@@ -405,6 +405,11 @@ export function createMatchSimulation(ctx) {
         if (typeof state.recalculatePlayerRatings === 'function') {
             state.recalculatePlayerRatings();
         }
+
+        // Cache events so page refreshes show the same feed
+        if (typeof state._cacheEvents === 'function') {
+            state._cacheEvents();
+        }
     }
 
     // =========================================================================

--- a/resources/views/live-match.blade.php
+++ b/resources/views/live-match.blade.php
@@ -19,6 +19,7 @@
     <div class="min-h-screen">
     <main class="text-text-body pt-0 pb-24 sm:pt-2 sm:pb-24">
         <div class="max-w-4xl mx-auto px-4 pb-8"
+             @if($animationSeen) x-cloak @endif
              x-data="liveMatch({
                 events: {{ Js::from($events) }},
                 homeTeamId: '{{ $match->home_team_id }}',
@@ -76,6 +77,8 @@
                 homeArticle: {{ Js::from($match->homeTeam->article) }},
                 awayArticle: {{ Js::from($match->awayTeam->article) }},
                 narrativeTemplates: {{ Js::from($narrativeTemplates) }},
+                matchId: '{{ $match->id }}',
+                animationSeen: {{ $animationSeen ? 'true' : 'false' }},
                 translations: {
                     unsavedTacticalChanges: {!! Js::from(__('game.tactical_unsaved_changes')) !!},
                     extraTime: {!! Js::from(__('game.live_extra_time')) !!},
@@ -993,7 +996,7 @@
                         </template>
 
                         {{-- Continue button --}}
-                        <form method="POST" action="{{ route('game.finalize-match', $game->id) }}">
+                        <form method="POST" action="{{ route('game.finalize-match', $game->id) }}" x-on:submit="_clearEventsCache()">
                             @csrf
                             <template x-if="isTournamentDecisive">
                                 <input type="hidden" name="tournament_end" value="1">


### PR DESCRIPTION
## Summary
This PR implements a mechanism to skip the live match animation on page refresh, allowing users to see the final match result immediately instead of replaying the entire live experience.

## Key Changes
- **Session-based animation tracking**: Added a session flag (`live_match_animated:{matchId}`) in `ShowLiveMatch.php` to track whether the animation has been viewed for a given match. The flag is set on first visit and cleared when the match is finalized.

- **New `skipToFullTimeImmediate()` method**: Implemented a cold-start method in `live-match.js` that:
  - Synthesizes any missing goal events
  - Reveals all regular-time events and processes substitutions
  - Sets final scores for regular time and extra time (if applicable)
  - Updates other match scores to their final values
  - Sets possession to base values without oscillation
  - Transitions directly to `full_time` phase and recalculates player ratings

- **Conditional initialization logic**: Modified the `mounted()` hook to check the `animationSeen` flag and either skip to full time or start the normal simulation.

- **Session cleanup**: Added session flag cleanup in `MatchFinalizationService.php` when a match is finalized, ensuring the flag doesn't persist unnecessarily.

- **Template integration**: Passed the `animationSeen` flag from the controller to the Blade template and into the Vue component configuration.

## Implementation Details
- The animation state is stored in the session rather than client-side to ensure consistency across browser tabs and prevent animation replay on refresh.
- The `skipToFullTimeImmediate()` method mirrors the logic of the normal simulation but executes all state changes synchronously without animation delays.
- Extra time data is handled if it was preloaded before the refresh, maintaining consistency with the match state.

https://claude.ai/code/session_014ue59DAYhC3ur6MCe5uFzr