### PR TITLE
Implement fitness-based rotation for player team lineups

### DIFF
--- a/app/Modules/Lineup/Services/LineupService.php
+++ b/app/Modules/Lineup/Services/LineupService.php
@@ -263,6 +263,17 @@ class LineupService
     }
 
     /**
+     * True when a player's fitness is below the rotation threshold and they
+     * should be swapped out in favour of a rested alternative when possible.
+     */
+    private function isTired(GamePlayer $player): bool
+    {
+        $threshold = (int) config('player.condition.ai_rotation_threshold', 80);
+
+        return $player->fitness < $threshold;
+    }
+
+    /**
      * Select the best formation for an AI team based on squad composition.
      * Uses FormationRecommender to evaluate all formations and pick the best fit.
      */
@@ -833,7 +844,10 @@ class LineupService
         }
 
         if ($isPlayerTeam && !empty($playerPreferredLineup)) {
-            // Select lineup with preferences using pre-loaded data
+            // Select lineup with preferences using pre-loaded data. Applies
+            // fitness rotation so tired preferred starters get swapped for
+            // rested same-position subs during automated (e.g. fast-mode) runs,
+            // matching AI behaviour and preventing squad exhaustion.
             $availableIds = $availablePlayers->pluck('id')->toArray();
             $allTeamPlayers = $allPlayersGrouped !== null
                 ? $allPlayersGrouped->get($teamId, collect())
@@ -843,11 +857,13 @@ class LineupService
                 $allTeamPlayers,
                 $playerFormation,
                 $playerPreferredLineup,
-                $availableIds
+                $availableIds,
+                applyFitnessRotation: true,
             );
         } elseif ($isPlayerTeam) {
-            // Player team without preferred lineup — auto-select without fitness rotation
-            $lineup = $this->selectBestXI($availablePlayers, $playerFormation)->pluck('id')->toArray();
+            // Player team without preferred lineup — auto-select with fitness
+            // rotation so automated matchday prep doesn't burn out the squad.
+            $lineup = $this->selectBestXI($availablePlayers, $playerFormation, applyFitnessRotation: true)->pluck('id')->toArray();
         } else {
             // AI team: use squad-fitted formation with fitness rotation
             $aiFormation = $this->selectAIFormation($availablePlayers);
@@ -921,6 +937,12 @@ class LineupService
     /**
      * Select lineup using preferred players from a pre-loaded collection (no DB queries).
      *
+     * When $applyFitnessRotation is true, tired preferred starters are treated
+     * like unavailable players and swapped for rested same-position subs where
+     * possible. If the entire position group is tired, the preferred tired
+     * player is kept rather than forcing an out-of-position replacement —
+     * a tired specialist outperforms a rested player in the wrong role.
+     *
      * @param Collection $availablePlayers Players available for selection (not injured/suspended)
      * @param Collection $allTeamPlayers All team players (including unavailable) for position lookups
      */
@@ -929,31 +951,43 @@ class LineupService
         Collection $allTeamPlayers,
         ?Formation $formation,
         array $preferredLineup,
-        array $availableIds
+        array $availableIds,
+        bool $applyFitnessRotation = false,
     ): array {
         $formation = $formation ?? Formation::F_4_3_3;
-        $requirements = $formation->requirements();
 
         // Separate preferred players into available and unavailable
         $availablePreferred = [];
-        $unavailablePositionGroups = [];
+        // Each replacement slot is [positionGroup, fallbackId|null]. The fallback
+        // is the preferred player kept in reserve for the tired-but-no-sub case;
+        // it is null when the preferred player is injured/suspended (no fallback
+        // is viable in that case).
+        $replacementSlots = [];
 
         // Use all team players for lookups so we can find position groups of unavailable players
         $allPlayersById = $allTeamPlayers->keyBy('id');
 
         foreach ($preferredLineup as $playerId) {
-            if (in_array($playerId, $availableIds)) {
-                $availablePreferred[] = $playerId;
-            } else {
-                // Find the player to determine their position group for replacement
+            if (!in_array($playerId, $availableIds)) {
+                // Injured/suspended — must be replaced, no fallback available.
                 $player = $allPlayersById->get($playerId);
                 if ($player) {
-                    $unavailablePositionGroups[] = $player->position_group;
+                    $replacementSlots[] = [$player->position_group, null];
                 }
+                continue;
             }
+
+            $player = $allPlayersById->get($playerId);
+            if ($applyFitnessRotation && $player && $this->isTired($player)) {
+                // Tired — try to find a rested same-group sub, keep as fallback.
+                $replacementSlots[] = [$player->position_group, $playerId];
+                continue;
+            }
+
+            $availablePreferred[] = $playerId;
         }
 
-        // If all preferred players are available, use them
+        // If all preferred players are available and fresh, use them as-is.
         if (count($availablePreferred) === 11) {
             return $availablePreferred;
         }
@@ -965,27 +999,51 @@ class LineupService
         $remainingAvailable = $availablePlayers->filter(fn ($p) => !in_array($p->id, $lineup));
         $grouped = $remainingAvailable->groupBy(fn ($p) => $p->position_group);
 
-        // Fill gaps with best available from each missing position group
-        foreach ($unavailablePositionGroups as $positionGroup) {
+        // Sort helper — when rotating, rank by fitness-adjusted effective score
+        // so rested high-raters float to the top of the fallback lists.
+        $rankScore = $applyFitnessRotation
+            ? fn ($p) => $this->effectiveScore($p)
+            : fn ($p) => $p->overall_score;
+
+        // Fill replacement slots: prefer a rested same-position sub; fall back
+        // to the tired preferred player if no rested sub exists in that group.
+        foreach ($replacementSlots as [$positionGroup, $fallbackId]) {
             if (count($lineup) >= 11) {
                 break;
             }
 
-            $candidates = ($grouped->get($positionGroup) ?? collect())
-                ->filter(fn ($p) => !in_array($p->id, $lineup))
-                ->sortByDesc('overall_score');
+            $groupCandidates = ($grouped->get($positionGroup) ?? collect())
+                ->filter(fn ($p) => !in_array($p->id, $lineup));
 
-            $replacement = $candidates->first();
+            if ($applyFitnessRotation) {
+                // Prefer rested players in the same position group.
+                $rested = $groupCandidates->filter(fn ($p) => !$this->isTired($p))->sortByDesc($rankScore);
+                $replacement = $rested->first();
+
+                // No rested same-group sub: keep the tired preferred starter
+                // rather than pulling an out-of-position player in.
+                if (!$replacement && $fallbackId !== null && !in_array($fallbackId, $lineup)) {
+                    $lineup[] = $fallbackId;
+                    continue;
+                }
+            } else {
+                $replacement = $groupCandidates->sortByDesc($rankScore)->first();
+            }
+
             if ($replacement) {
                 $lineup[] = $replacement->id;
+            } elseif ($fallbackId !== null && !in_array($fallbackId, $lineup)) {
+                // Last-ditch: preserve the preferred player even without rotation
+                // when no same-group sub exists.
+                $lineup[] = $fallbackId;
             }
         }
 
-        // If still not 11, fill with best available from any position
+        // If still not 11, fill with best available from any position.
         if (count($lineup) < 11) {
             $remaining = $availablePlayers
                 ->filter(fn ($p) => !in_array($p->id, $lineup))
-                ->sortByDesc('overall_score');
+                ->sortByDesc($rankScore);
 
             foreach ($remaining as $player) {
                 if (count($lineup) >= 11) {

--- a/tests/Feature/LineupFitnessRotationTest.php
+++ b/tests/Feature/LineupFitnessRotationTest.php
@@ -6,6 +6,7 @@ use App\Models\Competition;
 use App\Models\Game;
 use App\Models\GameMatch;
 use App\Models\GamePlayer;
+use App\Models\GamePlayerMatchState;
 use App\Models\GameTactics;
 use App\Models\Team;
 use App\Models\User;
@@ -166,10 +167,9 @@ class LineupFitnessRotationTest extends TestCase
         $seed = $this->seedSquadWithTiredMidfielder();
 
         // Exhaust every MC we created so no rested same-position sub exists.
-        foreach ($seed['freshSubs'] as $sub) {
-            $sub->fitness = 45;
-            $sub->save();
-        }
+        // Fitness lives on the GamePlayerMatchState satellite table, not game_players.
+        GamePlayerMatchState::whereIn('game_player_id', $seed['freshSubs']->pluck('id'))
+            ->update(['fitness' => 45]);
 
         $preferred = $seed['starters']->pluck('id')->all();
         $this->setPreferredLineup($preferred);

--- a/tests/Feature/LineupFitnessRotationTest.php
+++ b/tests/Feature/LineupFitnessRotationTest.php
@@ -1,0 +1,227 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Competition;
+use App\Models\Game;
+use App\Models\GameMatch;
+use App\Models\GamePlayer;
+use App\Models\GameTactics;
+use App\Models\Team;
+use App\Models\User;
+use App\Modules\Lineup\Services\LineupService;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Covers the fast-mode fitness-rotation behaviour for the user's team. Before
+ * this change the user's saved lineup was reused verbatim each matchday,
+ * leading to exhausted starters while rested alternates sat on the bench.
+ *
+ * ensureLineupsForMatches() now treats tired preferred starters (fitness below
+ * the AI rotation threshold — 70 by default) as candidates for replacement by
+ * rested same-position subs, while still preferring a tired specialist over
+ * an out-of-position sub when the whole group is tired.
+ */
+class LineupFitnessRotationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+    private Team $playerTeam;
+    private Team $opponentTeam;
+    private Competition $competition;
+    private Game $game;
+    private GameMatch $match;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = User::factory()->create();
+        $this->playerTeam = Team::factory()->create(['name' => 'Player Team']);
+        $this->opponentTeam = Team::factory()->create(['name' => 'Opponent Team']);
+
+        $this->competition = Competition::factory()->league()->create([
+            'id' => 'ESP1',
+            'name' => 'LaLiga',
+        ]);
+
+        $this->game = Game::factory()->create([
+            'user_id' => $this->user->id,
+            'team_id' => $this->playerTeam->id,
+            'competition_id' => $this->competition->id,
+            'season' => '2024',
+            'current_date' => '2024-09-01',
+        ]);
+
+        $this->match = GameMatch::factory()->create([
+            'game_id' => $this->game->id,
+            'competition_id' => $this->competition->id,
+            'round_number' => 1,
+            'home_team_id' => $this->playerTeam->id,
+            'away_team_id' => $this->opponentTeam->id,
+            'scheduled_date' => Carbon::parse('2024-09-01'),
+            'played' => false,
+        ]);
+    }
+
+    /**
+     * Build a full 11-man squad plus named midfield subs. One preferred MC is
+     * deliberately exhausted, two same-position subs are rested; the rest of
+     * the XI is fresh.
+     *
+     * @return array{starters: \Illuminate\Support\Collection, tiredMc: GamePlayer, freshSubs: \Illuminate\Support\Collection}
+     */
+    private function seedSquadWithTiredMidfielder(array $extra = []): array
+    {
+        $starterSpec = [
+            ['position' => 'Goalkeeper', 'fitness' => 95],
+            ['position' => 'Left-Back', 'fitness' => 95],
+            ['position' => 'Centre-Back', 'fitness' => 95],
+            ['position' => 'Centre-Back', 'fitness' => 95],
+            ['position' => 'Right-Back', 'fitness' => 95],
+            ['position' => 'Central Midfield', 'fitness' => 95],
+            ['position' => 'Central Midfield', 'fitness' => 95],
+            // The exhausted preferred MC the fast-mode loop must now bench.
+            ['position' => 'Central Midfield', 'fitness' => 50, 'game_technical_ability' => 75, 'game_physical_ability' => 75],
+            ['position' => 'Left Winger', 'fitness' => 95],
+            ['position' => 'Centre-Forward', 'fitness' => 95],
+            ['position' => 'Right Winger', 'fitness' => 95],
+        ];
+
+        $starters = collect($starterSpec)->map(fn (array $attrs) => GamePlayer::factory()
+            ->forGame($this->game)
+            ->forTeam($this->playerTeam)
+            ->create(array_merge(['morale' => 80], $attrs)));
+
+        $tiredMc = $starters[7];
+
+        $freshSubs = collect([
+            GamePlayer::factory()->forGame($this->game)->forTeam($this->playerTeam)->create([
+                'position' => 'Central Midfield',
+                'fitness' => 100,
+                'game_technical_ability' => 70,
+                'game_physical_ability' => 70,
+                'morale' => 80,
+            ]),
+            GamePlayer::factory()->forGame($this->game)->forTeam($this->playerTeam)->create([
+                'position' => 'Central Midfield',
+                'fitness' => 100,
+                'game_technical_ability' => 68,
+                'game_physical_ability' => 68,
+                'morale' => 80,
+            ]),
+        ]);
+
+        return ['starters' => $starters, 'tiredMc' => $tiredMc, 'freshSubs' => $freshSubs];
+    }
+
+    private function setPreferredLineup(array $playerIds, string $formation = '4-3-3'): void
+    {
+        GameTactics::updateOrCreate(
+            ['game_id' => $this->game->id],
+            [
+                'default_formation' => $formation,
+                'default_lineup' => $playerIds,
+                'default_mentality' => 'balanced',
+                'default_playing_style' => 'balanced',
+                'default_pressing' => 'standard',
+                'default_defensive_line' => 'normal',
+            ],
+        );
+
+        $this->game->refresh();
+    }
+
+    public function test_tired_preferred_starter_is_replaced_by_rested_same_position_sub(): void
+    {
+        $seed = $this->seedSquadWithTiredMidfielder();
+        $preferred = $seed['starters']->pluck('id')->all();
+        $this->setPreferredLineup($preferred);
+
+        /** @var LineupService $service */
+        $service = app(LineupService::class);
+
+        $service->ensureLineupsForMatches(collect([$this->match]), $this->game);
+        $this->match->refresh();
+
+        $lineup = $this->match->home_lineup;
+
+        $this->assertCount(11, $lineup);
+        $this->assertNotContains($seed['tiredMc']->id, $lineup, 'Tired preferred MC should have been rotated out.');
+
+        // The rested same-group sub with the higher rating wins the slot.
+        $this->assertContains($seed['freshSubs']->first()->id, $lineup);
+
+        // Every other preferred starter is preserved.
+        foreach ($seed['starters']->reject(fn ($p) => $p->id === $seed['tiredMc']->id) as $preserved) {
+            $this->assertContains($preserved->id, $lineup, "Fresh preferred starter {$preserved->position} should remain in XI.");
+        }
+    }
+
+    public function test_tired_specialist_is_kept_when_no_rested_same_group_sub_exists(): void
+    {
+        $seed = $this->seedSquadWithTiredMidfielder();
+
+        // Exhaust every MC we created so no rested same-position sub exists.
+        foreach ($seed['freshSubs'] as $sub) {
+            $sub->fitness = 45;
+            $sub->save();
+        }
+
+        $preferred = $seed['starters']->pluck('id')->all();
+        $this->setPreferredLineup($preferred);
+
+        /** @var LineupService $service */
+        $service = app(LineupService::class);
+
+        $service->ensureLineupsForMatches(collect([$this->match]), $this->game);
+        $this->match->refresh();
+
+        $lineup = $this->match->home_lineup;
+
+        $this->assertCount(11, $lineup);
+        $this->assertContains(
+            $seed['tiredMc']->id,
+            $lineup,
+            'With no rested MC available, the tired preferred specialist must still start.',
+        );
+    }
+
+    public function test_fresh_preferred_lineup_is_preserved_as_is(): void
+    {
+        // Build an 11-man squad where everyone is well above the rotation threshold.
+        $positions = [
+            'Goalkeeper',
+            'Left-Back', 'Centre-Back', 'Centre-Back', 'Right-Back',
+            'Central Midfield', 'Central Midfield', 'Central Midfield',
+            'Left Winger', 'Centre-Forward', 'Right Winger',
+        ];
+
+        $starters = collect($positions)->map(fn (string $pos) => GamePlayer::factory()
+            ->forGame($this->game)
+            ->forTeam($this->playerTeam)
+            ->create(['position' => $pos, 'fitness' => 95, 'morale' => 80]));
+
+        // Add an alternate so we have more than 11 total; it must remain benched.
+        $alternate = GamePlayer::factory()->forGame($this->game)->forTeam($this->playerTeam)->create([
+            'position' => 'Central Midfield',
+            'fitness' => 100,
+            'morale' => 80,
+        ]);
+
+        $preferred = $starters->pluck('id')->all();
+        $this->setPreferredLineup($preferred);
+
+        /** @var LineupService $service */
+        $service = app(LineupService::class);
+
+        $service->ensureLineupsForMatches(collect([$this->match]), $this->game);
+        $this->match->refresh();
+
+        $this->assertSame($preferred, $this->match->home_lineup);
+        $this->assertNotContains($alternate->id, $this->match->home_lineup);
+    }
+}


### PR DESCRIPTION
## Summary
Adds intelligent fitness-based rotation to the lineup selection system for the player's team. Previously, saved lineups were reused verbatim each matchday, causing preferred starters to become exhausted while rested substitutes remained benched. This change applies the same rotation logic used by AI teams to the player's team during automated matchday preparation (e.g., fast-mode), preventing squad exhaustion while respecting player preferences.

## Key Changes

- **New `isTired()` method**: Determines if a player's fitness is below the AI rotation threshold (configurable, default 80) and should be considered for rotation.

- **Enhanced `selectLineupWithPreferencesFromCollection()`**: 
  - Added `$applyFitnessRotation` parameter to enable fitness-aware selection
  - Tired preferred starters are now treated as candidates for replacement rather than automatic inclusions
  - Implements a fallback mechanism: prefers rested same-position substitutes, but keeps the tired specialist if no rested alternative exists in that position group
  - Avoids forcing out-of-position players when the entire position group is tired

- **Updated `ensureTeamLineup()` logic**:
  - Player teams with preferred lineups now apply fitness rotation during automated runs
  - Player teams without preferred lineups also apply fitness rotation when auto-selecting
  - AI teams continue to use fitness rotation as before

- **Comprehensive test coverage** (`LineupFitnessRotationTest`):
  - Verifies tired preferred starters are replaced by rested same-position subs
  - Confirms tired specialists are retained when no rested alternatives exist
  - Ensures fresh preferred lineups are preserved unchanged

## Implementation Details

The rotation logic prioritizes:
1. Rested preferred starters (unchanged)
2. Rested same-position substitutes (new rotation behavior)
3. Tired preferred specialists (fallback when no rested sub exists)
4. Best available players from any position (last resort)

This approach maintains squad quality while preventing burnout during fast-mode play, matching the AI's intelligent rotation behavior.

https://claude.ai/code/session_019owGTcHTvnwqUnWEEUWNGk