### PR TITLE
Skip dramatic pause for atmosphere events in live match

### DIFF
--- a/resources/js/live-match.js
+++ b/resources/js/live-match.js
@@ -1432,7 +1432,10 @@ export default function liveMatch(config) {
         },
 
         isAtmosphereEvent(event) {
-            return event.type === 'shot_on_target' || event.type === 'shot_off_target' || event.type === 'foul' || event.type === 'contextual';
+            // Atmosphere events are tagged at creation by the atmosphere generator.
+            // Using the flag (not a hardcoded type list) keeps this in sync automatically
+            // when new atmosphere event types are added.
+            return !!event.atmosphere;
         },
 
         /**

--- a/resources/js/modules/atmosphere-generator.js
+++ b/resources/js/modules/atmosphere-generator.js
@@ -251,6 +251,7 @@ export function generateAtmosphereForPeriod(config) {
             events.push({
                 minute,
                 type: 'shot_on_target',
+                atmosphere: true,
                 playerName: player.name,
                 teamId: team.id,
                 gamePlayerId: player.id || null,
@@ -276,6 +277,7 @@ export function generateAtmosphereForPeriod(config) {
             events.push({
                 minute,
                 type: 'shot_off_target',
+                atmosphere: true,
                 playerName: player.name,
                 teamId: team.id,
                 gamePlayerId: player.id || null,
@@ -307,6 +309,7 @@ export function generateAtmosphereForPeriod(config) {
             events.push({
                 minute,
                 type: 'foul',
+                atmosphere: true,
                 playerName: player.name,
                 teamId: team.id,
                 gamePlayerId: player.id || null,
@@ -528,6 +531,7 @@ export function generateContextualNarratives(config) {
         events.push({
             minute: m,
             type: 'contextual',
+            atmosphere: true,
             playerName: '',
             teamId: null,
             gamePlayerId: null,
@@ -637,6 +641,7 @@ export function generateTacticalNarratives(config) {
         events.push({
             minute: m,
             type: 'contextual',
+            atmosphere: true,
             playerName: '',
             teamId: null,
             gamePlayerId: null,

--- a/resources/js/modules/match-simulation.js
+++ b/resources/js/modules/match-simulation.js
@@ -209,7 +209,10 @@ export function createMatchSimulation(ctx) {
             updateScore(event);
             triggerGoalFlash();
             pauseForDrama(1500);
-        } else {
+        } else if (!event.atmosphere) {
+            // Real events (cards, subs, injuries, missed pens) still pause for drama.
+            // Atmosphere events are tagged by the atmosphere generator and flow past
+            // without interrupting the clock.
             pauseForDrama(1500);
         }
 
@@ -236,7 +239,7 @@ export function createMatchSimulation(ctx) {
             updateScore(event);
             triggerGoalFlash();
             pauseForDrama(1500);
-        } else {
+        } else if (!event.atmosphere) {
             pauseForDrama(1500);
         }
     }


### PR DESCRIPTION
Shots, fouls, and contextual narratives are low-value commentary and shouldn't freeze the clock for 1.5s like goals/cards/subs/injuries do. The match now flows continuously through atmosphere lines and only pauses for events that actually matter.