### PR TITLE
Reassign post-substitution events so subbed-off players never get carded

### DIFF
--- a/app/Modules/Match/Services/MatchSimulator.php
+++ b/app/Modules/Match/Services/MatchSimulator.php
@@ -911,12 +911,25 @@ class MatchSimulator
     }
 
     /**
-     * Reassign goal/assist events from players who were removed from the match
-     * (via injury or red card) to available teammates.
+     * Reassign goal/assist/card events from players who were removed from the match
+     * (via substitution or red card) to available teammates.
+     *
+     * Cards and goals are generated up-front for a whole period before injury
+     * substitutions are processed, so a player can end up with a card minute that
+     * falls after their sub minute. Without this reassignment, the user sees
+     * nonsensical events like "yellow card for player X at minute 70" when X was
+     * subbed off for injury at minute 40.
      *
      * For red cards, the first red card per team triggers a full xG recalculation
      * via simulateGoalsWithRedCardSplit(). This method handles any remaining cases
      * (injuries, or a second red card in the same match) by reassigning WHO scored.
+     *
+     * A player is considered removed only when they actually left the pitch:
+     *   - substitution (tactical, reactive, or injury auto-sub) — they left at the sub minute
+     *   - red card — they left at the red card minute
+     * An injury without a sub (e.g. when the bench is exhausted) does NOT remove
+     * the player: they stay on the pitch and can legitimately appear in later
+     * events of the same period.
      *
      * @return Collection<MatchEventData>
      */
