### PR TITLE
Stadium & Facilities Phase 2: introduce Club hub with Stadium and Reputation pages

### DIFF
--- a/app/Http/Actions/NegotiateTransfer.php
+++ b/app/Http/Actions/NegotiateTransfer.php
@@ -79,7 +79,7 @@ class NegotiateTransfer
                 'max_rounds' => self::MAX_ROUNDS,
                 'available_budget' => (int) (($this->transferService->availableBudget($game) + $existing->transfer_fee) / 100),
                 'budget_loan_available' => $this->budgetLoanService->canRequestLoan($game),
-                'budget_loan_url' => route('game.finances', $game->id),
+                'budget_loan_url' => route('game.club.finances', $game->id),
                 'messages' => [
                     $this->agentMessage('counter', [
                         'text' => __('transfers.chat_club_counter_resume', [
@@ -161,7 +161,7 @@ class NegotiateTransfer
             'max_rounds' => self::MAX_ROUNDS,
             'available_budget' => (int) ($this->transferService->availableBudget($game) / 100),
             'budget_loan_available' => $this->budgetLoanService->canRequestLoan($game),
-            'budget_loan_url' => route('game.finances', $game->id),
+            'budget_loan_url' => route('game.club.finances', $game->id),
             'messages' => [
                 $this->agentMessage('demand', [
                     'text' => __('transfers.chat_club_demand', [

--- a/app/Http/Actions/RequestBudgetLoan.php
+++ b/app/Http/Actions/RequestBudgetLoan.php
@@ -25,11 +25,11 @@ class RequestBudgetLoan
         try {
             $loan = $this->loanService->requestLoan($game, $amountInCents);
         } catch (\InvalidArgumentException $e) {
-            return redirect()->route('game.finances', $gameId)
+            return redirect()->route('game.club.finances', $gameId)
                 ->with('error', __($e->getMessage()));
         }
 
-        return redirect()->route('game.finances', $gameId)
+        return redirect()->route('game.club.finances', $gameId)
             ->with('success', __('messages.budget_loan_approved', [
                 'amount' => $loan->formatted_amount,
             ]));

--- a/app/Http/Actions/SaveBudgetAllocation.php
+++ b/app/Http/Actions/SaveBudgetAllocation.php
@@ -37,7 +37,7 @@ class SaveBudgetAllocation
                 ->with('error', __($e->getMessage()));
         }
 
-        return redirect()->route('game.finances', $gameId)
+        return redirect()->route('game.club.finances', $gameId)
             ->with('success', __('messages.budget_saved'));
     }
 }

--- a/app/Http/Actions/UpgradeInfrastructure.php
+++ b/app/Http/Actions/UpgradeInfrastructure.php
@@ -24,11 +24,11 @@ class UpgradeInfrastructure
         try {
             $this->upgradeService->upgrade($game, $validated['area'], (int) $validated['target_tier']);
         } catch (\InvalidArgumentException $e) {
-            return redirect()->route('game.finances', $gameId)
+            return redirect()->route('game.club.finances', $gameId)
                 ->with('error', $e->getMessage());
         }
 
-        return redirect()->route('game.finances', $gameId)
+        return redirect()->route('game.club.finances', $gameId)
             ->with('success', __('messages.infrastructure_upgraded', [
                 'area' => __("finances.{$validated['area']}"),
                 'tier' => $validated['target_tier'],

--- a/app/Http/Views/ShowClubReputation.php
+++ b/app/Http/Views/ShowClubReputation.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Views;
+
+use App\Models\Game;
+use App\Modules\Reputation\Services\ReputationSummaryService;
+
+class ShowClubReputation
+{
+    public function __construct(
+        private readonly ReputationSummaryService $reputationSummaryService,
+    ) {}
+
+    public function __invoke(string $gameId)
+    {
+        $game = Game::with('team')->findOrFail($gameId);
+        abort_if($game->isTournamentMode(), 404);
+
+        return view('club.reputation', [
+            'game' => $game,
+            'summary' => $this->reputationSummaryService->build($game),
+        ]);
+    }
+}

--- a/app/Http/Views/ShowClubReputation.php
+++ b/app/Http/Views/ShowClubReputation.php
@@ -3,22 +3,25 @@
 namespace App\Http\Views;
 
 use App\Models\Game;
+use App\Modules\Manager\Services\CareerSummaryService;
 use App\Modules\Reputation\Services\ReputationSummaryService;
 
 class ShowClubReputation
 {
     public function __construct(
         private readonly ReputationSummaryService $reputationSummaryService,
+        private readonly CareerSummaryService $careerSummaryService,
     ) {}
 
     public function __invoke(string $gameId)
     {
-        $game = Game::with('team')->findOrFail($gameId);
+        $game = Game::with('team.clubProfile')->findOrFail($gameId);
         abort_if($game->isTournamentMode(), 404);
 
         return view('club.reputation', [
             'game' => $game,
             'summary' => $this->reputationSummaryService->build($game),
+            'career' => $this->careerSummaryService->build($game, (int) auth()->id()),
         ]);
     }
 }

--- a/app/Http/Views/ShowClubStadium.php
+++ b/app/Http/Views/ShowClubStadium.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Views;
+
+use App\Models\Game;
+use App\Modules\Stadium\Services\StadiumSummaryService;
+
+class ShowClubStadium
+{
+    public function __construct(
+        private readonly StadiumSummaryService $stadiumSummaryService,
+    ) {}
+
+    public function __invoke(string $gameId)
+    {
+        $game = Game::with('team')->findOrFail($gameId);
+        abort_if($game->isTournamentMode(), 404);
+
+        return view('club.stadium', [
+            'game' => $game,
+            'summary' => $this->stadiumSummaryService->build($game),
+        ]);
+    }
+}

--- a/app/Http/Views/ShowFinances.php
+++ b/app/Http/Views/ShowFinances.php
@@ -102,7 +102,7 @@ class ShowFinances
         $canRequestLoan = $this->loanService->canRequestLoan($game);
         $maxLoanAmount = $this->loanService->maxLoanAmount($game);
 
-        return view('finances', [
+        return view('club.finances', [
             'game' => $game,
             'finances' => $finances,
             'investment' => $investment,

--- a/app/Models/GameNotification.php
+++ b/app/Models/GameNotification.php
@@ -230,7 +230,7 @@ class GameNotification extends Model
             'competition' => 'game.competition',
             'academy' => 'game.squad.academy',
             'transfer-activity' => 'game.transfer-activity',
-            'finances' => 'game.finances',
+            'finances' => 'game.club.finances',
             'registration' => 'game.squad.registration',
             default => 'game.squad.academy',
         };

--- a/app/Modules/Finance/Services/BudgetProjectionService.php
+++ b/app/Modules/Finance/Services/BudgetProjectionService.php
@@ -8,16 +8,19 @@ use App\Models\FinancialTransaction;
 use App\Models\Game;
 use App\Models\GameFinances;
 use App\Models\GameInvestment;
+use App\Models\GameMatch;
 use App\Models\GamePlayer;
 use App\Models\Team;
 use App\Models\TeamReputation;
 use App\Modules\Squad\Services\SquadService;
+use App\Modules\Stadium\Services\MatchAttendanceService;
 use Carbon\Carbon;
 
 class BudgetProjectionService
 {
     public function __construct(
         private readonly SquadService $squadService,
+        private readonly MatchAttendanceService $matchAttendanceService,
     ) {}
     /**
      * UEFA and RFEF solidarity funds (€250K)
@@ -125,23 +128,56 @@ class BudgetProjectionService
     }
 
     /**
-     * Calculate matchday revenue.
-     * Formula: Base (stadium_seats × revenue_per_seat) × Facilities Multiplier
+     * Project matchday revenue by walking the scheduled home fixtures for
+     * the upcoming season and summing per-fixture attendance from the demand
+     * curve. Cup and European home ties add bonus revenue on top of the
+     * league baseline at the same per-seat rate.
+     *
+     * `revenue_per_seat` is a per-seat per-SEASON rate, so we divide by the
+     * league home-game count to derive a per-match rate before summing.
+     *
+     * Runs at SeasonSetupPipeline priority 107 — after LeagueFixtureProcessor
+     * (30) and ContinentalAndCupInitProcessor (106), so the fixture list for
+     * the user's team is populated for leagues, Swiss-format competitions,
+     * and round-1 cup ties. Later cup rounds are drawn dynamically as the
+     * season progresses; treating them as upside rather than baseline mirrors
+     * how real clubs project revenue conservatively.
      */
     public function calculateMatchdayRevenue(Team $team, Game $game): int
     {
         $reputation = TeamReputation::resolveLevel($game->id, $team->id);
 
-        // Base matchday revenue from stadium size and competition config rates
-        $base = $team->stadium_seats * config("finances.revenue_per_seat.{$reputation}", 15_000);
+        $leagueHomeMatchCount = GameMatch::where('game_id', $game->id)
+            ->where('competition_id', $game->competition_id)
+            ->where('home_team_id', $team->id)
+            ->count();
 
-        // Get facilities multiplier from current investment (default to Tier 1 = 1.0)
+        if ($leagueHomeMatchCount === 0) {
+            return 0;
+        }
+
+        $perSeatSeasonRate = (int) config("finances.revenue_per_seat.{$reputation}", 15_000);
+        $perSeatMatchRate = $perSeatSeasonRate / $leagueHomeMatchCount;
+
+        $homeMatches = GameMatch::where('game_id', $game->id)
+            ->where('home_team_id', $team->id)
+            ->get();
+
+        $total = 0.0;
+        foreach ($homeMatches as $match) {
+            $projection = $this->matchAttendanceService->projectForMatch($match, $game);
+            if ($projection === null) {
+                continue;
+            }
+            $total += $projection['attendance'] * $perSeatMatchRate;
+        }
+
         $investment = $game->currentInvestment;
         $facilitiesMultiplier = $investment
             ? GameInvestment::FACILITIES_MULTIPLIER[$investment->facilities_tier] ?? 1.0
             : 1.0;
 
-        return (int) ($base * $facilitiesMultiplier);
+        return (int) ($total * $facilitiesMultiplier);
     }
 
     /**

--- a/app/Modules/Manager/Services/CareerSummaryService.php
+++ b/app/Modules/Manager/Services/CareerSummaryService.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Modules\Manager\Services;
+
+use App\Models\Game;
+use App\Models\ManagerStats;
+use App\Models\ManagerTrophy;
+
+/**
+ * Assembles the compact "career so far" strip shown on the Reputation page.
+ * All facts are derived from existing per-game records so the strip is
+ * meaningful from the first match onward. Cross-season history (highest
+ * league finish, promotions) is deferred to a dedicated history surface.
+ */
+class CareerSummaryService
+{
+    /**
+     * @return array{
+     *   seasons_managed:int,
+     *   matches_played:int,
+     *   trophies:int,
+     *   starting_tier:string,
+     * }
+     */
+    public function build(Game $game, int $userId): array
+    {
+        $stats = ManagerStats::where('user_id', $userId)
+            ->where('game_id', $game->id)
+            ->where('team_id', $game->team_id)
+            ->first();
+
+        $trophies = ManagerTrophy::where('user_id', $userId)
+            ->where('game_id', $game->id)
+            ->count();
+
+        $seasonsCompleted = (int) ($stats?->seasons_completed ?? 0);
+
+        return [
+            'seasons_managed' => $seasonsCompleted + 1,
+            'matches_played' => (int) ($stats?->matches_played ?? 0),
+            'trophies' => $trophies,
+            'starting_tier' => $game->team?->clubProfile?->reputation_level ?? 'local',
+        ];
+    }
+}

--- a/app/Modules/Reputation/Services/ReputationSummaryService.php
+++ b/app/Modules/Reputation/Services/ReputationSummaryService.php
@@ -10,29 +10,21 @@ use App\Models\TeamReputation;
 
 /**
  * Shapes the data shown on the Club > Reputation page: current tier,
- * progression within tier, the seeded anchor the club can't fall more than
- * two tiers below, and a directional hint projecting how the season's
- * current standing would move reputation at season end. Read-side only.
+ * progression within tier, loyalty, and a ladder of season-end outcomes
+ * derived from the same config the closing pipeline consumes. Read-side only.
  */
 class ReputationSummaryService
 {
     /**
      * @return array{
      *   current_level: string,
-     *   current_points: int,
-     *   base_level: string,
-     *   tier_floor: string,
      *   tier_index: int,
-     *   base_tier_index: int,
      *   points_in_tier: int,
      *   tier_span: int,
-     *   points_to_next_tier: ?int,
-     *   tier_thresholds: array<string,int>,
-     *   direction: 'rising'|'stable'|'declining',
-     *   direction_detail: array{points_delta:int,gravity:int,net:int,position:?int},
      *   loyalty_points: int,
-     *   base_loyalty: int,
-     *   loyalty_direction: 'rising'|'stable'|'declining',
+     *   qualitative_distance: ?string,
+     *   outcome_ladder: list<array{position_range:string,impact_key:string,is_current:bool,size:int}>,
+     *   tier_maintenance_applies: bool,
      * }
      */
     public function build(Game $game): array
@@ -43,18 +35,10 @@ class ReputationSummaryService
 
         $currentLevel = $reputation?->reputation_level ?? ClubProfile::REPUTATION_LOCAL;
         $currentPoints = (int) ($reputation?->reputation_points ?? 0);
-        $baseLevel = $reputation?->base_reputation_level ?? $currentLevel;
-
         $loyaltyPoints = (int) ($reputation?->loyalty_points ?? 0);
-        $baseLoyalty = (int) ($reputation?->base_loyalty ?? 0);
-        // Match the 5-point band used by the reputation-direction hint; small
-        // cosmetic drifts stay "stable" for a consistent Club-hub feel.
-        $loyaltyDelta = $loyaltyPoints - $baseLoyalty;
-        $loyaltyDirection = $loyaltyDelta > 5 ? 'rising' : ($loyaltyDelta < -5 ? 'declining' : 'stable');
 
         $thresholds = TeamReputation::TIER_THRESHOLDS;
         $tierIndex = ClubProfile::getReputationTierIndex($currentLevel);
-        $baseTierIndex = ClubProfile::getReputationTierIndex($baseLevel);
 
         $currentThreshold = $thresholds[$currentLevel] ?? 0;
         $nextLevel = ClubProfile::REPUTATION_TIERS[$tierIndex + 1] ?? null;
@@ -64,78 +48,101 @@ class ReputationSummaryService
         $tierSpan = $nextThreshold !== null ? $nextThreshold - $currentThreshold : 0;
         $pointsToNextTier = $nextThreshold !== null ? max(0, $nextThreshold - $currentPoints) : null;
 
-        $floorIndex = max(0, $baseTierIndex - TeamReputation::MAX_TIER_DROP_BELOW_BASE);
-        $tierFloor = ClubProfile::REPUTATION_TIERS[$floorIndex];
-
-        [$direction, $detail] = $this->projectDirection($game, $currentLevel);
+        $position = $this->currentLeaguePosition($game);
+        $outcomeLadder = $this->buildOutcomeLadder($game, $position);
+        $qualitativeDistance = $this->qualitativeDistance($pointsToNextTier);
+        $tierMaintenanceApplies = (int) (config('reputation.gravity', [])[$currentLevel] ?? 0) > 0;
 
         return [
             'current_level' => $currentLevel,
-            'current_points' => $currentPoints,
-            'base_level' => $baseLevel,
-            'tier_floor' => $tierFloor,
             'tier_index' => $tierIndex,
-            'base_tier_index' => $baseTierIndex,
             'points_in_tier' => $pointsInTier,
             'tier_span' => $tierSpan,
-            'points_to_next_tier' => $pointsToNextTier,
-            'tier_thresholds' => $thresholds,
-            'direction' => $direction,
-            'direction_detail' => $detail,
             'loyalty_points' => $loyaltyPoints,
-            'base_loyalty' => $baseLoyalty,
-            'loyalty_direction' => $loyaltyDirection,
+            'qualitative_distance' => $qualitativeDistance,
+            'outcome_ladder' => $outcomeLadder,
+            'tier_maintenance_applies' => $tierMaintenanceApplies,
         ];
     }
 
-    /**
-     * Project how reputation would move at season end if the league ended
-     * with the team at its current standings position — same formula the
-     * SeasonClosingPipeline's ReputationUpdateProcessor uses, so the hint
-     * stays calibrated against the actual mechanic.
-     *
-     * @return array{0: 'rising'|'stable'|'declining', 1: array{points_delta:int,gravity:int,net:int,position:?int}}
-     */
-    private function projectDirection(Game $game, string $level): array
+    private function currentLeaguePosition(Game $game): ?int
     {
         $position = GameStanding::where('game_id', $game->id)
             ->where('competition_id', $game->competition_id)
             ->where('team_id', $game->team_id)
             ->value('position');
 
-        $position = $position !== null ? (int) $position : null;
+        return $position !== null ? (int) $position : null;
+    }
 
-        $detail = ['points_delta' => 0, 'gravity' => 0, 'net' => 0, 'position' => $position];
-
-        if ($position === null) {
-            return ['stable', $detail];
-        }
-
+    /**
+     * Derive an always-visible ladder of season-end outcomes from the same
+     * position-delta config the season-close processor consumes. The player
+     * sees the decision landscape — what each finish is worth — whether or
+     * not a standing exists yet, and the current projected band is marked
+     * once a standing is recorded.
+     *
+     * Impact keys are qualitative buckets: the UI never prints raw points.
+     *
+     * @return list<array{position_range:string,impact_key:string,is_current:bool,size:int}>
+     */
+    private function buildOutcomeLadder(Game $game, ?int $position): array
+    {
         $competition = Competition::find($game->competition_id);
         $tier = $competition?->tier ?? 1;
         $deltas = config("reputation.position_deltas.{$tier}", config('reputation.position_deltas.1'));
 
-        $pointsDelta = 0;
+        $ladder = [];
+        $previousMax = 0;
         foreach ($deltas as $maxPosition => $delta) {
-            if ($position <= $maxPosition) {
-                $pointsDelta = $delta;
-                break;
-            }
+            $low = $previousMax + 1;
+            $high = (int) $maxPosition;
+            $range = $high >= 99 ? $low . '+' : ($low === $high ? (string) $low : $low . '–' . $high);
+            $isCurrent = $position !== null && $position >= $low && $position <= $high;
+            // Catchall (99) represents the relegation zone; cap it at a plausible
+            // tail width so the horizontal bar reads proportionally to league size.
+            $size = $high >= 99 ? 3 : max(1, $high - $low + 1);
+
+            $ladder[] = [
+                'position_range' => $range,
+                'impact_key' => $this->impactKey((int) $delta),
+                'is_current' => $isCurrent,
+                'size' => $size,
+            ];
+
+            $previousMax = $high;
         }
-        if ($pointsDelta === 0 && !empty($deltas)) {
-            $pointsDelta = end($deltas);
+
+        return $ladder;
+    }
+
+    private function impactKey(int $delta): string
+    {
+        return match (true) {
+            $delta >= 30 => 'major_leap',
+            $delta >= 15 => 'solid_step',
+            $delta >= 5 => 'small_step',
+            $delta === 0 => 'stalls',
+            default => 'setback',
+        };
+    }
+
+    /**
+     * Translate the points-to-next-tier gap into a felt distance the player
+     * can reason about in terms of seasons, not raw points. Buckets are tuned
+     * against a strong-season league reward of ~+30.
+     */
+    private function qualitativeDistance(?int $pointsToNextTier): ?string
+    {
+        if ($pointsToNextTier === null) {
+            return null;
         }
 
-        $gravity = (int) (config('reputation.gravity', [])[$level] ?? 0);
-        $net = $pointsDelta - $gravity;
-
-        $direction = $net > 5 ? 'rising' : ($net < -5 ? 'declining' : 'stable');
-
-        return [$direction, [
-            'points_delta' => $pointsDelta,
-            'gravity' => $gravity,
-            'net' => $net,
-            'position' => $position,
-        ]];
+        return match (true) {
+            $pointsToNextTier <= 30 => 'one_strong_season',
+            $pointsToNextTier <= 60 => 'two_strong_seasons',
+            $pointsToNextTier <= 100 => 'several_seasons',
+            default => 'long_road',
+        };
     }
 }

--- a/app/Modules/Reputation/Services/ReputationSummaryService.php
+++ b/app/Modules/Reputation/Services/ReputationSummaryService.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace App\Modules\Reputation\Services;
+
+use App\Models\ClubProfile;
+use App\Models\Competition;
+use App\Models\Game;
+use App\Models\GameStanding;
+use App\Models\TeamReputation;
+
+/**
+ * Shapes the data shown on the Club > Reputation page: current tier,
+ * progression within tier, the seeded anchor the club can't fall more than
+ * two tiers below, and a directional hint projecting how the season's
+ * current standing would move reputation at season end. Read-side only.
+ */
+class ReputationSummaryService
+{
+    /**
+     * @return array{
+     *   current_level: string,
+     *   current_points: int,
+     *   base_level: string,
+     *   tier_floor: string,
+     *   tier_index: int,
+     *   base_tier_index: int,
+     *   points_in_tier: int,
+     *   tier_span: int,
+     *   points_to_next_tier: ?int,
+     *   tier_thresholds: array<string,int>,
+     *   direction: 'rising'|'stable'|'declining',
+     *   direction_detail: array{points_delta:int,gravity:int,net:int,position:?int},
+     * }
+     */
+    public function build(Game $game): array
+    {
+        $reputation = TeamReputation::where('game_id', $game->id)
+            ->where('team_id', $game->team_id)
+            ->first();
+
+        $currentLevel = $reputation?->reputation_level ?? ClubProfile::REPUTATION_LOCAL;
+        $currentPoints = (int) ($reputation?->reputation_points ?? 0);
+        $baseLevel = $reputation?->base_reputation_level ?? $currentLevel;
+
+        $thresholds = TeamReputation::TIER_THRESHOLDS;
+        $tierIndex = ClubProfile::getReputationTierIndex($currentLevel);
+        $baseTierIndex = ClubProfile::getReputationTierIndex($baseLevel);
+
+        $currentThreshold = $thresholds[$currentLevel] ?? 0;
+        $nextLevel = ClubProfile::REPUTATION_TIERS[$tierIndex + 1] ?? null;
+        $nextThreshold = $nextLevel !== null ? ($thresholds[$nextLevel] ?? null) : null;
+
+        $pointsInTier = max(0, $currentPoints - $currentThreshold);
+        $tierSpan = $nextThreshold !== null ? $nextThreshold - $currentThreshold : 0;
+        $pointsToNextTier = $nextThreshold !== null ? max(0, $nextThreshold - $currentPoints) : null;
+
+        $floorIndex = max(0, $baseTierIndex - TeamReputation::MAX_TIER_DROP_BELOW_BASE);
+        $tierFloor = ClubProfile::REPUTATION_TIERS[$floorIndex];
+
+        [$direction, $detail] = $this->projectDirection($game, $currentLevel);
+
+        return [
+            'current_level' => $currentLevel,
+            'current_points' => $currentPoints,
+            'base_level' => $baseLevel,
+            'tier_floor' => $tierFloor,
+            'tier_index' => $tierIndex,
+            'base_tier_index' => $baseTierIndex,
+            'points_in_tier' => $pointsInTier,
+            'tier_span' => $tierSpan,
+            'points_to_next_tier' => $pointsToNextTier,
+            'tier_thresholds' => $thresholds,
+            'direction' => $direction,
+            'direction_detail' => $detail,
+        ];
+    }
+
+    /**
+     * Project how reputation would move at season end if the league ended
+     * with the team at its current standings position — same formula the
+     * SeasonClosingPipeline's ReputationUpdateProcessor uses, so the hint
+     * stays calibrated against the actual mechanic.
+     *
+     * @return array{0: 'rising'|'stable'|'declining', 1: array{points_delta:int,gravity:int,net:int,position:?int}}
+     */
+    private function projectDirection(Game $game, string $level): array
+    {
+        $position = GameStanding::where('game_id', $game->id)
+            ->where('competition_id', $game->competition_id)
+            ->where('team_id', $game->team_id)
+            ->value('position');
+
+        $position = $position !== null ? (int) $position : null;
+
+        $detail = ['points_delta' => 0, 'gravity' => 0, 'net' => 0, 'position' => $position];
+
+        if ($position === null) {
+            return ['stable', $detail];
+        }
+
+        $competition = Competition::find($game->competition_id);
+        $tier = $competition?->tier ?? 1;
+        $deltas = config("reputation.position_deltas.{$tier}", config('reputation.position_deltas.1'));
+
+        $pointsDelta = 0;
+        foreach ($deltas as $maxPosition => $delta) {
+            if ($position <= $maxPosition) {
+                $pointsDelta = $delta;
+                break;
+            }
+        }
+        if ($pointsDelta === 0 && !empty($deltas)) {
+            $pointsDelta = end($deltas);
+        }
+
+        $gravity = (int) (config('reputation.gravity', [])[$level] ?? 0);
+        $net = $pointsDelta - $gravity;
+
+        $direction = $net > 5 ? 'rising' : ($net < -5 ? 'declining' : 'stable');
+
+        return [$direction, [
+            'points_delta' => $pointsDelta,
+            'gravity' => $gravity,
+            'net' => $net,
+            'position' => $position,
+        ]];
+    }
+}

--- a/app/Modules/Reputation/Services/ReputationSummaryService.php
+++ b/app/Modules/Reputation/Services/ReputationSummaryService.php
@@ -30,6 +30,9 @@ class ReputationSummaryService
      *   tier_thresholds: array<string,int>,
      *   direction: 'rising'|'stable'|'declining',
      *   direction_detail: array{points_delta:int,gravity:int,net:int,position:?int},
+     *   loyalty_points: int,
+     *   base_loyalty: int,
+     *   loyalty_direction: 'rising'|'stable'|'declining',
      * }
      */
     public function build(Game $game): array
@@ -41,6 +44,13 @@ class ReputationSummaryService
         $currentLevel = $reputation?->reputation_level ?? ClubProfile::REPUTATION_LOCAL;
         $currentPoints = (int) ($reputation?->reputation_points ?? 0);
         $baseLevel = $reputation?->base_reputation_level ?? $currentLevel;
+
+        $loyaltyPoints = (int) ($reputation?->loyalty_points ?? 0);
+        $baseLoyalty = (int) ($reputation?->base_loyalty ?? 0);
+        // Match the 5-point band used by the reputation-direction hint; small
+        // cosmetic drifts stay "stable" for a consistent Club-hub feel.
+        $loyaltyDelta = $loyaltyPoints - $baseLoyalty;
+        $loyaltyDirection = $loyaltyDelta > 5 ? 'rising' : ($loyaltyDelta < -5 ? 'declining' : 'stable');
 
         $thresholds = TeamReputation::TIER_THRESHOLDS;
         $tierIndex = ClubProfile::getReputationTierIndex($currentLevel);
@@ -72,6 +82,9 @@ class ReputationSummaryService
             'tier_thresholds' => $thresholds,
             'direction' => $direction,
             'direction_detail' => $detail,
+            'loyalty_points' => $loyaltyPoints,
+            'base_loyalty' => $baseLoyalty,
+            'loyalty_direction' => $loyaltyDirection,
         ];
     }
 

--- a/app/Modules/Season/Processors/BudgetProjectionProcessor.php
+++ b/app/Modules/Season/Processors/BudgetProjectionProcessor.php
@@ -11,7 +11,11 @@ use App\Models\Game;
 
 /**
  * Generates budget projections for the new season.
- * Runs after all other processors so we have the new squad and standings.
+ *
+ * Runs after ContinentalAndCupInitProcessor (106) so that cup round-1 draws
+ * and Swiss-format fixtures are in place — BudgetProjectionService walks
+ * scheduled home fixtures for the demand-curve projection, and it needs the
+ * full schedule (league + Swiss + round-1 cup) to be visible.
  */
 class BudgetProjectionProcessor implements SeasonProcessor
 {
@@ -22,7 +26,7 @@ class BudgetProjectionProcessor implements SeasonProcessor
 
     public function priority(): int
     {
-        return 50; // After everything else, right before pre-season starts
+        return 107; // After ContinentalAndCupInit (106), before PreSeasonFixture (108)
     }
 
     public function process(Game $game, SeasonTransitionData $data): SeasonTransitionData

--- a/app/Modules/Season/Processors/SeasonArchiveProcessor.php
+++ b/app/Modules/Season/Processors/SeasonArchiveProcessor.php
@@ -349,10 +349,13 @@ class SeasonArchiveProcessor implements SeasonProcessor
                     ->delete();
             });
 
-        // Delete played matches (keep unplayed fixtures for potential reference)
-        GameMatch::where('game_id', $game->id)
-            ->where('played', true)
-            ->delete();
+        // GameMatch rows are intentionally left in place here. SeasonSettlement
+        // (priority 60) iterates this season's home matches to compute matchday
+        // revenue from MatchAttendance (whose FK cascades on game_match_id), so
+        // deleting them here would wipe the per-fixture attendance data before
+        // settlement sees it. LeagueFixtureProcessor (priority 30 in the setup
+        // pipeline) purges all GameMatches for this game_id immediately after
+        // the closing pipeline finishes, which does the cleanup.
 
         // Delete transfer records for this season
         GameTransfer::where('game_id', $game->id)

--- a/app/Modules/Season/Processors/SeasonSettlementProcessor.php
+++ b/app/Modules/Season/Processors/SeasonSettlementProcessor.php
@@ -5,11 +5,13 @@ namespace App\Modules\Season\Processors;
 use App\Modules\Season\Contracts\SeasonProcessor;
 use App\Modules\Season\DTOs\SeasonTransitionData;
 use App\Modules\Finance\Services\BudgetLoanService;
+use App\Modules\Stadium\Services\MatchAttendanceService;
 use App\Models\BudgetLoan;
 use App\Models\FinancialTransaction;
 use App\Models\TeamReputation;
 use App\Models\Game;
 use App\Models\GameInvestment;
+use App\Models\GameMatch;
 use App\Models\GamePlayer;
 use App\Models\GameStanding;
 use App\Models\Loan;
@@ -23,6 +25,9 @@ use Carbon\Carbon;
  */
 class SeasonSettlementProcessor implements SeasonProcessor
 {
+    public function __construct(
+        private readonly MatchAttendanceService $matchAttendanceService,
+    ) {}
 
     public function priority(): int
     {
@@ -47,7 +52,7 @@ class SeasonSettlementProcessor implements SeasonProcessor
 
         // Calculate actual revenues
         $actualTvRevenue = $this->calculateTvRevenue($actualPosition, $game);
-        $actualMatchdayRevenue = $this->calculateMatchdayRevenue($game, $actualPosition);
+        $actualMatchdayRevenue = $this->calculateMatchdayRevenue($game);
         $actualCommercialRevenue = $this->calculateCommercialRevenue(
             $finances->projected_commercial_revenue, $actualPosition
         );
@@ -129,26 +134,57 @@ class SeasonSettlementProcessor implements SeasonProcessor
         return $config->getTvRevenue($position);
     }
 
-    private function calculateMatchdayRevenue(Game $game, int $position): int
+    /**
+     * Sum actual matchday revenue across every played home fixture of the
+     * season, using the per-fixture MatchAttendance row. Rows that are missing
+     * (saves that span the Phase 1a upgrade) are backfilled in place via the
+     * idempotent MatchAttendanceService, so the formula sees uniform coverage.
+     *
+     * `revenue_per_seat` is a per-seat per-SEASON rate. To spread it across
+     * the fixture list we divide by the count of league home games — cup and
+     * European home ties then add bonus revenue on top at the same seat rate,
+     * which lines up with the demand curve already weighting those fixtures.
+     */
+    private function calculateMatchdayRevenue(Game $game): int
     {
         $team = $game->team;
         $reputation = TeamReputation::resolveLevel($game->id, $team->id);
-
         $league = $game->competition;
 
-        $base = $team->stadium_seats * config("finances.revenue_per_seat.{$reputation}", 15_000);
+        $leagueHomeMatchCount = GameMatch::where('game_id', $game->id)
+            ->where('competition_id', $league->id)
+            ->where('home_team_id', $team->id)
+            ->where('played', true)
+            ->count();
 
-        // Get facilities multiplier
+        if ($leagueHomeMatchCount === 0) {
+            return 0;
+        }
+
+        $perSeatSeasonRate = (int) config("finances.revenue_per_seat.{$reputation}", 15_000);
+        $perSeatMatchRate = $perSeatSeasonRate / $leagueHomeMatchCount;
+
+        $homeMatches = GameMatch::where('game_id', $game->id)
+            ->where('home_team_id', $team->id)
+            ->where('played', true)
+            ->get();
+
+        $total = 0.0;
+        foreach ($homeMatches as $match) {
+            $attendance = $this->matchAttendanceService->resolveForMatch($match, $game);
+            if ($attendance === null) {
+                // Neutral-venue finals don't feed the home club's matchday revenue.
+                continue;
+            }
+            $total += $attendance->attendance * $perSeatMatchRate;
+        }
+
         $investment = $game->currentInvestment;
         $facilitiesMultiplier = $investment
             ? GameInvestment::FACILITIES_MULTIPLIER[$investment->facilities_tier] ?? 1.0
             : 1.0;
 
-        // Position factor from competition config
-        $config = $league->getConfig();
-        $positionFactor = $config->getPositionFactor($position);
-
-        return (int) ($base * $facilitiesMultiplier * $positionFactor);
+        return (int) ($total * $facilitiesMultiplier);
     }
 
     /**

--- a/app/Modules/Season/Services/SeasonClosingPipeline.php
+++ b/app/Modules/Season/Services/SeasonClosingPipeline.php
@@ -25,6 +25,7 @@ use App\Modules\Season\Processors\SupercupQualificationProcessor;
 use App\Modules\Season\Processors\TransferMarketResetProcessor;
 use App\Modules\Season\Processors\UefaQualificationProcessor;
 use App\Modules\Season\Processors\YouthAcademyClosingProcessor;
+use App\Modules\Stadium\Processors\FanLoyaltyUpdateProcessor;
 use App\Models\Game;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
@@ -58,6 +59,7 @@ class SeasonClosingPipeline
         SupercupQualificationProcessor $supercupQualification,
         PromotionRelegationProcessor $promotionRelegation,
         ReputationUpdateProcessor $reputationUpdate,
+        FanLoyaltyUpdateProcessor $fanLoyaltyUpdate,
         YouthAcademyClosingProcessor $youthAcademyClosing,
         UefaQualificationProcessor $uefaQualification,
     ) {
@@ -81,6 +83,7 @@ class SeasonClosingPipeline
             $supercupQualification,
             $promotionRelegation,
             $reputationUpdate,
+            $fanLoyaltyUpdate,
             $youthAcademyClosing,
             $uefaQualification,
         ];

--- a/app/Modules/Stadium/Services/MatchAttendanceService.php
+++ b/app/Modules/Stadium/Services/MatchAttendanceService.php
@@ -37,7 +37,7 @@ class MatchAttendanceService
             return $existing;
         }
 
-        if ($match->neutral_venue_name !== null && $match->neutral_venue_capacity !== null) {
+        if ($match->isNeutralVenue() && $match->neutral_venue_capacity !== null) {
             $capacity = (int) $match->neutral_venue_capacity;
             return MatchAttendance::create([
                 'game_id' => $game->id,
@@ -45,6 +45,33 @@ class MatchAttendanceService
                 'attendance' => $capacity,
                 'capacity_at_match' => $capacity,
             ]);
+        }
+
+        $projection = $this->projectForMatch($match, $game);
+        if ($projection === null) {
+            return null;
+        }
+
+        return MatchAttendance::create([
+            'game_id' => $game->id,
+            'game_match_id' => $match->id,
+            'attendance' => $projection['attendance'],
+            'capacity_at_match' => $projection['capacity'],
+        ]);
+    }
+
+    /**
+     * Compute the projected attendance for a fixture without persisting it.
+     * Used by BudgetProjectionService to sum pre-season matchday revenue
+     * across the upcoming schedule. Returns null for neutral-venue fixtures
+     * and for matches whose home team can't be resolved.
+     *
+     * @return array{attendance: int, capacity: int}|null
+     */
+    public function projectForMatch(GameMatch $match, Game $game): ?array
+    {
+        if ($match->isNeutralVenue()) {
+            return null;
         }
 
         $home = Team::find($match->home_team_id);
@@ -74,12 +101,10 @@ class MatchAttendanceService
             $homePosition,
         );
 
-        return MatchAttendance::create([
-            'game_id' => $game->id,
-            'game_match_id' => $match->id,
+        return [
             'attendance' => $attendance,
-            'capacity_at_match' => (int) ($home->stadium_seats ?? 0),
-        ]);
+            'capacity' => (int) ($home->stadium_seats ?? 0),
+        ];
     }
 
     /**

--- a/app/Modules/Stadium/Services/StadiumSummaryService.php
+++ b/app/Modules/Stadium/Services/StadiumSummaryService.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace App\Modules\Stadium\Services;
+
+use App\Models\Game;
+use App\Models\GameFinances;
+use App\Models\GameMatch;
+use App\Models\MatchAttendance;
+use App\Models\TeamReputation;
+
+/**
+ * Shapes the data shown on the Club > Stadium page: capacity, fan-loyalty
+ * stat, most-recent home-match attendance, and the current season's
+ * projected vs. actual matchday revenue. Pure read-side service — no
+ * writes, no side effects.
+ */
+class StadiumSummaryService
+{
+    /**
+     * @return array{
+     *   stadium_name: ?string,
+     *   capacity: int,
+     *   loyalty_points: int,
+     *   base_loyalty: int,
+     *   loyalty_direction: 'rising'|'stable'|'declining',
+     *   last_home_match: ?array{
+     *     match: GameMatch,
+     *     attendance: int,
+     *     capacity_at_match: int,
+     *     fill_rate: int,
+     *   },
+     *   finances: ?GameFinances,
+     * }
+     */
+    public function build(Game $game): array
+    {
+        $team = $game->team;
+
+        $reputation = TeamReputation::where('game_id', $game->id)
+            ->where('team_id', $game->team_id)
+            ->first();
+
+        $loyaltyPoints = $reputation?->loyalty_points ?? 0;
+        $baseLoyalty = $reputation?->base_loyalty ?? 0;
+
+        // Match the 5-point band used by the reputation-direction hint for
+        // consistency across the Club hub. Below that band loyalty is
+        // considered "stable" even with small cosmetic drifts.
+        $loyaltyDelta = $loyaltyPoints - $baseLoyalty;
+        $direction = $loyaltyDelta > 5 ? 'rising' : ($loyaltyDelta < -5 ? 'declining' : 'stable');
+
+        $lastHomeMatch = $this->resolveLastHomeMatch($game);
+
+        return [
+            'stadium_name' => $team->stadium_name,
+            'capacity' => (int) ($team->stadium_seats ?? 0),
+            'loyalty_points' => $loyaltyPoints,
+            'base_loyalty' => $baseLoyalty,
+            'loyalty_direction' => $direction,
+            'last_home_match' => $lastHomeMatch,
+            'finances' => $game->currentFinances,
+        ];
+    }
+
+    /**
+     * Most recent played home match that also has a persisted attendance
+     * row. Returns null until the team has played its first home fixture of
+     * the save (pre-season / new-game state).
+     */
+    private function resolveLastHomeMatch(Game $game): ?array
+    {
+        $match = GameMatch::query()
+            ->where('game_id', $game->id)
+            ->where('home_team_id', $game->team_id)
+            ->where('played', true)
+            ->whereIn('id', MatchAttendance::query()->select('game_match_id')->where('game_id', $game->id))
+            ->with(['awayTeam', 'competition'])
+            ->orderByDesc('scheduled_date')
+            ->first();
+
+        if (!$match) {
+            return null;
+        }
+
+        $attendance = MatchAttendance::where('game_match_id', $match->id)->first();
+
+        if (!$attendance) {
+            return null;
+        }
+
+        return [
+            'match' => $match,
+            'attendance' => (int) $attendance->attendance,
+            'capacity_at_match' => (int) $attendance->capacity_at_match,
+            'fill_rate' => $attendance->fillRatePercent(),
+        ];
+    }
+}

--- a/lang/en/app.php
+++ b/lang/en/app.php
@@ -6,6 +6,7 @@ return [
     'squad' => 'Squad',
     'starting_xi' => 'Starting XI',
     'finances' => 'Finances',
+    'club' => 'Club',
     'transfers' => 'Transfers',
     'calendar' => 'Calendar',
     'competitions' => 'Competitions',

--- a/lang/en/club.php
+++ b/lang/en/club.php
@@ -16,13 +16,9 @@ return [
         'capacity_help' => 'Seat count snapshotted at each match for attendance calculations. Capacity expansion becomes a player decision in a later phase.',
 
         'fan_base' => 'Fan base',
-        'fan_base_help' => 'Fan loyalty moves season to season based on on-pitch outcomes. It drives stadium occupancy alongside reputation, which sets ticket prices. The tick marks the curated anchor the club was seeded with.',
+        'fan_base_help' => 'Loyalty rises with trophies and strong finishes and dips after poor seasons. Together with reputation, it drives how full the stadium gets on matchday.',
         'fan_base_trend' => 'Fan trend',
-        'current_loyalty' => 'Current loyalty',
-        'anchor' => 'Anchor',
-        'loyalty_rising' => 'Rising',
-        'loyalty_stable' => 'Stable',
-        'loyalty_declining' => 'Declining',
+        'current_loyalty' => 'Fan support',
 
         'last_attendance' => 'Last home match',
         'fill_rate' => 'Fill rate',
@@ -35,27 +31,62 @@ return [
 
     'reputation' => [
         'current_tier' => 'Current tier',
-        'points' => 'Reputation points',
-        'trend' => 'Projected trend',
 
         'tiers' => 'Reputation tiers',
-        'ladder_help' => 'Clubs move up the ladder by finishing high in their league; elite and continental clubs must offset tier gravity every season or drift back down. A club can never fall more than two tiers below its seeded anchor.',
+        'tiers_help_toggle' => 'How do reputation tiers work?',
+        'ladder_help' => 'Clubs move up the ladder by finishing high in their league. At the top tiers, reputation decays slightly each season unless backed up with results.',
 
         'current' => 'Current',
-        'anchor' => 'Anchor',
-        'floor' => 'Floor',
-        'threshold' => 'Threshold',
 
-        'progress' => 'Tier progress',
-        'points_to_next' => ':points points to :tier',
-        'at_top_tier' => 'Top of the ladder — no tier above this.',
+        'qualitative_distance' => [
+            'one_strong_season' => 'A strong season would reach :tier.',
+            'two_strong_seasons' => 'A couple of strong seasons from :tier.',
+            'several_seasons' => 'Several solid seasons from :tier.',
+            'long_road' => 'A long road to :tier.',
+        ],
 
-        'season_projection' => 'Season-end projection',
-        'current_position' => 'Current position',
-        'position_points' => 'Position points',
-        'gravity' => 'Tier gravity',
-        'net_change' => 'Net change',
-        'projection_help' => 'Assumes the season ends with the club at its current league position. Trophies and cup runs add on top at season close.',
-        'no_standing_yet' => 'League standings appear once the season is underway.',
+        'tier_descriptors' => [
+            'local' => 'A small-market club with a devoted local following.',
+            'modest' => 'A small club aiming to reach or stay in the top flight.',
+            'established' => 'A historic club with years of top-flight experience.',
+            'continental' => 'A fixture in European competitions.',
+            'elite' => 'A reference point in European football.',
+        ],
+
+        'career' => [
+            'title' => 'Career so far',
+            'seasons_managed' => 'Seasons managed',
+            'starting_tier' => 'Starting tier',
+            'matches_managed' => 'Matches managed',
+            'trophies' => 'Trophies',
+        ],
+
+        'path_title' => 'Path to the next tier',
+        'path_also' => 'Cup titles and European runs also count at season close.',
+        'maintenance_note' => 'At this tier, reputation decays slightly each season unless you back it up with results.',
+        'projected' => 'Projected',
+
+        'legend' => [
+            'forward' => 'Step forward',
+            'flat' => 'No progress',
+            'setback' => 'Setback',
+        ],
+
+        'impact' => [
+            'major_leap' => 'Major leap forward',
+            'solid_step' => 'Solid step forward',
+            'small_step' => 'Small step forward',
+            'stalls' => 'Stalls progress',
+            'setback' => 'Setback',
+        ],
+
+        'impact_title' => 'What reputation means for your club',
+        'impact_signings_title' => 'Attracting signings',
+        'impact_signings_body' => 'Higher-profile players are more willing to join more reputable clubs. Free agents, transfer targets and rival sellers all weigh your standing before sitting down to negotiate.',
+        'impact_retain_title' => 'Retaining talent',
+        'impact_retain_body' => 'Your own squad reacts to reputation too. A rising club holds on to its key players more easily; slipping down the ladder invites poachers and makes renewals harder.',
+        'impact_economy_title' => 'Economic opportunities',
+        'impact_economy_body' => 'Matchday attendance, ticket pricing and commercial revenue all scale with reputation. Climbing unlocks stronger income across the board; slipping tightens the budget.',
+
     ],
 ];

--- a/lang/en/club.php
+++ b/lang/en/club.php
@@ -1,0 +1,61 @@
+<?php
+
+return [
+    'hub_title' => 'Club',
+
+    'nav' => [
+        'finances' => 'Finances',
+        'stadium' => 'Stadium',
+        'reputation' => 'Reputation',
+    ],
+
+    'stadium' => [
+        'home_ground' => 'Home ground',
+        'stadium_name' => 'Stadium',
+        'capacity' => 'Capacity',
+        'capacity_help' => 'Seat count snapshotted at each match for attendance calculations. Capacity expansion becomes a player decision in a later phase.',
+
+        'fan_base' => 'Fan base',
+        'fan_base_help' => 'Fan loyalty moves season to season based on on-pitch outcomes. It drives stadium occupancy alongside reputation, which sets ticket prices. The tick marks the curated anchor the club was seeded with.',
+        'fan_base_trend' => 'Fan trend',
+        'current_loyalty' => 'Current loyalty',
+        'anchor' => 'Anchor',
+        'loyalty_rising' => 'Rising',
+        'loyalty_stable' => 'Stable',
+        'loyalty_declining' => 'Declining',
+
+        'last_attendance' => 'Last home match',
+        'fill_rate' => 'Fill rate',
+        'no_home_match_yet' => 'No home match has been played yet.',
+
+        'matchday_revenue' => 'Matchday revenue',
+        'matchday_revenue_help' => 'Projected figure uses the season budgeting formula; actuals land at season settlement. They will diverge once attendance drives matchday revenue directly.',
+        'no_finances_yet' => 'Season finances will appear once projections are generated.',
+    ],
+
+    'reputation' => [
+        'current_tier' => 'Current tier',
+        'points' => 'Reputation points',
+        'trend' => 'Projected trend',
+
+        'tiers' => 'Reputation tiers',
+        'ladder_help' => 'Clubs move up the ladder by finishing high in their league; elite and continental clubs must offset tier gravity every season or drift back down. A club can never fall more than two tiers below its seeded anchor.',
+
+        'current' => 'Current',
+        'anchor' => 'Anchor',
+        'floor' => 'Floor',
+        'threshold' => 'Threshold',
+
+        'progress' => 'Tier progress',
+        'points_to_next' => ':points points to :tier',
+        'at_top_tier' => 'Top of the ladder — no tier above this.',
+
+        'season_projection' => 'Season-end projection',
+        'current_position' => 'Current position',
+        'position_points' => 'Position points',
+        'gravity' => 'Tier gravity',
+        'net_change' => 'Net change',
+        'projection_help' => 'Assumes the season ends with the club at its current league position. Trophies and cup runs add on top at season close.',
+        'no_standing_yet' => 'League standings appear once the season is underway.',
+    ],
+];

--- a/lang/es/app.php
+++ b/lang/es/app.php
@@ -6,6 +6,7 @@ return [
     'squad' => 'Plantilla',
     'starting_xi' => 'Alineación',
     'finances' => 'Finanzas',
+    'club' => 'Club',
     'transfers' => 'Fichajes',
     'calendar' => 'Calendario',
     'competitions' => 'Competiciones',

--- a/lang/es/club.php
+++ b/lang/es/club.php
@@ -1,0 +1,61 @@
+<?php
+
+return [
+    'hub_title' => 'Club',
+
+    'nav' => [
+        'finances' => 'Finanzas',
+        'stadium' => 'Estadio',
+        'reputation' => 'Reputación',
+    ],
+
+    'stadium' => [
+        'home_ground' => 'Campo',
+        'stadium_name' => 'Estadio',
+        'capacity' => 'Aforo',
+        'capacity_help' => 'El aforo se registra en cada partido para calcular la asistencia. La ampliación del estadio se convertirá en una decisión del entrenador en una fase posterior.',
+
+        'fan_base' => 'Afición',
+        'fan_base_help' => 'La lealtad de la afición cambia cada temporada según los resultados. Impulsa la ocupación del estadio junto con la reputación, que marca el precio de las entradas. La marca indica el valor inicial del club.',
+        'fan_base_trend' => 'Tendencia',
+        'current_loyalty' => 'Lealtad actual',
+        'anchor' => 'Ancla',
+        'loyalty_rising' => 'Al alza',
+        'loyalty_stable' => 'Estable',
+        'loyalty_declining' => 'A la baja',
+
+        'last_attendance' => 'Último partido en casa',
+        'fill_rate' => 'Ocupación',
+        'no_home_match_yet' => 'Aún no se ha jugado ningún partido en casa.',
+
+        'matchday_revenue' => 'Ingresos por taquilla',
+        'matchday_revenue_help' => 'La proyección usa la fórmula presupuestaria de la temporada; los ingresos reales se liquidan al cierre. Empezarán a divergir cuando la asistencia determine directamente la taquilla.',
+        'no_finances_yet' => 'Las finanzas de la temporada aparecerán cuando se generen las proyecciones.',
+    ],
+
+    'reputation' => [
+        'current_tier' => 'Nivel actual',
+        'points' => 'Puntos de reputación',
+        'trend' => 'Tendencia prevista',
+
+        'tiers' => 'Niveles de reputación',
+        'ladder_help' => 'Los clubes suben de nivel terminando arriba en la liga; los clubes élite y continentales tienen que compensar la gravedad de su nivel cada temporada o bajarán. Un club nunca cae más de dos niveles por debajo de su ancla.',
+
+        'current' => 'Actual',
+        'anchor' => 'Ancla',
+        'floor' => 'Suelo',
+        'threshold' => 'Umbral',
+
+        'progress' => 'Progreso de nivel',
+        'points_to_next' => ':points puntos para :tier',
+        'at_top_tier' => 'Cima de la escalera — no hay nivel superior.',
+
+        'season_projection' => 'Proyección de fin de temporada',
+        'current_position' => 'Posición actual',
+        'position_points' => 'Puntos por posición',
+        'gravity' => 'Gravedad de nivel',
+        'net_change' => 'Cambio neto',
+        'projection_help' => 'Supone que la temporada termina con el club en su posición actual. Los títulos y rachas de copa suman encima al cierre de la temporada.',
+        'no_standing_yet' => 'La clasificación aparecerá cuando la temporada esté en marcha.',
+    ],
+];

--- a/lang/es/club.php
+++ b/lang/es/club.php
@@ -16,13 +16,9 @@ return [
         'capacity_help' => 'El aforo se registra en cada partido para calcular la asistencia. La ampliación del estadio se convertirá en una decisión del entrenador en una fase posterior.',
 
         'fan_base' => 'Afición',
-        'fan_base_help' => 'La lealtad de la afición cambia cada temporada según los resultados. Impulsa la ocupación del estadio junto con la reputación, que marca el precio de las entradas. La marca indica el valor inicial del club.',
+        'fan_base_help' => 'La lealtad sube con títulos y buenas campañas y baja tras temporadas flojas. Junto a la reputación, determina cuánto se llena el estadio los días de partido.',
         'fan_base_trend' => 'Tendencia',
-        'current_loyalty' => 'Lealtad actual',
-        'anchor' => 'Ancla',
-        'loyalty_rising' => 'Al alza',
-        'loyalty_stable' => 'Estable',
-        'loyalty_declining' => 'A la baja',
+        'current_loyalty' => 'Apoyo de la afición',
 
         'last_attendance' => 'Último partido en casa',
         'fill_rate' => 'Ocupación',
@@ -35,27 +31,62 @@ return [
 
     'reputation' => [
         'current_tier' => 'Nivel actual',
-        'points' => 'Puntos de reputación',
-        'trend' => 'Tendencia prevista',
 
         'tiers' => 'Niveles de reputación',
-        'ladder_help' => 'Los clubes suben de nivel terminando arriba en la liga; los clubes élite y continentales tienen que compensar la gravedad de su nivel cada temporada o bajarán. Un club nunca cae más de dos niveles por debajo de su ancla.',
+        'tiers_help_toggle' => '¿Cómo funcionan los niveles de reputación?',
+        'ladder_help' => 'Los clubes suben de nivel terminando arriba en la liga. En los niveles más altos, la reputación se desgasta cada temporada si no se respalda con resultados.',
 
         'current' => 'Actual',
-        'anchor' => 'Ancla',
-        'floor' => 'Suelo',
-        'threshold' => 'Umbral',
 
-        'progress' => 'Progreso de nivel',
-        'points_to_next' => ':points puntos para :tier',
-        'at_top_tier' => 'Cima de la escalera — no hay nivel superior.',
+        'qualitative_distance' => [
+            'one_strong_season' => 'Una buena temporada bastaría para llegar a :tier.',
+            'two_strong_seasons' => 'Un par de buenas temporadas te separan de :tier.',
+            'several_seasons' => 'Varias temporadas sólidas te separan de :tier.',
+            'long_road' => 'Queda un largo camino hasta :tier.',
+        ],
 
-        'season_projection' => 'Proyección de fin de temporada',
-        'current_position' => 'Posición actual',
-        'position_points' => 'Puntos por posición',
-        'gravity' => 'Gravedad de nivel',
-        'net_change' => 'Cambio neto',
-        'projection_help' => 'Supone que la temporada termina con el club en su posición actual. Los títulos y rachas de copa suman encima al cierre de la temporada.',
-        'no_standing_yet' => 'La clasificación aparecerá cuando la temporada esté en marcha.',
+        'tier_descriptors' => [
+            'local' => 'Un club modesto con una afición local fiel.',
+            'modest' => 'Un club pequeño que aspira a llegar o mantenerse en primera.',
+            'established' => 'Un club histórico, con años de experiencia en primera.',
+            'continental' => 'Habitual en competiciones europeas.',
+            'elite' => 'Referente del fútbol europeo.',
+        ],
+
+        'career' => [
+            'title' => 'Trayectoria',
+            'seasons_managed' => 'Temporadas dirigidas',
+            'starting_tier' => 'Nivel inicial',
+            'matches_managed' => 'Partidos dirigidos',
+            'trophies' => 'Títulos',
+        ],
+
+        'path_title' => 'Camino al siguiente nivel',
+        'path_also' => 'Los títulos de copa y las rachas europeas también suman al cierre de la temporada.',
+        'maintenance_note' => 'En este nivel, la reputación se desgasta cada temporada si no la respaldas con resultados.',
+        'projected' => 'Proyectado',
+
+        'legend' => [
+            'forward' => 'Avance',
+            'flat' => 'Sin avance',
+            'setback' => 'Retroceso',
+        ],
+
+        'impact' => [
+            'major_leap' => 'Gran salto adelante',
+            'solid_step' => 'Paso sólido adelante',
+            'small_step' => 'Pequeño avance',
+            'stalls' => 'Sin avance',
+            'setback' => 'Retroceso',
+        ],
+
+        'impact_title' => 'Qué aporta la reputación a tu club',
+        'impact_signings_title' => 'Atraer fichajes',
+        'impact_signings_body' => 'Los jugadores de mayor nivel se inclinan por clubes con más reputación. Agentes libres, objetivos de traspaso y clubes rivales valoran tu nivel antes de sentarse a negociar.',
+        'impact_retain_title' => 'Retener talento',
+        'impact_retain_body' => 'Tu propia plantilla también reacciona a la reputación. Un club en crecimiento retiene mejor a sus piezas clave; cuando se cae de nivel, aparecen los depredadores y las renovaciones se complican.',
+        'impact_economy_title' => 'Oportunidades económicas',
+        'impact_economy_body' => 'La asistencia al estadio, el precio de las entradas y los ingresos comerciales escalan con la reputación. Subir desbloquea mayores ingresos en todos los frentes; bajar aprieta el presupuesto.',
+
     ],
 ];

--- a/resources/views/budget-allocation.blade.php
+++ b/resources/views/budget-allocation.blade.php
@@ -19,7 +19,7 @@
                 <h2 class="font-heading text-2xl lg:text-3xl font-bold uppercase tracking-wide text-text-primary">{{ __('finances.budget_allocation') }}</h2>
                 <p class="text-sm text-text-muted mt-0.5">{{ __('finances.season_budget', ['season' => $game->formatted_season]) }}</p>
             </div>
-            <a href="{{ route('game.finances', $game->id) }}" class="text-sm text-text-muted hover:text-text-primary transition-colors">
+            <a href="{{ route('game.club.finances', $game->id) }}" class="text-sm text-text-muted hover:text-text-primary transition-colors">
                 &larr; {{ __('app.back') }}
             </a>
         </div>

--- a/resources/views/club/finances.blade.php
+++ b/resources/views/club/finances.blade.php
@@ -21,12 +21,14 @@
 
     <div class="max-w-7xl mx-auto px-4 pb-8">
 
-        @if($finances)
-
-        {{-- Page Title --}}
-        <div class="mt-6 mb-6">
-            <h2 class="font-heading text-2xl lg:text-3xl font-bold uppercase tracking-wide text-text-primary">{{ __('finances.finances') }}</h2>
+        {{-- Club hub title + subnav --}}
+        <div class="mt-6 mb-4">
+            <h2 class="font-heading text-2xl lg:text-3xl font-bold uppercase tracking-wide text-text-primary">{{ __('club.hub_title') }}</h2>
         </div>
+        <x-club-section-nav :game="$game" active="finances" />
+
+        @if($finances)
+        <div class="mt-6"></div>
 
         {{-- Post-season results banner --}}
         @if($finances->actual_total_revenue > 0)

--- a/resources/views/club/reputation.blade.php
+++ b/resources/views/club/reputation.blade.php
@@ -1,39 +1,21 @@
 @php
 /** @var App\Models\Game $game */
 /** @var array $summary */
+/** @var array $career */
 
 $currentLevel = $summary['current_level'];
-$currentPoints = $summary['current_points'];
-$baseLevel = $summary['base_level'];
-$tierFloor = $summary['tier_floor'];
 $tierIndex = $summary['tier_index'];
-$baseTierIndex = $summary['base_tier_index'];
 $pointsInTier = $summary['points_in_tier'];
 $tierSpan = $summary['tier_span'];
-$pointsToNextTier = $summary['points_to_next_tier'];
-$thresholds = $summary['tier_thresholds'];
-$direction = $summary['direction'];
-$detail = $summary['direction_detail'];
-
-$directionConfig = match ($direction) {
-    'rising' => ['icon' => '&#9650;', 'color' => 'text-accent-green', 'label' => __('season.reputation_rising')],
-    'declining' => ['icon' => '&#9660;', 'color' => 'text-accent-red', 'label' => __('season.reputation_declining')],
-    default => ['icon' => '&#9654;', 'color' => 'text-text-secondary', 'label' => __('season.reputation_stable')],
-};
 
 $tierProgressPercent = $tierSpan > 0 ? (int) round(min(100, ($pointsInTier / $tierSpan) * 100)) : 0;
 
 $allTiers = \App\Models\ClubProfile::REPUTATION_TIERS;
 
 $loyaltyPoints = $summary['loyalty_points'];
-$baseLoyalty = $summary['base_loyalty'];
-$loyaltyDirection = $summary['loyalty_direction'];
-
-$loyaltyDirectionConfig = match ($loyaltyDirection) {
-    'rising' => ['icon' => '&#9650;', 'color' => 'text-accent-green', 'label' => __('club.stadium.loyalty_rising')],
-    'declining' => ['icon' => '&#9660;', 'color' => 'text-accent-red', 'label' => __('club.stadium.loyalty_declining')],
-    default => ['icon' => '&#9654;', 'color' => 'text-text-secondary', 'label' => __('club.stadium.loyalty_stable')],
-};
+$qualitativeDistance = $summary['qualitative_distance'] ?? null;
+$outcomeLadder = $summary['outcome_ladder'] ?? [];
+$tierMaintenanceApplies = $summary['tier_maintenance_applies'] ?? false;
 @endphp
 
 <x-app-layout>
@@ -47,87 +29,137 @@ $loyaltyDirectionConfig = match ($loyaltyDirection) {
         <div class="mt-6 mb-4">
             <h2 class="font-heading text-2xl lg:text-3xl font-bold uppercase tracking-wide text-text-primary">{{ __('club.hub_title') }}</h2>
         </div>
-        <x-club-section-nav :game="$game" active="reputation" />
+        <div x-data="{ helpOpen: false }">
+            <x-club-section-nav :game="$game" active="reputation">
+                <x-ghost-button color="slate" @click="helpOpen = !helpOpen" class="gap-2">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="w-4 h-4 text-text-secondary shrink-0">
+                        <path fill-rule="evenodd" d="M18 10a8 8 0 1 1-16 0 8 8 0 0 1 16 0Zm-7-4a1 1 0 1 1-2 0 1 1 0 0 1 2 0ZM9 9a.75.75 0 0 0 0 1.5h.253a.25.25 0 0 1 .244.304l-.459 2.066A1.75 1.75 0 0 0 10.747 15H11a.75.75 0 0 0 0-1.5h-.253a.25.25 0 0 1-.244-.304l.459-2.066A1.75 1.75 0 0 0 9.253 9H9Z" clip-rule="evenodd" />
+                    </svg>
+                    <span class="hidden md:inline">{{ __('club.reputation.tiers_help_toggle') }}</span>
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="w-4 h-4 transition-transform hidden md:block" :class="helpOpen ? 'rotate-180' : ''">
+                        <path fill-rule="evenodd" d="M5.22 8.22a.75.75 0 0 1 1.06 0L10 11.94l3.72-3.72a.75.75 0 1 1 1.06 1.06l-4.25 4.25a.75.75 0 0 1-1.06 0L5.22 9.28a.75.75 0 0 1 0-1.06Z" clip-rule="evenodd" />
+                    </svg>
+                </x-ghost-button>
+            </x-club-section-nav>
 
-        {{-- KPI strip --}}
-        <div class="flex flex-wrap gap-3 mt-6 mb-6">
-            <x-summary-card :label="__('club.reputation.current_tier')">
-                <div class="font-heading text-xl font-bold text-text-primary mt-0.5">{{ __('finances.reputation.' . $currentLevel) }}</div>
-            </x-summary-card>
-            <x-summary-card
-                :label="__('club.reputation.points')"
-                :value="number_format($currentPoints)"
-            />
-            <x-summary-card :label="__('club.reputation.trend')">
-                <div class="flex items-center gap-1.5 mt-0.5">
-                    <span class="font-heading text-lg font-bold {{ $directionConfig['color'] }}">{!! $directionConfig['icon'] !!}</span>
-                    <span class="text-xs font-semibold {{ $directionConfig['color'] }} uppercase tracking-wider">{{ $directionConfig['label'] }}</span>
-                </div>
-            </x-summary-card>
+            <div x-show="helpOpen" x-transition x-cloak class="mt-3 bg-surface-800 border border-border-default rounded-xl p-4 text-sm">
+                <p class="text-text-secondary mb-3">{{ __('club.reputation.ladder_help') }}</p>
+                <ol class="space-y-1.5">
+                    @foreach(array_reverse($allTiers) as $tier)
+                        @php
+                            $isCurrent = $tier === $currentLevel;
+                        @endphp
+                        <li class="flex items-baseline gap-2 {{ $isCurrent ? 'text-text-primary font-semibold' : 'text-text-body' }}">
+                            <span class="w-1.5 h-1.5 rounded-full shrink-0 {{ $isCurrent ? 'bg-accent-blue' : 'bg-surface-600' }}"></span>
+                            <span class="uppercase tracking-wider text-xs">{{ __('finances.reputation.' . $tier) }}</span>
+                            <span class="text-text-secondary text-xs">— {{ __('club.reputation.tier_descriptors.' . $tier) }}</span>
+                            @if($isCurrent)
+                                <span class="text-[10px] font-semibold text-accent-blue uppercase tracking-widest">· {{ __('club.reputation.current') }}</span>
+                            @endif
+                        </li>
+                    @endforeach
+                </ol>
+            </div>
+        </div>
+
+        {{-- Status header --}}
+        <div class="mt-6 mb-4 rounded-lg border border-border-default bg-surface-700/40 px-5 py-4">
+            <div class="text-[10px] text-text-muted uppercase tracking-widest">{{ __('club.reputation.current_tier') }}</div>
+            <div class="font-heading text-2xl lg:text-3xl font-bold text-text-primary leading-tight">{{ __('finances.reputation.' . $currentLevel) }}</div>
+            <div class="text-sm text-text-body mt-1">{{ __('club.reputation.tier_descriptors.' . $currentLevel) }}</div>
         </div>
 
         <div class="grid grid-cols-1 lg:grid-cols-3 gap-6">
 
-            {{-- LEFT (2/3) — tier milestones ladder --}}
+            {{-- LEFT (2/3) — path to next tier (primary) --}}
             <div class="lg:col-span-2 space-y-6">
-                <x-section-card :title="__('club.reputation.tiers')">
+                <x-section-card :title="__('club.reputation.path_title')">
                     <div class="px-5 py-4">
-                        <div class="space-y-3">
-                            @foreach(array_reverse($allTiers) as $tier)
+                        @if(isset($allTiers[$tierIndex + 1]) && $qualitativeDistance !== null)
+                            <p class="text-sm text-text-body mb-3 leading-relaxed">
+                                {{ __('club.reputation.qualitative_distance.' . $qualitativeDistance, ['tier' => __('finances.reputation.' . $allTiers[$tierIndex + 1])]) }}
+                            </p>
+                        @endif
+
+                        {{-- Compact outcome bar: each segment is one league-finish band. --}}
+                        <div class="flex h-7 rounded-md overflow-hidden border border-border-default">
+                            @foreach($outcomeLadder as $band)
                                 @php
-                                    $threshold = $thresholds[$tier] ?? 0;
-                                    $tierIdx = \App\Models\ClubProfile::getReputationTierIndex($tier);
-                                    $isCurrent = $tier === $currentLevel;
-                                    $isBase = $tier === $baseLevel;
-                                    $isFloor = $tier === $tierFloor;
-                                    $isReached = $currentPoints >= $threshold;
+                                    $segmentBg = match ($band['impact_key']) {
+                                        'major_leap' => 'bg-accent-green',
+                                        'solid_step' => 'bg-accent-green/70',
+                                        'small_step' => 'bg-accent-green/35',
+                                        'stalls' => 'bg-surface-600',
+                                        'setback' => 'bg-accent-red/70',
+                                        default => 'bg-surface-600',
+                                    };
+                                    $segmentText = in_array($band['impact_key'], ['major_leap', 'solid_step', 'setback'], true)
+                                        ? 'text-white'
+                                        : 'text-text-primary';
                                 @endphp
-                                <div class="flex items-center gap-4 rounded-lg px-3 py-3 border {{ $isCurrent ? 'bg-accent-blue/10 border-accent-blue/40' : 'bg-surface-700/40 border-border-default' }}">
-                                    <div class="w-2 h-10 rounded-full {{ $isCurrent ? 'bg-accent-blue' : ($isReached ? 'bg-accent-green/50' : 'bg-surface-600') }}"></div>
-                                    <div class="flex-1 min-w-0">
-                                        <div class="flex items-center gap-2 flex-wrap">
-                                            <span class="font-heading text-sm font-bold {{ $isCurrent ? 'text-text-primary' : 'text-text-body' }} uppercase tracking-wider">{{ __('finances.reputation.' . $tier) }}</span>
-                                            @if($isCurrent)
-                                                <span class="text-[10px] font-semibold bg-accent-blue/20 text-accent-blue px-1.5 py-0.5 rounded-sm uppercase tracking-widest">{{ __('club.reputation.current') }}</span>
-                                            @endif
-                                            @if($isBase)
-                                                <span class="text-[10px] font-semibold bg-surface-600 text-text-body px-1.5 py-0.5 rounded-sm uppercase tracking-widest">{{ __('club.reputation.anchor') }}</span>
-                                            @endif
-                                            @if($isFloor && !$isBase)
-                                                <span class="text-[10px] font-semibold bg-surface-600 text-text-muted px-1.5 py-0.5 rounded-sm uppercase tracking-widest">{{ __('club.reputation.floor') }}</span>
-                                            @endif
-                                        </div>
-                                        <div class="text-[10px] text-text-muted uppercase tracking-widest mt-0.5">{{ __('club.reputation.threshold') }}: {{ number_format($threshold) }}</div>
-                                    </div>
+                                <div class="relative flex items-center justify-center text-[11px] font-heading font-bold {{ $segmentBg }} {{ $segmentText }} {{ $band['is_current'] ? 'ring-2 ring-accent-blue ring-inset z-10' : '' }}"
+                                     style="flex: {{ $band['size'] }} 1 0;"
+                                     title="{{ __('club.reputation.impact.' . $band['impact_key']) }}">
+                                    {{ $band['position_range'] }}
                                 </div>
                             @endforeach
                         </div>
-                        <p class="text-xs text-text-muted mt-4 leading-relaxed">{{ __('club.reputation.ladder_help') }}</p>
+
+                        {{-- Legend --}}
+                        <div class="flex flex-wrap items-center gap-x-4 gap-y-1 mt-3 text-[11px] text-text-muted">
+                            <span class="flex items-center gap-1.5"><span class="w-2.5 h-2.5 rounded-sm bg-accent-green"></span>{{ __('club.reputation.legend.forward') }}</span>
+                            <span class="flex items-center gap-1.5"><span class="w-2.5 h-2.5 rounded-sm bg-surface-600"></span>{{ __('club.reputation.legend.flat') }}</span>
+                            <span class="flex items-center gap-1.5"><span class="w-2.5 h-2.5 rounded-sm bg-accent-red/70"></span>{{ __('club.reputation.legend.setback') }}</span>
+                        </div>
+
+                        <p class="text-xs text-text-muted mt-3 leading-relaxed">{{ __('club.reputation.path_also') }}</p>
+                        @if($tierMaintenanceApplies)
+                            <p class="text-xs text-text-muted mt-1 leading-relaxed">{{ __('club.reputation.maintenance_note') }}</p>
+                        @endif
+                    </div>
+                </x-section-card>
+
+                {{-- What reputation means for your club --}}
+                <x-section-card :title="__('club.reputation.impact_title')">
+                    <div class="px-5 py-4 space-y-4">
+                        <div>
+                            <p class="font-semibold text-text-body text-sm mb-1">{{ __('club.reputation.impact_signings_title') }}</p>
+                            <p class="text-sm text-text-secondary leading-relaxed">{{ __('club.reputation.impact_signings_body') }}</p>
+                        </div>
+                        <div>
+                            <p class="font-semibold text-text-body text-sm mb-1">{{ __('club.reputation.impact_retain_title') }}</p>
+                            <p class="text-sm text-text-secondary leading-relaxed">{{ __('club.reputation.impact_retain_body') }}</p>
+                        </div>
+                        <div>
+                            <p class="font-semibold text-text-body text-sm mb-1">{{ __('club.reputation.impact_economy_title') }}</p>
+                            <p class="text-sm text-text-secondary leading-relaxed">{{ __('club.reputation.impact_economy_body') }}</p>
+                        </div>
                     </div>
                 </x-section-card>
             </div>
 
-            {{-- RIGHT (1/3) — tier progress + season projection --}}
+            {{-- RIGHT (1/3) — career so far + fan base --}}
             <div class="space-y-6">
-                {{-- Progress within current tier --}}
-                <x-section-card :title="__('club.reputation.progress')">
-                    <div class="px-5 py-4">
+                {{-- Career so far --}}
+                <x-section-card :title="__('club.reputation.career.title')">
+                    <div class="px-5 py-4 space-y-2.5">
                         <div class="flex items-baseline justify-between">
-                            <span class="text-[10px] text-text-muted uppercase tracking-widest">{{ __('finances.reputation.' . $currentLevel) }}</span>
-                            <span class="font-heading text-lg font-bold text-text-primary">{{ number_format($currentPoints) }}</span>
+                            <span class="text-xs text-text-muted">{{ __('club.reputation.career.seasons_managed') }}</span>
+                            <span class="font-heading text-base font-bold text-text-primary">{{ $career['seasons_managed'] }}</span>
                         </div>
-                        <div class="w-full h-2 bg-surface-600 rounded-full overflow-hidden mt-1.5">
-                            <div class="h-full rounded-full bg-accent-blue" style="width: {{ $tierProgressPercent }}%"></div>
+                        <div class="flex items-baseline justify-between">
+                            <span class="text-xs text-text-muted">{{ __('club.reputation.career.matches_managed') }}</span>
+                            <span class="font-heading text-base font-bold text-text-primary">{{ number_format($career['matches_played']) }}</span>
                         </div>
-                        @if($pointsToNextTier !== null && isset($allTiers[$tierIndex + 1]))
-                            <p class="text-xs text-text-muted mt-2">
-                                {{ __('club.reputation.points_to_next', [
-                                    'points' => number_format($pointsToNextTier),
-                                    'tier' => __('finances.reputation.' . $allTiers[$tierIndex + 1]),
-                                ]) }}
-                            </p>
-                        @else
-                            <p class="text-xs text-text-muted mt-2">{{ __('club.reputation.at_top_tier') }}</p>
+                        <div class="flex items-baseline justify-between">
+                            <span class="text-xs text-text-muted">{{ __('club.reputation.career.starting_tier') }}</span>
+                            <span class="font-heading text-xs font-bold text-text-primary uppercase tracking-wider">{{ __('finances.reputation.' . $career['starting_tier']) }}</span>
+                        </div>
+                        @if($career['trophies'] > 0)
+                            <div class="flex items-baseline justify-between">
+                                <span class="text-xs text-text-muted">{{ __('club.reputation.career.trophies') }}</span>
+                                <span class="font-heading text-base font-bold text-text-primary">{{ $career['trophies'] }}</span>
+                            </div>
                         @endif
                     </div>
                 </x-section-card>
@@ -139,50 +171,13 @@ $loyaltyDirectionConfig = match ($loyaltyDirection) {
                             <div class="text-[10px] text-text-muted uppercase tracking-widest">{{ __('club.stadium.current_loyalty') }}</div>
                             <span class="font-heading text-lg font-bold text-text-primary">{{ $loyaltyPoints }}<span class="text-xs font-normal text-text-muted"> / 100</span></span>
                         </div>
-                        <div class="w-full h-2 bg-surface-600 rounded-full overflow-hidden mt-1.5 relative">
+                        <div class="w-full h-2 bg-surface-600 rounded-full overflow-hidden mt-1.5">
                             <div class="h-full rounded-full bg-accent-blue" style="width: {{ max(0, min(100, $loyaltyPoints)) }}%"></div>
-                            @if($baseLoyalty > 0)
-                                <div class="absolute top-0 bottom-0 w-px bg-text-primary/60" style="left: {{ max(0, min(100, $baseLoyalty)) }}%;"></div>
-                            @endif
-                        </div>
-                        <div class="flex items-center justify-between mt-1">
-                            <span class="text-[10px] text-text-muted">{{ __('club.stadium.anchor') }}: {{ $baseLoyalty }}</span>
-                            <span class="text-[10px] font-semibold {{ $loyaltyDirectionConfig['color'] }}">{!! $loyaltyDirectionConfig['icon'] !!} {{ $loyaltyDirectionConfig['label'] }}</span>
                         </div>
                         <p class="text-xs text-text-muted mt-4 leading-relaxed">{{ __('club.stadium.fan_base_help') }}</p>
                     </div>
                 </x-section-card>
 
-                {{-- Season-end projection --}}
-                <x-section-card :title="__('club.reputation.season_projection')">
-                    <div class="px-5 py-4">
-                        @if($detail['position'] === null)
-                            <p class="text-sm text-text-muted">{{ __('club.reputation.no_standing_yet') }}</p>
-                        @else
-                            <div class="space-y-2 text-sm">
-                                <div class="flex items-center justify-between">
-                                    <span class="text-text-muted">{{ __('club.reputation.current_position') }}</span>
-                                    <span class="font-heading font-bold text-text-primary">{{ $detail['position'] }}</span>
-                                </div>
-                                <div class="flex items-center justify-between">
-                                    <span class="text-text-muted">{{ __('club.reputation.position_points') }}</span>
-                                    <span class="font-heading font-bold {{ $detail['points_delta'] > 0 ? 'text-accent-green' : ($detail['points_delta'] < 0 ? 'text-accent-red' : 'text-text-body') }}">{{ ($detail['points_delta'] > 0 ? '+' : '') . $detail['points_delta'] }}</span>
-                                </div>
-                                @if($detail['gravity'] > 0)
-                                    <div class="flex items-center justify-between">
-                                        <span class="text-text-muted">{{ __('club.reputation.gravity') }}</span>
-                                        <span class="font-heading font-bold text-accent-red">−{{ $detail['gravity'] }}</span>
-                                    </div>
-                                @endif
-                                <div class="flex items-center justify-between pt-2 border-t border-border-default">
-                                    <span class="text-text-muted">{{ __('club.reputation.net_change') }}</span>
-                                    <span class="font-heading font-bold {{ $detail['net'] > 0 ? 'text-accent-green' : ($detail['net'] < 0 ? 'text-accent-red' : 'text-text-body') }}">{{ ($detail['net'] > 0 ? '+' : '') . $detail['net'] }}</span>
-                                </div>
-                            </div>
-                            <p class="text-xs text-text-muted mt-4 leading-relaxed">{{ __('club.reputation.projection_help') }}</p>
-                        @endif
-                    </div>
-                </x-section-card>
             </div>
         </div>
     </div>

--- a/resources/views/club/reputation.blade.php
+++ b/resources/views/club/reputation.blade.php
@@ -1,0 +1,160 @@
+@php
+/** @var App\Models\Game $game */
+/** @var array $summary */
+
+$currentLevel = $summary['current_level'];
+$currentPoints = $summary['current_points'];
+$baseLevel = $summary['base_level'];
+$tierFloor = $summary['tier_floor'];
+$tierIndex = $summary['tier_index'];
+$baseTierIndex = $summary['base_tier_index'];
+$pointsInTier = $summary['points_in_tier'];
+$tierSpan = $summary['tier_span'];
+$pointsToNextTier = $summary['points_to_next_tier'];
+$thresholds = $summary['tier_thresholds'];
+$direction = $summary['direction'];
+$detail = $summary['direction_detail'];
+
+$directionConfig = match ($direction) {
+    'rising' => ['icon' => '&#9650;', 'color' => 'text-accent-green', 'label' => __('season.reputation_rising')],
+    'declining' => ['icon' => '&#9660;', 'color' => 'text-accent-red', 'label' => __('season.reputation_declining')],
+    default => ['icon' => '&#9654;', 'color' => 'text-text-secondary', 'label' => __('season.reputation_stable')],
+};
+
+$tierProgressPercent = $tierSpan > 0 ? (int) round(min(100, ($pointsInTier / $tierSpan) * 100)) : 0;
+
+$allTiers = \App\Models\ClubProfile::REPUTATION_TIERS;
+@endphp
+
+<x-app-layout>
+    <x-slot name="header">
+        <x-game-header :game="$game" :next-match="$game->next_match"></x-game-header>
+    </x-slot>
+
+    <div class="max-w-7xl mx-auto px-4 pb-8">
+
+        {{-- Club hub title + subnav --}}
+        <div class="mt-6 mb-4">
+            <h2 class="font-heading text-2xl lg:text-3xl font-bold uppercase tracking-wide text-text-primary">{{ __('club.hub_title') }}</h2>
+        </div>
+        <x-club-section-nav :game="$game" active="reputation" />
+
+        {{-- KPI strip --}}
+        <div class="flex flex-wrap gap-3 mt-6 mb-6">
+            <x-summary-card :label="__('club.reputation.current_tier')">
+                <div class="font-heading text-xl font-bold text-text-primary mt-0.5">{{ __('finances.reputation.' . $currentLevel) }}</div>
+            </x-summary-card>
+            <x-summary-card
+                :label="__('club.reputation.points')"
+                :value="number_format($currentPoints)"
+            />
+            <x-summary-card :label="__('club.reputation.trend')">
+                <div class="flex items-center gap-1.5 mt-0.5">
+                    <span class="font-heading text-lg font-bold {{ $directionConfig['color'] }}">{!! $directionConfig['icon'] !!}</span>
+                    <span class="text-xs font-semibold {{ $directionConfig['color'] }} uppercase tracking-wider">{{ $directionConfig['label'] }}</span>
+                </div>
+            </x-summary-card>
+        </div>
+
+        <div class="grid grid-cols-1 lg:grid-cols-3 gap-6">
+
+            {{-- LEFT (2/3) — tier milestones ladder --}}
+            <div class="lg:col-span-2 space-y-6">
+                <div class="bg-surface-800 border border-border-default rounded-xl p-5">
+                    <h3 class="font-heading text-base font-semibold uppercase tracking-wide text-text-primary mb-4">{{ __('club.reputation.tiers') }}</h3>
+
+                    <div class="space-y-3">
+                        @foreach(array_reverse($allTiers) as $tier)
+                            @php
+                                $threshold = $thresholds[$tier] ?? 0;
+                                $tierIdx = \App\Models\ClubProfile::getReputationTierIndex($tier);
+                                $isCurrent = $tier === $currentLevel;
+                                $isBase = $tier === $baseLevel;
+                                $isFloor = $tier === $tierFloor;
+                                $isReached = $currentPoints >= $threshold;
+                            @endphp
+                            <div class="flex items-center gap-4 rounded-lg px-3 py-3 border {{ $isCurrent ? 'bg-accent-blue/10 border-accent-blue/40' : 'bg-surface-700/40 border-border-default' }}">
+                                <div class="w-2 h-10 rounded-full {{ $isCurrent ? 'bg-accent-blue' : ($isReached ? 'bg-accent-green/50' : 'bg-surface-600') }}"></div>
+                                <div class="flex-1 min-w-0">
+                                    <div class="flex items-center gap-2 flex-wrap">
+                                        <span class="font-heading text-sm font-bold {{ $isCurrent ? 'text-text-primary' : 'text-text-body' }} uppercase tracking-wider">{{ __('finances.reputation.' . $tier) }}</span>
+                                        @if($isCurrent)
+                                            <span class="text-[10px] font-semibold bg-accent-blue/20 text-accent-blue px-1.5 py-0.5 rounded-sm uppercase tracking-widest">{{ __('club.reputation.current') }}</span>
+                                        @endif
+                                        @if($isBase)
+                                            <span class="text-[10px] font-semibold bg-surface-600 text-text-body px-1.5 py-0.5 rounded-sm uppercase tracking-widest">{{ __('club.reputation.anchor') }}</span>
+                                        @endif
+                                        @if($isFloor && !$isBase)
+                                            <span class="text-[10px] font-semibold bg-surface-600 text-text-muted px-1.5 py-0.5 rounded-sm uppercase tracking-widest">{{ __('club.reputation.floor') }}</span>
+                                        @endif
+                                    </div>
+                                    <div class="text-[10px] text-text-muted uppercase tracking-widest mt-0.5">{{ __('club.reputation.threshold') }}: {{ number_format($threshold) }}</div>
+                                </div>
+                            </div>
+                        @endforeach
+                    </div>
+
+                    <p class="text-xs text-text-muted mt-4 leading-relaxed">{{ __('club.reputation.ladder_help') }}</p>
+                </div>
+            </div>
+
+            {{-- RIGHT (1/3) — tier progress + season projection --}}
+            <div class="space-y-6">
+                {{-- Progress within current tier --}}
+                <div class="bg-surface-800 border border-border-default rounded-xl p-5">
+                    <h3 class="font-heading text-base font-semibold uppercase tracking-wide text-text-primary mb-4">{{ __('club.reputation.progress') }}</h3>
+                    <div>
+                        <div class="flex items-baseline justify-between">
+                            <span class="text-[10px] text-text-muted uppercase tracking-widest">{{ __('finances.reputation.' . $currentLevel) }}</span>
+                            <span class="font-heading text-lg font-bold text-text-primary">{{ number_format($currentPoints) }}</span>
+                        </div>
+                        <div class="w-full h-2 bg-surface-600 rounded-full overflow-hidden mt-1.5">
+                            <div class="h-full rounded-full bg-accent-blue" style="width: {{ $tierProgressPercent }}%"></div>
+                        </div>
+                        @if($pointsToNextTier !== null && isset($allTiers[$tierIndex + 1]))
+                            <p class="text-xs text-text-muted mt-2">
+                                {{ __('club.reputation.points_to_next', [
+                                    'points' => number_format($pointsToNextTier),
+                                    'tier' => __('finances.reputation.' . $allTiers[$tierIndex + 1]),
+                                ]) }}
+                            </p>
+                        @else
+                            <p class="text-xs text-text-muted mt-2">{{ __('club.reputation.at_top_tier') }}</p>
+                        @endif
+                    </div>
+                </div>
+
+                {{-- Season-end projection --}}
+                <div class="bg-surface-800 border border-border-default rounded-xl p-5">
+                    <h3 class="font-heading text-base font-semibold uppercase tracking-wide text-text-primary mb-4">{{ __('club.reputation.season_projection') }}</h3>
+
+                    @if($detail['position'] === null)
+                        <p class="text-sm text-text-muted">{{ __('club.reputation.no_standing_yet') }}</p>
+                    @else
+                        <div class="space-y-2 text-sm">
+                            <div class="flex items-center justify-between">
+                                <span class="text-text-muted">{{ __('club.reputation.current_position') }}</span>
+                                <span class="font-heading font-bold text-text-primary">{{ $detail['position'] }}</span>
+                            </div>
+                            <div class="flex items-center justify-between">
+                                <span class="text-text-muted">{{ __('club.reputation.position_points') }}</span>
+                                <span class="font-heading font-bold {{ $detail['points_delta'] > 0 ? 'text-accent-green' : ($detail['points_delta'] < 0 ? 'text-accent-red' : 'text-text-body') }}">{{ ($detail['points_delta'] > 0 ? '+' : '') . $detail['points_delta'] }}</span>
+                            </div>
+                            @if($detail['gravity'] > 0)
+                                <div class="flex items-center justify-between">
+                                    <span class="text-text-muted">{{ __('club.reputation.gravity') }}</span>
+                                    <span class="font-heading font-bold text-accent-red">−{{ $detail['gravity'] }}</span>
+                                </div>
+                            @endif
+                            <div class="flex items-center justify-between pt-2 border-t border-border-default">
+                                <span class="text-text-muted">{{ __('club.reputation.net_change') }}</span>
+                                <span class="font-heading font-bold {{ $detail['net'] > 0 ? 'text-accent-green' : ($detail['net'] < 0 ? 'text-accent-red' : 'text-text-body') }}">{{ ($detail['net'] > 0 ? '+' : '') . $detail['net'] }}</span>
+                            </div>
+                        </div>
+                        <p class="text-xs text-text-muted mt-4 leading-relaxed">{{ __('club.reputation.projection_help') }}</p>
+                    @endif
+                </div>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/club/reputation.blade.php
+++ b/resources/views/club/reputation.blade.php
@@ -24,6 +24,16 @@ $directionConfig = match ($direction) {
 $tierProgressPercent = $tierSpan > 0 ? (int) round(min(100, ($pointsInTier / $tierSpan) * 100)) : 0;
 
 $allTiers = \App\Models\ClubProfile::REPUTATION_TIERS;
+
+$loyaltyPoints = $summary['loyalty_points'];
+$baseLoyalty = $summary['base_loyalty'];
+$loyaltyDirection = $summary['loyalty_direction'];
+
+$loyaltyDirectionConfig = match ($loyaltyDirection) {
+    'rising' => ['icon' => '&#9650;', 'color' => 'text-accent-green', 'label' => __('club.stadium.loyalty_rising')],
+    'declining' => ['icon' => '&#9660;', 'color' => 'text-accent-red', 'label' => __('club.stadium.loyalty_declining')],
+    default => ['icon' => '&#9654;', 'color' => 'text-text-secondary', 'label' => __('club.stadium.loyalty_stable')],
+};
 @endphp
 
 <x-app-layout>
@@ -60,50 +70,48 @@ $allTiers = \App\Models\ClubProfile::REPUTATION_TIERS;
 
             {{-- LEFT (2/3) — tier milestones ladder --}}
             <div class="lg:col-span-2 space-y-6">
-                <div class="bg-surface-800 border border-border-default rounded-xl p-5">
-                    <h3 class="font-heading text-base font-semibold uppercase tracking-wide text-text-primary mb-4">{{ __('club.reputation.tiers') }}</h3>
-
-                    <div class="space-y-3">
-                        @foreach(array_reverse($allTiers) as $tier)
-                            @php
-                                $threshold = $thresholds[$tier] ?? 0;
-                                $tierIdx = \App\Models\ClubProfile::getReputationTierIndex($tier);
-                                $isCurrent = $tier === $currentLevel;
-                                $isBase = $tier === $baseLevel;
-                                $isFloor = $tier === $tierFloor;
-                                $isReached = $currentPoints >= $threshold;
-                            @endphp
-                            <div class="flex items-center gap-4 rounded-lg px-3 py-3 border {{ $isCurrent ? 'bg-accent-blue/10 border-accent-blue/40' : 'bg-surface-700/40 border-border-default' }}">
-                                <div class="w-2 h-10 rounded-full {{ $isCurrent ? 'bg-accent-blue' : ($isReached ? 'bg-accent-green/50' : 'bg-surface-600') }}"></div>
-                                <div class="flex-1 min-w-0">
-                                    <div class="flex items-center gap-2 flex-wrap">
-                                        <span class="font-heading text-sm font-bold {{ $isCurrent ? 'text-text-primary' : 'text-text-body' }} uppercase tracking-wider">{{ __('finances.reputation.' . $tier) }}</span>
-                                        @if($isCurrent)
-                                            <span class="text-[10px] font-semibold bg-accent-blue/20 text-accent-blue px-1.5 py-0.5 rounded-sm uppercase tracking-widest">{{ __('club.reputation.current') }}</span>
-                                        @endif
-                                        @if($isBase)
-                                            <span class="text-[10px] font-semibold bg-surface-600 text-text-body px-1.5 py-0.5 rounded-sm uppercase tracking-widest">{{ __('club.reputation.anchor') }}</span>
-                                        @endif
-                                        @if($isFloor && !$isBase)
-                                            <span class="text-[10px] font-semibold bg-surface-600 text-text-muted px-1.5 py-0.5 rounded-sm uppercase tracking-widest">{{ __('club.reputation.floor') }}</span>
-                                        @endif
+                <x-section-card :title="__('club.reputation.tiers')">
+                    <div class="px-5 py-4">
+                        <div class="space-y-3">
+                            @foreach(array_reverse($allTiers) as $tier)
+                                @php
+                                    $threshold = $thresholds[$tier] ?? 0;
+                                    $tierIdx = \App\Models\ClubProfile::getReputationTierIndex($tier);
+                                    $isCurrent = $tier === $currentLevel;
+                                    $isBase = $tier === $baseLevel;
+                                    $isFloor = $tier === $tierFloor;
+                                    $isReached = $currentPoints >= $threshold;
+                                @endphp
+                                <div class="flex items-center gap-4 rounded-lg px-3 py-3 border {{ $isCurrent ? 'bg-accent-blue/10 border-accent-blue/40' : 'bg-surface-700/40 border-border-default' }}">
+                                    <div class="w-2 h-10 rounded-full {{ $isCurrent ? 'bg-accent-blue' : ($isReached ? 'bg-accent-green/50' : 'bg-surface-600') }}"></div>
+                                    <div class="flex-1 min-w-0">
+                                        <div class="flex items-center gap-2 flex-wrap">
+                                            <span class="font-heading text-sm font-bold {{ $isCurrent ? 'text-text-primary' : 'text-text-body' }} uppercase tracking-wider">{{ __('finances.reputation.' . $tier) }}</span>
+                                            @if($isCurrent)
+                                                <span class="text-[10px] font-semibold bg-accent-blue/20 text-accent-blue px-1.5 py-0.5 rounded-sm uppercase tracking-widest">{{ __('club.reputation.current') }}</span>
+                                            @endif
+                                            @if($isBase)
+                                                <span class="text-[10px] font-semibold bg-surface-600 text-text-body px-1.5 py-0.5 rounded-sm uppercase tracking-widest">{{ __('club.reputation.anchor') }}</span>
+                                            @endif
+                                            @if($isFloor && !$isBase)
+                                                <span class="text-[10px] font-semibold bg-surface-600 text-text-muted px-1.5 py-0.5 rounded-sm uppercase tracking-widest">{{ __('club.reputation.floor') }}</span>
+                                            @endif
+                                        </div>
+                                        <div class="text-[10px] text-text-muted uppercase tracking-widest mt-0.5">{{ __('club.reputation.threshold') }}: {{ number_format($threshold) }}</div>
                                     </div>
-                                    <div class="text-[10px] text-text-muted uppercase tracking-widest mt-0.5">{{ __('club.reputation.threshold') }}: {{ number_format($threshold) }}</div>
                                 </div>
-                            </div>
-                        @endforeach
+                            @endforeach
+                        </div>
+                        <p class="text-xs text-text-muted mt-4 leading-relaxed">{{ __('club.reputation.ladder_help') }}</p>
                     </div>
-
-                    <p class="text-xs text-text-muted mt-4 leading-relaxed">{{ __('club.reputation.ladder_help') }}</p>
-                </div>
+                </x-section-card>
             </div>
 
             {{-- RIGHT (1/3) — tier progress + season projection --}}
             <div class="space-y-6">
                 {{-- Progress within current tier --}}
-                <div class="bg-surface-800 border border-border-default rounded-xl p-5">
-                    <h3 class="font-heading text-base font-semibold uppercase tracking-wide text-text-primary mb-4">{{ __('club.reputation.progress') }}</h3>
-                    <div>
+                <x-section-card :title="__('club.reputation.progress')">
+                    <div class="px-5 py-4">
                         <div class="flex items-baseline justify-between">
                             <span class="text-[10px] text-text-muted uppercase tracking-widest">{{ __('finances.reputation.' . $currentLevel) }}</span>
                             <span class="font-heading text-lg font-bold text-text-primary">{{ number_format($currentPoints) }}</span>
@@ -122,38 +130,59 @@ $allTiers = \App\Models\ClubProfile::REPUTATION_TIERS;
                             <p class="text-xs text-text-muted mt-2">{{ __('club.reputation.at_top_tier') }}</p>
                         @endif
                     </div>
-                </div>
+                </x-section-card>
+
+                {{-- Fan base panel --}}
+                <x-section-card :title="__('club.stadium.fan_base')">
+                    <div class="px-5 py-4">
+                        <div class="flex items-baseline justify-between">
+                            <div class="text-[10px] text-text-muted uppercase tracking-widest">{{ __('club.stadium.current_loyalty') }}</div>
+                            <span class="font-heading text-lg font-bold text-text-primary">{{ $loyaltyPoints }}<span class="text-xs font-normal text-text-muted"> / 100</span></span>
+                        </div>
+                        <div class="w-full h-2 bg-surface-600 rounded-full overflow-hidden mt-1.5 relative">
+                            <div class="h-full rounded-full bg-accent-blue" style="width: {{ max(0, min(100, $loyaltyPoints)) }}%"></div>
+                            @if($baseLoyalty > 0)
+                                <div class="absolute top-0 bottom-0 w-px bg-text-primary/60" style="left: {{ max(0, min(100, $baseLoyalty)) }}%;"></div>
+                            @endif
+                        </div>
+                        <div class="flex items-center justify-between mt-1">
+                            <span class="text-[10px] text-text-muted">{{ __('club.stadium.anchor') }}: {{ $baseLoyalty }}</span>
+                            <span class="text-[10px] font-semibold {{ $loyaltyDirectionConfig['color'] }}">{!! $loyaltyDirectionConfig['icon'] !!} {{ $loyaltyDirectionConfig['label'] }}</span>
+                        </div>
+                        <p class="text-xs text-text-muted mt-4 leading-relaxed">{{ __('club.stadium.fan_base_help') }}</p>
+                    </div>
+                </x-section-card>
 
                 {{-- Season-end projection --}}
-                <div class="bg-surface-800 border border-border-default rounded-xl p-5">
-                    <h3 class="font-heading text-base font-semibold uppercase tracking-wide text-text-primary mb-4">{{ __('club.reputation.season_projection') }}</h3>
-
-                    @if($detail['position'] === null)
-                        <p class="text-sm text-text-muted">{{ __('club.reputation.no_standing_yet') }}</p>
-                    @else
-                        <div class="space-y-2 text-sm">
-                            <div class="flex items-center justify-between">
-                                <span class="text-text-muted">{{ __('club.reputation.current_position') }}</span>
-                                <span class="font-heading font-bold text-text-primary">{{ $detail['position'] }}</span>
-                            </div>
-                            <div class="flex items-center justify-between">
-                                <span class="text-text-muted">{{ __('club.reputation.position_points') }}</span>
-                                <span class="font-heading font-bold {{ $detail['points_delta'] > 0 ? 'text-accent-green' : ($detail['points_delta'] < 0 ? 'text-accent-red' : 'text-text-body') }}">{{ ($detail['points_delta'] > 0 ? '+' : '') . $detail['points_delta'] }}</span>
-                            </div>
-                            @if($detail['gravity'] > 0)
+                <x-section-card :title="__('club.reputation.season_projection')">
+                    <div class="px-5 py-4">
+                        @if($detail['position'] === null)
+                            <p class="text-sm text-text-muted">{{ __('club.reputation.no_standing_yet') }}</p>
+                        @else
+                            <div class="space-y-2 text-sm">
                                 <div class="flex items-center justify-between">
-                                    <span class="text-text-muted">{{ __('club.reputation.gravity') }}</span>
-                                    <span class="font-heading font-bold text-accent-red">−{{ $detail['gravity'] }}</span>
+                                    <span class="text-text-muted">{{ __('club.reputation.current_position') }}</span>
+                                    <span class="font-heading font-bold text-text-primary">{{ $detail['position'] }}</span>
                                 </div>
-                            @endif
-                            <div class="flex items-center justify-between pt-2 border-t border-border-default">
-                                <span class="text-text-muted">{{ __('club.reputation.net_change') }}</span>
-                                <span class="font-heading font-bold {{ $detail['net'] > 0 ? 'text-accent-green' : ($detail['net'] < 0 ? 'text-accent-red' : 'text-text-body') }}">{{ ($detail['net'] > 0 ? '+' : '') . $detail['net'] }}</span>
+                                <div class="flex items-center justify-between">
+                                    <span class="text-text-muted">{{ __('club.reputation.position_points') }}</span>
+                                    <span class="font-heading font-bold {{ $detail['points_delta'] > 0 ? 'text-accent-green' : ($detail['points_delta'] < 0 ? 'text-accent-red' : 'text-text-body') }}">{{ ($detail['points_delta'] > 0 ? '+' : '') . $detail['points_delta'] }}</span>
+                                </div>
+                                @if($detail['gravity'] > 0)
+                                    <div class="flex items-center justify-between">
+                                        <span class="text-text-muted">{{ __('club.reputation.gravity') }}</span>
+                                        <span class="font-heading font-bold text-accent-red">−{{ $detail['gravity'] }}</span>
+                                    </div>
+                                @endif
+                                <div class="flex items-center justify-between pt-2 border-t border-border-default">
+                                    <span class="text-text-muted">{{ __('club.reputation.net_change') }}</span>
+                                    <span class="font-heading font-bold {{ $detail['net'] > 0 ? 'text-accent-green' : ($detail['net'] < 0 ? 'text-accent-red' : 'text-text-body') }}">{{ ($detail['net'] > 0 ? '+' : '') . $detail['net'] }}</span>
+                                </div>
                             </div>
-                        </div>
-                        <p class="text-xs text-text-muted mt-4 leading-relaxed">{{ __('club.reputation.projection_help') }}</p>
-                    @endif
-                </div>
+                            <p class="text-xs text-text-muted mt-4 leading-relaxed">{{ __('club.reputation.projection_help') }}</p>
+                        @endif
+                    </div>
+                </x-section-card>
             </div>
         </div>
     </div>

--- a/resources/views/club/stadium.blade.php
+++ b/resources/views/club/stadium.blade.php
@@ -1,0 +1,189 @@
+@php
+/** @var App\Models\Game $game */
+/** @var array $summary */
+
+$capacity = $summary['capacity'];
+$stadiumName = $summary['stadium_name'];
+$loyaltyPoints = $summary['loyalty_points'];
+$baseLoyalty = $summary['base_loyalty'];
+$loyaltyDirection = $summary['loyalty_direction'];
+$lastHomeMatch = $summary['last_home_match'];
+$finances = $summary['finances'];
+
+$directionConfig = match ($loyaltyDirection) {
+    'rising' => ['icon' => '&#9650;', 'color' => 'text-accent-green', 'label' => __('club.stadium.loyalty_rising')],
+    'declining' => ['icon' => '&#9660;', 'color' => 'text-accent-red', 'label' => __('club.stadium.loyalty_declining')],
+    default => ['icon' => '&#9654;', 'color' => 'text-text-secondary', 'label' => __('club.stadium.loyalty_stable')],
+};
+
+$projectedMatchday = (int) ($finances?->projected_matchday_revenue ?? 0);
+$actualMatchday = (int) ($finances?->actual_matchday_revenue ?? 0);
+$matchdayVariance = $actualMatchday - $projectedMatchday;
+$hasActualMatchday = $actualMatchday > 0;
+@endphp
+
+<x-app-layout>
+    <x-slot name="header">
+        <x-game-header :game="$game" :next-match="$game->next_match"></x-game-header>
+    </x-slot>
+
+    <div class="max-w-7xl mx-auto px-4 pb-8">
+
+        {{-- Club hub title + subnav --}}
+        <div class="mt-6 mb-4">
+            <h2 class="font-heading text-2xl lg:text-3xl font-bold uppercase tracking-wide text-text-primary">{{ __('club.hub_title') }}</h2>
+        </div>
+        <x-club-section-nav :game="$game" active="stadium" />
+
+        {{-- KPI strip: capacity + fan base --}}
+        <div class="flex flex-wrap gap-3 mt-6 mb-6">
+            <x-summary-card
+                :label="__('club.stadium.capacity')"
+                :value="number_format($capacity)"
+            />
+            <x-summary-card :label="__('club.stadium.fan_base')">
+                <div class="flex items-baseline gap-2 mt-0.5">
+                    <span class="font-heading text-xl font-bold text-text-primary">{{ $loyaltyPoints }}</span>
+                    <span class="text-[10px] text-text-muted">/ 100</span>
+                </div>
+            </x-summary-card>
+            <x-summary-card :label="__('club.stadium.fan_base_trend')">
+                <div class="flex items-center gap-1.5 mt-0.5">
+                    <span class="font-heading text-lg font-bold {{ $directionConfig['color'] }}">{!! $directionConfig['icon'] !!}</span>
+                    <span class="text-xs font-semibold {{ $directionConfig['color'] }} uppercase tracking-wider">{{ $directionConfig['label'] }}</span>
+                </div>
+            </x-summary-card>
+        </div>
+
+        <div class="grid grid-cols-1 lg:grid-cols-3 gap-6">
+
+            {{-- LEFT column (2/3): Stadium identity + last attendance --}}
+            <div class="lg:col-span-2 space-y-6">
+
+                {{-- Stadium identity card --}}
+                <div class="bg-surface-800 border border-border-default rounded-xl p-5">
+                    <div class="flex items-center justify-between mb-4">
+                        <h3 class="font-heading text-base font-semibold uppercase tracking-wide text-text-primary">{{ __('club.stadium.home_ground') }}</h3>
+                    </div>
+                    <div class="flex flex-col md:flex-row md:items-end md:justify-between gap-4">
+                        <div>
+                            <div class="text-[10px] text-text-muted uppercase tracking-widest mb-1">{{ __('club.stadium.stadium_name') }}</div>
+                            <div class="font-heading text-2xl font-bold text-text-primary">{{ $stadiumName ?? '—' }}</div>
+                        </div>
+                        <div class="md:text-right">
+                            <div class="text-[10px] text-text-muted uppercase tracking-widest mb-1">{{ __('club.stadium.capacity') }}</div>
+                            <div class="font-heading text-2xl font-bold text-text-primary">{{ number_format($capacity) }}</div>
+                        </div>
+                    </div>
+                    <p class="text-xs text-text-muted mt-4 leading-relaxed">{{ __('club.stadium.capacity_help') }}</p>
+                </div>
+
+                {{-- Last home-match attendance --}}
+                <div class="bg-surface-800 border border-border-default rounded-xl p-5">
+                    <h3 class="font-heading text-base font-semibold uppercase tracking-wide text-text-primary mb-4">{{ __('club.stadium.last_attendance') }}</h3>
+
+                    @if($lastHomeMatch)
+                        @php
+                            /** @var App\Models\GameMatch $lastMatch */
+                            $lastMatch = $lastHomeMatch['match'];
+                            $fillRate = $lastHomeMatch['fill_rate'];
+                            $fillColor = $fillRate >= 90 ? 'bg-accent-green' : ($fillRate >= 70 ? 'bg-accent-blue' : ($fillRate >= 50 ? 'bg-accent-gold' : 'bg-accent-red'));
+                        @endphp
+                        <div class="flex flex-col gap-4">
+                            <div class="flex items-center gap-3">
+                                <x-team-crest :team="$game->team" class="w-10 h-10 shrink-0" />
+                                <div class="flex-1 min-w-0">
+                                    <div class="text-[10px] text-text-muted uppercase tracking-widest">{{ __('game.vs') }}</div>
+                                    <div class="flex items-center gap-2">
+                                        <x-team-crest :team="$lastMatch->awayTeam" class="w-5 h-5" />
+                                        <span class="text-sm font-semibold text-text-primary truncate">{{ $lastMatch->awayTeam->name }}</span>
+                                    </div>
+                                </div>
+                                <div class="text-right shrink-0">
+                                    <div class="text-[10px] text-text-muted uppercase tracking-widest">{{ __($lastMatch->competition->name ?? '') }}</div>
+                                    <div class="text-xs text-text-body">{{ $lastMatch->scheduled_date->format('d M Y') }}</div>
+                                </div>
+                            </div>
+
+                            <div>
+                                <div class="flex items-baseline justify-between gap-3 mb-2">
+                                    <span class="font-heading text-3xl font-bold text-text-primary">{{ number_format($lastHomeMatch['attendance']) }}</span>
+                                    <span class="text-sm text-text-muted">/ {{ number_format($lastHomeMatch['capacity_at_match']) }}</span>
+                                </div>
+                                <div class="w-full h-2 bg-surface-600 rounded-full overflow-hidden">
+                                    <div class="h-full rounded-full {{ $fillColor }}" style="width: {{ min($fillRate, 100) }}%"></div>
+                                </div>
+                                <div class="flex items-center justify-between mt-1">
+                                    <span class="text-[10px] text-text-muted uppercase tracking-widest">{{ __('club.stadium.fill_rate') }}</span>
+                                    <span class="text-xs font-semibold text-text-body">{{ $fillRate }}%</span>
+                                </div>
+                            </div>
+                        </div>
+                    @else
+                        <div class="text-center py-8">
+                            <p class="text-sm text-text-muted">{{ __('club.stadium.no_home_match_yet') }}</p>
+                        </div>
+                    @endif
+                </div>
+            </div>
+
+            {{-- RIGHT column (1/3): Matchday revenue tracker --}}
+            <div class="space-y-6">
+                <div class="bg-surface-800 border border-border-default rounded-xl p-5">
+                    <h3 class="font-heading text-base font-semibold uppercase tracking-wide text-text-primary mb-4">{{ __('club.stadium.matchday_revenue') }}</h3>
+
+                    @if($finances)
+                        <div class="space-y-3">
+                            <div>
+                                <div class="text-[10px] text-text-muted uppercase tracking-widest">{{ __('finances.projected_revenue') }}</div>
+                                <div class="font-heading text-lg font-bold text-text-body">{{ $finances->formatted_projected_matchday_revenue }}</div>
+                            </div>
+                            <div>
+                                <div class="text-[10px] text-text-muted uppercase tracking-widest">{{ __('finances.actual_revenue') }}</div>
+                                <div class="font-heading text-lg font-bold {{ $hasActualMatchday ? 'text-text-primary' : 'text-text-muted' }}">
+                                    {{ $hasActualMatchday ? $finances->formatted_actual_matchday_revenue : '—' }}
+                                </div>
+                            </div>
+                            @if($hasActualMatchday)
+                                <div class="pt-3 border-t border-border-default">
+                                    <div class="text-[10px] text-text-muted uppercase tracking-widest">{{ __('finances.variance') }}</div>
+                                    <div class="font-heading text-lg font-bold {{ $matchdayVariance >= 0 ? 'text-accent-green' : 'text-accent-red' }}">
+                                        {{ \App\Support\Money::formatSigned($matchdayVariance) }}
+                                    </div>
+                                </div>
+                            @endif
+                        </div>
+                        <p class="text-xs text-text-muted mt-4 leading-relaxed">{{ __('club.stadium.matchday_revenue_help') }}</p>
+                    @else
+                        <p class="text-sm text-text-muted">{{ __('club.stadium.no_finances_yet') }}</p>
+                    @endif
+                </div>
+
+                {{-- Fan base panel --}}
+                <div class="bg-surface-800 border border-border-default rounded-xl p-5">
+                    <h3 class="font-heading text-base font-semibold uppercase tracking-wide text-text-primary mb-4">{{ __('club.stadium.fan_base') }}</h3>
+
+                    <div class="space-y-3">
+                        <div>
+                            <div class="flex items-baseline justify-between">
+                                <div class="text-[10px] text-text-muted uppercase tracking-widest">{{ __('club.stadium.current_loyalty') }}</div>
+                                <span class="font-heading text-lg font-bold text-text-primary">{{ $loyaltyPoints }}<span class="text-xs font-normal text-text-muted"> / 100</span></span>
+                            </div>
+                            <div class="w-full h-2 bg-surface-600 rounded-full overflow-hidden mt-1.5 relative">
+                                <div class="h-full rounded-full bg-accent-blue" style="width: {{ max(0, min(100, $loyaltyPoints)) }}%"></div>
+                                @if($baseLoyalty > 0)
+                                    <div class="absolute top-0 bottom-0 w-px bg-text-primary/60" style="left: {{ max(0, min(100, $baseLoyalty)) }}%;"></div>
+                                @endif
+                            </div>
+                            <div class="flex items-center justify-between mt-1">
+                                <span class="text-[10px] text-text-muted">{{ __('club.stadium.anchor') }}: {{ $baseLoyalty }}</span>
+                                <span class="text-[10px] font-semibold {{ $directionConfig['color'] }}">{!! $directionConfig['icon'] !!} {{ $directionConfig['label'] }}</span>
+                            </div>
+                        </div>
+                    </div>
+                    <p class="text-xs text-text-muted mt-4 leading-relaxed">{{ __('club.stadium.fan_base_help') }}</p>
+                </div>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/club/stadium.blade.php
+++ b/resources/views/club/stadium.blade.php
@@ -4,17 +4,8 @@
 
 $capacity = $summary['capacity'];
 $stadiumName = $summary['stadium_name'];
-$loyaltyPoints = $summary['loyalty_points'];
-$baseLoyalty = $summary['base_loyalty'];
-$loyaltyDirection = $summary['loyalty_direction'];
 $lastHomeMatch = $summary['last_home_match'];
 $finances = $summary['finances'];
-
-$directionConfig = match ($loyaltyDirection) {
-    'rising' => ['icon' => '&#9650;', 'color' => 'text-accent-green', 'label' => __('club.stadium.loyalty_rising')],
-    'declining' => ['icon' => '&#9660;', 'color' => 'text-accent-red', 'label' => __('club.stadium.loyalty_declining')],
-    default => ['icon' => '&#9654;', 'color' => 'text-text-secondary', 'label' => __('club.stadium.loyalty_stable')],
-};
 
 $projectedMatchday = (int) ($finances?->projected_matchday_revenue ?? 0);
 $actualMatchday = (int) ($finances?->actual_matchday_revenue ?? 0);
@@ -35,154 +26,108 @@ $hasActualMatchday = $actualMatchday > 0;
         </div>
         <x-club-section-nav :game="$game" active="stadium" />
 
-        {{-- KPI strip: capacity + fan base --}}
-        <div class="flex flex-wrap gap-3 mt-6 mb-6">
-            <x-summary-card
-                :label="__('club.stadium.capacity')"
-                :value="number_format($capacity)"
-            />
-            <x-summary-card :label="__('club.stadium.fan_base')">
-                <div class="flex items-baseline gap-2 mt-0.5">
-                    <span class="font-heading text-xl font-bold text-text-primary">{{ $loyaltyPoints }}</span>
-                    <span class="text-[10px] text-text-muted">/ 100</span>
-                </div>
-            </x-summary-card>
-            <x-summary-card :label="__('club.stadium.fan_base_trend')">
-                <div class="flex items-center gap-1.5 mt-0.5">
-                    <span class="font-heading text-lg font-bold {{ $directionConfig['color'] }}">{!! $directionConfig['icon'] !!}</span>
-                    <span class="text-xs font-semibold {{ $directionConfig['color'] }} uppercase tracking-wider">{{ $directionConfig['label'] }}</span>
-                </div>
-            </x-summary-card>
-        </div>
-
-        <div class="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        <div class="grid grid-cols-1 lg:grid-cols-3 gap-6 mt-6">
 
             {{-- LEFT column (2/3): Stadium identity + last attendance --}}
             <div class="lg:col-span-2 space-y-6">
 
                 {{-- Stadium identity card --}}
-                <div class="bg-surface-800 border border-border-default rounded-xl p-5">
-                    <div class="flex items-center justify-between mb-4">
-                        <h3 class="font-heading text-base font-semibold uppercase tracking-wide text-text-primary">{{ __('club.stadium.home_ground') }}</h3>
-                    </div>
-                    <div class="flex flex-col md:flex-row md:items-end md:justify-between gap-4">
-                        <div>
-                            <div class="text-[10px] text-text-muted uppercase tracking-widest mb-1">{{ __('club.stadium.stadium_name') }}</div>
-                            <div class="font-heading text-2xl font-bold text-text-primary">{{ $stadiumName ?? '—' }}</div>
+                <x-section-card :title="__('club.stadium.home_ground')">
+                    <div class="px-5 py-4">
+                        <div class="flex flex-col md:flex-row md:items-end md:justify-between gap-4">
+                            <div>
+                                <div class="text-[10px] text-text-muted uppercase tracking-widest mb-1">{{ __('club.stadium.stadium_name') }}</div>
+                                <div class="font-heading text-2xl font-bold text-text-primary">{{ $stadiumName ?? '—' }}</div>
+                            </div>
+                            <div class="md:text-right">
+                                <div class="text-[10px] text-text-muted uppercase tracking-widest mb-1">{{ __('club.stadium.capacity') }}</div>
+                                <div class="font-heading text-2xl font-bold text-text-primary">{{ number_format($capacity) }}</div>
+                            </div>
                         </div>
-                        <div class="md:text-right">
-                            <div class="text-[10px] text-text-muted uppercase tracking-widest mb-1">{{ __('club.stadium.capacity') }}</div>
-                            <div class="font-heading text-2xl font-bold text-text-primary">{{ number_format($capacity) }}</div>
-                        </div>
+                        <p class="text-xs text-text-muted mt-4 leading-relaxed">{{ __('club.stadium.capacity_help') }}</p>
                     </div>
-                    <p class="text-xs text-text-muted mt-4 leading-relaxed">{{ __('club.stadium.capacity_help') }}</p>
-                </div>
+                </x-section-card>
 
                 {{-- Last home-match attendance --}}
-                <div class="bg-surface-800 border border-border-default rounded-xl p-5">
-                    <h3 class="font-heading text-base font-semibold uppercase tracking-wide text-text-primary mb-4">{{ __('club.stadium.last_attendance') }}</h3>
-
-                    @if($lastHomeMatch)
-                        @php
-                            /** @var App\Models\GameMatch $lastMatch */
-                            $lastMatch = $lastHomeMatch['match'];
-                            $fillRate = $lastHomeMatch['fill_rate'];
-                            $fillColor = $fillRate >= 90 ? 'bg-accent-green' : ($fillRate >= 70 ? 'bg-accent-blue' : ($fillRate >= 50 ? 'bg-accent-gold' : 'bg-accent-red'));
-                        @endphp
-                        <div class="flex flex-col gap-4">
-                            <div class="flex items-center gap-3">
-                                <x-team-crest :team="$game->team" class="w-10 h-10 shrink-0" />
-                                <div class="flex-1 min-w-0">
-                                    <div class="text-[10px] text-text-muted uppercase tracking-widest">{{ __('game.vs') }}</div>
-                                    <div class="flex items-center gap-2">
-                                        <x-team-crest :team="$lastMatch->awayTeam" class="w-5 h-5" />
-                                        <span class="text-sm font-semibold text-text-primary truncate">{{ $lastMatch->awayTeam->name }}</span>
+                <x-section-card :title="__('club.stadium.last_attendance')">
+                    <div class="px-5 py-4">
+                        @if($lastHomeMatch)
+                            @php
+                                /** @var App\Models\GameMatch $lastMatch */
+                                $lastMatch = $lastHomeMatch['match'];
+                                $fillRate = $lastHomeMatch['fill_rate'];
+                                $fillColor = $fillRate >= 90 ? 'bg-accent-green' : ($fillRate >= 70 ? 'bg-accent-blue' : ($fillRate >= 50 ? 'bg-accent-gold' : 'bg-accent-red'));
+                            @endphp
+                            <div class="flex flex-col gap-4">
+                                <div class="flex items-center gap-3">
+                                    <x-team-crest :team="$game->team" class="w-10 h-10 shrink-0" />
+                                    <div class="flex-1 min-w-0">
+                                        <div class="text-[10px] text-text-muted uppercase tracking-widest">{{ __('game.vs') }}</div>
+                                        <div class="flex items-center gap-2">
+                                            <x-team-crest :team="$lastMatch->awayTeam" class="w-5 h-5" />
+                                            <span class="text-sm font-semibold text-text-primary truncate">{{ $lastMatch->awayTeam->name }}</span>
+                                        </div>
+                                    </div>
+                                    <div class="text-right shrink-0">
+                                        <div class="text-[10px] text-text-muted uppercase tracking-widest">{{ __($lastMatch->competition->name ?? '') }}</div>
+                                        <div class="text-xs text-text-body">{{ $lastMatch->scheduled_date->format('d M Y') }}</div>
                                     </div>
                                 </div>
-                                <div class="text-right shrink-0">
-                                    <div class="text-[10px] text-text-muted uppercase tracking-widest">{{ __($lastMatch->competition->name ?? '') }}</div>
-                                    <div class="text-xs text-text-body">{{ $lastMatch->scheduled_date->format('d M Y') }}</div>
-                                </div>
-                            </div>
 
-                            <div>
-                                <div class="flex items-baseline justify-between gap-3 mb-2">
-                                    <span class="font-heading text-3xl font-bold text-text-primary">{{ number_format($lastHomeMatch['attendance']) }}</span>
-                                    <span class="text-sm text-text-muted">/ {{ number_format($lastHomeMatch['capacity_at_match']) }}</span>
-                                </div>
-                                <div class="w-full h-2 bg-surface-600 rounded-full overflow-hidden">
-                                    <div class="h-full rounded-full {{ $fillColor }}" style="width: {{ min($fillRate, 100) }}%"></div>
-                                </div>
-                                <div class="flex items-center justify-between mt-1">
-                                    <span class="text-[10px] text-text-muted uppercase tracking-widest">{{ __('club.stadium.fill_rate') }}</span>
-                                    <span class="text-xs font-semibold text-text-body">{{ $fillRate }}%</span>
+                                <div>
+                                    <div class="flex items-baseline justify-between gap-3 mb-2">
+                                        <span class="font-heading text-3xl font-bold text-text-primary">{{ number_format($lastHomeMatch['attendance']) }}</span>
+                                        <span class="text-sm text-text-muted">/ {{ number_format($lastHomeMatch['capacity_at_match']) }}</span>
+                                    </div>
+                                    <div class="w-full h-2 bg-surface-600 rounded-full overflow-hidden">
+                                        <div class="h-full rounded-full {{ $fillColor }}" style="width: {{ min($fillRate, 100) }}%"></div>
+                                    </div>
+                                    <div class="flex items-center justify-between mt-1">
+                                        <span class="text-[10px] text-text-muted uppercase tracking-widest">{{ __('club.stadium.fill_rate') }}</span>
+                                        <span class="text-xs font-semibold text-text-body">{{ $fillRate }}%</span>
+                                    </div>
                                 </div>
                             </div>
-                        </div>
-                    @else
-                        <div class="text-center py-8">
-                            <p class="text-sm text-text-muted">{{ __('club.stadium.no_home_match_yet') }}</p>
-                        </div>
-                    @endif
-                </div>
+                        @else
+                            <div class="text-center py-8">
+                                <p class="text-sm text-text-muted">{{ __('club.stadium.no_home_match_yet') }}</p>
+                            </div>
+                        @endif
+                    </div>
+                </x-section-card>
             </div>
 
             {{-- RIGHT column (1/3): Matchday revenue tracker --}}
             <div class="space-y-6">
-                <div class="bg-surface-800 border border-border-default rounded-xl p-5">
-                    <h3 class="font-heading text-base font-semibold uppercase tracking-wide text-text-primary mb-4">{{ __('club.stadium.matchday_revenue') }}</h3>
-
-                    @if($finances)
-                        <div class="space-y-3">
-                            <div>
-                                <div class="text-[10px] text-text-muted uppercase tracking-widest">{{ __('finances.projected_revenue') }}</div>
-                                <div class="font-heading text-lg font-bold text-text-body">{{ $finances->formatted_projected_matchday_revenue }}</div>
-                            </div>
-                            <div>
-                                <div class="text-[10px] text-text-muted uppercase tracking-widest">{{ __('finances.actual_revenue') }}</div>
-                                <div class="font-heading text-lg font-bold {{ $hasActualMatchday ? 'text-text-primary' : 'text-text-muted' }}">
-                                    {{ $hasActualMatchday ? $finances->formatted_actual_matchday_revenue : '—' }}
+                <x-section-card :title="__('club.stadium.matchday_revenue')">
+                    <div class="px-5 py-4">
+                        @if($finances)
+                            <div class="space-y-3">
+                                <div>
+                                    <div class="text-[10px] text-text-muted uppercase tracking-widest">{{ __('finances.projected_revenue') }}</div>
+                                    <div class="font-heading text-lg font-bold text-text-body">{{ $finances->formatted_projected_matchday_revenue }}</div>
                                 </div>
-                            </div>
-                            @if($hasActualMatchday)
-                                <div class="pt-3 border-t border-border-default">
-                                    <div class="text-[10px] text-text-muted uppercase tracking-widest">{{ __('finances.variance') }}</div>
-                                    <div class="font-heading text-lg font-bold {{ $matchdayVariance >= 0 ? 'text-accent-green' : 'text-accent-red' }}">
-                                        {{ \App\Support\Money::formatSigned($matchdayVariance) }}
+                                <div>
+                                    <div class="text-[10px] text-text-muted uppercase tracking-widest">{{ __('finances.actual_revenue') }}</div>
+                                    <div class="font-heading text-lg font-bold {{ $hasActualMatchday ? 'text-text-primary' : 'text-text-muted' }}">
+                                        {{ $hasActualMatchday ? $finances->formatted_actual_matchday_revenue : '—' }}
                                     </div>
                                 </div>
-                            @endif
-                        </div>
-                        <p class="text-xs text-text-muted mt-4 leading-relaxed">{{ __('club.stadium.matchday_revenue_help') }}</p>
-                    @else
-                        <p class="text-sm text-text-muted">{{ __('club.stadium.no_finances_yet') }}</p>
-                    @endif
-                </div>
-
-                {{-- Fan base panel --}}
-                <div class="bg-surface-800 border border-border-default rounded-xl p-5">
-                    <h3 class="font-heading text-base font-semibold uppercase tracking-wide text-text-primary mb-4">{{ __('club.stadium.fan_base') }}</h3>
-
-                    <div class="space-y-3">
-                        <div>
-                            <div class="flex items-baseline justify-between">
-                                <div class="text-[10px] text-text-muted uppercase tracking-widest">{{ __('club.stadium.current_loyalty') }}</div>
-                                <span class="font-heading text-lg font-bold text-text-primary">{{ $loyaltyPoints }}<span class="text-xs font-normal text-text-muted"> / 100</span></span>
-                            </div>
-                            <div class="w-full h-2 bg-surface-600 rounded-full overflow-hidden mt-1.5 relative">
-                                <div class="h-full rounded-full bg-accent-blue" style="width: {{ max(0, min(100, $loyaltyPoints)) }}%"></div>
-                                @if($baseLoyalty > 0)
-                                    <div class="absolute top-0 bottom-0 w-px bg-text-primary/60" style="left: {{ max(0, min(100, $baseLoyalty)) }}%;"></div>
+                                @if($hasActualMatchday)
+                                    <div class="pt-3 border-t border-border-default">
+                                        <div class="text-[10px] text-text-muted uppercase tracking-widest">{{ __('finances.variance') }}</div>
+                                        <div class="font-heading text-lg font-bold {{ $matchdayVariance >= 0 ? 'text-accent-green' : 'text-accent-red' }}">
+                                            {{ \App\Support\Money::formatSigned($matchdayVariance) }}
+                                        </div>
+                                    </div>
                                 @endif
                             </div>
-                            <div class="flex items-center justify-between mt-1">
-                                <span class="text-[10px] text-text-muted">{{ __('club.stadium.anchor') }}: {{ $baseLoyalty }}</span>
-                                <span class="text-[10px] font-semibold {{ $directionConfig['color'] }}">{!! $directionConfig['icon'] !!} {{ $directionConfig['label'] }}</span>
-                            </div>
-                        </div>
+                            <p class="text-xs text-text-muted mt-4 leading-relaxed">{{ __('club.stadium.matchday_revenue_help') }}</p>
+                        @else
+                            <p class="text-sm text-text-muted">{{ __('club.stadium.no_finances_yet') }}</p>
+                        @endif
                     </div>
-                    <p class="text-xs text-text-muted mt-4 leading-relaxed">{{ __('club.stadium.fan_base_help') }}</p>
-                </div>
+                </x-section-card>
             </div>
         </div>
     </div>

--- a/resources/views/components/bottom-tab-bar.blade.php
+++ b/resources/views/components/bottom-tab-bar.blade.php
@@ -10,7 +10,8 @@
     $squadActive = Str::startsWith($currentRoute, 'game.squad');
     $lineupActive = $currentRoute === 'game.lineup';
     $transfersActive = in_array($currentRoute, ['game.transfers', 'game.transfers.outgoing', 'game.scouting', 'game.explore', 'game.transfer-activity', 'game.transfers.market']);
-    $moreActive = in_array($currentRoute, ['game.finances', 'game.calendar', 'game.competition']);
+    $clubRoutes = ['game.club', 'game.club.finances', 'game.club.stadium', 'game.club.reputation'];
+    $moreActive = in_array($currentRoute, array_merge($clubRoutes, ['game.calendar', 'game.competition']));
 
 @endphp
 
@@ -110,12 +111,27 @@
                 </a>
 
                 @if($isCareer)
-                {{-- Finances --}}
-                <a href="{{ route('game.finances', $game->id) }}" @click="moreOpen = false" class="flex items-center gap-3 px-4 py-4 rounded-xl transition-colors {{ $currentRoute === 'game.finances' ? 'bg-accent-blue/10 text-accent-blue' : 'text-text-body hover:bg-surface-700' }}">
+                {{-- Club section --}}
+                <div class="pt-2 pb-1 px-4">
+                    <span class="text-[10px] font-semibold text-text-muted uppercase tracking-widest">{{ __('app.club') }}</span>
+                </div>
+                <a href="{{ route('game.club.finances', $game->id) }}" @click="moreOpen = false" class="flex items-center gap-3 px-4 py-4 rounded-xl transition-colors {{ $currentRoute === 'game.club.finances' ? 'bg-accent-blue/10 text-accent-blue' : 'text-text-body hover:bg-surface-700' }}">
                     <svg class="w-5 h-5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 6v12m-3-2.818.879.659c1.171.879 3.07.879 4.242 0 1.172-.879 1.172-2.303 0-3.182C13.536 12.219 12.768 12 12 12c-.725 0-1.45-.22-2.003-.659-1.106-.879-1.106-2.303 0-3.182s2.9-.879 4.006 0l.415.33M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"/>
                     </svg>
-                    <span class="text-sm font-medium">{{ __('app.finances') }}</span>
+                    <span class="text-sm font-medium">{{ __('club.nav.finances') }}</span>
+                </a>
+                <a href="{{ route('game.club.stadium', $game->id) }}" @click="moreOpen = false" class="flex items-center gap-3 px-4 py-4 rounded-xl transition-colors {{ $currentRoute === 'game.club.stadium' ? 'bg-accent-blue/10 text-accent-blue' : 'text-text-body hover:bg-surface-700' }}">
+                    <svg class="w-5 h-5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M3.75 12h16.5m-16.5 3.75h16.5M3.75 19.5h16.5M5.625 4.5h12.75a1.875 1.875 0 010 3.75H5.625a1.875 1.875 0 010-3.75z"/>
+                    </svg>
+                    <span class="text-sm font-medium">{{ __('club.nav.stadium') }}</span>
+                </a>
+                <a href="{{ route('game.club.reputation', $game->id) }}" @click="moreOpen = false" class="flex items-center gap-3 px-4 py-4 rounded-xl transition-colors {{ $currentRoute === 'game.club.reputation' ? 'bg-accent-blue/10 text-accent-blue' : 'text-text-body hover:bg-surface-700' }}">
+                    <svg class="w-5 h-5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M11.48 3.499a.562.562 0 011.04 0l2.125 5.111a.563.563 0 00.475.345l5.518.442c.499.04.701.663.321.988l-4.204 3.602a.563.563 0 00-.182.557l1.285 5.385a.562.562 0 01-.84.61l-4.725-2.885a.563.563 0 00-.586 0L6.982 20.54a.562.562 0 01-.84-.61l1.285-5.386a.562.562 0 00-.182-.557l-4.204-3.602a.563.563 0 01.321-.988l5.518-.442a.563.563 0 00.475-.345L11.48 3.5z"/>
+                    </svg>
+                    <span class="text-sm font-medium">{{ __('club.nav.reputation') }}</span>
                 </a>
                 @endif
 

--- a/resources/views/components/club-section-nav.blade.php
+++ b/resources/views/components/club-section-nav.blade.php
@@ -1,0 +1,23 @@
+@props(['game', 'active'])
+
+@php
+    $items = [
+        [
+            'href' => route('game.club.finances', $game->id),
+            'label' => __('club.nav.finances'),
+            'active' => $active === 'finances',
+        ],
+        [
+            'href' => route('game.club.stadium', $game->id),
+            'label' => __('club.nav.stadium'),
+            'active' => $active === 'stadium',
+        ],
+        [
+            'href' => route('game.club.reputation', $game->id),
+            'label' => __('club.nav.reputation'),
+            'active' => $active === 'reputation',
+        ],
+    ];
+@endphp
+
+<x-section-nav :items="$items" />

--- a/resources/views/components/club-section-nav.blade.php
+++ b/resources/views/components/club-section-nav.blade.php
@@ -20,4 +20,6 @@
     ];
 @endphp
 
-<x-section-nav :items="$items" />
+<x-section-nav :items="$items">
+    {{ $slot }}
+</x-section-nav>

--- a/resources/views/components/game-header.blade.php
+++ b/resources/views/components/game-header.blade.php
@@ -44,7 +44,25 @@
                     <a href="{{ route('game.lineup', $game->id) }}" class="nav-item @if(Route::currentRouteName() == 'game.lineup') active @endif whitespace-nowrap px-3 py-2 text-xs font-medium uppercase tracking-wider {{ Route::currentRouteName() == 'game.lineup' ? 'text-text-primary' : 'text-text-muted hover:text-text-body' }}">{{ __('app.starting_xi') }}</a>
                     @endif
                     @if($game->isCareerMode())
-                    <a href="{{ route('game.finances', $game->id) }}" class="nav-item @if(Route::currentRouteName() == 'game.finances') active @endif whitespace-nowrap px-3 py-2 text-xs font-medium uppercase tracking-wider {{ Route::currentRouteName() == 'game.finances' ? 'text-text-primary' : 'text-text-muted hover:text-text-body' }}">{{ __('app.finances') }}</a>
+                    @php
+                        $clubRoutes = ['game.club', 'game.club.finances', 'game.club.stadium', 'game.club.reputation'];
+                        $clubActive = in_array(Route::currentRouteName(), $clubRoutes);
+                    @endphp
+                    <div class="relative" x-data="{ open: false }" @click.outside="open = false">
+                        <button type="button" @click="open = !open" class="nav-item @if($clubActive) active @endif inline-flex items-center gap-1 whitespace-nowrap px-3 py-2 text-xs font-medium uppercase tracking-wider transition-colors {{ $clubActive ? 'text-text-primary' : 'text-text-muted hover:text-text-body' }}">
+                            {{ __('app.club') }}
+                            <svg class="w-3 h-3 transition-transform" :class="{ 'rotate-180': open }" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+                            </svg>
+                        </button>
+                        <div x-show="open" x-transition:enter="transition ease-out duration-100" x-transition:enter-start="opacity-0 scale-95" x-transition:enter-end="opacity-100 scale-100" x-transition:leave="transition ease-in duration-75" x-transition:leave-start="opacity-100 scale-100" x-transition:leave-end="opacity-0 scale-95" class="absolute left-0 z-50 mt-2 w-48 rounded-lg shadow-xl bg-surface-800 border border-border-strong" style="display: none;">
+                            <div class="py-1">
+                                <a href="{{ route('game.club.finances', $game->id) }}" class="block px-4 py-2 text-sm {{ Route::currentRouteName() == 'game.club.finances' ? 'bg-surface-700 text-text-primary font-semibold' : 'text-text-body hover:bg-surface-700 hover:text-text-primary' }}">{{ __('club.nav.finances') }}</a>
+                                <a href="{{ route('game.club.stadium', $game->id) }}" class="block px-4 py-2 text-sm {{ Route::currentRouteName() == 'game.club.stadium' ? 'bg-surface-700 text-text-primary font-semibold' : 'text-text-body hover:bg-surface-700 hover:text-text-primary' }}">{{ __('club.nav.stadium') }}</a>
+                                <a href="{{ route('game.club.reputation', $game->id) }}" class="block px-4 py-2 text-sm {{ Route::currentRouteName() == 'game.club.reputation' ? 'bg-surface-700 text-text-primary font-semibold' : 'text-text-body hover:bg-surface-700 hover:text-text-primary' }}">{{ __('club.nav.reputation') }}</a>
+                            </div>
+                        </div>
+                    </div>
                     <a href="{{ route('game.transfers', $game->id) }}" class="nav-item @if(in_array(Route::currentRouteName(), ['game.transfers', 'game.transfers.outgoing', 'game.scouting', 'game.explore'])) active @endif whitespace-nowrap px-3 py-2 text-xs font-medium uppercase tracking-wider {{ in_array(Route::currentRouteName(), ['game.transfers', 'game.transfers.outgoing', 'game.scouting', 'game.explore']) ? 'text-text-primary' : 'text-text-muted hover:text-text-body' }}">{{ __('app.transfers') }}</a>
                     @endif
                     <a href="{{ route('game.calendar', $game->id) }}" class="nav-item @if(Route::currentRouteName() == 'game.calendar') active @endif whitespace-nowrap px-3 py-2 text-xs font-medium uppercase tracking-wider {{ Route::currentRouteName() == 'game.calendar' ? 'text-text-primary' : 'text-text-muted hover:text-text-body' }}">{{ __('app.calendar') }}</a>

--- a/routes/web.php
+++ b/routes/web.php
@@ -85,6 +85,8 @@ use App\Http\Controllers\ProfileController;
 use App\Http\Views\Dashboard;
 use App\Http\Views\SelectTeam;
 use App\Http\Views\ShowCalendar;
+use App\Http\Views\ShowClubReputation;
+use App\Http\Views\ShowClubStadium;
 use App\Http\Views\ShowFinances;
 use App\Http\Views\ShowFastMode;
 use App\Http\Views\ShowGame;
@@ -166,7 +168,11 @@ Route::middleware('auth')->group(function () {
         Route::post('/game/{gameId}/academy/{playerId}/promote', PromoteAcademyPlayer::class)->name('game.academy.promote');
         Route::post('/game/{gameId}/academy/{playerId}/loan', LoanAcademyPlayer::class)->name('game.academy.loan');
         Route::post('/game/{gameId}/academy/{playerId}/dismiss', DismissAcademyPlayer::class)->name('game.academy.dismiss');
-        Route::get('/game/{gameId}/finances', ShowFinances::class)->name('game.finances');
+        // Club hub — Finances, Stadium, Reputation (and future non-sporting tenants)
+        Route::get('/game/{gameId}/club', fn (string $gameId) => redirect()->route('game.club.finances', $gameId))->name('game.club');
+        Route::get('/game/{gameId}/club/finances', ShowFinances::class)->name('game.club.finances');
+        Route::get('/game/{gameId}/club/stadium', ShowClubStadium::class)->name('game.club.stadium');
+        Route::get('/game/{gameId}/club/reputation', ShowClubReputation::class)->name('game.club.reputation');
         Route::get('/game/{gameId}/transfers', ShowIncomingTransfers::class)->name('game.transfers');
         Route::get('/game/{gameId}/transfers/outgoing', ShowOutgoingTransfers::class)->name('game.transfers.outgoing');
         Route::get('/game/{gameId}/transfers/market', ShowTransferMarket::class)->name('game.transfers.market');

--- a/tests/Feature/FrontendSmokeTest.php
+++ b/tests/Feature/FrontendSmokeTest.php
@@ -290,7 +290,7 @@ class FrontendSmokeTest extends TestCase
     public function test_finances_page_loads(): void
     {
         $this->actingAs($this->user)
-            ->get("/game/{$this->game->id}/finances")
+            ->get("/game/{$this->game->id}/club/finances")
             ->assertOk();
     }
 


### PR DESCRIPTION
Adds a top-level Club nav entry that houses Finances (moved), and two
new read-only pages under /game/{id}/club:

- Stadium: capacity, fan-loyalty stat with direction + anchor marker,
  last home-match attendance, and projected vs. actual matchday revenue.
- Reputation: current tier with points progress, the seeded anchor and
  two-tier drop floor, and a season-end projection using the same
  formula as ReputationUpdateProcessor.

Desktop nav replaces the Finances entry with a Club dropdown; the mobile
More drawer groups the three pages under a Club section header. Finances
moves from /game/{id}/finances to /game/{id}/club/finances and is
renamed game.finances -> game.club.finances (callers updated).

Phase 1a plumbing (loyalty_points, MatchAttendance) becomes visible to
the player; no new decision surfaces or financial changes yet.