### PR TITLE
Update Croatia World Cup kit to quartered pattern

### DIFF
--- a/app/Support/TeamColors/WorldCup.php
+++ b/app/Support/TeamColors/WorldCup.php
@@ -301,7 +301,7 @@ final class WorldCup implements TeamColorProvider
                 'number' => 'blue-900',
             ],
             'Croatia' => [
-                'pattern' => 'hoops',
+                'pattern' => 'quarters',
                 'primary' => 'red-600',
                 'secondary' => 'white',
                 'number' => 'blue-700',


### PR DESCRIPTION
## Summary
- Change `Croatia` kit pattern in `WorldCup` team colors from `hoops` to `quarters`.
- Keep existing color tokens (`red-600`, `white`, `blue-700`) unchanged.
- Align render output with Croatia's checkerboard-style identity.

## Test plan
- Start a World Cup match involving Croatia.
- Verify shirt badges render with the quartered pattern.
- Confirm number color remains blue and contrast stays readable.