@@ -927,38 +940,73 @@ class MatchSimulator
         string $homeTeamId,
         string $awayTeamId,
     ): Collection {
-        // Build map of player_id => minute they were removed
-        $removedAt = [];
+        // Track sub-outs and red cards separately so that a red_card event doesn't
+        // treat itself as the reason to reassign itself. Red cards still exclude
+        // the carded player from LATER events via the combined removedAt map
+        // used for availability below.
+        $subRemovedAt = [];
+        $redRemovedAt = [];
         // Build map of player_id => minute they entered (substituted in)
         $enteredAt = [];
 
         foreach ($events as $event) {
-            if (in_array($event->type, ['injury', 'red_card', 'substitution']) && ! isset($removedAt[$event->gamePlayerId])) {
-                $removedAt[$event->gamePlayerId] = $event->minute;
-            }
-            if ($event->type === 'substitution' && isset($event->metadata['player_in_id'])) {
-                $enteredAt[$event->metadata['player_in_id']] = $event->minute;
+            if ($event->type === 'substitution') {
+                $outId = $event->gamePlayerId;
+                if (! isset($subRemovedAt[$outId]) || $event->minute < $subRemovedAt[$outId]) {
+                    $subRemovedAt[$outId] = $event->minute;
+                }
+                $playerInId = $event->metadata['player_in_id'] ?? null;
+                if ($playerInId !== null) {
+                    $enteredAt[$playerInId] = $event->minute;
+                }
+            } elseif ($event->type === 'red_card') {
+                $playerId = $event->gamePlayerId;
+                if (! isset($redRemovedAt[$playerId]) || $event->minute < $redRemovedAt[$playerId]) {
+                    $redRemovedAt[$playerId] = $event->minute;
+                }
             }
         }
 
-        if (empty($removedAt) && empty($enteredAt)) {
+        if (empty($subRemovedAt) && empty($redRemovedAt) && empty($enteredAt)) {
             return $events;
         }
 
-        return $events->map(function (MatchEventData $event) use ($removedAt, $enteredAt, $homePlayers, $awayPlayers, $homeTeamId, $awayTeamId) {
-            if (! in_array($event->type, ['goal', 'assist'])) {
+        // Combined map used when filtering which teammates are on the pitch at a
+        // given minute. For availability we treat either a sub-out or a red card
+        // as a removal.
+        $removedAt = $subRemovedAt;
+        foreach ($redRemovedAt as $playerId => $minute) {
+            if (! isset($removedAt[$playerId]) || $minute < $removedAt[$playerId]) {
+                $removedAt[$playerId] = $minute;
+            }
+        }
+
+        $reassignableTypes = ['goal', 'assist', 'yellow_card', 'red_card', 'own_goal', 'penalty_missed'];
+
+        return $events->map(function (MatchEventData $event) use ($subRemovedAt, $redRemovedAt, $removedAt, $enteredAt, $homePlayers, $awayPlayers, $homeTeamId, $awayTeamId, $reassignableTypes) {
+            if (! in_array($event->type, $reassignableTypes)) {
                 return $event;
             }
 
             $needsReassignment = false;
+            $playerId = $event->gamePlayerId;
 
-            // Player was removed (injury/red card/sub out) at or before this event
-            if (isset($removedAt[$event->gamePlayerId]) && $event->minute >= $removedAt[$event->gamePlayerId]) {
+            // Player was subbed off at or before this event — events after the
+            // sub minute can never belong to them. This is the main fix for the
+            // "yellow card after injury substitution" bug.
+            if (isset($subRemovedAt[$playerId]) && $event->minute >= $subRemovedAt[$playerId]) {
+                $needsReassignment = true;
+            }
+
+            // Player was sent off BEFORE this event (strictly earlier). A red
+            // card event at the same minute as its own entry is the cause of
+            // the removal, not a symptom — don't reassign it to a teammate.
+            if (isset($redRemovedAt[$playerId]) && $event->minute > $redRemovedAt[$playerId]) {
                 $needsReassignment = true;
             }
 
             // Player hadn't entered the match yet (sub in after this event)
-            if (isset($enteredAt[$event->gamePlayerId]) && $event->minute < $enteredAt[$event->gamePlayerId]) {
+            if (isset($enteredAt[$playerId]) && $event->minute < $enteredAt[$playerId]) {
                 $needsReassignment = true;
             }
 
@@ -987,18 +1035,39 @@ class MatchSimulator
                 return false;
             });
 
-            $replacement = $event->type === 'goal'
-                ? $this->pickGoalScorer($availablePlayers)
-                : $this->pickPlayerByPosition($availablePlayers, self::ASSIST_WEIGHTS);
+            $replacement = match ($event->type) {
+                'goal' => $this->pickGoalScorer($availablePlayers),
+                'assist' => $this->pickPlayerByPosition($availablePlayers, self::ASSIST_WEIGHTS),
+                'yellow_card', 'red_card' => $this->pickPlayerByPosition($availablePlayers, self::CARD_WEIGHTS),
+                'own_goal' => $this->pickPlayerByPosition($availablePlayers, [
+                    'Centre-Back' => 40,
+                    'Left-Back' => 20,
+                    'Right-Back' => 20,
+                    'Defensive Midfield' => 15,
+                    'Goalkeeper' => 5,
+                ]),
+                'penalty_missed' => $this->pickPlayerByPosition($availablePlayers, self::GOAL_SCORING_WEIGHTS),
+            };
 
             if (! $replacement) {
-                return $event;
+                // No replacement available — drop the event rather than leave it
+                // attributed to a player who wasn't on the pitch. Returning null
+                // is filtered out after the map.
+                return null;
             }
 
-            return $event->type === 'goal'
-                ? MatchEventData::goal($event->teamId, $replacement->id, $event->minute)
-                : MatchEventData::assist($event->teamId, $replacement->id, $event->minute);
-        });
+            return match ($event->type) {
+                'goal' => MatchEventData::goal($event->teamId, $replacement->id, $event->minute),
+                'assist' => MatchEventData::assist($event->teamId, $replacement->id, $event->minute),
+                'yellow_card' => MatchEventData::yellowCard($event->teamId, $replacement->id, $event->minute),
+                // Reassigned reds can't carry a "second yellow" narrative because
+                // the replacement player didn't have a first yellow — log as a
+                // direct red instead.
+                'red_card' => MatchEventData::redCard($event->teamId, $replacement->id, $event->minute, false),
+                'own_goal' => MatchEventData::ownGoal($event->teamId, $replacement->id, $event->minute),
+                'penalty_missed' => MatchEventData::penaltyMissed($event->teamId, $replacement->id, $event->minute),
+            };
+        })->filter()->values();
     }
 
     /**

--- a/app/Modules/Match/Services/MatchSimulator.php
+++ b/app/Modules/Match/Services/MatchSimulator.php
@@ -292,6 +292,18 @@ class MatchSimulator
             );
         }
 
+        // Capture the initial lineup and bench so a post-match reassignment pass
+        // can rebuild the pool of players who were ever on the pitch. The
+        // per-period reassignment inside simulateRemainder only sees its own
+        // events, so a card generated in period K can't "see" a red-card
+        // reactive sub or AI sub that fires between periods. We rerun the
+        // reassignment over the full event list at the end to guarantee no
+        // event is attributed to a player who was already off the pitch.
+        $initialHomePlayers = $homePlayers;
+        $initialAwayPlayers = $awayPlayers;
+        $initialHomeBench = $homeBenchPlayers;
+        $initialAwayBench = $awayBenchPlayers;
+
         // Reset performance cache once for the entire match
         $this->matchPerformance = [];
 
@@ -441,6 +453,14 @@ class MatchSimulator
         // Sort all events chronologically
         $allEvents = $allEvents->sortBy('minute')->values();
 
+        // Final cross-period reassignment pass. See note at the top of the
+        // function for why this is necessary.
+        $allHomePlayers = $this->buildAllPlayersSeen($initialHomePlayers, $initialHomeBench, $allEvents, $homeTeam->id);
+        $allAwayPlayers = $this->buildAllPlayersSeen($initialAwayPlayers, $initialAwayBench, $allEvents, $awayTeam->id);
+        $allEvents = $this->reassignEventsFromUnavailablePlayers(
+            $allEvents, $allHomePlayers, $allAwayPlayers, $homeTeam->id, $awayTeam->id
+        );
+
         // Apply xG adjustment using accumulated totals from all periods
         $this->adjustPerformancesForXG(
             $totalHomeScore, $totalAwayScore,
@@ -456,6 +476,41 @@ class MatchSimulator
             new MatchResult($totalHomeScore, $totalAwayScore, $allEvents, $finalResult->homePossession, $finalResult->awayPossession),
             $allPerformances,
         );
+    }
+
+    /**
+     * Build the set of players who were ever on the pitch for a team across a
+     * full match. Starts from the initial lineup and adds any player brought
+     * on via a substitution event. Used by the final cross-period
+     * reassignment pass so it can rebuild the pool of valid teammates at any
+     * minute (subbed-out and subbed-in players are both considered).
+     */
+    private function buildAllPlayersSeen(
+        Collection $initialLineup,
+        ?Collection $initialBench,
+        Collection $events,
+        string $teamId,
+    ): Collection {
+        $all = $initialLineup->keyBy('id');
+        if ($initialBench === null) {
+            return $all->values();
+        }
+        $benchById = $initialBench->keyBy('id');
+        foreach ($events as $event) {
+            if ($event->type !== 'substitution' || $event->teamId !== $teamId) {
+                continue;
+            }
+            $playerInId = $event->metadata['player_in_id'] ?? null;
+            if ($playerInId === null || $all->has($playerInId)) {
+                continue;
+            }
+            $subIn = $benchById->get($playerInId);
+            if ($subIn !== null) {
+                $all->put($playerInId, $subIn);
+            }
+        }
+
+        return $all->values();
     }
 
     /**
@@ -758,6 +813,13 @@ class MatchSimulator
             $this->matchPerformance = [];
         }
 
+        // Capture lineup/bench at entry so the final reassignment pass can
+        // rebuild the full pool of players who were ever on the pitch.
+        $initialHomePlayers = $homePlayers;
+        $initialAwayPlayers = $awayPlayers;
+        $initialHomeBench = $homeBenchPlayers;
+        $initialAwayBench = $awayBenchPlayers;
+
         $allEvents = collect();
         $totalHomeScore = 0;
         $totalAwayScore = 0;
@@ -892,6 +954,17 @@ class MatchSimulator
         $totalAwayXG += $finalResult->awayXG;
 
         $allEvents = $allEvents->sortBy('minute')->values();
+
+        // Final cross-period reassignment pass: catches any event whose target
+        // player was taken off the pitch by a sub that fired outside the
+        // event's period (red-card reactive sub, AI tactical sub at a split
+        // minute). Without this, a yellow card in period K can stick to a
+        // player who was reactively subbed between periods K-1 and K.
+        $allHomePlayers = $this->buildAllPlayersSeen($initialHomePlayers, $initialHomeBench, $allEvents, $homeTeam->id);
+        $allAwayPlayers = $this->buildAllPlayersSeen($initialAwayPlayers, $initialAwayBench, $allEvents, $awayTeam->id);
+        $allEvents = $this->reassignEventsFromUnavailablePlayers(
+            $allEvents, $allHomePlayers, $allAwayPlayers, $homeTeam->id, $awayTeam->id
+        );
 
         // Apply xG adjustment using accumulated totals from all periods
         // Use total scores including pre-resimulation goals for correct win/loss determination

--- a/tests/Unit/OffPitchEventReassignmentTest.php
+++ b/tests/Unit/OffPitchEventReassignmentTest.php
@@ -1,0 +1,169 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\Game;
+use App\Models\Team;
+use App\Modules\Lineup\Enums\Formation;
+use App\Modules\Lineup\Enums\Mentality;
+use App\Modules\Match\DTOs\MatchEventData;
+use App\Modules\Match\Services\MatchSimulator;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Collection;
+use Tests\TestCase;
+use Tests\Traits\CreatesLineups;
+
+/**
+ * Regression tests for the "off-pitch event" family of bugs.
+ *
+ * Cards, goals, own goals, assists and missed penalties are generated against
+ * the current lineup for a whole period, using random minutes across the period.
+ * When an injury substitution (or any substitution) happens mid-period, the
+ * replaced player must not appear in later events — otherwise the user sees
+ * nonsensical output like "yellow card for Vinicius at 70'" when Vinicius was
+ * substituted off at 40' due to injury.
+ *
+ * These tests crank the injury and card rates so every simulation produces the
+ * conditions that previously triggered the bug, then assert that no event
+ * occurs after a player's sub-out minute (or before their entry minute).
+ */
+class OffPitchEventReassignmentTest extends TestCase
+{
+    use RefreshDatabase;
+    use CreatesLineups;
+
+    private MatchSimulator $simulator;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->simulator = new MatchSimulator;
+    }
+
+    public function test_no_event_lands_on_a_player_who_has_already_been_subbed_off(): void
+    {
+        // Force an injury every match so the auto-sub path is always exercised,
+        // and crank yellows so at least one card lands in the same period as
+        // the injury auto-sub.
+        config([
+            'match_simulation.injury_chance' => 100,
+            'match_simulation.yellow_cards_per_team' => 6,
+        ]);
+
+        $game = Game::factory()->create(['current_date' => '2025-10-01']);
+        $homeTeam = Team::factory()->create();
+        $awayTeam = Team::factory()->create();
+
+        $homePlayers = $this->createLineup($game, $homeTeam, 11, 75);
+        $awayPlayers = $this->createLineup($game, $awayTeam, 11, 75);
+        $homeBench = $this->createBenchPlayers($game, $homeTeam, 7, 72);
+        $awayBench = $this->createBenchPlayers($game, $awayTeam, 7, 72);
+
+        for ($i = 0; $i < 30; $i++) {
+            $output = $this->simulator->simulate(
+                $homeTeam, $awayTeam,
+                $homePlayers, $awayPlayers,
+                Formation::F_4_4_2, Formation::F_4_4_2,
+                Mentality::BALANCED, Mentality::BALANCED,
+                $game,
+                homeBenchPlayers: $homeBench,
+                awayBenchPlayers: $awayBench,
+            );
+
+            $this->assertEventsConsistentWithSubstitutions($output->result->events, "iteration $i");
+        }
+    }
+
+    public function test_no_event_lands_on_a_substitute_before_they_enter_the_pitch(): void
+    {
+        config([
+            'match_simulation.injury_chance' => 100,
+            'match_simulation.yellow_cards_per_team' => 6,
+        ]);
+
+        $game = Game::factory()->create(['current_date' => '2025-10-01']);
+        $homeTeam = Team::factory()->create();
+        $awayTeam = Team::factory()->create();
+
+        $homePlayers = $this->createLineup($game, $homeTeam, 11, 75);
+        $awayPlayers = $this->createLineup($game, $awayTeam, 11, 75);
+        $homeBench = $this->createBenchPlayers($game, $homeTeam, 7, 72);
+        $awayBench = $this->createBenchPlayers($game, $awayTeam, 7, 72);
+
+        for ($i = 0; $i < 20; $i++) {
+            $output = $this->simulator->simulate(
+                $homeTeam, $awayTeam,
+                $homePlayers, $awayPlayers,
+                Formation::F_4_4_2, Formation::F_4_4_2,
+                Mentality::BALANCED, Mentality::BALANCED,
+                $game,
+                homeBenchPlayers: $homeBench,
+                awayBenchPlayers: $awayBench,
+            );
+
+            $enteredAt = [];
+            foreach ($output->result->substitutions() as $sub) {
+                $playerInId = $sub->metadata['player_in_id'] ?? null;
+                if ($playerInId !== null) {
+                    $enteredAt[$playerInId] = $sub->minute;
+                }
+            }
+
+            foreach ($output->result->events as $event) {
+                if (! isset($enteredAt[$event->gamePlayerId])) {
+                    continue;
+                }
+                if ($event->type === 'substitution') {
+                    continue;
+                }
+                $this->assertGreaterThanOrEqual(
+                    $enteredAt[$event->gamePlayerId],
+                    $event->minute,
+                    "A '{$event->type}' event at minute {$event->minute} was assigned to a player who only entered at minute {$enteredAt[$event->gamePlayerId]} (iteration $i)",
+                );
+            }
+        }
+    }
+
+    /**
+     * Assert that no gameplay event occurs after the player was subbed off.
+     *
+     * Exception: the substitution event itself is attributed to the outgoing
+     * player and has minute == sub minute, which is correct.
+     */
+    private function assertEventsConsistentWithSubstitutions(Collection $events, string $context = ''): void
+    {
+        $subbedOutAt = [];
+        foreach ($events as $event) {
+            if ($event->type === 'substitution') {
+                $outId = $event->gamePlayerId;
+                if (! isset($subbedOutAt[$outId]) || $event->minute < $subbedOutAt[$outId]) {
+                    $subbedOutAt[$outId] = $event->minute;
+                }
+            }
+        }
+
+        $problematicTypes = ['goal', 'assist', 'yellow_card', 'red_card', 'own_goal', 'penalty_missed'];
+
+        foreach ($events as $event) {
+            /** @var MatchEventData $event */
+            if (! in_array($event->type, $problematicTypes, true)) {
+                continue;
+            }
+            if (! isset($subbedOutAt[$event->gamePlayerId])) {
+                continue;
+            }
+            $this->assertLessThan(
+                $subbedOutAt[$event->gamePlayerId],
+                $event->minute,
+                sprintf(
+                    "A '%s' event at minute %d was assigned to a player already substituted off at minute %d (%s)",
+                    $event->type,
+                    $event->minute,
+                    $subbedOutAt[$event->gamePlayerId],
+                    $context,
+                ),
+            );
+        }
+    }
+}


### PR DESCRIPTION
Cards, goals, own goals, assists and missed penalties were generated for a
whole period against the starting lineup before injury auto-subs were
processed, using random minutes across the full range. A card minute could
fall after the player's sub-out minute, leaving the user with events like
"yellow card for Vinicius at 70'" when Vinicius was subbed off at 40' for
injury. reassignEventsFromUnavailablePlayers only rewrote goal/assist
events, so cards stuck to off-pitch players in both the initial simulation
and resimulation paths.

Extend the reassignment pass to cover yellow_card, red_card, own_goal and
penalty_missed, track sub-outs and red cards separately so a red_card
event doesn't reassign itself, and use the sub minute (not the injury
minute) as the player's actual exit from the pitch.