### PR TITLE
Fix asking price floor calculation to use raw importance

### DIFF
--- a/app/Modules/Transfer/Services/ScoutingService.php
+++ b/app/Modules/Transfer/Services/ScoutingService.php
@@ -283,10 +283,13 @@ class ScoutingService
 
         $totalMultiplier = $importanceMultiplier * $contractModifier * $ageModifier;
 
-        // Important players with contract leverage: team is reluctant to sell,
-        // never ask below market value. Players without leverage (expiring)
-        // or with low importance can be discounted down to 0.75x.
-        $floor = $effectiveImportance >= 0.5 ? 1.0 : 0.75;
+        // Important players are never sold below market value — the club's
+        // reluctance (see DispositionService::clubSellDisposition) is driven
+        // by raw importance, so the asking price floor must be too. Contract
+        // leverage decay still reduces the premium above market value via
+        // $importanceMultiplier, but shouldn't drag a key player's price
+        // below 1.0x. Non-key players can be discounted down to 0.75x.
+        $floor = $importance >= 0.5 ? 1.0 : 0.75;
         $totalMultiplier = min(max($totalMultiplier, $floor), 1.5);
 
         $askingPrice = $base * $totalMultiplier;


### PR DESCRIPTION
## Summary
Fixed a bug in the scouting service's asking price calculation where the price floor was incorrectly based on `$effectiveImportance` instead of `$importance`. This caused inconsistency with the club's sell disposition logic, which uses raw importance to determine reluctance to sell.

## Key Changes
- Changed the asking price floor calculation from `$effectiveImportance >= 0.5` to `$importance >= 0.5`
- Updated the accompanying comment to clarify the reasoning: the club's reluctance to sell (determined by raw importance) should be reflected in the asking price floor, while contract leverage decay still affects the premium above market value through the `$importanceMultiplier`

## Implementation Details
The fix ensures that:
- Key players (importance ≥ 0.5) maintain a minimum asking price of 1.0x market value, regardless of contract leverage
- Non-key players can still be discounted down to 0.75x market value
- The contract modifier's decay effect still reduces the premium above market value through `$importanceMultiplier`, but won't drag a key player's total price below the 1.0x floor
- The asking price logic now aligns with the club's sell disposition logic in `DispositionService`

https://claude.ai/code/session_011jJ3peCQUfT5dVRLZYVUfa