### PR TITLE
Fix skip-to-end, ET, and resimulation bugs; add frontend + backend test coverage

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,6 +35,12 @@ jobs:
           extensions: mbstring, xml, pgsql
           coverage: none
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
       - name: Get Composer cache directory
         id: composer-cache
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
@@ -46,15 +52,21 @@ jobs:
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
           restore-keys: ${{ runner.os }}-composer-
 
-      - name: Install dependencies
+      - name: Install PHP dependencies
         run: composer install --no-interaction --prefer-dist
+
+      - name: Install JS dependencies
+        run: npm ci
+
+      - name: Run JS tests
+        run: npm test
 
       - name: Prepare environment
         run: |
           cp .env.example .env
           php artisan key:generate
 
-      - name: Run tests
+      - name: Run PHP tests
         run: php artisan test --parallel --processes=4
         env:
           DB_CONNECTION: pgsql

--- a/app/Http/Actions/ProcessTacticalActions.php
+++ b/app/Http/Actions/ProcessTacticalActions.php
@@ -68,7 +68,7 @@ class ProcessTacticalActions
             return response()->json(['error' => __('game.tactical_no_changes')], 422);
         }
 
-        $isExtraTime = $validated['minute'] > 90;
+        $isExtraTime = $validated['minute'] > 90 || $match->is_extra_time;
 
         // Validate substitutions if present
         if ($hasSubs) {

--- a/app/Http/Actions/ProcessTacticalActions.php
+++ b/app/Http/Actions/ProcessTacticalActions.php
@@ -68,7 +68,7 @@ class ProcessTacticalActions
             return response()->json(['error' => __('game.tactical_no_changes')], 422);
         }
 
-        $isExtraTime = $validated['minute'] > 90 || $match->is_extra_time;
+        $isExtraTime = $match->is_extra_time;
 
         // Validate substitutions if present
         if ($hasSubs) {

--- a/app/Http/Actions/SkipMatchToEnd.php
+++ b/app/Http/Actions/SkipMatchToEnd.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace App\Http\Actions;
+
+use App\Models\Game;
+use App\Models\GameMatch;
+use App\Models\GamePlayer;
+use App\Models\PlayerSuspension;
+use App\Modules\Lineup\Services\SubstitutionService;
+use App\Modules\Lineup\Services\TacticalChangeService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Re-simulate a live match from the current minute to the end with AI
+ * substitutions enabled for the user's team. Triggered by the "Skip to end"
+ * button in the live match view so players who fast-forward don't finish with
+ * the tired starting 11.
+ *
+ * Normal live-match play (minute by minute) stays fully manual — auto-subs
+ * only kick in when this endpoint is called.
+ */
+class SkipMatchToEnd
+{
+    public function __construct(
+        private readonly TacticalChangeService $tacticalChangeService,
+    ) {}
+
+    public function __invoke(Request $request, string $gameId, string $matchId): JsonResponse
+    {
+        $game = Game::findOrFail($gameId);
+        $match = GameMatch::with(['homeTeam', 'awayTeam', 'competition'])
+            ->where('game_id', $gameId)
+            ->findOrFail($matchId);
+
+        if ($game->pending_finalization_match_id !== $match->id) {
+            return response()->json(['error' => __('game.match_not_in_progress')], 403);
+        }
+
+        if (! $match->involvesTeam($game->team_id)) {
+            return response()->json(['error' => __('game.sub_error_not_your_match')], 422);
+        }
+
+        $validated = $request->validate([
+            'minute' => 'required|integer|min:1|max:93',
+            'previousSubstitutions' => 'array',
+            'previousSubstitutions.*.playerOutId' => 'required|string',
+            'previousSubstitutions.*.playerInId' => 'required|string',
+            'previousSubstitutions.*.minute' => 'required|integer',
+        ]);
+
+        // Extra time is out of scope for this iteration — the existing
+        // client-only skipToEnd handles ET and penalties.
+        if ($match->is_extra_time) {
+            return $this->noop();
+        }
+
+        $previousSubstitutions = $validated['previousSubstitutions'] ?? [];
+        $minute = $validated['minute'];
+
+        // Nothing meaningful left to resimulate — AI sub windows are bounded
+        // by config('match_simulation.ai_substitutions.max_minute') anyway.
+        if ($minute >= 90) {
+            return $this->noop();
+        }
+
+        // If the user already burned all 5 subs or all 3 windows, there's no
+        // sub budget to top up. Avoid an unnecessary resimulation.
+        if (count($previousSubstitutions) >= SubstitutionService::MAX_SUBSTITUTIONS) {
+            return $this->noop();
+        }
+
+        $usedWindows = collect($previousSubstitutions)
+            ->pluck('minute')
+            ->unique()
+            ->count();
+        if ($usedWindows >= SubstitutionService::MAX_WINDOWS) {
+            return $this->noop();
+        }
+
+        // Empty user bench → nothing to bring on.
+        if ($this->availableBenchCount($match, $game, $previousSubstitutions) === 0) {
+            return $this->noop();
+        }
+
+        try {
+            $result = $this->tacticalChangeService->processLiveMatchChanges(
+                $match,
+                $game,
+                $minute,
+                $previousSubstitutions,
+                newSubstitutions: [],
+                isExtraTime: false,
+                autoSubUserTeam: true,
+            );
+        } catch (\Throwable $e) {
+            Log::error('SkipMatchToEnd failed', [
+                'match_id' => $match->id,
+                'game_id' => $game->id,
+                'minute' => $minute,
+                'error' => $e->getMessage(),
+                'trace' => $e->getTraceAsString(),
+            ]);
+
+            return response()->json([
+                'error' => __('game.tactical_error_generic'),
+            ], 422);
+        }
+
+        $result['autoSubsApplied'] = true;
+
+        return response()->json($result);
+    }
+
+    /**
+     * Return an empty "no-op" response that matches the shape of a successful
+     * resimulation so the frontend can fall through to its client-only
+     * fast-forward without special-casing the payload.
+     */
+    private function noop(): JsonResponse
+    {
+        return response()->json([
+            'autoSubsApplied' => false,
+            'newEvents' => [],
+        ]);
+    }
+
+    /**
+     * Count how many bench players are actually available (not already
+     * subbed in, not injured, not suspended). Cheap pre-check to avoid
+     * running the full resimulation when the bench can't contribute subs.
+     */
+    private function availableBenchCount(GameMatch $match, Game $game, array $previousSubstitutions): int
+    {
+        $isUserHome = $match->isHomeTeam($game->team_id);
+        $lineupIds = $isUserHome ? ($match->home_lineup ?? []) : ($match->away_lineup ?? []);
+
+        $subbedInIds = array_column($previousSubstitutions, 'playerInId');
+        $subbedOutIds = array_column($previousSubstitutions, 'playerOutId');
+
+        // Active on-pitch IDs = original lineup minus subbed-out plus subbed-in
+        $activeIds = array_values(array_filter(
+            $lineupIds,
+            fn ($id) => ! in_array($id, $subbedOutIds, true),
+        ));
+        $activeIds = array_merge($activeIds, $subbedInIds);
+
+        $suspendedIds = PlayerSuspension::suspendedPlayerIdsForCompetition($match->competition_id);
+
+        return GamePlayer::where('game_id', $game->id)
+            ->where('team_id', $game->team_id)
+            ->whereNotIn('id', $activeIds)
+            ->whereNotIn('id', $suspendedIds)
+            ->where(function ($q) use ($match) {
+                $q->whereNull('injury_until')
+                    ->orWhere('injury_until', '<', $match->scheduled_date);
+            })
+            ->when($game->requiresSquadEnrollment(), fn ($q) => $q->whereNotNull('number'))
+            ->count();
+    }
+}

--- a/app/Http/Views/ShowLiveMatch.php
+++ b/app/Http/Views/ShowLiveMatch.php
@@ -14,6 +14,7 @@ use App\Models\Game;
 use App\Models\GameMatch;
 use App\Models\GamePlayer;
 use App\Models\PlayerSuspension;
+use App\Modules\Match\Services\ExtraTimeAndPenaltyService;
 use App\Modules\Match\Services\MatchResimulationService;
 use App\Support\PitchGrid;
 use App\Support\PositionMapper;
@@ -24,6 +25,7 @@ class ShowLiveMatch
 {
     public function __construct(
         private readonly LineupService $lineupService,
+        private readonly ExtraTimeAndPenaltyService $extraTimeService,
     ) {}
 
     public function __invoke(string $gameId, string $matchId)
@@ -423,8 +425,12 @@ class ShowLiveMatch
                 'away' => $match->away_score_penalties,
             ];
         } else {
-            // ET done but penalties not yet — user needs to pick kickers
-            $data['needsPenalties'] = true;
+            // ET done but penalties not yet resolved — check whether the ET
+            // result is actually a draw. Without this, a page refresh after
+            // ET ended 2-1 would incorrectly send the user to penalties.
+            $data['needsPenalties'] = $this->extraTimeService->checkNeedsPenalties(
+                $match, $match->home_score_et ?? 0, $match->away_score_et ?? 0
+            );
         }
 
         return $data;

--- a/app/Http/Views/ShowLiveMatch.php
+++ b/app/Http/Views/ShowLiveMatch.php
@@ -343,6 +343,7 @@ class ShowLiveMatch
             'lineupPlayers' => $lineupPlayers,
             'benchPlayers' => $benchPlayers,
             'tacticalActionsUrl' => route('game.match.tactical-actions', ['gameId' => $game->id, 'matchId' => $playerMatch->id]),
+            'skipToEndUrl' => route('game.match.skip-to-end', ['gameId' => $game->id, 'matchId' => $playerMatch->id]),
             'extraTimeUrl' => route('game.match.extra-time', ['gameId' => $game->id, 'matchId' => $playerMatch->id]),
             'penaltiesUrl' => route('game.match.penalties', ['gameId' => $game->id, 'matchId' => $playerMatch->id]),
             'userFormation' => $userFormation,

--- a/app/Modules/Lineup/Services/TacticalChangeService.php
+++ b/app/Modules/Lineup/Services/TacticalChangeService.php
@@ -39,6 +39,7 @@ class TacticalChangeService
         ?string $defensiveLine = null,
         bool $isExtraTime = false,
         ?array $pitchPositions = null,
+        bool $autoSubUserTeam = false,
     ): array {
         $isUserHome = $match->isHomeTeam($game->team_id);
         $prefix = $isUserHome ? 'home' : 'away';
@@ -127,22 +128,53 @@ class TacticalChangeService
         if ($isExtraTime) {
             $result = $this->resimulationService->resimulateExtraTime($match, $game, $minute, $homePlayers, $awayPlayers, $allSubs, $homeBench, $awayBench);
         } else {
-            $result = $this->resimulationService->resimulate($match, $game, $minute, $homePlayers, $awayPlayers, $allSubs, $homeBench, $awayBench);
+            $result = $this->resimulationService->resimulate(
+                $match,
+                $game,
+                $minute,
+                $homePlayers,
+                $awayPlayers,
+                $allSubs,
+                $homeBench,
+                $awayBench,
+                autoSubUserTeam: $autoSubUserTeam,
+            );
         }
 
-        // Rebuild substitutions JSON: keep opponent entries, replace user entries with allSubs.
+        // Rebuild substitutions JSON: keep opponent entries, replace user entries.
         // This cleans up stale entries from previous simulations that were reverted.
+        // When $autoSubUserTeam is true, the resimulation may have generated fresh
+        // user-team substitution events in the remainder (they exist as MatchEvent
+        // rows but are not in $allSubs). Re-read the user substitutions from the
+        // events table so the JSON stays authoritative.
         $opponentSubs = collect($match->substitutions ?? [])
             ->filter(fn ($s) => ($s['team_id'] ?? null) !== $game->team_id)
             ->values()
             ->all();
 
-        $userSubs = array_map(fn ($s) => [
-            'team_id' => $game->team_id,
-            'player_out_id' => $s['playerOutId'],
-            'player_in_id' => $s['playerInId'],
-            'minute' => $s['minute'],
-        ], $allSubs);
+        if ($autoSubUserTeam) {
+            $userSubs = MatchEvent::where('game_match_id', $match->id)
+                ->where('event_type', MatchEvent::TYPE_SUBSTITUTION)
+                ->where('team_id', $game->team_id)
+                ->orderBy('minute')
+                ->get()
+                ->map(fn ($e) => [
+                    'team_id' => $game->team_id,
+                    'player_out_id' => $e->game_player_id,
+                    'player_in_id' => $e->metadata['player_in_id'] ?? null,
+                    'minute' => $e->minute,
+                ])
+                ->filter(fn ($s) => $s['player_in_id'] !== null)
+                ->values()
+                ->all();
+        } else {
+            $userSubs = array_map(fn ($s) => [
+                'team_id' => $game->team_id,
+                'player_out_id' => $s['playerOutId'],
+                'player_in_id' => $s['playerInId'],
+                'minute' => $s['minute'],
+            ], $allSubs);
+        }
 
         $match->update(['substitutions' => array_merge($opponentSubs, $userSubs)]);
 

--- a/app/Modules/Match/Services/FullMatchSimulationService.php
+++ b/app/Modules/Match/Services/FullMatchSimulationService.php
@@ -106,15 +106,14 @@ class FullMatchSimulationService
         $homePlayers = $this->getLineupPlayers($match, $allPlayers, 'home');
         $awayPlayers = $this->getLineupPlayers($match, $allPlayers, 'away');
 
-        // Don't pass bench players for the user's team — they make their own
-        // substitution decisions during the live match. The simulator already
-        // guards with `$benchPlayers !== null`, so injury events are still
-        // generated but no auto-substitution follows.
+        // Always pass both benches so injury auto-subs fire for the user's
+        // team too. The user team is excluded from tactical AI substitution
+        // windows (those only trigger via "Skip to end"); see
+        // simulateWithAISubstitutions() in MatchSimulator.
         $isUserMatch = $match->involvesTeam($game->team_id);
-        $isUserHome = $isUserMatch && $match->isHomeTeam($game->team_id);
 
-        $homeBenchPlayers = $isUserHome ? null : $this->getBenchPlayers($match, $allPlayers, 'home', $game);
-        $awayBenchPlayers = ($isUserMatch && ! $isUserHome) ? null : $this->getBenchPlayers($match, $allPlayers, 'away', $game);
+        $homeBenchPlayers = $this->getBenchPlayers($match, $allPlayers, 'home', $game);
+        $awayBenchPlayers = $this->getBenchPlayers($match, $allPlayers, 'away', $game);
 
         $tc = TacticalConfig::fromMatch($match);
         if (! $isUserMatch) {
@@ -141,6 +140,7 @@ class FullMatchSimulationService
             $awayBenchPlayers,
             matchSeed: $match->id,
             neutralVenue: $match->isNeutralVenue(),
+            userTeamId: $isUserMatch ? $game->team_id : null,
         );
 
         $result = $output->result;

--- a/app/Modules/Match/Services/MatchResimulationService.php
+++ b/app/Modules/Match/Services/MatchResimulationService.php
@@ -83,6 +83,37 @@ class MatchResimulationService
         $homePlayers = $homePlayers->reject(fn ($p) => in_array($p->id, $unavailablePlayerIds));
         $awayPlayers = $awayPlayers->reject(fn ($p) => in_array($p->id, $unavailablePlayerIds));
 
+        // 5b. Add back players who entered via substitution (injury auto-subs
+        // or tactical subs that happened during pre-simulation). Without this,
+        // the team plays with fewer than 11 players because the subbed-out
+        // player was removed above but the replacement was never added.
+        $isUserHome = $match->isHomeTeam($game->team_id);
+        $userTeamId = $game->team_id;
+
+        $userAutoSubEvents = MatchEvent::where('game_match_id', $match->id)
+            ->where('team_id', $userTeamId)
+            ->where('event_type', 'substitution')
+            ->where('minute', '<=', $minute)
+            ->whereNotIn('game_player_id', collect($allSubstitutions)->pluck('playerOutId')->all())
+            ->get();
+
+        $autoSubPlayerInIds = $userAutoSubEvents
+            ->map(fn ($e) => $e->metadata['player_in_id'] ?? null)
+            ->filter()
+            ->all();
+
+        if (! empty($autoSubPlayerInIds)) {
+            $autoSubPlayersIn = GamePlayer::with('player')
+                ->whereIn('id', $autoSubPlayerInIds)
+                ->get();
+
+            if ($isUserHome) {
+                $homePlayers = $homePlayers->merge($autoSubPlayersIn)->values();
+            } else {
+                $awayPlayers = $awayPlayers->merge($autoSubPlayersIn)->values();
+            }
+        }
+
         // 6. Get existing injuries/yellows for context
         $existingInjuryTeamIds = MatchEvent::where('game_match_id', $match->id)
             ->where('minute', '<=', $minute)
@@ -99,15 +130,27 @@ class MatchResimulationService
             ->all();
 
         // 7. Build entry minute maps from substitutions
-        $isUserHome = $match->isHomeTeam($game->team_id);
         $homeEntryMinutes = [];
         $awayEntryMinutes = [];
-        // User's substitutions
+        // User's manual substitutions
         foreach ($allSubstitutions as $sub) {
             if ($isUserHome) {
                 $homeEntryMinutes[$sub['playerInId']] = $sub['minute'];
             } else {
                 $awayEntryMinutes[$sub['playerInId']] = $sub['minute'];
+            }
+        }
+        // User's pre-simulated auto-subs (injury auto-subs from the initial
+        // simulation that aren't in the frontend's manual sub list).
+        foreach ($userAutoSubEvents as $subEvent) {
+            $playerInId = $subEvent->metadata['player_in_id'] ?? null;
+            if ($playerInId === null) {
+                continue;
+            }
+            if ($isUserHome) {
+                $homeEntryMinutes[$playerInId] = $subEvent->minute;
+            } else {
+                $awayEntryMinutes[$playerInId] = $subEvent->minute;
             }
         }
         // Opponent's substitutions up to the resimulation minute. Read from match_events
@@ -133,10 +176,11 @@ class MatchResimulationService
         }
 
         // 8. Count existing substitutions and windows per team to enforce limits.
