### PR TITLE
Tournament: decouple end-of-tournament via TournamentEnded event + cleanup

### DIFF
--- a/app/Console/Commands/FinalizeStrandedTournaments.php
+++ b/app/Console/Commands/FinalizeStrandedTournaments.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Events\TournamentEnded;
+use App\Models\Game;
+use App\Models\TournamentSummary;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+
+class FinalizeStrandedTournaments extends Command
+{
+    protected $signature = 'app:finalize-stranded-tournaments {--dry-run} {--limit=}';
+
+    protected $description = 'Finalize tournament-mode games that were left in limbo (e.g. legacy fast-mode runs): dispatch TournamentEnded so snapshot/soft-delete/activation listeners run.';
+
+    public function handle(): int
+    {
+        $dryRun = (bool) $this->option('dry-run');
+        $limit = $this->option('limit') !== null ? max(1, (int) $this->option('limit')) : null;
+
+        $query = Game::query()
+            ->where('game_mode', Game::MODE_TOURNAMENT)
+            ->whereNull('deleting_at')
+            ->whereDoesntHave('matches', fn ($q) => $q->where('played', false))
+            ->whereNotExists(function ($q) {
+                $q->select(DB::raw(1))
+                    ->from('tournament_summaries')
+                    ->whereColumn('tournament_summaries.original_game_id', 'games.id');
+            });
+
+        if ($limit !== null) {
+            $query->limit($limit);
+        }
+
+        $candidates = $query->pluck('id');
+        $total = $candidates->count();
+
+        $this->info("Found {$total} stranded tournament game(s).");
+
+        if ($dryRun || $total === 0) {
+            if ($dryRun) {
+                $this->warn('Dry run — no dispatch.');
+            }
+
+            return self::SUCCESS;
+        }
+
+        $finalized = 0;
+        $skipped = 0;
+
+        foreach ($candidates as $gameId) {
+            $dispatched = DB::transaction(function () use ($gameId) {
+                $game = Game::where('id', $gameId)->lockForUpdate()->first();
+
+                if (! $game) {
+                    return false;
+                }
+
+                if ($game->deleting_at !== null) {
+                    return false;
+                }
+
+                if ($game->matches()->where('played', false)->exists()) {
+                    return false;
+                }
+
+                if (TournamentSummary::where('original_game_id', $game->id)->exists()) {
+                    return false;
+                }
+
+                TournamentEnded::dispatch($game);
+
+                return true;
+            });
+
+            if ($dispatched) {
+                $finalized++;
+            } else {
+                $skipped++;
+            }
+        }
+
+        $this->info("Finalized: {$finalized}. Skipped (raced/stale): {$skipped}.");
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Events/TournamentCompleted.php
+++ b/app/Events/TournamentCompleted.php
@@ -4,6 +4,9 @@ namespace App\Events;
 
 use Illuminate\Foundation\Events\Dispatchable;
 
+// Fires AFTER a TournamentSummary has been persisted, carrying just the
+// user id and champion flag. Distinct from TournamentEnded, which fires
+// BEFORE the snapshot and drives the snapshot/delete listener chain.
 class TournamentCompleted
 {
     use Dispatchable;

--- a/app/Events/TournamentEnded.php
+++ b/app/Events/TournamentEnded.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Events;
+
+use App\Models\Game;
+use Illuminate\Foundation\Events\Dispatchable;
+
+// Fires when the last match of a tournament-mode game is finalized, BEFORE
+// the snapshot is created or the game is soft-deleted. Listeners drive the
+// three side effects (activation record, snapshot, soft-delete) in order.
+// Distinct from TournamentCompleted, which fires AFTER the snapshot exists
+// and carries the champion flag for downstream consumers.
+class TournamentEnded
+{
+    use Dispatchable;
+
+    public function __construct(
+        public readonly Game $game,
+    ) {}
+}

--- a/app/Http/Actions/FinalizeMatch.php
+++ b/app/Http/Actions/FinalizeMatch.php
@@ -3,12 +3,9 @@
 namespace App\Http\Actions;
 
 use App\Events\SeasonCompleted;
-use App\Models\ActivationEvent;
+use App\Models\TournamentSummary;
 use App\Modules\Match\Services\MatchdayOrchestrator;
 use App\Modules\Match\Services\MatchFinalizationService;
-use App\Modules\Report\Services\TournamentSnapshotService;
-use App\Modules\Season\Services\ActivationTracker;
-use App\Modules\Season\Services\GameDeletionService;
 use App\Models\Game;
 use App\Models\GameMatch;
 use Illuminate\Http\Request;
@@ -19,9 +16,6 @@ class FinalizeMatch
     public function __construct(
         private readonly MatchFinalizationService $finalizationService,
         private readonly MatchdayOrchestrator $orchestrator,
-        private readonly ActivationTracker $activationTracker,
-        private readonly TournamentSnapshotService $snapshotService,
-        private readonly GameDeletionService $deletionService,
     ) {}
 
     public function __invoke(Request $request, string $gameId)
@@ -63,13 +57,15 @@ class FinalizeMatch
         // This covers the case where the player's match is the last match of the
         // season (e.g. promotion playoff final) — ShowGame would redirect straight
         // to season-end, bypassing AdvanceMatchday which normally fires this event.
+        // Tournament mode is handled by the TournamentEnded event chain dispatched
+        // from the DetectTournamentEnded listener on MatchFinalized.
         $hasRemainingMatches = GameMatch::where('game_id', $game->id)
             ->where('played', false)
             ->exists();
 
         if (! $hasRemainingMatches) {
             if ($game->isTournamentMode()) {
-                return $this->completeTournament($game);
+                return $this->redirectToTournamentSummary($game);
             }
 
             event(new SeasonCompleted($game));
@@ -110,15 +106,19 @@ class FinalizeMatch
             $game->refresh()->setRelations([]);
         }
 
-        return $this->completeTournament($game);
+        return $this->redirectToTournamentSummary($game);
     }
 
-    private function completeTournament(Game $game)
+    private function redirectToTournamentSummary(Game $game)
     {
-        $this->activationTracker->record($game->user_id, ActivationEvent::EVENT_TOURNAMENT_COMPLETED, $game->id, Game::MODE_TOURNAMENT);
+        $summary = TournamentSummary::where('original_game_id', $game->id)->first();
 
-        $summary = $this->snapshotService->createSnapshot($game);
-        $this->deletionService->delete($game);
+        if (! $summary) {
+            // Should not happen: the TournamentEnded listener chain persists the
+            // summary synchronously before this method runs. Fall back to the game
+            // view rather than hard-failing.
+            return redirect()->route('show-game', $game->id);
+        }
 
         return redirect()->route('tournament-summary.show', $summary->id);
     }

--- a/app/Http/Actions/SimulateTournament.php
+++ b/app/Http/Actions/SimulateTournament.php
@@ -2,20 +2,14 @@
 
 namespace App\Http\Actions;
 
-use App\Models\ActivationEvent;
+use App\Models\TournamentSummary;
 use App\Modules\Match\Services\MatchdayOrchestrator;
-use App\Modules\Report\Services\TournamentSnapshotService;
-use App\Modules\Season\Services\ActivationTracker;
-use App\Modules\Season\Services\GameDeletionService;
 use App\Models\Game;
 
 class SimulateTournament
 {
     public function __construct(
         private readonly MatchdayOrchestrator $orchestrator,
-        private readonly ActivationTracker $activationTracker,
-        private readonly TournamentSnapshotService $snapshotService,
-        private readonly GameDeletionService $deletionService,
     ) {}
 
     public function __invoke(string $gameId)
@@ -49,10 +43,14 @@ class SimulateTournament
             $game->refresh()->setRelations([]);
         }
 
-        $this->activationTracker->record($game->user_id, ActivationEvent::EVENT_TOURNAMENT_COMPLETED, $game->id, Game::MODE_TOURNAMENT);
+        // Finalization (snapshot, soft-delete, activation) happens via the
+        // TournamentEnded listener chain fired from DetectTournamentEnded on
+        // the final match's MatchFinalized event inside the orchestrator loop.
+        $summary = TournamentSummary::where('original_game_id', $game->id)->first();
 
-        $summary = $this->snapshotService->createSnapshot($game);
-        $this->deletionService->delete($game);
+        if (! $summary) {
+            return redirect()->route('show-game', $game->id);
+        }
 
         return redirect()->route('tournament-summary.show', $summary->id);
     }

--- a/app/Modules/Match/Jobs/ProcessMatchdayAdvance.php
+++ b/app/Modules/Match/Jobs/ProcessMatchdayAdvance.php
@@ -105,6 +105,13 @@ class ProcessMatchdayAdvance implements ShouldQueue, ShouldBeUnique
             return;
         }
 
