### PR TITLE
Gate pre-contract signings by player-tier reputation floor

### DIFF
--- a/app/Http/Actions/NegotiatePreContract.php
+++ b/app/Http/Actions/NegotiatePreContract.php
@@ -64,6 +64,17 @@ class NegotiatePreContract
             ], 422);
         }
 
+        // Reputation gate: high-profile players refuse lower-reputation clubs outright.
+        // Same tier-vs-reputation floor the free-agent flow uses — without this check
+        // the wage-flexibility disposition alone lets a full-wage offer pass regardless
+        // of how large the reputation gap is.
+        if (!$this->dispositionService->canSignPreContract($player, $game->id, $game->team_id)) {
+            return response()->json([
+                'status' => 'error',
+                'message' => __('transfers.pre_contract_player_not_interested', ['player' => $player->name]),
+            ], 422);
+        }
+
         // Check for existing countered offer to resume
         $existing = TransferOffer::where('game_id', $game->id)
             ->where('game_player_id', $player->id)

--- a/app/Modules/Transfer/Services/DispositionService.php
+++ b/app/Modules/Transfer/Services/DispositionService.php
@@ -487,21 +487,27 @@ class DispositionService
     }
 
     /**
+     * Check whether a player is willing to accept a pre-contract offer from a team,
+     * based on the player's tier vs the bidding team's reputation.
+     *
+     * Uses the same tier-vs-reputation floor as free-agent signings: an expiring
+     * player moving on a free transfer is close enough to a free agent that the
+     * same ambition gate applies. Prevents e.g. a tier-5 star from accepting a
+     * pre-contract with a Segunda-level club regardless of wage offered.
+     */
+    public function canSignPreContract(GamePlayer $player, string $gameId, string $teamId): bool
+    {
+        return $this->meetsTierReputationFloor($player, $gameId, $teamId);
+    }
+
+    /**
      * Determine a free agent's willingness to sign for a team.
      *
      * @return string 'willing' (will sign), 'reluctant' (1 tier below minimum), or 'unwilling' (2+ below)
      */
     public function freeAgentWillingnessLevel(GamePlayer $player, string $gameId, string $teamId): string
     {
-        $playerTier = $player->tier ?? PlayerTierService::tierFromMarketValue($player->market_value_cents);
-        $minReputation = self::MIN_REPUTATION_BY_PLAYER_TIER[$playerTier] ?? ClubProfile::REPUTATION_LOCAL;
-
-        $teamReputation = TeamReputation::resolveLevel($gameId, $teamId);
-
-        $teamIndex = ClubProfile::getReputationTierIndex($teamReputation);
-        $minIndex = ClubProfile::getReputationTierIndex($minReputation);
-
-        $gap = $minIndex - $teamIndex;
+        $gap = $this->tierReputationGap($player, $gameId, $teamId);
 
         if ($gap <= 0) {
             return 'willing';
@@ -512,6 +518,31 @@ class DispositionService
         }
 
         return 'unwilling';
+    }
+
+    /**
+     * Whether the team's reputation meets the minimum required by the player's tier.
+     */
+    private function meetsTierReputationFloor(GamePlayer $player, string $gameId, string $teamId): bool
+    {
+        return $this->tierReputationGap($player, $gameId, $teamId) <= 0;
+    }
+
+    /**
+     * How far the team's reputation sits below the player-tier minimum.
+     * Positive = team is below the floor; 0 or negative = team meets or exceeds it.
+     */
+    private function tierReputationGap(GamePlayer $player, string $gameId, string $teamId): int
+    {
+        $playerTier = $player->tier ?? PlayerTierService::tierFromMarketValue($player->market_value_cents);
+        $minReputation = self::MIN_REPUTATION_BY_PLAYER_TIER[$playerTier] ?? ClubProfile::REPUTATION_LOCAL;
+
+        $teamReputation = TeamReputation::resolveLevel($gameId, $teamId);
+
+        $teamIndex = ClubProfile::getReputationTierIndex($teamReputation);
+        $minIndex = ClubProfile::getReputationTierIndex($minReputation);
+
+        return $minIndex - $teamIndex;
     }
 
     // =========================================

--- a/app/Modules/Transfer/Services/TransferService.php
+++ b/app/Modules/Transfer/Services/TransferService.php
@@ -1135,6 +1135,12 @@ class TransferService
             throw new \InvalidArgumentException(__('messages.player_not_expiring'));
         }
 
+        if (!$this->dispositionService->canSignPreContract($player, $game->id, $game->team_id)) {
+            throw new \InvalidArgumentException(
+                __('transfers.pre_contract_player_not_interested', ['player' => $player->name])
+            );
+        }
+
         $existingOffer = TransferOffer::where('game_id', $game->id)
             ->where('game_player_id', $player->id)
             ->where('direction', TransferOffer::DIRECTION_INCOMING)

--- a/lang/en/transfers.php
+++ b/lang/en/transfers.php
@@ -127,6 +127,7 @@ return [
     'counter_offer_received' => 'Counter Offer Received',
     'transfer_agreed' => 'Transfer Agreed',
     'already_bidding' => 'You already have a bid for this player',
+    'pre_contract_player_not_interested' => ":player isn't interested in signing for a club at our level.",
     'negotiation_cooldown' => 'Negotiations with this player broke down recently. Wait until the next matchday to try again.',
     'negotiation_cooldown_short' => 'Wait until next matchday',
     'renewal_cooldown' => 'This player rejected your renewal offer recently. Wait until the next matchday to try again.',

--- a/lang/es/transfers.php
+++ b/lang/es/transfers.php
@@ -128,6 +128,7 @@ return [
     'counter_offer_received' => 'Contraoferta Recibida',
     'transfer_agreed' => 'Fichaje Acordado',
     'already_bidding' => 'Ya tienes una oferta por este jugador',
+    'pre_contract_player_not_interested' => ':player no está interesado en fichar por un club de nuestra categoría.',
     'negotiation_cooldown' => 'Las negociaciones con este jugador se rompieron recientemente. Espera a la siguiente jornada para intentarlo de nuevo.',
     'negotiation_cooldown_short' => 'Espera a la próxima jornada',
     'renewal_cooldown' => 'Este jugador rechazó tu oferta de renovación recientemente. Espera a la siguiente jornada para intentarlo de nuevo.',


### PR DESCRIPTION
High-profile players could accept pre-contracts from far-lower-reputation
clubs: the sync negotiation fed reputation into disposition, but disposition
only scaled wage flexibility, so a full-wage offer always passed. Apply the
same tier-vs-reputation floor the free-agent flow uses as an upfront gate,
via a shared DispositionService helper.

https://claude.ai/code/session_01RY7LgmHXcRwzsuSKRWk3cd