### PR TITLE
Extract hot-write player stats to sparse GamePlayerMatchState satellite

### DIFF
--- a/app/Console/Commands/BackfillGamePlayerMatchState.php
+++ b/app/Console/Commands/BackfillGamePlayerMatchState.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Game;
+use App\Modules\Player\Support\GamePlayerScopeResolver;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * One-shot data backfill that copies match-state columns out of game_players
+ * into the new game_player_match_state satellite for every existing game.
+ *
+ * Run between the create-table migration and the drop-columns migration:
+ *
+ *   php artisan migrate                                        # creates the satellite table
+ *   php artisan app:backfill-game-player-match-state           # this command
+ *   php artisan migrate                                        # drops the 13 columns
+ *
+ * Idempotent: a player whose satellite row already exists is left alone.
+ * Per-game transactions so partial failure is recoverable.
+ */
+class BackfillGamePlayerMatchState extends Command
+{
+    protected $signature = 'app:backfill-game-player-match-state {--game= : Backfill a single game by id}';
+
+    protected $description = 'Backfill game_player_match_state from existing game_players hot-write columns';
+
+    public function handle(GamePlayerScopeResolver $scopeResolver): int
+    {
+        $gameQuery = Game::query();
+        if ($gameId = $this->option('game')) {
+            $gameQuery->where('id', $gameId);
+        }
+
+        $totalGames = (clone $gameQuery)->count();
+        if ($totalGames === 0) {
+            $this->info('No games to backfill.');
+            return self::SUCCESS;
+        }
+
+        $this->info("Backfilling match state for {$totalGames} game(s).");
+
+        $totalInserted = 0;
+        $bar = $this->output->createProgressBar($totalGames);
+
+        $gameQuery->each(function (Game $game) use ($scopeResolver, &$totalInserted, $bar) {
+            $totalInserted += $this->backfillGame($game, $scopeResolver);
+            $bar->advance();
+        });
+
+        $bar->finish();
+        $this->newLine();
+        $this->info("Done. Inserted {$totalInserted} match-state rows.");
+
+        return self::SUCCESS;
+    }
+
+    private function backfillGame(Game $game, GamePlayerScopeResolver $scopeResolver): int
+    {
+        $activeTeamIds = $scopeResolver->activeTeamIdsForGame($game);
+        if (empty($activeTeamIds)) {
+            return 0;
+        }
+
+        // Tournament games (e.g. World Cup) participate via national teams
+        // that aren't in the country-based active scope. Treat every team in
+        // the game as active for those — the satellite is small.
+        if ($game->isTournamentMode()) {
+            $activeTeamIds = DB::table('game_players')
+                ->where('game_id', $game->id)
+                ->whereNotNull('team_id')
+                ->distinct()
+                ->pluck('team_id')
+                ->all();
+        }
+
+        return DB::transaction(function () use ($game, $activeTeamIds): int {
+            $before = DB::table('game_player_match_state')
+                ->whereIn('game_player_id', function ($q) use ($game) {
+                    $q->select('id')->from('game_players')->where('game_id', $game->id);
+                })
+                ->count();
+
+            DB::statement(<<<'SQL'
+                INSERT INTO game_player_match_state (
+                    game_player_id, fitness, morale, injury_until, injury_type,
+                    appearances, season_appearances, goals, own_goals, assists,
+                    yellow_cards, red_cards, goals_conceded, clean_sheets
+                )
+                SELECT
+                    gp.id,
+                    COALESCE(gp.fitness, 80),
+                    COALESCE(gp.morale, 80),
+                    gp.injury_until,
+                    gp.injury_type,
+                    COALESCE(gp.appearances, 0),
+                    COALESCE(gp.season_appearances, 0),
+                    COALESCE(gp.goals, 0),
+                    COALESCE(gp.own_goals, 0),
+                    COALESCE(gp.assists, 0),
+                    COALESCE(gp.yellow_cards, 0),
+                    COALESCE(gp.red_cards, 0),
+                    COALESCE(gp.goals_conceded, 0),
+                    COALESCE(gp.clean_sheets, 0)
+                FROM game_players gp
+                WHERE gp.game_id = ?
+                  AND gp.team_id = ANY(?::uuid[])
+                ON CONFLICT (game_player_id) DO NOTHING
+            SQL, [$game->id, '{' . implode(',', $activeTeamIds) . '}']);
+
+            $after = DB::table('game_player_match_state')
+                ->whereIn('game_player_id', function ($q) use ($game) {
+                    $q->select('id')->from('game_players')->where('game_id', $game->id);
+                })
+                ->count();
+
+            return $after - $before;
+        });
+    }
+}

--- a/app/Http/Actions/SaveSquadSelection.php
+++ b/app/Http/Actions/SaveSquadSelection.php
@@ -6,6 +6,7 @@ use App\Modules\Player\Services\InjuryService;
 use App\Modules\Player\Services\PlayerDevelopmentService;
 use App\Models\Game;
 use App\Models\GamePlayer;
+use App\Models\GamePlayerMatchState;
 use App\Models\Player;
 use Illuminate\Http\Request;
 use Illuminate\Support\Str;
@@ -60,14 +61,17 @@ class SaveSquadSelection
         $playerModels = Player::whereIn('transfermarkt_id', $tmIds)->get()->keyBy('transfermarkt_id');
 
         $playerRows = [];
+        $matchStateRows = [];
         foreach ($tmIds as $tmId) {
             $player = $playerModels->get($tmId);
             if (!$player) {
                 continue;
             }
 
+            $gamePlayerId = Str::uuid()->toString();
+
             $playerRows[] = [
-                'id' => Str::uuid()->toString(),
+                'id' => $gamePlayerId,
                 'game_id' => $gameId,
                 'player_id' => $player->id,
                 'team_id' => $teamId,
@@ -77,15 +81,29 @@ class SaveSquadSelection
                 'market_value_cents' => 0,
                 'contract_until' => null,
                 'annual_wage' => 0,
-                'fitness' => rand(90, 100),
-                'morale' => rand(70, 85),
                 'durability' => InjuryService::generateDurability(),
                 'game_technical_ability' => $player->technical_ability,
                 'game_physical_ability' => $player->physical_ability,
-                'season_appearances' => 0,
             ];
+
+            // The user's tournament squad always plays matches → satellite row
+            // is required so fitness/morale/match stats accrue.
+            $matchStateRows[] = array_merge(
+                ['game_player_id' => $gamePlayerId],
+                GamePlayerMatchState::DEFAULTS,
+                [
+                    'fitness' => rand(90, 100),
+                    'morale' => rand(70, 85),
+                ]
+            );
         }
 
-        GamePlayer::insert($playerRows);
+        if (!empty($playerRows)) {
+            GamePlayer::insert($playerRows);
+        }
+
+        if (!empty($matchStateRows)) {
+            GamePlayerMatchState::insert($matchStateRows);
+        }
     }
 }

--- a/app/Http/Actions/SkipMatchToEnd.php
+++ b/app/Http/Actions/SkipMatchToEnd.php
@@ -148,15 +148,16 @@ class SkipMatchToEnd
 
         $suspendedIds = PlayerSuspension::suspendedPlayerIdsForCompetition($match->competition_id);
 
-        return GamePlayer::where('game_id', $game->id)
+        return GamePlayer::with('matchState')
+            ->where('game_id', $game->id)
             ->where('team_id', $game->team_id)
             ->whereNotIn('id', $activeIds)
             ->whereNotIn('id', $suspendedIds)
-            ->where(function ($q) use ($match) {
-                $q->whereNull('injury_until')
-                    ->orWhere('injury_until', '<', $match->scheduled_date);
-            })
             ->when($game->requiresSquadEnrollment(), fn ($q) => $q->whereNotNull('number'))
+            ->get()
+            // injury_until lives on the satellite — filter via accessor
+            // (the user's bench is small enough for PHP-side filtering).
+            ->reject(fn ($p) => $p->injury_until !== null && $p->injury_until->gte($match->scheduled_date))
             ->count();
     }
 }

--- a/app/Http/Views/ShowLiveMatch.php
+++ b/app/Http/Views/ShowLiveMatch.php
@@ -133,7 +133,7 @@ class ShowLiveMatch
 
         // Starting lineup players (for the "sub out" picker)
         $currentDate = $game->current_date;
