### PR TITLE
Fix loan dates when finalized outside transfer window

### DIFF
--- a/app/Models/Game.php
+++ b/app/Models/Game.php
@@ -571,6 +571,32 @@ class Game extends Model
     }
 
     /**
+     * Effective date a newly-finalized loan will start on: today if the
+     * transfer window is open, otherwise the next window opening date.
+     * Used so loans agreed while the window is closed record the date on
+     * which the player actually moves, not the date the deal was agreed.
+     */
+    public function getLoanEffectiveStartDate(): Carbon
+    {
+        $window = $this->transferWindow();
+
+        return $window->isOpen()
+            ? $this->current_date->copy()
+            : ($window->openingBoundaryDate() ?? $this->current_date->copy());
+    }
+
+    /**
+     * June 30 of the football season that contains the given date.
+     * A season runs July 1 → June 30 of the following calendar year.
+     */
+    public function getSeasonEndDateFor(Carbon $date): Carbon
+    {
+        $endYear = $date->month >= 7 ? $date->year + 1 : $date->year;
+
+        return Carbon::createFromDate($endYear, 6, 30);
+    }
+
+    /**
      * Get the first competitive match of the season.
      */
     public function getFirstCompetitiveMatch(): ?GameMatch

--- a/app/Modules/Transfer/Services/LoanService.php
+++ b/app/Modules/Transfer/Services/LoanService.php
@@ -520,14 +520,15 @@ class LoanService
             return;
         }
 
-        $returnDate = $game->getSeasonEndDate();
+        $effectiveStart = $game->getLoanEffectiveStartDate();
+        $returnDate = $game->getSeasonEndDateFor($effectiveStart);
 
         Loan::create([
             'game_id' => $game->id,
             'game_player_id' => $player->id,
             'parent_team_id' => $parentTeamId,
             'loan_team_id' => $game->team_id,
-            'started_at' => $game->current_date,
+            'started_at' => $effectiveStart,
             'return_at' => $returnDate,
             'status' => Loan::STATUS_ACTIVE,
         ]);
@@ -575,14 +576,15 @@ class LoanService
     {
         $player = $offer->gamePlayer;
         $destinationTeamId = $offer->offering_team_id;
-        $returnDate = $game->getSeasonEndDate();
+        $effectiveStart = $game->getLoanEffectiveStartDate();
+        $returnDate = $game->getSeasonEndDateFor($effectiveStart);
 
         Loan::create([
             'game_id' => $game->id,
             'game_player_id' => $player->id,
             'parent_team_id' => $game->team_id,
             'loan_team_id' => $destinationTeamId,
-            'started_at' => $game->current_date,
+            'started_at' => $effectiveStart,
             'return_at' => $returnDate,
             'status' => Loan::STATUS_ACTIVE,
         ]);

--- a/app/Modules/Transfer/Services/TransferCompletionService.php
+++ b/app/Modules/Transfer/Services/TransferCompletionService.php
@@ -46,13 +46,14 @@ class TransferCompletionService
 
         // For loan-out offers, create a loan record so the player returns at season end
         if ($isLoan) {
+            $effectiveStart = $game->getLoanEffectiveStartDate();
             Loan::create([
                 'game_id' => $game->id,
                 'game_player_id' => $player->id,
                 'parent_team_id' => $game->team_id,
                 'loan_team_id' => $offer->offering_team_id,
-                'started_at' => $game->current_date,
-                'return_at' => $game->getSeasonEndDate(),
+                'started_at' => $effectiveStart,
+                'return_at' => $game->getSeasonEndDateFor($effectiveStart),
                 'status' => Loan::STATUS_ACTIVE,
             ]);
         }


### PR DESCRIPTION
Loans agreed while the transfer window is closed were being materialised with started_at = current_date and return_at = getSeasonEndDate() of the current game.season. At season close (AgreedTransferCompletionProcessor, priority 35), season is still the outgoing year, so a loan agreed on 2026-05-24 got return_at = 2026-06-30 — a ~1 month loan instead of a full next-season loan.

Record loans with the date they actually take effect: today if the window is open, otherwise the next window opening date. Return date is June 30 of the football season that contains that effective start.