### PR TITLE
Scroll tactical panel to top when confirmation overlay opens

### DIFF
--- a/resources/js/live-match.js
+++ b/resources/js/live-match.js
@@ -840,6 +840,19 @@ export default function liveMatch(config) {
         showConfirmation() {
             this.tacticalError = null;
             this.showingConfirmation = true;
+            // On mobile the pitch and controls stack vertically in a single
+            // scroll container, and the confirmation overlay is positioned
+            // absolutely within the controls panel. If the user had scrolled
+            // down (e.g. to pick a bench player) before tapping "Apply",
+            // the overlay's content would sit above the viewport. Reset the
+            // scroll so the pitch and the "Revisar cambios" summary are
+            // both visible.
+            this.$nextTick(() => {
+                const scrollContainer = this.$refs.tacticalScrollContainer;
+                if (scrollContainer) {
+                    scrollContainer.scrollTop = 0;
+                }
+            });
         },
 
         cancelConfirmation() {

--- a/resources/views/partials/live-match/tactical-panel.blade.php
+++ b/resources/views/partials/live-match/tactical-panel.blade.php
@@ -76,7 +76,7 @@
             </div>
 
             {{-- Split layout: Pitch (left) + Controls (right) --}}
-            <div class="flex-1 min-h-0 overflow-y-auto lg:overflow-y-hidden">
+            <div x-ref="tacticalScrollContainer" class="flex-1 min-h-0 overflow-y-auto lg:overflow-y-hidden">
                 <div class="flex flex-col lg:flex-row lg:h-full">
 
                     {{-- LEFT: Pitch visualization --}}


### PR DESCRIPTION
On mobile, the pitch and substitution controls stack vertically inside
a single scroll container, and the confirmation overlay is positioned
absolutely within the controls panel. After picking a bench player the
user is scrolled near the bottom, so tapping "Apply" left the overlay's
"Revisar cambios" summary above the viewport, showing an empty screen
with only the header and footer. Reset the container scroll when the
overlay opens so the pitch and summary are both visible.