### PR TITLE
Force player names to Latin script and trim locale map

### DIFF
--- a/app/Modules/Squad/Services/PlayerGeneratorService.php
+++ b/app/Modules/Squad/Services/PlayerGeneratorService.php
@@ -457,20 +457,6 @@ class PlayerGeneratorService
     private const DOMESTIC_NATIONALITY_WEIGHT = 75;
 
     /**
-     * Countries from which the "any" 25% branch picks when no explicit nationality
-     * is supplied. A small curated set of footballing nations keeps generated
-     * foreigners believable rather than drawing from every locale Faker supports.
-     */
-    private const FOREIGN_NATIONALITY_POOL = [
-        'Spain', 'England', 'France', 'Germany', 'Italy', 'Portugal', 'Brazil',
-        'Argentina', 'Netherlands', 'Belgium', 'Poland', 'Denmark', 'Sweden',
-        'Norway', 'Croatia', 'Serbia', 'Switzerland', 'Austria', 'Greece',
-        'Türkiye', 'Morocco', 'Senegal', "Cote d'Ivoire", 'Nigeria', 'Ghana',
-        'Cameroon', 'Colombia', 'Uruguay', 'Chile', 'Mexico', 'Japan',
-        'Korea, South', 'United States',
-    ];
-
-    /**
      * Maximum attempts to draw a non-colliding name before giving up and
      * accepting the last candidate. With Faker's per-locale name space
      * (tens of thousands of combinations) this almost never loops more
@@ -529,7 +515,9 @@ class PlayerGeneratorService
             }
         }
 
-        return self::FOREIGN_NATIONALITY_POOL[array_rand(self::FOREIGN_NATIONALITY_POOL)];
+        $pool = PlayerNameGenerator::supportedNationalities();
+
+        return $pool[array_rand($pool)];
     }
 
     /**

--- a/app/Modules/Squad/Services/PlayerNameGenerator.php
+++ b/app/Modules/Squad/Services/PlayerNameGenerator.php
@@ -4,6 +4,7 @@ namespace App\Modules\Squad\Services;
 
 use Faker\Factory;
 use Faker\Generator;
+use Illuminate\Support\Str;
 
 /**
  * Generates player names (first + last) from Faker, locale-scoped by nationality.
@@ -25,82 +26,35 @@ class PlayerNameGenerator
     private const NATIONALITY_LOCALES = [
         'Spain' => 'es_ES',
         'Argentina' => 'es_AR',
-        'Peru' => 'es_PE',
-        'Venezuela' => 'es_VE',
-        'Mexico' => 'es_ES',
         'Colombia' => 'es_ES',
         'Chile' => 'es_ES',
         'Uruguay' => 'es_AR',
-        'Paraguay' => 'es_AR',
-        'Bolivia' => 'es_ES',
         'Ecuador' => 'es_ES',
-        'Cuba' => 'es_ES',
-        'Dominican Republic' => 'es_ES',
-        'Honduras' => 'es_ES',
-        'Panama' => 'es_ES',
 
         'England' => 'en_GB',
         'Wales' => 'en_GB',
         'Scotland' => 'en_GB',
         'Northern Ireland' => 'en_GB',
         'Ireland' => 'en_GB',
-        'United States' => 'en_US',
         'Nigeria' => 'en_NG',
-        'South Africa' => 'en_ZA',
         'Ghana' => 'en_NG',
-        'Liberia' => 'en_NG',
-        'Sierra Leone' => 'en_NG',
-        'Kenya' => 'en_NG',
-        'Zambia' => 'en_NG',
-        'Zimbabwe' => 'en_NG',
-        'Uganda' => 'en_NG',
-        'Jamaica' => 'en_GB',
-        'Trinidad and Tobago' => 'en_GB',
-        'Australia' => 'en_US',
-        'New Zealand' => 'en_US',
-        'Philippines' => 'en_PH',
 
         'France' => 'fr_FR',
         'Belgium' => 'fr_BE',
-        'Monaco' => 'fr_FR',
         'Senegal' => 'fr_FR',
         "Cote d'Ivoire" => 'fr_FR',
         'Ivory Coast' => 'fr_FR',
         'Cameroon' => 'fr_FR',
-        'Mali' => 'fr_FR',
-        'Burkina Faso' => 'fr_FR',
-        'Guinea' => 'fr_FR',
-        'Togo' => 'fr_FR',
-        'Benin' => 'fr_FR',
-        'Niger' => 'fr_FR',
-        'Gabon' => 'fr_FR',
-        'Congo' => 'fr_FR',
-        'DR Congo' => 'fr_FR',
-        'Central African Republic' => 'fr_FR',
-        'Chad' => 'fr_FR',
-        'Madagascar' => 'fr_FR',
-        'Canada' => 'fr_CA',
-        'Haiti' => 'fr_FR',
-        'Luxembourg' => 'fr_FR',
 
         'Germany' => 'de_DE',
         'Austria' => 'de_AT',
-        'Switzerland' => 'de_DE',
-        'Liechtenstein' => 'de_DE',
 
         'Italy' => 'it_IT',
-        'San Marino' => 'it_IT',
 
         'Portugal' => 'pt_PT',
         'Brazil' => 'pt_BR',
-        'Angola' => 'pt_PT',
-        'Mozambique' => 'pt_PT',
-        'Cape Verde' => 'pt_PT',
-        'Guinea-Bissau' => 'pt_PT',
-        'Sao Tome and Principe' => 'pt_PT',
 
         'Netherlands' => 'nl_NL',
-        'Suriname' => 'nl_NL',
 
         'Poland' => 'pl_PL',
         'Czech Republic' => 'cs_CZ',
@@ -110,71 +64,26 @@ class PlayerNameGenerator
         'Moldova' => 'ro_RO',
         'Bulgaria' => 'bg_BG',
         'Serbia' => 'sr_RS',
-        'Kosovo' => 'sr_RS',
-        'Montenegro' => 'sr_RS',
-        'Bosnia-Herzegovina' => 'hr_HR',
-        'North Macedonia' => 'sr_RS',
         'Croatia' => 'hr_HR',
         'Slovenia' => 'sl_SI',
         'Albania' => 'sr_RS',
 
         'Russia' => 'ru_RU',
         'Ukraine' => 'uk_UA',
-        'Belarus' => 'ru_RU',
-        'Lithuania' => 'lt_LT',
-        'Latvia' => 'lv_LV',
-        'Estonia' => 'et_EE',
 
         'Greece' => 'el_GR',
-        'Cyprus' => 'el_GR',
 
         'Denmark' => 'da_DK',
         'Sweden' => 'sv_SE',
         'Norway' => 'nb_NO',
-        'Finland' => 'fi_FI',
-        'Iceland' => 'is_IS',
-        'Faroe Islands' => 'is_IS',
 
         'Türkiye' => 'tr_TR',
         'Turkey' => 'tr_TR',
 
-        'Morocco' => 'ar_SA',
-        'Algeria' => 'ar_SA',
-        'Tunisia' => 'ar_SA',
-        'Libya' => 'ar_SA',
-        'Egypt' => 'ar_EG',
-        'Saudi Arabia' => 'ar_SA',
-        'United Arab Emirates' => 'ar_SA',
-        'Qatar' => 'ar_SA',
-        'Kuwait' => 'ar_SA',
-        'Bahrain' => 'ar_SA',
-        'Oman' => 'ar_SA',
-        'Yemen' => 'ar_SA',
-        'Jordan' => 'ar_JO',
-        'Lebanon' => 'ar_JO',
-        'Syria' => 'ar_JO',
-        'Iraq' => 'ar_JO',
-        'Palestine' => 'ar_JO',
-        'Sudan' => 'ar_SA',
-        'Mauritania' => 'ar_SA',
-
-        'Iran' => 'fa_IR',
-        'Israel' => 'he_IL',
-        'Georgia' => 'ka_GE',
-        'Armenia' => 'hy_AM',
-        'Kazakhstan' => 'kk_KZ',
-
-        'Japan' => 'ja_JP',
-        'Korea, South' => 'ko_KR',
-        'South Korea' => 'ko_KR',
-        'China' => 'zh_CN',
-        'Taiwan' => 'zh_CN',
-        'Thailand' => 'th_TH',
-        'Vietnam' => 'vi_VN',
-        'Indonesia' => 'id_ID',
-        'Malaysia' => 'ms_MY',
-        'Bangladesh' => 'bn_BD',
-        'Nepal' => 'ne_NP',
+        'Morocco' => 'ar_Latn',
+        'Algeria' => 'ar_Latn',
+        'Tunisia' => 'ar_Latn',
+        'Egypt' => 'ar_Latn',
     ];
 
     private const FALLBACK_LOCALE = 'en_US';
@@ -188,6 +97,17 @@ class PlayerNameGenerator
     private const REGION_PROVIDERS = [
         'basque' => \App\Support\Faker\Provider\eu_ES\Person::class,
         'catalan' => \App\Support\Faker\Provider\ca_ES\Person::class,
+    ];
+
+    /**
+     * Locale-level overrides for Faker locales whose native-script names don't
+     * survive transliteration to readable Latin. Arabic is consonantal, so a
+     * character-level romanisation (voku or ICU) produces consonant clusters
+     * rather than names — we ship our own pool of Latin-script Arabic names
+     * instead. Keyed by the pseudo-locale stored in {@see NATIONALITY_LOCALES}.
+     */
+    private const CUSTOM_LOCALE_PROVIDERS = [
+        'ar_Latn' => \App\Support\Faker\Provider\ar_Latn\Person::class,
     ];
 
     /**
@@ -213,7 +133,24 @@ class PlayerNameGenerator
             ? $this->fakerForRegion($region)
             : $this->fakerFor($nationality);
 
-        return $faker->firstNameMale() . ' ' . $faker->lastName();
+        $name = $faker->firstNameMale() . ' ' . $faker->lastName();
+
+        // Faker ships names in each locale's native script (Greek, Cyrillic,
+        // Arabic, CJK, etc.). The game UI assumes Latin script everywhere, so
+        // transliterate whenever the output contains non-Latin codepoints.
+        // Latin diacritics (ñ, é, ü, ł) are preserved — they're still Latin.
+        if (preg_match('/[^\p{Latin}\p{Common}\p{Inherited}]/u', $name) === 1) {
+            $name = Str::transliterate($name);
+        }
+
+        // Belt-and-braces cleanup: a few Faker locales (notably ar_SA) emit
+        // pre-transliterated strings peppered with symbols like '@' or '"' that
+        // sit in the Common script and so survive both the detection regex and
+        // Str::transliterate(). Strip anything that isn't a Latin letter or
+        // routine name punctuation, then collapse the whitespace that leaves.
+        $name = preg_replace("/[^\\p{Latin}\\s\\-'.]/u", '', $name) ?? $name;
+
+        return trim(preg_replace('/\s+/u', ' ', $name) ?? $name);
     }
 
     /**
@@ -224,11 +161,48 @@ class PlayerNameGenerator
         return self::NATIONALITY_LOCALES[$nationality] ?? self::FALLBACK_LOCALE;
     }
 
+    /**
+     * Every nationality this generator can produce believable names for. Callers
+     * that need to pick a random nationality (e.g. the 25% foreign branch in
+     * {@see PlayerGeneratorService}) should draw from this list so new entries
+     * automatically become drawable and removed ones stop leaking through as
+     * en_US fallbacks.
+     *
+     * @return string[]
+     */
+    public static function supportedNationalities(): array
+    {
+        return array_keys(self::NATIONALITY_LOCALES);
+    }
+
     private function fakerFor(string $nationality): Generator
     {
         $locale = $this->localeFor($nationality);
 
+        if (isset(self::CUSTOM_LOCALE_PROVIDERS[$locale])) {
+            return $this->fakerForCustomLocale($locale);
+        }
+
         return $this->generators[$locale] ??= Factory::create($locale);
+    }
+
+    /**
+     * Build (and cache) a Faker Generator backed by one of our custom
+     * locale-level Person providers (see {@see CUSTOM_LOCALE_PROVIDERS}).
+     * Mirrors {@see fakerForRegion()} but keyed by locale instead of region.
+     */
+    private function fakerForCustomLocale(string $locale): Generator
+    {
+        $cacheKey = 'locale:' . $locale;
+
+        if (! isset($this->generators[$cacheKey])) {
+            $providerClass = self::CUSTOM_LOCALE_PROVIDERS[$locale];
+            $generator = new Generator();
+            $generator->addProvider(new $providerClass($generator));
+            $this->generators[$cacheKey] = $generator;
+        }
+
+        return $this->generators[$cacheKey];
     }
 
     /**

--- a/app/Support/Faker/Provider/ar_Latn/Person.php
+++ b/app/Support/Faker/Provider/ar_Latn/Person.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Support\Faker\Provider\ar_Latn;
+
+use Faker\Provider\Person as BasePerson;
+
+/**
+ * Arabic names in Latin script.
+ *
+ * Faker ships Arabic names in Arabic script (ar_SA, ar_EG, ar_JO), and neither
+ * voku/portable-ascii nor ICU's character-level transliteration produces
+ * readable Latin forms — Arabic is a consonantal script, so letter-by-letter
+ * conversion yields consonant clusters like "sm lHSyn" that no reader would
+ * recognise. This provider replaces the Faker Arabic locales with a curated
+ * pool of names in the romanisations familiar from football media (Mohamed
+ * Salah, Achraf Hakimi, Youssef En-Nesyri, Riyad Mahrez, and the like), mixing
+ * Maghreb and Mashriq anthroponymy so Moroccan, Algerian, Egyptian, Saudi,
+ * etc. nationalities all draw plausible names. Pool size is deliberately large
+ * enough to keep PlayerGeneratorService's 10-attempt collision retry loop from
+ * stalling across many seasons.
+ */
+class Person extends BasePerson
+{
+    protected static $firstNameMale = [
+        'Achraf', 'Adam', 'Adel', 'Ahmed', 'Aissa', 'Ali', 'Amine', 'Amir',
+        'Anis', 'Anouar', 'Ayman', 'Ayoub', 'Aziz', 'Bilal', 'Fares', 'Faouzi',
+        'Farouk', 'Fayçal', 'Hakim', 'Hamza', 'Hassan', 'Hicham', 'Hussein',
+        'Ibrahim', 'Idriss', 'Ilyes', 'Imad', 'Ismail', 'Issam', 'Jamal',
+        'Kamel', 'Karim', 'Khaled', 'Lamine', 'Mahdi', 'Mahmoud', 'Marouane', 'Mehdi',
+        'Mohamed', 'Mourad', 'Moustafa', 'Nabil', 'Nacer', 'Nordin', 'Omar',
+        'Osama', 'Othmane', 'Rachid', 'Ramy', 'Rayan', 'Riyad', 'Saad',
+        'Said', 'Salah', 'Sami', 'Samir', 'Sofiane', 'Soufiane', 'Tarek',
+        'Tarik', 'Walid', 'Wassim', 'Yacine', 'Yahia', 'Yassine', 'Younes',
+        'Youssef', 'Zakaria', 'Ziyad',
+    ];
+
+    protected static $firstNameFemale = [
+        'Aicha', 'Amina', 'Amira', 'Asma', 'Dounia', 'Fatima', 'Fatin',
+        'Hajar', 'Hanane', 'Hiba', 'Imane', 'Jamila', 'Karima', 'Khadija',
+        'Laila', 'Latifa', 'Leila', 'Lina', 'Maha', 'Malak', 'Mariam',
+        'Maryam', 'Meryem', 'Mouna', 'Nadia', 'Najwa', 'Nesrine', 'Nora',
+        'Nour', 'Rania', 'Rim', 'Sabrina', 'Safia', 'Sahar', 'Salma',
+        'Samia', 'Sara', 'Selma', 'Sofia', 'Wafa', 'Yasmina', 'Zahra',
+        'Zeinab',
+    ];
+
+    protected static $lastName = [
+        'Alaoui', 'Amrani', 'Benali', 'Benjelloun', 'Bennani', 'Berrada', 'Bouazza',
+        'Bouchaib', 'Boukhari', 'Bourkia', 'Chaoui', 'Cherkaoui', 'Daoudi', 'El Amrani',
+        'El Fassi', 'El Ghazali', 'El Hadri', 'El Idrissi', 'El Kadiri', 'El Khatib',
+        'El Mansouri', 'El Ouali', 'Es-Sabbar', 'Fassi', 'Ghali', 'Guerraoui',
+        'Hajji', 'Hakimi', 'Hamdaoui', 'Hamdi', 'Hanafi', 'Harrak', 'Hassani',
+        'Ibrahimi', 'Idrissi', 'Jabri', 'Jalal', 'Jamal', 'Jebari', 'Kabbaj',
+        'Kadiri', 'Karimi', 'Kettani', 'Khalid', 'Khalifa', 'Lahlou', 'Lahrichi',
+        'Lamrani', 'Laraki', 'Lazrak', 'Lebbar', 'Mahfoud', 'Majidi', 'Mansouri',
+        'Marrakchi', 'Mekouar', 'Mernissi', 'Messari', 'Mouline', 'Moussaoui',
+        'Naciri', 'Nejjar', 'Ouazzani', 'Ouchen', 'Oufkir', 'Raji', 'Rami',
+        'Rhazi', 'Riad', 'Saadi', 'Sabbagh', 'Sabri', 'Saidi', 'Salaheddine',
+        'Salhi', 'Sebti', 'Sekkat', 'Sentissi', 'Skalli', 'Slaoui', 'Sqalli',
+        'Tahiri', 'Tangi', 'Tazi', 'Toumi', 'Touzani', 'Yacoubi', 'Yassine',
+        'Zaki', 'Zaoui', 'Zeroual', 'Ziani', 'Zineb',
+    ];
+}

