### PR TITLE
Add game_player_match_state satellite with encapsulated API

### DIFF
--- a/app/Console/Commands/BackfillGamePlayerMatchState.php
+++ b/app/Console/Commands/BackfillGamePlayerMatchState.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Game;
+use App\Modules\Player\Support\GamePlayerScopeResolver;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * One-shot data backfill that copies match-state columns out of game_players
+ * into the new game_player_match_state satellite for every existing game.
+ *
+ * Run between the create-table migration and the drop-columns migration:
+ *
+ *   php artisan migrate                                        # creates the satellite table
+ *   php artisan app:backfill-game-player-match-state           # this command
+ *   php artisan migrate                                        # drops the 13 columns
+ *
+ * Idempotent: a player whose satellite row already exists is left alone.
+ * Per-game transactions so partial failure is recoverable.
+ */
+class BackfillGamePlayerMatchState extends Command
+{
+    protected $signature = 'app:backfill-game-player-match-state {--game= : Backfill a single game by id}';
+
+    protected $description = 'Backfill game_player_match_state from existing game_players hot-write columns';
+
+    public function handle(GamePlayerScopeResolver $scopeResolver): int
+    {
+        $gameQuery = Game::query();
+        if ($gameId = $this->option('game')) {
+            $gameQuery->where('id', $gameId);
+        }
+
+        $totalGames = (clone $gameQuery)->count();
+        if ($totalGames === 0) {
+            $this->info('No games to backfill.');
+            return self::SUCCESS;
+        }
+
+        $this->info("Backfilling match state for {$totalGames} game(s).");
+
+        $totalInserted = 0;
+        $bar = $this->output->createProgressBar($totalGames);
+
+        $gameQuery->each(function (Game $game) use ($scopeResolver, &$totalInserted, $bar) {
+            $totalInserted += $this->backfillGame($game, $scopeResolver);
+            $bar->advance();
+        });
+
+        $bar->finish();
+        $this->newLine();
+        $this->info("Done. Inserted {$totalInserted} match-state rows.");
+
+        return self::SUCCESS;
+    }
+
+    private function backfillGame(Game $game, GamePlayerScopeResolver $scopeResolver): int
+    {
+        $activeTeamIds = $scopeResolver->activeTeamIdsForGame($game);
+        if (empty($activeTeamIds)) {
+            return 0;
+        }
+
+        // Tournament games (e.g. World Cup) participate via national teams
+        // that aren't in the country-based active scope. Treat every team in
+        // the game as active for those — the satellite is small.
+        if ($game->isTournamentMode()) {
+            $activeTeamIds = DB::table('game_players')
+                ->where('game_id', $game->id)
+                ->whereNotNull('team_id')
+                ->distinct()
+                ->pluck('team_id')
+                ->all();
+        }
+
+        return DB::transaction(function () use ($game, $activeTeamIds): int {
+            $before = DB::table('game_player_match_state')
+                ->whereIn('game_player_id', function ($q) use ($game) {
+                    $q->select('id')->from('game_players')->where('game_id', $game->id);
+                })
+                ->count();
+
+            DB::statement(<<<'SQL'
+                INSERT INTO game_player_match_state (
+                    game_player_id, fitness, morale, injury_until, injury_type,
+                    appearances, season_appearances, goals, own_goals, assists,
+                    yellow_cards, red_cards, goals_conceded, clean_sheets
+                )
+                SELECT
+                    gp.id,
+                    COALESCE(gp.fitness, 80),
+                    COALESCE(gp.morale, 80),
+                    gp.injury_until,
+                    gp.injury_type,
+                    COALESCE(gp.appearances, 0),
+                    COALESCE(gp.season_appearances, 0),
+                    COALESCE(gp.goals, 0),
+                    COALESCE(gp.own_goals, 0),
+                    COALESCE(gp.assists, 0),
+                    COALESCE(gp.yellow_cards, 0),
+                    COALESCE(gp.red_cards, 0),
+                    COALESCE(gp.goals_conceded, 0),
+                    COALESCE(gp.clean_sheets, 0)
+                FROM game_players gp
+                WHERE gp.game_id = ?
+                  AND gp.team_id = ANY(?::uuid[])
+                ON CONFLICT (game_player_id) DO NOTHING
+            SQL, [$game->id, '{' . implode(',', $activeTeamIds) . '}']);
+
+            $after = DB::table('game_player_match_state')
+                ->whereIn('game_player_id', function ($q) use ($game) {
+                    $q->select('id')->from('game_players')->where('game_id', $game->id);
+                })
+                ->count();
+
+            return $after - $before;
+        });
+    }
+}

--- a/app/Http/Actions/SaveSquadSelection.php
+++ b/app/Http/Actions/SaveSquadSelection.php
@@ -6,6 +6,7 @@ use App\Modules\Player\Services\InjuryService;
 use App\Modules\Player\Services\PlayerDevelopmentService;
 use App\Models\Game;
 use App\Models\GamePlayer;
+use App\Models\GamePlayerMatchState;
 use App\Models\Player;
 use Illuminate\Http\Request;
 use Illuminate\Support\Str;
@@ -60,14 +61,17 @@ class SaveSquadSelection
         $playerModels = Player::whereIn('transfermarkt_id', $tmIds)->get()->keyBy('transfermarkt_id');
 
         $playerRows = [];
+        $matchStateRows = [];
         foreach ($tmIds as $tmId) {
             $player = $playerModels->get($tmId);
             if (!$player) {
                 continue;
             }
 
+            $gamePlayerId = Str::uuid()->toString();
+
             $playerRows[] = [
-                'id' => Str::uuid()->toString(),
+                'id' => $gamePlayerId,
                 'game_id' => $gameId,
                 'player_id' => $player->id,
                 'team_id' => $teamId,
@@ -77,15 +81,24 @@ class SaveSquadSelection
                 'market_value_cents' => 0,
                 'contract_until' => null,
                 'annual_wage' => 0,
-                'fitness' => rand(90, 100),
-                'morale' => rand(70, 85),
                 'durability' => InjuryService::generateDurability(),
                 'game_technical_ability' => $player->technical_ability,
                 'game_physical_ability' => $player->physical_ability,
-                'season_appearances' => 0,
+            ];
+
+            $matchStateRows[] = [
+                'game_player_id' => $gamePlayerId,
+                'fitness' => rand(90, 100),
+                'morale' => rand(70, 85),
             ];
         }
 
-        GamePlayer::insert($playerRows);
+        if (!empty($playerRows)) {
+            GamePlayer::insert($playerRows);
+        }
+
+        if (!empty($matchStateRows)) {
+            GamePlayerMatchState::createForPlayers($matchStateRows);
+        }
     }
 }

--- a/app/Http/Actions/SkipMatchToEnd.php
+++ b/app/Http/Actions/SkipMatchToEnd.php
@@ -148,15 +148,13 @@ class SkipMatchToEnd
 
         $suspendedIds = PlayerSuspension::suspendedPlayerIdsForCompetition($match->competition_id);
 
-        return GamePlayer::where('game_id', $game->id)
+        return GamePlayer::query()
+            ->where('game_id', $game->id)
             ->where('team_id', $game->team_id)
             ->whereNotIn('id', $activeIds)
             ->whereNotIn('id', $suspendedIds)
-            ->where(function ($q) use ($match) {
-                $q->whereNull('injury_until')
-                    ->orWhere('injury_until', '<', $match->scheduled_date);
-            })
             ->when($game->requiresSquadEnrollment(), fn ($q) => $q->whereNotNull('number'))
+            ->notInjuredOn($match->scheduled_date)
             ->count();
     }
 }

--- a/app/Http/Views/ShowLiveMatch.php
+++ b/app/Http/Views/ShowLiveMatch.php
@@ -135,7 +135,7 @@ class ShowLiveMatch
 
         // Starting lineup players (for the "sub out" picker)
         $currentDate = $game->current_date;
