### PR TITLE
Allow unavailable players to be deselected from lineup

### DIFF
--- a/resources/js/lineup.js
+++ b/resources/js/lineup.js
@@ -334,7 +334,7 @@ export default function lineupManager(config) {
 
         // Toggle player selection (from player list)
         toggle(id, isUnavailable) {
-            if (isUnavailable) return;
+            if (isUnavailable && !this.isSelected(id)) return;
 
             // Suppress click after a list-to-pitch drag gesture
             if (this._listDragMoved) {

--- a/resources/views/lineup.blade.php
+++ b/resources/views/lineup.blade.php
@@ -282,11 +282,13 @@
                                                 @mousedown="startListDrag('{{ $player->id }}', $event)"
                                                 @mouseenter="hoveredPlayerId = '{{ $player->id }}'"
                                                 @mouseleave="hoveredPlayerId = null"
-                                                class="available-player px-3 py-2.5 border-b border-border-default {{ $isUnavailable ? 'opacity-40 cursor-not-allowed' : 'cursor-pointer' }}"
+                                                class="available-player px-3 py-2.5 border-b border-border-default"
                                                 :class="{
                                                     'bg-accent-blue/10 border-accent-blue/20': isSelected('{{ $player->id }}'),
                                                     'opacity-30': listDragPlayerId === '{{ $player->id }}',
-                                                    'opacity-50': !isSelected('{{ $player->id }}') && selectedCount >= 11 && !{{ $isUnavailable ? 'true' : 'false' }}
+                                                    'opacity-50': !isSelected('{{ $player->id }}') && selectedCount >= 11 && !{{ $isUnavailable ? 'true' : 'false' }},
+                                                    'opacity-40 cursor-not-allowed': {{ $isUnavailable ? 'true' : 'false' }} && !isSelected('{{ $player->id }}'),
+                                                    'cursor-pointer': !{{ $isUnavailable ? 'true' : 'false' }} || isSelected('{{ $player->id }}')
                                                 }"
                                             >
                                                 <div class="flex items-center gap-2.5">
@@ -316,14 +318,12 @@
                                                         </div>
                                                     </div>
                                                     <x-rating-badge :value="$player->overall_score" size="sm" class="shrink-0" />
-                                                    @if(!$isUnavailable)
                                                     <div class="w-5 h-5 rounded-sm border flex items-center justify-center transition-colors shrink-0"
                                                         :class="isSelected('{{ $player->id }}') ? 'border-accent-blue bg-accent-blue' : 'border-border-strong'">
                                                         <svg x-show="isSelected('{{ $player->id }}')" x-cloak class="w-3 h-3 text-white" fill="currentColor" viewBox="0 0 20 20">
                                                             <path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/>
                                                         </svg>
                                                     </div>
-                                                    @endif
                                                 </div>
                                             </div>
                                         @endforeach


### PR DESCRIPTION
## Summary
This change improves the user experience when managing unavailable players in the lineup by allowing them to be deselected even though they cannot be newly selected.

## Key Changes
- **Modified selection logic** (`lineup.js`): Updated the `toggle()` method to allow deselection of unavailable players while still preventing their selection. Changed condition from `if (isUnavailable) return;` to `if (isUnavailable && !this.isSelected(id)) return;`

- **Refactored styling approach** (`lineup.blade.php`): Moved unavailable player styling from static classes to dynamic `:class` bindings for better conditional control:
  - Removed hardcoded `opacity-40 cursor-not-allowed` classes
  - Added dynamic classes that apply `opacity-40 cursor-not-allowed` only when player is unavailable AND not selected
  - Added `cursor-pointer` class when player is available OR already selected

- **Removed conditional rendering**: Eliminated the `@if(!$isUnavailable)` check around the selection checkbox, allowing the checkbox to always be visible and functional for deselection

## Implementation Details
The changes ensure that unavailable players (e.g., injured or suspended) can be removed from a lineup if they were previously added, while still preventing them from being newly added. The visual feedback (opacity and cursor) now accurately reflects this behavior, showing the unavailable state only when the player cannot be interacted with.

https://claude.ai/code/session_015e31VcsmzMLeTC7iHwNRk1