### PR TITLE
Implement dynamic player list sorting by selection and availability

### DIFF
--- a/app/Http/Views/ShowLineup.php
+++ b/app/Http/Views/ShowLineup.php
@@ -12,6 +12,7 @@ use App\Modules\Lineup\Services\LineupService;
 
 use App\Models\Game;
 use App\Support\PitchGrid;
+use App\Support\PositionMapper;
 use App\Support\PositionSlotMapper;
 use App\Support\TeamColors;
 
@@ -102,6 +103,10 @@ class ShowLineup
                 'fitness' => $p->fitness,
                 'morale' => $p->morale,
                 'isAvailable' => $isAvailable,
+                // Position-based rank used by the client-side list sort
+                // (starters-first, then bench, then unavailable). Keeps
+                // PositionMapper as the single source of truth.
+                'sortOrder' => PositionMapper::positionSortOrder($p->position),
             ];
         })->keyBy('id')->toArray();
 

--- a/app/Http/Views/ShowLineup.php
+++ b/app/Http/Views/ShowLineup.php
@@ -11,6 +11,7 @@ use App\Modules\Lineup\Services\AITacticsService;
 use App\Modules\Lineup\Services\LineupService;
 
 use App\Support\PitchGrid;
+use App\Support\PositionMapper;
 use App\Support\PositionSlotMapper;
 use App\Support\PreMatchContext;
 use App\Support\TeamColors;
@@ -100,6 +101,10 @@ class ShowLineup
                 'fitness' => $p->fitness,
                 'morale' => $p->morale,
                 'isAvailable' => $isAvailable,
+                // Position-based rank used by the client-side list sort
+                // (starters-first, then bench, then unavailable). Keeps
+                // PositionMapper as the single source of truth.
+                'sortOrder' => PositionMapper::positionSortOrder($p->position),
             ];
         })->keyBy('id')->toArray();
 