-        $lineupPlayers = GamePlayer::with('player')
+        $lineupPlayers = GamePlayer::with(['player', 'matchState'])
             ->whereIn('id', $userLineupIds)
             ->get()
             ->map(fn ($p) => [
@@ -166,16 +166,13 @@ class ShowLiveMatch
 
         // Bench players (all squad players NOT in the starting lineup, not suspended, not injured)
         $matchDate = $playerMatch->scheduled_date;
-        $benchPlayers = GamePlayer::with('player')
+        $benchPlayers = GamePlayer::with(['player', 'matchState'])
             ->where('game_id', $gameId)
             ->where('team_id', $game->team_id)
             ->whereNotIn('id', $userLineupIds)
             ->whereNotIn('id', $suspendedPlayerIds)
-            ->where(function ($q) use ($matchDate) {
-                $q->whereNull('injury_until')
-                    ->orWhere('injury_until', '<', $matchDate);
-            })
             ->when($game->requiresSquadEnrollment(), fn ($q) => $q->whereNotNull('number'))
+            ->notInjuredOn($matchDate)
             ->get()
             ->map(fn ($p) => [
                 'id' => $p->id,
@@ -198,7 +195,7 @@ class ShowLiveMatch
             ->values()
             ->all();
 
-        $mapLineup = fn (array $ids) => GamePlayer::with('player')
+        $mapLineup = fn (array $ids) => GamePlayer::with(['player', 'matchState'])
             ->whereIn('id', $ids)
             ->get()
             ->map(fn ($p) => [

--- a/app/Http/Views/ShowPreMatchData.php
+++ b/app/Http/Views/ShowPreMatchData.php
@@ -49,9 +49,10 @@ class ShowPreMatchData
             $hasInjured = false;
             $hasSuspended = false;
 
-            $lineupPlayers = GamePlayer::where('game_id', $gameId)
+            $lineupPlayers = GamePlayer::with('matchState')
+                ->where('game_id', $gameId)
                 ->whereIn('id', $lineup)
-                ->get(['id', 'injury_until']);
+                ->get(['id']);
 
             foreach ($lineupPlayers as $player) {
                 if (in_array($player->id, $suspendedPlayerIds)) {

--- a/app/Models/GamePlayer.php
+++ b/app/Models/GamePlayer.php
@@ -135,26 +135,13 @@ class GamePlayer extends Model
         'contract_until',
         'annual_wage',
         'pending_annual_wage',
-        'fitness',
-        'morale',
         'durability',
-        'injury_until',
-        'injury_type',
-        'appearances',
-        'goals',
-        'own_goals',
-        'assists',
-        'yellow_cards',
-        'red_cards',
-        'goals_conceded',
-        'clean_sheets',
         'game_technical_ability',
         'game_physical_ability',
         'tier',
         'potential',
         'potential_low',
         'potential_high',
-        'season_appearances',
         'retiring_at_season',
     ];
 
@@ -165,18 +152,7 @@ class GamePlayer extends Model
         'contract_until' => 'date',
         'annual_wage' => 'integer',
         'pending_annual_wage' => 'integer',
-        'fitness' => 'integer',
-        'morale' => 'integer',
         'durability' => 'integer',
-        'injury_until' => 'date',
-        'appearances' => 'integer',
-        'goals' => 'integer',
-        'own_goals' => 'integer',
-        'assists' => 'integer',
-        'yellow_cards' => 'integer',
-        'red_cards' => 'integer',
-        'goals_conceded' => 'integer',
-        'clean_sheets' => 'integer',
         // Development fields
         'game_technical_ability' => 'integer',
         'game_physical_ability' => 'integer',
@@ -184,7 +160,6 @@ class GamePlayer extends Model
         'potential' => 'integer',
         'potential_low' => 'integer',
         'potential_high' => 'integer',
-        'season_appearances' => 'integer',
     ];
 
     /**
@@ -224,6 +199,22 @@ class GamePlayer extends Model
     public function team(): BelongsTo
     {
         return $this->belongsTo(Team::class);
+    }
+
+    /**
+     * Sparse satellite holding the per-matchday hot-write columns
+     * (fitness, morale, injury, match stats). Only "active" players
+     * have a row — see {@see \App\Modules\Player\Support\GamePlayerScopeResolver}.
+     *
+     * Read access is mediated by the get*Attribute() delegates below so
+     * existing call sites that use `$player->fitness`, `$player->goals`
+     * etc. work transparently. Write paths must update the satellite
+     * directly via `GamePlayerMatchState` queries — never via
+     * `$player->fitness = X`.
+     */
+    public function matchState(): HasOne
+    {
+        return $this->hasOne(GamePlayerMatchState::class, 'game_player_id');
     }
 
     public function matchEvents(): HasMany
@@ -851,5 +842,212 @@ class GamePlayer extends Model
             'name' => $nationalities[0],
             'code' => $code,
         ];
+    }
+
+    // ==========================================================================
+    // Match-state query scopes
+    //
+    // These scopes hide the satellite join so callers never reference
+    // the table name or column names directly.
+    // ==========================================================================
+
+    private static array $validMatchStatColumns;
+
+    private static function validMatchStatColumns(): array
+    {
+        return self::$validMatchStatColumns ??= array_keys(GamePlayerMatchState::DEFAULTS);
+    }
+
+    private static function assertValidMatchStatColumn(string $column): void
+    {
+        if (! in_array($column, self::validMatchStatColumns(), true)) {
+            throw new \InvalidArgumentException("Invalid match stat column: {$column}");
+        }
+    }
+
+    /**
+     * INNER JOIN the satellite table (only players with a satellite row).
+     */
+    public function scopeJoinMatchState($query)
+    {
+        return $query
+            ->join('game_player_match_state', 'game_players.id', '=', 'game_player_match_state.game_player_id')
+            ->select('game_players.*');
+    }
+
+    /**
+     * LEFT JOIN the satellite table (includes pool players without a row).
+     */
+    public function scopeLeftJoinMatchState($query)
+    {
+        return $query
+            ->leftJoin('game_player_match_state', 'game_players.id', '=', 'game_player_match_state.game_player_id')
+            ->select('game_players.*');
+    }
+
+    /**
+     * Order by a column on the satellite table.
+     */
+    public function scopeOrderByMatchStat($query, string $column, string $direction = 'desc')
+    {
+        self::assertValidMatchStatColumn($column);
+
+        return $query->orderBy("game_player_match_state.{$column}", $direction);
+    }
+
+    /**
+     * Filter by a column on the satellite table.
+     */
+    public function scopeWhereMatchStat($query, string $column, string $operator, $value = null)
+    {
+        self::assertValidMatchStatColumn($column);
+
+        return $query->where("game_player_match_state.{$column}", $operator, $value);
+    }
+
+    /**
+     * Filter by a satellite column being not null.
+     */
+    public function scopeWhereMatchStatNotNull($query, string $column)
+    {
+        self::assertValidMatchStatColumn($column);
+
+        return $query->whereNotNull("game_player_match_state.{$column}");
+    }
+
+    /**
+     * Exclude injured players (injury_until is null or in the past).
+     * Joins the satellite table if not already joined.
+     */
+    public function scopeNotInjuredOn($query, Carbon $date)
+    {
+        // Check if the satellite join is already present
+        $joins = $query->getQuery()->joins ?? [];
+        $alreadyJoined = collect($joins)->contains(fn ($join) => $join->table === 'game_player_match_state');
+
+        if (! $alreadyJoined) {
+            $query->join('game_player_match_state', 'game_players.id', '=', 'game_player_match_state.game_player_id')
+                ->select('game_players.*');
+        }
+
+        return $query->where(function ($q) use ($date) {
+            $q->whereNull('game_player_match_state.injury_until')
+                ->orWhere('game_player_match_state.injury_until', '<=', $date->toDateString());
+        });
+    }
+
+    // ==========================================================================
+    // Match-state delegates
+    //
+    // The 13 hot-write columns (fitness, morale, injury, match stats) live on
+    // {@see GamePlayerMatchState}. The accessors below let existing read sites
+    // keep using `$player->fitness` etc. without knowing about the satellite.
+    //
+    // Read priority:
+    //   1. In-memory override (`isDirty`) — e.g. CompetitionViewService
+    //      decorating a model with per-competition tallies.
+    //   2. Satellite (when eager-loaded) — authoritative after code deploy.
+    //   3. Legacy column from `$this->attributes` — backward compat during
+    //      the transition window before the drop-columns migration runs.
+    //   4. Lazy-load satellite (post-drop, when old column is gone).
+    //   5. Default from {@see GamePlayerMatchState::DEFAULTS}.
+    //
+    // To avoid N+1 in hot paths, callers should `with('matchState')` when
+    // loading collections. The match simulator, squad service, lineup loader
+    // and dashboard all do this.
+    // ==========================================================================
+
+    /**
+     * Read a match-state value through the standard priority chain.
+     */
+    private function matchStateValue(string $column, mixed $default): mixed
+    {
+        // 1. In-memory override (e.g. decoration for display)
+        if ($this->isDirty($column)) {
+            return $this->attributes[$column];
+        }
+
+        // 2. Satellite (authoritative when eager-loaded)
+        if ($this->relationLoaded('matchState') && $this->matchState !== null) {
+            return $this->matchState->{$column};
+        }
+
+        // 3. Legacy column (transition period before drop migration)
+        if (array_key_exists($column, $this->attributes) && ! $this->isDirty($column)) {
+            return $this->attributes[$column];
+        }
+
+        // 4. Lazy-load satellite (post-drop, column gone from attributes)
+        return $this->matchState?->{$column} ?? $default;
+    }
+
+    public function getFitnessAttribute(): int
+    {
+        return (int) $this->matchStateValue('fitness', GamePlayerMatchState::DEFAULTS['fitness']);
+    }
+
+    public function getMoraleAttribute(): int
+    {
+        return (int) $this->matchStateValue('morale', GamePlayerMatchState::DEFAULTS['morale']);
+    }
+
+    public function getInjuryUntilAttribute(): ?Carbon
+    {
+        $value = $this->matchStateValue('injury_until', null);
+        if ($value === null) {
+            return null;
+        }
+
+        return $value instanceof Carbon ? $value : Carbon::parse($value);
+    }
+
+    public function getInjuryTypeAttribute(): ?string
+    {
+        return $this->matchStateValue('injury_type', null);
+    }
+
+    public function getAppearancesAttribute(): int
+    {
+        return (int) $this->matchStateValue('appearances', GamePlayerMatchState::DEFAULTS['appearances']);
+    }
+
+    public function getSeasonAppearancesAttribute(): int
+    {
+        return (int) $this->matchStateValue('season_appearances', GamePlayerMatchState::DEFAULTS['season_appearances']);
+    }
+
+    public function getGoalsAttribute(): int
+    {
+        return (int) $this->matchStateValue('goals', GamePlayerMatchState::DEFAULTS['goals']);
+    }
+
+    public function getOwnGoalsAttribute(): int
+    {
+        return (int) $this->matchStateValue('own_goals', GamePlayerMatchState::DEFAULTS['own_goals']);
+    }
+
+    public function getAssistsAttribute(): int
+    {
+        return (int) $this->matchStateValue('assists', GamePlayerMatchState::DEFAULTS['assists']);
+    }
+
+    public function getYellowCardsAttribute(): int
+    {
+        return (int) $this->matchStateValue('yellow_cards', GamePlayerMatchState::DEFAULTS['yellow_cards']);
+    }
+
+    public function getRedCardsAttribute(): int
+    {
+        return (int) $this->matchStateValue('red_cards', GamePlayerMatchState::DEFAULTS['red_cards']);
+    }
+
+    public function getGoalsConcededAttribute(): int
+    {
+        return (int) $this->matchStateValue('goals_conceded', GamePlayerMatchState::DEFAULTS['goals_conceded']);
+    }
+
+    public function getCleanSheetsAttribute(): int
+    {
+        return (int) $this->matchStateValue('clean_sheets', GamePlayerMatchState::DEFAULTS['clean_sheets']);
     }
 }

--- a/app/Models/GamePlayerMatchState.php
+++ b/app/Models/GamePlayerMatchState.php
@@ -1,0 +1,461 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Sparse satellite of GamePlayer holding the per-matchday hot-write state:
+ * fitness, morale, injuries, appearances, goals, assists, cards, GK stats.
+ *
+ * Only populated for "active" players (teams in the user's competition
+ * footprint or European opponents for a season the user qualifies for).
+ * Pure transfer-pool foreign players have no row here.
+ *
+ * Read paths go through the {@see GamePlayer} accessor delegates so existing
+ * call sites that read `$player->fitness`, `$player->goals` etc. keep working.
+ *
+ * @property string $game_player_id
+ * @property int $fitness
+ * @property int $morale
+ * @property \Illuminate\Support\Carbon|null $injury_until
+ * @property string|null $injury_type
+ * @property int $appearances
+ * @property int $season_appearances
+ * @property int $goals
+ * @property int $own_goals
+ * @property int $assists
+ * @property int $yellow_cards
+ * @property int $red_cards
+ * @property int $goals_conceded
+ * @property int $clean_sheets
+ */
+class GamePlayerMatchState extends Model
+{
+    use HasFactory;
+
+    protected $table = 'game_player_match_state';
+
+    protected $primaryKey = 'game_player_id';
+
+    public $incrementing = false;
+
+    protected $keyType = 'string';
+
+    public $timestamps = false;
+
+    protected $fillable = [
+        'game_player_id',
+        'fitness',
+        'morale',
+        'injury_until',
+        'injury_type',
+        'appearances',
+        'season_appearances',
+        'goals',
+        'own_goals',
+        'assists',
+        'yellow_cards',
+        'red_cards',
+        'goals_conceded',
+        'clean_sheets',
+    ];
+
+    protected $casts = [
+        'fitness' => 'integer',
+        'morale' => 'integer',
+        'injury_until' => 'date',
+        'appearances' => 'integer',
+        'season_appearances' => 'integer',
+        'goals' => 'integer',
+        'own_goals' => 'integer',
+        'assists' => 'integer',
+        'yellow_cards' => 'integer',
+        'red_cards' => 'integer',
+        'goals_conceded' => 'integer',
+        'clean_sheets' => 'integer',
+    ];
+
+    /**
+     * Default values for a freshly-created satellite row. Mirrors the
+     * defaults the dropped game_players columns used to carry.
+     */
+    public const DEFAULTS = [
+        'fitness' => 80,
+        'morale' => 80,
+        'injury_until' => null,
+        'injury_type' => null,
+        'appearances' => 0,
+        'season_appearances' => 0,
+        'goals' => 0,
+        'own_goals' => 0,
+        'assists' => 0,
+        'yellow_cards' => 0,
+        'red_cards' => 0,
+        'goals_conceded' => 0,
+        'clean_sheets' => 0,
+    ];
+
+    public function gamePlayer(): BelongsTo
+    {
+        return $this->belongsTo(GamePlayer::class, 'game_player_id');
+    }
+
+    /**
+     * Dual-write a raw SQL UPDATE to the legacy `game_players` columns.
+     *
+     * Only executes while the legacy columns still exist (before the
+     * drop-columns migration). This keeps the old columns in sync so a
+     * rollback of the code deploy doesn't lose data.
+     *
+     * @param string $sql  The UPDATE statement targeting `game_players`.
+     * @param array  $bindings  Positional bind values.
+     */
+    public static function legacyWrite(string $sql, array $bindings = []): void
+    {
+        if (! static::legacyColumnsExist()) {
+            return;
+        }
+
+        DB::statement($sql, $bindings);
+    }
+
+    /**
+     * Dual-write an Eloquent-style update to the legacy `game_players` columns.
+     *
+     * @param \Illuminate\Database\Eloquent\Builder|\Illuminate\Database\Query\Builder $query  A query scoped to game_players rows.
+     * @param array $values  Column => value pairs to update.
+     */
+    public static function legacyEloquentWrite($query, array $values): void
+    {
+        if (! static::legacyColumnsExist()) {
+            return;
+        }
+
+        $query->update($values);
+    }
+
+    /**
+     * Whether the legacy match-state columns still exist on `game_players`.
+     *
+     * Cached once per request. Returns true before the drop-columns migration
+     * runs, false after. Used by write paths to dual-write to both tables
+     * during the transition window so that a rollback doesn't lose data.
+     */
+    private static ?bool $legacyColumnsExist = null;
+
+    public static function legacyColumnsExist(): bool
+    {
+        if (self::$legacyColumnsExist === null) {
+            self::$legacyColumnsExist = Schema::hasColumn('game_players', 'fitness');
+        }
+
+        return self::$legacyColumnsExist;
+    }
+
+    /**
+     * Reset the cached schema check. Only needed in tests that run
+     * migrations mid-test.
+     */
+    public static function resetLegacyColumnsCache(): void
+    {
+        self::$legacyColumnsExist = null;
+    }
+
+    // ──────────────────────────────────────────────────────────────
+    //  Centralized write API
+    //
+    //  All satellite writes go through these methods so callers never
+    //  reference the table name, column list, or dual-write mechanism.
+    // ──────────────────────────────────────────────────────────────
+
+    /**
+     * Bulk-insert satellite rows. Each entry must contain at least
+     * 'game_player_id'; 'fitness' and 'morale' are optional overrides.
+     * All other columns are filled from DEFAULTS.
+     *
+     * Uses insertOrIgnore so existing rows are silently skipped.
+     */
+    public static function createForPlayers(array $rows): void
+    {
+        if (empty($rows)) {
+            return;
+        }
+
+        $prepared = array_map(function (array $row) {
+            return array_merge(self::DEFAULTS, $row);
+        }, $rows);
+
+        foreach (array_chunk($prepared, 500) as $chunk) {
+            static::insertOrIgnore($chunk);
+        }
+    }
+
+    /**
+     * Create a single satellite row with defaults, or return the existing one.
+     */
+    public static function createWithDefaults(string $gamePlayerId, int $fitness = 80, int $morale = 80): self
+    {
+        return static::firstOrCreate(
+            ['game_player_id' => $gamePlayerId],
+            array_merge(self::DEFAULTS, [
+                'fitness' => $fitness,
+                'morale' => $morale,
+            ]),
+        );
+    }
+
+    /**
+     * Bulk-insert default satellite rows for every player on every team
+     * in the given set that doesn't already have one. Idempotent.
+     *
+     * Used when foreign-league teams enter the user's match scope
+     * (e.g., European competition qualification).
+     */
+    public static function ensureExistForGamePlayers(string $gameId, array $teamIds): void
+    {
+        if (empty($teamIds)) {
+            return;
+        }
+
+        $idList = '{' . implode(',', $teamIds) . '}';
+
+        DB::statement(<<<'SQL'
+            INSERT INTO game_player_match_state (
+                game_player_id, fitness, morale, injury_until, injury_type,
+                appearances, season_appearances, goals, own_goals, assists,
+                yellow_cards, red_cards, goals_conceded, clean_sheets
+            )
+            SELECT gp.id, 80, 80, NULL, NULL, 0, 0, 0, 0, 0, 0, 0, 0, 0
+            FROM game_players gp
+            WHERE gp.game_id = ?
+              AND gp.team_id IN (SELECT unnest(?::uuid[]))
+            ON CONFLICT (game_player_id) DO NOTHING
+        SQL, [$gameId, $idList]);
+    }
+
+    /**
+     * Bulk-increment stat columns using a single CASE WHEN query.
+     *
+     * @param  array<string, array<string, int>>  $increments  [playerId => [column => +amount]]
+     */
+    public static function bulkIncrementStats(array $increments): void
+    {
+        if (empty($increments)) {
+            return;
+        }
+
+        $columns = [];
+        foreach ($increments as $playerIncrements) {
+            foreach (array_keys($playerIncrements) as $col) {
+                $columns[$col] = true;
+            }
+        }
+
+        $ids = array_keys($increments);
+        $idList = "'" . implode("','", $ids) . "'";
+
+        $setClauses = [];
+        foreach (array_keys($columns) as $column) {
+            $cases = [];
+            foreach ($increments as $playerId => $playerIncrements) {
+                $amount = $playerIncrements[$column] ?? 0;
+                if ($amount !== 0) {
+                    $cases[] = "WHEN game_player_id = '{$playerId}' THEN {$column} + {$amount}";
+                }
+            }
+            if (! empty($cases)) {
+                $setClauses[] = "{$column} = CASE " . implode(' ', $cases) . " ELSE {$column} END";
+            }
+        }
+
+        if (! empty($setClauses)) {
+            DB::statement('UPDATE game_player_match_state SET ' . implode(', ', $setClauses) . " WHERE game_player_id IN ({$idList})");
+
+            $legacyClauses = str_replace('game_player_id', 'id', implode(', ', $setClauses));
+            static::legacyWrite("UPDATE game_players SET {$legacyClauses} WHERE id IN ({$idList})");
+        }
+    }
+
+    /**
+     * Increment appearances and season_appearances for the given player IDs.
+     *
+     * @param  string[]  $playerIds
+     */
+    public static function bulkIncrementAppearances(array $playerIds): void
+    {
+        if (empty($playerIds)) {
+            return;
+        }
+
+        $values = [
+            'appearances' => DB::raw('appearances + 1'),
+            'season_appearances' => DB::raw('season_appearances + 1'),
+        ];
+
+        DB::table('game_player_match_state')
+            ->whereIn('game_player_id', $playerIds)
+            ->update($values);
+
+        static::legacyEloquentWrite(
+            GamePlayer::whereIn('id', $playerIds),
+            $values
+        );
+    }
+
+    /**
+     * Bulk-set absolute values using a single CASE WHEN query.
+     *
+     * @param  array<string, array<string, mixed>>  $updates  [playerId => [column => value]]
+     */
+    public static function bulkSetValues(array $updates): void
+    {
+        if (empty($updates)) {
+            return;
+        }
+
+        $columns = [];
+        foreach ($updates as $playerValues) {
+            foreach (array_keys($playerValues) as $col) {
+                $columns[$col] = true;
+            }
+        }
+
+        $ids = array_keys($updates);
+        $idList = "'" . implode("','", $ids) . "'";
+
+        $setClauses = [];
+        foreach (array_keys($columns) as $column) {
+            $cases = [];
+            foreach ($updates as $playerId => $playerValues) {
+                if (array_key_exists($column, $playerValues)) {
+                    $value = $playerValues[$column];
+                    $cases[] = "WHEN game_player_id = '{$playerId}' THEN {$value}";
+                }
+            }
+            if (! empty($cases)) {
+                $setClauses[] = "{$column} = CASE " . implode(' ', $cases) . " ELSE {$column} END";
+            }
+        }
+
+        if (! empty($setClauses)) {
+            DB::statement('UPDATE game_player_match_state SET ' . implode(', ', $setClauses) . " WHERE game_player_id IN ({$idList})");
+
+            $legacyClauses = str_replace('game_player_id', 'id', implode(', ', $setClauses));
+            static::legacyWrite("UPDATE game_players SET {$legacyClauses} WHERE id IN ({$idList})");
+        }
+    }
+
+    /**
+     * Reset all satellite rows for a game to the given values.
+     */
+    public static function bulkResetForGame(string $gameId, array $values): void
+    {
+        DB::table('game_player_match_state')
+            ->whereIn('game_player_id', function ($q) use ($gameId) {
+                $q->select('id')->from('game_players')->where('game_id', $gameId);
+            })
+            ->update($values);
+
+        static::legacyEloquentWrite(
+            GamePlayer::where('game_id', $gameId),
+            $values
+        );
+    }
+
+    /**
+     * Set injury fields for a single player.
+     */
+    public static function setInjury(string $gamePlayerId, string $injuryType, string $injuryUntil): void
+    {
+        $values = [
+            'injury_type' => $injuryType,
+            'injury_until' => $injuryUntil,
+        ];
+
+        static::where('game_player_id', $gamePlayerId)->update($values);
+        static::legacyEloquentWrite(
+            GamePlayer::where('id', $gamePlayerId), $values
+        );
+    }
+
+    /**
+     * Batch-set injuries for multiple players in a single query.
+     *
+     * @param  array<array{playerId: string, injuryType: string, injuryUntil: \Carbon\Carbon}>  $injuries
+     */
+    public static function bulkSetInjuries(array $injuries): void
+    {
+        if (empty($injuries)) {
+            return;
+        }
+
+        $typeCases = [];
+        $untilCases = [];
+        $ids = [];
+        foreach ($injuries as $injury) {
+            $id = $injury['playerId'];
+            $type = str_replace("'", "''", $injury['injuryType']);
+            $until = $injury['injuryUntil']->toDateString();
+            $ids[] = "'{$id}'";
+            $typeCases[] = "WHEN game_player_id = '{$id}' THEN '{$type}'";
+            $untilCases[] = "WHEN game_player_id = '{$id}' THEN '{$until}'::date";
+        }
+
+        $idList = implode(',', $ids);
+        DB::statement(
+            'UPDATE game_player_match_state SET injury_type = CASE ' . implode(' ', $typeCases) . ' END, '
+            . 'injury_until = CASE ' . implode(' ', $untilCases) . ' END '
+            . "WHERE game_player_id IN ({$idList})"
+        );
+
+        $legacyTypeCases = str_replace('game_player_id', 'id', implode(' ', $typeCases));
+        $legacyUntilCases = str_replace('game_player_id', 'id', implode(' ', $untilCases));
+        static::legacyWrite(
+            "UPDATE game_players SET injury_type = CASE {$legacyTypeCases} END, injury_until = CASE {$legacyUntilCases} END WHERE id IN ({$idList})"
+        );
+    }
+
+    /**
+     * Clear injury fields for a single player.
+     */
+    public static function clearInjury(string $gamePlayerId): void
+    {
+        $values = ['injury_type' => null, 'injury_until' => null];
+
+        static::where('game_player_id', $gamePlayerId)->update($values);
+        static::legacyEloquentWrite(
+            GamePlayer::where('id', $gamePlayerId), $values
+        );
+    }
+
+    /**
+     * Decrement appearances for the given player IDs (used during resimulation).
+     *
+     * @param  string[]  $playerIds
+     */
+    public static function bulkDecrementAppearances(array $playerIds): void
+    {
+        if (empty($playerIds)) {
+            return;
+        }
+
+        $values = [
+            'appearances' => DB::raw('GREATEST(appearances - 1, 0)'),
+            'season_appearances' => DB::raw('GREATEST(season_appearances - 1, 0)'),
+        ];
+
+        static::whereIn('game_player_id', $playerIds)
+            ->where('appearances', '>', 0)
+            ->update($values);
+
+        static::legacyEloquentWrite(
+            GamePlayer::whereIn('id', $playerIds)->where('appearances', '>', 0),
+            $values
+        );
+    }
+}

--- a/app/Models/GamePlayerMatchState.php
+++ b/app/Models/GamePlayerMatchState.php
@@ -191,7 +191,17 @@ class GamePlayerMatchState extends Model
         }, $rows);
 
         foreach (array_chunk($prepared, 500) as $chunk) {
-            static::insertOrIgnore($chunk);
+            // Filter to only game_player_ids that actually exist, to avoid
+            // FK violations when a parent insert was partially skipped.
+            $candidateIds = array_column($chunk, 'game_player_id');
+            $existingIds = GamePlayer::whereIn('id', $candidateIds)->pluck('id')->all();
+            $existingSet = array_flip($existingIds);
+
+            $validChunk = array_filter($chunk, fn ($row) => isset($existingSet[$row['game_player_id']]));
+
+            if (! empty($validChunk)) {
+                static::insertOrIgnore(array_values($validChunk));
+            }
         }
     }
 