+        // Tournament mode has its own end-of-run event chain (TournamentEnded →
+        // snapshot/soft-delete listeners). Suppressing SeasonCompleted here keeps
+        // behavior consistent with the live path (FinalizeMatch does the same).
+        if ($game->isTournamentMode()) {
+            return;
+        }
+
         event(new SeasonCompleted($game));
     }
 

--- a/app/Modules/Report/Listeners/CreateTournamentSnapshot.php
+++ b/app/Modules/Report/Listeners/CreateTournamentSnapshot.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Modules\Report\Listeners;
+
+use App\Events\TournamentEnded;
+use App\Models\TournamentSummary;
+use App\Modules\Report\Services\TournamentSnapshotService;
+
+class CreateTournamentSnapshot
+{
+    public function __construct(
+        private readonly TournamentSnapshotService $snapshotService,
+    ) {}
+
+    public function handle(TournamentEnded $event): void
+    {
+        $game = $event->game;
+
+        // Defensive re-check: the unique index on tournament_summaries.original_game_id
+        // is the authoritative idempotency guard, but a short-circuit here avoids
+        // doing the (expensive) summary build work twice if the detector races
+        // with another path.
+        if (TournamentSummary::where('original_game_id', $game->id)->exists()) {
+            return;
+        }
+
+        $this->snapshotService->createSnapshot($game);
+    }
+}