-        // Opponent counts come from match_events (post-revert state) so repeated
-        // resimulations can't push the opponent past the sub/window caps by
-        // counting against a stale $match->substitutions snapshot.
-        $userSubCount = count($allSubstitutions);
+        // Both teams' counts come from match_events (post-revert state) so repeated
+        // resimulations can't push past the sub/window caps by counting against
+        // stale snapshots. The user's manual subs are combined with any pre-simulated
+        // auto-subs that occurred before the resimulation minute.
+        $userSubCount = count($allSubstitutions) + $userAutoSubEvents->count();
         $opponentSubCount = $opponentSubEvents->count();
         $homeExistingSubs = $isUserHome ? $userSubCount : $opponentSubCount;
         $awayExistingSubs = $isUserHome ? $opponentSubCount : $userSubCount;
@@ -145,8 +189,15 @@ class MatchResimulationService
             ->pluck('minute')
             ->unique()
             ->count();
-        $homeWindowsUsed = $isUserHome ? 0 : $opponentWindowsUsed;
-        $awayWindowsUsed = $isUserHome ? $opponentWindowsUsed : 0;
+        // Combine manual and auto-sub minutes to get total windows used.
+        // Subs at the same minute share a window (counted once).
+        $userWindowsUsed = collect($allSubstitutions)
+            ->pluck('minute')
+            ->merge($userAutoSubEvents->pluck('minute'))
+            ->unique()
+            ->count();
+        $homeWindowsUsed = $isUserHome ? $userWindowsUsed : $opponentWindowsUsed;
+        $awayWindowsUsed = $isUserHome ? $opponentWindowsUsed : $userWindowsUsed;
 
         // 9. Re-simulate the remainder with AI substitutions.
         // By default only the opponent gets auto-subs (the user controls their own

--- a/app/Modules/Match/Services/MatchResimulationService.php
+++ b/app/Modules/Match/Services/MatchResimulationService.php
@@ -361,8 +361,10 @@ class MatchResimulationService
             // 2. Revert all events after the minute
             $this->revertEventsAfterMinute($match, $minute, $competitionId);
 
-            // 3. Calculate ET-only score at minute (events with minute > 90 that remain)
-            $scoreAtMinute = $this->calculateScoreAtMinute($match, 90);
+            // 3. Calculate ET-only score at minute (events with minute > 93 that remain).
+            // Use 93 (not 90) because stoppage-time goals at minutes 91-93 are
+            // regular-time events already counted in home_score/away_score.
+            $scoreAtMinute = $this->calculateScoreAtMinute($match, 93);
 
             // 4. Read formation/mentality/instructions from match record
             $tc = TacticalConfig::fromMatch($match);

--- a/app/Modules/Match/Services/MatchResimulationService.php
+++ b/app/Modules/Match/Services/MatchResimulationService.php
@@ -40,9 +40,10 @@ class MatchResimulationService
         array $allSubstitutions = [],
         ?Collection $homeBenchPlayers = null,
         ?Collection $awayBenchPlayers = null,
+        bool $autoSubUserTeam = false,
     ): ResimulationResult {
-        return DB::transaction(function () use ($match, $game, $minute, $homePlayers, $awayPlayers, $allSubstitutions, $homeBenchPlayers, $awayBenchPlayers) {
-            return $this->doResimulate($match, $game, $minute, $homePlayers, $awayPlayers, $allSubstitutions, $homeBenchPlayers, $awayBenchPlayers);
+        return DB::transaction(function () use ($match, $game, $minute, $homePlayers, $awayPlayers, $allSubstitutions, $homeBenchPlayers, $awayBenchPlayers, $autoSubUserTeam) {
+            return $this->doResimulate($match, $game, $minute, $homePlayers, $awayPlayers, $allSubstitutions, $homeBenchPlayers, $awayBenchPlayers, $autoSubUserTeam);
         });
     }
 
@@ -55,6 +56,7 @@ class MatchResimulationService
         array $allSubstitutions = [],
         ?Collection $homeBenchPlayers = null,
         ?Collection $awayBenchPlayers = null,
+        bool $autoSubUserTeam = false,
     ): ResimulationResult {
         $competitionId = $match->competition_id;
 
@@ -146,13 +148,21 @@ class MatchResimulationService
         $homeWindowsUsed = $isUserHome ? 0 : $opponentWindowsUsed;
         $awayWindowsUsed = $isUserHome ? $opponentWindowsUsed : 0;
 
-        // 9. Re-simulate the remainder with AI substitutions for the opponent
+        // 9. Re-simulate the remainder with AI substitutions.
+        // By default only the opponent gets auto-subs (the user controls their own
+        // team via the tactical panel). When $autoSubUserTeam is true — set by the
+        // "Skip to end" flow — both teams get auto-subs so the match finishes with
+        // realistic substitutions instead of the tired starting 11.
         $hasOpponentBench = $isUserHome
             ? ($awayBenchPlayers !== null && $awayBenchPlayers->isNotEmpty())
             : ($homeBenchPlayers !== null && $homeBenchPlayers->isNotEmpty());
+        $hasUserBench = $isUserHome
+            ? ($homeBenchPlayers !== null && $homeBenchPlayers->isNotEmpty())
+            : ($awayBenchPlayers !== null && $awayBenchPlayers->isNotEmpty());
+        $hasAnyBench = $hasOpponentBench || ($autoSubUserTeam && $hasUserBench);
 
         $aiSubMode = config('match_simulation.ai_substitutions.mode', 'all');
-        $aiSubsActive = $hasOpponentBench && match ($aiSubMode) {
+        $aiSubsActive = $hasAnyBench && match ($aiSubMode) {
             'all' => true,
             'ai_only' => false, // user is in the match, so skip in ai_only mode
             default => false,
@@ -188,7 +198,8 @@ class MatchResimulationService
                 awayWindowsUsed: $awayWindowsUsed,
                 scoreHomeAtMinute: $scoreAtMinute['home'],
                 scoreAwayAtMinute: $scoreAtMinute['away'],
-                userTeamId: $game->team_id,
+                // Passing null opts the user team INTO auto-subs for this remainder.
+                userTeamId: $autoSubUserTeam ? null : $game->team_id,
             );
         } else {
             $remainderOutput = $this->matchSimulator->simulateRemainder(

--- a/app/Modules/Match/Services/MatchResimulationService.php
+++ b/app/Modules/Match/Services/MatchResimulationService.php
@@ -377,15 +377,55 @@ class MatchResimulationService
             $homePlayers = $homePlayers->reject(fn ($p) => in_array($p->id, $unavailablePlayerIds));
             $awayPlayers = $awayPlayers->reject(fn ($p) => in_array($p->id, $unavailablePlayerIds));
 
-            // 6. Build entry minute maps from substitutions
+            // 5b. Add back players who entered via auto-sub (same fix as doResimulate)
             $isUserHome = $match->isHomeTeam($game->team_id);
+            $userTeamId = $game->team_id;
+
+            $userAutoSubEvents = MatchEvent::where('game_match_id', $match->id)
+                ->where('team_id', $userTeamId)
+                ->where('event_type', 'substitution')
+                ->where('minute', '<=', $minute)
+                ->whereNotIn('game_player_id', collect($allSubstitutions)->pluck('playerOutId')->all())
+                ->get();
+
+            $autoSubPlayerInIds = $userAutoSubEvents
+                ->map(fn ($e) => $e->metadata['player_in_id'] ?? null)
+                ->filter()
+                ->all();
+
+            if (! empty($autoSubPlayerInIds)) {
+                $autoSubPlayersIn = GamePlayer::with('player')
+                    ->whereIn('id', $autoSubPlayerInIds)
+                    ->get();
+
+                if ($isUserHome) {
+                    $homePlayers = $homePlayers->merge($autoSubPlayersIn)->values();
+                } else {
+                    $awayPlayers = $awayPlayers->merge($autoSubPlayersIn)->values();
+                }
+            }
+
+            // 6. Build entry minute maps from substitutions
             $homeEntryMinutes = [];
             $awayEntryMinutes = [];
+            // User's manual substitutions
             foreach ($allSubstitutions as $sub) {
                 if ($isUserHome) {
                     $homeEntryMinutes[$sub['playerInId']] = $sub['minute'];
                 } else {
                     $awayEntryMinutes[$sub['playerInId']] = $sub['minute'];
+                }
+            }
+            // User's pre-simulated auto-subs
+            foreach ($userAutoSubEvents as $subEvent) {
+                $playerInId = $subEvent->metadata['player_in_id'] ?? null;
+                if ($playerInId === null) {
+                    continue;
+                }
+                if ($isUserHome) {
+                    $homeEntryMinutes[$playerInId] = $subEvent->minute;
+                } else {
+                    $awayEntryMinutes[$playerInId] = $subEvent->minute;
                 }
             }
 

--- a/app/Modules/Match/Services/MatchSimulator.php
+++ b/app/Modules/Match/Services/MatchSimulator.php
@@ -123,11 +123,13 @@ class MatchSimulator
         ?Collection $awayBenchPlayers = null,
         string $matchSeed = '',
         bool $neutralVenue = false,
+        ?string $userTeamId = null,
     ): MatchSimulationOutput {
         $homeBenchAvailable = $homeBenchPlayers !== null && $homeBenchPlayers->isNotEmpty();
         $awayBenchAvailable = $awayBenchPlayers !== null && $awayBenchPlayers->isNotEmpty();
         $hasAIBench = $homeBenchAvailable || $awayBenchAvailable;
-        $isUserMatch = ($homeBenchAvailable xor $awayBenchAvailable);
+        $isUserMatch = $userTeamId !== null
+            && ($userTeamId === $homeTeam->id || $userTeamId === $awayTeam->id);
 
         $aiSubMode = config('match_simulation.ai_substitutions.mode', 'all');
         $aiSubsActive = $hasAIBench && match ($aiSubMode) {
@@ -148,6 +150,7 @@ class MatchSimulator
                 $homeDefLine, $awayDefLine,
                 $homeBenchPlayers, $awayBenchPlayers,
                 $matchSeed,
+                $userTeamId,
             );
         }
 
@@ -197,6 +200,7 @@ class MatchSimulator
         ?Collection $homeBenchPlayers,
         ?Collection $awayBenchPlayers,
         string $matchSeed,
+        ?string $userTeamId = null,
     ): MatchSimulationOutput {
         $homeFormation = $homeFormation ?? Formation::F_4_4_2;
         $awayFormation = $awayFormation ?? Formation::F_4_4_2;
@@ -212,11 +216,14 @@ class MatchSimulator
         $homeTacticalDrain = $homePlayingStyle->energyDrainMultiplier() * $homePressing->energyDrainMultiplier();
         $awayTacticalDrain = $awayPlayingStyle->energyDrainMultiplier() * $awayPressing->energyDrainMultiplier();
 
-        // Determine how many subs each AI team will make
-        $homeTotalSubs = $homeBenchPlayers !== null
+        // Determine how many tactical subs each AI team will make.
+        // The user's team gets 0 tactical windows — their bench is only here
+        // so processInjurySubstitution() can fire inside simulateRemainder().
+        // Tactical AI subs for the user team are deferred to "Skip to end".
+        $homeTotalSubs = ($homeBenchPlayers !== null && $userTeamId !== $homeTeam->id)
             ? $this->aiSubstitutionService->decideTotalSubs($homeBenchPlayers->count())
             : 0;
-        $awayTotalSubs = $awayBenchPlayers !== null
+        $awayTotalSubs = ($awayBenchPlayers !== null && $userTeamId !== $awayTeam->id)
             ? $this->aiSubstitutionService->decideTotalSubs($awayBenchPlayers->count())
             : 0;
 

--- a/app/Modules/Player/Services/InjuryService.php
+++ b/app/Modules/Player/Services/InjuryService.php
@@ -14,19 +14,19 @@ class InjuryService
     /**
      * Base injury chance per player per match (percentage).
      */
-    private const BASE_INJURY_CHANCE = 1.0;
+    private const BASE_INJURY_CHANCE = 0.8;
 
     /**
      * Base training injury chance per player per matchday (percentage).
      * Applies to all squad members (playing and non-playing).
      */
-    private const TRAINING_INJURY_CHANCE = 1.05;
+    private const TRAINING_INJURY_CHANCE = 1.0;
 
     /**
      * Goalkeepers face far fewer physical duels and run significantly less
      * than outfield players, so their injury risk is much lower.
      */
-    private const GK_MATCH_INJURY_MULTIPLIER = 0.3;
+    private const GK_MATCH_INJURY_MULTIPLIER = 0.2;
 
     private const GK_TRAINING_INJURY_MULTIPLIER = 0.5;
 
@@ -120,18 +120,18 @@ class InjuryService
         'Metatarsal fracture' => [
             'weeks' => [8, 12],
             'positions' => ['MF', 'FW', 'DF'],
-            'weight' => 4,
+            'weight' => 6,
         ],
         // Severe (20+ weeks) - Rare
         'ACL tear' => [
             'weeks' => [24, 36],
             'positions' => ['DF', 'MF', 'FW'],
-            'weight' => 2,
+            'weight' => 4,
         ],
         'Achilles rupture' => [
             'weeks' => [20, 28],
             'positions' => ['FW', 'MF', 'DF'],
-            'weight' => 1,
+            'weight' => 2,
         ],
     ];
 
@@ -180,7 +180,6 @@ class InjuryService
     public function calculateInjuryProbability(GamePlayer $player, ?Carbon $lastMatchDate = null, ?Carbon $currentMatchDate = null, ?Game $game = null): float
     {
         $baseProbability = self::BASE_INJURY_CHANCE;
-
         // Get multipliers
         $durabilityMultiplier = $this->getDurabilityMultiplier($player);
         $ageMultiplier = $this->getAgeMultiplier($player->age($player->game->current_date));

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,8 @@
                 "laravel-vite-plugin": "^2.0.0",
                 "playwright": "^1.58.2",
                 "tailwindcss": "^4.2.1",
-                "vite": "7.1.11"
+                "vite": "7.1.11",
+                "vitest": "^4.1.4"
             }
         },
         "node_modules/@alpinejs/collapse": {
@@ -886,6 +887,13 @@
                 "tippy.js": "^6.3.1"
             }
         },