--- a/app/Modules/Competition/Services/CompetitionViewService.php
+++ b/app/Modules/Competition/Services/CompetitionViewService.php
@@ -88,7 +88,7 @@ class CompetitionViewService
             return collect();
         }
 
-        $players = GamePlayer::with('player')
+        $players = GamePlayer::with(['player', 'matchState'])
             ->whereIn('id', $scorerRows->pluck('game_player_id')->unique())
             ->get()
             ->keyBy('id');

--- a/app/Modules/Finance/Services/BudgetProjectionService.php
+++ b/app/Modules/Finance/Services/BudgetProjectionService.php
@@ -136,6 +136,9 @@ class BudgetProjectionService
             ->where(fn ($q) => $q->whereNull('game_technical_ability')->orWhereNull('game_physical_ability'))
             ->exists();
 
+        // matchState is needed by calculateStrengthFromPlayers — pool players
+        // (no satellite) fall back to default fitness/morale via the accessor.
+        $query->with('matchState');
         if ($needsPlayerRelation) {
             $query->with('player');
         }
@@ -162,7 +165,7 @@ class BudgetProjectionService
     {
         $players = GamePlayer::where('game_id', $game->id)
             ->where('team_id', $team->id)
-            ->with('player')
+            ->with(['player', 'matchState'])
             ->get();
 
         return $this->calculateStrengthFromPlayers($players);

--- a/app/Modules/Finance/Services/BudgetProjectionService.php
+++ b/app/Modules/Finance/Services/BudgetProjectionService.php
@@ -5,7 +5,6 @@ namespace App\Modules\Finance\Services;
 use App\Models\BudgetLoan;
 use App\Models\ClubProfile;
 use App\Models\Competition;
-use App\Models\CompetitionEntry;
 use App\Models\FinancialTransaction;
 use App\Models\Game;
 use App\Models\GameFinances;
@@ -13,10 +12,14 @@ use App\Models\GameInvestment;
 use App\Models\GamePlayer;
 use App\Models\Team;
 use App\Models\TeamReputation;
+use App\Modules\Squad\Services\SquadService;
 use Carbon\Carbon;
 
 class BudgetProjectionService
 {
+    public function __construct(
+        private readonly SquadService $squadService,
+    ) {}
     /**
      * UEFA and RFEF solidarity funds (€250K)
      */
@@ -44,10 +47,10 @@ class BudgetProjectionService
         $league = $game->competition;
 
         // Calculate squad strengths for all teams in the league
-        $teamStrengths = $this->calculateLeagueStrengths($game, $league);
+        $teamStrengths = $this->squadService->calculateLeagueStrengths($game, $league);
 
         // Get user's projected position
-        $projectedPosition = $this->getProjectedPosition($team->id, $teamStrengths);
+        $projectedPosition = $this->squadService->getProjectedPosition($team->id, $teamStrengths);
 
         // Calculate projected revenues
         $projectedTvRevenue = $this->calculateTvRevenue($projectedPosition, $league);
@@ -110,105 +113,6 @@ class BudgetProjectionService
         );
 
         return $finances;
-    }
-
-    /**
-     * Calculate squad strengths for all teams in a league.
-     * Returns array of [team_id => strength] sorted by strength descending.
-     *
-     * Loads all players across all teams in one query to avoid N+1.
-     */
-    public function calculateLeagueStrengths(Game $game, Competition $league): array
-    {
-        $teamIds = CompetitionEntry::where('game_id', $game->id)
-            ->where('competition_id', $league->id)
-            ->pluck('team_id')
-            ->toArray();
-
-        $teams = Team::whereIn('id', $teamIds)->get();
-
-        // Only eager-load player relation when game abilities are null (mid-season fallback)
-        $query = GamePlayer::where('game_id', $game->id)
-            ->whereIn('team_id', $teamIds);
-
-        $needsPlayerRelation = GamePlayer::where('game_id', $game->id)
-            ->whereIn('team_id', $teamIds)
-            ->where(fn ($q) => $q->whereNull('game_technical_ability')->orWhereNull('game_physical_ability'))
-            ->exists();
-
-        // matchState is needed by calculateStrengthFromPlayers — pool players
-        // (no satellite) fall back to default fitness/morale via the accessor.
-        $query->with('matchState');
-        if ($needsPlayerRelation) {
-            $query->with('player');
-        }
-
-        $playersByTeam = $query->get()->groupBy('team_id');
-
-        $strengths = [];
-        foreach ($teams as $team) {
-            $teamPlayers = $playersByTeam->get($team->id, collect());
-            $strengths[$team->id] = $this->calculateStrengthFromPlayers($teamPlayers);
-        }
-
-        // Sort by strength descending
-        arsort($strengths);
-
-        return $strengths;
-    }
-
-    /**
-     * Calculate squad strength for a team.
-     * Uses average OVR of best 18 players.
-     */
-    public function calculateSquadStrength(Game $game, Team $team): float
-    {
-        $players = GamePlayer::where('game_id', $game->id)
-            ->where('team_id', $team->id)
-            ->with(['player', 'matchState'])
-            ->get();
-
-        return $this->calculateStrengthFromPlayers($players);
-    }
-
-    /**
-     * Calculate strength from a pre-loaded collection of players.
-     * Uses average OVR of best 18 players.
-     */
-    private function calculateStrengthFromPlayers($players): float
-    {
-        $scores = $players->map(function ($player) {
-                $technical = $player->game_technical_ability ?? $player->player?->technical_ability ?? 50;
-                $physical = $player->game_physical_ability ?? $player->player?->physical_ability ?? 50;
-                $fitness = $player->fitness ?? 70;
-                $morale = $player->morale ?? 70;
-
-                return ($technical + $physical + $fitness + $morale) / 4;
-            })
-            ->sortDesc()
-            ->take(18);
-
-        if ($scores->isEmpty()) {
-            return 0;
-        }
-
-        return round($scores->avg(), 1);
-    }
-
-    /**
-     * Get projected position for a team based on strength rankings.
-     */
-    public function getProjectedPosition(string $teamId, array $teamStrengths): int
-    {
-        $position = 1;
-        foreach ($teamStrengths as $id => $strength) {
-            if ($id === $teamId) {
-                return $position;
-            }
-            $position++;
-        }
-
-        return $position; // Fallback to last position
     }
 
     /**

--- a/app/Modules/Lineup/Services/LineupService.php
+++ b/app/Modules/Lineup/Services/LineupService.php
@@ -33,7 +33,7 @@ class LineupService
      */
     public function getAvailablePlayers(string $gameId, string $teamId, Carbon $matchDate, string $competitionId, bool $requireEnrollment = false): Collection
     {
-        $players = GamePlayer::with('player')
+        $players = GamePlayer::with(['player', 'matchState'])
             ->where('game_id', $gameId)
             ->where('team_id', $teamId)
             ->get();
@@ -64,7 +64,7 @@ class LineupService
      */
     public function getAllPlayers(string $gameId, string $teamId): Collection
     {
-        return GamePlayer::with(['player', 'suspensions', 'transferOffers', 'activeLoan'])
+        return GamePlayer::with(['player', 'matchState', 'suspensions', 'transferOffers', 'activeLoan'])
             ->where('game_id', $gameId)
             ->where('team_id', $teamId)
             ->get();
@@ -555,7 +555,7 @@ class LineupService
             return collect();
         }
 
-        return GamePlayer::with('player')
+        return GamePlayer::with(['player', 'matchState'])
             ->where('game_id', $gameId)
             ->where('team_id', $teamId)
             ->whereIn('id', $playerIds)
@@ -845,7 +845,7 @@ class LineupService
             $availableIds = $availablePlayers->pluck('id')->toArray();
             $allTeamPlayers = $allPlayersGrouped !== null
                 ? $allPlayersGrouped->get($teamId, collect())
-                : GamePlayer::with('player')->where('game_id', $game->id)->where('team_id', $teamId)->get();
+                : GamePlayer::with(['player', 'matchState'])->where('game_id', $game->id)->where('team_id', $teamId)->get();
             $lineup = $this->selectLineupWithPreferencesFromCollection(
                 $availablePlayers,
                 $allTeamPlayers,

--- a/app/Modules/Lineup/Services/SubstitutionService.php
+++ b/app/Modules/Lineup/Services/SubstitutionService.php
@@ -157,7 +157,7 @@ class SubstitutionService
             $lineupIds[] = $sub['playerInId'];
         }
 
-        return GamePlayer::with('player')->whereIn('id', $lineupIds)->get();
+        return GamePlayer::with(['player', 'matchState'])->whereIn('id', $lineupIds)->get();
     }
 
     /**
@@ -179,7 +179,7 @@ class SubstitutionService
 
         // Load opponent full squad (1 query) to derive both lineup and bench
         $opponentTeamId = $isUserHome ? $match->away_team_id : $match->home_team_id;
-        $opponentSquad = GamePlayer::with('player')
+        $opponentSquad = GamePlayer::with(['player', 'matchState'])
             ->where('game_id', $game->id)
             ->where('team_id', $opponentTeamId)
             ->get();
@@ -233,7 +233,7 @@ class SubstitutionService
         // User bench: squad minus active lineup minus subbed-out players minus injured/suspended
         $activeLineupIds = $userLineup->pluck('id')->all();
         $subbedOutIds = array_column($substitutions, 'playerOutId');
-        $userSquad = GamePlayer::with('player')
+        $userSquad = GamePlayer::with(['player', 'matchState'])
             ->where('game_id', $game->id)
             ->where('team_id', $game->team_id)
             ->get();

--- a/app/Modules/Lineup/Services/TacticalChangeService.php
+++ b/app/Modules/Lineup/Services/TacticalChangeService.php
@@ -5,9 +5,9 @@ namespace App\Modules\Lineup\Services;
 use App\Models\Game;
 use App\Models\GameMatch;
 use App\Models\GamePlayer;
+use App\Models\GamePlayerMatchState;
 use App\Models\MatchEvent;
 use App\Modules\Lineup\Enums\Formation;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 use App\Modules\Match\Services\ExtraTimeAndPenaltyService;
 use App\Modules\Match\Services\MatchResimulationService;
@@ -200,12 +200,11 @@ class TacticalChangeService
                 $playerIds[] = $sub['playerInId'];
             }
 
-            // Batch: increment appearances, insert events
+            // Batch: increment appearances on the match-state satellite
+            // (subbed-in players belong to the user's team, so they always
+            // have a satellite row), insert events.
             $playerInIds = array_column($newSubstitutions, 'playerInId');
-            GamePlayer::whereIn('id', $playerInIds)->update([
-                'appearances' => DB::raw('appearances + 1'),
-                'season_appearances' => DB::raw('season_appearances + 1'),
-            ]);
+            GamePlayerMatchState::bulkIncrementAppearances($playerInIds);
             MatchEvent::insert($eventRows);
 
             // Load player names for response

--- a/app/Modules/Match/Listeners/UpdateGoalkeeperStats.php
+++ b/app/Modules/Match/Listeners/UpdateGoalkeeperStats.php
@@ -4,7 +4,7 @@ namespace App\Modules\Match\Listeners;
 
 use App\Modules\Match\Events\MatchFinalized;
 use App\Models\GamePlayer;
-use Illuminate\Support\Facades\DB;
+use App\Models\GamePlayerMatchState;
 
 class UpdateGoalkeeperStats
 {
@@ -47,24 +47,6 @@ class UpdateGoalkeeperStats
             return;
         }
 
-        $ids = array_keys($increments);
-        $idList = "'" . implode("','", $ids) . "'";
-        $setClauses = [];
-
-        foreach (['goals_conceded', 'clean_sheets'] as $column) {
-            $cases = [];
-            foreach ($increments as $gkId => $values) {
-                if ($values[$column] !== 0) {
-                    $cases[] = "WHEN id = '{$gkId}' THEN {$column} + {$values[$column]}";
-                }
-            }
-            if (! empty($cases)) {
-                $setClauses[] = "{$column} = CASE " . implode(' ', $cases) . " ELSE {$column} END";
-            }
-        }
-
-        if (! empty($setClauses)) {
-            DB::statement('UPDATE game_players SET ' . implode(', ', $setClauses) . " WHERE id IN ({$idList})");
-        }
+        GamePlayerMatchState::bulkIncrementStats($increments);
     }
 }

--- a/app/Modules/Match/Services/ExtraTimeAndPenaltyService.php
+++ b/app/Modules/Match/Services/ExtraTimeAndPenaltyService.php
@@ -144,7 +144,7 @@ class ExtraTimeAndPenaltyService
         $awayIds = array_values(array_filter($awayIds, fn ($id) => ! in_array($id, $redCardedIds)));
 
         $allIds = array_merge($homeIds, $awayIds);
-        $players = GamePlayer::with('player')->whereIn('id', $allIds)->get()->keyBy('id');
+        $players = GamePlayer::with(['player', 'matchState'])->whereIn('id', $allIds)->get()->keyBy('id');
 
         return [
             $players->only($homeIds)->values(),

--- a/app/Modules/Match/Services/MatchFinalizationService.php
+++ b/app/Modules/Match/Services/MatchFinalizationService.php
@@ -133,7 +133,7 @@ class MatchFinalizationService
     private function updateConditionsForDeferredMatch(GameMatch $match): void
     {
         $teamIds = [$match->home_team_id, $match->away_team_id];
-        $players = GamePlayer::with('player')
+        $players = GamePlayer::with(['player', 'matchState'])
             ->where('game_id', $match->game_id)
             ->whereIn('team_id', $teamIds)
             ->get();
@@ -192,7 +192,7 @@ class MatchFinalizationService
 
         // Build players collection for extra time / penalty simulation
         $allLineupIds = array_merge($match->home_lineup ?? [], $match->away_lineup ?? []);
-        $players = GamePlayer::with('player')->whereIn('id', $allLineupIds)->get();
+        $players = GamePlayer::with(['player', 'matchState'])->whereIn('id', $allLineupIds)->get();
         $allPlayers = collect([
             $match->home_team_id => $players->filter(fn ($p) => $p->team_id === $match->home_team_id),
             $match->away_team_id => $players->filter(fn ($p) => $p->team_id === $match->away_team_id),

--- a/app/Modules/Match/Services/MatchNarrativeService.php
+++ b/app/Modules/Match/Services/MatchNarrativeService.php
@@ -409,17 +409,19 @@ class MatchNarrativeService
     {
         $candidates = [];
 
-        $stats = GamePlayer::where('game_id', $game->id)
-            ->where('team_id', $game->team_id)
-            ->selectRaw('AVG(morale) as avg_morale, AVG(fitness) as avg_fitness')
+        $stats = GamePlayer::joinMatchState()
+            ->where('game_players.game_id', $game->id)
+            ->where('game_players.team_id', $game->team_id)
+            ->selectRaw('AVG(game_player_match_state.morale) as avg_morale, AVG(game_player_match_state.fitness) as avg_fitness')
             ->first();
 
         $avgMorale = (int) round($stats->avg_morale ?? 50);
         $avgFitness = (int) round($stats->avg_fitness ?? 50);
 
-        $injuryCount = GamePlayer::where('game_id', $game->id)
-            ->where('team_id', $game->team_id)
-            ->where('injury_until', '>', $game->current_date)
+        $injuryCount = GamePlayer::joinMatchState()
+            ->where('game_players.game_id', $game->id)
+            ->where('game_players.team_id', $game->team_id)
+            ->whereMatchStat('injury_until', '>', $game->current_date)
             ->count();
 
         if ($injuryCount >= 4) {

--- a/app/Modules/Match/Services/MatchNarrativeService.php
+++ b/app/Modules/Match/Services/MatchNarrativeService.php
@@ -409,7 +409,8 @@ class MatchNarrativeService
     {
         $candidates = [];
 
-        $stats = GamePlayer::joinMatchState()
+        $stats = GamePlayer::query()
+            ->join('game_player_match_state', 'game_players.id', '=', 'game_player_match_state.game_player_id')
             ->where('game_players.game_id', $game->id)
             ->where('game_players.team_id', $game->team_id)
             ->selectRaw('AVG(game_player_match_state.morale) as avg_morale, AVG(game_player_match_state.fitness) as avg_fitness')
@@ -418,10 +419,11 @@ class MatchNarrativeService
         $avgMorale = (int) round($stats->avg_morale ?? 50);
         $avgFitness = (int) round($stats->avg_fitness ?? 50);
 
-        $injuryCount = GamePlayer::joinMatchState()
+        $injuryCount = GamePlayer::query()
+            ->join('game_player_match_state', 'game_players.id', '=', 'game_player_match_state.game_player_id')
             ->where('game_players.game_id', $game->id)
             ->where('game_players.team_id', $game->team_id)
-            ->whereMatchStat('injury_until', '>', $game->current_date)
+            ->where('game_player_match_state.injury_until', '>', $game->current_date)
             ->count();
 
         if ($injuryCount >= 4) {

--- a/app/Modules/Match/Services/MatchResimulationService.php
+++ b/app/Modules/Match/Services/MatchResimulationService.php
@@ -9,6 +9,7 @@ use App\Modules\Match\DTOs\TacticalConfig;
 use App\Models\Game;
 use App\Models\GameMatch;
 use App\Models\GamePlayer;
+use App\Models\GamePlayerMatchState;
 use App\Models\MatchEvent;
 use App\Models\PlayerSuspension;
 use Carbon\Carbon;
@@ -556,8 +557,7 @@ class MatchResimulationService
             }
 
             if ($event->event_type === 'injury') {
-                GamePlayer::where('id', $event->game_player_id)
-                    ->update(['injury_type' => null, 'injury_until' => null]);
+                GamePlayerMatchState::clearInjury($event->game_player_id);
             }
         }
 
@@ -570,14 +570,7 @@ class MatchResimulationService
             ->all();
 
         if (! empty($subbedInPlayerIds)) {
-            $clamp = ['GREATEST(appearances - 1, 0)', 'GREATEST(season_appearances - 1, 0)'];
-
-            GamePlayer::whereIn('id', $subbedInPlayerIds)
-                ->where('appearances', '>', 0)
-                ->update([
-                    'appearances' => DB::raw($clamp[0]),
-                    'season_appearances' => DB::raw($clamp[1]),
-                ]);
+            GamePlayerMatchState::bulkDecrementAppearances($subbedInPlayerIds);
         }
 
         // Delete the events
@@ -624,17 +617,22 @@ class MatchResimulationService
             }
         }
 
-        // Update each affected player — set stats to counted values (0 if no events remain)
-        $players = GamePlayer::whereIn('id', $playerIds)->get();
-        foreach ($players as $player) {
-            $counts = $statsMap[$player->id] ?? [];
-            $player->goals = $counts['goals'] ?? 0;
-            $player->own_goals = $counts['own_goals'] ?? 0;
-            $player->assists = $counts['assists'] ?? 0;
-            $player->yellow_cards = $counts['yellow_cards'] ?? 0;
-            $player->red_cards = $counts['red_cards'] ?? 0;
-            $player->save();
+        // Set stats to counted values (0 if no events remain). Only
+        // resimulated matches involve active-team lineups, so the
+        // satellite row is guaranteed to exist.
+        $updates = [];
+        foreach ($playerIds as $playerId) {
+            $counts = $statsMap[$playerId] ?? [];
+            $updates[$playerId] = [
+                'goals' => $counts['goals'] ?? 0,
+                'own_goals' => $counts['own_goals'] ?? 0,
+                'assists' => $counts['assists'] ?? 0,
+                'yellow_cards' => $counts['yellow_cards'] ?? 0,
+                'red_cards' => $counts['red_cards'] ?? 0,
+            ];
         }
+
+        GamePlayerMatchState::bulkSetValues($updates);
     }
 
     /**
@@ -729,18 +727,11 @@ class MatchResimulationService
         ));
         $players = GamePlayer::whereIn('id', $allPlayerIds)->get()->keyBy('id');
 
-        // Apply stat increments
-        foreach ($statIncrements as $playerId => $increments) {
-            $player = $players->get($playerId);
-            if (! $player) {
-                continue;
-            }
-
-            foreach ($increments as $column => $amount) {
-                $player->{$column} += $amount;
-            }
-            $player->save();
-        }
+        // Apply stat increments (small dataset — typically ≤5 event-producing
+        // players per re-simulation). Filter to players that actually exist.
+        $validIncrements = array_intersect_key($statIncrements, $players->all());
+        $validIncrements = array_filter($validIncrements, fn ($inc) => ! empty($inc));
+        GamePlayerMatchState::bulkIncrementStats($validIncrements);
 
         // Process special events
         // Skip card suspensions for pre-season matches (cards are recorded but don't carry over)

--- a/app/Modules/Match/Services/MatchResultProcessor.php
+++ b/app/Modules/Match/Services/MatchResultProcessor.php
@@ -6,6 +6,7 @@ use App\Models\Competition;
 use App\Models\Game;
 use App\Models\GameMatch;
 use App\Models\GamePlayer;
+use App\Models\GamePlayerMatchState;
 use App\Models\MatchEvent;
 use App\Models\PlayerSuspension;
 use Carbon\Carbon;
@@ -366,19 +367,11 @@ class MatchResultProcessor
             ? $allPlayers->flatten()->keyBy('id')->only($allPlayerIds)
             : GamePlayer::whereIn('id', $allPlayerIds)->get()->keyBy('id');
 
-        // Apply stat increments in memory (for special events processing below)
-        foreach ($statIncrements as $playerId => $increments) {
-            $player = $players->get($playerId);
-            if (! $player) {
-                continue;
-            }
-
-            foreach ($increments as $column => $amount) {
-                $player->{$column} += $amount;
-            }
-        }
-
-        // Bulk update all stat increments in a single query
+        // Bulk update all stat increments in a single query.
+        // (We used to mirror the increments onto the in-memory $player models
+        // here, but nothing downstream in this method reads them — the
+        // following card/injury processing only touches PlayerSuspension and
+        // batchApplyInjuries, which both query their own state.)
         $this->bulkUpdatePlayerStats($statIncrements);
 
         // Separate card events from injury events
@@ -475,38 +468,7 @@ class MatchResultProcessor
      */
     private function bulkUpdatePlayerStats(array $statIncrements): void
     {
-        if (empty($statIncrements)) {
-            return;
-        }
-
-        // Collect all columns that need updating
-        $columns = [];
-        foreach ($statIncrements as $increments) {
-            foreach (array_keys($increments) as $col) {
-                $columns[$col] = true;
-            }
-        }
-
-        $ids = array_keys($statIncrements);
-        $idList = "'" . implode("','", $ids) . "'";
-
-        $setClauses = [];
-        foreach (array_keys($columns) as $column) {
-            $cases = [];
-            foreach ($statIncrements as $playerId => $increments) {
-                $amount = $increments[$column] ?? 0;
-                if ($amount !== 0) {
-                    $cases[] = "WHEN id = '{$playerId}' THEN {$column} + {$amount}";
-                }
-            }
-            if (! empty($cases)) {
-                $setClauses[] = "{$column} = CASE " . implode(' ', $cases) . " ELSE {$column} END";
-            }
-        }
-
-        if (! empty($setClauses)) {
-            DB::statement("UPDATE game_players SET " . implode(', ', $setClauses) . " WHERE id IN ({$idList})");
-        }
+        GamePlayerMatchState::bulkIncrementStats($statIncrements);
     }
 
     /**
@@ -530,12 +492,7 @@ class MatchResultProcessor
 
         $allLineupIds = array_unique($allLineupIds);
 
-        if (! empty($allLineupIds)) {
-            GamePlayer::whereIn('id', $allLineupIds)->update([
-                'appearances' => DB::raw('appearances + 1'),
-                'season_appearances' => DB::raw('season_appearances + 1'),
-            ]);
-        }
+        GamePlayerMatchState::bulkIncrementAppearances($allLineupIds);
     }
 
     /**
@@ -704,25 +661,6 @@ class MatchResultProcessor
             return;
         }
 
-        // Bulk update using CASE WHEN
-        $ids = array_keys($increments);
-        $idList = "'" . implode("','", $ids) . "'";
-        $setClauses = [];
-
-        foreach (['goals_conceded', 'clean_sheets'] as $column) {
-            $cases = [];
-            foreach ($increments as $gkId => $values) {
-                if ($values[$column] !== 0) {
-                    $cases[] = "WHEN id = '{$gkId}' THEN {$column} + {$values[$column]}";
-                }
-            }
-            if (! empty($cases)) {
-                $setClauses[] = "{$column} = CASE " . implode(' ', $cases) . " ELSE {$column} END";
-            }
-        }
-
-        if (! empty($setClauses)) {
-            DB::statement('UPDATE game_players SET ' . implode(', ', $setClauses) . " WHERE id IN ({$idList})");
-        }
+        GamePlayerMatchState::bulkIncrementStats($increments);
     }
 }

--- a/app/Modules/Match/Services/MatchdayOrchestrator.php
+++ b/app/Modules/Match/Services/MatchdayOrchestrator.php
@@ -155,15 +155,13 @@ class MatchdayOrchestrator
 
         $allPlayers = GamePlayer::select([
                 'id', 'game_id', 'player_id', 'team_id', 'number', 'position',
-                'fitness', 'morale', 'durability',
+                'durability',
                 'game_technical_ability', 'game_physical_ability',
-                'injury_until', 'injury_type',
-                'appearances', 'goals', 'own_goals', 'assists',
-                'yellow_cards', 'red_cards',
-                'goals_conceded', 'clean_sheets',
-                'season_appearances',
             ])
-            ->with(['player:id,name,date_of_birth,technical_ability,physical_ability'])
+            ->with([
+                'player:id,name,date_of_birth,technical_ability,physical_ability',
+                'matchState',
+            ])
             ->where('game_id', $game->id)
             ->whereIn('team_id', $teamIds)
             ->get();

--- a/app/Modules/Match/Services/MatchdayOrchestrator.php
+++ b/app/Modules/Match/Services/MatchdayOrchestrator.php
@@ -15,6 +15,7 @@ use App\Models\Game;
 use App\Models\GameMatch;
 use App\Models\GameNotification;
 use App\Models\GamePlayer;
+use App\Models\GamePlayerMatchState;
 use App\Models\GameStanding;
 use App\Models\PlayerSuspension;
 use Carbon\Carbon;
@@ -170,6 +171,20 @@ class MatchdayOrchestrator
         // (avoids ~220 queries from the age accessor)
         foreach ($allPlayers as $player) {
             $player->setRelation('game', $game);
+        }
+
+        // Ensure all players in this batch have a satellite row before
+        // simulation. Players from the foreign transfer pool (or recently
+        // transferred) may lack one. This is the single guarantee point —
+        // no other code needs to defensively create satellite rows.
+        GamePlayerMatchState::ensureExistForGamePlayers($game->id, $teamIds->all());
+
+        // Re-load matchState for any rows just created (players whose
+        // relation was null will now have a row).
+        foreach ($allPlayers as $player) {
+            if (! $player->relationLoaded('matchState') || $player->matchState === null) {
+                $player->load('matchState');
+            }
         }
 
         $allPlayers = $allPlayers->groupBy('team_id');

--- a/app/Modules/Player/Services/PlayerConditionService.php
+++ b/app/Modules/Player/Services/PlayerConditionService.php
@@ -3,10 +3,10 @@
 namespace App\Modules\Player\Services;
 
 use App\Models\GamePlayer;
+use App\Models\GamePlayerMatchState;
 use App\Modules\Match\Services\EnergyCalculator;
 use App\Modules\Player\PlayerAge;
 use Carbon\Carbon;
-use Illuminate\Support\Facades\DB;
 
 class PlayerConditionService
 {
@@ -98,27 +98,7 @@ class PlayerConditionService
      */
     private function bulkUpdateConditions(array $updates): void
     {
-        if (empty($updates)) {
-            return;
-        }
-
-        $ids = array_keys($updates);
-        $fitnessCases = [];
-        $moraleCases = [];
-
-        foreach ($updates as $id => $values) {
-            $fitnessCases[] = "WHEN id = '{$id}' THEN {$values['fitness']}";
-            $moraleCases[] = "WHEN id = '{$id}' THEN {$values['morale']}";
-        }
-
-        $idList = "'" . implode("','", $ids) . "'";
-
-        DB::statement("
-            UPDATE game_players
-            SET fitness = CASE " . implode(' ', $fitnessCases) . " END,
-                morale = CASE " . implode(' ', $moraleCases) . " END
-            WHERE id IN ({$idList})
-        ");
+        GamePlayerMatchState::bulkSetValues($updates);
     }
 
     /**

--- a/app/Modules/Player/Services/PlayerDevelopmentService.php
+++ b/app/Modules/Player/Services/PlayerDevelopmentService.php
@@ -3,6 +3,7 @@
 namespace App\Modules\Player\Services;
 
 use App\Models\GamePlayer;
+use App\Models\GamePlayerMatchState;
 use App\Modules\Player\PlayerAge;
 use App\Modules\Player\Services\DevelopmentCurve;
 
@@ -318,14 +319,21 @@ class PlayerDevelopmentService
 
     /**
      * Apply development changes to a player.
+     *
+     * Splits the write between game_players (ability columns) and the
+     * match-state satellite (season_appearances reset). Active-team players
+     * always have a satellite row by the time development runs; the silent
+     * no-op for missing rows is correct because pool players never accrue
+     * appearances anyway.
      */
     public function applyDevelopment(GamePlayer $player, int $newTech, int $newPhys): void
     {
         $player->update([
             'game_technical_ability' => $newTech,
             'game_physical_ability' => $newPhys,
-            'season_appearances' => 0, // Reset for new season
         ]);
+
+        GamePlayerMatchState::bulkSetValues([$player->id => ['season_appearances' => 0]]);
     }
 
     /**

--- a/app/Modules/Player/Support/GamePlayerScopeResolver.php
+++ b/app/Modules/Player/Support/GamePlayerScopeResolver.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace App\Modules\Player\Support;
+
+use App\Models\Competition;
+use App\Models\Game;
+use App\Models\Team;
+
+/**
+ * Single source of truth for the "active" team / player scope.
+ *
+ * A player is considered active (and therefore needs a
+ * {@see \App\Models\GamePlayerMatchState} satellite row) iff their team
+ * belongs to a competition in the game's country — i.e. the user's
+ * domestic pyramid (La Liga, Segunda, Copa del Rey for an ES game).
+ *
+ * Foreign-league teams (ENG1, DEU1, FRA1, ITA1, EUR pool) are out of scope:
+ * their players exist purely to populate the international transfer market
+ * and never participate in simulated matches. They get folded back into
+ * scope on demand by {@see \App\Modules\Season\Processors\ContinentalAndCupInitProcessor}
+ * when the user qualifies for a European competition that draws them.
+ *
+ * Mirrors the classification used by
+ * {@see \App\Modules\Transfer\Services\ScoutSearchQueryBuilder::applyScopeFilter()}.
+ */
+class GamePlayerScopeResolver
+{
+    /** @var array<string, string[]> Cached active team ids keyed by game id */
+    private array $cache = [];
+
+    /**
+     * Return the set of team ids that are "active" for the given game.
+     *
+     * @return string[]
+     */
+    public function activeTeamIdsForGame(Game $game): array
+    {
+        if (isset($this->cache[$game->id])) {
+            return $this->cache[$game->id];
+        }
+
+        return $this->cache[$game->id] = $this->resolve($game->country);
+    }
+
+    /**
+     * Variant that takes a country code directly. Useful at game-creation
+     * time before the Game model is fully hydrated.
+     *
+     * @return string[]
+     */
+    public function activeTeamIdsForCountry(string $country): array
+    {
+        return $this->resolve($country);
+    }
+
+    /**
+     * Forget any cached lookups for a game (e.g. after a transfer changes
+     * the active team set).
+     */
+    public function forget(string $gameId): void
+    {
+        unset($this->cache[$gameId]);
+    }
+
+    /**
+     * @return string[]
+     */
+    private function resolve(string $country): array
+    {
+        $competitionIds = Competition::where('country', $country)->pluck('id');
+
+        return Team::transferMarketEligible()
+            ->whereHas('competitions', fn ($q) => $q->whereIn('competitions.id', $competitionIds))
+            ->pluck('id')
+            ->all();
+    }
+}

--- a/app/Modules/Report/Services/AwardService.php
+++ b/app/Modules/Report/Services/AwardService.php
@@ -13,13 +13,14 @@ class AwardService
      */
     public function getTopScorers(string $gameId, Collection|array|null $teamIds = null, int $limit = 5): Collection
     {
-        return GamePlayer::with(['player', 'team'])
+        return GamePlayer::with(['player', 'team', 'matchState'])
+            ->joinMatchState()
             ->where('game_id', $gameId)
             ->when($teamIds, fn ($q) => $q->whereIn('team_id', $teamIds))
-            ->where('goals', '>', 0)
-            ->orderByDesc('goals')
-            ->orderByDesc('assists')
-            ->orderBy('appearances')
+            ->whereMatchStat('goals', '>', 0)
+            ->orderByMatchStat('goals')
+            ->orderByMatchStat('assists')
+            ->orderByMatchStat('appearances', 'asc')
             ->limit($limit)
             ->get();
     }
@@ -29,12 +30,13 @@ class AwardService
      */
     public function getTopAssisters(string $gameId, Collection|array|null $teamIds = null, int $limit = 5): Collection
     {
-        return GamePlayer::with(['player', 'team'])
+        return GamePlayer::with(['player', 'team', 'matchState'])
+            ->joinMatchState()
             ->where('game_id', $gameId)
             ->when($teamIds, fn ($q) => $q->whereIn('team_id', $teamIds))
-            ->where('assists', '>', 0)
-            ->orderByDesc('assists')
-            ->orderByDesc('goals')
+            ->whereMatchStat('assists', '>', 0)
+            ->orderByMatchStat('assists')
+            ->orderByMatchStat('goals')
             ->limit($limit)
             ->get();
     }
@@ -44,11 +46,12 @@ class AwardService
      */
     public function getTopGoalkeepers(string $gameId, Collection|array|null $teamIds = null, int $minAppearances = 3, int $limit = 5): Collection
     {
-        return GamePlayer::with(['player', 'team'])
+        return GamePlayer::with(['player', 'team', 'matchState'])
+            ->joinMatchState()
             ->where('game_id', $gameId)
             ->when($teamIds, fn ($q) => $q->whereIn('team_id', $teamIds))
             ->where('position', 'Goalkeeper')
-            ->where('appearances', '>=', $minAppearances)
+            ->whereMatchStat('appearances', '>=', $minAppearances)
             ->get()
             ->sortBy([
                 ['clean_sheets', 'desc'],
@@ -71,7 +74,7 @@ class AwardService
             return [collect(), null, $mvpCounts];
         }
 
-        $players = GamePlayer::with(['player', 'team'])
+        $players = GamePlayer::with(['player', 'team', 'matchState'])
             ->whereIn('id', $mvpCounts->keys()->all())
             ->get()
             ->keyBy('id');
@@ -96,10 +99,11 @@ class AwardService
      */
     public function getTeamSquadStats(string $gameId, string $teamId): Collection
     {
-        return GamePlayer::with('player')
+        return GamePlayer::with(['player', 'matchState'])
+            ->leftJoinMatchState()
             ->where('game_id', $gameId)
             ->where('team_id', $teamId)
-            ->orderByDesc('appearances')
+            ->orderByMatchStat('appearances')
             ->get();
     }
 }

--- a/app/Modules/Report/Services/SeasonSummaryService.php
+++ b/app/Modules/Report/Services/SeasonSummaryService.php
@@ -67,8 +67,10 @@ class SeasonSummaryService
         // Other competitions
         $otherCompetitionResults = $this->competitionSummaryService->buildOtherCompetitionResults($game);
 
-        // Team in numbers
-        $teamPlayers = GamePlayer::with(['player', 'team'])
+        // Team in numbers — eager-load matchState because every aggregation
+        // below (top scorer, assists, appearances, cards, clean sheets) reads
+        // through the satellite via the GamePlayer accessor delegates.
+        $teamPlayers = GamePlayer::with(['player', 'team', 'matchState'])
             ->where('game_id', $game->id)
             ->where('team_id', $game->team_id)
             ->get();

--- a/app/Modules/Season/Jobs/SetupNewGame.php
+++ b/app/Modules/Season/Jobs/SetupNewGame.php
@@ -14,7 +14,9 @@ use App\Models\CompetitionEntry;
 use App\Models\CompetitionTeam;
 use App\Models\Game;
 use App\Models\GamePlayer;
+use App\Models\GamePlayerMatchState;
 use App\Models\TeamReputation;
+use App\Modules\Player\Support\GamePlayerScopeResolver;
 use Carbon\Carbon;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldBeUnique;
@@ -295,18 +297,30 @@ class SetupNewGame implements ShouldQueue, ShouldBeUnique
 
         $gameId = $this->gameId;
 
+        // Determine the active team set so we know which players need a
+        // game_player_match_state satellite row at seed time. Players whose
+        // team is outside the active scope (foreign-league transfer pool) get
+        // no satellite row — see GamePlayerScopeResolver for the rules.
+        $game = Game::find($gameId);
+        $activeTeamIds = array_flip(
+            app(GamePlayerScopeResolver::class)->activeTeamIdsForGame($game)
+        );
+
         DB::table('game_player_templates')
             ->where('season', $this->season)
             ->whereNotIn('team_id', function ($query) {
                 $query->select('id')->from('teams')->where('type', 'national');
             })
             ->orderBy('player_id')
-            ->chunk(200, function ($templates) use ($gameId) {
+            ->chunk(200, function ($templates) use ($gameId, $activeTeamIds) {
                 $rows = [];
+                $matchStateRows = [];
 
                 foreach ($templates as $t) {
+                    $gamePlayerId = Str::uuid()->toString();
+
                     $rows[] = [
-                        'id' => Str::uuid()->toString(),
+                        'id' => $gamePlayerId,
                         'game_id' => $gameId,
                         'player_id' => $t->player_id,
                         'team_id' => $t->team_id,
@@ -317,8 +331,6 @@ class SetupNewGame implements ShouldQueue, ShouldBeUnique
                         'market_value_cents' => $t->market_value_cents,
                         'contract_until' => $t->contract_until,
                         'annual_wage' => $t->annual_wage,
-                        'fitness' => $t->fitness,
-                        'morale' => $t->morale,
                         'durability' => $t->durability,
                         'game_technical_ability' => $t->game_technical_ability,
                         'game_physical_ability' => $t->game_physical_ability,
@@ -326,12 +338,28 @@ class SetupNewGame implements ShouldQueue, ShouldBeUnique
                         'potential_low' => $t->potential_low,
                         'potential_high' => $t->potential_high,
                         'tier' => $t->tier,
-                        'season_appearances' => 0,
                     ];
+
+                    // Active-scope players get a satellite row carrying their
+                    // initial fitness/morale from the template. Pool players
+                    // (foreign leagues) skip this — they never participate in
+                    // simulated matches, so their hot-write columns stay at
+                    // GamePlayerMatchState::DEFAULTS via the accessor delegates.
+                    if (isset($activeTeamIds[$t->team_id])) {
+                        $matchStateRows[] = [
+                            'game_player_id' => $gamePlayerId,
+                            'fitness' => $t->fitness,
+                            'morale' => $t->morale,
+                        ];
+                    }
                 }
 
                 if (!empty($rows)) {
                     GamePlayer::insertOrIgnore($rows);
+                }
+
+                if (!empty($matchStateRows)) {
+                    GamePlayerMatchState::createForPlayers($matchStateRows);
                 }
             });
     }

--- a/app/Modules/Season/Jobs/SetupTournamentGame.php
+++ b/app/Modules/Season/Jobs/SetupTournamentGame.php
@@ -8,6 +8,7 @@ use App\Models\CompetitionTeam;
 use App\Models\Game;
 use App\Models\GameMatch;
 use App\Models\GamePlayer;
+use App\Models\GamePlayerMatchState;
 use App\Models\GameStanding;
 use App\Models\Team;
 use Illuminate\Bus\Queueable;
@@ -192,6 +193,9 @@ class SetupTournamentGame implements ShouldQueue
         $gameId = $this->gameId;
         $userTeamId = $this->teamId;
 
+        // Tournament mode (WC2026) only loads teams the user actually faces,
+        // so every player here is "active" — they all need a match-state
+        // satellite row from the start.
         DB::table('game_player_templates')
             ->where('season', '2025')
             ->whereIn('team_id', $wcTeamIds)
@@ -199,10 +203,13 @@ class SetupTournamentGame implements ShouldQueue
             ->orderBy('player_id')
             ->chunk(500, function ($templates) use ($gameId) {
                 $rows = [];
+                $matchStateRows = [];
 
                 foreach ($templates as $t) {
+                    $gamePlayerId = Str::uuid()->toString();
+
                     $rows[] = [
-                        'id' => Str::uuid()->toString(),
+                        'id' => $gamePlayerId,
                         'game_id' => $gameId,
                         'player_id' => $t->player_id,
                         'team_id' => $t->team_id,
@@ -212,8 +219,6 @@ class SetupTournamentGame implements ShouldQueue
                         'market_value_cents' => $t->market_value_cents,
                         'contract_until' => $t->contract_until,
                         'annual_wage' => $t->annual_wage,
-                        'fitness' => $t->fitness,
-                        'morale' => $t->morale,
                         'durability' => $t->durability,
                         'game_technical_ability' => $t->game_technical_ability,
                         'game_physical_ability' => $t->game_physical_ability,
@@ -221,12 +226,21 @@ class SetupTournamentGame implements ShouldQueue
                         'potential_low' => $t->potential_low,
                         'potential_high' => $t->potential_high,
                         'tier' => $t->tier,
-                        'season_appearances' => 0,
+                    ];
+
+                    $matchStateRows[] = [
+                        'game_player_id' => $gamePlayerId,
+                        'fitness' => $t->fitness,
+                        'morale' => $t->morale,
                     ];
                 }
 
                 if (!empty($rows)) {
                     GamePlayer::insert($rows);
+                }
+
+                if (!empty($matchStateRows)) {
+                    GamePlayerMatchState::createForPlayers($matchStateRows);
                 }
             });
     }

--- a/app/Modules/Season/Processors/ContinentalAndCupInitProcessor.php
+++ b/app/Modules/Season/Processors/ContinentalAndCupInitProcessor.php
@@ -6,10 +6,8 @@ use App\Modules\Season\Contracts\SeasonProcessor;
 use App\Modules\Season\DTOs\SeasonTransitionData;
 use App\Modules\Competition\Services\CountryConfig;
 use App\Modules\Season\Services\SeasonInitializationService;
-use App\Models\CompetitionEntry;
 use App\Models\Game;
 use App\Models\GameMatch;
-use App\Models\GamePlayerMatchState;
 use App\Models\GameStanding;
 use Carbon\Carbon;
 
@@ -65,26 +63,6 @@ class ContinentalAndCupInitProcessor implements SeasonProcessor
             // Use explicit pot data when available (initial season from JSON),
             // otherwise null triggers auto-assignment by market value
             $teamsWithPots = $swissPotData[$competitionId] ?? null;
-
-            // If the user actually qualified for this competition, foreign
-            // opponent rosters need a game_player_match_state row before
-            // their first fixture is simulated. Pool players (foreign-league
-            // teams that exist purely for the transfer market) are not
-            // seeded with satellite rows at game-creation time, so we
-            // backfill them here on demand.
-            $userParticipates = CompetitionEntry::where('game_id', $game->id)
-                ->where('competition_id', $competitionId)
-                ->where('team_id', $game->team_id)
-                ->exists();
-
-            if ($userParticipates) {
-                $opponentTeamIds = CompetitionEntry::where('game_id', $game->id)
-                    ->where('competition_id', $competitionId)
-                    ->pluck('team_id')
-                    ->all();
-
-                GamePlayerMatchState::ensureExistForGamePlayers($game->id, $opponentTeamIds);
-            }
 
             // Initialize Swiss fixtures + standings (skips if team doesn't participate)
             $this->service->initializeSwissCompetition(

--- a/app/Modules/Season/Processors/ContinentalAndCupInitProcessor.php
+++ b/app/Modules/Season/Processors/ContinentalAndCupInitProcessor.php
@@ -6,8 +6,10 @@ use App\Modules\Season\Contracts\SeasonProcessor;
 use App\Modules\Season\DTOs\SeasonTransitionData;
 use App\Modules\Competition\Services\CountryConfig;
 use App\Modules\Season\Services\SeasonInitializationService;
+use App\Models\CompetitionEntry;
 use App\Models\Game;
 use App\Models\GameMatch;
+use App\Models\GamePlayerMatchState;
 use App\Models\GameStanding;
 use Carbon\Carbon;
 
@@ -63,6 +65,26 @@ class ContinentalAndCupInitProcessor implements SeasonProcessor
             // Use explicit pot data when available (initial season from JSON),
             // otherwise null triggers auto-assignment by market value
             $teamsWithPots = $swissPotData[$competitionId] ?? null;
+
+            // If the user actually qualified for this competition, foreign
+            // opponent rosters need a game_player_match_state row before
+            // their first fixture is simulated. Pool players (foreign-league
+            // teams that exist purely for the transfer market) are not
+            // seeded with satellite rows at game-creation time, so we
+            // backfill them here on demand.
+            $userParticipates = CompetitionEntry::where('game_id', $game->id)
+                ->where('competition_id', $competitionId)
+                ->where('team_id', $game->team_id)
+                ->exists();
+
+            if ($userParticipates) {
+                $opponentTeamIds = CompetitionEntry::where('game_id', $game->id)
+                    ->where('competition_id', $competitionId)
+                    ->pluck('team_id')
+                    ->all();
+
+                GamePlayerMatchState::ensureExistForGamePlayers($game->id, $opponentTeamIds);
+            }
 
             // Initialize Swiss fixtures + standings (skips if team doesn't participate)
             $this->service->initializeSwissCompetition(

--- a/app/Modules/Season/Processors/PlayerDevelopmentProcessor.php
+++ b/app/Modules/Season/Processors/PlayerDevelopmentProcessor.php
@@ -10,6 +10,7 @@ use App\Modules\Player\Services\PlayerValuationService;
 use App\Models\Game;
 use App\Models\GamePlayer;
 use Carbon\Carbon;
+use Illuminate\Support\Facades\DB;
 
 /**
  * Applies player development changes at the end of the season.
@@ -33,8 +34,12 @@ class PlayerDevelopmentProcessor implements SeasonProcessor
         $upsertRows = [];
         $currentDate = $game->current_date;
 
-        // Join players table for date_of_birth (age calculation) and ability fallbacks
+        // Join players for date_of_birth (age calculation) and ability
+        // fallbacks. Left-join the satellite for season_appearances —
+        // pool players have no satellite row, in which case
+        // season_appearances is 0 (they never play, so this is correct).
         GamePlayer::join('players', 'game_players.player_id', '=', 'players.id')
+            ->leftJoinMatchState()
             ->where('game_players.game_id', $game->id)
             ->select([
                 'game_players.id',
@@ -45,7 +50,7 @@ class PlayerDevelopmentProcessor implements SeasonProcessor
                 'game_players.game_technical_ability',
                 'game_players.game_physical_ability',
                 'game_players.market_value_cents',
-                'game_players.season_appearances',
+                DB::raw('COALESCE(game_player_match_state.season_appearances, 0) AS season_appearances'),
                 'game_players.potential',
                 'players.technical_ability',
                 'players.physical_ability',

--- a/app/Modules/Season/Processors/PlayerRetirementProcessor.php
+++ b/app/Modules/Season/Processors/PlayerRetirementProcessor.php
@@ -86,7 +86,9 @@ class PlayerRetirementProcessor implements SeasonProcessor
         // set from ~500 to ~20-40 before PHP-side probability evaluation.
         $minRetirementCutoff = PlayerAge::dateOfBirthCutoff(PlayerAge::MIN_RETIREMENT_OUTFIELD, $game->current_date);
 
-        $candidates = GamePlayer::with(['player', 'team', 'game'])
+        // matchState is eager-loaded because shouldRetire() reads
+        // fitness/season_appearances via the GamePlayer accessor delegates.
+        $candidates = GamePlayer::with(['player', 'team', 'game', 'matchState'])
             ->where('game_id', $game->id)
             ->whereNotNull('team_id')
             ->whereNull('retiring_at_season')

--- a/app/Modules/Season/Processors/SeasonArchiveProcessor.php
+++ b/app/Modules/Season/Processors/SeasonArchiveProcessor.php
@@ -151,7 +151,7 @@ class SeasonArchiveProcessor implements SeasonProcessor
     {
         $stats = [];
 
-        GamePlayer::with('player')
+        GamePlayer::with(['player', 'matchState'])
             ->where('game_id', $game->id)
             ->whereNotNull('team_id')
             ->chunk(200, function ($chunk) use (&$stats) {
@@ -229,10 +229,11 @@ class SeasonArchiveProcessor implements SeasonProcessor
      */
     private function calculateBestGoalkeeper(Game $game): ?array
     {
-        $goalkeepers = GamePlayer::with('player')
+        $goalkeepers = GamePlayer::with(['player', 'matchState'])
+            ->joinMatchState()
             ->where('game_id', $game->id)
             ->where('position', 'Goalkeeper')
-            ->where('appearances', '>=', self::MIN_GOALKEEPER_APPEARANCES)
+            ->whereMatchStat('appearances', '>=', self::MIN_GOALKEEPER_APPEARANCES)
             ->get();
 
         if ($goalkeepers->isEmpty()) {

--- a/app/Modules/Season/Processors/StatsResetProcessor.php
+++ b/app/Modules/Season/Processors/StatsResetProcessor.php
@@ -6,9 +6,8 @@ use App\Modules\Season\Contracts\SeasonProcessor;
 use App\Modules\Season\DTOs\SeasonTransitionData;
 use App\Models\Game;
 use App\Models\GameNotification;
-use App\Models\GamePlayer;
+use App\Models\GamePlayerMatchState;
 use App\Models\PlayerSuspension;
-use Illuminate\Support\Facades\DB;
 
 /**
  * Resets player and game stats for the new season.
@@ -28,7 +27,10 @@ class StatsResetProcessor implements SeasonProcessor
             $query->select('id')->from('game_players')->where('game_id', $game->id);
         })->delete();
 
-        GamePlayer::where('game_id', $game->id)->update([
+        // Reset every active player's match-state. Pool players have no
+        // satellite row to reset — and they have no stats to reset either,
+        // so this is correct.
+        GamePlayerMatchState::bulkResetForGame($game->id, [
             'appearances' => 0,
             'goals' => 0,
             'own_goals' => 0,

--- a/app/Modules/Squad/Listeners/CheckRecoveredPlayers.php
+++ b/app/Modules/Squad/Listeners/CheckRecoveredPlayers.php
@@ -19,10 +19,14 @@ class CheckRecoveredPlayers
     {
         $game = $event->game;
 
-        $recoveredPlayers = GamePlayer::where('game_id', $game->id)
-            ->where('team_id', $game->team_id)
-            ->whereNotNull('injury_until')
-            ->where('injury_until', '<', $event->newDate->toDateString())
+        // Find players whose injury_until has passed. The user's squad
+        // always has match-state rows so an INNER JOIN is correct.
+        $recoveredPlayers = GamePlayer::with('matchState')
+            ->joinMatchState()
+            ->where('game_players.game_id', $game->id)
+            ->where('game_players.team_id', $game->team_id)
+            ->whereMatchStatNotNull('injury_until')
+            ->whereMatchStat('injury_until', '<', $event->newDate->toDateString())
             ->get();
 
         if ($recoveredPlayers->isEmpty()) {

--- a/app/Modules/Squad/Services/EligibilityService.php
+++ b/app/Modules/Squad/Services/EligibilityService.php
@@ -3,11 +3,11 @@
 namespace App\Modules\Squad\Services;
 
 use App\Models\GamePlayer;
+use App\Models\GamePlayerMatchState;
 use App\Models\PlayerSuspension;
 use App\Modules\Squad\DTOs\SuspensionRuleSet;
 use Carbon\Carbon;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 
 class EligibilityService
@@ -27,15 +27,21 @@ class EligibilityService
     /**
      * Apply an injury to a player.
      *
+     * Writes to the {@see GamePlayerMatchState} satellite. Injuries only ever
+     * happen to players in active match lineups, so the satellite row is
+     * guaranteed to exist.
+     *
      * @param string $injuryType Description of the injury
      * @param int $weeksOut Number of weeks the player will be out
      * @param Carbon $matchDate The date of the match when injury occurred
      */
     public function applyInjury(GamePlayer $player, string $injuryType, int $weeksOut, Carbon $matchDate): void
     {
-        $player->injury_type = $injuryType;
-        $player->injury_until = \Illuminate\Support\Carbon::instance($matchDate->copy()->addWeeks($weeksOut));
-        $player->save();
+        $injuryUntil = \Illuminate\Support\Carbon::instance($matchDate->copy()->addWeeks($weeksOut))->toDateString();
+
+        GamePlayerMatchState::setInjury($player->id, $injuryType, $injuryUntil);
+
+        $player->unsetRelation('matchState');
     }
 
     /**
@@ -45,28 +51,7 @@ class EligibilityService
      */
     public function batchApplyInjuries(array $injuries): void
     {
-        if (empty($injuries)) {
-            return;
-        }
-
-        $typeCases = [];
-        $untilCases = [];
-        $ids = [];
-        foreach ($injuries as $injury) {
-            $id = $injury['playerId'];
-            $type = str_replace("'", "''", $injury['injuryType']);
-            $until = $injury['injuryUntil']->toDateString();
-            $ids[] = "'{$id}'";
-            $typeCases[] = "WHEN id = '{$id}' THEN '{$type}'";
-            $untilCases[] = "WHEN id = '{$id}' THEN '{$until}'::date";
-        }
-
-        $idList = implode(',', $ids);
-        DB::statement(
-            'UPDATE game_players SET injury_type = CASE ' . implode(' ', $typeCases) . ' END, '
-            . 'injury_until = CASE ' . implode(' ', $untilCases) . ' END '
-            . "WHERE id IN ({$idList})"
-        );
+        GamePlayerMatchState::bulkSetInjuries($injuries);
     }
 
     /**
@@ -74,9 +59,9 @@ class EligibilityService
      */
     public function clearInjury(GamePlayer $player): void
     {
-        $player->injury_until = null;
-        $player->injury_type = null;
-        $player->save();
+        GamePlayerMatchState::clearInjury($player->id);
+
+        $player->unsetRelation('matchState');
     }
 
     /**

--- a/app/Modules/Squad/Services/PlayerGeneratorService.php
+++ b/app/Modules/Squad/Services/PlayerGeneratorService.php
@@ -5,6 +5,7 @@ namespace App\Modules\Squad\Services;
 use App\Modules\Squad\DTOs\GeneratedPlayerData;
 use App\Models\Game;
 use App\Models\GamePlayer;
+use App\Models\GamePlayerMatchState;
 use App\Models\Player;
 use Carbon\Carbon;
 use Illuminate\Support\Str;
@@ -127,20 +128,27 @@ class PlayerGeneratorService
             'market_value_cents' => $marketValue,
             'contract_until' => $contractUntil,
             'annual_wage' => $annualWage,
-            'fitness' => mt_rand($data->fitnessMin, $data->fitnessMax),
-            'morale' => mt_rand($data->moraleMin, $data->moraleMax),
             'durability' => InjuryService::generateDurability(),
             'game_technical_ability' => $data->technical,
             'game_physical_ability' => $data->physical,
             'potential' => $potential,
             'potential_low' => $potentialLow,
             'potential_high' => $potentialHigh,
-            'season_appearances' => 0,
             'tier' => PlayerTierService::tierFromMarketValue($marketValue),
         ]);
 
-        // Set relation to avoid lazy-load when caller accesses $gamePlayer->player
+        // Generated players (youth grads, replenishment) always belong to
+        // teams in the active scope, so they always need a match-state row.
+        $matchState = GamePlayerMatchState::createWithDefaults(
+            $gamePlayer->id,
+            mt_rand($data->fitnessMin, $data->fitnessMax),
+            mt_rand($data->moraleMin, $data->moraleMax),
+        );
+
+        // Set relations to avoid lazy-load when caller accesses derived
+        // attributes via the GamePlayer accessor delegates.
         $gamePlayer->setRelation('player', $player);
+        $gamePlayer->setRelation('matchState', $matchState);
 
         // Update cache with the newly created player
         $teamKey = "{$game->id}:{$data->teamId}";
@@ -171,6 +179,7 @@ class PlayerGeneratorService
 
         $playerRows = [];
         $gamePlayerRows = [];
+        $matchStateRows = [];
         $results = [];
         $batchNames = [];
 
@@ -228,16 +237,21 @@ class PlayerGeneratorService
                 'market_value_cents' => $marketValue,
                 'contract_until' => $contractUntil->format('Y-m-d'),
                 'annual_wage' => $annualWage,
-                'fitness' => mt_rand($data->fitnessMin, $data->fitnessMax),
-                'morale' => mt_rand($data->moraleMin, $data->moraleMax),
                 'durability' => InjuryService::generateDurability(),
                 'game_technical_ability' => $data->technical,
                 'game_physical_ability' => $data->physical,
                 'potential' => $potential,
                 'potential_low' => $potentialLow,
                 'potential_high' => $potentialHigh,
-                'season_appearances' => 0,
                 'tier' => PlayerTierService::tierFromMarketValue($marketValue),
+            ];
+
+            // Bulk-generated players (youth grads, replenishment) always end
+            // up on active-scope teams, so they always get a satellite row.
+            $matchStateRows[] = [
+                'game_player_id' => $gamePlayerId,
+                'fitness' => mt_rand($data->fitnessMin, $data->fitnessMax),
+                'morale' => mt_rand($data->moraleMin, $data->moraleMax),
             ];
 
             // Update caches for subsequent iterations
@@ -262,6 +276,9 @@ class PlayerGeneratorService
         foreach (array_chunk($gamePlayerRows, 500) as $chunk) {
             GamePlayer::insert($chunk);
         }
+
+        // Bulk insert satellite match-state rows
+        GamePlayerMatchState::createForPlayers($matchStateRows);
 
         return $results;
     }

--- a/app/Modules/Squad/Services/SquadService.php
+++ b/app/Modules/Squad/Services/SquadService.php
@@ -26,7 +26,7 @@ class SquadService
         $gameId = $game->id;
 
         // Get all players for user's team with relationships
-        $allPlayers = GamePlayer::with(['player', 'game', 'team', 'activeLoan', 'transferOffers', 'suspensions', 'activeRenewalNegotiation', 'latestRenewalNegotiation'])
+        $allPlayers = GamePlayer::with(['player', 'game', 'team', 'matchState', 'activeLoan', 'transferOffers', 'suspensions', 'activeRenewalNegotiation', 'latestRenewalNegotiation'])
             ->where('game_id', $gameId)
             ->where('team_id', $game->team_id)
             ->get();

--- a/app/Modules/Squad/Services/SquadService.php
+++ b/app/Modules/Squad/Services/SquadService.php
@@ -3,11 +3,13 @@
 namespace App\Modules\Squad\Services;
 
 use App\Models\AcademyPlayer;
+use App\Models\Competition;
+use App\Models\CompetitionEntry;
 use App\Models\Game;
 use App\Models\GameMatch;
 use App\Models\GamePlayer;
+use App\Models\Team;
 use App\Modules\Player\PlayerAge;
-
 use App\Modules\Player\Services\PlayerDevelopmentService;
 use App\Modules\Transfer\Enums\NegotiationScenario;
 use App\Modules\Transfer\Services\ContractService;
@@ -294,5 +296,80 @@ class SquadService
         }
 
         return $alerts;
+    }
+
+    /**
+     * Calculate squad strength as the average ability of the best 18 players.
+     * Uses only technical + physical ability (not volatile match state like fitness/morale).
+     */
+    public function calculateSquadStrength($players): float
+    {
+        $scores = $players->map(function ($player) {
+            return (int) round(($player->current_technical_ability + $player->current_physical_ability) / 2);
+        })
+            ->sortDesc()
+            ->take(18);
+
+        if ($scores->isEmpty()) {
+            return 0;
+        }
+
+        return round($scores->avg(), 1);
+    }
+
+    /**
+     * Calculate strength rankings for all teams in a league competition.
+     *
+     * @return array<string, float> Team ID => strength score, sorted descending
+     */
+    public function calculateLeagueStrengths(Game $game, Competition $league): array
+    {
+        $teamIds = CompetitionEntry::where('game_id', $game->id)
+            ->where('competition_id', $league->id)
+            ->pluck('team_id')
+            ->toArray();
+
+        $teams = Team::whereIn('id', $teamIds)->get();
+
+        $query = GamePlayer::where('game_id', $game->id)
+            ->whereIn('team_id', $teamIds);
+
+        // Only eager-load player relation when game abilities are null (mid-season fallback)
+        $needsPlayerRelation = GamePlayer::where('game_id', $game->id)
+            ->whereIn('team_id', $teamIds)
+            ->where(fn ($q) => $q->whereNull('game_technical_ability')->orWhereNull('game_physical_ability'))
+            ->exists();
+
+        if ($needsPlayerRelation) {
+            $query->with('player');
+        }
+
+        $playersByTeam = $query->get()->groupBy('team_id');
+
+        $strengths = [];
+        foreach ($teams as $team) {
+            $teamPlayers = $playersByTeam->get($team->id, collect());
+            $strengths[$team->id] = $this->calculateSquadStrength($teamPlayers);
+        }
+
+        arsort($strengths);
+
+        return $strengths;
+    }
+
+    /**
+     * Get projected position for a team based on strength rankings.
+     */
+    public function getProjectedPosition(string $teamId, array $teamStrengths): int
+    {
+        $position = 1;
+        foreach ($teamStrengths as $id => $strength) {
+            if ($id === $teamId) {
+                return $position;
+            }
+            $position++;
+        }
+
+        return $position;
     }
 }

--- a/app/Modules/Transfer/Services/TransferCompletionService.php
+++ b/app/Modules/Transfer/Services/TransferCompletionService.php
@@ -5,7 +5,6 @@ namespace App\Modules\Transfer\Services;
 use App\Models\FinancialTransaction;
 use App\Models\Game;
 use App\Models\GamePlayer;
-use App\Models\GamePlayerMatchState;
 use App\Models\GameTransfer;
 use App\Models\Loan;
 use App\Models\ShortlistedPlayer;
@@ -116,12 +115,6 @@ class TransferCompletionService
             'contract_until' => Carbon::createFromDate((int) $game->season + rand(2, 4) + 1, 6, 30),
         ]);
 
-        // If the destination team is in the active scope, the player will
-        // start playing matches against the user — make sure they have a
-        // satellite row. No-op for users selling to other active teams.
-        GamePlayerMatchState::createWithDefaults($player->id);
-        $player->unsetRelation('matchState');
-
         GameTransfer::record(
             gameId: $game->id,
             gamePlayerId: $player->id,
@@ -179,12 +172,6 @@ class TransferCompletionService
             'annual_wage' => $offer->offered_wage ?? $player->annual_wage,
         ]);
 
-        // The signing might be a foreign-pool player (no satellite row yet)
-        // — give them defaults so the user's match simulation can pick them
-        // up immediately. No-op if a row already exists.
-        GamePlayerMatchState::createWithDefaults($player->id);
-        $player->unsetRelation('matchState');
-
         GameTransfer::record(
             gameId: $game->id,
             gamePlayerId: $player->id,
@@ -237,12 +224,6 @@ class TransferCompletionService
             'contract_until' => $newContractEnd,
             'annual_wage' => $offer->offered_wage,
         ]);
-
-        // Free agents may originate from a foreign team that never had a
-        // satellite row — give them defaults so the user can immediately
-        // pick them in lineups. No-op if a row already exists.
-        GamePlayerMatchState::createWithDefaults($player->id);
-        $player->unsetRelation('matchState');
 
         $offer->update([
             'status' => TransferOffer::STATUS_COMPLETED,

--- a/app/Modules/Transfer/Services/TransferCompletionService.php
+++ b/app/Modules/Transfer/Services/TransferCompletionService.php
@@ -5,6 +5,7 @@ namespace App\Modules\Transfer\Services;
 use App\Models\FinancialTransaction;
 use App\Models\Game;
 use App\Models\GamePlayer;
+use App\Models\GamePlayerMatchState;
 use App\Models\GameTransfer;
 use App\Models\Loan;
 use App\Models\ShortlistedPlayer;
@@ -115,6 +116,12 @@ class TransferCompletionService
             'contract_until' => Carbon::createFromDate((int) $game->season + rand(2, 4) + 1, 6, 30),
         ]);
 
+        // If the destination team is in the active scope, the player will
+        // start playing matches against the user — make sure they have a
+        // satellite row. No-op for users selling to other active teams.
+        GamePlayerMatchState::createWithDefaults($player->id);
+        $player->unsetRelation('matchState');
+
         GameTransfer::record(
             gameId: $game->id,
             gamePlayerId: $player->id,
@@ -172,6 +179,12 @@ class TransferCompletionService
             'annual_wage' => $offer->offered_wage ?? $player->annual_wage,
         ]);
 