--- a/app/Modules/Report/Services/TournamentSnapshotService.php
+++ b/app/Modules/Report/Services/TournamentSnapshotService.php
@@ -25,6 +25,7 @@ class TournamentSnapshotService
             'user_id' => $game->user_id,
             'team_id' => $game->team_id,
             'competition_id' => $game->competition_id,
+            'original_game_id' => $game->id,
             'result_label' => $data['resultLabel'],
             'your_record' => $record,
             'summary_data' => $summaryData,

--- a/app/Modules/Season/Listeners/DetectTournamentEnded.php
+++ b/app/Modules/Season/Listeners/DetectTournamentEnded.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Modules\Season\Listeners;
+
+use App\Events\TournamentEnded;
+use App\Models\TournamentSummary;
+use App\Modules\Match\Events\MatchFinalized;
+
+class DetectTournamentEnded
+{
+    public function handle(MatchFinalized $event): void
+    {
+        $game = $event->game;
+
+        if (! $game->isTournamentMode()) {
+            return;
+        }
+
+        if ($game->deleting_at !== null) {
+            return;
+        }
+
+        $hasUnplayed = $game->matches()->where('played', false)->exists();
+
+        if ($hasUnplayed) {
+            return;
+        }
+
+        $summaryExists = TournamentSummary::where('original_game_id', $game->id)->exists();
+
+        if ($summaryExists) {
+            return;
+        }
+
+        TournamentEnded::dispatch($game);
+    }
+}

--- a/app/Modules/Season/Listeners/RecordTournamentCompletedActivation.php
+++ b/app/Modules/Season/Listeners/RecordTournamentCompletedActivation.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Modules\Season\Listeners;
+
+use App\Events\TournamentEnded;
+use App\Models\ActivationEvent;
+use App\Models\Game;
+use App\Modules\Season\Services\ActivationTracker;
+
+class RecordTournamentCompletedActivation
+{
+    public function __construct(
+        private readonly ActivationTracker $activationTracker,
+    ) {}
+
+    public function handle(TournamentEnded $event): void
+    {
+        $game = $event->game;
+
+        $this->activationTracker->record(
+            $game->user_id,
+            ActivationEvent::EVENT_TOURNAMENT_COMPLETED,
+            $game->id,
+            Game::MODE_TOURNAMENT,
+        );
+    }
+}

