### PR TITLE
Add size prop to action-button component

### DIFF
--- a/resources/views/components/action-button.blade.php
+++ b/resources/views/components/action-button.blade.php
@@ -1,4 +1,4 @@
-@props(['color' => 'blue'])
+@props(['color' => 'blue', 'size' => 'default'])
 
 @php
 $colors = [
@@ -9,8 +9,13 @@ $colors = [
     'violet' => 'border-violet-500/20 text-violet-400 bg-violet-500/10 hover:bg-violet-500/20',
 ];
 $colorClasses = $colors[$color] ?? $colors['blue'];
+
+$sizeClasses = match($size) {
+    'sm' => 'px-3 py-1.5 text-xs rounded-lg min-h-[36px]',
+    default => 'px-3 py-1.5 text-sm rounded-lg min-h-[44px]',
+};
 @endphp
 
-<button {{ $attributes->merge(['type' => 'submit', 'class' => "inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded-lg border {$colorClasses} transition-colors min-h-[44px]"]) }}>
+<button {{ $attributes->merge(['type' => 'submit', 'class' => "inline-flex items-center gap-1.5 {$sizeClasses} font-medium border {$colorClasses} transition-colors"]) }}>
     {{ $slot }}
 </button>

--- a/resources/views/outgoing-transfers.blade.php
+++ b/resources/views/outgoing-transfers.blade.php
@@ -151,7 +151,7 @@
                                                             ],
                                                         ]);
                                                     @endphp
-                                                    <x-primary-button type="button" x-on:click="$dispatch('open-negotiation', {{ $counterOfferDetail }})">
+                                                    <x-primary-button type="button" size="sm" x-on:click="$dispatch('open-negotiation', {{ $counterOfferDetail }})">
                                                         {{ __('transfers.negotiate') }}
                                                     </x-primary-button>
                                                 </div>
@@ -209,7 +209,7 @@
                                                                 ],
                                                             ]);
                                                         @endphp
-                                                        <x-action-button color="green" type="button" x-on:click="$dispatch('open-negotiation', {{ $renewalDetail }})">
+                                                        <x-action-button color="green" type="button" size="sm" x-on:click="$dispatch('open-negotiation', {{ $renewalDetail }})">
                                                             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" /></svg>
                                                             {{ __('squad.renew') }}
                                                         </x-action-button>
@@ -275,7 +275,7 @@
                                                             ],
                                                         ]);
                                                     @endphp
-                                                    <x-primary-button type="button" x-on:click="$dispatch('open-negotiation', {{ $counterOfferDetail }})">
+                                                    <x-primary-button type="button" size="sm" x-on:click="$dispatch('open-negotiation', {{ $counterOfferDetail }})">
                                                         {{ __('transfers.negotiate') }}
                                                     </x-primary-button>
                                                 </div>


### PR DESCRIPTION
## Summary
Added a configurable `size` prop to the `action-button` component to support different button sizes, with implementations applied to buttons in the outgoing transfers view.

## Key Changes
- **action-button component**: Added `size` prop with `default` and `sm` options that control padding, font size, and minimum height
  - `sm`: `px-3 py-1.5 text-xs rounded-lg min-h-[36px]`
  - `default`: `px-3 py-1.5 text-sm rounded-lg min-h-[44px]`
- **outgoing-transfers view**: Applied `size="sm"` to three button instances for more compact spacing in dense UI areas

## Implementation Details
- The size classes are defined using a PHP `match()` expression for clean, maintainable code
- Default size maintains backward compatibility with existing button styling
- The component's class attribute was refactored to use the new `$sizeClasses` variable, improving readability and maintainability

https://claude.ai/code/session_01Cdu3Z16KbX8iQiGWgyNBJA