### PR TITLE
Centralize current_date advancement into Game::advanceDateToNextMatch

### DIFF
--- a/app/Models/Game.php
+++ b/app/Models/Game.php
@@ -289,6 +289,45 @@ class Game extends Model
     }
 
     // ==========================================
+    // Date Advancement
+    // ==========================================
+
+    /**
+     * Advance current_date forward to the next unplayed match.
+     *
+     * This is the canonical forward-looking jump, used at match finalization
+     * to move the calendar to the upcoming match. Only moves forward — never
+     * regresses or holds the date (returns false in those cases).
+     *
+     * Note: batch processing (MatchResultProcessor) deliberately does NOT use
+     * this — it pins current_date to the matchday being processed so it can't
+     * jump past unplayed matches and steal the GameDateAdvanced event that
+     * finalization dispatches.
+     *
+     * @return bool Whether the date actually changed.
+     */
+    public function advanceDateToNextMatch(): bool
+    {
+        $nextMatch = GameMatch::where('game_id', $this->id)
+            ->where('played', false)
+            ->orderBy('scheduled_date')
+            ->first();
+
+        if (! $nextMatch) {
+            return false;
+        }
+
+        if ($this->current_date && $nextMatch->scheduled_date->lte($this->current_date)) {
+            return false;
+        }
+
+        $this->update(['current_date' => $nextMatch->scheduled_date->toDateString()]);
+        $this->refresh();
+
+        return true;
+    }
+
+    // ==========================================
     // Pending Actions (Game Progress Blocking)
     // ==========================================
 

--- a/app/Modules/Match/Services/MatchFinalizationService.php
+++ b/app/Modules/Match/Services/MatchFinalizationService.php
@@ -195,20 +195,8 @@ class MatchFinalizationService
      */
     private function advanceCurrentDate(Game $game, Carbon $previousDate): void
     {
-        $nextMatch = GameMatch::where('game_id', $game->id)
-            ->where('played', false)
-            ->orderBy('scheduled_date')
-            ->first();
-
-        if (! $nextMatch) {
-            return;
-        }
-
-        $game->update(['current_date' => $nextMatch->scheduled_date->toDateString()]);
-        $game->refresh();
-
-        if ($nextMatch->scheduled_date->gt($previousDate)) {
-            GameDateAdvanced::dispatch($game, $previousDate, $nextMatch->scheduled_date);
+        if ($game->advanceDateToNextMatch() && $game->current_date->gt($previousDate)) {
+            GameDateAdvanced::dispatch($game, $previousDate, $game->current_date);
         }
     }
 

--- a/app/Modules/Match/Services/MatchResultProcessor.php
+++ b/app/Modules/Match/Services/MatchResultProcessor.php
@@ -44,9 +44,13 @@ class MatchResultProcessor
         $game = $gameOrId instanceof Game ? $gameOrId : Game::findOrFail($gameOrId);
         $gameId = $game->id;
 
-        // 1. Update game state — only advance current_date forward.
-        // Background batch processing must not regress the date that was
-        // already set by the player's batch.
+        // 1. Pin current_date to this batch's date, but never regress it.
+        // Unlike Game::advanceDateToNextMatch(), this deliberately does NOT jump
+        // past still-unplayed matches — it keeps the calendar on the matchday
+        // being processed. The forward-looking jump to the next unplayed match
+        // (and the GameDateAdvanced event) is reserved for match finalization,
+        // so background batch processing can't silently advance past — and steal
+        // the GameDateAdvanced event from — the user's live match.
         $newDate = Carbon::parse($currentDate);
         if (! $game->current_date || $newDate->gte($game->current_date)) {
             Game::where('id', $gameId)->update(['current_date' => $newDate->toDateString()]);

--- a/tests/Feature/AdvanceMatchdayTest.php
+++ b/tests/Feature/AdvanceMatchdayTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature;
 
 use App\Http\Actions\AdvanceMatchday;
+use App\Modules\Match\Events\GameDateAdvanced;
 use App\Modules\Match\Services\MatchdayOrchestrator;
 use App\Modules\Match\Services\MatchFinalizationService;
 use App\Models\Competition;
@@ -14,6 +15,7 @@ use App\Models\Team;
 use App\Models\User;
 use Carbon\Carbon;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Event;
 use Tests\TestCase;
 
 class AdvanceMatchdayTest extends TestCase
@@ -363,6 +365,67 @@ class AdvanceMatchdayTest extends TestCase
             'home_team_id' => $team3->id,
             'played' => true,
         ]);
