### PR TITLE
Run matchday advance inline with client-side loading overlay

### DIFF
--- a/app/Http/Actions/AdvanceMatchday.php
+++ b/app/Http/Actions/AdvanceMatchday.php
@@ -22,11 +22,15 @@ class AdvanceMatchday
             return redirect()->route('game.fast-mode', $gameId);
         }
 
-        $this->coordinator->dispatchAsync($gameId);
+        // Run inline: with sibling matches on the AIMatchResolver fast path,
+        // a full matchday advance completes sub-second, so the queue hop +
+        // 2s polling cycle cost more than the work itself. A client-side
+        // overlay in game-header shows the branded loading screen while this
+        // request is in flight. runSync returning null (another request
+        // already holds the flag) falls through to ShowGame, which renders
+        // game-loading-matchday and polls — the existing safety net.
+        $this->coordinator->runSync($gameId);
 
-        // ShowGame polls matchday_advance_result and routes onward once the
-        // job finishes. A failed claim means another request already holds
-        // the flag, which lands on the same loading screen anyway.
         return redirect()->route('show-game', $gameId);
     }
 }

--- a/resources/views/components/game-header.blade.php
+++ b/resources/views/components/game-header.blade.php
@@ -186,6 +186,7 @@
             if (this.submitting) return;
             if (localStorage.getItem('autoLineup') === '1') {
                 this.submitting = true;
+                window.dispatchEvent(new CustomEvent('matchday-advance-starting'));
                 this.$refs.autoAdvanceForm.submit();
                 return;
             }
@@ -198,6 +199,7 @@
                         return r.json().then(data => {
                             if (data.lineupReady && !this.submitting) {
                                 this.submitting = true;
+                                window.dispatchEvent(new CustomEvent('matchday-advance-starting'));
                                 this.$refs.autoAdvanceForm.submit();
                             }
                         });
@@ -270,4 +272,61 @@
 
     {{-- Mobile Bottom Tab Bar --}}
     <x-bottom-tab-bar :game="$game" :next-match="$nextMatch" :team-competitions="$teamCompetitions" />
+
+    {{-- Matchday-advance overlay. Shown instantly (client-side) on submit of any
+         form that POSTs to game.advance so the user sees the branded loading
+         screen while the HTTP request runs the advance inline. Listens for a
+         window-level "matchday-advance-starting" event dispatched by those
+         forms. If the request fails or the browser is refreshed mid-flight,
+         ShowGame still renders game-loading-matchday as the server-side
+         fallback. --}}
+    <div x-data="{ visible: false }"
+         x-show="visible"
+         x-on:matchday-advance-starting.window="visible = true"
+         x-cloak
+         style="display: none"
+         class="fixed inset-0 z-[100] bg-surface-900 flex items-start md:items-center justify-center pt-24 md:pt-0 pb-8">
+        <div class="w-full max-w-md px-4">
+            @if($nextMatch)
+                @php($comp = $nextMatch->competition)
+                <div class="text-center mb-8">
+                    <x-competition-pill :competition="$comp" class="justify-center mb-2" />
+                    <h1 class="text-lg md:text-2xl font-bold text-text-primary">
+                        @if($nextMatch->round_name)
+                            {{ __($nextMatch->round_name) }}
+                        @elseif($nextMatch->round_number)
+                            {{ __('game.matchday_n', ['number' => $nextMatch->round_number]) }}
+                        @endif
+                    </h1>
+                    <p class="text-sm text-text-muted mt-1">
+                        {{ $nextMatch->venueName() ?? '' }} &middot; {{ $nextMatch->scheduled_date->locale(app()->getLocale())->translatedFormat('d M Y') }}
+                    </p>
+                </div>
+
+                <div class="flex items-center justify-center gap-4 md:gap-8 mb-8">
+                    <div class="flex-1 flex flex-col items-center text-center min-w-0">
+                        <x-team-crest :team="$nextMatch->homeTeam" class="w-16 h-16 md:w-24 md:h-24 mb-2" />
+                        <h4 class="text-sm md:text-base font-bold text-text-primary truncate max-w-full">{{ $nextMatch->homeTeam->short_name ?? $nextMatch->homeTeam->name }}</h4>
+                    </div>
+                    <div class="shrink-0">
+                        <span class="text-lg md:text-2xl font-black text-text-body tracking-tight">{{ __('game.vs') }}</span>
+                    </div>
+                    <div class="flex-1 flex flex-col items-center text-center min-w-0">
+                        <x-team-crest :team="$nextMatch->awayTeam" class="w-16 h-16 md:w-24 md:h-24 mb-2" />
+                        <h4 class="text-sm md:text-base font-bold text-text-primary truncate max-w-full">{{ $nextMatch->awayTeam->short_name ?? $nextMatch->awayTeam->name }}</h4>
+                    </div>
+                </div>
+            @endif
+
+            <div class="text-center">
+                <div class="flex justify-center mb-3">
+                    <svg class="animate-spin h-6 w-6 text-accent-blue" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                        <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                        <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                    </svg>
+                </div>
+                <p class="text-sm text-text-secondary">{{ __('game.simulating_matches_message') }}</p>
+            </div>
+        </div>
+    </div>
 </div>