-        $lineupPlayers = GamePlayer::with('player')
+        $lineupPlayers = GamePlayer::with(['player', 'matchState'])
             ->whereIn('id', $userLineupIds)
             ->get()
             ->map(fn ($p) => [
@@ -164,17 +164,16 @@ class ShowLiveMatch
 
         // Bench players (all squad players NOT in the starting lineup, not suspended, not injured)
         $matchDate = $playerMatch->scheduled_date;
-        $benchPlayers = GamePlayer::with('player')
+        $benchPlayers = GamePlayer::with(['player', 'matchState'])
             ->where('game_id', $gameId)
             ->where('team_id', $game->team_id)
             ->whereNotIn('id', $userLineupIds)
             ->whereNotIn('id', $suspendedPlayerIds)
-            ->where(function ($q) use ($matchDate) {
-                $q->whereNull('injury_until')
-                    ->orWhere('injury_until', '<', $matchDate);
-            })
             ->when($game->requiresSquadEnrollment(), fn ($q) => $q->whereNotNull('number'))
             ->get()
+            // injury_until lives on the satellite — filter via the accessor
+            // (the user's squad is small enough that PHP-side filtering is fine).
+            ->reject(fn ($p) => $p->injury_until !== null && $p->injury_until->gte($matchDate))
             ->map(fn ($p) => [
                 'id' => $p->id,
                 'name' => $p->player->name ?? '',
@@ -196,7 +195,7 @@ class ShowLiveMatch
             ->values()
             ->all();
 
-        $mapLineup = fn (array $ids) => GamePlayer::with('player')
+        $mapLineup = fn (array $ids) => GamePlayer::with(['player', 'matchState'])
             ->whereIn('id', $ids)
             ->get()
             ->map(fn ($p) => [

--- a/app/Http/Views/ShowPreMatchData.php
+++ b/app/Http/Views/ShowPreMatchData.php
@@ -49,9 +49,10 @@ class ShowPreMatchData
             $hasInjured = false;
             $hasSuspended = false;
 
-            $lineupPlayers = GamePlayer::where('game_id', $gameId)
+            $lineupPlayers = GamePlayer::with('matchState')
+                ->where('game_id', $gameId)
                 ->whereIn('id', $lineup)
-                ->get(['id', 'injury_until']);
+                ->get(['id']);
 
             foreach ($lineupPlayers as $player) {
                 if (in_array($player->id, $suspendedPlayerIds)) {

--- a/app/Models/GamePlayer.php
+++ b/app/Models/GamePlayer.php
@@ -135,26 +135,13 @@ class GamePlayer extends Model
         'contract_until',
         'annual_wage',
         'pending_annual_wage',
-        'fitness',
-        'morale',
         'durability',
-        'injury_until',
-        'injury_type',
-        'appearances',
-        'goals',
-        'own_goals',
-        'assists',
-        'yellow_cards',
-        'red_cards',
-        'goals_conceded',
-        'clean_sheets',
         'game_technical_ability',
         'game_physical_ability',
         'tier',
         'potential',
         'potential_low',
         'potential_high',
-        'season_appearances',
         'retiring_at_season',
     ];
 
@@ -165,18 +152,7 @@ class GamePlayer extends Model
         'contract_until' => 'date',
         'annual_wage' => 'integer',
         'pending_annual_wage' => 'integer',
-        'fitness' => 'integer',
-        'morale' => 'integer',
         'durability' => 'integer',
-        'injury_until' => 'date',
-        'appearances' => 'integer',
-        'goals' => 'integer',
-        'own_goals' => 'integer',
-        'assists' => 'integer',
-        'yellow_cards' => 'integer',
-        'red_cards' => 'integer',
-        'goals_conceded' => 'integer',
-        'clean_sheets' => 'integer',
         // Development fields
         'game_technical_ability' => 'integer',
         'game_physical_ability' => 'integer',
@@ -184,7 +160,6 @@ class GamePlayer extends Model
         'potential' => 'integer',
         'potential_low' => 'integer',
         'potential_high' => 'integer',
-        'season_appearances' => 'integer',
     ];
 
     /**
@@ -224,6 +199,22 @@ class GamePlayer extends Model
     public function team(): BelongsTo
     {
         return $this->belongsTo(Team::class);
+    }
+
+    /**
+     * Sparse satellite holding the per-matchday hot-write columns
+     * (fitness, morale, injury, match stats). Only "active" players
+     * have a row — see {@see \App\Modules\Player\Support\GamePlayerScopeResolver}.
+     *
+     * Read access is mediated by the get*Attribute() delegates below so
+     * existing call sites that use `$player->fitness`, `$player->goals`
+     * etc. work transparently. Write paths must update the satellite
+     * directly via `GamePlayerMatchState` queries — never via
+     * `$player->fitness = X`.
+     */
+    public function matchState(): HasOne
+    {
+        return $this->hasOne(GamePlayerMatchState::class, 'game_player_id');
     }
 
     public function matchEvents(): HasMany
@@ -851,5 +842,120 @@ class GamePlayer extends Model
             'name' => $nationalities[0],
             'code' => $code,
         ];
+    }
+
+    // ==========================================================================
+    // Match-state delegates
+    //
+    // The 13 hot-write columns (fitness, morale, injury, match stats) live on
+    // {@see GamePlayerMatchState}. The accessors below let existing read sites
+    // keep using `$player->fitness` etc. without knowing about the satellite.
+    //
+    // Read priority:
+    //   1. In-memory override (`isDirty`) — e.g. CompetitionViewService
+    //      decorating a model with per-competition tallies.
+    //   2. Satellite (when eager-loaded) — authoritative after code deploy.
+    //   3. Legacy column from `$this->attributes` — backward compat during
+    //      the transition window before the drop-columns migration runs.
+    //   4. Lazy-load satellite (post-drop, when old column is gone).
+    //   5. Default from {@see GamePlayerMatchState::DEFAULTS}.
+    //
+    // To avoid N+1 in hot paths, callers should `with('matchState')` when
+    // loading collections. The match simulator, squad service, lineup loader
+    // and dashboard all do this.
+    // ==========================================================================
+
+    /**
+     * Read a match-state value through the standard priority chain.
+     */
+    private function matchStateValue(string $column, mixed $default): mixed
+    {
+        // 1. In-memory override (e.g. decoration for display)
+        if ($this->isDirty($column)) {
+            return $this->attributes[$column];
+        }
+
+        // 2. Satellite (authoritative when eager-loaded)
+        if ($this->relationLoaded('matchState') && $this->matchState !== null) {
+            return $this->matchState->{$column};
+        }
+
+        // 3. Legacy column (transition period before drop migration)
+        if (array_key_exists($column, $this->attributes) && ! $this->isDirty($column)) {
+            return $this->attributes[$column];
+        }
+
+        // 4. Lazy-load satellite (post-drop, column gone from attributes)
+        return $this->matchState?->{$column} ?? $default;
+    }
+
+    public function getFitnessAttribute(): int
+    {
+        return (int) $this->matchStateValue('fitness', GamePlayerMatchState::DEFAULTS['fitness']);
+    }
+
+    public function getMoraleAttribute(): int
+    {
+        return (int) $this->matchStateValue('morale', GamePlayerMatchState::DEFAULTS['morale']);
+    }
+
+    public function getInjuryUntilAttribute(): ?Carbon
+    {
+        $value = $this->matchStateValue('injury_until', null);
+        if ($value === null) {
+            return null;
+        }
+
+        return $value instanceof Carbon ? $value : Carbon::parse($value);
+    }
+
+    public function getInjuryTypeAttribute(): ?string
+    {
+        return $this->matchStateValue('injury_type', null);
+    }
+
+    public function getAppearancesAttribute(): int
+    {
+        return (int) $this->matchStateValue('appearances', GamePlayerMatchState::DEFAULTS['appearances']);
+    }
+
+    public function getSeasonAppearancesAttribute(): int
+    {
+        return (int) $this->matchStateValue('season_appearances', GamePlayerMatchState::DEFAULTS['season_appearances']);
+    }
+
+    public function getGoalsAttribute(): int
+    {
+        return (int) $this->matchStateValue('goals', GamePlayerMatchState::DEFAULTS['goals']);
+    }
+
+    public function getOwnGoalsAttribute(): int
+    {
+        return (int) $this->matchStateValue('own_goals', GamePlayerMatchState::DEFAULTS['own_goals']);
+    }
+
+    public function getAssistsAttribute(): int
+    {
+        return (int) $this->matchStateValue('assists', GamePlayerMatchState::DEFAULTS['assists']);
+    }
+
+    public function getYellowCardsAttribute(): int
+    {
+        return (int) $this->matchStateValue('yellow_cards', GamePlayerMatchState::DEFAULTS['yellow_cards']);
+    }
+
+    public function getRedCardsAttribute(): int
+    {
+        return (int) $this->matchStateValue('red_cards', GamePlayerMatchState::DEFAULTS['red_cards']);
+    }
+
+    public function getGoalsConcededAttribute(): int
+    {
+        return (int) $this->matchStateValue('goals_conceded', GamePlayerMatchState::DEFAULTS['goals_conceded']);
+    }
+
+    public function getCleanSheetsAttribute(): int
+    {
+        return (int) $this->matchStateValue('clean_sheets', GamePlayerMatchState::DEFAULTS['clean_sheets']);
     }
 }

--- a/app/Models/GamePlayerMatchState.php
+++ b/app/Models/GamePlayerMatchState.php
@@ -1,0 +1,168 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Sparse satellite of GamePlayer holding the per-matchday hot-write state:
+ * fitness, morale, injuries, appearances, goals, assists, cards, GK stats.
+ *
+ * Only populated for "active" players (teams in the user's competition
+ * footprint or European opponents for a season the user qualifies for).
+ * Pure transfer-pool foreign players have no row here.
+ *
+ * Read paths go through the {@see GamePlayer} accessor delegates so existing
+ * call sites that read `$player->fitness`, `$player->goals` etc. keep working.
+ *
+ * @property string $game_player_id
+ * @property int $fitness
+ * @property int $morale
+ * @property \Illuminate\Support\Carbon|null $injury_until
+ * @property string|null $injury_type
+ * @property int $appearances
+ * @property int $season_appearances
+ * @property int $goals
+ * @property int $own_goals
+ * @property int $assists
+ * @property int $yellow_cards
+ * @property int $red_cards
+ * @property int $goals_conceded
+ * @property int $clean_sheets
+ */
+class GamePlayerMatchState extends Model
+{
+    use HasFactory;
+
+    protected $table = 'game_player_match_state';
+
+    protected $primaryKey = 'game_player_id';
+
+    public $incrementing = false;
+
+    protected $keyType = 'string';
+
+    public $timestamps = false;
+
+    protected $fillable = [
+        'game_player_id',
+        'fitness',
+        'morale',
+        'injury_until',
+        'injury_type',
+        'appearances',
+        'season_appearances',
+        'goals',
+        'own_goals',
+        'assists',
+        'yellow_cards',
+        'red_cards',
+        'goals_conceded',
+        'clean_sheets',
+    ];
+
+    protected $casts = [
+        'fitness' => 'integer',
+        'morale' => 'integer',
+        'injury_until' => 'date',
+        'appearances' => 'integer',
+        'season_appearances' => 'integer',
+        'goals' => 'integer',
+        'own_goals' => 'integer',
+        'assists' => 'integer',
+        'yellow_cards' => 'integer',
+        'red_cards' => 'integer',
+        'goals_conceded' => 'integer',
+        'clean_sheets' => 'integer',
+    ];
+
+    /**
+     * Default values for a freshly-created satellite row. Mirrors the
+     * defaults the dropped game_players columns used to carry.
+     */
+    public const DEFAULTS = [
+        'fitness' => 80,
+        'morale' => 80,
+        'injury_until' => null,
+        'injury_type' => null,
+        'appearances' => 0,
+        'season_appearances' => 0,
+        'goals' => 0,
+        'own_goals' => 0,
+        'assists' => 0,
+        'yellow_cards' => 0,
+        'red_cards' => 0,
+        'goals_conceded' => 0,
+        'clean_sheets' => 0,
+    ];
+
+    public function gamePlayer(): BelongsTo
+    {
+        return $this->belongsTo(GamePlayer::class, 'game_player_id');
+    }
+
+    /**
+     * Dual-write a raw SQL UPDATE to the legacy `game_players` columns.
+     *
+     * Only executes while the legacy columns still exist (before the
+     * drop-columns migration). This keeps the old columns in sync so a
+     * rollback of the code deploy doesn't lose data.
+     *
+     * @param string $sql  The UPDATE statement targeting `game_players`.
+     * @param array  $bindings  Positional bind values.
+     */
+    public static function legacyWrite(string $sql, array $bindings = []): void
+    {
+        if (! static::legacyColumnsExist()) {
+            return;
+        }
+
+        DB::statement($sql, $bindings);
+    }
+
+    /**
+     * Dual-write an Eloquent-style update to the legacy `game_players` columns.
+     *
+     * @param \Illuminate\Database\Eloquent\Builder|\Illuminate\Database\Query\Builder $query  A query scoped to game_players rows.
+     * @param array $values  Column => value pairs to update.
+     */
+    public static function legacyEloquentWrite($query, array $values): void
+    {
+        if (! static::legacyColumnsExist()) {
+            return;
+        }
+
+        $query->update($values);
+    }
+
+    /**
+     * Whether the legacy match-state columns still exist on `game_players`.
+     *
+     * Cached once per request. Returns true before the drop-columns migration
+     * runs, false after. Used by write paths to dual-write to both tables
+     * during the transition window so that a rollback doesn't lose data.
+     */
+    private static ?bool $legacyColumnsExist = null;
+
+    public static function legacyColumnsExist(): bool
+    {
+        if (self::$legacyColumnsExist === null) {
+            self::$legacyColumnsExist = Schema::hasColumn('game_players', 'fitness');
+        }
+
+        return self::$legacyColumnsExist;
+    }
+
+    /**
+     * Reset the cached schema check. Only needed in tests that run
+     * migrations mid-test.
+     */
+    public static function resetLegacyColumnsCache(): void
+    {
+        self::$legacyColumnsExist = null;
+    }
+}

--- a/app/Modules/Competition/Services/CompetitionViewService.php
+++ b/app/Modules/Competition/Services/CompetitionViewService.php
@@ -88,7 +88,7 @@ class CompetitionViewService
             return collect();
         }
 
-        $players = GamePlayer::with('player')
+        $players = GamePlayer::with(['player', 'matchState'])
             ->whereIn('id', $scorerRows->pluck('game_player_id')->unique())
             ->get()
             ->keyBy('id');

--- a/app/Modules/Finance/Services/BudgetProjectionService.php
+++ b/app/Modules/Finance/Services/BudgetProjectionService.php
@@ -136,6 +136,9 @@ class BudgetProjectionService
             ->where(fn ($q) => $q->whereNull('game_technical_ability')->orWhereNull('game_physical_ability'))
             ->exists();
 
+        // matchState is needed by calculateStrengthFromPlayers — pool players
+        // (no satellite) fall back to default fitness/morale via the accessor.
+        $query->with('matchState');
         if ($needsPlayerRelation) {
             $query->with('player');
         }
@@ -162,7 +165,7 @@ class BudgetProjectionService
     {
         $players = GamePlayer::where('game_id', $game->id)
             ->where('team_id', $team->id)
-            ->with('player')
+            ->with(['player', 'matchState'])
             ->get();
 
         return $this->calculateStrengthFromPlayers($players);

--- a/app/Modules/Lineup/Services/LineupService.php
+++ b/app/Modules/Lineup/Services/LineupService.php
@@ -33,7 +33,7 @@ class LineupService
      */
     public function getAvailablePlayers(string $gameId, string $teamId, Carbon $matchDate, string $competitionId, bool $requireEnrollment = false): Collection
     {
-        $players = GamePlayer::with('player')
+        $players = GamePlayer::with(['player', 'matchState'])
             ->where('game_id', $gameId)
             ->where('team_id', $teamId)
             ->get();
@@ -64,7 +64,7 @@ class LineupService
      */
     public function getAllPlayers(string $gameId, string $teamId): Collection
     {
-        return GamePlayer::with(['player', 'suspensions', 'transferOffers', 'activeLoan'])
+        return GamePlayer::with(['player', 'matchState', 'suspensions', 'transferOffers', 'activeLoan'])
             ->where('game_id', $gameId)
             ->where('team_id', $teamId)
             ->get();
@@ -555,7 +555,7 @@ class LineupService
             return collect();
         }
 
-        return GamePlayer::with('player')
+        return GamePlayer::with(['player', 'matchState'])
             ->where('game_id', $gameId)
             ->where('team_id', $teamId)
             ->whereIn('id', $playerIds)
@@ -845,7 +845,7 @@ class LineupService
             $availableIds = $availablePlayers->pluck('id')->toArray();
             $allTeamPlayers = $allPlayersGrouped !== null
                 ? $allPlayersGrouped->get($teamId, collect())
-                : GamePlayer::with('player')->where('game_id', $game->id)->where('team_id', $teamId)->get();
+                : GamePlayer::with(['player', 'matchState'])->where('game_id', $game->id)->where('team_id', $teamId)->get();
             $lineup = $this->selectLineupWithPreferencesFromCollection(
                 $availablePlayers,
                 $allTeamPlayers,

--- a/app/Modules/Lineup/Services/SubstitutionService.php
+++ b/app/Modules/Lineup/Services/SubstitutionService.php
@@ -157,7 +157,7 @@ class SubstitutionService
             $lineupIds[] = $sub['playerInId'];
         }
 
-        return GamePlayer::with('player')->whereIn('id', $lineupIds)->get();
+        return GamePlayer::with(['player', 'matchState'])->whereIn('id', $lineupIds)->get();
     }
 
     /**
@@ -179,7 +179,7 @@ class SubstitutionService
 
         // Load opponent full squad (1 query) to derive both lineup and bench
         $opponentTeamId = $isUserHome ? $match->away_team_id : $match->home_team_id;
-        $opponentSquad = GamePlayer::with('player')
+        $opponentSquad = GamePlayer::with(['player', 'matchState'])
             ->where('game_id', $game->id)
             ->where('team_id', $opponentTeamId)
             ->get();
@@ -233,7 +233,7 @@ class SubstitutionService
         // User bench: squad minus active lineup minus subbed-out players minus injured/suspended
         $activeLineupIds = $userLineup->pluck('id')->all();
         $subbedOutIds = array_column($substitutions, 'playerOutId');
-        $userSquad = GamePlayer::with('player')
+        $userSquad = GamePlayer::with(['player', 'matchState'])
             ->where('game_id', $game->id)
             ->where('team_id', $game->team_id)
             ->get();

--- a/app/Modules/Lineup/Services/TacticalChangeService.php
+++ b/app/Modules/Lineup/Services/TacticalChangeService.php
@@ -5,6 +5,7 @@ namespace App\Modules\Lineup\Services;
 use App\Models\Game;
 use App\Models\GameMatch;
 use App\Models\GamePlayer;
+use App\Models\GamePlayerMatchState;
 use App\Models\MatchEvent;
 use App\Modules\Lineup\Enums\Formation;
 use Illuminate\Support\Facades\DB;
@@ -200,12 +201,18 @@ class TacticalChangeService
                 $playerIds[] = $sub['playerInId'];
             }
 
-            // Batch: increment appearances, insert events
+            // Batch: increment appearances on the match-state satellite
+            // (subbed-in players belong to the user's team, so they always
+            // have a satellite row), insert events.
             $playerInIds = array_column($newSubstitutions, 'playerInId');
-            GamePlayer::whereIn('id', $playerInIds)->update([
-                'appearances' => DB::raw('appearances + 1'),
-                'season_appearances' => DB::raw('season_appearances + 1'),
-            ]);
+            $appearanceUpdate = ['appearances' => DB::raw('appearances + 1'), 'season_appearances' => DB::raw('season_appearances + 1')];
+            DB::table('game_player_match_state')
+                ->whereIn('game_player_id', $playerInIds)
+                ->update($appearanceUpdate);
+            GamePlayerMatchState::legacyEloquentWrite(
+                GamePlayer::whereIn('id', $playerInIds),
+                $appearanceUpdate
+            );
             MatchEvent::insert($eventRows);
 
             // Load player names for response

--- a/app/Modules/Match/Listeners/UpdateGoalkeeperStats.php
+++ b/app/Modules/Match/Listeners/UpdateGoalkeeperStats.php
@@ -4,6 +4,7 @@ namespace App\Modules\Match\Listeners;
 
 use App\Modules\Match\Events\MatchFinalized;
 use App\Models\GamePlayer;
+use App\Models\GamePlayerMatchState;
 use Illuminate\Support\Facades\DB;
 
 class UpdateGoalkeeperStats
@@ -55,7 +56,7 @@ class UpdateGoalkeeperStats
             $cases = [];
             foreach ($increments as $gkId => $values) {
                 if ($values[$column] !== 0) {
-                    $cases[] = "WHEN id = '{$gkId}' THEN {$column} + {$values[$column]}";
+                    $cases[] = "WHEN game_player_id = '{$gkId}' THEN {$column} + {$values[$column]}";
                 }
             }
             if (! empty($cases)) {
@@ -64,7 +65,10 @@ class UpdateGoalkeeperStats
         }
 
         if (! empty($setClauses)) {
-            DB::statement('UPDATE game_players SET ' . implode(', ', $setClauses) . " WHERE id IN ({$idList})");
+            DB::statement('UPDATE game_player_match_state SET ' . implode(', ', $setClauses) . " WHERE game_player_id IN ({$idList})");
+
+            $legacyClauses = str_replace('game_player_id', 'id', implode(', ', $setClauses));
+            GamePlayerMatchState::legacyWrite("UPDATE game_players SET {$legacyClauses} WHERE id IN ({$idList})");
         }
     }
 }

--- a/app/Modules/Match/Services/ExtraTimeAndPenaltyService.php
+++ b/app/Modules/Match/Services/ExtraTimeAndPenaltyService.php
@@ -144,7 +144,7 @@ class ExtraTimeAndPenaltyService
         $awayIds = array_values(array_filter($awayIds, fn ($id) => ! in_array($id, $redCardedIds)));
 
         $allIds = array_merge($homeIds, $awayIds);
-        $players = GamePlayer::with('player')->whereIn('id', $allIds)->get()->keyBy('id');
+        $players = GamePlayer::with(['player', 'matchState'])->whereIn('id', $allIds)->get()->keyBy('id');
 
         return [
             $players->only($homeIds)->values(),

--- a/app/Modules/Match/Services/MatchFinalizationService.php
+++ b/app/Modules/Match/Services/MatchFinalizationService.php
@@ -133,7 +133,7 @@ class MatchFinalizationService
     private function updateConditionsForDeferredMatch(GameMatch $match): void
     {
         $teamIds = [$match->home_team_id, $match->away_team_id];
-        $players = GamePlayer::with('player')
+        $players = GamePlayer::with(['player', 'matchState'])
             ->where('game_id', $match->game_id)
             ->whereIn('team_id', $teamIds)
             ->get();
@@ -192,7 +192,7 @@ class MatchFinalizationService
 
         // Build players collection for extra time / penalty simulation
         $allLineupIds = array_merge($match->home_lineup ?? [], $match->away_lineup ?? []);
-        $players = GamePlayer::with('player')->whereIn('id', $allLineupIds)->get();
+        $players = GamePlayer::with(['player', 'matchState'])->whereIn('id', $allLineupIds)->get();
         $allPlayers = collect([
             $match->home_team_id => $players->filter(fn ($p) => $p->team_id === $match->home_team_id),
             $match->away_team_id => $players->filter(fn ($p) => $p->team_id === $match->away_team_id),

--- a/app/Modules/Match/Services/MatchNarrativeService.php
+++ b/app/Modules/Match/Services/MatchNarrativeService.php
@@ -6,6 +6,7 @@ use App\Models\Competition;
 use App\Models\Game;
 use App\Models\GameMatch;
 use App\Models\GamePlayer;
+use App\Models\GamePlayerMatchState;
 use App\Models\GameStanding;
 use App\Modules\Competition\Contracts\HasSeasonGoals;
 use App\Modules\Match\DTOs\MatchNarrative;
@@ -409,17 +410,22 @@ class MatchNarrativeService
     {
         $candidates = [];
 
-        $stats = GamePlayer::where('game_id', $game->id)
-            ->where('team_id', $game->team_id)
-            ->selectRaw('AVG(morale) as avg_morale, AVG(fitness) as avg_fitness')
+        // morale/fitness/injury_until live on the satellite — query it via
+        // JOIN so we only hit active-scope players (pool players have no
+        // satellite and are not on the user's team anyway).
+        $stats = GamePlayerMatchState::join('game_players', 'game_players.id', '=', 'game_player_match_state.game_player_id')
+            ->where('game_players.game_id', $game->id)
+            ->where('game_players.team_id', $game->team_id)
+            ->selectRaw('AVG(game_player_match_state.morale) as avg_morale, AVG(game_player_match_state.fitness) as avg_fitness')
             ->first();
 
         $avgMorale = (int) round($stats->avg_morale ?? 50);
         $avgFitness = (int) round($stats->avg_fitness ?? 50);
 
-        $injuryCount = GamePlayer::where('game_id', $game->id)
-            ->where('team_id', $game->team_id)
-            ->where('injury_until', '>', $game->current_date)
+        $injuryCount = GamePlayerMatchState::join('game_players', 'game_players.id', '=', 'game_player_match_state.game_player_id')
+            ->where('game_players.game_id', $game->id)
+            ->where('game_players.team_id', $game->team_id)
+            ->where('game_player_match_state.injury_until', '>', $game->current_date)
             ->count();
 
         if ($injuryCount >= 4) {

--- a/app/Modules/Match/Services/MatchResimulationService.php
+++ b/app/Modules/Match/Services/MatchResimulationService.php
@@ -9,6 +9,7 @@ use App\Modules\Match\DTOs\TacticalConfig;
 use App\Models\Game;
 use App\Models\GameMatch;
 use App\Models\GamePlayer;
+use App\Models\GamePlayerMatchState;
 use App\Models\MatchEvent;
 use App\Models\PlayerSuspension;
 use Carbon\Carbon;
@@ -463,8 +464,12 @@ class MatchResimulationService
             }
 
             if ($event->event_type === 'injury') {
-                GamePlayer::where('id', $event->game_player_id)
-                    ->update(['injury_type' => null, 'injury_until' => null]);
+                $clearValues = ['injury_type' => null, 'injury_until' => null];
+                GamePlayerMatchState::where('game_player_id', $event->game_player_id)
+                    ->update($clearValues);
+                GamePlayerMatchState::legacyEloquentWrite(
+                    GamePlayer::where('id', $event->game_player_id), $clearValues
+                );
             }
         }
 
@@ -477,14 +482,17 @@ class MatchResimulationService
             ->all();
 
         if (! empty($subbedInPlayerIds)) {
-            $clamp = ['GREATEST(appearances - 1, 0)', 'GREATEST(season_appearances - 1, 0)'];
-
-            GamePlayer::whereIn('id', $subbedInPlayerIds)
+            $decrementValues = [
+                'appearances' => DB::raw('GREATEST(appearances - 1, 0)'),
+                'season_appearances' => DB::raw('GREATEST(season_appearances - 1, 0)'),
+            ];
+            GamePlayerMatchState::whereIn('game_player_id', $subbedInPlayerIds)
                 ->where('appearances', '>', 0)
-                ->update([
-                    'appearances' => DB::raw($clamp[0]),
-                    'season_appearances' => DB::raw($clamp[1]),
-                ]);
+                ->update($decrementValues);
+            GamePlayerMatchState::legacyEloquentWrite(
+                GamePlayer::whereIn('id', $subbedInPlayerIds)->where('appearances', '>', 0),
+                $decrementValues
+            );
         }
 
         // Delete the events
@@ -531,16 +539,22 @@ class MatchResimulationService
             }
         }
 
-        // Update each affected player — set stats to counted values (0 if no events remain)
-        $players = GamePlayer::whereIn('id', $playerIds)->get();
-        foreach ($players as $player) {
-            $counts = $statsMap[$player->id] ?? [];
-            $player->goals = $counts['goals'] ?? 0;
-            $player->own_goals = $counts['own_goals'] ?? 0;
-            $player->assists = $counts['assists'] ?? 0;
-            $player->yellow_cards = $counts['yellow_cards'] ?? 0;
-            $player->red_cards = $counts['red_cards'] ?? 0;
-            $player->save();
+        // Update each affected player's satellite — set stats to counted
+        // values (0 if no events remain). Only resimulated matches involve
+        // active-team lineups, so the satellite row is guaranteed to exist.
+        foreach ($playerIds as $playerId) {
+            $counts = $statsMap[$playerId] ?? [];
+            $statValues = [
+                'goals' => $counts['goals'] ?? 0,
+                'own_goals' => $counts['own_goals'] ?? 0,
+                'assists' => $counts['assists'] ?? 0,
+                'yellow_cards' => $counts['yellow_cards'] ?? 0,
+                'red_cards' => $counts['red_cards'] ?? 0,
+            ];
+            GamePlayerMatchState::where('game_player_id', $playerId)->update($statValues);
+            GamePlayerMatchState::legacyEloquentWrite(
+                GamePlayer::where('id', $playerId), $statValues
+            );
         }
     }
 
@@ -636,17 +650,21 @@ class MatchResimulationService
         ));
         $players = GamePlayer::whereIn('id', $allPlayerIds)->get()->keyBy('id');
 
-        // Apply stat increments
+        // Apply stat increments to the satellite in individual UPDATE queries
+        // (small dataset — typically ≤5 event-producing players per re-simulation).
         foreach ($statIncrements as $playerId => $increments) {
-            $player = $players->get($playerId);
-            if (! $player) {
+            if (empty($increments) || ! $players->has($playerId)) {
                 continue;
             }
 
+            $updates = [];
             foreach ($increments as $column => $amount) {
-                $player->{$column} += $amount;
+                $updates[$column] = DB::raw("{$column} + {$amount}");
             }
-            $player->save();
+            GamePlayerMatchState::where('game_player_id', $playerId)->update($updates);
+            GamePlayerMatchState::legacyEloquentWrite(
+                GamePlayer::where('id', $playerId), $updates
+            );
         }
 
         // Process special events

--- a/app/Modules/Match/Services/MatchResultProcessor.php
+++ b/app/Modules/Match/Services/MatchResultProcessor.php
@@ -6,6 +6,7 @@ use App\Models\Competition;
 use App\Models\Game;
 use App\Models\GameMatch;
 use App\Models\GamePlayer;
+use App\Models\GamePlayerMatchState;
 use App\Models\MatchEvent;
 use App\Models\PlayerSuspension;
 use Carbon\Carbon;
@@ -366,19 +367,11 @@ class MatchResultProcessor
             ? $allPlayers->flatten()->keyBy('id')->only($allPlayerIds)
             : GamePlayer::whereIn('id', $allPlayerIds)->get()->keyBy('id');
 
-        // Apply stat increments in memory (for special events processing below)
-        foreach ($statIncrements as $playerId => $increments) {
-            $player = $players->get($playerId);
-            if (! $player) {
-                continue;
-            }
-
-            foreach ($increments as $column => $amount) {
-                $player->{$column} += $amount;
-            }
-        }
-
-        // Bulk update all stat increments in a single query
+        // Bulk update all stat increments in a single query.
+        // (We used to mirror the increments onto the in-memory $player models
+        // here, but nothing downstream in this method reads them — the
+        // following card/injury processing only touches PlayerSuspension and
+        // batchApplyInjuries, which both query their own state.)
         $this->bulkUpdatePlayerStats($statIncrements);
 
         // Separate card events from injury events
@@ -471,6 +464,10 @@ class MatchResultProcessor
     /**
      * Bulk update player stat increments in a single query using CASE WHEN.
      *
+     * Targets the {@see \App\Models\GamePlayerMatchState} satellite — every
+     * id here originates from a match lineup, so the satellite row is
+     * guaranteed to exist for all of them.
+     *
      * @param  array<string, array<string, int>>  $statIncrements  [playerId => [column => increment]]
      */
     private function bulkUpdatePlayerStats(array $statIncrements): void
@@ -496,7 +493,7 @@ class MatchResultProcessor
             foreach ($statIncrements as $playerId => $increments) {
                 $amount = $increments[$column] ?? 0;
                 if ($amount !== 0) {
-                    $cases[] = "WHEN id = '{$playerId}' THEN {$column} + {$amount}";
+                    $cases[] = "WHEN game_player_id = '{$playerId}' THEN {$column} + {$amount}";
                 }
             }
             if (! empty($cases)) {
@@ -505,7 +502,11 @@ class MatchResultProcessor
         }
 
         if (! empty($setClauses)) {
-            DB::statement("UPDATE game_players SET " . implode(', ', $setClauses) . " WHERE id IN ({$idList})");
+            DB::statement("UPDATE game_player_match_state SET " . implode(', ', $setClauses) . " WHERE game_player_id IN ({$idList})");
+
+            // Dual-write to legacy columns for rollback safety
+            $legacyClauses = str_replace('game_player_id', 'id', implode(', ', $setClauses));
+            GamePlayerMatchState::legacyWrite("UPDATE game_players SET {$legacyClauses} WHERE id IN ({$idList})");
         }
     }
 
@@ -531,10 +532,18 @@ class MatchResultProcessor
         $allLineupIds = array_unique($allLineupIds);
 
         if (! empty($allLineupIds)) {
-            GamePlayer::whereIn('id', $allLineupIds)->update([
-                'appearances' => DB::raw('appearances + 1'),
-                'season_appearances' => DB::raw('season_appearances + 1'),
-            ]);
+            DB::table('game_player_match_state')
+                ->whereIn('game_player_id', $allLineupIds)
+                ->update([
+                    'appearances' => DB::raw('appearances + 1'),
+                    'season_appearances' => DB::raw('season_appearances + 1'),
+                ]);
+
+            // Dual-write to legacy columns for rollback safety
+            GamePlayerMatchState::legacyEloquentWrite(
+                GamePlayer::whereIn('id', $allLineupIds),
+                ['appearances' => DB::raw('appearances + 1'), 'season_appearances' => DB::raw('season_appearances + 1')]
+            );
         }
     }
 
@@ -704,7 +713,8 @@ class MatchResultProcessor
             return;
         }
 
