### PR TITLE
Consider secondary positions when auto-selecting lineup

### DIFF
--- a/app/Modules/Lineup/Services/FormationRecommender.php
+++ b/app/Modules/Lineup/Services/FormationRecommender.php
@@ -22,6 +22,11 @@ class FormationRecommender
      *                         original slot for a less versatile unused player.
      *   Pass 4 — Weighted:    best-available fallback for slots that no natural
      *                         fit can cover.
+     *   Pass 6 — Improve:     after all slots are filled, swap any placed player
+     *                         for a higher-rated bench player who is a natural
+     *                         (compat 100) fit for that slot — catches cases
+     *                         where a high-rated versatile player was benched
+     *                         because their primary slots were saturated.
      *
      * This is the single public entry point other services should use to
      * resolve "given these players and this formation, where does each go?".
@@ -128,6 +133,7 @@ class FormationRecommender
         $this->trySwapFill($sortedSlots, $sortedPlayers, $assigned, $usedPlayerIds);
         $this->fillByWeighted($sortedSlots, $sortedPlayers, $assigned, $usedPlayerIds);
         $this->fillByForceAssignment($sortedSlots, $sortedPlayers, $assigned, $usedPlayerIds);
+        $this->improveByRating($sortedPlayers, $assigned, $usedPlayerIds);
 
         // Strip internal-only `pass` field and return sorted by original slot id.
         $result = [];
@@ -375,6 +381,71 @@ class FormationRecommender
                 $this->assignPlayer($assigned, $slot, $player, $compat, 'force');
                 $usedPlayerIds[] = $player['id'];
                 break;
+            }
+        }
+    }
+
+    /**
+     * Final pass — swap a placed player for a higher-rated bench player who is
+     * a natural (compat 100) fit for that slot. The earlier passes lock in
+     * primary-position specialists slot-by-slot, which can leave a higher-rated
+     * player on the bench when their primary slots are saturated but they
+     * would be a natural fit elsewhere via a secondary position. This pass
+     * corrects that by evicting a weaker occupant whenever a stronger natural
+     * fit is available.
+     *
+     * Manual pins are never evicted — they are the caller's explicit intent.
+     * The loop is monotonic: each swap strictly increases the sum of placed
+     * ratings, so it always terminates.
+     */
+    private function improveByRating(array $sortedPlayers, array &$assigned, array &$usedPlayerIds): void
+    {
+        $maxIterations = 22;
+        while ($maxIterations-- > 0) {
+            $swapped = false;
+
+            foreach ($assigned as $slotId => $row) {
+                if ($row['player'] === null || $row['pass'] === 'manual') {
+                    continue;
+                }
+
+                $slot = $row['slot'];
+                $occupantId = $row['player']['id'];
+                $occupantRating = $row['player']['overallScore'];
+
+                // sortedPlayers is rating-desc, so the first compat-100 candidate
+                // with a higher rating is necessarily the best swap target.
+                foreach ($sortedPlayers as $candidate) {
+                    if ($candidate['overall_score'] <= $occupantRating) {
+                        break;
+                    }
+                    if (in_array($candidate['id'], $usedPlayerIds, true)) {
+                        continue;
+                    }
+                    $compat = PositionSlotMapper::getPlayerCompatibilityScore(
+                        $candidate['position'],
+                        $candidate['secondary_positions'] ?? null,
+                        $slot['label']
+                    );
+                    if ($compat !== 100) {
+                        continue;
+                    }
+
+                    // Evict occupant, place candidate.
+                    $usedPlayerIds = array_values(array_diff($usedPlayerIds, [$occupantId]));
+                    $this->assignPlayer($assigned, $slot, $candidate, 100, 'improved');
+                    $usedPlayerIds[] = $candidate['id'];
+                    $swapped = true;
+                    break;
+                }
+
+                if ($swapped) {
+                    break;
+                }
+            }
+
+            if (! $swapped) {
+                return;
             }
         }
     }

--- a/tests/Unit/FormationRecommenderTest.php
+++ b/tests/Unit/FormationRecommenderTest.php
@@ -364,6 +364,74 @@ class FormationRecommenderTest extends TestCase
         $this->assertNotSame('CF', $orphanRow['slot']['label'], 'CF slots are already taken by higher-rated forwards');
     }
 
