### PR TITLE
Fix defensive tactical modifiers over-compounding in user matches

### DIFF
--- a/app/Models/GamePlayer.php
+++ b/app/Models/GamePlayer.php
@@ -932,7 +932,7 @@ class GamePlayer extends Model
 
         return $query->where(function ($q) use ($date) {
             $q->whereNull('game_player_match_state.injury_until')
-                ->orWhere('game_player_match_state.injury_until', '<=', $date->toDateString());
+                ->orWhere('game_player_match_state.injury_until', '<', $date->toDateString());
         });
     }
 

--- a/app/Modules/Match/Services/MatchNarrativeService.php
+++ b/app/Modules/Match/Services/MatchNarrativeService.php
@@ -423,7 +423,7 @@ class MatchNarrativeService
             ->join('game_player_match_state', 'game_players.id', '=', 'game_player_match_state.game_player_id')
             ->where('game_players.game_id', $game->id)
             ->where('game_players.team_id', $game->team_id)
-            ->where('game_player_match_state.injury_until', '>', $game->current_date)
+            ->where('game_player_match_state.injury_until', '>=', $game->current_date)
             ->count();
 
         if ($injuryCount >= 4) {

--- a/app/Modules/Match/Services/MatchSimulator.php
+++ b/app/Modules/Match/Services/MatchSimulator.php
@@ -1532,6 +1532,9 @@ class MatchSimulator
      * Covers playing style, pressing (with minute-based fade), defensive line
      * (with high-line nullification), and tactical interactions.
      *
+     * Defensive modifiers are attenuated when the attacking team is significantly
+     * stronger — quality eventually prevails against a parked bus.
+     *
      * @return array{0: float, 1: float} [homeXG, awayXG]
      */
     private function applyTacticalModifiers(
@@ -1546,7 +1549,11 @@ class MatchSimulator
         Mentality $homeMentality,
         Mentality $awayMentality,
         float $effectiveMinute,
+        float $strengthRatio = 1.0,
     ): array {
+        $preHomeXG = $homeXG;
+        $preAwayXG = $awayXG;
+
         // Playing Style: own xG modifier and opponent xG modifier
         $homeXG *= $homePlayingStyle->ownXGModifier();
         $homeXG *= $awayPlayingStyle->opponentXGModifier();
@@ -1647,6 +1654,29 @@ class MatchSimulator
             $homeXG *= $attackingHighLineVuln;
         }
 
+        // Attenuate defensive effect based on the attacker's quality advantage.
+        // When a team is much stronger, opponent's defensive tactics are less
+        // effective — quality prevails through possession, individual skill,
+        // and forcing defensive errors over 90 minutes.
+        $damping = (float) config('match_simulation.defensive_quality_damping', 1.2);
+
+        if ($preHomeXG > 0) {
+            $homeReduction = $homeXG / $preHomeXG;
+            if ($homeReduction < 1.0 && $strengthRatio > 1.0) {
+                $attenuation = 1.0 / pow($strengthRatio, $damping);
+                $homeXG = $preHomeXG * (1.0 - (1.0 - $homeReduction) * $attenuation);
+            }
+        }
+
+        if ($preAwayXG > 0) {
+            $awayReduction = $awayXG / $preAwayXG;
+            $inverseRatio = $strengthRatio > 0 ? 1.0 / $strengthRatio : 1.0;
+            if ($awayReduction < 1.0 && $inverseRatio > 1.0) {
+                $attenuation = 1.0 / pow($inverseRatio, $damping);
+                $awayXG = $preAwayXG * (1.0 - (1.0 - $awayReduction) * $attenuation);
+            }
+        }
+
         return [$homeXG, $awayXG];
     }
 
@@ -1725,6 +1755,7 @@ class MatchSimulator
         );
 
         $effectiveMinute = $fromMinute + ($toMinute - $fromMinute) / 2;
+        $strengthRatio = $awayStrength > 0 ? $homeStrength / $awayStrength : 1.0;
 
         [$homeExpectedGoals, $awayExpectedGoals] = $this->applyTacticalModifiers(
             $homeExpectedGoals, $awayExpectedGoals,
@@ -1733,6 +1764,7 @@ class MatchSimulator
             $homeDefLine, $awayDefLine,
             $homeMentality, $awayMentality,
             $effectiveMinute,
+            $strengthRatio,
         );
 
         // Goalkeeper quality: missing/out-of-position GK increases opponent xG
@@ -1826,6 +1858,8 @@ class MatchSimulator
                     $neutralVenue,
                 );
 
+                $strengthRatio = $awayStrength > 0 ? $homeStrength / $awayStrength : 1.0;
+
                 [$homeExpectedGoals, $awayExpectedGoals] = $this->applyTacticalModifiers(
                     $homeExpectedGoals, $awayExpectedGoals,
                     $homePlayingStyle, $awayPlayingStyle,
@@ -1833,7 +1867,7 @@ class MatchSimulator
                     $homeDefLine, $awayDefLine,
                     $homeMentality, $awayMentality,
                     $effectiveMinute,
-                    $homePlayers, $awayPlayers,
+                    $strengthRatio,
                 );
 
                 $awayExpectedGoals *= $this->calculateGoalkeeperModifier($homePlayers);