-        // Bulk update using CASE WHEN
+        // Bulk update using CASE WHEN. Targets the satellite — every GK id
+        // came from a lineup, so the satellite row exists.
         $ids = array_keys($increments);
         $idList = "'" . implode("','", $ids) . "'";
         $setClauses = [];
@@ -713,7 +723,7 @@ class MatchResultProcessor
             $cases = [];
             foreach ($increments as $gkId => $values) {
                 if ($values[$column] !== 0) {
-                    $cases[] = "WHEN id = '{$gkId}' THEN {$column} + {$values[$column]}";
+                    $cases[] = "WHEN game_player_id = '{$gkId}' THEN {$column} + {$values[$column]}";
                 }
             }
             if (! empty($cases)) {
@@ -722,7 +732,11 @@ class MatchResultProcessor
         }
 
         if (! empty($setClauses)) {
-            DB::statement('UPDATE game_players SET ' . implode(', ', $setClauses) . " WHERE id IN ({$idList})");
+            DB::statement('UPDATE game_player_match_state SET ' . implode(', ', $setClauses) . " WHERE game_player_id IN ({$idList})");
+
+            // Dual-write to legacy columns for rollback safety
+            $legacyClauses = str_replace('game_player_id', 'id', implode(', ', $setClauses));
+            GamePlayerMatchState::legacyWrite("UPDATE game_players SET {$legacyClauses} WHERE id IN ({$idList})");
         }
     }
 }