+    public function test_improve_pass_swaps_weaker_primary_for_stronger_secondary(): void
+    {
+        // 4-3-3: 3 CM slots, 2 CB slots.
+        //
+        // Midfielders with CB secondary (84/83) can't reach a CM slot in Pass 1
+        // because three higher-rated CM-primary players (87/86/85) saturate the
+        // midfield. CB slots get the two CB-primary players (82/80). Without
+        // the improve pass, 84 and 83 end up benched even though they'd be a
+        // natural compat-100 fit in CB and outrate the occupants.
+        $players = collect([
+            $this->player('gk', 'Goalkeeper', 75),
+            $this->player('lb', 'Left-Back', 75),
+            $this->player('rb', 'Right-Back', 75),
+            $this->player('lw', 'Left Winger', 75),
+            $this->player('rw', 'Right Winger', 75),
+            $this->player('cf', 'Centre-Forward', 75),
+            $this->player('cm1', 'Central Midfield', 87),
+            $this->player('cm2', 'Central Midfield', 86),
+            $this->player('cm3', 'Central Midfield', 85),
+            $this->player('cmCb1', 'Central Midfield', 84, ['Centre-Back']),
+            $this->player('cmCb2', 'Central Midfield', 83, ['Centre-Back']),
+            $this->player('cbWeak1', 'Centre-Back', 82),
+            $this->player('cbWeak2', 'Centre-Back', 80),
+        ]);
+
+        $bestXI = $this->recommender->bestXIFor(Formation::F_4_3_3, $players);
+        $map = $this->slotMap($bestXI);
+
+        // CB slots (ids 2, 3) must go to the higher-rated secondary-CB players.
+        $this->assertContains('cmCb1', [$map[2], $map[3]]);
+        $this->assertContains('cmCb2', [$map[2], $map[3]]);
+        $this->assertNotContains('cbWeak1', [$map[2], $map[3]]);
+        $this->assertNotContains('cbWeak2', [$map[2], $map[3]]);
+
+        // All CB placements are at compatibility 100 (via secondary).
+        foreach ($bestXI as $row) {
+            if ($row['slot']['label'] === 'CB') {
+                $this->assertSame(100, $row['compatibility']);
+            }
+        }
+    }
+
+    public function test_improve_pass_never_evicts_manual_pin(): void
+    {
+        // User pins a weaker player; improve pass must not overrule that.
+        $players = collect([
+            $this->player('gk', 'Goalkeeper', 75),
+            $this->player('lb', 'Left-Back', 75),
+            $this->player('cb1', 'Centre-Back', 75),
+            $this->player('cb2', 'Centre-Back', 75),
+            $this->player('rb', 'Right-Back', 75),
+            $this->player('cm1', 'Central Midfield', 75),
+            $this->player('cm2', 'Central Midfield', 75),
+            $this->player('cm3', 'Central Midfield', 75),
+            $this->player('lwPinned', 'Left Winger', 60),
+            $this->player('cf', 'Centre-Forward', 75),
+            $this->player('rw', 'Right Winger', 75),
+            // Bench: a far better LW that improve pass would normally swap in.
+            $this->player('lwStar', 'Left Winger', 90),
+        ]);
+
+        // Slot 8 is LW in F_4_3_3.
+        $bestXI = $this->recommender->bestXIFor(Formation::F_4_3_3, $players, [8 => 'lwPinned']);
+        $map = $this->slotMap($bestXI);
+
+        $this->assertSame('lwPinned', $map[8], 'Manual pin must survive the improve pass');
+    }
+
     public function test_getBestFormation_still_returns_a_formation_enum(): void
     {
         // Sanity: the legacy public method must keep working for its current


### PR DESCRIPTION
Add a final rating-improvement pass to FormationRecommender that swaps a placed player for a higher-rated bench player who is a natural (compat 100) fit for the slot via primary or secondary position. Fixes the case where a lower-rated primary-position player was chosen over a better secondary-position fit stuck on the bench.