### PR TITLE
Improve scout report results layout responsiveness on mobile

### DIFF
--- a/resources/views/partials/scout-report-results.blade.php
+++ b/resources/views/partials/scout-report-results.blade.php
@@ -61,17 +61,17 @@
                 @endphp
                 <div class="px-4 md:px-6 py-4" x-data="{ expanded: false, shortlisted: {{ $isShortlisted ? 'true' : 'false' }}, toggling: false }" @shortlist-toggled.window="if($event.detail.playerId === '{{ $player->id }}') { shortlisted = $event.detail.action === 'added' }">
                     {{-- Player Summary Row --}}
-                    <div class="flex items-center gap-3 cursor-pointer" @click="expanded = !expanded">
+                    <div class="flex flex-col md:flex-row md:items-center gap-3 cursor-pointer" @click="expanded = !expanded">
                         {{-- Position + Name --}}
                         <div class="flex items-center gap-3 min-w-0 flex-1">
                             <div class="flex items-center gap-1 shrink-0">
                                 @foreach($player->positions as $pos)
-                                    <x-position-badge :position="$pos" />
+                                    <x-position-badge :position="$pos" class="md:w-5 md:h-5 md:text-[8px]" />
                                 @endforeach
                             </div>
                             <div class="min-w-0">
                                 <div class="flex items-center gap-2 flex-wrap">
-                                    <span class="font-semibold text-text-primary truncate">{{ $player->name }}</span>
+                                    <span class="font-semibold text-text-primary">{{ $player->name }}</span>
                                     <span class="text-xs text-text-secondary">{{ $player->age($game->current_date) }} {{ __('app.years') }}</span>
                                     @if($isFreeAgent)
                                         <span class="inline-flex items-center px-1.5 py-0.5 rounded-sm text-[10px] font-medium bg-accent-green/10 text-accent-green">{{ __('transfers.free_agent') }}</span>
@@ -89,7 +89,7 @@
                         </div>
 
                         {{-- Ability estimate + Price + Shortlist --}}
-                        <div class="flex items-center gap-3 sm:gap-4 shrink-0">
+                        <div class="flex items-center justify-between gap-4 md:justify-end md:shrink-0">
                             <div class="text-right">
                                 <div class="text-xs text-text-secondary">{{ __('transfers.ability') }}</div>
                                 <div class="text-sm font-semibold text-text-body tabular-nums">{{ $techRange[0] }}-{{ $techRange[1] }}</div>


### PR DESCRIPTION
## Summary
This PR improves the mobile responsiveness of the scout report results player card layout by adjusting flex direction, spacing, and text handling for smaller screens.

## Key Changes
- Changed the main player summary row from a fixed horizontal layout to a responsive flex layout that stacks vertically on mobile (`flex-col`) and horizontally on medium screens and up (`md:flex-row md:items-center`)
- Added responsive sizing to position badges to make them smaller on medium screens and above (`md:w-5 md:h-5 md:text-[8px]`)
- Removed `truncate` class from player name to allow full name display and prevent text overflow issues
- Updated the ability/price/shortlist section to use `justify-between` for mobile spacing and `md:justify-end` for desktop alignment, with improved gap handling (`gap-4 md:justify-end md:shrink-0`)

## Implementation Details
The changes maintain the existing functionality while providing better visual hierarchy and spacing across different screen sizes. The layout now gracefully adapts from a stacked mobile view to a horizontal desktop view without compromising readability or usability.

https://claude.ai/code/session_019DXBsHafnjWvbsjw4Ez6ZA