--- a/resources/views/game.blade.php
+++ b/resources/views/game.blade.php
@@ -198,7 +198,7 @@
             </div>
             <h2 class="text-3xl font-bold text-text-primary mb-2">{{ __('game.other_competitions_in_progress') }}</h2>
             <p class="text-text-muted mb-8">{{ __('game.other_competitions_desc') }}</p>
-            <form action="{{ route('game.advance', $game->id) }}" method="POST" x-data="{ submitting: false }" @submit="if (submitting) { $event.preventDefault(); return; } submitting = true">
+            <form action="{{ route('game.advance', $game->id) }}" method="POST" x-data="{ submitting: false }" @submit="if (submitting) { $event.preventDefault(); return; } submitting = true; $dispatch('matchday-advance-starting')">
                 @csrf
                 <x-primary-button color="red" x-bind:disabled="submitting">
                     {{ __('game.advance_other_matches') }}

--- a/resources/views/partials/pre-match-modal-content.blade.php
+++ b/resources/views/partials/pre-match-modal-content.blade.php
@@ -56,7 +56,7 @@
        class="flex-1 md:flex-none inline-flex items-center justify-center px-4 py-2 min-h-[44px] text-sm rounded-lg border border-border-strong font-semibold text-text-body uppercase tracking-wider hover:bg-surface-700 transition ease-in-out duration-150">
         {{ __('messages.pre_match_edit_lineup') }}
     </a>
-    <form method="post" action="{{ route('game.advance', $game->id) }}" x-data="{ loading: false }" @submit="if (loading) { $event.preventDefault(); return; } loading = true" class="flex-1 md:flex-none">
+    <form method="post" action="{{ route('game.advance', $game->id) }}" x-data="{ loading: false }" @submit="if (loading) { $event.preventDefault(); return; } loading = true; $dispatch('matchday-advance-starting')" class="flex-1 md:flex-none">
         @csrf
         <x-primary-button-spin color="blue" class="w-full md:w-auto">
             {{ __('messages.pre_match_continue') }}


### PR DESCRIPTION
With sibling AI matches on the AIMatchResolver fast path a full matchday advance now completes sub-second. Dispatching ProcessMatchdayAdvance to the Redis queue + rendering game-loading-matchday + polling game.setup-status every 2s is pure overhead: two processes, a minimum 2s delay, and no visible benefit.

Swap AdvanceMatchday to coordinator->runSync() so the orchestrator runs inline in the HTTP request. Add a full-screen branded overlay to the shared x-game-header component that shows instantly on submit of any form POSTing to game.advance — user sees team crests + competition pill
+ spinner from the moment of click until the server's redirect arrives.

Forms dispatch a window-level matchday-advance-starting CustomEvent. $dispatch handles the two Alpine-bound forms (pre-match modal and the advance-other-matches button); the hidden auto-advance form is submitted via form.submit() which bypasses the submit event, so those two paths dispatch explicitly before calling .submit().

game-loading-matchday.blade.php, GameSetupStatus, and ShowGame's isAdvancingMatchday() branch are unchanged. They remain the server-side fallback for: concurrent advance requests (flag claim fails), refresh-mid-request, stuck-flag recovery via GameSetupStatus's 2-minute timeout, and the other truly-async flows (season transition, remaining batches, career actions).

https://claude.ai/code/session_012rJqV4xEakPqhKFYTFibR9