+        // The signing might be a foreign-pool player (no satellite row yet)
+        // — give them defaults so the user's match simulation can pick them
+        // up immediately. No-op if a row already exists.
+        GamePlayerMatchState::createWithDefaults($player->id);
+        $player->unsetRelation('matchState');
+
         GameTransfer::record(
             gameId: $game->id,
             gamePlayerId: $player->id,
@@ -224,6 +237,12 @@ class TransferCompletionService
             'contract_until' => $newContractEnd,
             'annual_wage' => $offer->offered_wage,
         ]);
+
+        // Free agents may originate from a foreign team that never had a
+        // satellite row — give them defaults so the user can immediately
+        // pick them in lineups. No-op if a row already exists.
+        GamePlayerMatchState::createWithDefaults($player->id);
+        $player->unsetRelation('matchState');
 
         $offer->update([
             'status' => TransferOffer::STATUS_COMPLETED,

--- a/database/factories/GamePlayerFactory.php
+++ b/database/factories/GamePlayerFactory.php
@@ -4,6 +4,7 @@ namespace Database\Factories;
 
 use App\Models\Game;
 use App\Models\GamePlayer;
+use App\Models\GamePlayerMatchState;
 use App\Models\Player;
 use App\Models\Team;
 use App\Modules\Player\Services\PlayerTierService;
@@ -13,6 +14,17 @@ use Illuminate\Support\Str;
 class GamePlayerFactory extends Factory
 {
     protected $model = GamePlayer::class;
+
+    /**
+     * Match-state overrides stashed by newModel() so configure() can apply
+     * them after the GamePlayer row is persisted. Keyed by spl_object_id of
+     * the GamePlayer instance — unique per call even when createMany() is
+     * looping. Static so the value survives the newModel → afterCreating
+     * trip across stateful and unstateful Eloquent factory wrappers.
+     *
+     * @var array<int, array<string, mixed>>
+     */
+    protected static array $pendingOverrides = [];
 
     public function definition(): array
     {
@@ -28,17 +40,76 @@ class GamePlayerFactory extends Factory
             'market_value_cents' => $marketValueCents,
             'contract_until' => now()->addYears(2),
             'annual_wage' => $this->faker->numberBetween(10_000_00, 1_000_000_00),
-            'fitness' => $this->faker->numberBetween(70, 100),
-            'morale' => $this->faker->numberBetween(60, 90),
             'durability' => $this->faker->numberBetween(50, 95),
             'game_technical_ability' => $this->faker->numberBetween(40, 90),
             'game_physical_ability' => $this->faker->numberBetween(40, 90),
             'potential' => $this->faker->numberBetween(60, 95),
             'potential_low' => $this->faker->numberBetween(55, 85),
             'potential_high' => $this->faker->numberBetween(70, 99),
-            'season_appearances' => 0,
             'tier' => PlayerTierService::tierFromMarketValue($marketValueCents),
         ];
+    }
+
+    /**
+     * Tests still pass match-state attributes via `->create(['fitness' =>
+     * 50, 'goals' => 5])`. Strip them out of the GamePlayer attribute set
+     * and stash them so afterCreating() can apply them to the satellite row.
+     *
+     * @param  array<string, mixed>  $attributes
+     */
+    public function newModel(array $attributes = []): GamePlayer
+    {
+        $matchStateColumns = array_keys(GamePlayerMatchState::DEFAULTS);
+        $overrides = array_intersect_key($attributes, array_flip($matchStateColumns));
+
+        if (! empty($overrides)) {
+            $attributes = array_diff_key($attributes, $overrides);
+        }
+
+        /** @var GamePlayer $model */
+        $model = parent::newModel($attributes);
+
+        if (! empty($overrides)) {
+            self::$pendingOverrides[spl_object_id($model)] = $overrides;
+        }
+
+        return $model;
+    }
+
+    public function configure(): static
+    {
+        return $this->afterCreating(function (GamePlayer $player) {
+            $oid = spl_object_id($player);
+            $overrides = self::$pendingOverrides[$oid] ?? [];
+            unset(self::$pendingOverrides[$oid]);
+
+            // Every test-created GamePlayer gets a satellite row by default
+            // — tests historically assumed game_players carried fitness etc.,
+            // and the cheapest fix is to mirror that assumption.
+            GamePlayerMatchState::create(array_merge(
+                ['game_player_id' => $player->id],
+                GamePlayerMatchState::DEFAULTS,
+                [
+                    'fitness' => $this->faker->numberBetween(70, 100),
+                    'morale' => $this->faker->numberBetween(60, 90),
+                ],
+                $overrides,
+            ));
+
+            $player->unsetRelation('matchState');
+        });
+    }
+
+    /**
+     * Create a "pool" player — no satellite row, mirroring foreign-league
+     * players that exist purely for the transfer market.
+     */
+    public function pool(): static
+    {
+        return $this->afterCreating(function (GamePlayer $player) {
+            GamePlayerMatchState::where('game_player_id', $player->id)->delete();
+            $player->unsetRelation('matchState');
+        });
     }
 
     public function forGame(Game $game): static

--- a/database/migrations/2026_04_11_000001_create_game_player_match_state_table.php
+++ b/database/migrations/2026_04_11_000001_create_game_player_match_state_table.php
@@ -1,0 +1,49 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Create the sparse game_player_match_state satellite table.
+     *
+     * Holds the 13 hot-write columns that get updated on every matchday by
+     * PlayerConditionService and MatchResultProcessor (fitness, morale, injury,
+     * appearances, goals, assists, cards, GK stats). Only populated for
+     * "active" players — those whose team belongs to a competition in the
+     * game's country (La Liga, Segunda, Copa del Rey) or who become a
+     * European opponent for a season the user qualifies for. Foreign
+     * transfer-pool players have no row here at all.
+     */
+    public function up(): void
+    {
+        Schema::create('game_player_match_state', function (Blueprint $table) {
+            $table->uuid('game_player_id')->primary();
+            $table->unsignedTinyInteger('fitness')->default(80);
+            $table->unsignedTinyInteger('morale')->default(80);
+            $table->date('injury_until')->nullable();
+            $table->string('injury_type')->nullable();
+            $table->unsignedSmallInteger('appearances')->default(0);
+            $table->unsignedSmallInteger('season_appearances')->default(0);
+            $table->unsignedSmallInteger('goals')->default(0);
+            $table->unsignedSmallInteger('own_goals')->default(0);
+            $table->unsignedSmallInteger('assists')->default(0);
+            $table->unsignedSmallInteger('yellow_cards')->default(0);
+            $table->unsignedSmallInteger('red_cards')->default(0);
+            $table->unsignedInteger('goals_conceded')->default(0);
+            $table->unsignedInteger('clean_sheets')->default(0);
+
+            $table->foreign('game_player_id')
+                ->references('id')
+                ->on('game_players')
+                ->onDelete('cascade');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('game_player_match_state');
+    }
+};

--- a/tests/Unit/GamePlayerMatchStateTest.php
+++ b/tests/Unit/GamePlayerMatchStateTest.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\Game;
+use App\Models\GamePlayer;
+use App\Models\GamePlayerMatchState;
+use App\Models\Player;
+use App\Models\Team;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class GamePlayerMatchStateTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_factory_creates_satellite_row_by_default(): void
+    {
+        $player = GamePlayer::factory()->create();
+
+        $this->assertNotNull($player->matchState);
+        $this->assertGreaterThanOrEqual(70, $player->matchState->fitness);
+        $this->assertLessThanOrEqual(100, $player->matchState->fitness);
+    }
+
+    public function test_pool_factory_state_skips_satellite_row(): void
+    {
+        $player = GamePlayer::factory()->pool()->create();
+
+        $this->assertNull($player->matchState);
+        $this->assertDatabaseMissing('game_player_match_state', [
+            'game_player_id' => $player->id,
+        ]);
+    }
+
+    public function test_accessor_returns_satellite_value(): void
+    {
+        $player = GamePlayer::factory()->create();
+        GamePlayerMatchState::where('game_player_id', $player->id)->update([
+            'fitness' => 55,
+            'morale' => 65,
+            'goals' => 7,
+            'assists' => 3,
+            'appearances' => 12,
+        ]);
+
+        $player = $player->fresh(['matchState']);
+
+        $this->assertSame(55, $player->fitness);
+        $this->assertSame(65, $player->morale);
+        $this->assertSame(7, $player->goals);
+        $this->assertSame(3, $player->assists);
+        $this->assertSame(12, $player->appearances);
+    }
+
+    public function test_accessor_returns_defaults_for_pool_player(): void
+    {
+        $player = GamePlayer::factory()->pool()->create();
+
+        $this->assertSame(GamePlayerMatchState::DEFAULTS['fitness'], $player->fitness);
+        $this->assertSame(GamePlayerMatchState::DEFAULTS['morale'], $player->morale);
+        $this->assertSame(0, $player->goals);
+        $this->assertSame(0, $player->appearances);
+        $this->assertNull($player->injury_until);
+    }
+
+    public function test_in_memory_override_wins_over_satellite(): void
+    {
+        $player = GamePlayer::factory()->create();
+        GamePlayerMatchState::where('game_player_id', $player->id)->update(['goals' => 5]);
+        $player = $player->fresh(['matchState']);
+
+        // Mimics CompetitionViewService stuffing per-competition tallies onto
+        // the model for display.
+        $clone = clone $player;
+        $clone->goals = 99;
+
+        $this->assertSame(99, $clone->goals);
+        // The original is unaffected.
+        $this->assertSame(5, $player->goals);
+    }
+
+    public function test_satellite_cascades_on_game_player_delete(): void
+    {
+        $player = GamePlayer::factory()->create();
+
+        $this->assertDatabaseHas('game_player_match_state', [
+            'game_player_id' => $player->id,
+        ]);
+
+        $player->delete();
+
+        $this->assertDatabaseMissing('game_player_match_state', [
+            'game_player_id' => $player->id,
+        ]);
+    }
+
+    public function test_injured_player_is_unavailable(): void
+    {
+        $game = Game::factory()->create(['current_date' => '2025-10-01']);
+        $player = GamePlayer::factory()->forGame($game)->create();
+
+        GamePlayerMatchState::where('game_player_id', $player->id)->update([
+            'injury_until' => '2025-10-15',
+            'injury_type' => 'Hamstring tear',
+        ]);
+
+        $player = $player->fresh(['matchState']);
+
+        $this->assertFalse($player->isAvailable(Carbon::parse('2025-10-01')));
+        $this->assertTrue($player->isInjured(Carbon::parse('2025-10-01')));
+        $this->assertSame('Hamstring tear', $player->injury_type);
+    }
+
+    public function test_overall_score_reads_through_satellite(): void
+    {
+        $player = GamePlayer::factory()->create([
+            'game_technical_ability' => 80,
+            'game_physical_ability' => 70,
+        ]);
+        GamePlayerMatchState::where('game_player_id', $player->id)->update([
+            'fitness' => 100,
+            'morale' => 100,
+        ]);
+        $player = $player->fresh(['matchState']);
+
+        // (80*0.35 + 70*0.35 + 100*0.15 + 100*0.15) = 28 + 24.5 + 15 + 15 = 82.5 → 83
+        $this->assertSame(83, $player->overall_score);
+    }
+}

--- a/tests/Unit/GamePlayerScopeResolverTest.php
+++ b/tests/Unit/GamePlayerScopeResolverTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\Competition;
+use App\Models\Game;
+use App\Models\Team;
+use App\Modules\Player\Support\GamePlayerScopeResolver;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class GamePlayerScopeResolverTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_active_team_ids_includes_country_competition_teams(): void
+    {
+        $espCompetition = Competition::factory()->create([
+            'country' => 'ES',
+            'role' => Competition::ROLE_LEAGUE,
+        ]);
+        $espTeam = Team::factory()->create();
+        $espCompetition->teams()->attach($espTeam->id, ['season' => '2025']);
+
+        $game = Game::factory()->create(['country' => 'ES']);
+
+        $resolver = new GamePlayerScopeResolver();
+
+        $this->assertContains($espTeam->id, $resolver->activeTeamIdsForGame($game));
+    }
+
+    public function test_active_team_ids_excludes_foreign_country_teams(): void
+    {
+        $engCompetition = Competition::factory()->create([
+            'country' => 'EN',
+            'role' => Competition::ROLE_LEAGUE,
+        ]);
+        $engTeam = Team::factory()->create();
+        $engCompetition->teams()->attach($engTeam->id, ['season' => '2025']);
+
+        $game = Game::factory()->create(['country' => 'ES']);
+
+        $resolver = new GamePlayerScopeResolver();
+
+        $this->assertNotContains($engTeam->id, $resolver->activeTeamIdsForGame($game));
+    }
+
+    public function test_results_are_cached_per_game(): void
+    {
+        $game = Game::factory()->create(['country' => 'ES']);
+        $resolver = new GamePlayerScopeResolver();
+
+        $first = $resolver->activeTeamIdsForGame($game);
+        $second = $resolver->activeTeamIdsForGame($game);
+
+        $this->assertSame($first, $second);
+    }
+
+    public function test_forget_clears_cache(): void
+    {
+        $game = Game::factory()->create(['country' => 'ES']);
+        $resolver = new GamePlayerScopeResolver();
+
+        $resolver->activeTeamIdsForGame($game);
+        $resolver->forget($game->id);
+
+        // Add a new active team after caching has been cleared.
+        $newCompetition = Competition::factory()->create([
+            'country' => 'ES',
+            'role' => Competition::ROLE_LEAGUE,
+        ]);
+        $newTeam = Team::factory()->create();
+        $newCompetition->teams()->attach($newTeam->id, ['season' => '2025']);
+
+        $this->assertContains($newTeam->id, $resolver->activeTeamIdsForGame($game));
+    }
+}


### PR DESCRIPTION
Create a sparse satellite table holding the 13 per-matchday hot-write columns (fitness, morale, injury, appearances, goals, assists, cards, GK stats). Only "active" players get a satellite row — pure transfer-pool foreign players have none.

All satellite writes go through centralized static methods on GamePlayerMatchState (createForPlayers, bulkIncrementStats, bulkSetValues, setInjury, clearInjury, etc.) and query scopes on GamePlayer (joinMatchState, whereMatchStat, notInjuredOn, etc.). External modules never reference the table name, build column arrays, or call dual-write methods directly.

Backward compatible: all write paths dual-write to both the satellite AND the legacy game_players columns, so a rollback doesn't lose data. Reads prefer the satellite when eager-loaded, fall back to the old columns otherwise.