### PR TITLE
Show live player ratings on the half-time sub screen

### DIFF
--- a/app/Modules/Match/Services/MatchResimulationService.php
+++ b/app/Modules/Match/Services/MatchResimulationService.php
@@ -224,6 +224,16 @@ class MatchResimulationService
         $homePlayerSlots = $isUserHome ? $this->playerSlotMapWithSubs($match, 'home', $allSubstitutions) : $match->playerSlotMap('home');
         $awayPlayerSlots = $isUserHome ? $match->playerSlotMap('away') : $this->playerSlotMapWithSubs($match, 'away', $allSubstitutions);
 
+        // Seed the simulator with previously rolled performance modifiers so a
+        // player's "form on the day" persists across the full match. Without
+        // this, every resimulation (tactical change, half-time play, skip to
+        // end) re-rolls performance — making the in-match player rating
+        // non-predictive and misleading the user's sub decisions.
+        // Subs who weren't on the pitch yet will get a fresh roll naturally
+        // via getMatchPerformance() when first called.
+        $cachedPerformances = Cache::get("match_performances:{$match->id}", []);
+        $this->matchSimulator->seedPerformance($cachedPerformances);
+
         if ($aiSubsActive) {
             $remainderOutput = $this->matchSimulator->simulateRemainderWithAISubs(
                 $match->homeTeam,
@@ -258,6 +268,7 @@ class MatchResimulationService
                 userTeamId: $autoSubUserTeam ? null : $game->team_id,
                 homePlayerSlots: $homePlayerSlots,
                 awayPlayerSlots: $awayPlayerSlots,
+                preservePerformance: true,
             );
         } else {
             $remainderOutput = $this->matchSimulator->simulateRemainder(
@@ -286,6 +297,7 @@ class MatchResimulationService
                 homeExistingSubstitutions: $homeExistingSubs,
                 awayExistingSubstitutions: $awayExistingSubs,
                 neutralVenue: $match->isNeutralVenue(),
+                preservePerformance: true,
                 homePlayerSlots: $homePlayerSlots,
                 awayPlayerSlots: $awayPlayerSlots,
             );
@@ -296,8 +308,14 @@ class MatchResimulationService
         $newHomeScore = $scoreAtMinute['home'] + $remainderResult->homeScore;
         $newAwayScore = $scoreAtMinute['away'] + $remainderResult->awayScore;
 
-        // 11. Merge performances with cached values (preserves subbed-out players' data)
-        $cachedPerformances = Cache::get("match_performances:{$match->id}", []);
+        // 11. Merge performances with cached values.
+        // The simulator was seeded with these cached values so players on the
+        // pitch keep their original "form on the day" and appear unchanged in
+        // $remainderOutput->performances. array_merge still serves a purpose:
+        // it keeps the records of subbed-out players (who aren't touched by
+        // the remainder simulation) and folds in any fresh rolls for subs who
+        // came onto the pitch. It also preserves any xG-adjustment tweaks
+        // applied during the remainder (±0.04).
         $mergedPerformances = array_merge($cachedPerformances, $remainderOutput->performances);
         Cache::put("match_performances:{$match->id}", $mergedPerformances, now()->addHours(24));
 
@@ -443,6 +461,13 @@ class MatchResimulationService
             // 7. Re-simulate extra time remainder
             $homePlayerSlots = $isUserHome ? $this->playerSlotMapWithSubs($match, 'home', $allSubstitutions) : $match->playerSlotMap('home');
             $awayPlayerSlots = $isUserHome ? $match->playerSlotMap('away') : $this->playerSlotMapWithSubs($match, 'away', $allSubstitutions);
+
+            // Seed the simulator with previously rolled performance modifiers so
+            // players keep their "form on the day" into extra time instead of
+            // getting fresh rolls. Subs who came on during ET will get a fresh
+            // roll naturally on first call to getMatchPerformance().
+            $etSeedPerformances = Cache::get("match_performances:{$match->id}", []);
+            $this->matchSimulator->seedPerformance($etSeedPerformances);
 
             $remainderResult = $this->matchSimulator->simulateExtraTime(
                 $match->homeTeam,

--- a/app/Modules/Match/Services/MatchSimulator.php
+++ b/app/Modules/Match/Services/MatchSimulator.php
@@ -42,6 +42,26 @@ class MatchSimulator
      */
     private array $matchPerformance = [];
 
+    /**
+     * Seed the per-player performance cache with values from a prior simulation.
+     *
+     * Used by MatchResimulationService so that a player's "form on the day" is
+     * preserved across resimulations (e.g. half-time tactical changes). Without
+     * this, every resimulation would re-roll performance and make the in-match
+     * player rating non-predictive — a 6.9 striker at half-time could randomly
+     * become a 9.0 striker in the 2nd half just because the user clicked play.
+     *
+     * Players not present in the seed will get a fresh roll on first call to
+     * getMatchPerformance() — this is intentional for substitutes who weren't
+     * previously on the pitch.
+     *
+     * @param  array<string, float>  $performances  Map of player ID → performance modifier
+     */
+    public function seedPerformance(array $performances): void
+    {
+        $this->matchPerformance = $performances;
+    }
+
     /** @var array<string, string> Player ID → slot code for home team (for position penalty) */
     private array $homePlayerSlotMap = [];
 
@@ -657,6 +677,7 @@ class MatchSimulator
         ?string $userTeamId = null,
         ?array $homePlayerSlots = null,
         ?array $awayPlayerSlots = null,
+        bool $preservePerformance = false,
     ): MatchSimulationOutput {
         if ($homePlayerSlots !== null) {
             $this->homePlayerSlotMap = $homePlayerSlots;
@@ -731,8 +752,11 @@ class MatchSimulator
             );
         }
 
-        // Reset performance cache for the resimulation
-        $this->matchPerformance = [];
+        // Reset performance cache for the resimulation unless the caller has
+        // seeded it from a prior simulation (preserves "form on the day").
+        if (! $preservePerformance) {
+            $this->matchPerformance = [];
+        }
 
         $allEvents = collect();
         $totalHomeScore = 0;

--- a/resources/js/live-match.js
+++ b/resources/js/live-match.js
@@ -26,7 +26,7 @@ import { createPenaltyShootout } from './modules/penalty-shootout.js';
 import { createSubstitutionManager } from './modules/substitution-manager.js';
 import { createMatchSimulation } from './modules/match-simulation.js';
 import { generateRegularTimeAtmosphere, generateExtraTimeAtmosphere, generateTacticalNarratives, addGoalNarratives, regenerateShotsAndFouls, regenerateNarratives } from './modules/atmosphere-generator.js';
-import { calculatePlayerRatings, ratingColor as _ratingColor, updateRosterPerformances, countEvents, buildSubstitutionMap } from './modules/player-ratings.js';
+import { calculatePlayerRatings, ratingColor as _ratingColor, updateRosterPerformances, countEvents, buildSubstitutionMap, performanceToBaseRating } from './modules/player-ratings.js';
 
 /**
  * Copy all own properties from source to target. Regular properties are
@@ -1367,6 +1367,30 @@ export default function liveMatch(config) {
 
         ratingColor(rating) {
             return _ratingColor(rating);
+        },
+
+        /**
+         * Live (pre-full-time) rating for a player, derived solely from the
+         * cached performance modifier — no event, score, or card bonuses.
+         *
+         * Only exposed during the half-time (and ET half-time) substitution
+         * window. Outside those windows the rating has no actionable value —
+         * showing it during live play would just be noise, and showing it at
+         * full time would compete with the proper event-weighted rating.
+         *
+         * Returns null when not in a half-time window or when no performance
+         * data is available for the player.
+         */
+        getBaseRating(playerId) {
+            if (!playerId) return null;
+            if (this.phase !== 'half_time' && this.phase !== 'extra_time_half_time') {
+                return null;
+            }
+            const player = this.homeLineupRoster.find(p => p.id === playerId)
+                || this.awayLineupRoster.find(p => p.id === playerId)
+                || (this.benchPlayers || []).find(p => p.id === playerId);
+            if (!player) return null;
+            return performanceToBaseRating(player.performance);
         },
 
         getEventIcons() {

--- a/resources/js/modules/player-ratings.js
+++ b/resources/js/modules/player-ratings.js
@@ -183,6 +183,25 @@ export function calculatePlayerRatings(homeRoster, awayRoster, events, homeScore
 }
 
 /**
+ * Convert a raw performance modifier (0.70–1.30) to a 1–10 base rating.
+ *
+ * Used for the live / half-time rating shown before the match is decided —
+ * no event, score, or clean-sheet adjustments. Mirrors the normalisation step
+ * in calculatePlayerRatings() and MatchSimulator::performanceToRating() so
+ * the in-match reading stays consistent with the final full-time rating for
+ * players whose match is event-neutral.
+ *
+ * @param {number|null|undefined} performance - Raw performance modifier
+ * @returns {number|null} Rating on 1–10 scale, or null when no data.
+ */
+export function performanceToBaseRating(performance) {
+    if (performance == null) return null;
+    const normalized = (performance - 0.70) / 0.60;
+    const rating = Math.max(1, Math.min(10, normalized * 4 + 5));
+    return Math.round(rating * 10) / 10;
+}
+
+/**
  * Return CSS classes for a rating value's color tier.
  *
  * @param {number} rating - Rating on 1–10 scale

--- a/resources/views/partials/live-match/tactical-panel.blade.php
+++ b/resources/views/partials/live-match/tactical-panel.blade.php
@@ -270,8 +270,14 @@
                                                         <span x-show="isPlayerYellowCarded(player.id)"
                                                               x-tooltip.raw="{{ __('game.player_booked') }}"
                                                               class="shrink-0 w-2 h-3 rounded-[1px] bg-yellow-400 border border-yellow-500"></span>
+                                                        {{-- Live match rating (performance-only, shown when data is available) --}}
+                                                        <span x-show="getBaseRating(player.id) !== null"
+                                                              class="ml-auto inline-flex items-center justify-center min-w-[1.5rem] h-5 rounded-full px-1 text-[9px] font-semibold shrink-0"
+                                                              :class="ratingColor(getBaseRating(player.id))"
+                                                              x-text="getBaseRating(player.id)?.toFixed(1)"></span>
                                                         {{-- Energy bar --}}
-                                                        <span class="ml-auto flex items-center gap-1 shrink-0">
+                                                        <span class="flex items-center gap-1 shrink-0"
+                                                              :class="getBaseRating(player.id) === null ? 'ml-auto' : ''">
                                                             <span class="text-[10px] tabular-nums font-semibold"
                                                                   :class="getEnergyTextColor(getPlayerEnergy(player))"
                                                                   x-text="getPlayerEnergy(player) + '%'"></span>


### PR DESCRIPTION
Managers couldn't see who was underperforming when picking subs at half-time because ratings only appeared at full-time. Add a performance-only rating (no event/score bonuses applied, since the match isn't decided yet) next to each starter in the tactical panel's player-out picker. Uses the same color tiers as the full-time badges so the reading stays consistent.