### PR TITLE
Optimize sibling match simulation with statistical resolver

### DIFF
--- a/app/Modules/Match/Services/FullMatchSimulationService.php
+++ b/app/Modules/Match/Services/FullMatchSimulationService.php
@@ -60,7 +60,7 @@ class FullMatchSimulationService
         // cost; sibling AI matches in the same batch go through the fast
         // statistical AIMatchResolver (still emits goal/card events so the
         // live-match "other scores" ticker has real data).
-        $useSplit = $playerMatch && config('match_simulation.ai_resolver_for_sibling_matches', true);
+        $useSplit = $playerMatch && config('match_simulation.ai_resolver_enabled', false);
 
         $lineupMatches = $useSplit ? collect([$playerMatch]) : $matches;
         $this->lineupService->ensureLineupsForMatches($lineupMatches, $game, $allPlayers, $suspendedByCompetition, $clubProfiles);

--- a/app/Modules/Match/Services/FullMatchSimulationService.php
+++ b/app/Modules/Match/Services/FullMatchSimulationService.php
@@ -25,6 +25,7 @@ class FullMatchSimulationService
         private readonly MatchSimulator $matchSimulator,
         private readonly LineupService $lineupService,
         private readonly NotificationService $notificationService,
+        private readonly AIMatchResolver $aiMatchResolver = new AIMatchResolver,
     ) {}
 
     /**
@@ -54,10 +55,17 @@ class FullMatchSimulationService
         $clubProfiles = TeamReputation::where('game_id', $game->id)
             ->whereIn('team_id', $teamIds)->get()->keyBy('team_id');
 
-        $this->lineupService->ensureLineupsForMatches($matches, $game, $allPlayers, $suspendedByCompetition, $clubProfiles);
+        $playerMatch = $matches->first(fn ($m) => $m->involvesTeam($game->team_id));
+        // Only the user's match pays the full minute-by-minute MatchSimulator
+        // cost; sibling AI matches in the same batch go through the fast
+        // statistical AIMatchResolver (still emits goal/card events so the
+        // live-match "other scores" ticker has real data).
+        $useSplit = $playerMatch && config('match_simulation.ai_resolver_for_sibling_matches', true);
+
+        $lineupMatches = $useSplit ? collect([$playerMatch]) : $matches;
+        $this->lineupService->ensureLineupsForMatches($lineupMatches, $game, $allPlayers, $suspendedByCompetition, $clubProfiles);
 
         // --- Check for forfeit (user's team has < 7 available players) ---
-        $playerMatch = $matches->first(fn ($m) => $m->involvesTeam($game->team_id));
         $forfeitResult = null;
 
         if ($playerMatch) {
@@ -93,9 +101,26 @@ class FullMatchSimulationService
             : $matches;
 
         $matchResults = [];
-        foreach ($matchesToSimulate as $match) {
-            $suspendedForCompetition = $suspendedByCompetition[$match->competition_id] ?? [];
-            $matchResults[] = $this->simulateMatch($match, $allPlayers, $game, $fastForward, $suspendedForCompetition);
+        if ($useSplit) {
+            $userMatchToSimulate = $matchesToSimulate->first(fn ($m) => $m->id === $playerMatch->id);
+            $siblingMatches = $matchesToSimulate->reject(fn ($m) => $m->id === $playerMatch->id);
+
+            if ($userMatchToSimulate) {
+                $suspendedForCompetition = $suspendedByCompetition[$userMatchToSimulate->competition_id] ?? [];
+                $matchResults[] = $this->simulateMatch($userMatchToSimulate, $allPlayers, $game, $fastForward, $suspendedForCompetition);
+            }
+
+            if ($siblingMatches->isNotEmpty()) {
+                $matchResults = array_merge(
+                    $matchResults,
+                    $this->aiMatchResolver->resolveMatches($siblingMatches, $allPlayers, $game, $suspendedByCompetition)
+                );
+            }
+        } else {
+            foreach ($matchesToSimulate as $match) {
+                $suspendedForCompetition = $suspendedByCompetition[$match->competition_id] ?? [];
+                $matchResults[] = $this->simulateMatch($match, $allPlayers, $game, $fastForward, $suspendedForCompetition);
+            }
         }
 
         if ($forfeitResult) {

--- a/app/Modules/Match/Services/MatchdayOrchestrator.php
+++ b/app/Modules/Match/Services/MatchdayOrchestrator.php
@@ -75,6 +75,9 @@ class MatchdayOrchestrator
             while ($batch = $this->matchdayService->getNextMatchBatch($game)) {
                 // Simulate every match in the batch inline so the live-match
                 // "other scores" ticker has real sibling events to reveal.
+                // FullMatchSimulationService routes siblings through the fast
+                // statistical AIMatchResolver so only the user's match pays the
+                // full MatchSimulator cost.
                 $result = $this->processBatch($game, $batch, $fastForward);
 
                 if ($result['playerMatch']) {

--- a/config/match_simulation.php
+++ b/config/match_simulation.php
@@ -16,7 +16,10 @@ return [
     |
     | When enabled, AI-vs-AI matches use a lightweight statistical resolver
     | instead of the full MatchSimulator pipeline. This dramatically reduces
-    | CPU, memory, and database load for background batch processing.
+    | CPU, memory, and database load for background batch processing. It also
+    | applies to sibling AI matches in a player-involved batch — only the
+    | user's match runs the full simulator, siblings fast-resolve while still
+    | emitting the goal/card events the live-match ticker consumes.
     |
     | The resolver uses the same Dixon-Coles model and xG formula but skips:
     | - Full lineup generation (FormationRecommender, tactical instructions)
@@ -28,22 +31,6 @@ return [
     |
     */
     'ai_resolver_enabled' => true,
