### PR TITLE
Add cup competition achievements to season evaluation

### DIFF
--- a/app/Modules/Season/Services/SeasonGoalService.php
+++ b/app/Modules/Season/Services/SeasonGoalService.php
@@ -3,13 +3,18 @@
 namespace App\Modules\Season\Services;
 
 use App\Models\Competition;
+use App\Models\CompetitionEntry;
+use App\Models\CupTie;
 use App\Models\Game;
 use App\Models\Team;
 use App\Models\TeamReputation;
 use App\Modules\Competition\Contracts\HasSeasonGoals;
+use Illuminate\Support\Facades\Lang;
 
 class SeasonGoalService
 {
+    private const GRADE_ORDER = ['disaster', 'below', 'met', 'exceeded', 'exceptional'];
+
     /**
      * Determine the season goal for a team based on reputation and competition.
      */
@@ -119,20 +124,134 @@ class SeasonGoalService
                 default => 'exceptional',
             };
 
-            $gradeOrder = ['disaster', 'below', 'met', 'exceeded', 'exceptional'];
-            $currentIndex = array_search($grade, $gradeOrder);
-            $minIndex = array_search($minGrade, $gradeOrder);
+            $currentIndex = array_search($grade, self::GRADE_ORDER);
+            $minIndex = array_search($minGrade, self::GRADE_ORDER);
 
             if ($currentIndex < $minIndex) {
                 $grade = $minGrade;
             }
         }
 