+        "node_modules/@standard-schema/spec": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+            "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@tailwindcss/forms": {
             "version": "0.5.11",
             "resolved": "https://registry.npmjs.org/@tailwindcss/forms/-/forms-0.5.11.tgz",
@@ -1198,12 +1206,143 @@
                 "vite": "^5.2.0 || ^6 || ^7"
             }
         },
+        "node_modules/@types/chai": {
+            "version": "5.2.3",
+            "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+            "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/deep-eql": "*",
+                "assertion-error": "^2.0.1"
+            }
+        },
+        "node_modules/@types/deep-eql": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+            "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@types/estree": {
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
             "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/@vitest/expect": {
+            "version": "4.1.4",
+            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.4.tgz",
+            "integrity": "sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@standard-schema/spec": "^1.1.0",
+                "@types/chai": "^5.2.2",
+                "@vitest/spy": "4.1.4",
+                "@vitest/utils": "4.1.4",
+                "chai": "^6.2.2",
+                "tinyrainbow": "^3.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/mocker": {
+            "version": "4.1.4",
+            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.4.tgz",
+            "integrity": "sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/spy": "4.1.4",
+                "estree-walker": "^3.0.3",
+                "magic-string": "^0.30.21"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "msw": "^2.4.9",
+                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+            },
+            "peerDependenciesMeta": {
+                "msw": {
+                    "optional": true
+                },
+                "vite": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@vitest/pretty-format": {
+            "version": "4.1.4",
+            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.4.tgz",
+            "integrity": "sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tinyrainbow": "^3.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/runner": {
+            "version": "4.1.4",
+            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.4.tgz",
+            "integrity": "sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/utils": "4.1.4",
+                "pathe": "^2.0.3"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/snapshot": {
+            "version": "4.1.4",
+            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.4.tgz",
+            "integrity": "sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/pretty-format": "4.1.4",
+                "@vitest/utils": "4.1.4",
+                "magic-string": "^0.30.21",
+                "pathe": "^2.0.3"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/spy": {
+            "version": "4.1.4",
+            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.4.tgz",
+            "integrity": "sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/utils": {
+            "version": "4.1.4",
+            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.4.tgz",
+            "integrity": "sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/pretty-format": "4.1.4",
+                "convert-source-map": "^2.0.0",
+                "tinyrainbow": "^3.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
         },
         "node_modules/@vue/reactivity": {
             "version": "3.1.5",
@@ -1244,6 +1383,16 @@
                 "url": "https://github.com/chalk/ansi-styles?sponsor=1"
             }
         },
+        "node_modules/assertion-error": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+            "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            }
+        },
         "node_modules/asynckit": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -1275,6 +1424,16 @@
             },
             "engines": {
                 "node": ">= 0.4"
+            }
+        },
+        "node_modules/chai": {
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+            "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/chalk": {
@@ -1433,6 +1592,13 @@
                 "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
             }
         },
+        "node_modules/convert-source-map": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+            "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/cssesc": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -1514,6 +1680,13 @@
                 "node": ">= 0.4"
             }
         },
+        "node_modules/es-module-lexer": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+            "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/es-object-atoms": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -1592,6 +1765,26 @@
             "dev": true,
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/estree-walker": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+            "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/estree": "^1.0.0"
+            }
+        },
+        "node_modules/expect-type": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+            "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=12.0.0"
             }
         },
         "node_modules/follow-redirects": {
@@ -2151,6 +2344,24 @@
                 "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
             }
         },
+        "node_modules/obug": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+            "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+            "dev": true,
+            "funding": [
+                "https://github.com/sponsors/sxzz",
+                "https://opencollective.com/debug"
+            ],
+            "license": "MIT"
+        },
+        "node_modules/pathe": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+            "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/picocolors": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -2323,6 +2534,13 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/siginfo": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+            "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+            "dev": true,
+            "license": "ISC"
+        },
         "node_modules/source-map-js": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -2331,6 +2549,20 @@
             "engines": {
                 "node": ">=0.10.0"
             }
+        },
+        "node_modules/stackback": {
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+            "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/std-env": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
+            "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/supports-color": {
             "version": "8.1.1",
@@ -2366,6 +2598,23 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/webpack"
+            }
+        },
+        "node_modules/tinybench": {
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+            "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/tinyexec": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
+            "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/tinyglobby": {
@@ -2414,6 +2663,16 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/tinyrainbow": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+            "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.0.0"
             }
         },
         "node_modules/tippy.js": {
@@ -2559,6 +2818,126 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/vitest": {
+            "version": "4.1.4",
+            "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.4.tgz",
+            "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/expect": "4.1.4",
+                "@vitest/mocker": "4.1.4",
+                "@vitest/pretty-format": "4.1.4",
+                "@vitest/runner": "4.1.4",
+                "@vitest/snapshot": "4.1.4",
+                "@vitest/spy": "4.1.4",
+                "@vitest/utils": "4.1.4",
+                "es-module-lexer": "^2.0.0",
+                "expect-type": "^1.3.0",
+                "magic-string": "^0.30.21",
+                "obug": "^2.1.1",
+                "pathe": "^2.0.3",
+                "picomatch": "^4.0.3",
+                "std-env": "^4.0.0-rc.1",
+                "tinybench": "^2.9.0",
+                "tinyexec": "^1.0.2",
+                "tinyglobby": "^0.2.15",
+                "tinyrainbow": "^3.1.0",
+                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+                "why-is-node-running": "^2.3.0"
+            },
+            "bin": {
+                "vitest": "vitest.mjs"
+            },
+            "engines": {
+                "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "@edge-runtime/vm": "*",
+                "@opentelemetry/api": "^1.9.0",
+                "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+                "@vitest/browser-playwright": "4.1.4",
+                "@vitest/browser-preview": "4.1.4",
+                "@vitest/browser-webdriverio": "4.1.4",
+                "@vitest/coverage-istanbul": "4.1.4",
+                "@vitest/coverage-v8": "4.1.4",
+                "@vitest/ui": "4.1.4",
+                "happy-dom": "*",
+                "jsdom": "*",
+                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@edge-runtime/vm": {
+                    "optional": true
+                },
+                "@opentelemetry/api": {
+                    "optional": true
+                },
+                "@types/node": {
+                    "optional": true
+                },
+                "@vitest/browser-playwright": {
+                    "optional": true
+                },
+                "@vitest/browser-preview": {
+                    "optional": true
+                },
+                "@vitest/browser-webdriverio": {
+                    "optional": true
+                },
+                "@vitest/coverage-istanbul": {
+                    "optional": true
+                },
+                "@vitest/coverage-v8": {
+                    "optional": true
+                },
+                "@vitest/ui": {
+                    "optional": true
+                },
+                "happy-dom": {
+                    "optional": true
+                },
+                "jsdom": {
+                    "optional": true
+                },
+                "vite": {
+                    "optional": false
+                }
+            }
+        },
+        "node_modules/vitest/node_modules/picomatch": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/why-is-node-running": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+            "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "siginfo": "^2.0.0",
+                "stackback": "0.0.2"
+            },
+            "bin": {
+                "why-is-node-running": "cli.js"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/y18n": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
     "type": "module",
     "scripts": {
         "build": "vite build",
-        "dev": "vite"
+        "dev": "vite",
+        "test": "vitest run",
+        "test:watch": "vitest"
     },
     "devDependencies": {
         "@tailwindcss/forms": "^0.5.11",
@@ -15,7 +17,8 @@
         "laravel-vite-plugin": "^2.0.0",
         "playwright": "^1.58.2",
         "tailwindcss": "^4.2.1",
-        "vite": "7.1.11"
+        "vite": "7.1.11",
+        "vitest": "^4.1.4"
     },
     "dependencies": {
         "@alpinejs/collapse": "^3.15.8",

--- a/resources/js/live-match.js
+++ b/resources/js/live-match.js
@@ -73,6 +73,7 @@ export default function liveMatch(config) {
         lineupPlayers: config.lineupPlayers || [],
         benchPlayers: config.benchPlayers || [],
         tacticalActionsUrl: config.tacticalActionsUrl || '',
+        skipToEndUrl: config.skipToEndUrl || '',
         csrfToken: config.csrfToken || '',
         maxSubstitutions: config.maxSubstitutions || 5,
         maxWindows: config.maxWindows || 3,
@@ -1123,6 +1124,109 @@ export default function liveMatch(config) {
             } finally {
                 this.applyingChanges = false;
             }
+        },
+
+        /**
+         * Called by skipToEnd() before the client-only fast-forward.
+         * Asks the backend to re-simulate the remainder of the regular-time
+         * match with AI substitutions enabled for the user's team — so
+         * players who fast-forward don't finish with the tired starting 11.
+         *
+         * Returns true if the backend produced new events (caller should
+         * use the updated state.events), false if the call was skipped,
+         * no-op'd, or failed (caller falls through to the pure client-side
+         * fast-forward with the original pre-computed events).
+         */
+        async autoSubUserTeamBeforeSkip(minute) {
+            // Guard: endpoint, phase, bench, sub budget.
+            if (!this.skipToEndUrl) return false;
+            if (minute >= 90) return false;
+            if (!this.benchPlayers || this.benchPlayers.length === 0) return false;
+            if (this.substitutionsMade.length >= this.maxSubstitutions) return false;
+
+            // Windows-used check (mirrors getWindowsUsed in substitution-manager).
+            const freeMinutes = this.freeSubWindowMinutes || [45, 90, 105];
+            const usedWindowMinutes = new Set(this.substitutionsMade.map(s => s.minute));
+            freeMinutes.forEach(m => usedWindowMinutes.delete(m));
+            if (usedWindowMinutes.size >= this.maxWindows) return false;
+
+            let result;
+            try {
+                const response = await fetch(this.skipToEndUrl, {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'X-CSRF-TOKEN': this.csrfToken,
+                        'Accept': 'application/json',
+                    },
+                    body: JSON.stringify({
+                        minute,
+                        previousSubstitutions: this.substitutionsMade.map(s => ({
+                            playerOutId: s.playerOutId,
+                            playerInId: s.playerInId,
+                            minute: s.minute,
+                        })),
+                    }),
+                });
+
+                if (!response.ok) {
+                    console.warn('Skip-to-end auto-sub request returned', response.status);
+                    return false;
+                }
+
+                result = await response.json();
+            } catch (err) {
+                console.warn('Skip-to-end auto-sub request failed, falling back:', err);
+                return false;
+            }
+
+            if (!result || !result.autoSubsApplied) {
+                return false;
+            }
+
+            // Merge: drop pre-computed events after the skip minute and
+            // replace them with the freshly-simulated remainder. The existing
+            // trackSubstitutionIfNeeded picks up any new user-team sub events
+            // as the fast-forward reveals them.
+            this.events = this.events.filter(e => e.minute <= minute);
+
+            if (result.newEvents && result.newEvents.length > 0) {
+                this.events.push(...result.newEvents);
+                this.events.sort((a, b) => a.minute - b.minute);
+            }
+
+            // Update final score (the resimulation may have changed it).
+            if (result.newScore) {
+                this.finalHomeScore = result.newScore.home;
+                this.finalAwayScore = result.newScore.away;
+            }
+
+            // Update possession bar.
+            if (result.homePossession !== undefined) {
+                this._basePossession = result.homePossession;
+                this._possessionDisplay = result.homePossession;
+                this.homePossession = result.homePossession;
+                this.awayPossession = result.awayPossession;
+                if (typeof this.resetPossessionTarget === 'function') {
+                    this.resetPossessionTarget();
+                }
+            }
+
+            // Update player performances and post-match ratings.
+            if (result.playerPerformances) {
+                updateRosterPerformances(this.homeLineupRoster, this.awayLineupRoster, result.playerPerformances);
+                if (typeof this.recalculatePlayerRatings === 'function') {
+                    this.recalculatePlayerRatings();
+                }
+            }
+
+            // Update MVP (may have changed after resimulation).
+            if (result.mvpPlayerName !== undefined) {
+                this.mvpPlayerName = result.mvpPlayerName;
+                this.mvpPlayerTeamId = result.mvpPlayerTeamId;
+            }
+
+            return true;
         },
 
         // =============================

--- a/resources/js/live-match.js
+++ b/resources/js/live-match.js
@@ -45,6 +45,25 @@ function mixinModule(target, source) {
     }
 }
 
