### PR TITLE
Accept loan requests for transfer-listed players

### DIFF
--- a/app/Modules/Transfer/Services/DispositionService.php
+++ b/app/Modules/Transfer/Services/DispositionService.php
@@ -502,6 +502,17 @@ class DispositionService
 
         $importance = $this->playerImportance($player);
 
+        // If the club has already publicly signalled willingness to part with the player
+        // (listed for sale or actively loan-searched), skip the importance-based rejection
+        // gates. Rejecting as "key player" would contradict the club's own market stance —
+        // see clubSellDisposition() which already applies the same signal to sell willingness.
+        if ($player->isTransferListed() || $player->hasActiveLoanSearch()) {
+            return [
+                'result' => 'accepted',
+                'message' => __('transfers.loan_accepted', ['team' => $player->team?->name, 'player' => $player->name]),
+            ];
+        }
+
         if ($importance > 0.7) {
             return [
                 'result' => 'rejected',
@@ -550,8 +561,13 @@ class DispositionService
 
         $importance = $this->playerImportance($player);
 
+        // If the club has publicly signalled willingness to part with the player
+        // (listed for sale or actively loan-searched), bypass the "key player" gate —
+        // rejecting on importance grounds would contradict the club's own market stance.
+        $publicMarketSignal = $player->isTransferListed() || $player->hasActiveLoanSearch();
+
         // Gate 1: Key player — club refuses to loan
-        if ($importance > 0.70) {
+        if (! $publicMarketSignal && $importance > 0.70) {
             return [
                 'result' => 'rejected',
                 'disposition' => 0.15,


### PR DESCRIPTION
DispositionService's loan evaluators gated acceptance purely on
playerImportance(), so a club that had publicly listed a player for sale
could still reject an incoming loan with "is a key player for them" — a
direct contradiction of its own market stance. clubSellDisposition()
already consults isTransferListed(); loan evaluation now matches.

Both evaluateLoanRequest() and evaluateLoanRequestSync() now bypass the
importance-based rejection when the player is transfer-listed or in an
active loan search. Reputation and player-willingness gates still apply.

https://claude.ai/code/session_01KvAR6iq8VhWnosH91zP7g4