### PR TITLE
Reorder scouting hub columns on mobile devices

### DIFF
--- a/resources/views/scouting-hub.blade.php
+++ b/resources/views/scouting-hub.blade.php
@@ -76,7 +76,7 @@
                         {{-- ============================== --}}
                         {{-- LEFT COLUMN (2/3) — Shortlist + Search History --}}
                         {{-- ============================== --}}
-                        <div class="md:col-span-2 space-y-6">
+                        <div class="md:col-span-2 space-y-6 order-2 md:order-1">
 
                             {{-- Shortlist Section (Reactive Alpine.js) --}}
                             <div x-data="{
@@ -677,7 +677,7 @@
                         {{-- ============================== --}}
                         {{-- RIGHT COLUMN (1/3) — Search Panel --}}
                         {{-- ============================== --}}
-                        <div class="space-y-6">
+                        <div class="space-y-6 order-1 md:order-2">
 
                             @if($searchingReport)
                                 {{-- Searching State --}}


### PR DESCRIPTION
## Summary
This PR reorders the layout of the scouting hub page on mobile devices to improve the user experience by displaying the search panel before the shortlist section.

## Key Changes
- Added Tailwind CSS flexbox ordering utilities to the left column (shortlist + search history):
  - `order-2` on mobile (default)
  - `md:order-1` on medium screens and up
- Added Tailwind CSS flexbox ordering utilities to the right column (search panel):
  - `order-1` on mobile (default)
  - `md:order-2` on medium screens and up

## Implementation Details
The changes leverage Tailwind's responsive ordering utilities to reorder the two-column layout on mobile devices. On smaller screens, users will now see the search panel first (order-1), followed by the shortlist section (order-2). On medium screens and larger, the original layout is preserved with the shortlist on the left and search panel on the right.

This improves mobile usability by prioritizing the search functionality before showing results.

https://claude.ai/code/session_01LvuW1stsPFMcSyoXvSqSHs