--- a/app/Modules/Season/Listeners/SoftDeleteCompletedTournamentGame.php
+++ b/app/Modules/Season/Listeners/SoftDeleteCompletedTournamentGame.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Modules\Season\Listeners;
+
+use App\Events\TournamentEnded;
+use App\Modules\Season\Services\GameDeletionService;
+
+class SoftDeleteCompletedTournamentGame
+{
+    public function __construct(
+        private readonly GameDeletionService $deletionService,
+    ) {}
+
+    public function handle(TournamentEnded $event): void
+    {
+        $this->deletionService->delete($event->game);
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -5,6 +5,7 @@ namespace App\Providers;
 use App\Events\SeasonCompleted;
 use App\Events\SeasonStarted;
 use App\Events\TournamentCompleted;
+use App\Events\TournamentEnded;
 use App\Models\User;
 use App\Modules\Academy\Listeners\GenerateInitialAcademyBatch;
 use App\Modules\Match\Events\CupTieResolved;
@@ -28,7 +29,11 @@ use App\Modules\Notification\Listeners\SendMatchNotifications;
 use App\Modules\Match\Listeners\UpdateGoalkeeperStats;
 use App\Modules\Match\Listeners\UpdateLeagueStandings;
 use App\Modules\Match\Listeners\UpdateManagerStats;
+use App\Modules\Report\Listeners\CreateTournamentSnapshot;
+use App\Modules\Season\Listeners\DetectTournamentEnded;
 use App\Modules\Season\Listeners\GrantCareerAccessToChampion;
+use App\Modules\Season\Listeners\RecordTournamentCompletedActivation;
+use App\Modules\Season\Listeners\SoftDeleteCompletedTournamentGame;
 use App\Modules\Squad\Listeners\CheckRecoveredPlayers;
 use App\Modules\Squad\Listeners\EnforceSquadRegistration;
 use App\Modules\Transfer\Listeners\ApplyWageGapMoraleDrip;
@@ -96,6 +101,9 @@ class AppServiceProvider extends ServiceProvider
         Event::listen(MatchFinalized::class, SendCompetitionProgressNotifications::class);
         Event::listen(MatchFinalized::class, UpdateManagerStats::class);
         Event::listen(MatchFinalized::class, EnsureMatchAttendance::class);
+        // Must run after standings/stats listeners above: the tournament snapshot
+        // it eventually triggers reads final standings and manager stats.
+        Event::listen(MatchFinalized::class, DetectTournamentEnded::class);
 
         Event::listen(CupTieResolved::class, AwardCupPrizeMoney::class);
         Event::listen(CupTieResolved::class, ConductNextCupRoundDraw::class);
@@ -105,6 +113,13 @@ class AppServiceProvider extends ServiceProvider
 
         Event::listen(SeasonCompleted::class, SimulateOtherLeagues::class);
         Event::listen(SeasonCompleted::class, RecordSeasonCompleted::class);
+
+        // Order matters: snapshot must run BEFORE soft-delete (snapshot reads many
+        // game relations). Activation is first so the analytics row exists even
+        // if the snapshot build throws.
+        Event::listen(TournamentEnded::class, RecordTournamentCompletedActivation::class);
+        Event::listen(TournamentEnded::class, CreateTournamentSnapshot::class);
+        Event::listen(TournamentEnded::class, SoftDeleteCompletedTournamentGame::class);
 
         Event::listen(TournamentCompleted::class, GrantCareerAccessToChampion::class);
 

--- a/database/migrations/2026_04_23_000001_add_original_game_id_to_tournament_summaries.php
+++ b/database/migrations/2026_04_23_000001_add_original_game_id_to_tournament_summaries.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('tournament_summaries', function (Blueprint $table) {
+            $table->uuid('original_game_id')->nullable()->unique();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('tournament_summaries', function (Blueprint $table) {
+            $table->dropUnique(['original_game_id']);
+            $table->dropColumn('original_game_id');
+        });
+    }
+};

--- a/tests/Feature/Console/FinalizeStrandedTournamentsTest.php
+++ b/tests/Feature/Console/FinalizeStrandedTournamentsTest.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace Tests\Feature\Console;
+
+use App\Events\TournamentEnded;
+use App\Models\Competition;
+use App\Models\Game;
+use App\Models\GameMatch;
+use App\Models\Team;
+use App\Models\TournamentSummary;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Event;
+use Tests\TestCase;
+
+class FinalizeStrandedTournamentsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+    private Team $team;
+    private Competition $competition;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = User::factory()->create();
+        $this->team = Team::factory()->create();
+        $this->competition = Competition::factory()->knockoutCup()->create(['id' => 'TEST_CUP']);
+    }
+
+    public function test_dispatches_tournament_ended_for_stranded_game(): void
+    {
+        $game = $this->makeStrandedTournamentGame();
+        Event::fake([TournamentEnded::class]);
+
+        $this->artisan('app:finalize-stranded-tournaments')
+            ->assertSuccessful();
+
+        Event::assertDispatched(TournamentEnded::class, fn (TournamentEnded $e) => $e->game->id === $game->id);
+    }
+
+    public function test_skips_games_with_existing_summary(): void
+    {
+        $game = $this->makeStrandedTournamentGame();
+        TournamentSummary::create([
+            'user_id' => $game->user_id,
+            'team_id' => $game->team_id,
+            'competition_id' => $this->competition->id,
+            'original_game_id' => $game->id,
+            'result_label' => 'champion',
+            'your_record' => [],
+            'summary_data' => [],
+            'tournament_date' => '2024-08-15',
+        ]);
+        Event::fake([TournamentEnded::class]);
+
+        $this->artisan('app:finalize-stranded-tournaments')->assertSuccessful();
+
+        Event::assertNotDispatched(TournamentEnded::class);
+    }
+
+    public function test_skips_soft_deleted_games(): void
+    {
+        $game = $this->makeStrandedTournamentGame();
+        $game->update(['deleting_at' => now()]);
+        Event::fake([TournamentEnded::class]);
+
+        $this->artisan('app:finalize-stranded-tournaments')->assertSuccessful();
+
+        Event::assertNotDispatched(TournamentEnded::class);
+    }
+
+    public function test_skips_games_with_unplayed_matches(): void
+    {
+        $game = $this->makeStrandedTournamentGame();
+        GameMatch::factory()
+            ->forGame($game)
+            ->forCompetition($this->competition)
+            ->create(['played' => false]);
+        Event::fake([TournamentEnded::class]);
+
+        $this->artisan('app:finalize-stranded-tournaments')->assertSuccessful();
+
+        Event::assertNotDispatched(TournamentEnded::class);
+    }
+
+    public function test_skips_career_mode_games(): void
+    {
+        $game = $this->makeStrandedTournamentGame();
+        $game->update(['game_mode' => Game::MODE_CAREER]);
+        Event::fake([TournamentEnded::class]);
+
+        $this->artisan('app:finalize-stranded-tournaments')->assertSuccessful();
+
+        Event::assertNotDispatched(TournamentEnded::class);
+    }
+
+    public function test_dry_run_does_not_dispatch(): void
+    {
+        $this->makeStrandedTournamentGame();
+        Event::fake([TournamentEnded::class]);
+
+        $this->artisan('app:finalize-stranded-tournaments', ['--dry-run' => true])->assertSuccessful();
+
+        Event::assertNotDispatched(TournamentEnded::class);
+    }
+
+    private function makeStrandedTournamentGame(): Game
+    {
+        $game = Game::factory()->create([
+            'user_id' => $this->user->id,
+            'team_id' => $this->team->id,
+            'competition_id' => $this->competition->id,
+            'game_mode' => Game::MODE_TOURNAMENT,
+        ]);
+
+        GameMatch::factory()
+            ->forGame($game)
+            ->forCompetition($this->competition)
+            ->played(1, 0)
+            ->create();
+
+        return $game;
+    }
+}