+    }
+
+    public function test_finalization_dispatches_game_date_advanced_after_inline_sibling_simulation(): void
+    {
+        // Regression: batch processing must PIN current_date to the matchday being
+        // played, never forward-jump to the next unplayed match. If processAll used
+        // the forward-looking Game::advanceDateToNextMatch(), simulating the live
+        // matchday would push current_date all the way to the next matchday before
+        // the user even finalizes — and finalize() would then find nothing left to
+        // advance and silently skip the GameDateAdvanced event that drives transfer
+        // windows, squad registration and recovered-player checks.
+        //
+        // Scenario: matchday 1 has the user's match (08-16) + an AI sibling (08-17),
+        // both simulated inline; matchday 2 (08-23) is the next upcoming user match.
+        // current_date must stay on matchday 1 until the user finalizes, and only
+        // then advance to matchday 2 and fire the event.
+        $this->createMatchdayWithAiSibling();
+
+        GameMatch::factory()->create([
+            'game_id' => $this->game->id,
+            'competition_id' => $this->leagueCompetition->id,
+            'round_number' => 2,
+            'home_team_id' => $this->playerTeam->id,
+            'away_team_id' => $this->opponentTeam->id,
+            'scheduled_date' => Carbon::parse('2024-08-23'),
+        ]);
+
+        // Fake only GameDateAdvanced so all other finalization side effects run normally.
+        Event::fake([GameDateAdvanced::class]);
+
+        $orchestrator = app(MatchdayOrchestrator::class);
+        $result = $orchestrator->advance($this->game);
+        $this->assertEquals('live_match', $result->type);
+
+        // After the live matchday is simulated inline, current_date must NOT have
+        // jumped to the next matchday, and no event has fired yet.
+        Event::assertNotDispatched(GameDateAdvanced::class);
+        $this->assertTrue(
+            $this->game->fresh()->current_date->lt(Carbon::parse('2024-08-23')),
+            'current_date must stay on the live matchday until the user finalizes',
+        );
+
+        // User finalizes their matchday-1 match.
+        $this->game->refresh();
+        $finalizationService = app(MatchFinalizationService::class);
+        $finalizationService->dispatchPostFinalizeEffects(
+            $finalizationService->finalize(
+                GameMatch::find($this->game->pending_finalization_match_id),
+                $this->game,
+            )
+        );
+
+        // The event must fire, advancing to matchday 2 (08-23).
+        Event::assertDispatched(GameDateAdvanced::class, function (GameDateAdvanced $event) {
+            return $event->game->id === $this->game->id
+                && $event->newDate->toDateString() === '2024-08-23'
+                && $event->previousDate->lt($event->newDate);
+        });
+
+        // And current_date should land on the upcoming matchday.
+        $this->assertEquals('2024-08-23', $this->game->fresh()->current_date->toDateString());
     }
 
     public function test_returns_season_complete_when_no_matches(): void


### PR DESCRIPTION
## What

Consolidates the forward-looking calendar advance — "find the next unplayed match, move `current_date` to it, and dispatch `GameDateAdvanced`" — into a single canonical method, `Game::advanceDateToNextMatch()`. `MatchFinalizationService` now delegates to it instead of carrying its own inline copy of the query.

## Why

The advance logic lived inline in `MatchFinalizationService::advanceCurrentDate()`. Pulling it into one documented method removes the duplication and gives the calendar advance a single home.

The important subtlety: the two date operations in the match pipeline look similar but are **not** the same, and must stay distinct:

- **Finalization** does a forward-looking *jump* to the next unplayed match and fires `GameDateAdvanced` — the event that drives transfer windows, squad registration, and recovered-player checks.
- **Batch processing** (`MatchResultProcessor::processAll`) only *pins* `current_date` to the matchday being processed. It must **not** jump past still-unplayed matches. If it did, simulating the live matchday would push `current_date` to the next matchday before the user finalizes, and finalization would then find nothing left to advance and silently skip `GameDateAdvanced`.

So `processAll` deliberately keeps its "pin to batch date, never regress" logic and does **not** use `advanceDateToNextMatch()`. (This corrects an earlier revision of this PR that routed `processAll` through the shared method too — that conflated the pin with the jump and dropped the event.) A comment in `processAll` and the method's docblock both record the constraint.

## Changes

- Add `Game::advanceDateToNextMatch()` — the canonical forward-looking advance. Only moves forward; never regresses or holds the date.
- `MatchFinalizationService::advanceCurrentDate()` delegates to it. Behavior-preserving — `GameDateAdvanced` still fires exactly once per finalization.
- `MatchResultProcessor::processAll()` — behavior unchanged; added a comment explaining why it pins rather than jumps.
- Regression test (`AdvanceMatchdayTest`) asserting `current_date` stays on the live matchday through `advance()` and only advances to the next matchday — firing `GameDateAdvanced` — at finalization. It fails if `processAll` is ever switched to the forward-looking jump.

## Test plan

- [ ] `php artisan test --filter=AdvanceMatchdayTest`
