### PR TITLE
Fix duplicate substitution bug in match resimulation

### DIFF
--- a/app/Modules/Lineup/Services/SubstitutionService.php
+++ b/app/Modules/Lineup/Services/SubstitutionService.php
@@ -163,6 +163,9 @@ class SubstitutionService
     /**
      * Load both teams' lineups and benches for resimulation.
      *
+     * @param  int|null  $minute  If provided, reconstructs the opponent lineup/bench as of
+     *                            this minute (only subs with minute ≤ $minute are applied).
+     *                            Pass null for a full-match reconstruction (all subs applied).
      * @return array{homePlayers: \Illuminate\Support\Collection, awayPlayers: \Illuminate\Support\Collection, homeBench: \Illuminate\Support\Collection, awayBench: \Illuminate\Support\Collection}
      */
     public function loadTeamsForResimulation(
@@ -170,6 +173,7 @@ class SubstitutionService
         Game $game,
         \Illuminate\Support\Collection $userLineup,
         array $substitutions,
+        ?int $minute = null,
     ): array {
         $isUserHome = $match->isHomeTeam($game->team_id);
 
@@ -182,15 +186,36 @@ class SubstitutionService
 
         $opponentLineupIds = $isUserHome ? ($match->away_lineup ?? []) : ($match->home_lineup ?? []);
 
-        // Apply opponent substitutions from match record (auto-subs from initial simulation)
-        // so that injured/subbed-out players are excluded and their replacements are included.
-        foreach ($match->substitutions ?? [] as $sub) {
-            if ($sub['team_id'] === $opponentTeamId) {
+        // Read opponent substitution events from match_events (source of truth) rather
+        // than $match->substitutions, which is populated once during initial simulation
+        // and is not updated by subsequent resimulations. Filtering by minute ensures
+        // the reconstructed lineup matches the actual state at $minute — any sub events
+        // at minute > $minute will be reverted by doResimulate() anyway.
+        $opponentSubEventsQuery = MatchEvent::where('game_match_id', $match->id)
+            ->where('team_id', $opponentTeamId)
+            ->where('event_type', 'substitution');
+        if ($minute !== null) {
+            $opponentSubEventsQuery->where('minute', '<=', $minute);
+        }
+        $opponentSubEvents = $opponentSubEventsQuery->orderBy('minute')->get();
+
+        // Track subbed-out players explicitly so they are excluded from the bench.
+        // Without this, a starter who was subbed out ends up back on the bench
+        // (because "squad − lineup" sees them as off-pitch), letting the AI wrongly
+        // pick them again as a replacement later in the match.
+        $opponentSubbedOutIds = [];
+        foreach ($opponentSubEvents as $subEvent) {
+            $playerOutId = $subEvent->game_player_id;
+            $playerInId = $subEvent->metadata['player_in_id'] ?? null;
+            if ($playerOutId !== null) {
                 $opponentLineupIds = array_values(array_filter(
                     $opponentLineupIds,
-                    fn ($id) => $id !== $sub['player_out_id']
+                    fn ($id) => $id !== $playerOutId
                 ));
-                $opponentLineupIds[] = $sub['player_in_id'];
+                $opponentSubbedOutIds[] = $playerOutId;
+            }
+            if ($playerInId !== null) {
+                $opponentLineupIds[] = $playerInId;
             }
         }
 
@@ -200,6 +225,7 @@ class SubstitutionService
         $opponentPlayers = $opponentSquad->filter(fn ($p) => in_array($p->id, $opponentLineupIds));
         $opponentBench = $opponentSquad
             ->reject(fn ($p) => in_array($p->id, $opponentLineupIds))
+            ->reject(fn ($p) => in_array($p->id, $opponentSubbedOutIds))
             ->reject(fn ($p) => $p->isInjured($match->scheduled_date))
             ->reject(fn ($p) => in_array($p->id, $suspendedPlayerIds))
             ->values();

--- a/app/Modules/Lineup/Services/TacticalChangeService.php
+++ b/app/Modules/Lineup/Services/TacticalChangeService.php
@@ -94,9 +94,11 @@ class TacticalChangeService
             ], $newSubstitutions),
         );
 
-        // Build active lineup and load teams for resimulation
+        // Build active lineup and load teams for resimulation. Pass $minute so that
+        // the opponent's lineup/bench is reconstructed as of the resimulation point —
+        // otherwise subbed-out starters end up wrongly available for reselection.
         $userLineup = $this->substitutionService->buildActiveLineup($match, $game->team_id, $allSubs);