-        return $this->buildEvaluationResult($grade, $actualPosition, $targetPosition, $goal, $goalLabel, $achieved, $positionDiff);
+        // Titles won and finals reached in other competitions (cups, Europe)
+        // bump the grade upwards — a Champions League win or a Copa del Rey
+        // should offset a mediocre league campaign.
+        $boost = $this->computeAchievementBoost($game);
+        if ($boost['steps'] > 0) {
+            $grade = $this->upgradeGrade($grade, $boost['steps']);
+        }
+
+        return $this->buildEvaluationResult(
+            $grade,
+            $actualPosition,
+            $targetPosition,
+            $goal,
+            $goalLabel,
+            $achieved,
+            $positionDiff,
+            $boost['achievements']
+        );
+    }
+
+    /**
+     * Walk up the grade ladder by $steps, capped at 'exceptional'.
+     */
+    private function upgradeGrade(string $grade, int $steps): string
+    {
+        $index = array_search($grade, self::GRADE_ORDER);
+
+        if ($index === false) {
+            return $grade;
+        }
+
+        $newIndex = min($index + $steps, count(self::GRADE_ORDER) - 1);
+
+        return self::GRADE_ORDER[$newIndex];
+    }
+
+    /**
+     * Compute how many grade-ladder steps to add because of titles won or
+     * finals reached in competitions other than the team's primary league.
+     *
+     * Returns ['steps' => int, 'achievements' => string[]] where each entry
+     * in `achievements` is an already-translated label like "Champions
+     * League winner" or "Copa del Rey runner-up" — ready to interpolate
+     * into the board message.
+     */
+    private function computeAchievementBoost(Game $game): array
+    {
+        $supercupIds = $this->getSupercupCompetitionIds();
+        $achievements = [];
+        $steps = 0;
+
+        $entries = CompetitionEntry::with('competition')
+            ->where('game_id', $game->id)
+            ->where('team_id', $game->team_id)
+            ->where('competition_id', '!=', $game->competition_id)
+            ->get();
+
+        foreach ($entries as $entry) {
+            $competition = $entry->competition;
+
+            if (! $competition || in_array($competition->id, $supercupIds, true)) {
+                continue;
+            }
+
+            if (! in_array($competition->role, [Competition::ROLE_EUROPEAN, Competition::ROLE_DOMESTIC_CUP], true)) {
+                continue;
+            }
+
+            $finalTie = CupTie::where('game_id', $game->id)
+                ->where('competition_id', $competition->id)
+                ->where('completed', true)
+                ->orderByDesc('round_number')
+                ->first();
+
+            if (! $finalTie) {
+                continue;
+            }
+
+            $competitionName = __($competition->name);
+
+            if ($finalTie->winner_id === $game->team_id) {
+                $steps += $competition->role === Competition::ROLE_EUROPEAN ? 2 : 1;
+                $achievements[] = __('season.achievement_winner', ['competition' => $competitionName]);
+                continue;
+            }
+
+            $teamPlayedFinal = $finalTie->home_team_id === $game->team_id
+                || $finalTie->away_team_id === $game->team_id;
+
+            if ($teamPlayedFinal) {
+                $steps += 1;
+                $achievements[] = __('season.achievement_runner_up', ['competition' => $competitionName]);
+            }
+        }
+
+        return ['steps' => $steps, 'achievements' => $achievements];
+    }
+
+    /**
+     * Supercups are single matches, not full-season achievements — exclude
+     * them from the board assessment. Mirrors the list used by
+     * TrophyRecordingProcessor.
+     */
+    private function getSupercupCompetitionIds(): array
+    {
+        $ids = [];
+
+        foreach (config('countries', []) as $country) {
+            if (isset($country['supercup']['competition'])) {
+                $ids[] = $country['supercup']['competition'];
+            }
+        }
+
+        return $ids;
     }
 
     /**
      * Build the evaluation result array.
+     *
+     * @param  string[]  $achievements
      */
     private function buildEvaluationResult(
         string $grade,
@@ -141,25 +260,59 @@ class SeasonGoalService
         string $goal,
         string $goalLabel,
         bool $achieved,
-        int $positionDiff
+        int $positionDiff,
+        array $achievements = []
     ): array {
         $titleKey = "season.evaluation_{$grade}";
         $messageKey = "season.evaluation_{$grade}_message";
+        $placeholders = [
+            'target' => $targetPosition,
+            'actual' => $actualPosition,
+            'diff' => abs($positionDiff),
+        ];
+
+        if ($achievements !== []) {
+            $withTrophiesKey = "{$messageKey}_with_trophies";
+            if (Lang::has($withTrophiesKey)) {
+                $messageKey = $withTrophiesKey;
+                $placeholders['trophies'] = $this->joinAchievements($achievements);
+            }
+        }
 
         return [
             'grade' => $grade,
             'title' => __($titleKey),
-            'message' => __($messageKey, [
-                'target' => $targetPosition,
-                'actual' => $actualPosition,
-                'diff' => abs($positionDiff),
-            ]),
+            'message' => __($messageKey, $placeholders),
             'actualPosition' => $actualPosition,
             'targetPosition' => $targetPosition,
             'goal' => $goal,
             'goalLabel' => __($goalLabel),
             'achieved' => $achieved,
             'positionDiff' => $positionDiff,
+            'achievements' => $achievements,
         ];
+    }
+
+    /**
+     * Join achievement labels into a human-readable list, locale-aware:
+     * "X", "X and Y", "X, Y and Z".
+     *
+     * @param  string[]  $achievements
+     */
+    private function joinAchievements(array $achievements): string
+    {
+        $count = count($achievements);
+
+        if ($count === 0) {
+            return '';
+        }
+
+        if ($count === 1) {
+            return $achievements[0];
+        }
+
+        $last = array_pop($achievements);
+
+        return implode(', ', $achievements) . ' ' . __('season.achievement_and') . ' ' . $last;
     }
 }