--- a/app/Modules/Match/Services/MatchdayOrchestrator.php
+++ b/app/Modules/Match/Services/MatchdayOrchestrator.php
@@ -155,15 +155,13 @@ class MatchdayOrchestrator
 
         $allPlayers = GamePlayer::select([
                 'id', 'game_id', 'player_id', 'team_id', 'number', 'position',
-                'fitness', 'morale', 'durability',
+                'durability',
                 'game_technical_ability', 'game_physical_ability',
-                'injury_until', 'injury_type',
-                'appearances', 'goals', 'own_goals', 'assists',
-                'yellow_cards', 'red_cards',
-                'goals_conceded', 'clean_sheets',
-                'season_appearances',
             ])
-            ->with(['player:id,name,date_of_birth,technical_ability,physical_ability'])
+            ->with([
+                'player:id,name,date_of_birth,technical_ability,physical_ability',
+                'matchState',
+            ])
             ->where('game_id', $game->id)
             ->whereIn('team_id', $teamIds)
             ->get();

--- a/app/Modules/Player/Services/PlayerConditionService.php
+++ b/app/Modules/Player/Services/PlayerConditionService.php
@@ -3,6 +3,7 @@
 namespace App\Modules\Player\Services;
 
 use App\Models\GamePlayer;
+use App\Models\GamePlayerMatchState;
 use App\Modules\Match\Services\EnergyCalculator;
 use App\Modules\Player\PlayerAge;
 use Carbon\Carbon;