--- a/tests/Unit/PlayerNameGeneratorTest.php
+++ b/tests/Unit/PlayerNameGeneratorTest.php
@@ -31,7 +31,6 @@ class PlayerNameGeneratorTest extends TestCase
         $this->assertSame('de_DE', $this->generator->localeFor('Germany'));
         $this->assertSame('it_IT', $this->generator->localeFor('Italy'));
         $this->assertSame('pt_BR', $this->generator->localeFor('Brazil'));
-        $this->assertSame('ja_JP', $this->generator->localeFor('Japan'));
     }
 
     public function test_unknown_nationality_falls_back_to_en_us(): void
@@ -78,6 +77,55 @@ class PlayerNameGeneratorTest extends TestCase
         $name = $this->generator->generate('Spain', 'atlantean');
         $this->assertNotEmpty($name);
         $this->assertMatchesRegularExpression('/\S+ \S+/', $name);
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function nonLatinNationalityProvider(): iterable
+    {
+        yield 'Greek' => ['Greece'];
+        yield 'Russian (Cyrillic)' => ['Russia'];
+        yield 'Ukrainian (Cyrillic)' => ['Ukraine'];
+        yield 'Bulgarian (Cyrillic)' => ['Bulgaria'];
+        yield 'Serbian (Cyrillic)' => ['Serbia'];
+        yield 'Arabic' => ['Morocco'];
+    }
+
+    /**
+     * @dataProvider nonLatinNationalityProvider
+     */
+    public function test_non_latin_script_nationality_produces_latin_only_name(string $nationality): void
+    {
+        for ($i = 0; $i < 30; $i++) {
+            $name = $this->generator->generate($nationality);
+
+            $this->assertNotEmpty($name);
+            // Only Latin-script codepoints (plus whitespace, hyphens, apostrophes,
+            // periods) — no Greek, Cyrillic, Arabic, CJK, etc. should leak through.
+            $this->assertMatchesRegularExpression(
+                "/^[\p{Latin}\s\-'.]+$/u",
+                $name,
+                "Name '{$name}' for {$nationality} contains non-Latin characters",
+            );
+        }
+    }
+
+    public function test_latin_diacritics_are_preserved_for_latin_script_locales(): void
+    {
+        // Spanish names regularly include ñ, á, é, í, ó, ú. Over 200 draws we
+        // expect at least one accented character — proving transliteration only
+        // strips non-Latin scripts, not Latin diacritics.
+        $combined = '';
+        for ($i = 0; $i < 200; $i++) {
+            $combined .= $this->generator->generate('Spain') . ' ';
+        }
+
+        $this->assertMatchesRegularExpression(
+            '/[áéíóúñÁÉÍÓÚÑ]/u',
+            $combined,
+            'Expected at least one Latin diacritic across 200 Spanish names',
+        );
     }
 
     /**


### PR DESCRIPTION
Builds on the Faker-backed name generator (https://github.com/pabloroman/virtua-fc/pull/822) with the fixes to make generated names display cleanly everywhere in the UI:

- Transliterate any non-Latin-script output (Greek, Cyrillic, Arabic) while preserving Latin diacritics (ñ, é, ü, ł).
- Strip stray symbols (@, ", etc.) that survive transliteration from some locales like ar_SA, then collapse whitespace.
- Replace ar_SA/ar_EG/ar_JO with a curated ar_Latn pool of Latin-script Arabic first and last names — character-level romanisation of consonantal Arabic produces consonant clusters, not names.
- Trim NATIONALITY_LOCALES to nationalities that transliterate believably, dropping low-signal CJK/Farsi/Hebrew/etc. mappings that would otherwise fall back via ugly romanisations.
- Make PlayerNameGenerator the single source of truth for supported nationalities via supportedNationalities(); PlayerGeneratorService now derives its random foreign pool from that list instead of maintaining a duplicate constant that silently drifted out of sync.