@@ -1989,6 +2023,8 @@ class MatchSimulator
             $neutralVenue,
         );
 
+        $strengthRatio = $awayStrength > 0 ? $homeStrength / $awayStrength : 1.0;
+
         [$homeXG1, $awayXG1] = $this->applyTacticalModifiers(
             $homeXG1, $awayXG1,
             $homePlayingStyle, $awayPlayingStyle,
@@ -1996,7 +2032,7 @@ class MatchSimulator
             $homeDefLine, $awayDefLine,
             $homeMentality, $awayMentality,
             $effectiveMinute1,
-            $homePlayers, $awayPlayers,
+            $strengthRatio,
         );
 
         $awayXG1 *= $this->calculateGoalkeeperModifier($homePlayers);
@@ -2047,6 +2083,8 @@ class MatchSimulator
             $neutralVenue,
         );
 
+        $strengthRatio2 = $awayStrength2 > 0 ? $homeStrength2 / $awayStrength2 : 1.0;
+
         [$homeXG2, $awayXG2] = $this->applyTacticalModifiers(
             $homeXG2, $awayXG2,
             $homePlayingStyle, $awayPlayingStyle,
@@ -2054,6 +2092,7 @@ class MatchSimulator
             $homeDefLine, $awayDefLine,
             $homeMentality, $awayMentality,
             $effectiveMinute2,
+            $strengthRatio2,
         );
 
         $awayXG2 *= $this->calculateGoalkeeperModifier($homePlayers2);
@@ -2533,6 +2572,8 @@ class MatchSimulator
 
         $etEffectiveMinute = $fromMinute + ($etMinutesRemaining / 2);
 
+        $strengthRatio = $awayStrength > 0 ? $homeStrength / $awayStrength : 1.0;
+
         [$homeExpectedGoals, $awayExpectedGoals] = $this->applyTacticalModifiers(
             $homeExpectedGoals, $awayExpectedGoals,
             $homePlayingStyle, $awayPlayingStyle,
@@ -2540,7 +2581,7 @@ class MatchSimulator
             $homeDefLine, $awayDefLine,
             $homeMentality, $awayMentality,
             $etEffectiveMinute,
-            $homePlayers, $awayPlayers,
+            $strengthRatio,
         );
 
         // Goalkeeper quality

--- a/config/match_simulation.php
+++ b/config/match_simulation.php
@@ -64,6 +64,7 @@ return [
     'base_goals' => 1.4,                // avg xG per team when evenly matched (~2.6 total)
     'skill_dominance' => 2.4,           // how much team quality widens the xG gap (see above)
     'home_advantage_goals' => 0.20,     // fixed home xG bonus
+    'defensive_quality_damping' => 0.6, // how much quality advantage erodes defensive tactics (0=none, higher=more erosion)
 
     /*
     |--------------------------------------------------------------------------
@@ -209,8 +210,8 @@ return [
         '3-4-3'   => ['attack' => 1.12, 'defense' => 1.10],   // Very attacking, very exposed
         '3-5-2'   => ['attack' => 0.97, 'defense' => 0.96],   // Midfield control, conservative
         '4-1-4-1' => ['attack' => 0.95, 'defense' => 0.93],   // Defensive midfield shield
-        '5-3-2'   => ['attack' => 0.90, 'defense' => 0.88],   // Defensive, hard to break
-        '5-4-1'   => ['attack' => 0.84, 'defense' => 0.82],   // Park the bus
+        '5-3-2'   => ['attack' => 0.90, 'defense' => 0.90],   // Defensive, hard to break
+        '5-4-1'   => ['attack' => 0.84, 'defense' => 0.86],   // Park the bus
         '4-1-2-3' => ['attack' => 1.08, 'defense' => 1.07],   // Attacking with DM anchor
         '4-3-2-1' => ['attack' => 1.04, 'defense' => 1.03],   // Creative, narrow attack
     ],
@@ -226,7 +227,7 @@ return [
     |
     */
     'mentalities' => [
-        'defensive' => ['own_goals' => 0.82, 'opponent_goals' => 0.78],
+        'defensive' => ['own_goals' => 0.88, 'opponent_goals' => 0.84],
         'balanced'  => ['own_goals' => 1.00, 'opponent_goals' => 1.00],
         'attacking' => ['own_goals' => 1.15, 'opponent_goals' => 1.12],
     ],


### PR DESCRIPTION
User matches (MatchSimulator) produced drastically fewer goals than AI-vs-AI matches (AIMatchResolver) because defensive tactical modifiers — formation, mentality, playing style, pressing, defensive line — compounded multiplicatively to reduce xG by up to 57%. This made strong user teams score ~1 goal/game instead of the realistic ~2.5.

Add strength-ratio-based tactical attenuation: the bigger the quality gap between teams, the less effective defensive tactics are. A team parking the bus against a much stronger opponent will still concede regularly, as quality prevails through possession and defensive fatigue.

Also reduce the most extreme defensive config values (mentality opponent_goals 0.78→0.84, 5-4-1 defense 0.82→0.86) and add a configurable defensive_quality_damping parameter (default 1.2).