### PR TITLE
Rename Athletic Bilbao to Athletic Club

### DIFF
--- a/app/Models/ClubProfile.php
+++ b/app/Models/ClubProfile.php
@@ -48,7 +48,7 @@ class ClubProfile extends Model
      * not a measurement. A club's cultural tendency to fill its stadium
      * regardless of competitive tier. Calibration:
      *
-     *   10 — iconic / cult loyalty (Athletic Bilbao, St. Pauli, Celtic)
+     *   10 — iconic / cult loyalty (Athletic Club, St. Pauli, Celtic)
      *    9 — huge, passionate followings (Red Star, Dortmund, Marseille)
      *    8 — strong loyal support (Real Madrid, Union Berlin, PAOK)
      *    7 — good loyal support (Real Sociedad, Leeds, Benfica)

--- a/app/Modules/Academy/Services/YouthAcademyService.php
+++ b/app/Modules/Academy/Services/YouthAcademyService.php
@@ -389,7 +389,7 @@ class YouthAcademyService
      * Maps team name → exact nationality filter (overrides weighted selection).
      */
     private const CANTERA_TEAMS = [
-        'Athletic Bilbao' => 'Spain',
+        'Athletic Club' => 'Spain',
     ];
 
     /**

--- a/app/Modules/Squad/Configs/TeamRegionalOrigins.php
+++ b/app/Modules/Squad/Configs/TeamRegionalOrigins.php
@@ -25,7 +25,7 @@ class TeamRegionalOrigins
      */
     private const TEAMS = [
         // Basque clubs (Euskadi / País Vasco + Navarre via Osasuna).
-        'Athletic Bilbao' => self::REGION_BASQUE,
+        'Athletic Club' => self::REGION_BASQUE,
         'Real Sociedad' => self::REGION_BASQUE,
         'Real Sociedad B' => self::REGION_BASQUE,
         'Deportivo Alavés' => self::REGION_BASQUE,

--- a/app/Modules/Squad/Services/PlayerGeneratorService.php
+++ b/app/Modules/Squad/Services/PlayerGeneratorService.php
@@ -467,7 +467,7 @@ class PlayerGeneratorService
     /**
      * Pick a random identity (name + nationality + height + foot) for a generated player.
      *
-     * @param  string|null  $nationality    Exact nationality filter (100% match, e.g. for Athletic Bilbao)
+     * @param  string|null  $nationality    Exact nationality filter (100% match, e.g. for Athletic Club)
      * @param  string|null  $teamCountry    Country code for weighted selection (75% domestic / 25% any)
      * @param  string[]     $excludedNames  Names to exclude (game-wide player + academy names)
      * @param  string|null  $region         Regional naming override for Basque/Catalan clubs

--- a/app/Support/Faker/Provider/eu_ES/Person.php
+++ b/app/Support/Faker/Provider/eu_ES/Person.php
@@ -8,7 +8,7 @@ use Faker\Provider\Person as BasePerson;
  * Basque (Euskara) Person provider for Faker.
  *
  * Used for youth academy and replenishment name generation at Basque clubs
- * (Athletic Bilbao, Real Sociedad, Alavés, Osasuna, Eibar — see
+ * (Athletic Club, Real Sociedad, Alavés, Osasuna, Eibar — see
  * {@see \App\Modules\Squad\Configs\TeamRegionalOrigins}). Faker ships no
  * native eu_ES locale, so this provider fills that gap. Nationality stays
  * "Spain" at the data layer; only the name source changes.

--- a/app/Support/TeamColors/LaLiga.php
+++ b/app/Support/TeamColors/LaLiga.php
@@ -25,7 +25,7 @@ final class LaLiga implements TeamColorProvider
                 'secondary' => 'white',
                 'number' => 'blue-700',
             ],
-            'Athletic Bilbao' => [
+            'Athletic Club' => [
                 'pattern' => 'stripes',
                 'primary' => 'red-600',
                 'secondary' => 'white',

--- a/config/finances.php
+++ b/config/finances.php
@@ -130,6 +130,6 @@ return [
     // synthetic youth academy for squad replenishment. They can still sell
     // players, but cannot buy, sign free agents, or receive loan moves.
     'ai_excluded_from_signing' => [
-        'athletic-bilbao',
+        'athletic-club',
     ],
 ];

--- a/data/2025/ESP1/teams.json
+++ b/data/2025/ESP1/teams.json
@@ -1508,7 +1508,7 @@
     },
     {
       "image": "https://tmssl.akamaized.net/images/wappen/big/621.png",
-      "name": "Athletic Bilbao",
+      "name": "Athletic Club",
       "players": [
         {
           "contract": "Jun 30, 2029",

--- a/data/2025/ESPCUP/teams.json
+++ b/data/2025/ESPCUP/teams.json
@@ -4,7 +4,7 @@
     "clubs": [
         { "id": "131", "name": "Barcelona" },
         { "id": "13", "name": "Atlético de Madrid" },
-        { "id": "621", "name": "Athletic Bilbao" },
+        { "id": "621", "name": "Athletic Club" },
         { "id": "681", "name": "Real Sociedad" },
         { "id": "150", "name": "Real Betis Balompié" },
         { "id": "1049", "name": "Valencia CF" },

--- a/data/2025/UCL/teams.json
+++ b/data/2025/UCL/teams.json
@@ -38,7 +38,7 @@
         { "id": "141", "name": "Galatasaray", "country": "TR", "pot": 4 },
         { "id": "3948", "name": "Union Saint-Gilloise", "country": "BE", "pot": 4 },
         { "id": "10625", "name": "Qarabağ FK", "country": "AZ", "pot": 4 },
-        { "id": "621", "name": "Athletic Bilbao", "country": "ES", "pot": 4 },
+        { "id": "621", "name": "Athletic Club", "country": "ES", "pot": 4 },
         { "id": "762", "name": "Newcastle United", "country": "EN", "pot": 4 },
         { "id": "45457", "name": "Pafos FC", "country": "CY", "pot": 4 },
         { "id": "10482", "name": "Kairat Almaty", "country": "KZ", "pot": 4 }

--- a/database/migrations/2026_04_16_000001_add_fan_loyalty_to_club_profiles.php
+++ b/database/migrations/2026_04_16_000001_add_fan_loyalty_to_club_profiles.php
@@ -7,7 +7,7 @@ use Illuminate\Support\Facades\Schema;
 /**
  * Curated per-club fan_loyalty anchor on a coarse 0-10 editorial scale.
  * Captures a club's cultural stadium-filling power independent of its
- * competitive tier. 10 = iconic (Athletic, St. Pauli, Celtic); 5 = average
+ * competitive tier. 10 = iconic (Athletic Club, St. Pauli, Celtic); 5 = average
  * (the default for any club not explicitly curated); 4 and below =
  * notably low-following. See ClubProfile::FAN_LOYALTY_* constants for the
  * full rubric.

--- a/database/migrations/2026_04_20_000002_rename_athletic_bilbao_to_athletic_club.php
+++ b/database/migrations/2026_04_20_000002_rename_athletic_bilbao_to_athletic_club.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Rename the club to its official registered name. Keyed by
+     * transfermarkt_id (stable identifier) rather than name, so this migration
+     * is safe to re-run and independent of whichever name the row currently
+     * holds.
+     */
+    public function up(): void
+    {
+        DB::table('teams')
+            ->where('transfermarkt_id', 621)
+            ->update([
+                'name' => 'Athletic Club',
+                'slug' => 'athletic-club',
+            ]);
+    }
+
+    public function down(): void
+    {
+        DB::table('teams')
+            ->where('transfermarkt_id', 621)
+            ->update([
+                'name' => 'Athletic Bilbao',
+                'slug' => 'athletic-bilbao',
+            ]);
+    }
+};

