### PR TITLE
Fix Sabadell quartered shirt color orientation

### DIFF
--- a/app/Support/TeamColors/PrimeraFederacionB.php
+++ b/app/Support/TeamColors/PrimeraFederacionB.php
@@ -39,8 +39,8 @@ final class PrimeraFederacionB implements TeamColorProvider
             ],
             'CE Sabadell FC' => [
                 'pattern' => 'quarters',
-                'primary' => 'white',
-                'secondary' => 'blue-700',
+                'primary' => 'blue-700',
+                'secondary' => 'white',
                 'number' => 'black',
             ],
             'Marbella FC' => [


### PR DESCRIPTION
## Summary
- Swap `primary` and `secondary` for `CE Sabadell FC` in `PrimeraFederacionB`.
- Keep `pattern: quarters` and `number: black` unchanged.
- This corrects the arlequinado quadrant order that was rendering inverted.

## Why
The quartered layout depends on color order. With the previous order, Sabadell's shirt appeared visually flipped versus the expected arrangement.

## Test plan
- Open a lineup/live-match view with `CE Sabadell FC`.
- Verify the quartered shirt now displays with blue as primary and white as secondary in the expected orientation.