### PR TITLE
Differentiate draw commentary for knockout vs league matches

### DIFF
--- a/app/Http/Views/ShowLiveMatch.php
+++ b/app/Http/Views/ShowLiveMatch.php
@@ -66,6 +66,15 @@ class ShowLiveMatch
             $twoLeggedInfo = $this->buildTwoLeggedInfo($playerMatch);
         }
 
+        // True when the current match is either leg of a two-legged cup tie.
+        // Used to suppress late-game "draw" commentary in two-legged ties,
+        // where aggregate scoring (not this single match) determines the
+        // winner so "heading to extra time" phrasing would be misleading.
+        $isTwoLeggedTie = false;
+        if ($isKnockout) {
+            $isTwoLeggedTie = CupTie::find($playerMatch->cup_tie_id)?->isTwoLegged() ?? false;
+        }
+
         // Build the events payload for the Alpine.js component
         // When ET is already played, separate regular (<=93) and ET events (>93)
         $allEvents = $playerMatch->events;
@@ -297,6 +306,7 @@ class ShowLiveMatch
             'contextualEndLosingByOne' => __('commentary.contextual_end_losing_by_one'),
             'contextualEndWinning' => __('commentary.contextual_end_winning'),
             'contextualEndDraw' => __('commentary.contextual_end_draw'),
+            'contextualEndDrawKnockout' => __('commentary.contextual_end_draw_knockout'),
             'contextualSecondHalfStart' => __('commentary.contextual_second_half_start'),
             'contextualAwayFans' => __('commentary.contextual_away_fans'),
             'contextualHomeFans' => __('commentary.contextual_home_fans'),
@@ -350,6 +360,7 @@ class ShowLiveMatch
             'availablePressing' => $availablePressing,
             'availableDefLine' => $availableDefLine,
             'isKnockout' => $isKnockout,
+            'isTwoLeggedTie' => $isTwoLeggedTie,
             'extraTimeData' => $extraTimeData,
             'twoLeggedInfo' => $twoLeggedInfo,
             'isTournamentMode' => $isTournamentMode,

--- a/lang/en/commentary.php
+++ b/lang/en/commentary.php
@@ -102,6 +102,13 @@ return [
         'Heading for a stalemate at :venue, neither side able to find a winner',
         'One point apiece it seems, the clock ticking down at :venue',
     ],
