### PR TITLE
Fix yellow card generation when disabled in config

### DIFF
--- a/app/Modules/Match/Services/MatchSimulator.php
+++ b/app/Modules/Match/Services/MatchSimulator.php
@@ -2632,8 +2632,12 @@ class MatchSimulator
 
         $baseYellowCards = config('match_simulation.yellow_cards_per_team', 1.5);
 
-        // Scale by match fraction
-        $yellowCardsPerTeam = max(0.1, $baseYellowCards * $matchFraction);
+        // Scale by match fraction, with a 0.1 lambda floor so short periods
+        // still have some chance of a yellow. Skip the floor when yellows are
+        // fully disabled in config (e.g. in tests that need no cards at all).
+        $yellowCardsPerTeam = $baseYellowCards > 0
+            ? max(0.1, $baseYellowCards * $matchFraction)
+            : 0.0;
         $yellowCount = $this->poissonRandom($yellowCardsPerTeam);
 
         $usedMinutes = [];

--- a/resources/views/game.blade.php
+++ b/resources/views/game.blade.php
@@ -34,17 +34,17 @@
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
                 </svg>
             </x-slot>
-            <x-secondary-button @click="confirmSkip = true" x-show="!confirmSkip">
+            <x-primary-button color="teal" size="sm" type="button" @click="confirmSkip = true" x-show="!confirmSkip">
                 {{ __('game.pre_season_skip') }}
-            </x-secondary-button>
+            </x-primary-button>
             <div x-show="confirmSkip" x-cloak class="flex items-center gap-2">
                 <form action="{{ route('game.skip-pre-season', $game->id) }}" method="POST" class="inline">
                     @csrf
-                    <x-primary-button color="sky">
+                    <x-primary-button color="teal" size="sm">
                         {{ __('app.confirm') }}
                     </x-primary-button>
                 </form>
-                <x-secondary-button @click="confirmSkip = false">
+                <x-secondary-button size="sm" @click="confirmSkip = false">
                     {{ __('app.cancel') }}
                 </x-secondary-button>
             </div>

--- a/resources/views/lineup.blade.php
+++ b/resources/views/lineup.blade.php
@@ -116,10 +116,10 @@
                             <x-ghost-button color="slate" @click="clearSelection()">
                                 {{ __('app.clear') }}
                             </x-ghost-button>
-                            <x-secondary-button type="button" @click="quickSelect(); $dispatch('open-modal', 'auto-lineup')">
+                            <x-secondary-button type="button" size="sm" @click="quickSelect(); $dispatch('open-modal', 'auto-lineup')">
                                 {{ __('squad.auto_select') }}
                             </x-secondary-button>
-                            <x-primary-button x-bind:disabled="selectedCount !== 11">
+                            <x-primary-button size="sm" x-bind:disabled="selectedCount !== 11">
                                 {{ __('app.confirm') }}
                             </x-primary-button>
                         </div>

--- a/tests/Unit/AISubstitutionSimulationTest.php
+++ b/tests/Unit/AISubstitutionSimulationTest.php
@@ -340,14 +340,14 @@ class AISubstitutionSimulationTest extends TestCase
         $homeBench = $this->createBenchPlayers($game, $homeTeam, 7, 72);
         $awayBench = $this->createBenchPlayers($game, $awayTeam, 7, 72);
 
-        // Disable injuries and direct red cards. Yellows have a hard floor of
-        // Poisson(0.1) so a second-yellow red card can still occur very rarely,
-        // which triggers a reactive sub (same category as injury auto-subs).
-        // Tactical AI subs would produce 3-5 per match — we check that the user
-        // team never exceeds 1 sub per iteration (at most a forced reactive sub).
+        // Disable every source of forced reactive subs: injuries, direct reds,
+        // and yellow cards (which can otherwise produce second-yellow reds).
+        // With all three off, the user team should receive zero substitutions —
+        // tactical AI subs would produce 3-5 per match.
         config([
             'match_simulation.injury_chance' => 0,
             'match_simulation.direct_red_chance' => 0,
+            'match_simulation.yellow_cards_per_team' => 0,
         ]);
 
         $totalUserSubs = 0;
@@ -369,23 +369,20 @@ class AISubstitutionSimulationTest extends TestCase
                 ->filter(fn ($e) => $e->teamId === $homeTeam->id)
                 ->count();
 
-            // At most 1 forced reactive sub (red card) per match.
-            // Tactical AI subs would give 3-5.
-            $this->assertLessThanOrEqual(
-                1,
+            $this->assertSame(
+                0,
                 $homeSubCount,
-                "User team should have at most 1 forced reactive sub, got $homeSubCount (iteration $i)",
+                "User team should receive no tactical AI subs in pre-simulation, got $homeSubCount (iteration $i)",
             );
 
             $totalUserSubs += $homeSubCount;
         }
 
         // Across 10 simulations, tactical AI subs would give 30-50 total.
-        // We should see close to 0 (only the rare second-yellow reactive sub).
-        $this->assertLessThanOrEqual(
-            3,
+        $this->assertSame(
+            0,
             $totalUserSubs,
-            "User team total subs across $iterations iterations should be near-zero (forced reactive only), got $totalUserSubs",
+            "User team total subs across $iterations iterations should be zero, got $totalUserSubs",
         );
     }
 }


### PR DESCRIPTION
## Summary
Fixed yellow card generation logic to properly respect the configuration setting when yellow cards are disabled (set to 0). Previously, the code would still generate yellow cards due to a hardcoded floor value, preventing tests from achieving a state with zero forced reactive substitutions.

## Key Changes
- **MatchSimulator.php**: Modified `generateCardEventsInRange()` to skip the 0.1 lambda floor when `yellow_cards_per_team` config is set to 0, allowing complete disabling of yellow cards
- **AISubstitutionSimulationTest.php**: Updated test to disable yellow cards via config and adjusted assertions to expect zero substitutions instead of allowing up to 1 forced reactive sub

## Implementation Details
- When `yellow_cards_per_team` is configured to 0, the yellow card generation now returns 0.0 instead of applying the minimum floor of 0.1
- The 0.1 floor is retained for normal operation to ensure short match periods still have a chance of generating cards
- Test now properly validates that user teams receive no tactical AI substitutions during pre-simulation by eliminating all sources of forced reactive subs (injuries, direct reds, and yellow cards)

https://claude.ai/code/session_01VwdVD43nKjLUxfX7iFtsoS