### PR TITLE
Remove striker bonus from expected goals calculation

### DIFF
--- a/app/Modules/Match/Services/MatchSimulator.php
+++ b/app/Modules/Match/Services/MatchSimulator.php
@@ -1101,41 +1101,6 @@ class MatchSimulator
     }
 
     /**
-     * Calculate striker quality bonus for expected goals.
-     *
-     * Elite forwards (90+) provide a significant boost to their team's
-     * expected goals, reflecting their ability to create chances from nothing.
-     *
-     * @param  Collection<GamePlayer>  $lineup
-     * @return float Bonus expected goals (0.0 to ~0.5)
-     */
-    private function calculateStrikerBonus(Collection $lineup): float
-    {
-        $forwardPositions = ['Centre-Forward', 'Second Striker', 'Left Winger', 'Right Winger'];
-
-        // Get the best forward in the lineup (using effective score for match-day variance)
-        $bestForwardScore = 0;
-        foreach ($lineup as $player) {
-            if (in_array($player->position, $forwardPositions)) {
-                $effectiveScore = $this->getEffectiveScore($player);
-                $bestForwardScore = max($bestForwardScore, $effectiveScore);
-            }
-        }
-
-        // No bonus if no forwards or if best forward is below 85
-        if ($bestForwardScore < 85) {
-            return 0.0;
-        }
-
-        // Bonus scales from 0 at 85 to ~0.30 at 100
-        // Formula: (rating - 85) / 50 gives 0.0 to 0.30 range
-        // Only truly elite forwards provide a noticeable boost
-        // A 94-rated forward gets +0.18 expected goals
-        // A 88-rated striker gets +0.06 expected goals
-        return ($bestForwardScore - 85) / 50;
-    }
-
-    /**
      * Calculate opponent xG multiplier based on goalkeeper quality.
      *
      * Returns a multiplier >= 1.0 applied to the OPPONENT's expected goals.
@@ -1518,7 +1483,7 @@ class MatchSimulator
 
     /**
      * Calculate base expected goals from strength ratio, formation, mentality, and match fraction.
-     * Does not include tactical instruction modifiers, striker bonus, or max goals cap.
+     * Does not include tactical instruction modifiers or max goals cap.
      *
      * @return array{0: float, 1: float} [homeXG, awayXG]
      */
@@ -1763,9 +1728,6 @@ class MatchSimulator
             $effectiveMinute,
         );
 
-        $homeExpectedGoals += $this->calculateStrikerBonus($homePlayers) * $matchFraction;
-        $awayExpectedGoals += $this->calculateStrikerBonus($awayPlayers) * $matchFraction;
-
         // Goalkeeper quality: missing/out-of-position GK increases opponent xG
         $awayExpectedGoals *= $this->calculateGoalkeeperModifier($homePlayers);
         $homeExpectedGoals *= $this->calculateGoalkeeperModifier($awayPlayers);
@@ -1866,9 +1828,6 @@ class MatchSimulator
                     $effectiveMinute,
                     $homePlayers, $awayPlayers,
                 );
-
-                $homeExpectedGoals += $this->calculateStrikerBonus($homePlayers) * $matchFraction;
-                $awayExpectedGoals += $this->calculateStrikerBonus($awayPlayers) * $matchFraction;
 
                 $awayExpectedGoals *= $this->calculateGoalkeeperModifier($homePlayers);
                 $homeExpectedGoals *= $this->calculateGoalkeeperModifier($awayPlayers);
@@ -2033,9 +1992,6 @@ class MatchSimulator
             $homePlayers, $awayPlayers,
         );
 
-        $homeXG1 += $this->calculateStrikerBonus($homePlayers) * $fraction1;
-        $awayXG1 += $this->calculateStrikerBonus($awayPlayers) * $fraction1;
-
         $awayXG1 *= $this->calculateGoalkeeperModifier($homePlayers);
         $homeXG1 *= $this->calculateGoalkeeperModifier($awayPlayers);
 
@@ -2092,9 +2048,6 @@ class MatchSimulator
             $homeMentality, $awayMentality,
             $effectiveMinute2,
         );
-
-        $homeXG2 += $this->calculateStrikerBonus($homePlayers2) * $fraction2;
-        $awayXG2 += $this->calculateStrikerBonus($awayPlayers2) * $fraction2;
 
         $awayXG2 *= $this->calculateGoalkeeperModifier($homePlayers2);
         $homeXG2 *= $this->calculateGoalkeeperModifier($awayPlayers2);

--- a/docs/game-systems/match-simulation.md
+++ b/docs/game-systems/match-simulation.md
@@ -20,8 +20,6 @@ The stronger team is always favored regardless of venue — home advantage is a 
 
 **Team strength** is calculated from the 11-player lineup with ability-dominant weights (technical 57.5%, physical 37.5%, morale 5%), each modified by a per-player energy effectiveness modifier and a random daily performance variance (normal distribution, tight range). See `calculateTeamStrength()` in `MatchSimulator`.
 
-**Striker bonus**: The best forward in the lineup above a quality threshold adds bonus xG. See `calculateStrikerBonus()`.
-
 All base values and exponents are configurable in `config/match_simulation.php`.
 
 ## Formation & Mentality


### PR DESCRIPTION
## Summary
This PR removes the striker quality bonus mechanic from the match simulation's expected goals (xG) calculation. The `calculateStrikerBonus()` method and all its usages have been removed, simplifying the xG calculation logic.

## Changes Made
- **Removed `calculateStrikerBonus()` method**: Deleted the private method that calculated bonus expected goals based on the best forward's rating (90+ rated forwards received 0.0-0.5 xG bonus)
- **Removed striker bonus application**: Eliminated all calls to `calculateStrikerBonus()` across three simulation methods:
  - `simulateRemainder()` - removed 2 bonus applications (initial and during minute-by-minute simulation)
  - `simulateGoalsWithRedCardSplit()` - removed 4 bonus applications (2 for each half of the split simulation)
- **Updated documentation**: Removed reference to striker bonus from `match-simulation.md`
- **Updated method comment**: Clarified that `calculateBaseExpectedGoals()` no longer includes striker bonus in its calculation

## Rationale
This change simplifies the xG calculation by removing a specialized bonus mechanic that rewarded elite strikers. The expected goals calculation now relies solely on team strength, formation, mentality, possession, and goalkeeper quality modifiers.

https://claude.ai/code/session_01XFqundvYmn42CFkx4aLfT3