--- a/lang/en/squad.php
+++ b/lang/en/squad.php
@@ -361,6 +361,7 @@ return [
     // Lineup redesign
     'opponent_goal' => 'Opponent Goal',
     'available_players' => 'Available Players',
+    'starting_xi' => 'Starting XI',
     'substitutes' => 'Substitutes',
     'lineup_overview' => 'Lineup Overview',
 

--- a/lang/en/squad.php
+++ b/lang/en/squad.php
@@ -337,6 +337,7 @@ return [
     // Lineup redesign
     'opponent_goal' => 'Opponent Goal',
     'available_players' => 'Available Players',
+    'starting_xi' => 'Starting XI',
     'substitutes' => 'Substitutes',
     'lineup_overview' => 'Lineup Overview',
 

--- a/lang/es/squad.php
+++ b/lang/es/squad.php
@@ -337,6 +337,7 @@ return [
     // Lineup redesign
     'opponent_goal' => 'Portería Rival',
     'available_players' => 'Jugadores Disponibles',
+    'starting_xi' => 'Once Titular',
     'substitutes' => 'Suplentes',
     'lineup_overview' => 'Resumen de Alineación',
 

--- a/lang/es/squad.php
+++ b/lang/es/squad.php
@@ -361,6 +361,7 @@ return [
     // Lineup redesign
     'opponent_goal' => 'Portería Rival',
     'available_players' => 'Jugadores Disponibles',
+    'starting_xi' => 'Once Titular',
     'substitutes' => 'Suplentes',
     'lineup_overview' => 'Resumen de Alineación',
 

--- a/resources/js/lineup.js
+++ b/resources/js/lineup.js
@@ -332,6 +332,22 @@ export default function lineupManager(config) {
 
         isSelected(id) { return this.selectedPlayers.includes(id) },
 
+        // Reactive sort order for the Available Players list. Used as a CSS
+        // `order` value so the list re-settles whenever selection state
+        // changes (drag, toggle, formation swap, auto XI, pitch removal).
+        //   0–99    → starting XI, sorted by position (GK, DEF, MID, FWD)
+        //   1000+   → bench, sorted by position
+        //   2000+   → unavailable (injured/suspended), sorted by position
+        listSortOrder(playerId) {
+            const player = this.playersData[playerId];
+            if (!player) return 9999;
+            const positionRank = player.sortOrder ?? 99;
+            if (!player.isAvailable) {
+                return 2000 + positionRank;
+            }
+            return (this.isSelected(playerId) ? 0 : 1000) + positionRank;
+        },
+
         // Toggle player selection (from player list)
         toggle(id, isUnavailable) {
             if (isUnavailable) return;

--- a/resources/js/lineup.js
+++ b/resources/js/lineup.js
@@ -348,6 +348,31 @@ export default function lineupManager(config) {
             return (this.isSelected(playerId) ? 0 : 1000) + positionRank;
         },
 
+        // Map a formation slot label (e.g. "CB", "LM") to the same rank
+        // PositionMapper::positionSortOrder uses server-side, so empty
+        // starter placeholders interleave correctly with filled rows.
+        slotLabelSortOrder(label) {
+            const map = { GK: 1, CB: 10, LB: 11, RB: 12, DM: 20, CM: 21, LM: 22, RM: 23, AM: 24, LW: 30, RW: 31, CF: 33 };
+            return map[label] ?? 99;
+        },
+
+        // Map a slot label → position group, for the posTab filter tabs.
+        slotLabelToGroup(label) {
+            if (label === 'GK') return 'Goalkeeper';
+            if (['CB', 'LB', 'RB'].includes(label)) return 'Defender';
+            if (['DM', 'CM', 'AM', 'LM', 'RM'].includes(label)) return 'Midfielder';
+            return 'Forward';
+        },
+
+        // Guard: empty slot placeholders should only render when the
+        // slotMap is in sync with selectedPlayers. Prevents the visual
+        // flash during the formation-change fetch window, where slotMap
+        // is momentarily {} but selectedPlayers still has 11 entries.
+        // Self-healing — no state flag needed.
+        slotMapIsConsistent() {
+            return Object.keys(this.slotMap).length === this.selectedPlayers.length;
+        },
+
         // Toggle player selection (from player list)
         toggle(id, isUnavailable) {
             if (isUnavailable) return;

--- a/resources/js/lineup.js
+++ b/resources/js/lineup.js
@@ -418,6 +418,31 @@ export default function lineupManager(config) {
             return (this.isSelected(playerId) ? 0 : 1000) + positionRank;
         },
 
+        // Map a formation slot label (e.g. "CB", "LM") to the same rank
+        // PositionMapper::positionSortOrder uses server-side, so empty
+        // starter placeholders interleave correctly with filled rows.
+        slotLabelSortOrder(label) {
+            const map = { GK: 1, CB: 10, LB: 11, RB: 12, DM: 20, CM: 21, LM: 22, RM: 23, AM: 24, LW: 30, RW: 31, CF: 33 };
+            return map[label] ?? 99;
+        },
+
+        // Map a slot label → position group, for the posTab filter tabs.
+        slotLabelToGroup(label) {
+            if (label === 'GK') return 'Goalkeeper';
+            if (['CB', 'LB', 'RB'].includes(label)) return 'Defender';
+            if (['DM', 'CM', 'AM', 'LM', 'RM'].includes(label)) return 'Midfielder';
+            return 'Forward';
+        },
+
+        // Guard: empty slot placeholders should only render when the
+        // slotMap is in sync with selectedPlayers. Prevents the visual
+        // flash during the formation-change fetch window, where slotMap
+        // is momentarily {} but selectedPlayers still has 11 entries.
+        // Self-healing — no state flag needed.
+        slotMapIsConsistent() {
+            return Object.keys(this.slotMap).length === this.selectedPlayers.length;
+        },
+
         // Toggle player selection (from player list)
         toggle(id, isUnavailable) {
             if (isUnavailable && !this.isSelected(id)) return;

--- a/resources/js/lineup.js
+++ b/resources/js/lineup.js
@@ -402,6 +402,22 @@ export default function lineupManager(config) {
 
         isSelected(id) { return this.selectedPlayers.includes(id) },
 
+        // Reactive sort order for the Available Players list. Used as a CSS
+        // `order` value so the list re-settles whenever selection state
+        // changes (drag, toggle, formation swap, auto XI, pitch removal).
+        //   0–99    → starting XI, sorted by position (GK, DEF, MID, FWD)
+        //   1000+   → bench, sorted by position
+        //   2000+   → unavailable (injured/suspended), sorted by position
+        listSortOrder(playerId) {
+            const player = this.playersData[playerId];
+            if (!player) return 9999;
+            const positionRank = player.sortOrder ?? 99;
+            if (!player.isAvailable) {
+                return 2000 + positionRank;
+            }
+            return (this.isSelected(playerId) ? 0 : 1000) + positionRank;
+        },
+
         // Toggle player selection (from player list)
         toggle(id, isUnavailable) {
             if (isUnavailable && !this.isSelected(id)) return;

--- a/resources/views/lineup.blade.php
+++ b/resources/views/lineup.blade.php
@@ -256,7 +256,7 @@
                             </div>
 
                             {{-- Player list --}}
-                            <div :class="{ 'select-none': listDragPlayerId }">
+                            <div class="flex flex-col" :class="{ 'select-none': listDragPlayerId }">
                                 @foreach([
                                     ['name' => __('squad.goalkeepers'), 'players' => $goalkeepers, 'role' => 'Goalkeeper'],
                                     ['name' => __('squad.defenders'), 'players' => $defenders, 'role' => 'Defender'],
@@ -275,6 +275,7 @@
                                             @endphp
                                             <div
                                                 x-show="posTab === 'all' || posTab === '{{ $posGroup }}'"
+                                                :style="`order: ${listSortOrder('{{ $player->id }}')}`"
                                                 @click="toggle('{{ $player->id }}', {{ $isUnavailable ? 'true' : 'false' }})"
                                                 @mousedown="startListDrag('{{ $player->id }}', $event)"
                                                 @mouseenter="hoveredPlayerId = '{{ $player->id }}'"

--- a/resources/views/lineup.blade.php
+++ b/resources/views/lineup.blade.php
@@ -257,6 +257,37 @@
 
                             {{-- Player list --}}
                             <div class="flex flex-col" :class="{ 'select-none': listDragPlayerId }">
+                                {{-- Starting XI section header --}}
+                                <div :style="`order: -1`" class="px-3 py-2 bg-surface-700/40 border-b border-border-default">
+                                    <h4 class="text-[10px] font-semibold uppercase tracking-widest text-text-secondary">
+                                        {{ __('squad.starting_xi') }}
+                                        <span class="text-text-faint normal-case tracking-normal ml-1" x-text="`(${selectedCount}/11)`"></span>
+                                    </h4>
+                                </div>
+
+                                {{-- Empty starter slot placeholders (one per unfilled slot in current formation) --}}
+                                <template x-for="slot in currentSlots" :key="slot.id">
+                                    <div
+                                        x-show="slotMapIsConsistent() && !slotMap[slot.id] && (posTab === 'all' || posTab === slotLabelToGroup(slot.label))"
+                                        :style="`order: ${slotLabelSortOrder(slot.label)}`"
+                                        @click="assigningSlotId = slot.id"
+                                        :class="assigningSlotId === slot.id ? 'ring-2 ring-accent-blue ring-inset' : ''"
+                                        class="px-3 py-2.5 border-b border-dashed border-border-default cursor-pointer hover:bg-surface-700/30 transition-colors"
+                                    >
+                                        <div class="flex items-center gap-2.5">
+                                            <div class="w-8 h-8 rounded-full border-2 border-dashed border-border-strong flex items-center justify-center text-[10px] font-semibold text-text-faint" x-text="slot.label"></div>
+                                            <span class="text-xs text-text-muted">{{ __('squad.empty_slot') }}</span>
+                                        </div>
+                                    </div>
+                                </template>
+
+                                {{-- Substitutes section header (sits between starter region order 0-99 and bench region 1000+) --}}
+                                <div :style="`order: 999`" class="px-3 py-2 bg-surface-700/40 border-b border-t border-border-default">
+                                    <h4 class="text-[10px] font-semibold uppercase tracking-widest text-text-secondary">
+                                        {{ __('squad.substitutes') }}
+                                    </h4>
+                                </div>
+
                                 @foreach([
                                     ['name' => __('squad.goalkeepers'), 'players' => $goalkeepers, 'role' => 'Goalkeeper'],
                                     ['name' => __('squad.defenders'), 'players' => $defenders, 'role' => 'Defender'],

--- a/resources/views/lineup.blade.php
+++ b/resources/views/lineup.blade.php
@@ -259,7 +259,7 @@
                             </div>
 
                             {{-- Player list --}}
-                            <div :class="{ 'select-none': listDragPlayerId }">
+                            <div class="flex flex-col" :class="{ 'select-none': listDragPlayerId }">
                                 @foreach([
                                     ['name' => __('squad.goalkeepers'), 'players' => $goalkeepers, 'role' => 'Goalkeeper'],
                                     ['name' => __('squad.defenders'), 'players' => $defenders, 'role' => 'Defender'],
@@ -278,6 +278,7 @@
                                             @endphp
                                             <div
                                                 x-show="posTab === 'all' || posTab === '{{ $posGroup }}'"
+                                                :style="`order: ${listSortOrder('{{ $player->id }}')}`"
                                                 @click="toggle('{{ $player->id }}', {{ $isUnavailable ? 'true' : 'false' }})"
                                                 @mousedown="startListDrag('{{ $player->id }}', $event)"
                                                 @mouseenter="hoveredPlayerId = '{{ $player->id }}'"

--- a/resources/views/lineup.blade.php
+++ b/resources/views/lineup.blade.php
@@ -260,6 +260,37 @@
 
                             {{-- Player list --}}
                             <div class="flex flex-col" :class="{ 'select-none': listDragPlayerId }">
+                                {{-- Starting XI section header --}}
+                                <div :style="`order: -1`" class="px-3 py-2 bg-surface-700/40 border-b border-border-default">
+                                    <h4 class="text-[10px] font-semibold uppercase tracking-widest text-text-secondary">
+                                        {{ __('squad.starting_xi') }}
+                                        <span class="text-text-faint normal-case tracking-normal ml-1" x-text="`(${selectedCount}/11)`"></span>
+                                    </h4>
+                                </div>
+
+                                {{-- Empty starter slot placeholders (one per unfilled slot in current formation) --}}
+                                <template x-for="slot in currentSlots" :key="slot.id">
+                                    <div
+                                        x-show="slotMapIsConsistent() && !slotMap[slot.id] && (posTab === 'all' || posTab === slotLabelToGroup(slot.label))"
+                                        :style="`order: ${slotLabelSortOrder(slot.label)}`"
+                                        @click="assigningSlotId = slot.id"
+                                        :class="assigningSlotId === slot.id ? 'ring-2 ring-accent-blue ring-inset' : ''"
+                                        class="px-3 py-2.5 border-b border-dashed border-border-default cursor-pointer hover:bg-surface-700/30 transition-colors"
+                                    >
+                                        <div class="flex items-center gap-2.5">
+                                            <div class="w-8 h-8 rounded-full border-2 border-dashed border-border-strong flex items-center justify-center text-[10px] font-semibold text-text-faint" x-text="slot.label"></div>
+                                            <span class="text-xs text-text-muted">{{ __('squad.empty_slot') }}</span>
+                                        </div>
+                                    </div>
+                                </template>
+
+                                {{-- Substitutes section header (sits between starter region order 0-99 and bench region 1000+) --}}
+                                <div :style="`order: 999`" class="px-3 py-2 bg-surface-700/40 border-b border-t border-border-default">
+                                    <h4 class="text-[10px] font-semibold uppercase tracking-widest text-text-secondary">
+                                        {{ __('squad.substitutes') }}
+                                    </h4>
+                                </div>
+
                                 @foreach([
                                     ['name' => __('squad.goalkeepers'), 'players' => $goalkeepers, 'role' => 'Goalkeeper'],
                                     ['name' => __('squad.defenders'), 'players' => $defenders, 'role' => 'Defender'],


### PR DESCRIPTION
## Summary
This PR implements a reactive sorting system for the Available Players list that dynamically reorders players based on their selection state and availability status. Players are now grouped into three tiers: starting XI, bench, and unavailable (injured/suspended), with each tier sorted by position.

## Key Changes
- **Added `listSortOrder()` method** in `lineup.js` that computes CSS `order` values for players:
  - 0–99: Starting XI players, sorted by position
  - 1000+: Bench players, sorted by position
  - 2000+: Unavailable players, sorted by position
  
- **Added `sortOrder` field** to player data in `ShowLineup.php` controller:
  - Leverages `PositionMapper::positionSortOrder()` as the single source of truth for position-based ranking
  - Ensures consistent position ordering across the application

- **Updated player list container** in `lineup.blade.php`:
  - Added `flex flex-col` classes to enable CSS flexbox ordering
  - Applied dynamic `:style` binding with `order` property to each player element
  - List automatically re-settles on drag, toggle, formation swap, auto XI, or pitch removal

## Implementation Details
The sorting is purely CSS-based using flexbox `order` property, making it performant and reactive. The `listSortOrder()` method is called reactively whenever selection state changes, ensuring the visual order always reflects the current lineup state without requiring DOM manipulation.

https://claude.ai/code/session_01MAosENJ7kZ9UewxFfcJwWC