--- a/lang/en/season.php
+++ b/lang/en/season.php
@@ -34,6 +34,14 @@ return [
     'evaluation_met_message' => 'A solid season that met our objectives. The board is satisfied with your work and expects further progress next season.',
     'evaluation_below_message' => 'A disappointing campaign. We expected better results and the board will be monitoring performance closely next season.',
     'evaluation_disaster_message' => 'This season has been a disaster. The board expected a finish around position :target, but :actual is unacceptable. Significant improvement is required.',
+    'evaluation_exceptional_message_with_trophies' => 'A historic campaign. Not only did you finish :diff places above expectations, but you also delivered :trophies. The board could not be happier.',
+    'evaluation_exceeded_message_with_trophies' => 'An outstanding season. You exceeded the projected league position and, on top of that, :trophies brought further glory to the club. The board is thrilled.',
+    'evaluation_met_message_with_trophies' => 'A satisfying season. League objectives were met and :trophies made the campaign even more memorable. The board expects you to build on this next year.',
+    'evaluation_below_message_with_trophies' => 'The league campaign fell short of expectations, but :trophies softened the blow in terms of both prestige and revenue. The board still expects a stronger league effort next season.',
+    'evaluation_disaster_message_with_trophies' => 'A chaotic season. The league finish around position :actual was far below the expected :target, and only :trophies prevented an outright catastrophe. The board demands a major turnaround.',
+    'achievement_winner' => ':competition winner',
+    'achievement_runner_up' => ':competition runner-up',
+    'achievement_and' => 'and',
 
     // Individual awards
     'individual_awards' => 'Individual Awards',

--- a/lang/es/season.php
+++ b/lang/es/season.php
@@ -34,6 +34,14 @@ return [
     'evaluation_met_message' => 'Una temporada sólida que cumplió con nuestros objetivos. La directiva está satisfecha con tu trabajo y espera más progreso la próxima temporada.',
     'evaluation_below_message' => 'Una campaña decepcionante. Esperábamos mejores resultados y la directiva estará monitoreando de cerca el rendimiento la próxima temporada.',
     'evaluation_disaster_message' => 'Esta temporada ha sido un desastre. La directiva esperaba terminar alrededor de la posición :target, pero la :actual es inaceptable. Se requiere una mejora significativa.',
+    'evaluation_exceptional_message_with_trophies' => 'Una campaña histórica. No solo terminaste :diff puestos por encima de lo esperado, sino que además conquistaste :trophies. La directiva no podría estar más contenta.',
+    'evaluation_exceeded_message_with_trophies' => 'Una temporada sobresaliente. Has superado la posición proyectada en la liga y, además, :trophies han aportado aún más gloria al club. La directiva está encantada.',
+    'evaluation_met_message_with_trophies' => 'Una temporada satisfactoria. Se cumplieron los objetivos de liga y :trophies han hecho la campaña aún más memorable. La directiva espera que construyas sobre esto el próximo año.',
+    'evaluation_below_message_with_trophies' => 'La campaña en la liga se quedó corta respecto a las expectativas, pero :trophies han suavizado el golpe, tanto en prestigio como en ingresos. Aun así, la directiva espera un mejor rendimiento liguero la próxima temporada.',
+    'evaluation_disaster_message_with_trophies' => 'Una temporada caótica. La posición :actual en la liga queda muy lejos de la esperada :target, y solo :trophies han evitado una catástrofe total. La directiva exige un giro radical.',
+    'achievement_winner' => 'campeón de :competition',
+    'achievement_runner_up' => 'subcampeón de :competition',
+    'achievement_and' => 'y',
 
     // Individual awards
     'individual_awards' => 'Premios Individuales',


### PR DESCRIPTION
## Summary
Enhanced the season evaluation system to recognize and reward teams for winning titles or reaching finals in cup competitions and European tournaments. These achievements now boost the overall performance grade, acknowledging that success beyond the league campaign should positively impact the board's assessment.

## Key Changes
- **Achievement Boost System**: Added `computeAchievementBoost()` method that scans for cup and European competition achievements in the same season
  - European competition wins grant +2 grade steps
  - Domestic cup wins grant +1 grade step
  - Finals reached (runner-up) grant +1 grade step
  - Supercups are excluded as they're single-match events, not full-season achievements

- **Grade Upgrade Logic**: Implemented `upgradeGrade()` method to safely advance grades along the ladder (disaster → below → met → exceeded → exceptional), capped at the maximum

- **Enhanced Evaluation Results**: Modified `buildEvaluationResult()` to include achievements in the response and support locale-aware message variants
  - Added `_with_trophies` message variants for each grade that mention the achievements
  - Falls back to standard messages if trophy variants aren't available for a locale

- **Achievement Formatting**: Added `joinAchievements()` helper for human-readable list formatting ("X, Y and Z" style) that respects locale conventions

- **Code Organization**: Extracted `GRADE_ORDER` constant to class level for reusability

## Localization
Added translation keys for English and Spanish:
- Achievement labels: "winner" and "runner-up" with competition name interpolation
- Grade-specific messages acknowledging trophy wins
- Conjunction word ("and") for locale-aware list joining

## Notable Details
- Achievements are only counted from competitions other than the team's primary league
- Uses existing `CompetitionEntry` and `CupTie` models to determine winners and finalists
- Supercup IDs are dynamically loaded from country configuration to maintain consistency with trophy recording logic

https://claude.ai/code/session_018fkJ3jWGUf1gHrRKqM3N8U