### PR TITLE
Populate match feed and scores when skip-to-end backend call no-ops

### DIFF
--- a/resources/js/modules/match-simulation.js
+++ b/resources/js/modules/match-simulation.js
@@ -753,9 +753,23 @@ export function createMatchSimulation(ctx) {
         animateClockToEnd(fromMinute, () => enterFullTime());
 
         // Generate match summary after the resimulation resolves (or
-        // no-ops). Both paths produce correct summaries: resimulation
-        // merges fresh events/scores first; no-op keeps the originals.
-        skipPromise.then(() => {
+        // no-ops). When autoSubs are applied the backend rebuilds
+        // events/scores; when it no-ops (no bench, sub budget spent,
+        // endpoint missing, network failure) nobody has populated them
+        // yet — enterFullTime skipped the reveal because _skippingToEnd
+        // was set. Fall back to the pre-computed events here so the
+        // feed and scoreline aren't left empty.
+        skipPromise.then((autoSubsApplied) => {
+            if (!autoSubsApplied) {
+                state.homeScore = state.finalHomeScore;
+                state.awayScore = state.finalAwayScore;
+                for (let i = state.lastRevealedIndex + 1; i < state.events.length; i++) {
+                    const event = state.events[i];
+                    state.revealedEvents.unshift(event);
+                    trackSubstitutionIfNeeded(event);
+                }
+                state.lastRevealedIndex = state.events.length - 1;
+            }
             if (typeof state._generateMatchSummary === 'function') {
                 state.matchSummary = state._generateMatchSummary();
             }


### PR DESCRIPTION
The skipToEnd flow sets _skippingToEnd=true so enterFullTime defers
event/score population, expecting autoSubUserTeamBeforeSkip to rebuild
them atomically when the resimulation response arrives. But when the
auto-sub request no-ops (no bench, sub budget spent, missing endpoint,
or network failure), it returns false without touching events or
scores — leaving the feed empty and the scoreline at 0:0 while the
match summary text still shows the correct final result.

Pass the resolved value through skipPromise.then and, on the no-op
path, replay the same event reveal and score assignment that
enterFullTime would have done in the non-skipping branch.

https://claude.ai/code/session_01V6PaFrZeFKZbZTwRJgRLQP