--- a/tests/Feature/ProcessMatchdayAdvanceTest.php
+++ b/tests/Feature/ProcessMatchdayAdvanceTest.php
@@ -96,6 +96,20 @@ class ProcessMatchdayAdvanceTest extends TestCase
         Event::assertNotDispatched(SeasonCompleted::class);
     }
 
+    public function test_does_not_dispatch_season_completed_for_tournament_mode(): void
+    {
+        // Tournament mode has its own end-of-run event chain (TournamentEnded).
+        // SeasonCompleted must be suppressed for tournaments in the fast path
+        // to match FinalizeMatch's live-path behavior.
+        $this->game->update(['game_mode' => Game::MODE_TOURNAMENT]);
+        $this->mockOrchestrator(MatchdayAdvanceResult::seasonComplete());
+        Event::fake([SeasonCompleted::class]);
+
+        $this->runSync();
+
+        Event::assertNotDispatched(SeasonCompleted::class);
+    }
+
     public function test_returns_null_when_advancing_flag_not_set(): void
     {
         // Job bails immediately if the caller didn't claim the flag first —

--- a/tests/Feature/Tournament/DetectTournamentEndedTest.php
+++ b/tests/Feature/Tournament/DetectTournamentEndedTest.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace Tests\Feature\Tournament;
+
+use App\Events\TournamentEnded;
+use App\Models\Competition;
+use App\Models\Game;
+use App\Models\GameMatch;
+use App\Models\Team;
+use App\Models\TournamentSummary;
+use App\Models\User;
+use App\Modules\Match\Events\MatchFinalized;
+use App\Modules\Season\Listeners\DetectTournamentEnded;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Event;
+use Tests\TestCase;
+
+class DetectTournamentEndedTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Game $game;
+    private GameMatch $finalMatch;
+    private Competition $competition;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $user = User::factory()->create();
+        $team = Team::factory()->create();
+        $this->competition = Competition::factory()->knockoutCup()->create(['id' => 'TEST_CUP']);
+
+        $this->game = Game::factory()->create([
+            'user_id' => $user->id,
+            'team_id' => $team->id,
+            'competition_id' => $this->competition->id,
+            'game_mode' => Game::MODE_TOURNAMENT,
+        ]);
+
+        $this->finalMatch = GameMatch::factory()
+            ->forGame($this->game)
+            ->forCompetition($this->competition)
+            ->played(1, 0)
+            ->create();
+    }
+
+    public function test_dispatches_tournament_ended_when_last_match_finalizes(): void
+    {
+        Event::fake([TournamentEnded::class]);
+
+        $this->handle();
+
+        Event::assertDispatched(TournamentEnded::class, function (TournamentEnded $event) {
+            return $event->game->id === $this->game->id;
+        });
+    }
+
+    public function test_does_not_dispatch_for_career_mode_games(): void
+    {
+        $this->game->update(['game_mode' => Game::MODE_CAREER]);
+        Event::fake([TournamentEnded::class]);
+
+        $this->handle();
+
+        Event::assertNotDispatched(TournamentEnded::class);
+    }
+
+    public function test_does_not_dispatch_when_unplayed_matches_remain(): void
+    {
+        GameMatch::factory()
+            ->forGame($this->game)
+            ->forCompetition($this->competition)
+            ->create(['played' => false]);
+
+        Event::fake([TournamentEnded::class]);
+
+        $this->handle();
+
+        Event::assertNotDispatched(TournamentEnded::class);
+    }
+
+    public function test_does_not_dispatch_when_summary_already_exists(): void
+    {
+        TournamentSummary::create([
+            'user_id' => $this->game->user_id,
+            'team_id' => $this->game->team_id,
+            'competition_id' => $this->competition->id,
+            'original_game_id' => $this->game->id,
+            'result_label' => 'champion',
+            'your_record' => [],
+            'summary_data' => [],
+            'tournament_date' => '2024-08-15',
+        ]);
+
+        Event::fake([TournamentEnded::class]);
+
+        $this->handle();
+
+        Event::assertNotDispatched(TournamentEnded::class);
+    }
+
+    public function test_does_not_dispatch_when_game_is_already_soft_deleted(): void
+    {
+        $this->game->update(['deleting_at' => now()]);
+
+        Event::fake([TournamentEnded::class]);
+
+        $this->handle();
+
+        Event::assertNotDispatched(TournamentEnded::class);
+    }
+
+    private function handle(): void
+    {
+        $event = new MatchFinalized($this->finalMatch, $this->game->fresh(), $this->competition);
+        (new DetectTournamentEnded())->handle($event);
+    }
+}

