### PR TITLE
Scope player_suspensions by game_id

### DIFF
--- a/app/Http/Actions/SkipMatchToEnd.php
+++ b/app/Http/Actions/SkipMatchToEnd.php
@@ -146,7 +146,7 @@ class SkipMatchToEnd
         ));
         $activeIds = array_merge($activeIds, $subbedInIds);
 
-        $suspendedIds = PlayerSuspension::suspendedPlayerIdsForCompetition($match->competition_id);
+        $suspendedIds = PlayerSuspension::suspendedPlayerIdsForCompetition($match->game_id, $match->competition_id);
 
         return GamePlayer::query()
             ->where('game_players.game_id', $game->id)

--- a/app/Http/Views/ShowLiveMatch.php
+++ b/app/Http/Views/ShowLiveMatch.php
@@ -159,7 +159,7 @@ class ShowLiveMatch
             ->all();
 
         // Batch load suspended player IDs for this competition
-        $suspendedPlayerIds = PlayerSuspension::suspendedPlayerIdsForCompetition($playerMatch->competition_id);
+        $suspendedPlayerIds = PlayerSuspension::suspendedPlayerIdsForCompetition($gameId, $playerMatch->competition_id);
 
         // Load cached performances for all players (starters + subs)
         $playerPerformances = Cache::get("match_performances:{$playerMatch->id}", []);