-        $teams = $this->substitutionService->loadTeamsForResimulation($match, $game, $userLineup, $allSubs);
+        $teams = $this->substitutionService->loadTeamsForResimulation($match, $game, $userLineup, $allSubs, $minute);
         ['homePlayers' => $homePlayers, 'awayPlayers' => $awayPlayers, 'homeBench' => $homeBench, 'awayBench' => $awayBench] = $teams;
 
         // Capture effective tactical values before re-simulation

--- a/app/Modules/Match/Services/MatchResimulationService.php
+++ b/app/Modules/Match/Services/MatchResimulationService.php
@@ -108,28 +108,38 @@ class MatchResimulationService
                 $awayEntryMinutes[$sub['playerInId']] = $sub['minute'];
             }
         }
-        // Opponent's substitutions that happened before the resimulation minute
-        foreach ($match->substitutions ?? [] as $sub) {
-            if ($sub['team_id'] !== $game->team_id && $sub['minute'] <= $minute) {
-                if ($isUserHome) {
-                    $awayEntryMinutes[$sub['player_in_id']] = $sub['minute'];
-                } else {
-                    $homeEntryMinutes[$sub['player_in_id']] = $sub['minute'];
-                }
+        // Opponent's substitutions up to the resimulation minute. Read from match_events
+        // (source of truth after any prior resimulations) rather than $match->substitutions,
+        // which is populated by the initial simulation and not updated by subsequent resims
+        // — leaving it stale and out of sync with the actual events.
+        $opponentTeamId = $isUserHome ? $match->away_team_id : $match->home_team_id;
+        $opponentSubEvents = MatchEvent::where('game_match_id', $match->id)
+            ->where('team_id', $opponentTeamId)
+            ->where('event_type', 'substitution')
+            ->where('minute', '<=', $minute)
+            ->get();
+        foreach ($opponentSubEvents as $subEvent) {
+            $playerInId = $subEvent->metadata['player_in_id'] ?? null;
+            if ($playerInId === null) {
+                continue;
+            }
+            if ($isUserHome) {
+                $awayEntryMinutes[$playerInId] = $subEvent->minute;
+            } else {
+                $homeEntryMinutes[$playerInId] = $subEvent->minute;
             }
         }
 
-        // 8. Count existing substitutions and windows per team to enforce limits
+        // 8. Count existing substitutions and windows per team to enforce limits.
+        // Opponent counts come from match_events (post-revert state) so repeated
+        // resimulations can't push the opponent past the sub/window caps by
+        // counting against a stale $match->substitutions snapshot.
         $userSubCount = count($allSubstitutions);
-        $opponentSubs = collect($match->substitutions ?? [])
-            ->filter(fn ($s) => $s['team_id'] !== $game->team_id);
-        $opponentSubCount = $opponentSubs->count();
+        $opponentSubCount = $opponentSubEvents->count();
         $homeExistingSubs = $isUserHome ? $userSubCount : $opponentSubCount;
         $awayExistingSubs = $isUserHome ? $opponentSubCount : $userSubCount;
 
-        // Count opponent windows used before the resimulation minute
-        $opponentWindowsUsed = $opponentSubs
-            ->filter(fn ($s) => $s['minute'] <= $minute)
+        $opponentWindowsUsed = $opponentSubEvents
             ->pluck('minute')
             ->unique()
             ->count();

--- a/tests/Feature/ResimulationBenchStateTest.php
+++ b/tests/Feature/ResimulationBenchStateTest.php
@@ -1,0 +1,217 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Modules\Lineup\Services\SubstitutionService;
+use App\Models\Competition;
+use App\Models\Game;
+use App\Models\GameMatch;
+use App\Models\GamePlayer;
+use App\Models\MatchEvent;
+use App\Models\Team;
+use App\Models\User;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Regression tests for the "duplicate substitution" bug.
+ *
+ * Before the fix, loadTeamsForResimulation computed the opponent lineup/bench
+ * by applying every sub from $match->substitutions to the initial lineup and
+ * treating "squad − final lineup" as the bench. This put subbed-out starters
+ * back on the bench, letting the AI pick them again during resimulation —
+ * producing match_events where the same player was brought on twice.
+ */
+class ResimulationBenchStateTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+    private Team $playerTeam;
+    private Team $opponentTeam;
+    private Competition $competition;
+    private Game $game;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = User::factory()->create();
+        $this->playerTeam = Team::factory()->create(['name' => 'Player Team']);
+        $this->opponentTeam = Team::factory()->create(['name' => 'Opponent Team']);
+
+        $this->competition = Competition::factory()->league()->create([
+            'id' => 'ESP1',
+            'name' => 'LaLiga',
+        ]);
+
+        $this->playerTeam->competitions()->attach($this->competition->id, ['season' => '2024']);
+        $this->opponentTeam->competitions()->attach($this->competition->id, ['season' => '2024']);
+
+        $this->game = Game::factory()->create([
+            'user_id' => $this->user->id,
+            'team_id' => $this->playerTeam->id,
+            'competition_id' => $this->competition->id,
+            'season' => '2024',
+            'current_date' => '2024-08-15',
+        ]);
+    }
+
+    public function test_subbed_out_opponent_starter_does_not_reappear_on_the_bench(): void
+    {
+        $this->createSquad($this->playerTeam);
+        $this->createSquad($this->opponentTeam);
+
+        // Take 11 opponent players as the starting lineup. Pick one starter
+        // (the first centre-back) to be "subbed out" during the match.
+        $opponentPlayers = GamePlayer::where('game_id', $this->game->id)
+            ->where('team_id', $this->opponentTeam->id)
+            ->orderBy('position')
+            ->limit(11)
+            ->get();
+
+        $opponentLineupIds = $opponentPlayers->pluck('id')->toArray();
+        $subbedOutStarter = $opponentPlayers
+            ->firstWhere('position', 'Centre-Back');
+        $this->assertNotNull($subbedOutStarter, 'Test setup needs a centre-back starter');
+
+        // Create a replacement bench player to come on in their place
+        $replacement = GamePlayer::factory()
+            ->forGame($this->game)
+            ->forTeam($this->opponentTeam)
+            ->create(['position' => 'Centre-Back']);
+
+        $userLineupIds = GamePlayer::where('game_id', $this->game->id)
+            ->where('team_id', $this->playerTeam->id)
+            ->limit(11)
+            ->pluck('id')
+            ->toArray();
+
+        $match = GameMatch::factory()->create([
+            'game_id' => $this->game->id,
+            'competition_id' => $this->competition->id,
+            'round_number' => 1,
+            'home_team_id' => $this->playerTeam->id,
+            'away_team_id' => $this->opponentTeam->id,
+            'scheduled_date' => Carbon::parse('2024-08-16'),
+            'played' => true,
+            'home_lineup' => $userLineupIds,
+            'away_lineup' => $opponentLineupIds,
+            // Simulate the state after the initial background simulation:
+            // the JSON records an opponent sub that also exists in match_events.
+            'substitutions' => [
+                [
+                    'team_id' => $this->opponentTeam->id,
+                    'player_out_id' => $subbedOutStarter->id,
+                    'player_in_id' => $replacement->id,
+                    'minute' => 66,
+                    'auto' => true,
+                ],
+            ],
+        ]);
+
+        MatchEvent::create([
+            'game_id' => $this->game->id,
+            'game_match_id' => $match->id,
+            'game_player_id' => $subbedOutStarter->id,
+            'team_id' => $this->opponentTeam->id,
+            'minute' => 66,
+            'event_type' => MatchEvent::TYPE_SUBSTITUTION,
+            'metadata' => ['player_in_id' => $replacement->id],
+        ]);
+
+        $userLineup = GamePlayer::with('player')->whereIn('id', $userLineupIds)->get();
+
+        $service = app(SubstitutionService::class);
+
+        // Resim without a specific minute (full-match reconstruction). The
+        // subbed-out starter must be in neither the lineup nor the bench;
+        // the replacement should be on the pitch.
+        $result = $service->loadTeamsForResimulation(
+            $match,
+            $this->game,
+            $userLineup,
+            []
+        );
+
+        $awayLineupIds = $result['awayPlayers']->pluck('id')->toArray();
+        $awayBenchIds = $result['awayBench']->pluck('id')->toArray();
+
+        $this->assertNotContains(
+            $subbedOutStarter->id,
+            $awayBenchIds,
+            'A subbed-out starter must never reappear on the bench — '
+            .'otherwise the AI can re-pick them as a replacement, creating '
+            .'duplicate sub-in events for the same player.'
+        );
+        $this->assertNotContains(
+            $subbedOutStarter->id,
+            $awayLineupIds,
+            'A subbed-out starter must not be in the reconstructed lineup'
+        );
+        $this->assertContains(
+            $replacement->id,
+            $awayLineupIds,
+            'The replacement should be on the pitch in the reconstructed lineup'
+        );
+
+        // Resim at minute 50 (before the sub). The starter should still
+        // be on the pitch; the replacement should still be on the bench.
+        $result = $service->loadTeamsForResimulation(
+            $match,
+            $this->game,
+            $userLineup,
+            [],
+            50,
+        );
+
+        $awayLineupIds = $result['awayPlayers']->pluck('id')->toArray();
+        $awayBenchIds = $result['awayBench']->pluck('id')->toArray();
+
+        $this->assertContains(
+            $subbedOutStarter->id,
+            $awayLineupIds,
+            'Before the sub minute, the starter should still be on the pitch'
+        );
+        $this->assertNotContains(
+            $subbedOutStarter->id,
+            $awayBenchIds,
+            'The starter must not appear on the bench while still on the pitch'
+        );
+        $this->assertContains(
+            $replacement->id,
+            $awayBenchIds,
+            'Before the sub minute, the replacement should still be on the bench'
+        );
+    }
+
+    private function createSquad(Team $team): void
+    {
+        GamePlayer::factory()
+            ->forGame($this->game)
+            ->forTeam($team)
+            ->goalkeeper()
+            ->create();
+
+        foreach (['Centre-Back', 'Centre-Back', 'Left-Back', 'Right-Back'] as $position) {
+            GamePlayer::factory()
+                ->forGame($this->game)
+                ->forTeam($team)
+                ->create(['position' => $position]);
+        }
+
+        GamePlayer::factory()
+            ->forGame($this->game)
+            ->forTeam($team)
+            ->count(4)
+            ->create(['position' => 'Central Midfield']);
+
+        foreach (['Centre-Forward', 'Centre-Forward'] as $position) {
+            GamePlayer::factory()
+                ->forGame($this->game)
+                ->forTeam($team)
+                ->create(['position' => $position]);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Fixes a critical bug where subbed-out opponent players could reappear on the bench during match resimulation, allowing the AI to select them again as replacements and creating duplicate substitution events for the same player.

## Root Cause
The `loadTeamsForResimulation` method was computing the opponent's bench as "squad minus final lineup". When a starter was subbed out, they were removed from the lineup but remained in the squad, causing them to incorrectly appear on the bench. This allowed the resimulation engine to pick them again as a replacement, generating duplicate match events.

## Key Changes

- **SubstitutionService.php**: 
  - Added `$minute` parameter to `loadTeamsForResimulation()` to support point-in-time lineup reconstruction
  - Changed opponent substitution source from stale `$match->substitutions` JSON to authoritative `MatchEvent` records
  - Explicitly track subbed-out player IDs and exclude them from the bench calculation, preventing them from being reselected
  - Filter opponent sub events by minute when provided, ensuring the reconstructed lineup matches the actual state at that point in the match

- **MatchResimulationService.php**:
  - Updated opponent substitution tracking to read from `MatchEvent` records instead of `$match->substitutions`
  - Pass `$minute` parameter when calling `loadTeamsForResimulation()` for accurate point-in-time reconstruction
  - Use match events for opponent sub/window counting to prevent stale data from inflating limits on repeated resimulations

- **TacticalChangeService.php**:
  - Pass `$minute` parameter to `loadTeamsForResimulation()` to ensure opponent lineup is reconstructed as of the resimulation point

- **ResimulationBenchStateTest.php** (new):
  - Comprehensive regression test verifying that subbed-out starters don't reappear on the bench
  - Tests both full-match and point-in-time resimulation scenarios
  - Ensures replacements are correctly positioned on the pitch and bench

## Implementation Details
The fix prioritizes `MatchEvent` records as the source of truth for substitutions, since they are updated by each resimulation cycle, whereas `$match->substitutions` is only populated during initial simulation and becomes stale. By explicitly tracking which players have been subbed out and excluding them from the bench pool, we prevent the AI from incorrectly reselecting them during resimulation.

https://claude.ai/code/session_017KDQoq63fq9a3WTe6RgdBj