### PR TITLE
Remove retiring free agents and announce retirement for aged free agents

### DIFF
--- a/app/Modules/Season/Processors/PlayerRetirementProcessor.php
+++ b/app/Modules/Season/Processors/PlayerRetirementProcessor.php
@@ -51,9 +51,12 @@ class PlayerRetirementProcessor implements SeasonProcessor
      */
     private function processRetirements(Game $game, SeasonTransitionData $data): array
     {
+        // Include free agents (team_id IS NULL): a player who announced retirement
+        // while on a team can have their contract expire in the same season closing
+        // (ContractExpirationProcessor runs first), leaving team_id null. We still
+        // want those players removed from the game.
         $retiringPlayers = GamePlayer::with(['player', 'team', 'game'])
             ->where('game_id', $game->id)
-            ->whereNotNull('team_id')
             ->where('retiring_at_season', $data->oldSeason)
             ->get();
 
@@ -88,9 +91,10 @@ class PlayerRetirementProcessor implements SeasonProcessor
 
         // matchState is eager-loaded because shouldRetire() reads
         // fitness/season_appearances via the GamePlayer accessor delegates.
+        // Free agents (team_id IS NULL) are included so they also receive
+        // retirement announcements on the same cadence as rostered players.
         $candidates = GamePlayer::with(['player', 'team', 'game', 'matchState'])
             ->where('game_id', $game->id)
-            ->whereNotNull('team_id')
             ->whereNull('retiring_at_season')
             ->whereHas('player', fn ($q) => $q->where('date_of_birth', '<=', $minRetirementCutoff))
             ->get()

--- a/tests/Feature/PlayerRetirementTest.php
+++ b/tests/Feature/PlayerRetirementTest.php
@@ -234,6 +234,75 @@ class PlayerRetirementTest extends TestCase
         $this->assertTrue($retired[0]['wasUserTeam']);
     }
 
+    public function test_processor_deletes_retiring_free_agent(): void
+    {
+        // A player who announced retirement while on a team, then lost their
+        // team_id (e.g. contract expiration earlier in the same closing), must
+        // still be removed — not linger as a free agent next season.
+        $player = Player::factory()->age(36)->create([
+            'technical_ability' => 65,
+            'physical_ability' => 65,
+        ]);
+        $gamePlayer = GamePlayer::factory()->create([
+            'game_id' => $this->game->id,
+            'player_id' => $player->id,
+            'team_id' => null,
+            'position' => 'Central Midfield',
+            'fitness' => 80,
+            'season_appearances' => 15,
+            'game_technical_ability' => 65,
+            'game_physical_ability' => 65,
+            'retiring_at_season' => '2024',
+        ]);
+
+        $processor = app(PlayerRetirementProcessor::class);
+        $data = new SeasonTransitionData(oldSeason: '2024', newSeason: '2025', competitionId: 'ESP1');
+
+        $result = $processor->process($this->game, $data);
+
+        $this->assertDatabaseMissing('game_players', ['id' => $gamePlayer->id]);
+
+        $retired = $result->getMetadata('retiredPlayers');
+        $this->assertCount(1, $retired);
+        $this->assertEquals($gamePlayer->id, $retired[0]['playerId']);
+        $this->assertNull($retired[0]['teamId']);
+        $this->assertFalse($retired[0]['wasUserTeam']);
+    }
+
+    public function test_processor_announces_retirement_for_free_agent(): void
+    {
+        // Free agents aged past retirement should receive an announcement on
+        // the same closing-cycle cadence as rostered players. Age 40 outfield
+        // is MAX_CAREER_OUTFIELD, so shouldRetire() returns true deterministically.
+        $player = Player::factory()->age(40)->create([
+            'technical_ability' => 65,
+            'physical_ability' => 65,
+        ]);
+        $gamePlayer = GamePlayer::factory()->create([
+            'game_id' => $this->game->id,
+            'player_id' => $player->id,
+            'team_id' => null,
+            'position' => 'Central Midfield',
+            'fitness' => 80,
+            'season_appearances' => 0,
+            'game_technical_ability' => 65,
+            'game_physical_ability' => 65,
+            'retiring_at_season' => null,
+        ]);
+
+        $processor = app(PlayerRetirementProcessor::class);
+        $data = new SeasonTransitionData(oldSeason: '2024', newSeason: '2025', competitionId: 'ESP1');
+
+        $result = $processor->process($this->game, $data);
+
+        $gamePlayer->refresh();
+        $this->assertEquals('2025', $gamePlayer->retiring_at_season);
+
+        $announcements = $result->getMetadata('retirementAnnouncements');
+        $announcedIds = array_column($announcements, 'playerId');
+        $this->assertContains($gamePlayer->id, $announcedIds);
+    }
+
     public function test_processor_does_not_retire_players_from_different_season(): void
     {
         $player = $this->createGamePlayer(


### PR DESCRIPTION
PlayerRetirementProcessor only considered players with team_id IS NOT
NULL, so two bugs leaked through each season closing:

1. A player who announced retirement while on a team, and whose contract
   expired in the same closing (ContractExpirationProcessor runs first),
   had team_id cleared and was silently skipped in Phase 1 — surviving
   as a free agent the next season.
2. Existing free agents aged past MIN_RETIREMENT never received a
   Phase 2 retirement announcement, letting them linger in the free
   agent list past the retirement age threshold.

Dropping the team_id filter in both phases makes retirement apply
uniformly. The loop bodies already tolerate null team_id via
`team?->name ?? 'Unknown'` and strict `===` team comparison.

https://claude.ai/code/session_01UeGj75zmZYXzqz14Hm7hVj