+/**
+ * Determine the minute value to send to the backend for a tactical change.
+ * During ET-related phases, the currentMinute may be 90 (set by
+ * enterRegularTimeEnd), which the backend would interpret as regular time.
+ * Clamp to 93 so the backend routes to resimulateExtraTime and doesn't
+ * delete stoppage-time goal events.
+ */
+export function resolveMinuteForTacticalChange(currentMinute, phase) {
+    const minute = Math.floor(currentMinute);
+    const isETPhase = phase === 'going_to_extra_time'
+        || phase === 'extra_time_first_half'
+        || phase === 'extra_time_second_half'
+        || phase === 'extra_time_half_time';
+    if (isETPhase && minute <= 93) {
+        return Math.max(minute, 93);
+    }
+    return minute;
+}
+
 export default function liveMatch(config) {
     // Create modules early with a deferred context reference so their
     // getters are defined on the raw data object BEFORE Alpine wraps it.
@@ -846,20 +865,7 @@ export default function liveMatch(config) {
             this.tacticalError = null;
             this.applyingChanges = true;
 
-            let minute = Math.floor(this.currentMinute);
-
-            // A sub made during the going_to_extra_time phase has
-            // currentMinute = 90 (set by enterRegularTimeEnd), which the
-            // backend would interpret as regular time (minute <= 90). Clamp
-            // to 93 so the backend correctly routes to resimulateExtraTime
-            // and doesn't delete stoppage-time goal events (minutes 91-93).
-            const isETPhase = this.phase === 'going_to_extra_time'
-                || this.phase === 'extra_time_first_half'
-                || this.phase === 'extra_time_second_half'
-                || this.phase === 'extra_time_half_time';
-            if (isETPhase && minute <= 93) {
-                minute = Math.max(minute, 93);
-            }
+            const minute = resolveMinuteForTacticalChange(this.currentMinute, this.phase);
 
             try {
                 const payload = {

--- a/resources/js/live-match.js
+++ b/resources/js/live-match.js
@@ -846,7 +846,20 @@ export default function liveMatch(config) {
             this.tacticalError = null;
             this.applyingChanges = true;
 
-            const minute = Math.floor(this.currentMinute);
+            let minute = Math.floor(this.currentMinute);
+
+            // A sub made during the going_to_extra_time phase has
+            // currentMinute = 90 (set by enterRegularTimeEnd), which the
+            // backend would interpret as regular time (minute <= 90). Clamp
+            // to 93 so the backend correctly routes to resimulateExtraTime
+            // and doesn't delete stoppage-time goal events (minutes 91-93).
+            const isETPhase = this.phase === 'going_to_extra_time'
+                || this.phase === 'extra_time_first_half'
+                || this.phase === 'extra_time_second_half'
+                || this.phase === 'extra_time_half_time';
+            if (isETPhase && minute <= 93) {
+                minute = Math.max(minute, 93);
+            }
 
             try {
                 const payload = {

--- a/resources/js/live-match.js
+++ b/resources/js/live-match.js
@@ -1201,16 +1201,26 @@ export default function liveMatch(config) {
                 this.finalAwayScore = result.newScore.away;
             }
 
-            // Reset the revealed-events feed and re-reveal only events up to
-            // the skip minute. Without this, any events that the tick loop
-            // revealed from the original pre-simulation before the backend
-            // responded would remain as stale "ghost" entries in the feed.
+            // Reset the revealed-events feed, substitution tracking, and
+            // re-reveal only events up to the skip minute. Without this:
+            // - Ghost entries from the original pre-simulation linger in the feed
+            // - substitutionsMade has stale entries from the old simulation
             this.revealedEvents = [];
+            this.substitutionsMade = [];
             this.lastRevealedIndex = -1;
             for (let i = 0; i < this.events.length; i++) {
                 if (this.events[i].minute <= minute) {
                     this.revealedEvents.unshift(this.events[i]);
                     this.lastRevealedIndex = i;
+                    if (this.events[i].type === 'substitution' && this.events[i].teamId === this.userTeamId) {
+                        this.substitutionsMade.push({
+                            playerOutId: this.events[i].gamePlayerId,
+                            playerInId: this.events[i].metadata?.player_in_id ?? '',
+                            minute: this.events[i].minute,
+                            playerOutName: this.events[i].playerName ?? '',
+                            playerInName: this.events[i].playerInName ?? '',
+                        });
+                    }
                 } else {
                     break;
                 }

--- a/resources/js/live-match.js
+++ b/resources/js/live-match.js
@@ -1201,6 +1201,21 @@ export default function liveMatch(config) {
                 this.finalAwayScore = result.newScore.away;
             }
 
+            // Reset the revealed-events feed and re-reveal only events up to
+            // the skip minute. Without this, any events that the tick loop
+            // revealed from the original pre-simulation before the backend
+            // responded would remain as stale "ghost" entries in the feed.
+            this.revealedEvents = [];
+            this.lastRevealedIndex = -1;
+            for (let i = 0; i < this.events.length; i++) {
+                if (this.events[i].minute <= minute) {
+                    this.revealedEvents.unshift(this.events[i]);
+                    this.lastRevealedIndex = i;
+                } else {
+                    break;
+                }
+            }
+
             // Update possession bar.
             if (result.homePossession !== undefined) {
                 this._basePossession = result.homePossession;

--- a/resources/js/modules/match-simulation.js
+++ b/resources/js/modules/match-simulation.js
@@ -672,6 +672,16 @@ export function createMatchSimulation(ctx) {
         // fast-forward with the original pre-computed events.
         if (state._skippingToEnd) return;
         state._skippingToEnd = true;
+
+        // Stop the tick loop while awaiting the backend resimulation.
+        // Without this, tick keeps revealing events from the original
+        // pre-simulation into revealedEvents, causing "ghost goals" when
+        // the resimulation produces a different result.
+        if (_animFrame) {
+            cancelAnimationFrame(_animFrame);
+            _animFrame = null;
+        }
+
         try {
             const skipMinute = Math.max(1, Math.min(89, Math.floor(state.currentMinute)));
             if (typeof state.autoSubUserTeamBeforeSkip === 'function') {

--- a/resources/js/modules/match-simulation.js
+++ b/resources/js/modules/match-simulation.js
@@ -620,7 +620,7 @@ export function createMatchSimulation(ctx) {
         enterHalfTime();
     }
 
-    function skipToEnd() {
+    async function skipToEnd() {
         const state = ctx();
         state.userPaused = false;
 
@@ -662,6 +662,23 @@ export function createMatchSimulation(ctx) {
             || state.phase === 'extra_time_second_half' || state.phase === 'extra_time_half_time')) {
             skipExtraTime();
             return;
+        }
+
+        // Regular-time skip: before fast-forwarding, ask the backend to
+        // re-simulate the remainder with AI substitutions enabled for the
+        // user's team. Only kicks in when the user presses Skip — normal
+        // minute-by-minute play stays fully manual. If the request is
+        // skipped, no-op'd, or fails, we fall through to the pure client
+        // fast-forward with the original pre-computed events.
+        if (state._skippingToEnd) return;
+        state._skippingToEnd = true;
+        try {
+            const skipMinute = Math.max(1, Math.min(89, Math.floor(state.currentMinute)));
+            if (typeof state.autoSubUserTeamBeforeSkip === 'function') {
+                await state.autoSubUserTeamBeforeSkip(skipMinute);
+            }
+        } finally {
+            state._skippingToEnd = false;
         }
 
         state.currentMinute = 93;

--- a/resources/views/live-match.blade.php
+++ b/resources/views/live-match.blade.php
@@ -35,6 +35,7 @@
                 benchPlayers: {{ Js::from($benchPlayers) }},
                 userTeamId: '{{ $game->team_id }}',
                 tacticalActionsUrl: '{{ $tacticalActionsUrl }}',
+                skipToEndUrl: '{{ $skipToEndUrl }}',
                 csrfToken: '{{ csrf_token() }}',
                 maxSubstitutions: 5,
                 maxWindows: 3,

--- a/routes/web.php
+++ b/routes/web.php
@@ -119,6 +119,7 @@ use App\Http\Views\ShowTournamentLeaderboard;
 use App\Http\Views\ShowTournamentSummary;
 use App\Http\Actions\ProcessTacticalActions;
 use App\Http\Actions\PromoteAcademyPlayer;
+use App\Http\Actions\SkipMatchToEnd;
 use App\Http\Actions\StartNewSeason;
 use Illuminate\Support\Facades\Route;
 
@@ -182,6 +183,7 @@ Route::middleware('auth')->group(function () {
         Route::delete('/game/{gameId}/tactical-presets/{presetId}', DeleteTacticalPreset::class)->name('game.tactical-presets.delete');
 
         Route::post('/game/{gameId}/match/{matchId}/tactical-actions', ProcessTacticalActions::class)->name('game.match.tactical-actions');
+        Route::post('/game/{gameId}/match/{matchId}/skip-to-end', SkipMatchToEnd::class)->name('game.match.skip-to-end');
         Route::post('/game/{gameId}/match/{matchId}/extra-time', ProcessExtraTime::class)->name('game.match.extra-time');
         Route::post('/game/{gameId}/match/{matchId}/penalties', ProcessPenalties::class)->name('game.match.penalties');
         Route::post('/game/{gameId}/finalize-match', FinalizeMatch::class)->name('game.finalize-match');

--- a/tests/Feature/ExtraTimePenaltyDecisionTest.php
+++ b/tests/Feature/ExtraTimePenaltyDecisionTest.php
@@ -170,7 +170,7 @@ class ExtraTimePenaltyDecisionTest extends TestCase
                 'first_leg_match_id' => $firstLeg->id,
             ]);
 
-        // Second leg (reversed home/away): 0-1 → aggregate 1-1
+        // Second leg (reversed home/away): 1-0 for opponent → aggregate 1-1
         $secondLeg = GameMatch::factory()->create([
             'game_id' => $this->game->id,
             'competition_id' => $this->cupCompetition->id,
@@ -179,8 +179,8 @@ class ExtraTimePenaltyDecisionTest extends TestCase
             'away_team_id' => $this->playerTeam->id,
             'scheduled_date' => Carbon::parse('2024-08-17'),
             'played' => true,
-            'home_score' => 0,
-            'away_score' => 1,
+            'home_score' => 1,
+            'away_score' => 0,
             'cup_tie_id' => $cupTie->id,
         ]);
 

--- a/tests/Feature/ExtraTimePenaltyDecisionTest.php
+++ b/tests/Feature/ExtraTimePenaltyDecisionTest.php
@@ -1,0 +1,296 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Competition;
+use App\Models\CupTie;
+use App\Models\Game;
+use App\Models\GameMatch;
+use App\Models\GamePlayer;
+use App\Models\MatchEvent;
+use App\Models\Team;
+use App\Models\User;
+use App\Modules\Match\Services\ExtraTimeAndPenaltyService;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Regression tests for the "needs penalties" decision after extra time.
+ *
+ * Bug: buildExtraTimeData (page-refresh path) unconditionally set
+ * needsPenalties=true whenever ET was played and penalties hadn't been
+ * resolved — even if the ET score was not a draw. Users who refreshed
+ * after a decisive ET result were sent to the penalty picker incorrectly.
+ */
+class ExtraTimePenaltyDecisionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+    private Team $playerTeam;
+    private Team $opponentTeam;
+    private Competition $cupCompetition;
+    private Game $game;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = User::factory()->create();
+        $this->playerTeam = Team::factory()->create(['name' => 'Spain']);
+        $this->opponentTeam = Team::factory()->create(['name' => 'Austria']);
+
+        $this->cupCompetition = Competition::factory()->knockoutCup()->create([
+            'id' => 'CUP1',
+            'name' => 'Test Cup',
+        ]);
+
+        $this->playerTeam->competitions()->attach($this->cupCompetition->id, ['season' => '2024']);
+        $this->opponentTeam->competitions()->attach($this->cupCompetition->id, ['season' => '2024']);
+
+        $this->game = Game::factory()->create([
+            'user_id' => $this->user->id,
+            'team_id' => $this->playerTeam->id,
+            'competition_id' => $this->cupCompetition->id,
+            'season' => '2024',
+            'current_date' => '2024-08-15',
+        ]);
+    }
+
+    public function test_penalties_not_needed_when_et_has_a_winner(): void
+    {
+        $service = app(ExtraTimeAndPenaltyService::class);
+
+        $match = $this->createKnockoutMatch(homeScore: 1, awayScore: 1);
+
+        // ET result: 1-0 for home → total 2-1, not a draw
+        $result = $service->checkNeedsPenalties($match, 1, 0);
+
+        $this->assertFalse($result, 'Penalties should not be needed when ET produces a winner');
+    }
+
+    public function test_penalties_needed_when_et_is_a_draw(): void
+    {
+        $service = app(ExtraTimeAndPenaltyService::class);
+
+        $match = $this->createKnockoutMatch(homeScore: 1, awayScore: 1);
+
+        // ET result: 0-0 → total 1-1, still a draw
+        $result = $service->checkNeedsPenalties($match, 0, 0);
+
+        $this->assertTrue($result, 'Penalties should be needed when ET is a draw');
+    }
+
+    /**
+     * The exact bug reported by the user: ET ends 2-1 but page refresh
+     * incorrectly triggers the penalty picker.
+     */
+    public function test_page_refresh_after_et_winner_does_not_trigger_penalties(): void
+    {
+        $this->actingAs($this->user);
+
+        $match = $this->createKnockoutMatch(homeScore: 1, awayScore: 1);
+
+        // Simulate ET already played with a decisive result
+        $match->update([
+            'is_extra_time' => true,
+            'home_score_et' => 1,
+            'away_score_et' => 0,
+            // home_score_penalties is null — penalties not played
+        ]);
+
+        $this->game->update(['pending_finalization_match_id' => $match->id]);
+
+        // Load the live match page (simulates page refresh)
+        $response = $this->get(route('show-live-match', [
+            'gameId' => $this->game->id,
+            'matchId' => $match->id,
+        ]));
+
+        $response->assertOk();
+
+        // The preloaded ET data should NOT trigger penalties
+        $response->assertViewHas('extraTimeData', function ($data) {
+            return $data['needsPenalties'] === false
+                && $data['homeScoreET'] === 1
+                && $data['awayScoreET'] === 0;
+        });
+    }
+
+    public function test_page_refresh_after_et_draw_triggers_penalties(): void
+    {
+        $this->actingAs($this->user);
+
+        $match = $this->createKnockoutMatch(homeScore: 1, awayScore: 1);
+
+        // Simulate ET already played with a draw
+        $match->update([
+            'is_extra_time' => true,
+            'home_score_et' => 0,
+            'away_score_et' => 0,
+        ]);
+
+        $this->game->update(['pending_finalization_match_id' => $match->id]);
+
+        $response = $this->get(route('show-live-match', [
+            'gameId' => $this->game->id,
+            'matchId' => $match->id,
+        ]));
+
+        $response->assertOk();
+
+        $response->assertViewHas('extraTimeData', function ($data) {
+            return $data['needsPenalties'] === true;
+        });
+    }
+
+    public function test_two_legged_aggregate_draw_triggers_penalties(): void
+    {
+        $service = app(ExtraTimeAndPenaltyService::class);
+
+        // First leg: home 1-0 away
+        $firstLeg = GameMatch::factory()->create([
+            'game_id' => $this->game->id,
+            'competition_id' => $this->cupCompetition->id,
+            'round_number' => 1,
+            'home_team_id' => $this->playerTeam->id,
+            'away_team_id' => $this->opponentTeam->id,
+            'scheduled_date' => Carbon::parse('2024-08-10'),
+            'played' => true,
+            'home_score' => 1,
+            'away_score' => 0,
+        ]);
+
+        $cupTie = CupTie::factory()
+            ->forGame($this->game)
+            ->between($this->playerTeam, $this->opponentTeam)
+            ->create([
+                'competition_id' => $this->cupCompetition->id,
+                'first_leg_match_id' => $firstLeg->id,
+            ]);
+
+        // Second leg (reversed home/away): 0-1 → aggregate 1-1
+        $secondLeg = GameMatch::factory()->create([
+            'game_id' => $this->game->id,
+            'competition_id' => $this->cupCompetition->id,
+            'round_number' => 1,
+            'home_team_id' => $this->opponentTeam->id,
+            'away_team_id' => $this->playerTeam->id,
+            'scheduled_date' => Carbon::parse('2024-08-17'),
+            'played' => true,
+            'home_score' => 0,
+            'away_score' => 1,
+            'cup_tie_id' => $cupTie->id,
+        ]);
+
+        $cupTie->update(['second_leg_match_id' => $secondLeg->id]);
+
+        // ET 0-0 → aggregate still 1-1 → penalties needed
+        $result = $service->checkNeedsPenalties($secondLeg->fresh(), 0, 0);
+
+        $this->assertTrue($result, 'Penalties should be needed when two-legged aggregate is a draw after ET');
+    }
+
+    public function test_two_legged_aggregate_winner_after_et_skips_penalties(): void
+    {
+        $service = app(ExtraTimeAndPenaltyService::class);
+
+        $firstLeg = GameMatch::factory()->create([
+            'game_id' => $this->game->id,
+            'competition_id' => $this->cupCompetition->id,
+            'round_number' => 1,
+            'home_team_id' => $this->playerTeam->id,
+            'away_team_id' => $this->opponentTeam->id,
+            'scheduled_date' => Carbon::parse('2024-08-10'),
+            'played' => true,
+            'home_score' => 1,
+            'away_score' => 0,
+        ]);
+
+        $cupTie = CupTie::factory()
+            ->forGame($this->game)
+            ->between($this->playerTeam, $this->opponentTeam)
+            ->create([
+                'competition_id' => $this->cupCompetition->id,
+                'first_leg_match_id' => $firstLeg->id,
+            ]);
+
+        $secondLeg = GameMatch::factory()->create([
+            'game_id' => $this->game->id,
+            'competition_id' => $this->cupCompetition->id,
+            'round_number' => 1,
+            'home_team_id' => $this->opponentTeam->id,
+            'away_team_id' => $this->playerTeam->id,
+            'scheduled_date' => Carbon::parse('2024-08-17'),
+            'played' => true,
+            'home_score' => 0,
+            'away_score' => 1,
+            'cup_tie_id' => $cupTie->id,
+        ]);
+
+        $cupTie->update(['second_leg_match_id' => $secondLeg->id]);
+
+        // ET 1-0 for second leg home → aggregate: home 1+0=1, away 0+1+1=2 → away wins
+        $result = $service->checkNeedsPenalties($secondLeg->fresh(), 1, 0);
+
+        $this->assertFalse($result, 'Penalties should not be needed when aggregate has a winner after ET');
+    }
+
+    private function createKnockoutMatch(int $homeScore = 0, int $awayScore = 0): GameMatch
+    {
+        $this->createSquad($this->playerTeam);
+        $this->createSquad($this->opponentTeam);
+
+        $homeLineup = GamePlayer::where('game_id', $this->game->id)
+            ->where('team_id', $this->playerTeam->id)
+            ->limit(11)
+            ->pluck('id')
+            ->toArray();
+
+        $awayLineup = GamePlayer::where('game_id', $this->game->id)
+            ->where('team_id', $this->opponentTeam->id)
+            ->limit(11)
+            ->pluck('id')
+            ->toArray();
+
+        $cupTie = CupTie::factory()
+            ->forGame($this->game)
+            ->between($this->playerTeam, $this->opponentTeam)
+            ->create(['competition_id' => $this->cupCompetition->id]);
+
+        return GameMatch::factory()->create([
+            'game_id' => $this->game->id,
+            'competition_id' => $this->cupCompetition->id,
+            'round_number' => 1,
+            'home_team_id' => $this->playerTeam->id,
+            'away_team_id' => $this->opponentTeam->id,
+            'scheduled_date' => Carbon::parse('2024-08-16'),
+            'played' => true,
+            'home_score' => $homeScore,
+            'away_score' => $awayScore,
+            'home_lineup' => $homeLineup,
+            'away_lineup' => $awayLineup,
+            'cup_tie_id' => $cupTie->id,
+        ]);
+    }
+
+    private function createSquad(Team $team): void
+    {
+        GamePlayer::factory()
+            ->forGame($this->game)
+            ->forTeam($team)
+            ->goalkeeper()
+            ->create();
+
+        foreach (['Centre-Back', 'Centre-Back', 'Left-Back', 'Right-Back'] as $pos) {
+            GamePlayer::factory()->forGame($this->game)->forTeam($team)->create(['position' => $pos]);
+        }
+
+        GamePlayer::factory()->forGame($this->game)->forTeam($team)->count(4)->create(['position' => 'Central Midfield']);
+
+        foreach (['Centre-Forward', 'Centre-Forward'] as $pos) {
+            GamePlayer::factory()->forGame($this->game)->forTeam($team)->create(['position' => $pos]);
+        }
+    }
+}

--- a/tests/Feature/ExtraTimePenaltyDecisionTest.php
+++ b/tests/Feature/ExtraTimePenaltyDecisionTest.php
@@ -103,7 +103,7 @@ class ExtraTimePenaltyDecisionTest extends TestCase
         $this->game->update(['pending_finalization_match_id' => $match->id]);
 
         // Load the live match page (simulates page refresh)
-        $response = $this->get(route('show-live-match', [
+        $response = $this->get(route('game.live-match', [
             'gameId' => $this->game->id,
             'matchId' => $match->id,
         ]));
@@ -133,7 +133,7 @@ class ExtraTimePenaltyDecisionTest extends TestCase
 
         $this->game->update(['pending_finalization_match_id' => $match->id]);
 
-        $response = $this->get(route('show-live-match', [
+        $response = $this->get(route('game.live-match', [
             'gameId' => $this->game->id,
             'matchId' => $match->id,
         ]));

--- a/tests/Feature/ResimulationAutoSubParityTest.php
+++ b/tests/Feature/ResimulationAutoSubParityTest.php
@@ -1,0 +1,273 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Competition;
+use App\Models\Game;
+use App\Models\GameMatch;
+use App\Models\GamePlayer;
+use App\Models\MatchEvent;
+use App\Models\Team;
+use App\Models\User;
+use App\Modules\Lineup\Services\SubstitutionService;
+use App\Modules\Match\Services\MatchResimulationService;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Regression tests for the auto-sub blind spot in resimulation.
+ *
+ * The resimulation system was written when the user team never had
+ * auto-substitutions. When injury auto-subs were enabled for the user
+ * team, those DB events were invisible to the resimulation — the subbed-in
+ * player was never added back to the lineup, sub/window counts were wrong,
+ * and entry minutes were missing.
+ */
+class ResimulationAutoSubParityTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+    private Team $playerTeam;
+    private Team $opponentTeam;
+    private Competition $competition;
+    private Game $game;
+    private GameMatch $match;
+    private string $injuredPlayerId;
+    private string $replacementPlayerId;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = User::factory()->create();
+        $this->playerTeam = Team::factory()->create(['name' => 'Player Team']);
+        $this->opponentTeam = Team::factory()->create(['name' => 'Opponent Team']);
+
+        $this->competition = Competition::factory()->league()->create([
+            'id' => 'ESP1',
+            'name' => 'LaLiga',
+        ]);
+
+        $this->playerTeam->competitions()->attach($this->competition->id, ['season' => '2024']);
+        $this->opponentTeam->competitions()->attach($this->competition->id, ['season' => '2024']);
+
+        $this->game = Game::factory()->create([
+            'user_id' => $this->user->id,
+            'team_id' => $this->playerTeam->id,
+            'competition_id' => $this->competition->id,
+            'season' => '2024',
+            'current_date' => '2024-08-15',
+        ]);
+
+        $this->createSquad($this->playerTeam, 18);
+        $this->createSquad($this->opponentTeam, 18);
+
+        $homeLineup = GamePlayer::where('game_id', $this->game->id)
+            ->where('team_id', $this->playerTeam->id)
+            ->limit(11)
+            ->pluck('id')
+            ->toArray();
+
+        $awayLineup = GamePlayer::where('game_id', $this->game->id)
+            ->where('team_id', $this->opponentTeam->id)
+            ->limit(11)
+            ->pluck('id')
+            ->toArray();
+
+        $this->match = GameMatch::factory()->create([
+            'game_id' => $this->game->id,
+            'competition_id' => $this->competition->id,
+            'round_number' => 1,
+            'home_team_id' => $this->playerTeam->id,
+            'away_team_id' => $this->opponentTeam->id,
+            'scheduled_date' => Carbon::parse('2024-08-16'),
+            'played' => true,
+            'home_score' => 1,
+            'away_score' => 0,
+            'home_lineup' => $homeLineup,
+            'away_lineup' => $awayLineup,
+            'home_possession' => 55,
+            'away_possession' => 45,
+            'substitutions' => [],
+        ]);
+
+        $this->game->update(['pending_finalization_match_id' => $this->match->id]);
+
+        // Seed a pre-simulated injury auto-sub for the user team at minute 25
+        $this->injuredPlayerId = $homeLineup[3];
+
+        $benchPlayer = GamePlayer::where('game_id', $this->game->id)
+            ->where('team_id', $this->playerTeam->id)
+            ->whereNotIn('id', $homeLineup)
+            ->first();
+        $this->replacementPlayerId = $benchPlayer->id;
+
+        MatchEvent::create([
+            'game_id' => $this->game->id,
+            'game_match_id' => $this->match->id,
+            'game_player_id' => $this->injuredPlayerId,
+            'team_id' => $this->playerTeam->id,
+            'minute' => 25,
+            'event_type' => MatchEvent::TYPE_INJURY,
+            'metadata' => ['severity' => 'minor'],
+        ]);
+
+        MatchEvent::create([
+            'game_id' => $this->game->id,
+            'game_match_id' => $this->match->id,
+            'game_player_id' => $this->injuredPlayerId,
+            'team_id' => $this->playerTeam->id,
+            'minute' => 25,
+            'event_type' => MatchEvent::TYPE_SUBSTITUTION,
+            'metadata' => ['player_in_id' => $this->replacementPlayerId],
+        ]);
+    }
+
+    /**
+     * After resimulation at a minute AFTER the auto-sub, the replacement
+     * player must be on the pitch and the injured player must not.
+     */
+    public function test_user_auto_sub_player_is_on_pitch_after_resimulation(): void
+    {
+        $this->actingAs($this->user);
+
+        $response = $this->postJson(
+            route('game.match.tactical-actions', ['gameId' => $this->game->id, 'matchId' => $this->match->id]),
+            [
+                'minute' => 50,
+                'previousSubstitutions' => [],
+                'newSubstitutions' => [],
+                'formation' => '4-4-2',
+            ],
+        );
+
+        $response->assertOk();
+
+        // The resimulation must have produced a valid match result.
+        // If the auto-sub player was missing, team strength would be
+        // significantly reduced (10v11), producing distorted results.
+        $this->match->refresh();
+        $this->assertNotNull($this->match->home_score);
+    }
+
+    /**
+     * Sub count must include both manual subs AND pre-sim auto-subs.
+     * Without this, the 5-sub limit could be exceeded.
+     */
+    public function test_skip_to_end_respects_combined_sub_limit(): void
+    {
+        $this->actingAs($this->user);
+
+        // User made 4 manual subs at different minutes
+        $homeLineup = $this->match->home_lineup;
+        $benchIds = GamePlayer::where('game_id', $this->game->id)
+            ->where('team_id', $this->playerTeam->id)
+            ->whereNotIn('id', $homeLineup)
+            ->where('id', '!=', $this->replacementPlayerId)
+            ->limit(4)
+            ->pluck('id')
+            ->toArray();
+
+        $manualSubs = [];
+        // Start from index 5 to avoid the injured player (index 3)
+        $availableStarters = array_values(array_diff($homeLineup, [$this->injuredPlayerId]));
+        foreach ($benchIds as $i => $inId) {
+            $manualSubs[] = [
+                'playerOutId' => $availableStarters[$i],
+                'playerInId' => $inId,
+                'minute' => 55 + $i,
+            ];
+        }
+
+        // With 1 auto-sub + 4 manual = 5 total, should be at the limit
+        $response = $this->postJson(
+            route('game.match.skip-to-end', ['gameId' => $this->game->id, 'matchId' => $this->match->id]),
+            [
+                'minute' => 60,
+                'previousSubstitutions' => $manualSubs,
+            ],
+        );
+
+        $response->assertOk();
+
+        // Total user-team subs should not exceed the limit
+        $totalUserSubs = MatchEvent::where('game_match_id', $this->match->id)
+            ->where('event_type', MatchEvent::TYPE_SUBSTITUTION)
+            ->where('team_id', $this->playerTeam->id)
+            ->count();
+
+        $this->assertLessThanOrEqual(
+            SubstitutionService::MAX_SUBSTITUTIONS,
+            $totalUserSubs,
+            "Total user subs ({$totalUserSubs}) exceeds the " . SubstitutionService::MAX_SUBSTITUTIONS . '-sub limit',
+        );
+    }
+
+    /**
+     * Auto-sub events at minutes AFTER the resimulation minute should be
+     * reverted (deleted) and not counted — they're in the future.
+     */
+    public function test_auto_sub_after_resim_minute_is_reverted(): void
+    {
+        $this->actingAs($this->user);
+
+        // Move the auto-sub to minute 60 (after our resim minute of 40)
+        MatchEvent::where('game_match_id', $this->match->id)
+            ->where('event_type', MatchEvent::TYPE_INJURY)
+            ->update(['minute' => 60]);
+        MatchEvent::where('game_match_id', $this->match->id)
+            ->where('event_type', MatchEvent::TYPE_SUBSTITUTION)
+            ->update(['minute' => 60]);
+
+        // Resim at minute 40 (before the auto-sub)
+        $response = $this->postJson(
+            route('game.match.tactical-actions', ['gameId' => $this->game->id, 'matchId' => $this->match->id]),
+            [
+                'minute' => 40,
+                'previousSubstitutions' => [],
+                'newSubstitutions' => [],
+                'mentality' => 'attacking',
+            ],
+        );
+
+        $response->assertOk();
+
+        // The auto-sub at minute 60 should have been reverted
+        $autoSubAtMinute60 = MatchEvent::where('game_match_id', $this->match->id)
+            ->where('event_type', MatchEvent::TYPE_SUBSTITUTION)
+            ->where('team_id', $this->playerTeam->id)
+            ->where('game_player_id', $this->injuredPlayerId)
+            ->where('minute', 60)
+            ->exists();
+
+        $this->assertFalse(
+            $autoSubAtMinute60,
+            'Auto-sub event at minute 60 should have been reverted since it is after the resimulation minute (40)',
+        );
+    }
+
+    private function createSquad(Team $team, int $size): void
+    {
+        GamePlayer::factory()->forGame($this->game)->forTeam($team)->goalkeeper()->create();
+
+        foreach (['Centre-Back', 'Centre-Back', 'Left-Back', 'Right-Back'] as $pos) {
+            GamePlayer::factory()->forGame($this->game)->forTeam($team)->create(['position' => $pos]);
+        }
+
+        GamePlayer::factory()->forGame($this->game)->forTeam($team)->count(4)->create(['position' => 'Central Midfield']);
+
+        foreach (['Centre-Forward', 'Centre-Forward'] as $pos) {
+            GamePlayer::factory()->forGame($this->game)->forTeam($team)->create(['position' => $pos]);
+        }
+
+        $positionsCycle = ['Centre-Back', 'Left-Back', 'Right-Back', 'Central Midfield', 'Centre-Forward', 'Goalkeeper', 'Right Winger'];
+        $bench = $size - 11;
+        for ($i = 0; $i < $bench; $i++) {
+            GamePlayer::factory()->forGame($this->game)->forTeam($team)->create([
+                'position' => $positionsCycle[$i % count($positionsCycle)],
+            ]);
+        }
+    }
+}

--- a/tests/Feature/ResimulationScoreConsistencyTest.php
+++ b/tests/Feature/ResimulationScoreConsistencyTest.php
@@ -1,0 +1,288 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Competition;
+use App\Models\Game;
+use App\Models\GameMatch;
+use App\Models\GamePlayer;
+use App\Models\MatchEvent;
+use App\Models\Team;
+use App\Models\User;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Regression tests for the critical invariant: after any resimulation,
+ * the goal/own_goal event count in the DB must match home_score + away_score
+ * on the match record.
+ *
+ * This invariant broke in production ("ghost goals") when the skip-to-end
+ * commit introduced an async resimulation that raced with the animation loop.
+ */
+class ResimulationScoreConsistencyTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+    private Team $playerTeam;
+    private Team $opponentTeam;
+    private Competition $competition;
+    private Game $game;
+    private GameMatch $match;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = User::factory()->create();
+        $this->playerTeam = Team::factory()->create(['name' => 'Player Team']);
+        $this->opponentTeam = Team::factory()->create(['name' => 'Opponent Team']);
+
+        $this->competition = Competition::factory()->league()->create([
+            'id' => 'ESP1',
+            'name' => 'LaLiga',
+        ]);
+
+        $this->playerTeam->competitions()->attach($this->competition->id, ['season' => '2024']);
+        $this->opponentTeam->competitions()->attach($this->competition->id, ['season' => '2024']);
+
+        $this->game = Game::factory()->create([
+            'user_id' => $this->user->id,
+            'team_id' => $this->playerTeam->id,
+            'competition_id' => $this->competition->id,
+            'season' => '2024',
+            'current_date' => '2024-08-15',
+        ]);
+
+        $this->createSquad($this->playerTeam, 18);
+        $this->createSquad($this->opponentTeam, 18);
+
+        $homeLineup = GamePlayer::where('game_id', $this->game->id)
+            ->where('team_id', $this->playerTeam->id)
+            ->limit(11)
+            ->pluck('id')
+            ->toArray();
+
+        $awayLineup = GamePlayer::where('game_id', $this->game->id)
+            ->where('team_id', $this->opponentTeam->id)
+            ->limit(11)
+            ->pluck('id')
+            ->toArray();
+
+        $this->match = GameMatch::factory()->create([
+            'game_id' => $this->game->id,
+            'competition_id' => $this->competition->id,
+            'round_number' => 1,
+            'home_team_id' => $this->playerTeam->id,
+            'away_team_id' => $this->opponentTeam->id,
+            'scheduled_date' => Carbon::parse('2024-08-16'),
+            'played' => true,
+            'home_score' => 1,
+            'away_score' => 0,
+            'home_lineup' => $homeLineup,
+            'away_lineup' => $awayLineup,
+            'home_possession' => 55,
+            'away_possession' => 45,
+            'substitutions' => [],
+        ]);
+
+        $this->game->update(['pending_finalization_match_id' => $this->match->id]);
+    }
+
+    public function test_score_matches_events_after_tactical_change(): void
+    {
+        $this->actingAs($this->user);
+
+        $response = $this->postJson(
+            route('game.match.tactical-actions', ['gameId' => $this->game->id, 'matchId' => $this->match->id]),
+            [
+                'minute' => 50,
+                'previousSubstitutions' => [],
+                'newSubstitutions' => [],
+                'formation' => '4-4-2',
+            ],
+        );
+
+        $response->assertOk();
+
+        $this->assertScoreMatchesEvents($this->match);
+    }
+
+    public function test_score_matches_events_after_skip_to_end(): void
+    {
+        $this->actingAs($this->user);
+
+        $response = $this->postJson(
+            route('game.match.skip-to-end', ['gameId' => $this->game->id, 'matchId' => $this->match->id]),
+            [
+                'minute' => 20,
+                'previousSubstitutions' => [],
+            ],
+        );
+
+        $response->assertOk();
+
+        $this->assertScoreMatchesEvents($this->match);
+    }
+
+    public function test_score_matches_events_after_multiple_resimulations(): void
+    {
+        $this->actingAs($this->user);
+
+        // First tactical change at minute 30
+        $this->postJson(
+            route('game.match.tactical-actions', ['gameId' => $this->game->id, 'matchId' => $this->match->id]),
+            [
+                'minute' => 30,
+                'previousSubstitutions' => [],
+                'newSubstitutions' => [],
+                'mentality' => 'attacking',
+            ],
+        )->assertOk();
+
+        $this->assertScoreMatchesEvents($this->match);
+
+        // Second tactical change at minute 60
+        $this->postJson(
+            route('game.match.tactical-actions', ['gameId' => $this->game->id, 'matchId' => $this->match->id]),
+            [
+                'minute' => 60,
+                'previousSubstitutions' => [],
+                'newSubstitutions' => [],
+                'mentality' => 'defensive',
+            ],
+        )->assertOk();
+
+        $this->assertScoreMatchesEvents($this->match);
+    }
+
+    public function test_team_has_eleven_players_after_resimulation_with_pre_sim_auto_sub(): void
+    {
+        $this->actingAs($this->user);
+
+        // Seed a pre-simulated injury auto-sub for the user team at minute 25
+        $homeLineup = $this->match->home_lineup;
+        $injuredPlayerId = $homeLineup[3]; // a defender
+
+        $benchPlayers = GamePlayer::where('game_id', $this->game->id)
+            ->where('team_id', $this->playerTeam->id)
+            ->whereNotIn('id', $homeLineup)
+            ->limit(1)
+            ->get();
+
+        $replacementPlayerId = $benchPlayers->first()->id;
+
+        // Seed injury event
+        MatchEvent::create([
+            'game_id' => $this->game->id,
+            'game_match_id' => $this->match->id,
+            'game_player_id' => $injuredPlayerId,
+            'team_id' => $this->playerTeam->id,
+            'minute' => 25,
+            'event_type' => MatchEvent::TYPE_INJURY,
+            'metadata' => ['severity' => 'minor'],
+        ]);
+
+        // Seed substitution event (the auto-sub)
+        MatchEvent::create([
+            'game_id' => $this->game->id,
+            'game_match_id' => $this->match->id,
+            'game_player_id' => $injuredPlayerId,
+            'team_id' => $this->playerTeam->id,
+            'minute' => 25,
+            'event_type' => MatchEvent::TYPE_SUBSTITUTION,
+            'metadata' => ['player_in_id' => $replacementPlayerId],
+        ]);
+
+        // Trigger a resimulation at minute 50 (after the auto-sub at 25)
+        $response = $this->postJson(
+            route('game.match.tactical-actions', ['gameId' => $this->game->id, 'matchId' => $this->match->id]),
+            [
+                'minute' => 50,
+                'previousSubstitutions' => [],
+                'newSubstitutions' => [],
+                'formation' => '4-4-2',
+            ],
+        );
+
+        $response->assertOk();
+
+        $this->assertScoreMatchesEvents($this->match);
+
+        // The response must include events — the team should be playing with
+        // a full complement (11 players minus any red cards). Verify the match
+        // produced a valid result (non-null score).
+        $this->match->refresh();
+        $this->assertNotNull($this->match->home_score);
+        $this->assertNotNull($this->match->away_score);
+    }
+
+    /**
+     * Assert the critical invariant: goal event count in the DB matches
+     * home_score + away_score on the match record.
+     */
+    private function assertScoreMatchesEvents(GameMatch $match): void
+    {
+        $match->refresh();
+
+        $goalEvents = MatchEvent::where('game_match_id', $match->id)
+            ->whereIn('event_type', [MatchEvent::TYPE_GOAL, MatchEvent::TYPE_OWN_GOAL])
+            ->where('minute', '<=', 93)
+            ->get();
+
+        $homeGoals = 0;
+        $awayGoals = 0;
+
+        foreach ($goalEvents as $event) {
+            if ($event->event_type === MatchEvent::TYPE_GOAL) {
+                if ($event->team_id === $match->home_team_id) {
+                    $homeGoals++;
+                } else {
+                    $awayGoals++;
+                }
+            } elseif ($event->event_type === MatchEvent::TYPE_OWN_GOAL) {
+                if ($event->team_id === $match->home_team_id) {
+                    $awayGoals++;
+                } else {
+                    $homeGoals++;
+                }
+            }
+        }
+
+        $this->assertEquals(
+            $match->home_score,
+            $homeGoals,
+            "Home score ({$match->home_score}) does not match home goal event count ({$homeGoals}) — ghost goals detected",
+        );
+        $this->assertEquals(
+            $match->away_score,
+            $awayGoals,
+            "Away score ({$match->away_score}) does not match away goal event count ({$awayGoals}) — ghost goals detected",
+        );
+    }
+
+    private function createSquad(Team $team, int $size): void
+    {
+        GamePlayer::factory()->forGame($this->game)->forTeam($team)->goalkeeper()->create();
+
+        foreach (['Centre-Back', 'Centre-Back', 'Left-Back', 'Right-Back'] as $pos) {
+            GamePlayer::factory()->forGame($this->game)->forTeam($team)->create(['position' => $pos]);
+        }
+
+        GamePlayer::factory()->forGame($this->game)->forTeam($team)->count(4)->create(['position' => 'Central Midfield']);
+
+        foreach (['Centre-Forward', 'Centre-Forward'] as $pos) {
+            GamePlayer::factory()->forGame($this->game)->forTeam($team)->create(['position' => $pos]);
+        }
+
+        $positionsCycle = ['Centre-Back', 'Left-Back', 'Right-Back', 'Central Midfield', 'Centre-Forward', 'Goalkeeper', 'Right Winger'];
+        $bench = $size - 11;
+        for ($i = 0; $i < $bench; $i++) {
+            GamePlayer::factory()->forGame($this->game)->forTeam($team)->create([
+                'position' => $positionsCycle[$i % count($positionsCycle)],
+            ]);
+        }
+    }
+}

--- a/tests/Feature/SkipMatchToEndTest.php
+++ b/tests/Feature/SkipMatchToEndTest.php
@@ -1,0 +1,288 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Competition;
+use App\Models\Game;
+use App\Models\GameMatch;
+use App\Models\GamePlayer;
+use App\Models\MatchEvent;
+use App\Models\Team;
+use App\Models\User;
+use App\Modules\Lineup\Services\SubstitutionService;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Covers the "Skip to end" flow that re-simulates the remainder of a user
+ * match with AI substitutions enabled for the user's team. This is the only
+ * path that auto-subs the user team — normal minute-by-minute play still
+ * leaves the user in full control.
+ */
+class SkipMatchToEndTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+    private Team $playerTeam;
+    private Team $opponentTeam;
+    private Competition $competition;
+    private Game $game;
+    private GameMatch $match;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = User::factory()->create();
+        $this->playerTeam = Team::factory()->create(['name' => 'Player Team']);
+        $this->opponentTeam = Team::factory()->create(['name' => 'Opponent Team']);
+
+        $this->competition = Competition::factory()->league()->create([
+            'id' => 'ESP1',
+            'name' => 'LaLiga',
+        ]);
+
+        $this->playerTeam->competitions()->attach($this->competition->id, ['season' => '2024']);
+        $this->opponentTeam->competitions()->attach($this->competition->id, ['season' => '2024']);
+
+        $this->game = Game::factory()->create([
+            'user_id' => $this->user->id,
+            'team_id' => $this->playerTeam->id,
+            'competition_id' => $this->competition->id,
+            'season' => '2024',
+            'current_date' => '2024-08-15',
+        ]);
+
+        // 18-player squads guarantee a 7-player bench after the starting 11.
+        $this->createSquad($this->playerTeam, 18);
+        $this->createSquad($this->opponentTeam, 18);
+
+        $homeLineup = GamePlayer::where('game_id', $this->game->id)
+            ->where('team_id', $this->playerTeam->id)
+            ->limit(11)
+            ->pluck('id')
+            ->toArray();
+
+        $awayLineup = GamePlayer::where('game_id', $this->game->id)
+            ->where('team_id', $this->opponentTeam->id)
+            ->limit(11)
+            ->pluck('id')
+            ->toArray();
+
+        $this->match = GameMatch::factory()->create([
+            'game_id' => $this->game->id,
+            'competition_id' => $this->competition->id,
+            'round_number' => 1,
+            'home_team_id' => $this->playerTeam->id,
+            'away_team_id' => $this->opponentTeam->id,
+            'scheduled_date' => Carbon::parse('2024-08-16'),
+            'played' => true,
+            'home_score' => 1,
+            'away_score' => 0,
+            'home_lineup' => $homeLineup,
+            'away_lineup' => $awayLineup,
+            'home_possession' => 55,
+            'away_possession' => 45,
+            'substitutions' => [],
+        ]);
+
+        $this->game->update(['pending_finalization_match_id' => $this->match->id]);
+    }
+
+    public function test_skip_to_end_generates_user_team_substitutions(): void
+    {
+        $this->actingAs($this->user);
+
+        $userTeamSubsBefore = MatchEvent::where('game_match_id', $this->match->id)
+            ->where('event_type', 'substitution')
+            ->where('team_id', $this->playerTeam->id)
+            ->count();
+        $this->assertSame(0, $userTeamSubsBefore);
+
+        $response = $this->postJson(
+            route('game.match.skip-to-end', ['gameId' => $this->game->id, 'matchId' => $this->match->id]),
+            [
+                'minute' => 20,
+                'previousSubstitutions' => [],
+            ],
+        );
+
+        $response->assertOk();
+        $response->assertJson(['autoSubsApplied' => true]);
+
+        $userTeamSubsAfter = MatchEvent::where('game_match_id', $this->match->id)
+            ->where('event_type', 'substitution')
+            ->where('team_id', $this->playerTeam->id)
+            ->get();
+
+        $this->assertGreaterThan(
+            0,
+            $userTeamSubsAfter->count(),
+            'Skip-to-end must generate at least one user-team substitution event',
+        );
+        $this->assertLessThanOrEqual(
+            SubstitutionService::MAX_SUBSTITUTIONS,
+            $userTeamSubsAfter->count(),
+            'User-team sub count must stay within the 5-sub limit',
+        );
+
+        // Sub minutes should fall in the remainder [skip minute + 1, 93] and
+        // typically within the AI window [min_minute, max_minute].
+        foreach ($userTeamSubsAfter as $sub) {
+            $this->assertGreaterThan(
+                20,
+                $sub->minute,
+                'Auto-sub minute must be after the skip minute',
+            );
+            $this->assertLessThanOrEqual(
+                93,
+                $sub->minute,
+                'Auto-sub minute must not exceed end of regular time',
+            );
+        }
+
+        // The substitutions JSON on the match row must be rebuilt to contain
+        // the new user-team entries (so any subsequent bookkeeping stays
+        // consistent).
+        $this->match->refresh();
+        $userSubsInJson = collect($this->match->substitutions ?? [])
+            ->filter(fn ($s) => ($s['team_id'] ?? null) === $this->playerTeam->id);
+        $this->assertCount(
+            $userTeamSubsAfter->count(),
+            $userSubsInJson,
+            'Rebuilt substitutions JSON must reflect the newly-generated user auto-subs',
+        );
+    }
+
+    public function test_skip_to_end_is_noop_when_user_has_used_all_subs(): void
+    {
+        $this->actingAs($this->user);
+
+        $lineupIds = $this->match->home_lineup;
+        $benchIds = GamePlayer::where('game_id', $this->game->id)
+            ->where('team_id', $this->playerTeam->id)
+            ->whereNotIn('id', $lineupIds)
+            ->limit(5)
+            ->pluck('id')
+            ->toArray();
+
+        $previousSubs = [];
+        foreach ($benchIds as $i => $inId) {
+            $previousSubs[] = [
+                'playerOutId' => $lineupIds[$i],
+                'playerInId' => $inId,
+                'minute' => 55 + $i,
+            ];
+        }
+
+        $response = $this->postJson(
+            route('game.match.skip-to-end', ['gameId' => $this->game->id, 'matchId' => $this->match->id]),
+            [
+                'minute' => 70,
+                'previousSubstitutions' => $previousSubs,
+            ],
+        );
+
+        $response->assertOk();
+        $response->assertJson([
+            'autoSubsApplied' => false,
+            'newEvents' => [],
+        ]);
+
+        // No new user-team sub events should have been generated.
+        $userTeamSubs = MatchEvent::where('game_match_id', $this->match->id)
+            ->where('event_type', 'substitution')
+            ->where('team_id', $this->playerTeam->id)
+            ->count();
+
+        $this->assertSame(
+            0,
+            $userTeamSubs,
+            'No auto-subs should be generated when the user has already used all 5 subs',
+        );
+    }
+
+    public function test_skip_to_end_rejects_request_when_match_is_not_in_progress(): void
+    {
+        $this->actingAs($this->user);
+
+        $this->game->update(['pending_finalization_match_id' => null]);
+
+        $response = $this->postJson(
+            route('game.match.skip-to-end', ['gameId' => $this->game->id, 'matchId' => $this->match->id]),
+            [
+                'minute' => 20,
+                'previousSubstitutions' => [],
+            ],
+        );
+
+        $response->assertStatus(403);
+    }
+
+    public function test_skip_to_end_is_noop_after_minute_89(): void
+    {
+        $this->actingAs($this->user);
+
+        $response = $this->postJson(
+            route('game.match.skip-to-end', ['gameId' => $this->game->id, 'matchId' => $this->match->id]),
+            [
+                'minute' => 90,
+                'previousSubstitutions' => [],
+            ],
+        );
+
+        $response->assertOk();
+        $response->assertJson(['autoSubsApplied' => false]);
+
+        $userTeamSubs = MatchEvent::where('game_match_id', $this->match->id)
+            ->where('event_type', 'substitution')
+            ->where('team_id', $this->playerTeam->id)
+            ->count();
+        $this->assertSame(0, $userTeamSubs);
+    }
+
+    /**
+     * Seed a squad of $size players with a realistic position distribution so
+     * the bench has a mix of positions for the AI substitution logic.
+     */
+    private function createSquad(Team $team, int $size): void
+    {
+        GamePlayer::factory()
+            ->forGame($this->game)
+            ->forTeam($team)
+            ->goalkeeper()
+            ->create();
+
+        foreach (['Centre-Back', 'Centre-Back', 'Left-Back', 'Right-Back'] as $position) {
+            GamePlayer::factory()
+                ->forGame($this->game)
+                ->forTeam($team)
+                ->create(['position' => $position]);
+        }
+
+        GamePlayer::factory()
+            ->forGame($this->game)
+            ->forTeam($team)
+            ->count(4)
+            ->create(['position' => 'Central Midfield']);
+
+        foreach (['Centre-Forward', 'Centre-Forward'] as $position) {
+            GamePlayer::factory()
+                ->forGame($this->game)
+                ->forTeam($team)
+                ->create(['position' => $position]);
+        }
+
+        // Bench-only positions to round out to $size players.
+        $positionsCycle = ['Centre-Back', 'Left-Back', 'Right-Back', 'Central Midfield', 'Centre-Forward', 'Goalkeeper', 'Right Winger'];
+        $bench = $size - 11;
+        for ($i = 0; $i < $bench; $i++) {
+            GamePlayer::factory()
+                ->forGame($this->game)
+                ->forTeam($team)
+                ->create(['position' => $positionsCycle[$i % count($positionsCycle)]]);
+        }
+    }
+}

--- a/tests/Unit/AISubstitutionSimulationTest.php
+++ b/tests/Unit/AISubstitutionSimulationTest.php
@@ -273,4 +273,119 @@ class AISubstitutionSimulationTest extends TestCase
 
         $this->assertTrue($subsSeen, 'ai_only mode should still produce subs in AI-vs-AI matches');
     }
+
+    public function test_user_team_gets_injury_auto_sub_when_bench_passed_with_user_team_id(): void
+    {
+        // Crank injury chance to 100% so every simulation produces an injury.
+        config(['match_simulation.injury_chance' => 100]);
+
+        $game = Game::factory()->create(['current_date' => '2025-10-01']);
+        $homeTeam = Team::factory()->create();
+        $awayTeam = Team::factory()->create();
+
+        $homePlayers = $this->createLineup($game, $homeTeam, 11, 75);
+        $awayPlayers = $this->createLineup($game, $awayTeam, 11, 75);
+        $homeBench = $this->createBenchPlayers($game, $homeTeam, 7, 72);
+        $awayBench = $this->createBenchPlayers($game, $awayTeam, 7, 72);
+
+        $injurySubSeen = false;
+        for ($i = 0; $i < 10; $i++) {
+            $output = $this->simulator->simulate(
+                $homeTeam, $awayTeam,
+                $homePlayers, $awayPlayers,
+                Formation::F_4_4_2, Formation::F_4_4_2,
+                Mentality::BALANCED, Mentality::BALANCED,
+                $game,
+                homeBenchPlayers: $homeBench,
+                awayBenchPlayers: $awayBench,
+                userTeamId: $homeTeam->id,
+            );
+
+            // Look for a substitution event on the user team (home)
+            $homeSubEvents = $output->result->substitutions()
+                ->filter(fn ($e) => $e->teamId === $homeTeam->id);
+
+            if ($homeSubEvents->isNotEmpty()) {
+                $injurySubSeen = true;
+
+                // The sub should be at injury minute + 1, not at a tactical
+                // window (60-85). Injury auto-subs fire within the first half
+                // too, so some may be well before minute 46.
+                $injuryEvents = $output->result->events
+                    ->filter(fn ($e) => $e->type === 'injury' && $e->teamId === $homeTeam->id);
+                if ($injuryEvents->isNotEmpty()) {
+                    $injuryMinute = $injuryEvents->first()->minute;
+                    $subMinute = $homeSubEvents->first()->minute;
+                    $this->assertEquals(
+                        $injuryMinute + 1,
+                        $subMinute,
+                        'Injury auto-sub should fire at injury minute + 1',
+                    );
+                }
+                break;
+            }
+        }
+
+        $this->assertTrue($injurySubSeen, 'User team should get an injury auto-sub when bench is passed with userTeamId');
+    }
+
+    public function test_user_team_gets_no_tactical_ai_subs_in_pre_simulation(): void
+    {
+        $game = Game::factory()->create(['current_date' => '2025-10-01']);
+        $homeTeam = Team::factory()->create();
+        $awayTeam = Team::factory()->create();
+
+        $homePlayers = $this->createLineup($game, $homeTeam, 11, 75);
+        $awayPlayers = $this->createLineup($game, $awayTeam, 11, 75);
+        $homeBench = $this->createBenchPlayers($game, $homeTeam, 7, 72);
+        $awayBench = $this->createBenchPlayers($game, $awayTeam, 7, 72);
+
+        // Disable injuries and direct red cards. Yellows have a hard floor of
+        // Poisson(0.1) so a second-yellow red card can still occur very rarely,
+        // which triggers a reactive sub (same category as injury auto-subs).
+        // Tactical AI subs would produce 3-5 per match — we check that the user
+        // team never exceeds 1 sub per iteration (at most a forced reactive sub).
+        config([
+            'match_simulation.injury_chance' => 0,
+            'match_simulation.direct_red_chance' => 0,
+        ]);
+
+        $totalUserSubs = 0;
+        $iterations = 10;
+
+        for ($i = 0; $i < $iterations; $i++) {
+            $output = $this->simulator->simulate(
+                $homeTeam, $awayTeam,
+                $homePlayers, $awayPlayers,
+                Formation::F_4_4_2, Formation::F_4_4_2,
+                Mentality::BALANCED, Mentality::BALANCED,
+                $game,
+                homeBenchPlayers: $homeBench,
+                awayBenchPlayers: $awayBench,
+                userTeamId: $homeTeam->id,
+            );
+
+            $homeSubCount = $output->result->substitutions()
+                ->filter(fn ($e) => $e->teamId === $homeTeam->id)
+                ->count();
+
+            // At most 1 forced reactive sub (red card) per match.
+            // Tactical AI subs would give 3-5.
+            $this->assertLessThanOrEqual(
+                1,
+                $homeSubCount,
+                "User team should have at most 1 forced reactive sub, got $homeSubCount (iteration $i)",
+            );
+
+            $totalUserSubs += $homeSubCount;
+        }
+
+        // Across 10 simulations, tactical AI subs would give 30-50 total.
+        // We should see close to 0 (only the rare second-yellow reactive sub).
+        $this->assertLessThanOrEqual(
+            3,
+            $totalUserSubs,
+            "User team total subs across $iterations iterations should be near-zero (forced reactive only), got $totalUserSubs",
+        );
+    }
 }

--- a/tests/js/live-match-helpers.test.js
+++ b/tests/js/live-match-helpers.test.js
@@ -1,0 +1,99 @@
+/**
+ * Tests for live-match.js exported helpers.
+ *
+ * These test the critical decision logic that routes tactical changes
+ * to the correct backend handler (regular time vs extra time).
+ *
+ * The stoppage-time goal bug was caused by a sub at minute 90 during
+ * going_to_extra_time being treated as a regular-time resimulation,
+ * which deleted the stoppage-time goal and changed the score.
+ */
+import { describe, it, expect } from 'vitest';
+import { resolveMinuteForTacticalChange } from '@/live-match.js';
+
+describe('resolveMinuteForTacticalChange', () => {
+    // ========================================================================
+    // Regular time — should pass minute through unchanged
+    // ========================================================================
+
+    it('passes through minute during first_half', () => {
+        expect(resolveMinuteForTacticalChange(30, 'first_half')).toBe(30);
+    });
+
+    it('passes through minute during second_half', () => {
+        expect(resolveMinuteForTacticalChange(75, 'second_half')).toBe(75);
+    });
+
+    it('passes through minute 90 during second_half', () => {
+        expect(resolveMinuteForTacticalChange(90, 'second_half')).toBe(90);
+    });
+
+    it('floors fractional minutes', () => {
+        expect(resolveMinuteForTacticalChange(45.7, 'first_half')).toBe(45);
+    });
+
+    // ========================================================================
+    // ET phases — must clamp to >= 93 to protect stoppage-time events
+    // ========================================================================
+
+    it('clamps minute 90 to 93 during going_to_extra_time', () => {
+        // This is the exact bug scenario: enterRegularTimeEnd sets
+        // currentMinute=90, user makes a sub, backend would treat
+        // minute=90 as regular time and delete stoppage-time goals.
+        expect(resolveMinuteForTacticalChange(90, 'going_to_extra_time')).toBe(93);
+    });
+
+    it('clamps minute 90 to 93 during extra_time_first_half', () => {
+        expect(resolveMinuteForTacticalChange(90, 'extra_time_first_half')).toBe(93);
+    });
+
+    it('clamps minute 90 to 93 during extra_time_half_time', () => {
+        expect(resolveMinuteForTacticalChange(90, 'extra_time_half_time')).toBe(93);
+    });
+
+    it('clamps minute 90 to 93 during extra_time_second_half', () => {
+        expect(resolveMinuteForTacticalChange(90, 'extra_time_second_half')).toBe(93);
+    });
+
+    // ========================================================================
+    // ET phases with minutes > 93 — should pass through unchanged
+    // ========================================================================
+
+    it('passes through minute 100 during extra_time_first_half', () => {
+        expect(resolveMinuteForTacticalChange(100, 'extra_time_first_half')).toBe(100);
+    });
+
+    it('passes through minute 110 during extra_time_second_half', () => {
+        expect(resolveMinuteForTacticalChange(110, 'extra_time_second_half')).toBe(110);
+    });
+
+    it('passes through minute 105 during extra_time_half_time', () => {
+        expect(resolveMinuteForTacticalChange(105, 'extra_time_half_time')).toBe(105);
+    });
+
+    // ========================================================================
+    // Edge cases
+    // ========================================================================
+
+    it('does not clamp non-ET phases even at boundary minutes', () => {
+        expect(resolveMinuteForTacticalChange(93, 'second_half')).toBe(93);
+    });
+
+    it('clamps minute 91 to 93 during ET phase', () => {
+        // Minute 91-93 are stoppage time; they must not be sent to backend
+        // as ET resimulation start points that would delete the events.
+        expect(resolveMinuteForTacticalChange(91, 'going_to_extra_time')).toBe(93);
+    });
+
+    it('clamps minute 93 to 93 during ET phase (boundary)', () => {
+        expect(resolveMinuteForTacticalChange(93, 'going_to_extra_time')).toBe(93);
+    });
+
+    it('handles pre_match phase normally', () => {
+        expect(resolveMinuteForTacticalChange(0, 'pre_match')).toBe(0);
+    });
+
+    it('handles full_time phase normally', () => {
+        expect(resolveMinuteForTacticalChange(90, 'full_time')).toBe(90);
+    });
+});

--- a/tests/js/match-simulation.test.js
+++ b/tests/js/match-simulation.test.js
@@ -1,0 +1,333 @@
+/**
+ * Tests for match-simulation.js — the animation/score/phase state machine.
+ *
+ * These test the critical frontend logic that caused production bugs:
+ * - Ghost goals: synthesizeGoalsIfNeeded creating phantom events
+ * - Incorrect ET trigger: needsExtraTime returning wrong values
+ * - Score forcing: enterRegularTimeEnd/enterFullTime setting wrong scores
+ * - revealedEvents not being reset after resimulation
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createMatchSimulation } from '@/modules/match-simulation.js';
+
+// Stub browser APIs that the module uses
+globalThis.requestAnimationFrame = vi.fn(() => 1);
+globalThis.cancelAnimationFrame = vi.fn();
+globalThis.performance = { now: () => 0 };
+
+function createMockState(overrides = {}) {
+    return {
+        // Core match data
+        homeTeamId: 'home-1',
+        awayTeamId: 'away-1',
+        homeTeamName: 'Home FC',
+        awayTeamName: 'Away FC',
+        userTeamId: 'home-1',
+        finalHomeScore: 0,
+        finalAwayScore: 0,
+        homeScore: 0,
+        awayScore: 0,
+
+        // ET data
+        isKnockout: false,
+        hasExtraTime: false,
+        etHomeScore: 0,
+        etAwayScore: 0,
+        _needsPenalties: false,
+        twoLeggedInfo: null,
+        extraTimeEvents: [],
+        extraTimeLoading: false,
+        preloadedExtraTimeData: null,
+        lastRevealedETIndex: -1,
+
+        // Events
+        events: [],
+        revealedEvents: [],
+        lastRevealedIndex: -1,
+
+        // Phase
+        phase: 'pre_match',
+        currentMinute: 0,
+        userPaused: false,
+        _skippingToEnd: false,
+
+        // Stubs for methods the module calls on state
+        substitutionsMade: [],
+        openPenaltyPicker: vi.fn(),
+        skipPenaltyReveal: vi.fn(() => false),
+        extraTimeUrl: '',
+        csrfToken: '',
+        autoSubUserTeamBeforeSkip: vi.fn(() => Promise.resolve(false)),
+
+        // Possession
+        homePossession: 50,
+        awayPossession: 50,
+        _basePossession: 50,
+        _possessionDisplay: 50,
+        penaltyResult: null,
+
+        // Speed
+        matchSpeed: 1,
+
+        ...overrides,
+    };
+}
+
+// ============================================================================
+// synthesizeGoalsIfNeeded
+// ============================================================================
+
+describe('synthesizeGoalsIfNeeded', () => {
+    it('does not synthesize when events match the score', () => {
+        const state = createMockState({
+            finalHomeScore: 1,
+            finalAwayScore: 0,
+            events: [
+                { minute: 35, type: 'goal', teamId: 'home-1', gamePlayerId: 'p1', metadata: {} },
+            ],
+        });
+
+        const sim = createMatchSimulation(() => state);
+        const result = sim.synthesizeGoalsIfNeeded(state.events);
+
+        expect(result.length).toBe(1);
+        expect(result[0].gamePlayerId).toBe('p1');
+    });
+
+    it('synthesizes missing home goals', () => {
+        const state = createMockState({
+            finalHomeScore: 2,
+            finalAwayScore: 0,
+            events: [
+                { minute: 35, type: 'goal', teamId: 'home-1', gamePlayerId: 'p1', metadata: {} },
+            ],
+        });
+
+        const sim = createMatchSimulation(() => state);
+        const result = sim.synthesizeGoalsIfNeeded(state.events);
+
+        expect(result.length).toBe(2);
+        const synthetic = result.find(e => e.gamePlayerId === null);
+        expect(synthetic).toBeDefined();
+        expect(synthetic.teamId).toBe('home-1');
+    });
+
+    it('synthesizes missing away goals', () => {
+        const state = createMockState({
+            finalHomeScore: 0,
+            finalAwayScore: 1,
+            events: [],
+        });
+
+        const sim = createMatchSimulation(() => state);
+        const result = sim.synthesizeGoalsIfNeeded(state.events);
+
+        expect(result.length).toBe(1);
+        expect(result[0].teamId).toBe('away-1');
+        expect(result[0].gamePlayerId).toBeNull();
+    });
+
+    it('does not synthesize when events exceed the score (no phantom removal)', () => {
+        const state = createMockState({
+            finalHomeScore: 0,
+            finalAwayScore: 1,
+            events: [
+                { minute: 10, type: 'goal', teamId: 'home-1', gamePlayerId: 'p1', metadata: {} },
+                { minute: 55, type: 'goal', teamId: 'away-1', gamePlayerId: 'p2', metadata: {} },
+            ],
+        });
+
+        const sim = createMatchSimulation(() => state);
+        const result = sim.synthesizeGoalsIfNeeded(state.events);
+
+        // Should NOT add synthetic goals and should NOT remove the extra home goal
+        expect(result.length).toBe(2);
+    });
+
+    it('counts own goals correctly for the benefiting team', () => {
+        const state = createMockState({
+            finalHomeScore: 1,
+            finalAwayScore: 0,
+            events: [
+                // Away team own goal = home team gets the point
+                { minute: 20, type: 'own_goal', teamId: 'away-1', gamePlayerId: 'p3', metadata: {} },
+            ],
+        });
+
+        const sim = createMatchSimulation(() => state);
+        const result = sim.synthesizeGoalsIfNeeded(state.events);
+
+        // own_goal by away team counts as home goal, so score matches — no synthesis
+        expect(result.length).toBe(1);
+    });
+
+    it('synthesized goals have minutes within 1-90', () => {
+        const state = createMockState({
+            finalHomeScore: 3,
+            finalAwayScore: 0,
+            events: [],
+        });
+
+        const sim = createMatchSimulation(() => state);
+        const result = sim.synthesizeGoalsIfNeeded(state.events);
+
+        expect(result.length).toBe(3);
+        for (const event of result) {
+            expect(event.minute).toBeGreaterThanOrEqual(1);
+            expect(event.minute).toBeLessThanOrEqual(90);
+        }
+    });
+});
+
+// ============================================================================
+// enterRegularTimeEnd — score forcing
+// ============================================================================
+
+describe('enterRegularTimeEnd score forcing', () => {
+    it('forces score to finalHomeScore/finalAwayScore regardless of revealed events', () => {
+        const state = createMockState({
+            phase: 'second_half',
+            currentMinute: 93,
+            finalHomeScore: 1,
+            finalAwayScore: 1,
+            homeScore: 2,  // Wrong — was incremented by extra event reveals
+            awayScore: 1,
+            isKnockout: false,
+            events: [
+                { minute: 30, type: 'goal', teamId: 'home-1', gamePlayerId: 'p1', metadata: {} },
+                { minute: 60, type: 'goal', teamId: 'away-1', gamePlayerId: 'p2', metadata: {} },
+            ],
+            lastRevealedIndex: 1,
+        });
+
+        const sim = createMatchSimulation(() => state);
+
+        // enterFullTime is the non-knockout path
+        sim.enterFullTime();
+
+        expect(state.homeScore).toBe(1);
+        expect(state.awayScore).toBe(1);
+    });
+});
+
+// ============================================================================
+// enterExtraTimeEnd — ET score forcing and penalty decision
+// ============================================================================
+
+describe('enterExtraTimeEnd penalty decision', () => {
+    it('does not open penalty picker when ET has a winner', () => {
+        const state = createMockState({
+            phase: 'extra_time_second_half',
+            currentMinute: 123,
+            isKnockout: true,
+            hasExtraTime: true,
+            finalHomeScore: 1,
+            finalAwayScore: 1,
+            etHomeScore: 1,
+            etAwayScore: 0,
+            homeScore: 2,
+            awayScore: 1,
+            _needsPenalties: false,
+            extraTimeEvents: [],
+            lastRevealedETIndex: -1,
+            penaltyResult: null,
+        });
+
+        const sim = createMatchSimulation(() => state);
+
+        // This should call enterFullTime, not openPenaltyPicker
+        // (since _needsPenalties is false)
+        // We can verify by checking that phase becomes 'full_time'
+        // and openPenaltyPicker was not called
+        sim.enterFullTime();
+        expect(state.phase).toBe('full_time');
+        expect(state.openPenaltyPicker).not.toHaveBeenCalled();
+    });
+
+    it('forces total score (regular + ET) at end of extra time', () => {
+        const state = createMockState({
+            phase: 'extra_time_second_half',
+            currentMinute: 120,
+            isKnockout: true,
+            hasExtraTime: true,
+            finalHomeScore: 1,
+            finalAwayScore: 1,
+            etHomeScore: 1,
+            etAwayScore: 0,
+            homeScore: 0,  // Wrong
+            awayScore: 0,  // Wrong
+            _needsPenalties: false,
+            extraTimeEvents: [],
+            lastRevealedETIndex: -1,
+            penaltyResult: null,
+        });
+
+        const sim = createMatchSimulation(() => state);
+        sim.enterFullTime();
+
+        // In ET mode, enterFullTime sets currentMinute=120 but doesn't re-force scores
+        // The score was already forced by enterExtraTimeEnd
+        expect(state.phase).toBe('full_time');
+    });
+});
+
+// ============================================================================
+// needsExtraTime — single-leg and two-legged
+// ============================================================================
+
+describe('needsExtraTime (via skipToEnd)', () => {
+    it('triggers ET when single-leg knockout score is a draw', async () => {
+        const state = createMockState({
+            phase: 'second_half',
+            currentMinute: 93,
+            isKnockout: true,
+            hasExtraTime: false,
+            finalHomeScore: 1,
+            finalAwayScore: 1,
+            homeScore: 1,
+            awayScore: 1,
+            events: [],
+            lastRevealedIndex: -1,
+            extraTimeUrl: '/et',
+            csrfToken: 'token',
+            preloadedExtraTimeData: null,
+            otherMatches: [],
+        });
+
+        // Mock fetch so fetchExtraTime doesn't crash
+        globalThis.fetch = vi.fn(() => Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve({ needed: false }),
+        }));
+
+        const sim = createMatchSimulation(() => state);
+
+        // skipToEnd is async — await it
+        await sim.skipToEnd();
+
+        // Knockout with finalHomeScore === finalAwayScore → going_to_extra_time
+        expect(state.phase).toBe('going_to_extra_time');
+    });
+
+    it('does not trigger ET when knockout score is not a draw', async () => {
+        const state = createMockState({
+            phase: 'second_half',
+            currentMinute: 93,
+            isKnockout: true,
+            hasExtraTime: false,
+            finalHomeScore: 2,
+            finalAwayScore: 1,
+            homeScore: 2,
+            awayScore: 1,
+            events: [],
+            lastRevealedIndex: -1,
+            otherMatches: [],
+        });
+
+        const sim = createMatchSimulation(() => state);
+        await sim.skipToEnd();
+
+        // Non-draw knockout → full_time
+        expect(state.phase).toBe('full_time');
+    });
+});

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vitest/config';
+import path from 'path';
+
+export default defineConfig({
+    test: {
+        environment: 'node',
+        include: ['tests/js/**/*.test.js'],
+        globals: true,
+    },
+    resolve: {
+        alias: {
+            '@': path.resolve(__dirname, 'resources/js'),
+        },
+    },
+});


### PR DESCRIPTION
## Summary

- Re-applies #740 (auto-substitute user team on Skip to end) with fixes for the ghost goals bug that forced the revert, plus four additional bugs found during audit — two in ET, one in resimulation, one pre-existing
- Adds Vitest infrastructure and 27 JS tests + 3 PHP test files covering the match simulation invariants that were previously untested
- Adds JS test step to CI pipeline

## Bugs fixed

**Ghost goals race condition** — `skipToEnd` was changed to async but the tick animation loop kept running during the await, revealing stale pre-simulation events into `revealedEvents`. The score was then forced to the resimulation result while the feed still showed old events.

**Resimulation auto-sub blind spot** — The resimulation system only knew about user subs from the frontend's manual list. Pre-simulated injury auto-subs (enabled by #740) were invisible: replacement players were never added back to the lineup (team played with 10), sub/window counts were too low, and entry minutes were missing.

**Incorrect penalty trigger on page refresh** — `buildExtraTimeData` unconditionally set `needsPenalties=true` when ET was played but penalties hadn't been resolved, regardless of the actual ET score. A page refresh after ET ended 2-1 sent users to the penalty picker.

**ET resimulation had the same auto-sub blind spot** — `resimulateExtraTime` was missing the same fixes applied to `doResimulate`. Also fixed `calculateScoreAtMinute` to use `afterMinute=93` so stoppage-time goals (minutes 91-93) aren't double-counted in `home_score_et`.

**Sub during going\_to\_extra\_time erased stoppage-time goals** (pre-existing) — `enterRegularTimeEnd` set `currentMinute=90`, so a sub made before ET started was sent as `minute=90` to the backend, which treated it as a regular-time resimulation and deleted events after minute 90 — including the stoppage-time goal that forced the draw.