### PR TITLE
Fix missing full-time ratings for substitutes on both teams

### DIFF
--- a/app/Http/Views/ShowLiveMatch.php
+++ b/app/Http/Views/ShowLiveMatch.php
@@ -195,6 +195,25 @@ class ShowLiveMatch
             ->values()
             ->all();
 
+        // Opponent bench — minimal payload used only to rate opponent
+        // substitutes at full-time. We don't show this list in the UI, so we
+        // only expose the fields the client-side rating formula needs.
+        $opponentTeamId = $isUserHome ? $playerMatch->away_team_id : $playerMatch->home_team_id;
+        $opponentLineupIds = $isUserHome
+            ? ($playerMatch->away_lineup ?? [])
+            : ($playerMatch->home_lineup ?? []);
+        $opponentBenchPlayers = GamePlayer::where('game_players.game_id', $gameId)
+            ->where('team_id', $opponentTeamId)
+            ->whereNotIn('id', $opponentLineupIds)
+            ->get()
+            ->map(fn ($p) => [
+                'id' => $p->id,
+                'positionGroup' => $p->position_group,
+                'performance' => $playerPerformances[$p->id] ?? null,
+                'teamId' => $opponentTeamId,
+            ])
+            ->all();
+
         $mapLineup = fn (array $ids) => GamePlayer::with(['player', 'matchState'])
             ->whereIn('id', $ids)
             ->get()
@@ -342,6 +361,7 @@ class ShowLiveMatch
             'resultsUrl' => $resultsUrl,
             'lineupPlayers' => $lineupPlayers,
             'benchPlayers' => $benchPlayers,
+            'opponentBenchPlayers' => $opponentBenchPlayers,
             'tacticalActionsUrl' => route('game.match.tactical-actions', ['gameId' => $game->id, 'matchId' => $playerMatch->id]),
             'skipToEndUrl' => route('game.match.skip-to-end', ['gameId' => $game->id, 'matchId' => $playerMatch->id]),
             'extraTimeUrl' => route('game.match.extra-time', ['gameId' => $game->id, 'matchId' => $playerMatch->id]),