--- a/app/Http/Views/ShowPreMatchData.php
+++ b/app/Http/Views/ShowPreMatchData.php
@@ -45,7 +45,7 @@ class ShowPreMatchData
         } elseif (count($lineup) < 11) {
             $issueMessage = __('messages.pre_match_incomplete');
         } else {
-            $suspendedPlayerIds = PlayerSuspension::suspendedPlayerIdsForCompetition($competitionId);
+            $suspendedPlayerIds = PlayerSuspension::suspendedPlayerIdsForCompetition($gameId, $competitionId);
             $hasInjured = false;
             $hasSuspended = false;
 

--- a/app/Models/PlayerSuspension.php
+++ b/app/Models/PlayerSuspension.php
@@ -9,20 +9,21 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 /**
  * @property string $id
  * @property string $game_player_id
+ * @property string $game_id
  * @property string $competition_id
  * @property int $matches_remaining
  * @property int $yellow_cards
  * @property-read \App\Models\Competition|null $competition
+ * @property-read \App\Models\Game $game
  * @property-read \App\Models\GamePlayer $gamePlayer
  * @method static \Illuminate\Database\Eloquent\Builder<static>|PlayerSuspension newModelQuery()
  * @method static \Illuminate\Database\Eloquent\Builder<static>|PlayerSuspension newQuery()
  * @method static \Illuminate\Database\Eloquent\Builder<static>|PlayerSuspension query()
  * @method static \Illuminate\Database\Eloquent\Builder<static>|PlayerSuspension whereCompetitionId($value)
- * @method static \Illuminate\Database\Eloquent\Builder<static>|PlayerSuspension whereCreatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|PlayerSuspension whereGameId($value)
  * @method static \Illuminate\Database\Eloquent\Builder<static>|PlayerSuspension whereGamePlayerId($value)
  * @method static \Illuminate\Database\Eloquent\Builder<static>|PlayerSuspension whereId($value)
  * @method static \Illuminate\Database\Eloquent\Builder<static>|PlayerSuspension whereMatchesRemaining($value)
- * @method static \Illuminate\Database\Eloquent\Builder<static>|PlayerSuspension whereUpdatedAt($value)
  * @mixin \Eloquent
  */
 class PlayerSuspension extends Model
@@ -33,6 +34,7 @@ class PlayerSuspension extends Model
 
     protected $fillable = [
         'game_player_id',
+        'game_id',
         'competition_id',
         'matches_remaining',
         'yellow_cards',
@@ -46,6 +48,11 @@ class PlayerSuspension extends Model
     public function gamePlayer(): BelongsTo
     {
         return $this->belongsTo(GamePlayer::class);
+    }
+
+    public function game(): BelongsTo
+    {
+        return $this->belongsTo(Game::class);
     }
 
     public function competition(): BelongsTo
@@ -76,12 +83,16 @@ class PlayerSuspension extends Model
 
     /**
      * Create or update a suspension for a player in a competition.
+     *
+     * The (game_player_id, competition_id) pair is already unique (game_player_id
+     * is globally unique via UUID), so game_id is set only on insert and kept
+     * out of the lookup keys.
      */
-    public static function applySuspension(string $gamePlayerId, string $competitionId, int $matches): self
+    public static function applySuspension(string $gamePlayerId, string $gameId, string $competitionId, int $matches): self
     {
         return self::updateOrCreate(
             ['game_player_id' => $gamePlayerId, 'competition_id' => $competitionId],
-            ['matches_remaining' => $matches],
+            ['game_id' => $gameId, 'matches_remaining' => $matches],
         );
     }
 
@@ -90,11 +101,11 @@ class PlayerSuspension extends Model
      *
      * @return int The updated yellow card count for this competition
      */
-    public static function recordYellowCard(string $gamePlayerId, string $competitionId): int
+    public static function recordYellowCard(string $gamePlayerId, string $gameId, string $competitionId): int
     {
         $record = self::firstOrCreate(
             ['game_player_id' => $gamePlayerId, 'competition_id' => $competitionId],
-            ['matches_remaining' => 0, 'yellow_cards' => 0],
+            ['game_id' => $gameId, 'matches_remaining' => 0, 'yellow_cards' => 0],
         );
 
         $record->increment('yellow_cards');
@@ -126,13 +137,19 @@ class PlayerSuspension extends Model
     }
 
     /**
-     * Get all suspended player IDs for a competition (single query, for batch filtering).
+     * Get all suspended player IDs for a given game + competition (single query, for batch filtering).
+     *
+     * Scoping by game_id is essential: competition_id is a shared reference (e.g. 'ESP1'
+     * is the same row across all games), so without it this query would return suspensions
+     * from every active game that uses the competition. Backed by the partial index
+     * `player_suspensions_active_idx (game_id, competition_id) WHERE matches_remaining > 0`.
      *
      * @return array<string>
      */
-    public static function suspendedPlayerIdsForCompetition(string $competitionId): array
+    public static function suspendedPlayerIdsForCompetition(string $gameId, string $competitionId): array
     {
-        return self::where('competition_id', $competitionId)
+        return self::where('game_id', $gameId)
+            ->where('competition_id', $competitionId)
             ->where('matches_remaining', '>', 0)
             ->pluck('game_player_id')
             ->all();

--- a/app/Modules/Lineup/Services/LineupService.php
+++ b/app/Modules/Lineup/Services/LineupService.php
@@ -39,7 +39,7 @@ class LineupService
             ->get();
 
         // Batch load suspended player IDs for this competition (single query)
-        $suspendedPlayerIds = PlayerSuspension::suspendedPlayerIdsForCompetition($competitionId);
+        $suspendedPlayerIds = PlayerSuspension::suspendedPlayerIdsForCompetition($gameId, $competitionId);
 
         // Filter in memory using pre-loaded suspension data
         return $players->filter(function (GamePlayer $player) use ($matchDate, $suspendedPlayerIds, $requireEnrollment) {

--- a/app/Modules/Lineup/Services/SubstitutionService.php
+++ b/app/Modules/Lineup/Services/SubstitutionService.php
@@ -64,7 +64,7 @@ class SubstitutionService
         }
 
         // Pre-load all suspended player IDs for this competition (single query)
-        $suspendedPlayerIds = PlayerSuspension::suspendedPlayerIdsForCompetition($match->competition_id);
+        $suspendedPlayerIds = PlayerSuspension::suspendedPlayerIdsForCompetition($match->game_id, $match->competition_id);
 
         // Pre-load red-carded player IDs up to this minute (single query instead of N)
         $playerOutIds = array_column($newSubstitutions, 'playerOutId');
@@ -220,7 +220,7 @@ class SubstitutionService
         }
 
         // Pre-load suspended player IDs for this competition (single query)
-        $suspendedPlayerIds = PlayerSuspension::suspendedPlayerIdsForCompetition($match->competition_id);
+        $suspendedPlayerIds = PlayerSuspension::suspendedPlayerIdsForCompetition($match->game_id, $match->competition_id);
 
         $opponentPlayers = $opponentSquad->filter(fn ($p) => in_array($p->id, $opponentLineupIds));
         $opponentBench = $opponentSquad

--- a/app/Modules/Match/Services/MatchResimulationService.php
+++ b/app/Modules/Match/Services/MatchResimulationService.php
@@ -540,8 +540,11 @@ class MatchResimulationService
         $isPreseason = $handlerType === 'preseason';
 
         if (! $isPreseason) {
-            // Pre-load all suspensions for affected players in this competition (single query)
-            $suspensionsByPlayer = PlayerSuspension::where('competition_id', $competitionId)
+            // Pre-load all suspensions for affected players in this competition (single query).
+            // game_id scoping is redundant here since whereIn on globally-unique game_player_ids
+            // already constrains the result, but we keep it for index alignment and hygiene.
+            $suspensionsByPlayer = PlayerSuspension::where('game_id', $match->game_id)
+                ->where('competition_id', $competitionId)
                 ->whereIn('game_player_id', $affectedPlayerIds)
                 ->get()
                 ->keyBy('game_player_id');
@@ -759,7 +762,7 @@ class MatchResimulationService
             switch ($event->type) {
                 case 'yellow_card':
                     if (! $isPreseason) {
-                        $this->eligibilityService->processYellowCard($player->id, $competitionId, $handlerType);
+                        $this->eligibilityService->processYellowCard($player->id, $player->game_id, $competitionId, $handlerType);
                     }
                     break;
                 case 'red_card':

--- a/app/Modules/Match/Services/MatchResultProcessor.php
+++ b/app/Modules/Match/Services/MatchResultProcessor.php
@@ -395,7 +395,7 @@ class MatchResultProcessor
         }
 
         // Batch process all card events (~4-5 queries total instead of ~3 per card)
-        $cardResults = $this->eligibilityService->batchProcessCards($cardEvents, $competitions);
+        $cardResults = $this->eligibilityService->batchProcessCards($cardEvents, $competitions, $game->id);
 
         // Build a lookup of which match each card event came from (for notification filtering)
         $cardEventMatchLookup = [];

--- a/app/Modules/Squad/Services/EligibilityService.php
+++ b/app/Modules/Squad/Services/EligibilityService.php
@@ -21,7 +21,7 @@ class EligibilityService
      */
     public function applySuspension(GamePlayer $player, int $matches, string $competitionId): void
     {
-        PlayerSuspension::applySuspension($player->id, $competitionId, $matches);
+        PlayerSuspension::applySuspension($player->id, $player->game_id, $competitionId, $matches);
     }
 
     /**
@@ -71,13 +71,13 @@ class EligibilityService
      *
      * @return int|null Number of matches banned, or null if no suspension
      */
-    public function processYellowCard(string $gamePlayerId, string $competitionId, string $handlerType = 'league'): ?int
+    public function processYellowCard(string $gamePlayerId, string $gameId, string $competitionId, string $handlerType = 'league'): ?int
     {
-        $competitionYellows = PlayerSuspension::recordYellowCard($gamePlayerId, $competitionId);
+        $competitionYellows = PlayerSuspension::recordYellowCard($gamePlayerId, $gameId, $competitionId);
         $banLength = $this->checkYellowCardAccumulation($competitionYellows, $handlerType);
 
         if ($banLength) {
-            PlayerSuspension::applySuspension($gamePlayerId, $competitionId, $banLength);
+            PlayerSuspension::applySuspension($gamePlayerId, $gameId, $competitionId, $banLength);
         }
 
         return $banLength;
@@ -131,9 +131,10 @@ class EligibilityService
      *
      * @param  array  $cardEvents  [{game_player_id, competitionId, event_type, metadata}]
      * @param  Collection  $competitions  keyed by ID
+     * @param  string  $gameId  The game these events belong to (all events in a batch share one game)
      * @return array  [suspensions => [{game_player_id, competition_id, ban_length, reason}]]
      */
-    public function batchProcessCards(array $cardEvents, Collection $competitions): array
+    public function batchProcessCards(array $cardEvents, Collection $competitions, string $gameId): array
     {
         if (empty($cardEvents)) {
             return ['suspensions' => []];
@@ -181,6 +182,7 @@ class EligibilityService
                 $missingRows[] = [
                     'id' => $newId,
                     'game_player_id' => $pair['game_player_id'],
+                    'game_id' => $gameId,
                     'competition_id' => $pair['competition_id'],
                     'yellow_cards' => 0,
                     'matches_remaining' => 0,
@@ -189,6 +191,7 @@ class EligibilityService
                 $record = new PlayerSuspension();
                 $record->id = $newId;
                 $record->game_player_id = $pair['game_player_id'];
+                $record->game_id = $gameId;
                 $record->competition_id = $pair['competition_id'];
                 $record->yellow_cards = 0;
                 $record->matches_remaining = 0;
@@ -298,8 +301,8 @@ class EligibilityService
      */
     public function resetYellowCardsForCompetition(string $gameId, string $competitionId): void
     {
-        PlayerSuspension::where('competition_id', $competitionId)
-            ->whereHas('gamePlayer', fn ($q) => $q->where('game_id', $gameId))
+        PlayerSuspension::where('game_id', $gameId)
+            ->where('competition_id', $competitionId)
             ->where('yellow_cards', '>', 0)
             ->update(['yellow_cards' => 0]);
     }

--- a/database/migrations/2026_04_14_000002_add_game_id_to_player_suspensions.php
+++ b/database/migrations/2026_04_14_000002_add_game_id_to_player_suspensions.php
@@ -1,0 +1,50 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        // Phase 1: Add nullable column
+        Schema::table('player_suspensions', function (Blueprint $table) {
+            $table->uuid('game_id')->nullable()->after('game_player_id');
+        });
+
+        // Phase 2: Backfill from game_players
+        DB::statement(<<<'SQL'
+            UPDATE player_suspensions
+            SET game_id = gp.game_id
+            FROM game_players gp
+            WHERE player_suspensions.game_player_id = gp.id
+        SQL);
+
+        // Phase 3: Add NOT NULL constraint + FK
+        Schema::table('player_suspensions', function (Blueprint $table) {
+            $table->uuid('game_id')->nullable(false)->change();
+            $table->foreign('game_id')->references('id')->on('games')->onDelete('cascade');
+        });
+
+        // Phase 4: Partial index for the hot-path query (active suspensions per game+competition).
+        // Excludes rows where matches_remaining = 0 (kept around for yellow_card tracking),
+        // keeping the index tight and making suspendedPlayerIdsForCompetition() an index-only scan.
+        DB::statement(<<<'SQL'
+            CREATE INDEX player_suspensions_active_idx
+            ON player_suspensions (game_id, competition_id)
+            WHERE matches_remaining > 0
+        SQL);
+    }
+
+    public function down(): void
+    {
+        DB::statement('DROP INDEX IF EXISTS player_suspensions_active_idx');
+
+        Schema::table('player_suspensions', function (Blueprint $table) {
+            $table->dropForeign(['game_id']);
+            $table->dropColumn('game_id');
+        });
+    }
+};

--- a/tests/Feature/PreseasonSuspensionTest.php
+++ b/tests/Feature/PreseasonSuspensionTest.php
@@ -228,6 +228,7 @@ class PreseasonSuspensionTest extends TestCase
         // Manually set up a PlayerSuspension record with 4 yellows (just under threshold)
         PlayerSuspension::create([
             'game_player_id' => $player->id,
+            'game_id' => $this->game->id,
             'competition_id' => 'PRESEASON',
             'matches_remaining' => 0,
             'yellow_cards' => 4,

--- a/tests/Feature/SuspensionDeferralTest.php
+++ b/tests/Feature/SuspensionDeferralTest.php
@@ -69,6 +69,7 @@ class SuspensionDeferralTest extends TestCase
 
         PlayerSuspension::create([
             'game_player_id' => $suspendedPlayer->id,
+            'game_id' => $this->game->id,
             'competition_id' => $this->competition->id,
             'matches_remaining' => 1,
             'yellow_cards' => 5,
@@ -130,6 +131,7 @@ class SuspensionDeferralTest extends TestCase
 
         PlayerSuspension::create([
             'game_player_id' => $suspendedPlayer->id,
+            'game_id' => $this->game->id,
             'competition_id' => $this->competition->id,
             'matches_remaining' => 1,
             'yellow_cards' => 5,
@@ -156,7 +158,8 @@ class SuspensionDeferralTest extends TestCase
         $playerMatch = GameMatch::find($this->game->pending_finalization_match_id);
         $userLineupIds = $playerMatch->home_lineup ?? [];
 
-        $suspendedPlayerIds = PlayerSuspension::where('competition_id', $playerMatch->competition_id)
+        $suspendedPlayerIds = PlayerSuspension::where('game_id', $this->game->id)
+            ->where('competition_id', $playerMatch->competition_id)
             ->where('matches_remaining', '>', 0)
             ->pluck('game_player_id')
             ->toArray();
@@ -225,6 +228,7 @@ class SuspensionDeferralTest extends TestCase
 
         PlayerSuspension::create([
             'game_player_id' => $redCardPlayer->id,
+            'game_id' => $this->game->id,
             'competition_id' => $this->competition->id,
             'matches_remaining' => 1,
             'yellow_cards' => 0,
@@ -270,6 +274,7 @@ class SuspensionDeferralTest extends TestCase
 
         PlayerSuspension::create([
             'game_player_id' => $suspendedPlayer->id,
+            'game_id' => $this->game->id,
             'competition_id' => $this->competition->id,
             'matches_remaining' => 1,
             'yellow_cards' => 5,
@@ -322,6 +327,7 @@ class SuspensionDeferralTest extends TestCase
 
         PlayerSuspension::create([
             'game_player_id' => $redCardPlayer->id,
+            'game_id' => $this->game->id,
             'competition_id' => $this->competition->id,
             'matches_remaining' => 1,
             'yellow_cards' => 0,
@@ -365,6 +371,7 @@ class SuspensionDeferralTest extends TestCase
 
         PlayerSuspension::create([
             'game_player_id' => $suspendedPlayer->id,
+            'game_id' => $this->game->id,
             'competition_id' => $this->competition->id,
             'matches_remaining' => 1,
             'yellow_cards' => 5,
@@ -437,6 +444,7 @@ class SuspensionDeferralTest extends TestCase
 
         PlayerSuspension::create([
             'game_player_id' => $suspendedPlayer->id,
+            'game_id' => $this->game->id,
             'competition_id' => $copa->id,
             'matches_remaining' => 1,
             'yellow_cards' => 3,
@@ -505,6 +513,7 @@ class SuspensionDeferralTest extends TestCase
 
         PlayerSuspension::create([
             'game_player_id' => $suspendedPlayer->id,
+            'game_id' => $this->game->id,
             'competition_id' => $this->competition->id,
             'matches_remaining' => 1,
             'yellow_cards' => 5,


### PR DESCRIPTION
Adds game_id to player_suspensions so suspendedPlayerIdsForCompetition only returns rows for the current game (competition_id like 'ESP1' is shared across all games). Backed by a partial index on (game_id, competition_id) WHERE matches_remaining > 0.