### PR TITLE
Drop unused match_events_archive column from season_archives

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,8 @@ php artisan config:clear                        # Clear config cache after chang
 
 The queue worker must be running for background jobs. `composer dev` handles this via `php artisan queue:listen --tries=1`.
 
+**Do not run tests automatically after making changes.** Tests run in CI after pushing to a branch. Only run tests locally when explicitly asked.
+
 ## Architecture
 
 ### HTTP Layer

--- a/app/Console/Commands/BackfillManagerStats.php
+++ b/app/Console/Commands/BackfillManagerStats.php
@@ -46,7 +46,7 @@ class BackfillManagerStats extends Command
 
         // Phase 1: Process archived seasons (oldest first)
         // Only select match_results to avoid loading large JSON blobs
-        // (player_season_stats, final_standings, match_events_archive)
+        // (player_season_stats, final_standings)
         $seasonsCompleted = 0;
 
         SeasonArchive::where('game_id', $game->id)

--- a/app/Models/SeasonArchive.php
+++ b/app/Models/SeasonArchive.php
@@ -14,13 +14,11 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  * @property array<array-key, mixed> $player_season_stats
  * @property array<array-key, mixed> $season_awards
  * @property array<array-key, mixed> $match_results
- * @property string|null $match_events_archive
  * @property \Illuminate\Support\Carbon|null $created_at
  * @property \Illuminate\Support\Carbon|null $updated_at
  * @property-read \App\Models\Game $game
  * @property-read array|null $best_goalkeeper
  * @property-read array|null $champion
- * @property-read array $match_events
  * @property-read array|null $most_assists
  * @property-read array|null $top_scorer
  * @method static \Illuminate\Database\Eloquent\Builder<static>|SeasonArchive newModelQuery()
@@ -30,7 +28,6 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  * @method static \Illuminate\Database\Eloquent\Builder<static>|SeasonArchive whereFinalStandings($value)
  * @method static \Illuminate\Database\Eloquent\Builder<static>|SeasonArchive whereGameId($value)
  * @method static \Illuminate\Database\Eloquent\Builder<static>|SeasonArchive whereId($value)
- * @method static \Illuminate\Database\Eloquent\Builder<static>|SeasonArchive whereMatchEventsArchive($value)
  * @method static \Illuminate\Database\Eloquent\Builder<static>|SeasonArchive whereMatchResults($value)
  * @method static \Illuminate\Database\Eloquent\Builder<static>|SeasonArchive wherePlayerSeasonStats($value)
  * @method static \Illuminate\Database\Eloquent\Builder<static>|SeasonArchive whereSeason($value)
@@ -50,7 +47,6 @@ class SeasonArchive extends Model
         'season_awards',
         'match_results',
         'transfer_activity',
-        'match_events_archive',
         'transition_log',
     ];
 
@@ -66,30 +62,6 @@ class SeasonArchive extends Model
     public function game(): BelongsTo
     {
         return $this->belongsTo(Game::class);
-    }
-
-    /**
-     * Get decompressed match events from archive.
-     */
-    public function getMatchEventsAttribute(): array
-    {
-        if (empty($this->match_events_archive)) {
-            return [];
-        }
-
-        $decoded = @base64_decode($this->match_events_archive, true);
-
-        if ($decoded === false) {
-            return [];
-        }
-
-        $decompressed = @gzuncompress($decoded);
-
-        if ($decompressed === false) {
-            return [];
-        }
-
-        return json_decode($decompressed, true) ?? [];
     }
 
     /**

--- a/app/Modules/Season/Processors/SeasonArchiveProcessor.php
+++ b/app/Modules/Season/Processors/SeasonArchiveProcessor.php
@@ -12,7 +12,6 @@ use App\Models\GameMatch;
 use App\Models\GamePlayer;
 use App\Models\GameStanding;
 use App\Models\GameTransfer;
-use App\Models\MatchEvent;
 use App\Models\SeasonArchive;
 use Illuminate\Support\Facades\DB;
 
@@ -61,9 +60,6 @@ class SeasonArchiveProcessor implements SeasonProcessor
         // Capture transfer activity
         $transferActivity = $this->captureTransferActivity($game);
 
-        // Compress detailed match events
-        $eventsArchive = $this->compressMatchEvents($game);
-
         // Create archive record
         SeasonArchive::create([
             'game_id' => $game->id,
@@ -73,7 +69,6 @@ class SeasonArchiveProcessor implements SeasonProcessor
             'season_awards' => $awards,
             'match_results' => $matchResults,
             'transfer_activity' => $transferActivity,
-            'match_events_archive' => $eventsArchive,
         ]);
 
         // Delete archived data to free up space
@@ -303,34 +298,6 @@ class SeasonArchiveProcessor implements SeasonProcessor
             });
 
         return $results;
-    }
-
-    /**
-     * Compress all match events into a gzipped blob.
-     */
-    private function compressMatchEvents(Game $game): ?string
-    {
-        $events = [];
-
-        MatchEvent::where('game_id', $game->id)
-            ->chunk(1000, function ($chunk) use (&$events) {
-                foreach ($chunk as $event) {
-                    $events[] = [
-                        'match_id' => $event->game_match_id,
-                        'player_id' => $event->game_player_id,
-                        'team_id' => $event->team_id,
-                        'minute' => $event->minute,
-                        'event_type' => $event->event_type,
-                        'metadata' => $event->metadata,
-                    ];
-                }
-            });
-
-        if (empty($events)) {
-            return null;
-        }
-
-        return base64_encode(gzcompress(json_encode($events), 6));
     }
 
     /**

--- a/database/migrations/2026_04_12_161959_drop_match_events_archive_from_season_archives.php
+++ b/database/migrations/2026_04_12_161959_drop_match_events_archive_from_season_archives.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('season_archives', function (Blueprint $table) {
+            $table->dropColumn('match_events_archive');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('season_archives', function (Blueprint $table) {
+            $table->binary('match_events_archive')->nullable();
+        });
+    }
+};


### PR DESCRIPTION
The column stored compressed match events during season closing but was never read anywhere in the application. Removes the column, its accessor, the compression logic, and adds a note to CLAUDE.md about not running tests automatically.