### PR TITLE
Complete agreed transfers when transfer window opens

### DIFF
--- a/app/Models/Game.php
+++ b/app/Models/Game.php
@@ -544,7 +544,12 @@ class Game extends Model
             return __('app.summer_window');
         }
 
-        return $this->transferWindow()->nextWindowDisplayName();
+        // If a window is currently open, that is the window any pending "agreed"
+        // transfer will complete in — not the chronologically next one.
+        $tw = $this->transferWindow();
+
+        return ($tw->isOpen() ? $tw->displayName() : null)
+            ?? $tw->nextWindowDisplayName();
     }
 
     /**

--- a/app/Modules/Transfer/Listeners/CompleteAgreedTransfersOnWindowOpen.php
+++ b/app/Modules/Transfer/Listeners/CompleteAgreedTransfersOnWindowOpen.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Modules\Transfer\Listeners;
+
+use App\Modules\Match\Events\GameDateAdvanced;
+use App\Modules\Notification\Services\NotificationService;
+use App\Modules\Transfer\Enums\TransferWindowType;
+use App\Modules\Transfer\Services\TransferService;
+
+/**
+ * Completes agreed transfers the moment the transfer window opens.
+ *
+ * Transfers accepted while the window is closed are marked STATUS_AGREED and
+ * sit waiting until the window opens. Without this listener, they are only
+ * flushed by CareerActionProcessor on the next matchday played *inside* the
+ * window — which, combined with the forward-looking current_date, can leave a
+ * user-visible ~1 week gap between finalising the last match before the window
+ * and actually playing the first match in the window. This listener closes
+ * that gap by completing agreed transfers in the same finalization flow that
+ * advances current_date into the window.
+ */
+class CompleteAgreedTransfersOnWindowOpen
+{
+    public function __construct(
+        private readonly TransferService $transferService,
+        private readonly NotificationService $notificationService,
+    ) {}
+
+    public function handle(GameDateAdvanced $event): void
+    {
+        // Detect boundary crossing: previousDate was outside a window, newDate is inside one.
+        $previousWindow = TransferWindowType::fromDate($event->previousDate);
+        $newWindow = TransferWindowType::fromDate($event->newDate);
+
+        if ($previousWindow !== null || $newWindow === null) {
+            return;
+        }
+
+        $game = $event->game;
+
+        $completedOutgoing = $this->transferService->completeAgreedTransfers($game);
+        $completedIncoming = $this->transferService->completeIncomingTransfers($game);
+
+        foreach ($completedOutgoing->merge($completedIncoming) as $offer) {
+            $this->notificationService->notifyTransferComplete($game, $offer);
+        }
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -30,6 +30,7 @@ use App\Modules\Match\Listeners\UpdateManagerStats;
 use App\Modules\Season\Listeners\GrantCareerAccessToChampion;
 use App\Modules\Squad\Listeners\CheckRecoveredPlayers;
 use App\Modules\Squad\Listeners\EnforceSquadRegistration;
+use App\Modules\Transfer\Listeners\CompleteAgreedTransfersOnWindowOpen;
 use App\Modules\Transfer\Listeners\ProcessTransferWindowClose;
 use App\Modules\Season\Listeners\RecordSeasonCompleted;
 use App\Modules\Season\Listeners\SimulateOtherLeagues;
@@ -106,6 +107,7 @@ class AppServiceProvider extends ServiceProvider
 
         Event::listen(GameDateAdvanced::class, CheckRecoveredPlayers::class);
         Event::listen(GameDateAdvanced::class, NotifyTransferWindowOpen::class);
+        Event::listen(GameDateAdvanced::class, CompleteAgreedTransfersOnWindowOpen::class);
         Event::listen(GameDateAdvanced::class, NotifyTransferWindowClosing::class);
         Event::listen(GameDateAdvanced::class, ProcessTransferWindowClose::class);
         Event::listen(GameDateAdvanced::class, NotifyTransferWindowClosed::class);

--- a/tests/Unit/CompleteAgreedTransfersOnWindowOpenTest.php
+++ b/tests/Unit/CompleteAgreedTransfersOnWindowOpenTest.php
@@ -1,0 +1,247 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\Game;
+use App\Models\GameFinances;
+use App\Models\GameInvestment;
+use App\Models\GameNotification;
+use App\Models\GamePlayer;
+use App\Models\Team;
+use App\Models\TransferOffer;
+use App\Modules\Match\Events\GameDateAdvanced;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Covers the CompleteAgreedTransfersOnWindowOpen listener, which finalises
+ * agreed transfers the moment the transfer window opens — closing the gap
+ * where the forward-looking current_date bumps into a window but no match
+ * has yet been played inside it.
+ */
+class CompleteAgreedTransfersOnWindowOpenTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function setupGameWithFinances(string $currentDate, string $season): Game
+    {
+        $game = Game::factory()->create([
+            'current_date' => $currentDate,
+            'season' => $season,
+        ]);
+
+        GameInvestment::create([
+            'game_id' => $game->id,
+            'season' => $season,
+            'transfer_budget' => 50_000_000_00,
+            'scouting_tier' => 1,
+        ]);
+        GameFinances::create([
+            'game_id' => $game->id,
+            'season' => $season,
+            'projected_revenue' => 100_000_000_00,
+            'projected_wages' => 50_000_000_00,
+            'projected_position' => 10,
+        ]);
+
+        return $game;
+    }
+
+    /**
+     * Offer accepted in December (window closed) is completed the moment the
+     * finalisation of the last pre-window match advances current_date into
+     * January (winter window opens).
+     */
+    public function test_outgoing_agreed_transfer_completes_when_winter_window_opens(): void
+    {
+        $game = $this->setupGameWithFinances('2024-12-28', '2024');
+        $userTeam = $game->team;
+        $buyerTeam = Team::factory()->create();
+
+        $player = GamePlayer::factory()->forGame($game)->forTeam($userTeam)->create([
+            'contract_until' => '2027-06-30',
+        ]);
+
+        $offer = TransferOffer::create([
+            'game_id' => $game->id,
+            'game_player_id' => $player->id,
+            'offering_team_id' => $buyerTeam->id,
+            'offer_type' => TransferOffer::TYPE_LISTED,
+            'transfer_fee' => 10_000_000_00,
+            'status' => TransferOffer::STATUS_AGREED,
+            'direction' => TransferOffer::DIRECTION_OUTGOING,
+            'expires_at' => '2025-02-01',
+            'game_date' => '2024-12-28',
+            'resolved_at' => '2024-12-28',
+        ]);
+
+        // Simulate the date advancing from Dec 28 → Jan 4 (window opens).
+        $game->update(['current_date' => '2025-01-04']);
+        GameDateAdvanced::dispatch(
+            $game->refresh(),
+            Carbon::parse('2024-12-28'),
+            Carbon::parse('2025-01-04'),
+        );
+
+        $offer->refresh();
+        $player->refresh();
+
+        $this->assertSame(TransferOffer::STATUS_COMPLETED, $offer->status);
+        $this->assertSame($buyerTeam->id, $player->team_id,
+            'Player should have moved to the buyer team when the window opened');
+        $this->assertDatabaseHas('game_notifications', [
+            'game_id' => $game->id,
+            'type' => GameNotification::TYPE_TRANSFER_COMPLETE,
+        ]);
+    }
+
+    /**
+     * Incoming offers (user buying) are also flushed on window open.
+     */
+    public function test_incoming_agreed_transfer_completes_when_winter_window_opens(): void
+    {
+        $game = $this->setupGameWithFinances('2024-12-28', '2024');
+        $userTeam = $game->team;
+        $sellerTeam = Team::factory()->create();
+
+        $player = GamePlayer::factory()->forGame($game)->forTeam($sellerTeam)->create([
+            'contract_until' => '2027-06-30',
+        ]);
+
+        $offer = TransferOffer::create([
+            'game_id' => $game->id,
+            'game_player_id' => $player->id,
+            'offering_team_id' => $userTeam->id,
+            'selling_team_id' => $sellerTeam->id,
+            'offer_type' => TransferOffer::TYPE_USER_BID,
+            'transfer_fee' => 8_000_000_00,
+            'status' => TransferOffer::STATUS_AGREED,
+            'direction' => TransferOffer::DIRECTION_INCOMING,
+            'expires_at' => '2025-02-01',
+            'game_date' => '2024-12-28',
+            'resolved_at' => '2024-12-28',
+        ]);
+
+        $game->update(['current_date' => '2025-01-04']);
+        GameDateAdvanced::dispatch(
+            $game->refresh(),
+            Carbon::parse('2024-12-28'),
+            Carbon::parse('2025-01-04'),
+        );
+
+        $offer->refresh();
+        $player->refresh();
+
+        $this->assertSame(TransferOffer::STATUS_COMPLETED, $offer->status);
+        $this->assertSame($userTeam->id, $player->team_id,
+            'Player should have joined the user team when the window opened');
+    }
+
+    /**
+     * Guard: the listener must not fire on a date advance that stays outside
+     * any window (e.g. mid-November → mid-December).
+     */
+    public function test_listener_does_not_fire_when_staying_outside_window(): void
+    {
+        $game = $this->setupGameWithFinances('2024-11-15', '2024');
+        $userTeam = $game->team;
+        $buyerTeam = Team::factory()->create();
+
+        $player = GamePlayer::factory()->forGame($game)->forTeam($userTeam)->create([
+            'contract_until' => '2027-06-30',
+        ]);
+
+        $offer = TransferOffer::create([
+            'game_id' => $game->id,
+            'game_player_id' => $player->id,
+            'offering_team_id' => $buyerTeam->id,
+            'offer_type' => TransferOffer::TYPE_LISTED,
+            'transfer_fee' => 10_000_000_00,
+            'status' => TransferOffer::STATUS_AGREED,
+            'direction' => TransferOffer::DIRECTION_OUTGOING,
+            'expires_at' => '2025-02-01',
+            'game_date' => '2024-11-15',
+            'resolved_at' => '2024-11-15',
+        ]);
+
+        $game->update(['current_date' => '2024-12-20']);
+        GameDateAdvanced::dispatch(
+            $game->refresh(),
+            Carbon::parse('2024-11-15'),
+            Carbon::parse('2024-12-20'),
+        );
+
+        $offer->refresh();
+        $player->refresh();
+
+        $this->assertSame(TransferOffer::STATUS_AGREED, $offer->status);
+        $this->assertSame($userTeam->id, $player->team_id);
+    }
+
+    /**
+     * Guard: the listener must not re-fire on subsequent advances that stay
+     * inside the same already-open window.
+     */
+    public function test_listener_does_not_refire_on_intra_window_advances(): void
+    {
+        $game = $this->setupGameWithFinances('2025-01-04', '2024');
+        $userTeam = $game->team;
+        $buyerTeam = Team::factory()->create();
+
+        $player = GamePlayer::factory()->forGame($game)->forTeam($userTeam)->create([
+            'contract_until' => '2027-06-30',
+        ]);
+
+        // Simulate a fresh offer that slipped into AGREED somehow while the
+        // window is already open (race / edge case). A Jan → Jan advance
+        // must NOT be treated as a window-open transition.
+        $offer = TransferOffer::create([
+            'game_id' => $game->id,
+            'game_player_id' => $player->id,
+            'offering_team_id' => $buyerTeam->id,
+            'offer_type' => TransferOffer::TYPE_LISTED,
+            'transfer_fee' => 10_000_000_00,
+            'status' => TransferOffer::STATUS_AGREED,
+            'direction' => TransferOffer::DIRECTION_OUTGOING,
+            'expires_at' => '2025-02-01',
+            'game_date' => '2025-01-04',
+            'resolved_at' => '2025-01-04',
+        ]);
+
+        $game->update(['current_date' => '2025-01-18']);
+        GameDateAdvanced::dispatch(
+            $game->refresh(),
+            Carbon::parse('2025-01-04'),
+            Carbon::parse('2025-01-18'),
+        );
+
+        $offer->refresh();
+        $this->assertSame(TransferOffer::STATUS_AGREED, $offer->status,
+            'Listener should only act on a closed→open transition, not on intra-window advances');
+    }
+
+    /**
+     * Display fix: when the winter window is currently open, getNextWindowName()
+     * must return "Invierno" (the current open window), not "Verano".
+     */
+    public function test_get_next_window_name_returns_current_when_window_is_open(): void
+    {
+        $game = $this->setupGameWithFinances('2025-01-15', '2024');
+
+        $this->assertTrue($game->isTransferWindowOpen());
+        $this->assertSame(__('app.winter_window'), $game->getNextWindowName());
+    }
+
+    /**
+     * Display fix (baseline): when outside any window, getNextWindowName()
+     * still returns the next chronological window.
+     */
+    public function test_get_next_window_name_returns_next_when_window_is_closed(): void
+    {
+        $game = $this->setupGameWithFinances('2024-11-15', '2024');
+
+        $this->assertFalse($game->isTransferWindowOpen());
+        $this->assertSame(__('app.winter_window'), $game->getNextWindowName());
+    }
+}


### PR DESCRIPTION
## Summary
Implements automatic completion of agreed transfers the moment a transfer window opens, eliminating the gap between finalizing the last pre-window match and playing the first match inside the window.

## Key Changes
- **New Listener**: `CompleteAgreedTransfersOnWindowOpen` listens to `GameDateAdvanced` events and detects when `current_date` crosses from outside a transfer window into an open window
- **Transfer Completion**: When a window-open boundary is detected, the listener automatically completes all pending agreed transfers (both outgoing and incoming) and generates appropriate notifications
- **Display Fix**: Updated `Game::getNextWindowName()` to return the currently open window name instead of the next chronological window when a window is active
- **Event Registration**: Registered the new listener in `AppServiceProvider`

## Implementation Details
- The listener uses `TransferWindowType::fromDate()` to detect boundary crossings by comparing the previous and new dates
- Only fires when transitioning from a closed state (previousWindow = null) to an open state (newWindow ≠ null)
- Prevents re-firing on subsequent advances within the same open window
- Comprehensive test coverage includes:
  - Outgoing and incoming transfer completion scenarios
  - Guard tests to prevent firing outside windows or during intra-window advances
  - Display fix validation for `getNextWindowName()`

https://claude.ai/code/session_017eB67pJHgS7iTeNNWgjgip