### PR TITLE
Delete ensureExistForGamePlayers lazy path and its per-batch call

### DIFF
--- a/app/Models/GamePlayerMatchState.php
+++ b/app/Models/GamePlayerMatchState.php
@@ -6,15 +6,16 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Log;
 
 /**
- * Sparse satellite of GamePlayer holding the per-matchday hot-write state:
+ * Satellite of GamePlayer holding the per-matchday hot-write state:
  * fitness, morale, injuries, appearances, goals, assists, cards, GK stats.
  *
- * Only populated for "active" players (teams in the user's competition
- * footprint or European opponents for a season the user qualifies for).
- * Pure transfer-pool foreign players have no row here.
+ * Every game_player has exactly one row here, created in the same
+ * transaction that inserts the parent. Foreign transfer-pool players carry
+ * defaults that never get updated in practice, but the invariant "every
+ * game_player has a matchState row" lets simulation code assume presence
+ * without a lazy-ensure fallback.
  *
  * Read paths go through the {@see GamePlayer} accessor delegates so existing
  * call sites that read `$player->fitness`, `$player->goals` etc. keep working.
@@ -163,74 +164,6 @@ class GamePlayerMatchState extends Model
                 'morale' => $morale,
             ]),
         );
-    }
-
-    /**
-     * Bulk-insert default satellite rows for every player on every team
-     * in the given set that doesn't already have one. Idempotent.
-     *
-     * Phase A of the eager-materialization rollout guarantees every
-     * game_player gets a satellite row at creation time, so this method is
-     * expected to be a no-op in steady state. Any row it does create is a
-     * signal that some GamePlayer::insert site skipped its satellite row —
-     * we log a warning with the offending game_player_id / team_id so the
-     * missed path can be identified and fixed. Once logs are silent for a
-     * release cycle the whole method can be deleted (Phase C).
-     *
-     * ORDER BY gp.id ensures concurrent inserts acquire PK / FK index
-     * locks in a deterministic order. Without it, two sessions running
-     * this statement on overlapping player sets can lock rows in opposite
-     * order and deadlock on the PK index (40P01).
-     */
-    public static function ensureExistForGamePlayers(string $gameId, array $teamIds): void
-    {
-        if (empty($teamIds)) {
-            return;
-        }
-
-        $idList = '{' . implode(',', $teamIds) . '}';
-
-        $created = DB::select(<<<'SQL'
-            INSERT INTO game_player_match_state (
-                game_player_id, game_id, fitness, morale, injury_until, injury_type,
-                appearances, season_appearances, goals, own_goals, assists,
-                yellow_cards, red_cards, goals_conceded, clean_sheets
-            )
-            SELECT gp.id, gp.game_id, 80, 80, NULL, NULL, 0, 0, 0, 0, 0, 0, 0, 0, 0
-            FROM game_players gp
-            WHERE gp.game_id = ?
-              AND gp.team_id IN (SELECT unnest(?::uuid[]))
-            ORDER BY gp.id
-            ON CONFLICT (game_player_id) DO NOTHING
-            RETURNING game_player_id
-        SQL, [$gameId, $idList]);
-
-        if (empty($created)) {
-            return;
-        }
-
-        $missingIds = array_map(fn ($row) => $row->game_player_id, $created);
-
-        // Resolve team_id per missing player so the log points at the
-        // creation path that needs fixing.
-        $teamByPlayerId = GamePlayer::whereIn('id', $missingIds)
-            ->pluck('team_id', 'id')
-            ->all();
-
-        // Cap the logged sample to keep payloads bounded in the (should-
-        // never-happen-in-steady-state) mass-miss case. Count stays accurate.
-        $sampleLimit = 50;
-        $sampled = array_slice($missingIds, 0, $sampleLimit);
-
-        Log::warning('GamePlayerMatchState: satellite row was missing and backfilled inline', [
-            'game_id' => $gameId,
-            'count' => count($missingIds),
-            'truncated' => count($missingIds) > $sampleLimit,
-            'missing' => array_map(fn ($id) => [
-                'game_player_id' => $id,
-                'team_id' => $teamByPlayerId[$id] ?? null,
-            ], $sampled),
-        ]);
     }
 
     /**

--- a/app/Modules/Match/Jobs/ProcessCareerActions.php
+++ b/app/Modules/Match/Jobs/ProcessCareerActions.php
@@ -39,8 +39,7 @@ class ProcessCareerActions implements ShouldQueue, ShouldBeUnique
         // This serializes career actions against matchday advancement, the
         // ProcessRemainingBatches job, and FinalizeMatch — all of which write
         // to the same game_player_match_state / game_players rows and would
-        // otherwise deadlock at the PK/FK index level (e.g. AI transfer UPDATEs
-        // on game_players vs. ensureExistForGamePlayers INSERTs).
+        // otherwise deadlock at the PK/FK index level.
         //
         // Per-tick (rather than whole-job) locking keeps the critical section
         // short so a user advancing to the next matchday is only ever blocked

--- a/app/Modules/Match/Services/MatchdayOrchestrator.php
+++ b/app/Modules/Match/Services/MatchdayOrchestrator.php
@@ -27,9 +27,6 @@ class MatchdayOrchestrator
 {
     private int $careerActionTicks = 0;
 
-    /** @var string[] Team IDs whose satellite rows have been ensured this run */
-    private array $ensuredTeamIds = [];
-
     public function __construct(
         private readonly MatchdayService $matchdayService,
         private readonly FullMatchSimulationService $fullMatchSimulation,
@@ -46,7 +43,6 @@ class MatchdayOrchestrator
     public function advance(Game $game, bool $fastForward = false): MatchdayAdvanceResult
     {
         $this->careerActionTicks = 0;
-        $this->ensuredTeamIds = [];
 
         $result = DB::transaction(function () use ($game, $fastForward) {
             // Lock the game row to prevent concurrent matchday advancement
@@ -213,36 +209,6 @@ class MatchdayOrchestrator
             $player->setRelation('game', $game);
         }
 
-        // Ensure satellite rows exist for teams not yet ensured this run.
-        // Skips the INSERT...ON CONFLICT for teams whose rows were already
-        // guaranteed in a prior batch (same orchestrator instance).
-        $newTeamIds = $teamIds->diff($this->ensuredTeamIds)->values()->all();
-
-        if (! empty($newTeamIds)) {
-            GamePlayerMatchState::ensureExistForGamePlayers($game->id, $newTeamIds);
-            $this->ensuredTeamIds = array_merge($this->ensuredTeamIds, $newTeamIds);
-        }
-
-        // Batch re-load matchState for players whose satellite row was
-        // missing at eager-load time (just created by ensureExist, or
-        // recently transferred). Single query instead of N individual loads.
-        $missingIds = $allPlayers
-            ->filter(fn ($p) => ! $p->relationLoaded('matchState') || $p->matchState === null)
-            ->pluck('id')
-            ->all();
-
-        if (! empty($missingIds)) {
-            $freshStates = GamePlayerMatchState::whereIn('game_player_id', $missingIds)
-                ->get()
-                ->keyBy('game_player_id');
-
-            foreach ($allPlayers as $player) {
-                if (isset($freshStates[$player->id])) {
-                    $player->setRelation('matchState', $freshStates[$player->id]);
-                }
-            }
-        }
-
         $allPlayers = $allPlayers->groupBy('team_id');
 
         $competitionIds = $matches->pluck('competition_id')->unique()->toArray();
@@ -401,7 +367,6 @@ class MatchdayOrchestrator
     public function processRemainingBatches(Game $game, int $priorCareerActionTicks): void
     {
         $this->careerActionTicks = 0;
-        $this->ensuredTeamIds = [];
         $gameId = $game->id;
 
         while ($nextBatch = $this->matchdayService->getNextMatchBatch($game)) {

--- a/app/Modules/Season/Jobs/SetupNewGame.php
+++ b/app/Modules/Season/Jobs/SetupNewGame.php
@@ -345,9 +345,9 @@ class SetupNewGame implements ShouldQueue, ShouldBeUnique
 
                     // Every game_player gets a satellite row. Pool players
                     // (foreign leagues) carry template defaults they never read
-                    // in practice, but keeping the invariant "every game_player
-                    // has a matchState row" removes the need for the lazy
-                    // ensureExistForGamePlayers path at matchday time.
+                    // in practice, but the invariant "every game_player has a
+                    // matchState row" lets simulation code assume presence
+                    // without a lazy-ensure fallback at matchday time.
                     $matchStateRows[] = [
                         'game_player_id' => $gamePlayerId,
                         'game_id' => $gameId,

--- a/app/Modules/Transfer/Services/AITransferMarketService.php
+++ b/app/Modules/Transfer/Services/AITransferMarketService.php
@@ -1445,8 +1445,7 @@ class AITransferMarketService
     {
         // Sort by id so the PK / FK locks inside each upsert chunk are
         // acquired in a deterministic order — prevents cross-session
-        // deadlocks with other writers that follow the same ordering
-        // (e.g. GamePlayerMatchState::ensureExistForGamePlayers).
+        // deadlocks with other writers that follow the same ordering.
         usort($playerUpdates, fn ($a, $b) => strcmp($a['id'], $b['id']));
 
         foreach (array_chunk($playerUpdates, 100) as $chunk) {

--- a/app/Modules/Transfer/Services/TransferService.php
+++ b/app/Modules/Transfer/Services/TransferService.php
@@ -609,9 +609,8 @@ class TransferService
     public function completeAgreedTransfers(Game $game): Collection
     {
         // Sorted by game_player_id so the per-player UPDATE locks are
-        // acquired in PK order — matches the ORDER BY used by
-        // GamePlayerMatchState::ensureExistForGamePlayers and keeps
-        // lock acquisition deterministic across concurrent writers.
+        // acquired in PK order, keeping lock acquisition deterministic
+        // across concurrent writers and avoiding cross-session deadlocks.
         $agreedOffers = TransferOffer::with(['gamePlayer.player', 'offeringTeam'])
             ->where('game_id', $game->id)
             ->where('status', TransferOffer::STATUS_AGREED)

--- a/database/migrations/2026_04_20_000001_backfill_missing_game_player_match_state_rows.php
+++ b/database/migrations/2026_04_20_000001_backfill_missing_game_player_match_state_rows.php
@@ -15,9 +15,7 @@ return new class extends Migration
      *     php artisan app:backfill-match-states
      *
      * The command iterates games one at a time with progress output and is
-     * idempotent (NOT EXISTS filter). It is safe to run at any time; until it
-     * does, {@see \App\Models\GamePlayerMatchState::ensureExistForGamePlayers}
-     * fills any remaining gaps at matchday time.
+     * idempotent (NOT EXISTS filter). It is safe to run at any time.
      *
      * The file remains so environments that already recorded this migration
      * don't see it as "pending" — removing it would break the migrations


### PR DESCRIPTION
Every game_player is materialized with a matchState row at creation (SetupNewGame / PlayerGeneratorService / SetupTournamentGame / SaveSquadSelection) plus the one-shot app:backfill-match-states artisan command for existing games. Phase B's RETURNING + warning instrumentation stayed silent, and the production deadlock rate dropped from ~132/day to ~2/day — the residual being the INSERT itself still racing even with zero actual work. Removing the call site closes that window entirely.

Deletions:
  - GamePlayerMatchState::ensureExistForGamePlayers (method + Log import)
  - MatchdayOrchestrator::$ensuredTeamIds + both initializations
  - The ensureExist call in processBatch
  - The "re-load missing matchStates" fallback in processBatch

GamePlayer::matchStateValue keeps its null-safe fallback as a soft safety net for any stragglers the backfill command may have missed; degrades to defaults rather than crashing.

Stale comment references to the deleted method are updated to drop the specific name while preserving the underlying why (deterministic lock ordering is still good practice for concurrent writers).