### PR TITLE
Hint that Career Mode unlocks by winning the World Cup

### DIFF
--- a/lang/en/game.php
+++ b/lang/en/game.php
@@ -393,7 +393,7 @@ return [
     'mode_tournament_desc' => 'Manage a national team in the World Cup',
     'mode_tournament_badge' => 'World Cup',
     'wc2026_name' => 'World Cup 2026',
-    'career_requires_invite' => 'Coming soon',
+    'career_unlock_hint' => 'Win the World Cup to unlock',
 
     // Season Goals
     'goal_title' => 'Win the League',

--- a/lang/es/game.php
+++ b/lang/es/game.php
@@ -393,7 +393,7 @@ return [
     'mode_tournament_desc' => 'Dirige una selección en el Mundial',
     'mode_tournament_badge' => 'Copa del Mundo',
     'wc2026_name' => 'Copa del Mundo 2026',
-    'career_requires_invite' => 'Próximamente',
+    'career_unlock_hint' => 'Gana el Mundial para desbloquearlo',
 
     // Season Goals
     'goal_title' => 'Ganar la Liga',

--- a/resources/views/select-team.blade.php
+++ b/resources/views/select-team.blade.php
@@ -67,7 +67,7 @@
                                         {{ __('game.mode_career') }}
                                     </h3>
                                     <p class="text-xs md:text-sm mt-0.5 text-text-muted">
-                                        {{ __('game.career_requires_invite') }}
+                                        {{ __('game.career_unlock_hint') }}
                                     </p>
                                 </div>
                                 <div class="shrink-0">


### PR DESCRIPTION
The locked Career Mode card on the new game screen previously showed a
generic "Coming soon" message, leaving users unaware that the mode is
unlocked by winning the World Cup in Tournament mode. Replace with a
clear hint so players understand the path to unlocking it.

https://claude.ai/code/session_01EJ1RsxzuyVCxbFYfm1LQkZ