--- a/tests/Feature/Tournament/TournamentEndedListenersTest.php
+++ b/tests/Feature/Tournament/TournamentEndedListenersTest.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Tests\Feature\Tournament;
+
+use App\Events\TournamentEnded;
+use App\Models\ActivationEvent;
+use App\Models\Competition;
+use App\Models\Game;
+use App\Models\Team;
+use App\Models\TournamentSummary;
+use App\Models\User;
+use App\Modules\Report\Listeners\CreateTournamentSnapshot;
+use App\Modules\Report\Services\TournamentSnapshotService;
+use App\Modules\Season\Listeners\RecordTournamentCompletedActivation;
+use App\Modules\Season\Listeners\SoftDeleteCompletedTournamentGame;
+use App\Modules\Season\Services\ActivationTracker;
+use App\Modules\Season\Services\GameDeletionService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Bus;
+use Mockery;
+use Tests\TestCase;
+
+class TournamentEndedListenersTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Game $game;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $user = User::factory()->create();
+        $team = Team::factory()->create();
+        $competition = Competition::factory()->knockoutCup()->create(['id' => 'TEST_CUP']);
+
+        $this->game = Game::factory()->create([
+            'user_id' => $user->id,
+            'team_id' => $team->id,
+            'competition_id' => $competition->id,
+            'game_mode' => Game::MODE_TOURNAMENT,
+        ]);
+    }
+
+    public function test_record_activation_listener_inserts_activation_event(): void
+    {
+        $listener = new RecordTournamentCompletedActivation(app(ActivationTracker::class));
+
+        $listener->handle(new TournamentEnded($this->game));
+
+        $this->assertDatabaseHas('activation_events', [
+            'user_id' => $this->game->user_id,
+            'game_id' => $this->game->id,
+            'game_mode' => Game::MODE_TOURNAMENT,
+            'event' => ActivationEvent::EVENT_TOURNAMENT_COMPLETED,
+        ]);
+    }
+
+    public function test_create_snapshot_listener_calls_snapshot_service(): void
+    {
+        $snapshotService = Mockery::mock(TournamentSnapshotService::class);
+        $snapshotService->shouldReceive('createSnapshot')
+            ->once()
+            ->with(Mockery::on(fn (Game $g) => $g->id === $this->game->id));
+
+        $listener = new CreateTournamentSnapshot($snapshotService);
+
+        $listener->handle(new TournamentEnded($this->game));
+    }
+
+    public function test_create_snapshot_listener_skips_when_summary_already_exists(): void
+    {
+        TournamentSummary::create([
+            'user_id' => $this->game->user_id,
+            'team_id' => $this->game->team_id,
+            'competition_id' => $this->game->competition_id,
+            'original_game_id' => $this->game->id,
+            'result_label' => 'champion',
+            'your_record' => [],
+            'summary_data' => [],
+            'tournament_date' => '2024-08-15',
+        ]);
+
+        $snapshotService = Mockery::mock(TournamentSnapshotService::class);
+        $snapshotService->shouldNotReceive('createSnapshot');
+
+        $listener = new CreateTournamentSnapshot($snapshotService);
+
+        $listener->handle(new TournamentEnded($this->game));
+    }
+
+    public function test_soft_delete_listener_marks_game_deleting(): void
+    {
+        Bus::fake();
+
+        $listener = new SoftDeleteCompletedTournamentGame(app(GameDeletionService::class));
+
+        $listener->handle(new TournamentEnded($this->game));
+
+        $this->assertNotNull($this->game->refresh()->deleting_at);
+    }
+}


### PR DESCRIPTION
Tournament-end side effects (activation, snapshot, soft-delete) were hardcoded in FinalizeMatch/SimulateTournament, so the legacy fast-mode path bypassed them entirely — stranded tournament games in DB.

Moves the three effects behind a sync TournamentEnded event fired from a DetectTournamentEnded listener on MatchFinalized, which both live and fast paths already reach via MatchFinalizationService::finalize. Adds original_game_id (unique) to tournament_summaries as the idempotency and redirect-lookup key, and an app:finalize-stranded-tournaments command to reconcile historical stranded games.