@@ -95,6 +96,10 @@ class PlayerConditionService
 
     /**
      * Perform bulk update of fitness and morale using a single query.
+     *
+     * Targets the sparse {@see \App\Models\GamePlayerMatchState} satellite —
+     * the id list is built from match lineups, so by construction every id
+     * is an active player and has a satellite row already.
      */
     private function bulkUpdateConditions(array $updates): void
     {
@@ -107,18 +112,25 @@ class PlayerConditionService
         $moraleCases = [];
 
         foreach ($updates as $id => $values) {
-            $fitnessCases[] = "WHEN id = '{$id}' THEN {$values['fitness']}";
-            $moraleCases[] = "WHEN id = '{$id}' THEN {$values['morale']}";
+            $fitnessCases[] = "WHEN game_player_id = '{$id}' THEN {$values['fitness']}";
+            $moraleCases[] = "WHEN game_player_id = '{$id}' THEN {$values['morale']}";
         }
 
         $idList = "'" . implode("','", $ids) . "'";
 
         DB::statement("
-            UPDATE game_players
+            UPDATE game_player_match_state
             SET fitness = CASE " . implode(' ', $fitnessCases) . " END,
                 morale = CASE " . implode(' ', $moraleCases) . " END
-            WHERE id IN ({$idList})
+            WHERE game_player_id IN ({$idList})
         ");
+
+        // Dual-write to legacy columns for rollback safety
+        $legacyFitnessCases = str_replace('game_player_id', 'id', implode(' ', $fitnessCases));
+        $legacyMoraleCases = str_replace('game_player_id', 'id', implode(' ', $moraleCases));
+        GamePlayerMatchState::legacyWrite(
+            "UPDATE game_players SET fitness = CASE {$legacyFitnessCases} END, morale = CASE {$legacyMoraleCases} END WHERE id IN ({$idList})"
+        );
     }
 
     /**

--- a/app/Modules/Player/Services/PlayerDevelopmentService.php
+++ b/app/Modules/Player/Services/PlayerDevelopmentService.php
@@ -3,6 +3,7 @@
 namespace App\Modules\Player\Services;
 
 use App\Models\GamePlayer;
+use App\Models\GamePlayerMatchState;
 use App\Modules\Player\PlayerAge;
 use App\Modules\Player\Services\DevelopmentCurve;
 
@@ -318,14 +319,28 @@ class PlayerDevelopmentService
 
     /**
      * Apply development changes to a player.
+     *
+     * Splits the write between game_players (ability columns) and the
+     * match-state satellite (season_appearances reset). Active-team players
+     * always have a satellite row by the time development runs; the silent
+     * no-op for missing rows is correct because pool players never accrue
+     * appearances anyway.
      */
     public function applyDevelopment(GamePlayer $player, int $newTech, int $newPhys): void
     {
         $player->update([
             'game_technical_ability' => $newTech,
             'game_physical_ability' => $newPhys,
-            'season_appearances' => 0, // Reset for new season
         ]);
+
+        GamePlayerMatchState::where('game_player_id', $player->id)
+            ->update(['season_appearances' => 0]);
+
+        // Dual-write to legacy columns for rollback safety
+        GamePlayerMatchState::legacyEloquentWrite(
+            GamePlayer::where('id', $player->id),
+            ['season_appearances' => 0]
+        );
     }
 
     /**

--- a/app/Modules/Player/Support/GamePlayerScopeResolver.php
+++ b/app/Modules/Player/Support/GamePlayerScopeResolver.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace App\Modules\Player\Support;
+
+use App\Models\Competition;
+use App\Models\Game;
+use App\Models\Team;
+
+/**
+ * Single source of truth for the "active" team / player scope.
+ *
+ * A player is considered active (and therefore needs a
+ * {@see \App\Models\GamePlayerMatchState} satellite row) iff their team
+ * belongs to a competition in the game's country — i.e. the user's
+ * domestic pyramid (La Liga, Segunda, Copa del Rey for an ES game).
+ *
+ * Foreign-league teams (ENG1, DEU1, FRA1, ITA1, EUR pool) are out of scope:
+ * their players exist purely to populate the international transfer market
+ * and never participate in simulated matches. They get folded back into
+ * scope on demand by {@see \App\Modules\Season\Processors\ContinentalAndCupInitProcessor}
+ * when the user qualifies for a European competition that draws them.
+ *
+ * Mirrors the classification used by
+ * {@see \App\Modules\Transfer\Services\ScoutSearchQueryBuilder::applyScopeFilter()}.
+ */
+class GamePlayerScopeResolver
+{
+    /** @var array<string, string[]> Cached active team ids keyed by game id */
+    private array $cache = [];
+
+    /**
+     * Return the set of team ids that are "active" for the given game.
+     *
+     * @return string[]
+     */
+    public function activeTeamIdsForGame(Game $game): array
+    {
+        if (isset($this->cache[$game->id])) {
+            return $this->cache[$game->id];
+        }
+
+        return $this->cache[$game->id] = $this->resolve($game->country);
+    }
+
+    /**
+     * Variant that takes a country code directly. Useful at game-creation
+     * time before the Game model is fully hydrated.
+     *
+     * @return string[]
+     */
+    public function activeTeamIdsForCountry(string $country): array
+    {
+        return $this->resolve($country);
+    }
+
+    /**
+     * Forget any cached lookups for a game (e.g. after a transfer changes
+     * the active team set).
+     */
+    public function forget(string $gameId): void
+    {
+        unset($this->cache[$gameId]);
+    }
+
+    /**
+     * @return string[]
+     */
+    private function resolve(string $country): array
+    {
+        $competitionIds = Competition::where('country', $country)->pluck('id');
+
+        return Team::transferMarketEligible()
+            ->whereHas('competitions', fn ($q) => $q->whereIn('competitions.id', $competitionIds))
+            ->pluck('id')
+            ->all();
+    }
+}

--- a/app/Modules/Report/Services/AwardService.php
+++ b/app/Modules/Report/Services/AwardService.php
@@ -13,13 +13,15 @@ class AwardService
      */
     public function getTopScorers(string $gameId, Collection|array|null $teamIds = null, int $limit = 5): Collection
     {
-        return GamePlayer::with(['player', 'team'])
+        return GamePlayer::with(['player', 'team', 'matchState'])
+            ->join('game_player_match_state', 'game_players.id', '=', 'game_player_match_state.game_player_id')
             ->where('game_id', $gameId)
             ->when($teamIds, fn ($q) => $q->whereIn('team_id', $teamIds))
-            ->where('goals', '>', 0)
-            ->orderByDesc('goals')
-            ->orderByDesc('assists')
-            ->orderBy('appearances')
+            ->where('game_player_match_state.goals', '>', 0)
+            ->orderByDesc('game_player_match_state.goals')
+            ->orderByDesc('game_player_match_state.assists')
+            ->orderBy('game_player_match_state.appearances')
+            ->select('game_players.*')
             ->limit($limit)
             ->get();
     }
@@ -29,12 +31,14 @@ class AwardService
      */
     public function getTopAssisters(string $gameId, Collection|array|null $teamIds = null, int $limit = 5): Collection
     {
-        return GamePlayer::with(['player', 'team'])
+        return GamePlayer::with(['player', 'team', 'matchState'])
+            ->join('game_player_match_state', 'game_players.id', '=', 'game_player_match_state.game_player_id')
             ->where('game_id', $gameId)
             ->when($teamIds, fn ($q) => $q->whereIn('team_id', $teamIds))
-            ->where('assists', '>', 0)
-            ->orderByDesc('assists')
-            ->orderByDesc('goals')
+            ->where('game_player_match_state.assists', '>', 0)
+            ->orderByDesc('game_player_match_state.assists')
+            ->orderByDesc('game_player_match_state.goals')
+            ->select('game_players.*')
             ->limit($limit)
             ->get();
     }
@@ -44,11 +48,13 @@ class AwardService
      */
     public function getTopGoalkeepers(string $gameId, Collection|array|null $teamIds = null, int $minAppearances = 3, int $limit = 5): Collection
     {
-        return GamePlayer::with(['player', 'team'])
+        return GamePlayer::with(['player', 'team', 'matchState'])
+            ->join('game_player_match_state', 'game_players.id', '=', 'game_player_match_state.game_player_id')
             ->where('game_id', $gameId)
             ->when($teamIds, fn ($q) => $q->whereIn('team_id', $teamIds))
             ->where('position', 'Goalkeeper')
-            ->where('appearances', '>=', $minAppearances)
+            ->where('game_player_match_state.appearances', '>=', $minAppearances)
+            ->select('game_players.*')
             ->get()
             ->sortBy([
                 ['clean_sheets', 'desc'],
@@ -71,7 +77,7 @@ class AwardService
             return [collect(), null, $mvpCounts];
         }
 
-        $players = GamePlayer::with(['player', 'team'])
+        $players = GamePlayer::with(['player', 'team', 'matchState'])
             ->whereIn('id', $mvpCounts->keys()->all())
             ->get()
             ->keyBy('id');
@@ -96,10 +102,12 @@ class AwardService
      */
     public function getTeamSquadStats(string $gameId, string $teamId): Collection
     {
-        return GamePlayer::with('player')
+        return GamePlayer::with(['player', 'matchState'])
+            ->leftJoin('game_player_match_state', 'game_players.id', '=', 'game_player_match_state.game_player_id')
             ->where('game_id', $gameId)
             ->where('team_id', $teamId)
-            ->orderByDesc('appearances')
+            ->orderByDesc('game_player_match_state.appearances')
+            ->select('game_players.*')
             ->get();
     }
 }

--- a/app/Modules/Report/Services/SeasonSummaryService.php
+++ b/app/Modules/Report/Services/SeasonSummaryService.php
@@ -67,8 +67,10 @@ class SeasonSummaryService
         // Other competitions
         $otherCompetitionResults = $this->competitionSummaryService->buildOtherCompetitionResults($game);
 
-        // Team in numbers
-        $teamPlayers = GamePlayer::with(['player', 'team'])
+        // Team in numbers — eager-load matchState because every aggregation
+        // below (top scorer, assists, appearances, cards, clean sheets) reads
+        // through the satellite via the GamePlayer accessor delegates.
+        $teamPlayers = GamePlayer::with(['player', 'team', 'matchState'])
             ->where('game_id', $game->id)
             ->where('team_id', $game->team_id)
             ->get();

--- a/app/Modules/Season/Jobs/SetupNewGame.php
+++ b/app/Modules/Season/Jobs/SetupNewGame.php
@@ -14,7 +14,9 @@ use App\Models\CompetitionEntry;
 use App\Models\CompetitionTeam;
 use App\Models\Game;
 use App\Models\GamePlayer;
+use App\Models\GamePlayerMatchState;
 use App\Models\TeamReputation;
+use App\Modules\Player\Support\GamePlayerScopeResolver;
 use Carbon\Carbon;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldBeUnique;
@@ -295,18 +297,30 @@ class SetupNewGame implements ShouldQueue, ShouldBeUnique
 
         $gameId = $this->gameId;
 
+        // Determine the active team set so we know which players need a
+        // game_player_match_state satellite row at seed time. Players whose
+        // team is outside the active scope (foreign-league transfer pool) get
+        // no satellite row — see GamePlayerScopeResolver for the rules.
+        $game = Game::find($gameId);
+        $activeTeamIds = array_flip(
+            app(GamePlayerScopeResolver::class)->activeTeamIdsForGame($game)
+        );
+
         DB::table('game_player_templates')
             ->where('season', $this->season)
             ->whereNotIn('team_id', function ($query) {
                 $query->select('id')->from('teams')->where('type', 'national');
             })
             ->orderBy('player_id')
-            ->chunk(200, function ($templates) use ($gameId) {
+            ->chunk(200, function ($templates) use ($gameId, $activeTeamIds) {
                 $rows = [];
+                $matchStateRows = [];
 
                 foreach ($templates as $t) {
+                    $gamePlayerId = Str::uuid()->toString();
+
                     $rows[] = [
-                        'id' => Str::uuid()->toString(),
+                        'id' => $gamePlayerId,
                         'game_id' => $gameId,
                         'player_id' => $t->player_id,
                         'team_id' => $t->team_id,
@@ -317,8 +331,6 @@ class SetupNewGame implements ShouldQueue, ShouldBeUnique
                         'market_value_cents' => $t->market_value_cents,
                         'contract_until' => $t->contract_until,
                         'annual_wage' => $t->annual_wage,
-                        'fitness' => $t->fitness,
-                        'morale' => $t->morale,
                         'durability' => $t->durability,
                         'game_technical_ability' => $t->game_technical_ability,
                         'game_physical_ability' => $t->game_physical_ability,
@@ -326,12 +338,39 @@ class SetupNewGame implements ShouldQueue, ShouldBeUnique
                         'potential_low' => $t->potential_low,
                         'potential_high' => $t->potential_high,
                         'tier' => $t->tier,
-                        'season_appearances' => 0,
                     ];
+
+                    // Active-scope players get a satellite row carrying their
+                    // initial fitness/morale from the template. Pool players
+                    // (foreign leagues) skip this — they never participate in
+                    // simulated matches, so their hot-write columns stay at
+                    // GamePlayerMatchState::DEFAULTS via the accessor delegates.
+                    if (isset($activeTeamIds[$t->team_id])) {
+                        $matchStateRows[] = [
+                            'game_player_id' => $gamePlayerId,
+                            'fitness' => $t->fitness,
+                            'morale' => $t->morale,
+                            'injury_until' => null,
+                            'injury_type' => null,
+                            'appearances' => 0,
+                            'season_appearances' => 0,
+                            'goals' => 0,
+                            'own_goals' => 0,
+                            'assists' => 0,
+                            'yellow_cards' => 0,
+                            'red_cards' => 0,
+                            'goals_conceded' => 0,
+                            'clean_sheets' => 0,
+                        ];
+                    }
                 }
 
                 if (!empty($rows)) {
                     GamePlayer::insertOrIgnore($rows);
+                }
+
+                if (!empty($matchStateRows)) {
+                    GamePlayerMatchState::insertOrIgnore($matchStateRows);
                 }
             });
     }

--- a/app/Modules/Season/Jobs/SetupTournamentGame.php
+++ b/app/Modules/Season/Jobs/SetupTournamentGame.php
@@ -8,6 +8,7 @@ use App\Models\CompetitionTeam;
 use App\Models\Game;
 use App\Models\GameMatch;
 use App\Models\GamePlayer;
+use App\Models\GamePlayerMatchState;
 use App\Models\GameStanding;
 use App\Models\Team;
 use Illuminate\Bus\Queueable;
@@ -192,6 +193,9 @@ class SetupTournamentGame implements ShouldQueue
         $gameId = $this->gameId;
         $userTeamId = $this->teamId;
 
+        // Tournament mode (WC2026) only loads teams the user actually faces,
+        // so every player here is "active" — they all need a match-state
+        // satellite row from the start.
         DB::table('game_player_templates')
             ->where('season', '2025')
             ->whereIn('team_id', $wcTeamIds)
@@ -199,10 +203,13 @@ class SetupTournamentGame implements ShouldQueue
             ->orderBy('player_id')
             ->chunk(500, function ($templates) use ($gameId) {
                 $rows = [];
+                $matchStateRows = [];
 
                 foreach ($templates as $t) {
+                    $gamePlayerId = Str::uuid()->toString();
+
                     $rows[] = [
-                        'id' => Str::uuid()->toString(),
+                        'id' => $gamePlayerId,
                         'game_id' => $gameId,
                         'player_id' => $t->player_id,
                         'team_id' => $t->team_id,
@@ -212,8 +219,6 @@ class SetupTournamentGame implements ShouldQueue
                         'market_value_cents' => $t->market_value_cents,
                         'contract_until' => $t->contract_until,
                         'annual_wage' => $t->annual_wage,
-                        'fitness' => $t->fitness,
-                        'morale' => $t->morale,
                         'durability' => $t->durability,
                         'game_technical_ability' => $t->game_technical_ability,
                         'game_physical_ability' => $t->game_physical_ability,
@@ -221,12 +226,32 @@ class SetupTournamentGame implements ShouldQueue
                         'potential_low' => $t->potential_low,
                         'potential_high' => $t->potential_high,
                         'tier' => $t->tier,
+                    ];
+
+                    $matchStateRows[] = [
+                        'game_player_id' => $gamePlayerId,
+                        'fitness' => $t->fitness,
+                        'morale' => $t->morale,
+                        'injury_until' => null,
+                        'injury_type' => null,
+                        'appearances' => 0,
                         'season_appearances' => 0,
+                        'goals' => 0,
+                        'own_goals' => 0,
+                        'assists' => 0,
+                        'yellow_cards' => 0,
+                        'red_cards' => 0,
+                        'goals_conceded' => 0,
+                        'clean_sheets' => 0,
                     ];
                 }
 
                 if (!empty($rows)) {
                     GamePlayer::insert($rows);
+                }
+
+                if (!empty($matchStateRows)) {
+                    GamePlayerMatchState::insert($matchStateRows);
                 }
             });
     }

--- a/app/Modules/Season/Processors/ContinentalAndCupInitProcessor.php
+++ b/app/Modules/Season/Processors/ContinentalAndCupInitProcessor.php
@@ -6,10 +6,12 @@ use App\Modules\Season\Contracts\SeasonProcessor;
 use App\Modules\Season\DTOs\SeasonTransitionData;
 use App\Modules\Competition\Services\CountryConfig;
 use App\Modules\Season\Services\SeasonInitializationService;
+use App\Models\CompetitionEntry;
 use App\Models\Game;
 use App\Models\GameMatch;
 use App\Models\GameStanding;
 use Carbon\Carbon;
+use Illuminate\Support\Facades\DB;
 
 /**
  * Initializes Swiss format competitions (UCL) and conducts cup draws
@@ -64,6 +66,21 @@ class ContinentalAndCupInitProcessor implements SeasonProcessor
             // otherwise null triggers auto-assignment by market value
             $teamsWithPots = $swissPotData[$competitionId] ?? null;
 
+            // If the user actually qualified for this competition, foreign
+            // opponent rosters need a game_player_match_state row before
+            // their first fixture is simulated. Pool players (foreign-league
+            // teams that exist purely for the transfer market) are not
+            // seeded with satellite rows at game-creation time, so we
+            // backfill them here on demand.
+            $userParticipates = CompetitionEntry::where('game_id', $game->id)
+                ->where('competition_id', $competitionId)
+                ->where('team_id', $game->team_id)
+                ->exists();
+
+            if ($userParticipates) {
+                $this->ensureMatchStateForOpponents($game->id, $competitionId);
+            }
+
             // Initialize Swiss fixtures + standings (skips if team doesn't participate)
             $this->service->initializeSwissCompetition(
                 $game->id,
@@ -73,6 +90,36 @@ class ContinentalAndCupInitProcessor implements SeasonProcessor
                 $teamsWithPots,
             );
         }
+    }
+
+    /**
+     * Bulk-insert default match-state rows for every player on every team
+     * that participates in $competitionId in this game and doesn't already
+     * have one. Idempotent — opponents promoted in a previous European
+     * campaign keep their existing satellite (and its accumulated stats).
+     */
+    private function ensureMatchStateForOpponents(string $gameId, string $competitionId): void
+    {
+        $opponentTeamIds = CompetitionEntry::where('game_id', $gameId)
+            ->where('competition_id', $competitionId)
+            ->pluck('team_id');
+
+        if ($opponentTeamIds->isEmpty()) {
+            return;
+        }
+
+        DB::statement(<<<'SQL'
+            INSERT INTO game_player_match_state (
+                game_player_id, fitness, morale, injury_until, injury_type,
+                appearances, season_appearances, goals, own_goals, assists,
+                yellow_cards, red_cards, goals_conceded, clean_sheets
+            )
+            SELECT gp.id, 80, 80, NULL, NULL, 0, 0, 0, 0, 0, 0, 0, 0, 0
+            FROM game_players gp
+            WHERE gp.game_id = ?
+              AND gp.team_id IN (SELECT unnest(?::uuid[]))
+            ON CONFLICT (game_player_id) DO NOTHING
+        SQL, [$gameId, '{' . implode(',', $opponentTeamIds->all()) . '}']);
     }
 
     /**

--- a/app/Modules/Season/Processors/PlayerDevelopmentProcessor.php
+++ b/app/Modules/Season/Processors/PlayerDevelopmentProcessor.php
@@ -10,6 +10,7 @@ use App\Modules\Player\Services\PlayerValuationService;
 use App\Models\Game;
 use App\Models\GamePlayer;
 use Carbon\Carbon;
+use Illuminate\Support\Facades\DB;
 
 /**
  * Applies player development changes at the end of the season.
@@ -33,8 +34,12 @@ class PlayerDevelopmentProcessor implements SeasonProcessor
         $upsertRows = [];
         $currentDate = $game->current_date;
 
-        // Join players table for date_of_birth (age calculation) and ability fallbacks
+        // Join players for date_of_birth (age calculation) and ability
+        // fallbacks. Left-join the satellite for season_appearances —
+        // pool players have no satellite row, in which case
+        // season_appearances is 0 (they never play, so this is correct).
         GamePlayer::join('players', 'game_players.player_id', '=', 'players.id')
+            ->leftJoin('game_player_match_state', 'game_players.id', '=', 'game_player_match_state.game_player_id')
             ->where('game_players.game_id', $game->id)
             ->select([
                 'game_players.id',
@@ -45,7 +50,7 @@ class PlayerDevelopmentProcessor implements SeasonProcessor
                 'game_players.game_technical_ability',
                 'game_players.game_physical_ability',
                 'game_players.market_value_cents',
-                'game_players.season_appearances',
+                DB::raw('COALESCE(game_player_match_state.season_appearances, 0) AS season_appearances'),
                 'game_players.potential',
                 'players.technical_ability',
                 'players.physical_ability',

--- a/app/Modules/Season/Processors/PlayerRetirementProcessor.php
+++ b/app/Modules/Season/Processors/PlayerRetirementProcessor.php
@@ -86,7 +86,9 @@ class PlayerRetirementProcessor implements SeasonProcessor
         // set from ~500 to ~20-40 before PHP-side probability evaluation.
         $minRetirementCutoff = PlayerAge::dateOfBirthCutoff(PlayerAge::MIN_RETIREMENT_OUTFIELD, $game->current_date);
 
-        $candidates = GamePlayer::with(['player', 'team', 'game'])
+        // matchState is eager-loaded because shouldRetire() reads
+        // fitness/season_appearances via the GamePlayer accessor delegates.
+        $candidates = GamePlayer::with(['player', 'team', 'game', 'matchState'])
             ->where('game_id', $game->id)
             ->whereNotNull('team_id')
             ->whereNull('retiring_at_season')

--- a/app/Modules/Season/Processors/SeasonArchiveProcessor.php
+++ b/app/Modules/Season/Processors/SeasonArchiveProcessor.php
@@ -151,7 +151,7 @@ class SeasonArchiveProcessor implements SeasonProcessor
     {
         $stats = [];
 
-        GamePlayer::with('player')
+        GamePlayer::with(['player', 'matchState'])
             ->where('game_id', $game->id)
             ->whereNotNull('team_id')
             ->chunk(200, function ($chunk) use (&$stats) {
@@ -229,10 +229,12 @@ class SeasonArchiveProcessor implements SeasonProcessor
      */
     private function calculateBestGoalkeeper(Game $game): ?array
     {
-        $goalkeepers = GamePlayer::with('player')
+        $goalkeepers = GamePlayer::with(['player', 'matchState'])
+            ->join('game_player_match_state', 'game_players.id', '=', 'game_player_match_state.game_player_id')
             ->where('game_id', $game->id)
             ->where('position', 'Goalkeeper')
-            ->where('appearances', '>=', self::MIN_GOALKEEPER_APPEARANCES)
+            ->where('game_player_match_state.appearances', '>=', self::MIN_GOALKEEPER_APPEARANCES)
+            ->select('game_players.*')
             ->get();
 
         if ($goalkeepers->isEmpty()) {

--- a/app/Modules/Season/Processors/StatsResetProcessor.php
+++ b/app/Modules/Season/Processors/StatsResetProcessor.php
@@ -7,6 +7,7 @@ use App\Modules\Season\DTOs\SeasonTransitionData;
 use App\Models\Game;
 use App\Models\GameNotification;
 use App\Models\GamePlayer;
+use App\Models\GamePlayerMatchState;
 use App\Models\PlayerSuspension;
 use Illuminate\Support\Facades\DB;
 
@@ -28,7 +29,10 @@ class StatsResetProcessor implements SeasonProcessor
             $query->select('id')->from('game_players')->where('game_id', $game->id);
         })->delete();
 
-        GamePlayer::where('game_id', $game->id)->update([
+        // Reset every active player's match-state. Pool players have no
+        // satellite row to reset — and they have no stats to reset either,
+        // so this is correct.
+        $resetValues = [
             'appearances' => 0,
             'goals' => 0,
             'own_goals' => 0,
@@ -42,7 +46,19 @@ class StatsResetProcessor implements SeasonProcessor
             'injury_type' => null,
             'fitness' => 80,
             'morale' => 80,
-        ]);
+        ];
+
+        DB::table('game_player_match_state')
+            ->whereIn('game_player_id', function ($q) use ($game) {
+                $q->select('id')->from('game_players')->where('game_id', $game->id);
+            })
+            ->update($resetValues);
+
+        // Dual-write to legacy columns for rollback safety
+        GamePlayerMatchState::legacyEloquentWrite(
+            GamePlayer::where('game_id', $game->id),
+            $resetValues
+        );
 
         // Mark all previous-season notifications as read so the new season starts clean
         GameNotification::where('game_id', $game->id)

--- a/app/Modules/Squad/Listeners/CheckRecoveredPlayers.php
+++ b/app/Modules/Squad/Listeners/CheckRecoveredPlayers.php
@@ -4,6 +4,7 @@ namespace App\Modules\Squad\Listeners;
 
 use App\Models\GameNotification;
 use App\Models\GamePlayer;
+use App\Models\GamePlayerMatchState;
 use App\Modules\Match\Events\GameDateAdvanced;
 use App\Modules\Notification\Services\NotificationService;
 use App\Modules\Squad\Services\EligibilityService;
@@ -19,10 +20,18 @@ class CheckRecoveredPlayers
     {
         $game = $event->game;
 
-        $recoveredPlayers = GamePlayer::where('game_id', $game->id)
-            ->where('team_id', $game->team_id)
-            ->whereNotNull('injury_until')
-            ->where('injury_until', '<', $event->newDate->toDateString())
+        // injury_until lives on the satellite — join through it. The user's
+        // squad always has match-state rows so an INNER JOIN is correct.
+        $recoveredPlayerIds = GamePlayerMatchState::query()
+            ->join('game_players', 'game_players.id', '=', 'game_player_match_state.game_player_id')
+            ->where('game_players.game_id', $game->id)
+            ->where('game_players.team_id', $game->team_id)
+            ->whereNotNull('game_player_match_state.injury_until')
+            ->where('game_player_match_state.injury_until', '<', $event->newDate->toDateString())
+            ->pluck('game_player_match_state.game_player_id');
+
+        $recoveredPlayers = GamePlayer::with('matchState')
+            ->whereIn('id', $recoveredPlayerIds)
             ->get();
 
         if ($recoveredPlayers->isEmpty()) {

--- a/app/Modules/Squad/Services/EligibilityService.php
+++ b/app/Modules/Squad/Services/EligibilityService.php
@@ -3,6 +3,7 @@
 namespace App\Modules\Squad\Services;
 
 use App\Models\GamePlayer;
+use App\Models\GamePlayerMatchState;
 use App\Models\PlayerSuspension;
 use App\Modules\Squad\DTOs\SuspensionRuleSet;
 use Carbon\Carbon;
@@ -27,15 +28,27 @@ class EligibilityService
     /**
      * Apply an injury to a player.
      *
+     * Writes to the {@see GamePlayerMatchState} satellite. Injuries only ever
+     * happen to players in active match lineups, so the satellite row is
+     * guaranteed to exist.
+     *
      * @param string $injuryType Description of the injury
      * @param int $weeksOut Number of weeks the player will be out
      * @param Carbon $matchDate The date of the match when injury occurred
      */
     public function applyInjury(GamePlayer $player, string $injuryType, int $weeksOut, Carbon $matchDate): void
     {
-        $player->injury_type = $injuryType;
-        $player->injury_until = \Illuminate\Support\Carbon::instance($matchDate->copy()->addWeeks($weeksOut));
-        $player->save();
+        $injuryValues = [
+            'injury_type' => $injuryType,
+            'injury_until' => \Illuminate\Support\Carbon::instance($matchDate->copy()->addWeeks($weeksOut))->toDateString(),
+        ];
+
+        GamePlayerMatchState::where('game_player_id', $player->id)->update($injuryValues);
+        GamePlayerMatchState::legacyEloquentWrite(
+            GamePlayer::where('id', $player->id), $injuryValues
+        );
+
+        $player->unsetRelation('matchState');
     }
 
     /**
@@ -57,15 +70,22 @@ class EligibilityService
             $type = str_replace("'", "''", $injury['injuryType']);
             $until = $injury['injuryUntil']->toDateString();
             $ids[] = "'{$id}'";
-            $typeCases[] = "WHEN id = '{$id}' THEN '{$type}'";
-            $untilCases[] = "WHEN id = '{$id}' THEN '{$until}'::date";
+            $typeCases[] = "WHEN game_player_id = '{$id}' THEN '{$type}'";
+            $untilCases[] = "WHEN game_player_id = '{$id}' THEN '{$until}'::date";
         }
 
         $idList = implode(',', $ids);
         DB::statement(
-            'UPDATE game_players SET injury_type = CASE ' . implode(' ', $typeCases) . ' END, '
+            'UPDATE game_player_match_state SET injury_type = CASE ' . implode(' ', $typeCases) . ' END, '
             . 'injury_until = CASE ' . implode(' ', $untilCases) . ' END '
-            . "WHERE id IN ({$idList})"
+            . "WHERE game_player_id IN ({$idList})"
+        );
+
+        // Dual-write to legacy columns for rollback safety
+        $legacyTypeCases = str_replace('game_player_id', 'id', implode(' ', $typeCases));
+        $legacyUntilCases = str_replace('game_player_id', 'id', implode(' ', $untilCases));
+        GamePlayerMatchState::legacyWrite(
+            "UPDATE game_players SET injury_type = CASE {$legacyTypeCases} END, injury_until = CASE {$legacyUntilCases} END WHERE id IN ({$idList})"
         );
     }
 
@@ -74,9 +94,14 @@ class EligibilityService
      */
     public function clearInjury(GamePlayer $player): void
     {
-        $player->injury_until = null;
-        $player->injury_type = null;
-        $player->save();
+        $clearValues = ['injury_type' => null, 'injury_until' => null];
+
+        GamePlayerMatchState::where('game_player_id', $player->id)->update($clearValues);
+        GamePlayerMatchState::legacyEloquentWrite(
+            GamePlayer::where('id', $player->id), $clearValues
+        );
+
+        $player->unsetRelation('matchState');
     }
 
     /**

--- a/app/Modules/Squad/Services/PlayerGeneratorService.php
+++ b/app/Modules/Squad/Services/PlayerGeneratorService.php
@@ -5,6 +5,7 @@ namespace App\Modules\Squad\Services;
 use App\Modules\Squad\DTOs\GeneratedPlayerData;
 use App\Models\Game;
 use App\Models\GamePlayer;
+use App\Models\GamePlayerMatchState;
 use App\Models\Player;
 use Carbon\Carbon;
 use Illuminate\Support\Str;
@@ -127,20 +128,30 @@ class PlayerGeneratorService
             'market_value_cents' => $marketValue,
             'contract_until' => $contractUntil,
             'annual_wage' => $annualWage,
-            'fitness' => mt_rand($data->fitnessMin, $data->fitnessMax),
-            'morale' => mt_rand($data->moraleMin, $data->moraleMax),
             'durability' => InjuryService::generateDurability(),
             'game_technical_ability' => $data->technical,
             'game_physical_ability' => $data->physical,
             'potential' => $potential,
             'potential_low' => $potentialLow,
             'potential_high' => $potentialHigh,
-            'season_appearances' => 0,
             'tier' => PlayerTierService::tierFromMarketValue($marketValue),
         ]);
 
-        // Set relation to avoid lazy-load when caller accesses $gamePlayer->player
+        // Generated players (youth grads, replenishment) always belong to
+        // teams in the active scope, so they always need a match-state row.
+        $matchState = GamePlayerMatchState::create(array_merge(
+            ['game_player_id' => $gamePlayer->id],
+            GamePlayerMatchState::DEFAULTS,
+            [
+                'fitness' => mt_rand($data->fitnessMin, $data->fitnessMax),
+                'morale' => mt_rand($data->moraleMin, $data->moraleMax),
+            ]
+        ));
+
+        // Set relations to avoid lazy-load when caller accesses derived
+        // attributes via the GamePlayer accessor delegates.
         $gamePlayer->setRelation('player', $player);
+        $gamePlayer->setRelation('matchState', $matchState);
 
         // Update cache with the newly created player
         $teamKey = "{$game->id}:{$data->teamId}";
@@ -171,6 +182,7 @@ class PlayerGeneratorService
 
         $playerRows = [];
         $gamePlayerRows = [];
+        $matchStateRows = [];
         $results = [];
         $batchNames = [];
 
@@ -228,17 +240,25 @@ class PlayerGeneratorService
                 'market_value_cents' => $marketValue,
                 'contract_until' => $contractUntil->format('Y-m-d'),
                 'annual_wage' => $annualWage,
-                'fitness' => mt_rand($data->fitnessMin, $data->fitnessMax),
-                'morale' => mt_rand($data->moraleMin, $data->moraleMax),
                 'durability' => InjuryService::generateDurability(),
                 'game_technical_ability' => $data->technical,
                 'game_physical_ability' => $data->physical,
                 'potential' => $potential,
                 'potential_low' => $potentialLow,
                 'potential_high' => $potentialHigh,
-                'season_appearances' => 0,
                 'tier' => PlayerTierService::tierFromMarketValue($marketValue),
             ];
+
+            // Bulk-generated players (youth grads, replenishment) always end
+            // up on active-scope teams, so they always get a satellite row.
+            $matchStateRows[] = array_merge(
+                ['game_player_id' => $gamePlayerId],
+                GamePlayerMatchState::DEFAULTS,
+                [
+                    'fitness' => mt_rand($data->fitnessMin, $data->fitnessMax),
+                    'morale' => mt_rand($data->moraleMin, $data->moraleMax),
+                ]
+            );
 
             // Update caches for subsequent iterations
             $teamKey = "{$game->id}:{$data->teamId}";
@@ -261,6 +281,11 @@ class PlayerGeneratorService
         // Bulk insert GamePlayer records
         foreach (array_chunk($gamePlayerRows, 500) as $chunk) {
             GamePlayer::insert($chunk);
+        }
+
+        // Bulk insert satellite match-state rows
+        foreach (array_chunk($matchStateRows, 500) as $chunk) {
+            GamePlayerMatchState::insert($chunk);
         }
 
         return $results;

--- a/app/Modules/Squad/Services/SquadService.php
+++ b/app/Modules/Squad/Services/SquadService.php
@@ -26,7 +26,7 @@ class SquadService
         $gameId = $game->id;
 
         // Get all players for user's team with relationships
-        $allPlayers = GamePlayer::with(['player', 'game', 'team', 'activeLoan', 'transferOffers', 'suspensions', 'activeRenewalNegotiation', 'latestRenewalNegotiation'])
+        $allPlayers = GamePlayer::with(['player', 'game', 'team', 'matchState', 'activeLoan', 'transferOffers', 'suspensions', 'activeRenewalNegotiation', 'latestRenewalNegotiation'])
             ->where('game_id', $gameId)
             ->where('team_id', $game->team_id)
             ->get();

--- a/app/Modules/Transfer/Services/TransferCompletionService.php
+++ b/app/Modules/Transfer/Services/TransferCompletionService.php
@@ -5,6 +5,7 @@ namespace App\Modules\Transfer\Services;
 use App\Models\FinancialTransaction;
 use App\Models\Game;
 use App\Models\GamePlayer;
+use App\Models\GamePlayerMatchState;
 use App\Models\GameTransfer;
 use App\Models\Loan;
 use App\Models\ShortlistedPlayer;
@@ -115,6 +116,15 @@ class TransferCompletionService
             'contract_until' => Carbon::createFromDate((int) $game->season + rand(2, 4) + 1, 6, 30),
         ]);
 
+        // If the destination team is in the active scope, the player will
+        // start playing matches against the user — make sure they have a
+        // satellite row. No-op for users selling to other active teams.
+        GamePlayerMatchState::firstOrCreate(
+            ['game_player_id' => $player->id],
+            GamePlayerMatchState::DEFAULTS,
+        );
+        $player->unsetRelation('matchState');
+
         GameTransfer::record(
             gameId: $game->id,
             gamePlayerId: $player->id,
@@ -172,6 +182,15 @@ class TransferCompletionService
             'annual_wage' => $offer->offered_wage ?? $player->annual_wage,
         ]);
 
+        // The signing might be a foreign-pool player (no satellite row yet)
+        // — give them defaults so the user's match simulation can pick them
+        // up immediately. No-op if a row already exists.
+        GamePlayerMatchState::firstOrCreate(
+            ['game_player_id' => $player->id],
+            GamePlayerMatchState::DEFAULTS,
+        );
+        $player->unsetRelation('matchState');
+
         GameTransfer::record(
             gameId: $game->id,
             gamePlayerId: $player->id,
@@ -224,6 +243,15 @@ class TransferCompletionService
             'contract_until' => $newContractEnd,
             'annual_wage' => $offer->offered_wage,
         ]);
+
+        // Free agents may originate from a foreign team that never had a
+        // satellite row — give them defaults so the user can immediately
+        // pick them in lineups. No-op if a row already exists.
+        GamePlayerMatchState::firstOrCreate(
+            ['game_player_id' => $player->id],
+            GamePlayerMatchState::DEFAULTS,
+        );
+        $player->unsetRelation('matchState');
 
         $offer->update([
             'status' => TransferOffer::STATUS_COMPLETED,

--- a/database/factories/GamePlayerFactory.php
+++ b/database/factories/GamePlayerFactory.php
@@ -4,6 +4,7 @@ namespace Database\Factories;
 
 use App\Models\Game;
 use App\Models\GamePlayer;
+use App\Models\GamePlayerMatchState;
 use App\Models\Player;
 use App\Models\Team;
 use App\Modules\Player\Services\PlayerTierService;
@@ -13,6 +14,17 @@ use Illuminate\Support\Str;
 class GamePlayerFactory extends Factory
 {
     protected $model = GamePlayer::class;
+
+    /**
+     * Match-state overrides stashed by newModel() so configure() can apply
+     * them after the GamePlayer row is persisted. Keyed by spl_object_id of
+     * the GamePlayer instance — unique per call even when createMany() is
+     * looping. Static so the value survives the newModel → afterCreating
+     * trip across stateful and unstateful Eloquent factory wrappers.
+     *
+     * @var array<int, array<string, mixed>>
+     */
+    protected static array $pendingOverrides = [];
 
     public function definition(): array
     {
@@ -28,17 +40,76 @@ class GamePlayerFactory extends Factory
             'market_value_cents' => $marketValueCents,
             'contract_until' => now()->addYears(2),
             'annual_wage' => $this->faker->numberBetween(10_000_00, 1_000_000_00),
-            'fitness' => $this->faker->numberBetween(70, 100),
-            'morale' => $this->faker->numberBetween(60, 90),
             'durability' => $this->faker->numberBetween(50, 95),
             'game_technical_ability' => $this->faker->numberBetween(40, 90),
             'game_physical_ability' => $this->faker->numberBetween(40, 90),
             'potential' => $this->faker->numberBetween(60, 95),
             'potential_low' => $this->faker->numberBetween(55, 85),
             'potential_high' => $this->faker->numberBetween(70, 99),
-            'season_appearances' => 0,
             'tier' => PlayerTierService::tierFromMarketValue($marketValueCents),
         ];
+    }
+
+    /**
+     * Tests still pass match-state attributes via `->create(['fitness' =>
+     * 50, 'goals' => 5])`. Strip them out of the GamePlayer attribute set
+     * and stash them so afterCreating() can apply them to the satellite row.
+     *
+     * @param  array<string, mixed>  $attributes
+     */
+    public function newModel(array $attributes = []): GamePlayer
+    {
+        $matchStateColumns = array_keys(GamePlayerMatchState::DEFAULTS);
+        $overrides = array_intersect_key($attributes, array_flip($matchStateColumns));
+
+        if (! empty($overrides)) {
+            $attributes = array_diff_key($attributes, $overrides);
+        }
+
+        /** @var GamePlayer $model */
+        $model = parent::newModel($attributes);
+
+        if (! empty($overrides)) {
+            self::$pendingOverrides[spl_object_id($model)] = $overrides;
+        }
+
+        return $model;
+    }
+
+    public function configure(): static
+    {
+        return $this->afterCreating(function (GamePlayer $player) {
+            $oid = spl_object_id($player);
+            $overrides = self::$pendingOverrides[$oid] ?? [];
+            unset(self::$pendingOverrides[$oid]);
+
+            // Every test-created GamePlayer gets a satellite row by default
+            // — tests historically assumed game_players carried fitness etc.,
+            // and the cheapest fix is to mirror that assumption.
+            GamePlayerMatchState::create(array_merge(
+                ['game_player_id' => $player->id],
+                GamePlayerMatchState::DEFAULTS,
+                [
+                    'fitness' => $this->faker->numberBetween(70, 100),
+                    'morale' => $this->faker->numberBetween(60, 90),
+                ],
+                $overrides,
+            ));
+
+            $player->unsetRelation('matchState');
+        });
+    }
+
+    /**
+     * Create a "pool" player — no satellite row, mirroring foreign-league
+     * players that exist purely for the transfer market.
+     */
+    public function pool(): static
+    {
+        return $this->afterCreating(function (GamePlayer $player) {
+            GamePlayerMatchState::where('game_player_id', $player->id)->delete();
+            $player->unsetRelation('matchState');
+        });
     }
 
     public function forGame(Game $game): static

--- a/database/migrations/2026_04_11_000001_create_game_player_match_state_table.php
+++ b/database/migrations/2026_04_11_000001_create_game_player_match_state_table.php
@@ -1,0 +1,49 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Create the sparse game_player_match_state satellite table.
+     *
+     * Holds the 13 hot-write columns that get updated on every matchday by
+     * PlayerConditionService and MatchResultProcessor (fitness, morale, injury,
+     * appearances, goals, assists, cards, GK stats). Only populated for
+     * "active" players — those whose team belongs to a competition in the
+     * game's country (La Liga, Segunda, Copa del Rey) or who become a
+     * European opponent for a season the user qualifies for. Foreign
+     * transfer-pool players have no row here at all.
+     */
+    public function up(): void
+    {
+        Schema::create('game_player_match_state', function (Blueprint $table) {
+            $table->uuid('game_player_id')->primary();
+            $table->unsignedTinyInteger('fitness')->default(80);
+            $table->unsignedTinyInteger('morale')->default(80);
+            $table->date('injury_until')->nullable();
+            $table->string('injury_type')->nullable();
+            $table->unsignedSmallInteger('appearances')->default(0);
+            $table->unsignedSmallInteger('season_appearances')->default(0);
+            $table->unsignedSmallInteger('goals')->default(0);
+            $table->unsignedSmallInteger('own_goals')->default(0);
+            $table->unsignedSmallInteger('assists')->default(0);
+            $table->unsignedSmallInteger('yellow_cards')->default(0);
+            $table->unsignedSmallInteger('red_cards')->default(0);
+            $table->unsignedInteger('goals_conceded')->default(0);
+            $table->unsignedInteger('clean_sheets')->default(0);
+
+            $table->foreign('game_player_id')
+                ->references('id')
+                ->on('game_players')
+                ->onDelete('cascade');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('game_player_match_state');
+    }
+};

--- a/database/migrations/2026_04_11_000002_drop_match_state_columns_from_game_players.php
+++ b/database/migrations/2026_04_11_000002_drop_match_state_columns_from_game_players.php
@@ -1,0 +1,58 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Drop the 13 hot-write columns from game_players that are now stored
+     * in the game_player_match_state satellite table. Reads are mediated
+     * by the GamePlayer accessor delegates so no application code should
+     * notice the columns are gone.
+     *
+     * In production this runs strictly AFTER the
+     * app:backfill-game-player-match-state command has copied existing
+     * values out of game_players for every legacy game.
+     */
+    public function up(): void
+    {
+        Schema::table('game_players', function (Blueprint $table) {
+            $table->dropColumn([
+                'fitness',
+                'morale',
+                'injury_until',
+                'injury_type',
+                'appearances',
+                'season_appearances',
+                'goals',
+                'own_goals',
+                'assists',
+                'yellow_cards',
+                'red_cards',
+                'goals_conceded',
+                'clean_sheets',
+            ]);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('game_players', function (Blueprint $table) {
+            $table->unsignedTinyInteger('fitness')->default(80);
+            $table->unsignedTinyInteger('morale')->default(80);
+            $table->date('injury_until')->nullable();
+            $table->string('injury_type')->nullable();
+            $table->unsignedSmallInteger('appearances')->default(0);
+            $table->unsignedSmallInteger('season_appearances')->default(0);
+            $table->unsignedSmallInteger('goals')->default(0);
+            $table->unsignedSmallInteger('own_goals')->default(0);
+            $table->unsignedSmallInteger('assists')->default(0);
+            $table->unsignedSmallInteger('yellow_cards')->default(0);
+            $table->unsignedSmallInteger('red_cards')->default(0);
+            $table->unsignedInteger('goals_conceded')->default(0);
+            $table->unsignedInteger('clean_sheets')->default(0);
+        });
+    }
+};

--- a/tests/Unit/GamePlayerMatchStateTest.php
+++ b/tests/Unit/GamePlayerMatchStateTest.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\Game;
+use App\Models\GamePlayer;
+use App\Models\GamePlayerMatchState;
+use App\Models\Player;
+use App\Models\Team;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class GamePlayerMatchStateTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_factory_creates_satellite_row_by_default(): void
+    {
+        $player = GamePlayer::factory()->create();
+
+        $this->assertNotNull($player->matchState);
+        $this->assertGreaterThanOrEqual(70, $player->matchState->fitness);
+        $this->assertLessThanOrEqual(100, $player->matchState->fitness);
+    }
+
+    public function test_pool_factory_state_skips_satellite_row(): void
+    {
+        $player = GamePlayer::factory()->pool()->create();
+
+        $this->assertNull($player->matchState);
+        $this->assertDatabaseMissing('game_player_match_state', [
+            'game_player_id' => $player->id,
+        ]);
+    }
+
+    public function test_accessor_returns_satellite_value(): void
+    {
+        $player = GamePlayer::factory()->create();
+        GamePlayerMatchState::where('game_player_id', $player->id)->update([
+            'fitness' => 55,
+            'morale' => 65,
+            'goals' => 7,
+            'assists' => 3,
+            'appearances' => 12,
+        ]);
+
+        $player = $player->fresh(['matchState']);
+
+        $this->assertSame(55, $player->fitness);
+        $this->assertSame(65, $player->morale);
+        $this->assertSame(7, $player->goals);
+        $this->assertSame(3, $player->assists);
+        $this->assertSame(12, $player->appearances);
+    }
+
+    public function test_accessor_returns_defaults_for_pool_player(): void
+    {
+        $player = GamePlayer::factory()->pool()->create();
+
+        $this->assertSame(GamePlayerMatchState::DEFAULTS['fitness'], $player->fitness);
+        $this->assertSame(GamePlayerMatchState::DEFAULTS['morale'], $player->morale);
+        $this->assertSame(0, $player->goals);
+        $this->assertSame(0, $player->appearances);
+        $this->assertNull($player->injury_until);
+    }
+
+    public function test_in_memory_override_wins_over_satellite(): void
+    {
+        $player = GamePlayer::factory()->create();
+        GamePlayerMatchState::where('game_player_id', $player->id)->update(['goals' => 5]);
+        $player = $player->fresh(['matchState']);
+
+        // Mimics CompetitionViewService stuffing per-competition tallies onto
+        // the model for display.
+        $clone = clone $player;
+        $clone->goals = 99;
+
+        $this->assertSame(99, $clone->goals);
+        // The original is unaffected.
+        $this->assertSame(5, $player->goals);
+    }
+
+    public function test_satellite_cascades_on_game_player_delete(): void
+    {
+        $player = GamePlayer::factory()->create();
+
+        $this->assertDatabaseHas('game_player_match_state', [
+            'game_player_id' => $player->id,
+        ]);
+
+        $player->delete();
+
+        $this->assertDatabaseMissing('game_player_match_state', [
+            'game_player_id' => $player->id,
+        ]);
+    }
+
+    public function test_injured_player_is_unavailable(): void
+    {
+        $game = Game::factory()->create(['current_date' => '2025-10-01']);
+        $player = GamePlayer::factory()->forGame($game)->create();
+
+        GamePlayerMatchState::where('game_player_id', $player->id)->update([
+            'injury_until' => '2025-10-15',
+            'injury_type' => 'Hamstring tear',
+        ]);
+
+        $player = $player->fresh(['matchState']);
+
+        $this->assertFalse($player->isAvailable(Carbon::parse('2025-10-01')));
+        $this->assertTrue($player->isInjured(Carbon::parse('2025-10-01')));
+        $this->assertSame('Hamstring tear', $player->injury_type);
+    }
+
+    public function test_overall_score_reads_through_satellite(): void
+    {
+        $player = GamePlayer::factory()->create([
+            'game_technical_ability' => 80,
+            'game_physical_ability' => 70,
+        ]);
+        GamePlayerMatchState::where('game_player_id', $player->id)->update([
+            'fitness' => 100,
+            'morale' => 100,
+        ]);
+        $player = $player->fresh(['matchState']);
+
+        // (80*0.35 + 70*0.35 + 100*0.15 + 100*0.15) = 28 + 24.5 + 15 + 15 = 82.5 → 83
+        $this->assertSame(83, $player->overall_score);
+    }
+}

--- a/tests/Unit/GamePlayerScopeResolverTest.php
+++ b/tests/Unit/GamePlayerScopeResolverTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\Competition;
+use App\Models\Game;
+use App\Models\Team;
+use App\Modules\Player\Support\GamePlayerScopeResolver;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class GamePlayerScopeResolverTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_active_team_ids_includes_country_competition_teams(): void
+    {
+        $espCompetition = Competition::factory()->create([
+            'country' => 'ES',
+            'role' => Competition::ROLE_LEAGUE,
+        ]);
+        $espTeam = Team::factory()->create();
+        $espCompetition->teams()->attach($espTeam->id, ['season' => '2025']);
+
+        $game = Game::factory()->create(['country' => 'ES']);
+
+        $resolver = new GamePlayerScopeResolver();
+
+        $this->assertContains($espTeam->id, $resolver->activeTeamIdsForGame($game));
+    }
+
+    public function test_active_team_ids_excludes_foreign_country_teams(): void
+    {
+        $engCompetition = Competition::factory()->create([
+            'country' => 'EN',
+            'role' => Competition::ROLE_LEAGUE,
+        ]);
+        $engTeam = Team::factory()->create();
+        $engCompetition->teams()->attach($engTeam->id, ['season' => '2025']);
+
+        $game = Game::factory()->create(['country' => 'ES']);
+
+        $resolver = new GamePlayerScopeResolver();
+
+        $this->assertNotContains($engTeam->id, $resolver->activeTeamIdsForGame($game));
+    }
+
+    public function test_results_are_cached_per_game(): void
+    {
+        $game = Game::factory()->create(['country' => 'ES']);
+        $resolver = new GamePlayerScopeResolver();
+
+        $first = $resolver->activeTeamIdsForGame($game);
+        $second = $resolver->activeTeamIdsForGame($game);
+
+        $this->assertSame($first, $second);
+    }
+
+    public function test_forget_clears_cache(): void
+    {
+        $game = Game::factory()->create(['country' => 'ES']);
+        $resolver = new GamePlayerScopeResolver();
+
+        $resolver->activeTeamIdsForGame($game);
+        $resolver->forget($game->id);
+
+        // Add a new active team after caching has been cleared.
+        $newCompetition = Competition::factory()->create([
+            'country' => 'ES',
+            'role' => Competition::ROLE_LEAGUE,
+        ]);
+        $newTeam = Team::factory()->create();
+        $newCompetition->teams()->attach($newTeam->id, ['season' => '2025']);
+
+        $this->assertContains($newTeam->id, $resolver->activeTeamIdsForGame($game));
+    }
+}


### PR DESCRIPTION
## Summary

Refactors the GamePlayer model to move 13 frequently-updated columns (fitness, morale, injury state, match statistics) into a sparse satellite table `game_player_match_state`. This reduces write contention on the main `game_players` table and enables selective population based on player scope.

## Key Changes

- **New Model & Table**: Created `GamePlayerMatchState` model and migration to hold per-matchday hot-write state (fitness, morale, injury_until, injury_type, appearances, season_appearances, goals, own_goals, assists, yellow_cards, red_cards, goals_conceded, clean_sheets)

- **Sparse Population**: Only "active" players (those in competitions within the game's country) get a satellite row at game creation. Foreign transfer-pool players have no row, reducing storage footprint.

- **Transparent Read Access**: Added 13 accessor methods on `GamePlayer` that delegate to the satellite via `matchState` relationship. Existing code reading `$player->fitness` or `$player->goals` works unchanged. In-memory overrides (e.g., for per-competition tallies) take precedence over satellite values.

- **Scope Resolution**: Introduced `GamePlayerScopeResolver` service as single source of truth for determining which teams/players are "active" for a given game. Cached per-game to avoid repeated queries.

- **Data Migration**: Added `BackfillGamePlayerMatchState` command to copy existing values from `game_players` columns into the new satellite table before dropping the columns.

- **Factory Updates**: Modified `GamePlayerFactory` to intercept match-state attributes and apply them to the satellite row after creation, maintaining test compatibility.

- **Write Path Updates**: Updated all write paths to target `GamePlayerMatchState` directly:
  - `MatchResultProcessor`: bulk stat updates via satellite
  - `PlayerConditionService`: fitness/morale updates
  - `EligibilityService`: injury application
  - `StatsResetProcessor`: season reset
  - `MatchResimulationService`: event reversion
  - `TransferCompletionService`: ensure satellite row on transfer
  - `TacticalChangeService`: appearance increments

- **Query Optimization**: Added `with('matchState')` eager loading to hot paths (match simulator, squad service, lineup loader, dashboard, award service) to prevent N+1 queries.

- **Tournament Support**: Extended `ContinentalAndCupInitProcessor` to backfill satellite rows for foreign opponents when user qualifies for European competitions.

## Implementation Details

- Satellite uses `game_player_id` as primary key (UUID) for direct 1:1 relationship
- Defaults mirror original column defaults (fitness/morale: 80, stats: 0)
- Cascading delete on `GamePlayer` deletion
- Comprehensive test coverage for accessor behavior, pool player handling, and scope resolution
- Migration sequence: create table → backfill → drop columns (idempotent backfill command)

https://claude.ai/code/session_016pou2mAwhuWYWEXHXDT3iC