### PR TITLE
Adjust AI transfer market reputation tiers from 6 to 4 levels

### DIFF
--- a/app/Modules/Transfer/Services/AITransferMarketService.php
+++ b/app/Modules/Transfer/Services/AITransferMarketService.php
@@ -60,7 +60,7 @@ class AITransferMarketService
     private const MAX_SQUAD_SIZE = 30;
 
     /**
-     * Maximum transfer fee an AI team can pay, by reputation index (0=elite, 6=local).
+     * Maximum transfer fee an AI team can pay, by reputation index (0=elite, 4=local).
      * Only elite clubs can spend 120M+; mid-table clubs are limited to realistic levels.
      */
     private const MAX_FEE_BY_REPUTATION_INDEX = [
@@ -69,8 +69,6 @@ class AITransferMarketService
         2 => 3_000_000_000,   // €30M  — established clubs
         3 => 1_500_000_000,   // €15M  — modest clubs
         4 => 500_000_000,     // €5M   — local clubs
-        5 => 500_000_000,     // €5M
-        6 => 500_000_000,     // €5M
     ];
 
     /** Minimum free agents to preserve — AI stops signing when pool drops to this */
@@ -964,7 +962,7 @@ class AITransferMarketService
         array &$transferInserts,
         int $minContractYears = 2,
         int $maxContractYears = 3,
-        int $buyerReputationIndex = 6,
+        int $buyerReputationIndex = 4,
     ): void {
         $maxFee = self::MAX_FEE_BY_REPUTATION_INDEX[$buyerReputationIndex] ?? 500_000_000;
         $fee = min($player->market_value_cents, $maxFee);
@@ -1400,7 +1398,7 @@ class AITransferMarketService
     /**
      * Load reputation tier indices for all AI teams.
      *
-     * @return Collection<string, int> teamId => reputation index (0 = elite, 6 = local)
+     * @return Collection<string, int> teamId => reputation index (0 = elite, 4 = local)
      */
     private function loadTeamReputations(Game $game, Collection $teamRosters): Collection
     {
@@ -1409,14 +1407,14 @@ class AITransferMarketService
         return $teamRosters->keys()->mapWithKeys(function ($teamId) use ($levels) {
             $level = $levels->get($teamId) ?? ClubProfile::REPUTATION_LOCAL;
 
-            // Invert: ClubProfile uses 0=local,6=elite; this service needs 0=elite,6=local
-            return [$teamId => 6 - ClubProfile::getReputationTierIndex($level)];
+            // Invert: ClubProfile uses 0=local,4=elite; this service needs 0=elite,4=local
+            return [$teamId => 4 - ClubProfile::getReputationTierIndex($level)];
         });
     }
 
     private function getReputationIndex(string $teamId, Collection $teamReputations): int
     {
-        return $teamReputations->get($teamId, 6);
+        return $teamReputations->get($teamId, 4);
     }
 
     // ── Utility helpers ─────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
This PR updates the AITransferMarketService to use a 4-tier reputation system (0=elite, 4=local) instead of the previous 6-tier system. This aligns the transfer market logic with the actual reputation tier structure used by ClubProfile.

## Key Changes
- **Removed duplicate reputation tiers**: Eliminated reputation indices 5 and 6 from `MAX_FEE_BY_REPUTATION_INDEX`, as they were redundant entries with identical fee caps (€5M)
- **Updated reputation index range**: Changed all references from 0-6 scale to 0-4 scale throughout the service
- **Fixed reputation inversion logic**: Updated the calculation in `loadTeamReputations()` from `6 - index` to `4 - index` to correctly map ClubProfile's 0=local,4=elite scale to the service's 0=elite,4=local scale
- **Updated default values**: Changed default `buyerReputationIndex` parameter from 6 to 4 in `prepareTransfer()` method
- **Updated fallback values**: Changed default reputation lookup from 6 to 4 in `getReputationIndex()` method
- **Updated documentation**: Corrected JSDoc comments to reflect the new 4-tier system

## Implementation Details
The changes ensure consistency between the transfer market service's internal reputation representation and the ClubProfile's actual tier structure. The inversion logic remains the same (converting from local-first to elite-first ordering), but now operates on a 0-4 range instead of 0-6.

https://claude.ai/code/session_01XiEXrgqp9NZoWUzgT77Zxv