--- a/resources/js/live-match.js
+++ b/resources/js/live-match.js
@@ -91,6 +91,9 @@ export default function liveMatch(config) {
         // Substitution config
         lineupPlayers: config.lineupPlayers || [],
         benchPlayers: config.benchPlayers || [],
+        // Opponent bench — minimal payload { id, positionGroup, performance, teamId }
+        // used only to rate opponent subs at full-time. Not displayed in the UI.
+        opponentBenchPlayers: config.opponentBenchPlayers || [],
         tacticalActionsUrl: config.tacticalActionsUrl || '',
         skipToEndUrl: config.skipToEndUrl || '',
         csrfToken: config.csrfToken || '',
@@ -1135,7 +1138,10 @@ export default function liveMatch(config) {
 
                 // Update player performances and recalculate ratings
                 if (result.playerPerformances) {
-                    updateRosterPerformances(this.homeLineupRoster, this.awayLineupRoster, result.playerPerformances);
+                    updateRosterPerformances(
+                        [this.homeLineupRoster, this.awayLineupRoster, this.benchPlayers, this.opponentBenchPlayers],
+                        result.playerPerformances,
+                    );
                     this.recalculatePlayerRatings();
                 }
 
@@ -1293,7 +1299,10 @@ export default function liveMatch(config) {
 
             // Update player performances and post-match ratings.
             if (result.playerPerformances) {
-                updateRosterPerformances(this.homeLineupRoster, this.awayLineupRoster, result.playerPerformances);
+                updateRosterPerformances(
+                    [this.homeLineupRoster, this.awayLineupRoster, this.benchPlayers, this.opponentBenchPlayers],
+                    result.playerPerformances,
+                );
                 if (typeof this.recalculatePlayerRatings === 'function') {
                     this.recalculatePlayerRatings();
                 }
@@ -1329,8 +1338,8 @@ export default function liveMatch(config) {
             const allEvents = [...this.events, ...(this.extraTimeEvents || [])];
             const subMap = buildSubstitutionMap(allEvents);
 
-            // Build sub-in player list for rating calculation
-            // User bench players who entered have performance data
+            // Build sub-in player list for rating calculation: any bench player
+            // (user or opponent) who came on and has cached performance data.
             const subsIn = [];
             for (const bp of this.benchPlayers) {
                 if (bp.performance != null && subMap.subbedIn[bp.id]) {
@@ -1342,14 +1351,14 @@ export default function liveMatch(config) {
                     });
                 }
             }
-            // Opponent subs: check if they have performance in the roster cache
-            for (const [inId, sub] of Object.entries(subMap.subbedIn)) {
-                if (sub.teamId && sub.teamId !== this.userTeamId) {
-                    // Find performance from the cached performances (passed via roster update)
-                    const opponentRoster = this.homeTeamId === this.userTeamId
-                        ? this.awayLineupRoster : this.homeLineupRoster;
-                    // Opponent subs aren't in the roster, but may have performance from resim
-                    // We can't rate them without performance data
+            for (const bp of this.opponentBenchPlayers) {
+                if (bp.performance != null && subMap.subbedIn[bp.id]) {
+                    subsIn.push({
+                        id: bp.id,
+                        performance: bp.performance,
+                        positionGroup: bp.positionGroup,
+                        teamId: bp.teamId,
+                    });
                 }
             }
 

--- a/resources/js/modules/player-ratings.js
+++ b/resources/js/modules/player-ratings.js
@@ -216,14 +216,18 @@ export function ratingColor(rating) {
 }
 
 /**
- * Merge new performance values into roster arrays.
+ * Merge new performance values into one or more roster arrays.
  *
- * @param {Array} homeRoster       - Home team roster
- * @param {Array} awayRoster       - Away team roster
+ * Pass every array that holds player performance data (starters AND benches
+ * for both teams) so post-resimulation ratings include late substitutes —
+ * leaving out the benches causes substitute ratings to silently disappear.
+ *
+ * @param {Array<Array>} rosters   - Arrays of player objects to update in place
  * @param {Object} newPerformances - Map of playerId → performance modifier
  */
-export function updateRosterPerformances(homeRoster, awayRoster, newPerformances) {
-    for (const roster of [homeRoster, awayRoster]) {
+export function updateRosterPerformances(rosters, newPerformances) {
+    for (const roster of rosters) {
+        if (!roster) continue;
         for (const player of roster) {
             if (newPerformances[player.id] !== undefined) {
                 player.performance = newPerformances[player.id];

--- a/resources/views/live-match.blade.php
+++ b/resources/views/live-match.blade.php
@@ -33,6 +33,7 @@
                 awayTeamImage: '{{ $match->awayTeam->image }}',
                 lineupPlayers: {{ Js::from($lineupPlayers) }},
                 benchPlayers: {{ Js::from($benchPlayers) }},
+                opponentBenchPlayers: {{ Js::from($opponentBenchPlayers) }},
                 userTeamId: '{{ $game->team_id }}',
                 tacticalActionsUrl: '{{ $tacticalActionsUrl }}',
                 skipToEndUrl: '{{ $skipToEndUrl }}',


### PR DESCRIPTION
Two bugs caused substitute ratings to go missing at full-time:

1. Opponent bench players were never sent to the frontend, so any opponent sub silently fell through the rating loop (which had a TODO comment and no-oped). Add a minimal opponentBenchPlayers payload (id/positionGroup/performance/teamId only — not rendered anywhere in the UI) and include those subs in the rating set when they appear in the match event stream.

2. After the user made subs, the backend cached fresh performance values but updateRosterPerformances only refreshed starter rosters, leaving benchPlayers stale. Late-joining subs ended up with performance == null and were skipped. Generalise the helper to accept any list of rosters and update starters + both benches at both call sites.