### PR TITLE
Make mobile squad rows react to viewMode tabs

### DIFF
--- a/resources/views/squad.blade.php
+++ b/resources/views/squad.blade.php
@@ -275,20 +275,62 @@
                                                     @endif
                                                 </div>
                                                 <div class="flex items-center gap-2 mt-0.5">
-                                                    <div class="flex items-center gap-0.5">
+                                                    <div class="flex items-center gap-0.5 shrink-0">
                                                         @foreach($gp->positions as $pos)
                                                             <x-position-badge :position="$pos" size="sm" />
                                                         @endforeach
                                                     </div>
-                                                    @if(!$isUnavailable)
-                                                        <div class="flex items-center gap-1">
-                                                            <div class="w-8 h-1 rounded-full bg-surface-600 overflow-hidden">
-                                                                <div class="h-full rounded-full fitness-bar @if($gp->fitness >= 80) bg-accent-green @elseif($gp->fitness >= 60) bg-accent-gold @elseif($gp->fitness >= 40) bg-accent-orange @else bg-accent-red @endif" style="width: {{ $gp->fitness }}%"></div>
-                                                            </div>
-                                                            <span class="text-[8px] text-text-faint">{{ $gp->fitness }}%</span>
+
+                                                    {{-- Tactical: fitness + morale --}}
+                                                    <template x-if="viewMode === 'tactical'">
+                                                        <div class="flex items-center gap-2 min-w-0">
+                                                            @if(!$isUnavailable)
+                                                                <div class="flex items-center gap-1 shrink-0">
+                                                                    <div class="w-8 h-1 rounded-full bg-surface-600 overflow-hidden">
+                                                                        <div class="h-full rounded-full fitness-bar @if($gp->fitness >= 80) bg-accent-green @elseif($gp->fitness >= 60) bg-accent-gold @elseif($gp->fitness >= 40) bg-accent-orange @else bg-accent-red @endif" style="width: {{ $gp->fitness }}%"></div>
+                                                                    </div>
+                                                                    <span class="text-[8px] text-text-faint">{{ $gp->fitness }}%</span>
+                                                                </div>
+                                                                <x-morale-indicator :value="$gp->morale" class="shrink-0" />
+                                                            @endif
                                                         </div>
-                                                        <x-morale-indicator :value="$gp->morale" class="shrink-0" />
+                                                    </template>
+
+                                                    @if($isCareerMode)
+                                                    {{-- Planning: potential + contract year + dev status --}}
+                                                    <template x-if="viewMode === 'planning'">
+                                                        <div class="flex items-center gap-1.5 min-w-0 grow">
+                                                            <x-potential-bar
+                                                                :current-ability="$gp->overall_score"
+                                                                :potential-low="$gp->potential_low"
+                                                                :potential-high="$gp->potential_high"
+                                                                size="sm"
+                                                            />
+                                                            @if($gp->contract_expiry_year)
+                                                                <span class="text-[10px] tabular-nums shrink-0 @if($gp->isContractExpiring($seasonEndDate)) text-accent-red font-medium @else text-text-muted @endif">{{ $gp->contract_expiry_year }}</span>
+                                                            @endif
+                                                            @php $ds = $gp->dev_status; @endphp
+                                                            <span class="shrink-0 @if($ds === 'growing') text-accent-green @elseif($ds === 'peak') text-accent-blue @else text-orange-600 @endif">
+                                                                @if($ds === 'growing')
+                                                                    <svg class="w-3 h-3" fill="none" stroke="currentColor" stroke-width="3" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M5 15l7-7 7 7"/></svg>
+                                                                @elseif($ds === 'declining')
+                                                                    <svg class="w-3 h-3" fill="none" stroke="currentColor" stroke-width="3" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7"/></svg>
+                                                                @else
+                                                                    <svg class="w-3 h-3" fill="none" stroke="currentColor" stroke-width="3" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M5 12h14"/></svg>
+                                                                @endif
+                                                            </span>
+                                                        </div>
+                                                    </template>
                                                     @endif
+
+                                                    {{-- Stats: apps + goals + assists --}}
+                                                    <template x-if="viewMode === 'stats'">
+                                                        <div class="flex items-center gap-2 text-[10px] shrink-0">
+                                                            <span class="tabular-nums text-text-secondary"><span class="text-text-faint">{{ __('squad.apps') }}</span> {{ $gp->appearances }}</span>
+                                                            <span class="tabular-nums text-text-secondary"><span class="text-text-faint">{{ __('squad.goals') }}</span> {{ $gp->goals }}</span>
+                                                            <span class="tabular-nums text-text-secondary"><span class="text-text-faint">{{ __('squad.assists') }}</span> {{ $gp->assists }}</span>
+                                                        </div>
+                                                    </template>
                                                 </div>
                                             </div>
 


### PR DESCRIPTION
The Táctico/Planificación/Estadísticas tabs updated the Alpine viewMode
state but the mobile row rendered a single static layout, so tapping the
tabs appeared to do nothing on small screens. Branch the mobile row meta
strip on viewMode so each tab shows tab-appropriate stats (fitness/morale,
potential/contract/dev, apps/goals/assists) matching the desktop table.