-
-    /*
-    |--------------------------------------------------------------------------
-    | Sibling AI Matches on Player-Involved Batches
-    |--------------------------------------------------------------------------
-    |
-    | When the user's team is in a matchday batch, only the user's match needs
-    | the full minute-by-minute MatchSimulator pipeline. Sibling AI matches in
-    | the same batch can be resolved statistically (same model as
-    | ai_resolver_enabled) while still emitting the goal/card events that the
-    | live-match "other scores" ticker consumes.
-    |
-    | Turn off to revert to fully simulating every match in the batch inline.
-    |
-    */
-    'ai_resolver_for_sibling_matches' => true,
 
     /*
     |--------------------------------------------------------------------------

--- a/config/match_simulation.php
+++ b/config/match_simulation.php
@@ -31,6 +31,22 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Sibling AI Matches on Player-Involved Batches
+    |--------------------------------------------------------------------------
+    |
+    | When the user's team is in a matchday batch, only the user's match needs
+    | the full minute-by-minute MatchSimulator pipeline. Sibling AI matches in
+    | the same batch can be resolved statistically (same model as
+    | ai_resolver_enabled) while still emitting the goal/card events that the
+    | live-match "other scores" ticker consumes.
+    |
+    | Turn off to revert to fully simulating every match in the batch inline.
+    |
+    */
+    'ai_resolver_for_sibling_matches' => true,
+
+    /*
+    |--------------------------------------------------------------------------
     | Expected Goals (Ratio-Based Formula)
     |--------------------------------------------------------------------------
     |


### PR DESCRIPTION
## Summary
Optimize match simulation performance by routing sibling AI matches through a fast statistical resolver when the user's team is involved in a matchday batch, while maintaining full minute-by-minute simulation only for the player's match.

## Key Changes
- **Added `AIMatchResolver` dependency** to `FullMatchSimulationService` for fast statistical match resolution
- **Implemented split simulation logic**: When a player match exists in a batch, only that match uses the full `MatchSimulator` pipeline; sibling matches are resolved statistically via `AIMatchResolver`
- **Added configuration option** `ai_resolver_for_sibling_matches` (default: `true`) to control this optimization behavior
- **Optimized lineup preparation**: Only prepare lineups for the player's match when using split simulation, reducing unnecessary database operations
- **Updated documentation** in `MatchdayOrchestrator` to clarify the new routing behavior

## Implementation Details
- The `useSplit` flag determines whether to apply the optimization based on:
  - Presence of a player match in the batch
  - Configuration setting `match_simulation.ai_resolver_for_sibling_matches`
- When split simulation is active:
  - Player match: Full minute-by-minute simulation with complete lineup preparation
  - Sibling matches: Fast statistical resolution that still emits goal/card events for the live-match ticker
- When disabled, all matches are simulated inline using the original behavior
- The optimization maintains feature parity for the live-match "other scores" ticker while reducing computational cost

https://claude.ai/code/session_012rJqV4xEakPqhKFYTFibR9