--- a/database/seeders/ClubProfilesSeeder.php
+++ b/database/seeders/ClubProfilesSeeder.php
@@ -25,7 +25,7 @@ class ClubProfilesSeeder extends Seeder
         'Atlético de Madrid' => ClubProfile::REPUTATION_ELITE,
 
         // Continental - Objetivo: Europa League
-        'Athletic Bilbao' => ClubProfile::REPUTATION_CONTINENTAL,
+        'Athletic Club' => ClubProfile::REPUTATION_CONTINENTAL,
         'Villarreal CF' => ClubProfile::REPUTATION_CONTINENTAL,
         'Real Betis Balompié' => ClubProfile::REPUTATION_CONTINENTAL,
         'Sevilla FC' => ClubProfile::REPUTATION_CONTINENTAL,
@@ -281,7 +281,7 @@ class ClubProfilesSeeder extends Seeder
         'Real Madrid' => 8,              // 87.5%
         'FC Barcelona' => 6,             // 67.7%
         'Atlético de Madrid' => 8,       // 87.2%
-        'Athletic Bilbao' => 9,          // 89.8%
+        'Athletic Club' => 9,            // 89.8%
         'Real Betis Balompié' => 7,      // 84.1%
         'Villarreal CF' => 5,            // 77.1%
         'Sevilla FC' => 7,              // 79.4%

