### PR TITLE
Add trophy won notification for cup competition finals

### DIFF
--- a/app/Modules/Notification/Listeners/SendCupTieNotifications.php
+++ b/app/Modules/Notification/Listeners/SendCupTieNotifications.php
@@ -25,12 +25,20 @@ class SendCupTieNotifications
         $competitionName = $event->competition->name ?? 'Cup';
 
         if ($event->winnerId === $game->team_id) {
-            $this->notificationService->notifyCompetitionAdvancement(
-                $game,
-                $event->competition->id,
-                $competitionName,
-                __('cup.advanced_past_round', ['round' => __($roundName)]),
-            );
+            if ($roundName === 'cup.final') {
+                $this->notificationService->notifyTrophyWon(
+                    $game,
+                    $event->competition->id,
+                    $competitionName,
+                );
+            } else {
+                $this->notificationService->notifyCompetitionAdvancement(
+                    $game,
+                    $event->competition->id,
+                    $competitionName,
+                    __('cup.advanced_past_round', ['round' => __($roundName)]),
+                );
+            }
         } else {
             $this->notificationService->notifyCompetitionElimination(
                 $game,

--- a/app/Modules/Notification/Services/NotificationService.php
+++ b/app/Modules/Notification/Services/NotificationService.php
@@ -545,6 +545,24 @@ class NotificationService
     }
 
     /**
+     * Create a trophy won notification (cup final won).
+     */
+    public function notifyTrophyWon(
+        Game $game, string $competitionId, string $competitionName
+    ): GameNotification {
+        return $this->create(
+            game: $game,
+            type: GameNotification::TYPE_COMPETITION_ADVANCEMENT,
+            title: __('notifications.trophy_won_title', ['competition' => __($competitionName)]),
+            message: __('cup.champion_message', ['competition' => __($competitionName)]),
+            priority: GameNotification::PRIORITY_MILESTONE,
+            metadata: [
+                'competition_id' => $competitionId,
+            ],
+        );
+    }
+
+    /**
      * Create a competition elimination notification.
      */
     public function notifyCompetitionElimination(

--- a/lang/en/notifications.php
+++ b/lang/en/notifications.php
@@ -80,6 +80,7 @@ return [
     'competition_advancement_message' => ':stage',
     'competition_elimination_title' => ':competition elimination',
     'competition_elimination_message' => ':stage',
+    'trophy_won_title' => ':competition champions!',
 
     // Academy
     'academy_batch_title' => 'New academy prospects',

--- a/lang/es/notifications.php
+++ b/lang/es/notifications.php
@@ -80,6 +80,7 @@ return [
     'competition_advancement_message' => ':stage',
     'competition_elimination_title' => 'Eliminación de :competition',
     'competition_elimination_message' => ':stage',
+    'trophy_won_title' => '¡Campeón de :competition!',
 
     // Academy
     'academy_batch_title' => 'Nuevos canteranos',


### PR DESCRIPTION
## Summary
This PR adds a dedicated notification for when a team wins a cup competition (reaches the final and wins), distinct from the standard advancement notification used for other rounds.

## Key Changes
- **SendCupTieNotifications listener**: Added conditional logic to detect when a team wins the cup final and trigger a different notification path
- **NotificationService**: Introduced new `notifyTrophyWon()` method that creates a milestone-priority notification specifically for trophy wins
- **Localization**: Added `trophy_won_title` translation keys in English and Spanish language files to provide appropriate messaging for championship victories

## Implementation Details
- The listener now checks if the round is `'cup.final'` and routes to the new `notifyTrophyWon()` method instead of the standard `notifyCompetitionAdvancement()` method
- The trophy won notification uses `PRIORITY_MILESTONE` to highlight the significance of winning the competition
- The notification message references the existing `cup.champion_message` translation key for consistency with other cup-related messaging
- Both English and Spanish translations follow the existing pattern and naming conventions in the notifications language files

https://claude.ai/code/session_017mvCpUk6zgoKbXZGStKoYz