### PR TITLE
Fix contract renewal for loaned-out players

### DIFF
--- a/app/Http/Actions/DeclineRenewal.php
+++ b/app/Http/Actions/DeclineRenewal.php
@@ -17,7 +17,7 @@ class DeclineRenewal
     {
         $game = Game::findOrFail($gameId);
         $player = GamePlayer::where('game_id', $gameId)
-            ->where('team_id', $game->team_id)
+            ->ownedByTeam($game->team_id)
             ->findOrFail($playerId);
 
         if (!$player->isContractExpiring() || $player->isRetiring() || $player->hasRenewalAgreed()) {

--- a/app/Http/Actions/NegotiateRenewal.php
+++ b/app/Http/Actions/NegotiateRenewal.php
@@ -35,7 +35,7 @@ class NegotiateRenewal
 
         $player = GamePlayer::with($eagerLoads)
             ->where('game_id', $gameId)
-            ->where('team_id', $game->team_id)
+            ->ownedByTeam($game->team_id)
             ->findOrFail($playerId);
 
         return match ($action) {

--- a/app/Http/Actions/ReconsiderRenewal.php
+++ b/app/Http/Actions/ReconsiderRenewal.php
@@ -17,7 +17,7 @@ class ReconsiderRenewal
         $game = Game::findOrFail($gameId);
         $player = GamePlayer::with('latestRenewalNegotiation')
             ->where('game_id', $gameId)
-            ->where('team_id', $game->team_id)
+            ->ownedByTeam($game->team_id)
             ->findOrFail($playerId);
 
         if (!$player->hasDeclinedRenewal()) {

--- a/app/Http/Views/ShowOutgoingTransfers.php
+++ b/app/Http/Views/ShowOutgoingTransfers.php
@@ -113,7 +113,7 @@ class ShowOutgoingTransfers
         $seasonEndDate = $game->getSeasonEndDate();
         $declinedRenewals = GamePlayer::with(['player', 'latestRenewalNegotiation'])
             ->where('game_id', $gameId)
-            ->where('team_id', $game->team_id)
+            ->ownedByTeam($game->team_id)
             ->whereHas('latestRenewalNegotiation', fn ($q) => $q->where('status', RenewalNegotiation::STATUS_CLUB_DECLINED))
             ->get()
             ->filter(fn (GamePlayer $p) => $p->isContractExpiring($seasonEndDate) && $p->hasDeclinedRenewal());
@@ -129,7 +129,7 @@ class ShowOutgoingTransfers
         if (!empty($cooldownPlayerIds)) {
             $cooldownRenewals = GamePlayer::with(['player'])
                 ->where('game_id', $gameId)
-                ->where('team_id', $game->team_id)
+                ->ownedByTeam($game->team_id)
                 ->whereIn('id', $cooldownPlayerIds)
                 ->get()
                 ->filter(fn (GamePlayer $p) => $p->isContractExpiring($seasonEndDate));

--- a/app/Models/GamePlayer.php
+++ b/app/Models/GamePlayer.php
@@ -347,6 +347,28 @@ class GamePlayer extends Model
     }
 
     /**
+     * Scope: players owned by a team.
+     *
+     * A team "owns" a player if either:
+     *   - the player is currently at the team and is not a borrowed (loaned-in) player, OR
+     *   - the player is loaned out from the team (an active Loan exists with parent_team_id = $teamId).
+     *
+     * Loaned-in players (currently at the team but belonging to another club)
+     * are explicitly excluded. Use this for contract-related operations
+     * (renewals, pre-contracts) where the owning club retains authority even
+     * while a player is away on loan.
+     */
+    public function scopeOwnedByTeam($query, string $teamId)
+    {
+        return $query->where(function ($q) use ($teamId) {
+            $q->where(function ($present) use ($teamId) {
+                $present->where('team_id', $teamId)
+                    ->whereDoesntHave('activeLoan');
+            })->orWhereHas('activeLoan', fn ($loanQuery) => $loanQuery->where('parent_team_id', $teamId));
+        });
+    }
+
+    /**
      * Check if player is transfer listed.
      */
     public function isTransferListed(): bool
@@ -497,8 +519,9 @@ class GamePlayer extends Model
             return false;
         }
 
-        // Loaned-in players belong to another club — we can't renew them
-        if ($this->isOnLoan()) {
+        // Loaned-in players belong to another club — we can't renew them.
+        // Loaned-out players (ours, playing elsewhere) can still be renewed.
+        if ($this->isLoanedIn($this->game->team_id)) {
             return false;
         }
 

--- a/app/Modules/Match/Services/CareerActionProcessor.php
+++ b/app/Modules/Match/Services/CareerActionProcessor.php
@@ -163,6 +163,7 @@ class CareerActionProcessor
             ->where('game_id', $game->id)
             ->where('team_id', $game->team_id)
             ->whereNull('pending_annual_wage') // not already renewed
+            ->whereNull('retiring_at_season') // retiring players can't be renewed — don't nag
             ->where('contract_until', '<=', $sixMonthsOut)
             ->where('contract_until', '>', $currentDate)
             ->whereDoesntHave('transferOffers', function ($q) {

--- a/app/Modules/Squad/Services/SquadService.php
+++ b/app/Modules/Squad/Services/SquadService.php
@@ -127,7 +127,10 @@ class SquadService
         $highEarners = collect();
 
         if ($isCareerMode) {
-            $expiringThisSeason = $allPlayers->filter(fn ($p) => $p->isContractExpiring($seasonEndDate))
+            // Retiring players can't be renewed or sold — exclude them from the watchlist
+            // so the user isn't nudged to act on something they can't resolve.
+            $expiringThisSeason = $allPlayers
+                ->filter(fn ($p) => $p->isContractExpiring($seasonEndDate) && !$p->isRetiring())
                 ->sortByDesc('overall_score')
                 ->values();
 

--- a/app/Modules/Transfer/Services/ContractService.php
+++ b/app/Modules/Transfer/Services/ContractService.php
@@ -325,7 +325,7 @@ class ContractService
 
         return GamePlayer::with(['player', 'team', 'game', 'transferOffers', 'latestRenewalNegotiation', 'activeRenewalNegotiation', 'activeLoan'])
             ->where('game_id', $game->id)
-            ->where('team_id', $game->team_id)
+            ->ownedByTeam($game->team_id)
             ->get()
             ->filter(fn ($player) => $player->canBeOfferedRenewal($seasonEndDate, $game->current_date))
             ->sortBy('contract_until');
@@ -341,7 +341,7 @@ class ContractService
     {
         return GamePlayer::with('player')
             ->where('game_id', $game->id)
-            ->where('team_id', $game->team_id)
+            ->ownedByTeam($game->team_id)
             ->whereNotNull('pending_annual_wage')
             ->orderByDesc('pending_annual_wage')
             ->get();

--- a/tests/Feature/RenewalForLoanedPlayerTest.php
+++ b/tests/Feature/RenewalForLoanedPlayerTest.php
@@ -1,0 +1,212 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Competition;
+use App\Models\Game;
+use App\Models\GamePlayer;
+use App\Models\Loan;
+use App\Models\Player;
+use App\Models\Team;
+use App\Models\User;
+use App\Modules\Transfer\Services\ContractService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Covers the regression where a contract renewal could not be negotiated for
+ * a player whose last-year contract was loaned out mid-season. The parent
+ * club should retain full contract authority while the player is away.
+ */
+class RenewalForLoanedPlayerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+    private Team $userTeam;
+    private Team $otherTeam;
+    private Game $game;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = User::factory()->create();
+        $this->userTeam = Team::factory()->create(['name' => 'User Team']);
+        $this->otherTeam = Team::factory()->create(['name' => 'Other Team']);
+        Competition::factory()->league()->create(['id' => 'ESP1']);
+
+        $this->game = Game::factory()->create([
+            'user_id' => $this->user->id,
+            'team_id' => $this->userTeam->id,
+            'competition_id' => 'ESP1',
+            'season' => '2024',
+            'current_date' => '2025-02-15',
+        ]);
+    }
+
+    public function test_loaned_out_player_can_still_be_offered_renewal(): void
+    {
+        $player = $this->createExpiringPlayer();
+        $this->loanPlayerOut($player, $this->otherTeam);
+
+        $player->refresh()->load('game', 'activeLoan');
+
+        $this->assertSame($this->otherTeam->id, $player->team_id,
+            'Sanity check: loaning-out moves team_id to the borrowing club');
+        $this->assertTrue($player->isLoanedOut($this->userTeam->id));
+        $this->assertTrue(
+            $player->canBeOfferedRenewal($this->game->getSeasonEndDate()),
+            'A player loaned out by the user team must still be renewable'
+        );
+    }
+
+    public function test_loaned_in_player_still_cannot_be_offered_renewal(): void
+    {
+        $player = $this->createExpiringPlayer(team: $this->otherTeam);
+        $this->loanPlayerIn($player, parentTeam: $this->otherTeam);
+
+        $player->refresh()->load('game', 'activeLoan');
+
+        $this->assertSame($this->userTeam->id, $player->team_id);
+        $this->assertTrue($player->isLoanedIn($this->userTeam->id));
+        $this->assertFalse(
+            $player->canBeOfferedRenewal($this->game->getSeasonEndDate()),
+            'Loaned-in players belong to another club and must not be renewable by us'
+        );
+    }
+
+    public function test_get_players_eligible_for_renewal_includes_loaned_out_player(): void
+    {
+        $onSite = $this->createExpiringPlayer();
+        $loanedOut = $this->createExpiringPlayer();
+        $this->loanPlayerOut($loanedOut, $this->otherTeam);
+
+        $eligible = app(ContractService::class)->getPlayersEligibleForRenewal($this->game);
+        $eligibleIds = $eligible->pluck('id')->all();
+
+        $this->assertContains($onSite->id, $eligibleIds);
+        $this->assertContains($loanedOut->id, $eligibleIds,
+            'Players loaned out by the user team must appear in the renewal list'
+        );
+    }
+
+    public function test_get_players_eligible_for_renewal_excludes_loaned_in_player(): void
+    {
+        $loanedIn = $this->createExpiringPlayer(team: $this->otherTeam);
+        $this->loanPlayerIn($loanedIn, parentTeam: $this->otherTeam);
+
+        $eligible = app(ContractService::class)->getPlayersEligibleForRenewal($this->game);
+
+        $this->assertNotContains($loanedIn->id, $eligible->pluck('id')->all(),
+            'Players loaned in from another club must never show in the renewal list'
+        );
+    }
+
+    public function test_negotiate_renewal_endpoint_accepts_loaned_out_player(): void
+    {
+        $player = $this->createExpiringPlayer();
+        $this->loanPlayerOut($player, $this->otherTeam);
+
+        $response = $this->actingAs($this->user)
+            ->postJson(
+                route('game.negotiate.renewal', [$this->game->id, $player->id]),
+                ['action' => 'start']
+            );
+
+        $response->assertOk();
+        $response->assertJsonPath('status', 'ok');
+        $response->assertJsonPath('negotiation_status', 'open');
+    }
+
+    public function test_negotiate_renewal_endpoint_rejects_loaned_in_player(): void
+    {
+        $player = $this->createExpiringPlayer(team: $this->otherTeam);
+        $this->loanPlayerIn($player, parentTeam: $this->otherTeam);
+
+        $response = $this->actingAs($this->user)
+            ->postJson(
+                route('game.negotiate.renewal', [$this->game->id, $player->id]),
+                ['action' => 'start']
+            );
+
+        // Loaned-in players are not owned by us — the scope must not find them.
+        $response->assertNotFound();
+    }
+
+    public function test_process_renewal_stores_pending_wage_for_loaned_out_player(): void
+    {
+        $player = $this->createExpiringPlayer();
+        $this->loanPlayerOut($player, $this->otherTeam);
+        $player->refresh();
+
+        $success = app(ContractService::class)
+            ->processRenewal($player, newWage: 500_000_00, contractYears: 2);
+
+        $this->assertTrue($success);
+
+        $player->refresh();
+        $this->assertSame(500_000_00, $player->pending_annual_wage);
+        $this->assertTrue(
+            $player->contract_until->greaterThan($this->game->getSeasonEndDate()),
+            'Contract end date should be pushed beyond the current season'
+        );
+    }
+
+    // =====================================================
+    // Helpers
+    // =====================================================
+
+    private function createExpiringPlayer(?Team $team = null): GamePlayer
+    {
+        $player = Player::factory()->age(28)->create([
+            'technical_ability' => 70,
+            'physical_ability' => 70,
+        ]);
+
+        return GamePlayer::factory()->create([
+            'game_id' => $this->game->id,
+            'player_id' => $player->id,
+            'team_id' => ($team ?? $this->userTeam)->id,
+            'position' => 'Central Midfield',
+            // Contract expires before the season end (June 30) → "last year"
+            'contract_until' => '2025-06-30',
+            'annual_wage' => 200_000_00,
+        ]);
+    }
+
+    private function loanPlayerOut(GamePlayer $player, Team $destination): Loan
+    {
+        $loan = Loan::create([
+            'game_id' => $this->game->id,
+            'game_player_id' => $player->id,
+            'parent_team_id' => $this->userTeam->id,
+            'loan_team_id' => $destination->id,
+            'started_at' => $this->game->current_date,
+            'return_at' => $this->game->getSeasonEndDate(),
+            'status' => Loan::STATUS_ACTIVE,
+        ]);
+
+        // Mirror LoanService::processLoanOut: the player physically moves.
+        $player->update(['team_id' => $destination->id, 'number' => null]);
+
+        return $loan;
+    }
+
+    private function loanPlayerIn(GamePlayer $player, Team $parentTeam): Loan
+    {
+        $loan = Loan::create([
+            'game_id' => $this->game->id,
+            'game_player_id' => $player->id,
+            'parent_team_id' => $parentTeam->id,
+            'loan_team_id' => $this->userTeam->id,
+            'started_at' => $this->game->current_date,
+            'return_at' => $this->game->getSeasonEndDate(),
+            'status' => Loan::STATUS_ACTIVE,
+        ]);
+
+        $player->update(['team_id' => $this->userTeam->id]);
+
+        return $loan;
+    }
+}

--- a/tests/Feature/RetiringPlayerExpiringContractTest.php
+++ b/tests/Feature/RetiringPlayerExpiringContractTest.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Competition;
+use App\Models\Game;
+use App\Models\GameFinances;
+use App\Models\GameInvestment;
+use App\Models\GameNotification;
+use App\Models\GamePlayer;
+use App\Models\Player;
+use App\Models\Team;
+use App\Models\User;
+use App\Modules\Match\Services\CareerActionProcessor;
+use App\Modules\Squad\Services\SquadService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use ReflectionMethod;
+use Tests\TestCase;
+
+/**
+ * Guards against nagging the user with "contract expiring" reminders for
+ * players that have already announced their retirement — those contracts
+ * cannot be renewed or sold, so a notification is just noise the user can't
+ * act on.
+ */
+class RetiringPlayerExpiringContractTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+    private Team $userTeam;
+    private Game $game;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = User::factory()->create();
+        $this->userTeam = Team::factory()->create(['name' => 'User Team']);
+        Competition::factory()->league()->create(['id' => 'ESP1']);
+
+        $this->game = Game::factory()->create([
+            'user_id' => $this->user->id,
+            'team_id' => $this->userTeam->id,
+            'competition_id' => 'ESP1',
+            'season' => '2024',
+            'current_date' => '2025-02-15',
+        ]);
+
+        GameInvestment::create([
+            'game_id' => $this->game->id,
+            'season' => '2024',
+            'transfer_budget' => 50_000_000_00,
+            'scouting_tier' => 1,
+        ]);
+        GameFinances::create([
+            'game_id' => $this->game->id,
+            'season' => '2024',
+            'projected_revenue' => 100_000_000_00,
+            'projected_wages' => 50_000_000_00,
+            'projected_position' => 10,
+        ]);
+    }
+
+    public function test_check_expiring_contracts_skips_retiring_players(): void
+    {
+        $active = $this->createExpiringPlayer(age: 28);
+        $retiring = $this->createExpiringPlayer(age: 36, retiringAtSeason: '2024');
+
+        $this->invokeCheckExpiringContracts();
+
+        $this->assertDatabaseHas('game_notifications', [
+            'game_id' => $this->game->id,
+            'type' => GameNotification::TYPE_CONTRACT_EXPIRING,
+        ]);
+
+        $notifiedPlayerIds = GameNotification::where('game_id', $this->game->id)
+            ->where('type', GameNotification::TYPE_CONTRACT_EXPIRING)
+            ->get()
+            ->pluck('metadata.player_id')
+            ->all();
+
+        $this->assertContains($active->id, $notifiedPlayerIds,
+            'Non-retiring players with expiring contracts must still be notified'
+        );
+        $this->assertNotContains($retiring->id, $notifiedPlayerIds,
+            'Retiring players must not trigger contract-expiring notifications'
+        );
+    }
+
+    public function test_squad_overview_watchlist_excludes_retiring_players(): void
+    {
+        $active = $this->createExpiringPlayer(age: 27);
+        $retiring = $this->createExpiringPlayer(age: 37, retiringAtSeason: '2024');
+
+        $overview = app(SquadService::class)->buildSquadOverview($this->game->refresh());
+
+        $watchlistIds = $overview['expiringThisSeason']->pluck('id')->all();
+
+        $this->assertContains($active->id, $watchlistIds);
+        $this->assertNotContains($retiring->id, $watchlistIds,
+            'Retiring players must not appear in the squad sidebar contract watchlist'
+        );
+    }
+
+    // =====================================================
+    // Helpers
+    // =====================================================
+
+    private function createExpiringPlayer(int $age, ?string $retiringAtSeason = null): GamePlayer
+    {
+        $player = Player::factory()->age($age)->create([
+            'technical_ability' => 65,
+            'physical_ability' => 65,
+        ]);
+
+        return GamePlayer::factory()->create([
+            'game_id' => $this->game->id,
+            'player_id' => $player->id,
+            'team_id' => $this->userTeam->id,
+            'position' => 'Central Midfield',
+            // Contract ends at the end of the current season.
+            'contract_until' => '2025-06-30',
+            'annual_wage' => 200_000_00,
+            'retiring_at_season' => $retiringAtSeason,
+        ]);
+    }
+
+    private function invokeCheckExpiringContracts(): void
+    {
+        $processor = app(CareerActionProcessor::class);
+        $method = new ReflectionMethod($processor, 'checkExpiringContracts');
+        $method->setAccessible(true);
+        $method->invoke($processor, $this->game->refresh());
+    }
+}


### PR DESCRIPTION
## Summary
Fixes a regression where contract renewals could not be negotiated for players whose contracts were loaned out mid-season. The parent club should retain full contract authority while the player is away on loan.

## Key Changes
- **New `ownedByTeam()` scope** in `GamePlayer` model: Distinguishes between players a team owns (including those loaned out) versus players loaned in from other clubs. A team "owns" a player if they're at the team and not borrowed, OR if they're loaned out from that team.

- **Updated `canBeOfferedRenewal()` logic**: Changed from rejecting all loaned players (`isOnLoan()`) to only rejecting loaned-in players (`isLoanedIn()`). This allows loaned-out players to be renewed by their parent club.

- **Updated contract-related queries**: Replaced direct `team_id` checks with the new `ownedByTeam()` scope in:
  - `ContractService::getPlayersEligibleForRenewal()`
  - `ContractService::getPlayersWithPendingRenewals()`
  - `NegotiateRenewal` action
  - `DeclineRenewal` action
  - `ReconsiderRenewal` action
  - `ShowOutgoingTransfers` view

- **Comprehensive test coverage**: Added `RenewalForLoanedPlayerTest` with 6 test cases covering:
  - Loaned-out players can be offered renewals
  - Loaned-in players cannot be offered renewals
  - Renewal eligibility lists include loaned-out but exclude loaned-in players
  - API endpoints properly accept/reject loaned players
  - Renewal processing works for loaned-out players

## Implementation Details
The `ownedByTeam()` scope uses a compound WHERE clause to match players in either state:
1. Players at the team without an active loan (normal roster players)
2. Players with an active loan where the parent team matches (loaned out)

This ensures contract authority remains with the parent club throughout the loan period, while preventing unauthorized contract modifications by borrowing clubs.

https://claude.ai/code/session_01LQhdA1SJNdpxozE1zC821y