+    'contextual_end_draw_knockout' => [
+        'Normal time winding down at :venue with the tie still wide open',
+        'Still level at :venue, extra time is looming',
+        'Neither side can find the decisive goal, this is heading to extra time',
+        'The clock runs down at :venue and the deadlock keeps the tie alive',
+        'One last push to avoid extra time, neither side wants to prolong this',
+    ],
     'contextual_second_half_start' => [
         'Second half underway at :venue with the score :score',
         'Back to action at :venue. :score at the break',

--- a/lang/es/commentary.php
+++ b/lang/es/commentary.php
@@ -102,6 +102,13 @@ return [
         'Se encamina hacia las tablas en el :venue, ninguno encuentra el gol de la victoria',
         'Un punto para cada uno parece ser el resultado final en el :venue',
     ],
+    'contextual_end_draw_knockout' => [
+        'Se acerca el final del tiempo reglamentario en el :venue y la eliminatoria sigue abierta',
+        'Tablas en el :venue, esto huele a prórroga',
+        'Ninguno encuentra el gol decisivo, el tiempo extra está cada vez más cerca',
+        'Se agotan los minutos en el :venue con el empate que no rompe la incógnita',
+        'Último empujón para evitar la prórroga, ninguno quiere prolongar la agonía',
+    ],
     'contextual_second_half_start' => [
         'Comienza la segunda parte en el :venue con el marcador :score',
         'De vuelta a la acción en el :venue. :score al descanso',

--- a/resources/js/live-match.js
+++ b/resources/js/live-match.js
@@ -104,6 +104,7 @@ export default function liveMatch(config) {
 
         // Extra time / knockout config
         isKnockout: config.isKnockout || false,
+        isTwoLeggedTie: config.isTwoLeggedTie || false,
         extraTimeUrl: config.extraTimeUrl || '',
         penaltiesUrl: config.penaltiesUrl || '',
         twoLeggedInfo: config.twoLeggedInfo || null,
@@ -1293,6 +1294,8 @@ export default function liveMatch(config) {
                 awayArticle: this.awayArticle,
                 narrativeTemplates: this.narrativeTemplates,
                 userTeamId: this.userTeamId,
+                isKnockout: this.isKnockout,
+                isTwoLeggedTie: this.isTwoLeggedTie,
                 tactics: {
                     userPlayingStyle: this.activePlayingStyle,
                     userPressing: this.activePressing,

--- a/resources/js/modules/atmosphere-generator.js
+++ b/resources/js/modules/atmosphere-generator.js
@@ -386,6 +386,7 @@ export function generateContextualNarratives(config) {
         homeTeamId, awayTeamId, homeTeamName, awayTeamName,
         homeArticle, awayArticle,
         venueName, narrativeTemplates, allEvents,
+        isKnockout, isTwoLeggedTie,
     } = config;
 
     const venue = venueName || '';
@@ -476,7 +477,20 @@ export function generateContextualNarratives(config) {
                     templateKey = deficit === 1 ? 'contextualEndLosingByOne' : 'contextualEndLosing';
                 }
             } else {
-                templateKey = 'contextualEndDraw';
+                // Tied at minute 85. Select pool by competition type.
+                if (isKnockout && isTwoLeggedTie) {
+                    // Aggregate across two legs (plus away goals / first-leg
+                    // result) determines the winner — a draw here is not
+                    // inherently "heading to extra time". Stay silent; the
+                    // null templateKey is handled by the guard below.
+                    templateKey = null;
+                } else if (isKnockout) {
+                    // Single-leg knockout: a draw leads to extra time.
+                    templateKey = 'contextualEndDrawKnockout';
+                } else {
+                    // League / regular phase: a draw yields a point each.
+                    templateKey = 'contextualEndDraw';
+                }
             }
         } else {
             // Mid-game: pick based on state

--- a/resources/views/live-match.blade.php
+++ b/resources/views/live-match.blade.php
@@ -53,6 +53,7 @@
                 availablePressing: {{ Js::from($availablePressing) }},
                 availableDefLine: {{ Js::from($availableDefLine) }},
                 isKnockout: {{ $isKnockout ? 'true' : 'false' }},
+                isTwoLeggedTie: {{ $isTwoLeggedTie ? 'true' : 'false' }},
                 extraTimeUrl: '{{ $extraTimeUrl }}',
                 penaltiesUrl: '{{ $penaltiesUrl }}',
                 extraTimeData: {{ Js::from($extraTimeData) }},


### PR DESCRIPTION
## Summary
This PR enhances late-game commentary generation to distinguish between different competition formats when a match ends in a draw. Two-legged cup ties now suppress draw commentary (since aggregate scoring determines the winner), while single-leg knockouts receive specific "extra time incoming" messaging, and league matches retain their existing draw commentary.

## Key Changes
- **Atmosphere generator logic**: Added conditional branching in `generateContextualNarratives()` to handle three draw scenarios:
  - Two-legged ties: suppress commentary (returns `null` templateKey)
  - Single-leg knockouts: use new `contextualEndDrawKnockout` template
  - League/regular phase: use existing `contextualEndDraw` template

- **Backend configuration**: 
  - Added `isTwoLeggedTie` flag determination in `ShowLiveMatch.php` by checking if the match's cup tie is two-legged
  - Passed both `isKnockout` and `isTwoLeggedTie` flags through to the frontend

- **Frontend data flow**: 
  - Updated `live-match.js` to accept and pass `isTwoLeggedTie` to the narrative generator
  - Updated Blade template to pass the flag to Alpine.js component

- **Localization**: Added new `contextual_end_draw_knockout` commentary strings in English and Spanish with extra-time-focused messaging

## Implementation Details
The solution uses a hierarchical check: first determines if it's a knockout match, then if it's two-legged. This prevents misleading "heading to extra time" commentary in two-legged ties where the aggregate result (not extra time in the current leg) determines progression.

https://claude.ai/code/session_01FkYKnvV3PwJ93Gu2pdx9Aa