--- a/docs/game-systems/academy-redesign.md
+++ b/docs/game-systems/academy-redesign.md
@@ -36,7 +36,7 @@ Academy tier (from budget allocation) determines batch size, base quality mean, 
 
 Team context adjusts the ability mean by -3 to +4 based on first-team median tier.
 
-"Cantera" teams (e.g., Athletic Bilbao) only generate Spanish nationality prospects.
+"Cantera" teams (e.g., Athletic Club) only generate Spanish nationality prospects.
 
 ## Development
 

--- a/docs/game-systems/stadium-and-facilities.md
+++ b/docs/game-systems/stadium-and-facilities.md
@@ -29,7 +29,7 @@ Per-match attendance replaces annualized matchday revenue. Each fixture computes
 
 **Fan loyalty** is the stadium-occupancy stat. Its storage is split across two scales to separate editorial curation from in-game math:
 
-- **`ClubProfile.fan_loyalty`** — the curated real-world anchor on a coarse 0–10 editorial scale. 10 = iconic/cult (Athletic Bilbao, St. Pauli, Celtic), 8 = strong (Real Madrid, Union Berlin), 5 = average (the default), 4 and below = notably low-following. Deliberately low-resolution: the number is an editorial judgment, not a measurement.
+- **`ClubProfile.fan_loyalty`** — the curated real-world anchor on a coarse 0–10 editorial scale. 10 = iconic/cult (Athletic Club, St. Pauli, Celtic), 8 = strong (Real Madrid, Union Berlin), 5 = average (the default), 4 and below = notably low-following. Deliberately low-resolution: the number is an editorial judgment, not a measurement.
 - **`TeamReputation.base_loyalty`** — the seeded anchor on the 0–100 internal scale (copied from `fan_loyalty × 10` at game start). Never moves during the game. Captures cultural identity.
 - **`TeamReputation.loyalty_points`** — the current value (0–100). Starts equal to `base_loyalty` and drifts with outcomes: trophies, European nights, homegrown stars, and promotion push it up; relegation, scandals, and long-term overpricing pull it down. The finer 0–100 resolution lets small season-end nudges accumulate meaningfully. Clamped so it can't fall more than 15 points below `base_loyalty` — the "Newcastle doesn't lose its fans in the Championship" floor.
 


### PR DESCRIPTION
## Summary
Updates all references to "Athletic Bilbao" to use the club's official registered name "Athletic Club" throughout the codebase and data files.

## Key Changes
- **Database Migration**: Added migration to rename the team in the `teams` table, keyed by `transfermarkt_id` (621) for safety and idempotency
- **Seeder Updates**: Updated `ClubProfilesSeeder.php` to reference "Athletic Club" in reputation tiers and fan loyalty mappings
- **Configuration Files**: Updated team references in:
  - `TeamRegionalOrigins.php` (Basque region classification)
  - `LaLiga.php` (team colors configuration)
  - `finances.php` (AI signing exclusion list)
- **Service Layer**: Updated references in:
  - `YouthAcademyService.php` (cantera teams mapping)
  - `PlayerGeneratorService.php` (documentation)
- **Data Files**: Updated team names in:
  - `data/2025/ESP1/teams.json`
  - `data/2025/ESPCUP/teams.json`
  - `data/2025/UCL/teams.json`
- **Documentation**: Updated references in:
  - `ClubProfile.php` (fan loyalty calibration comments)
  - `Person.php` (Basque name provider documentation)
  - `academy-redesign.md` and `stadium-and-facilities.md` (game systems docs)
  - Migration file comments

## Implementation Details
- Migration uses `transfermarkt_id` as the stable identifier rather than name, making it safe to re-run and independent of the current name value
- Both `name` and `slug` fields are updated in the migration for consistency
- All references across configuration, services, seeders, and documentation have been systematically updated to maintain consistency

https://claude.ai/code/session_01KRqRkXDFKPMiCcsYXYQm1b