### PR TITLE
Add performance history chart to club reputation page

### DIFF
--- a/app/Console/Commands/BackfillSeasonArchiveCompetitionIds.php
+++ b/app/Console/Commands/BackfillSeasonArchiveCompetitionIds.php
@@ -1,0 +1,148 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Competition;
+use App\Models\SeasonArchive;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Writes `competition_id` onto every row in `season_archives.final_standings`
+ * so the league tier of each archived season can be read without scanning
+ * match_results. Idempotent: rows already carrying the field are skipped
+ * at the database level.
+ *
+ * Memory strategy: archives can be large (player_season_stats + match_results
+ * are the heavy blobs). We only select the three JSON fields we need, and
+ * we walk the table with small chunkById() pages so memory stays bounded
+ * regardless of table size.
+ */
+class BackfillSeasonArchiveCompetitionIds extends Command
+{
+    protected $signature = 'app:backfill-season-archive-competition-ids
+                            {--chunk=50 : Rows loaded into memory per page}
+                            {--dry-run : Report what would change without writing}';
+
+    protected $description = 'Backfill competition_id onto season_archives.final_standings rows.';
+
+    public function handle(): int
+    {
+        $chunkSize = max(1, (int) $this->option('chunk'));
+        $dryRun = (bool) $this->option('dry-run');
+
+        // League competitions form a small reference set (a dozen or so rows).
+        // Load them once and key by id so each archive resolution is O(1).
+        $leagueCompetitionIds = Competition::where('role', Competition::ROLE_LEAGUE)
+            ->pluck('id')
+            ->flip();
+
+        // Skip archives whose first standings row already carries competition_id.
+        // Filtering in SQL avoids decoding JSON blobs for already-backfilled rows
+        // on re-runs, which matters on a large table.
+        $baseQuery = SeasonArchive::query()
+            ->whereRaw("(final_standings->0->>'competition_id') IS NULL");
+
+        $total = (clone $baseQuery)->count();
+
+        if ($total === 0) {
+            $this->info('No archives require backfill.');
+
+            return self::SUCCESS;
+        }
+
+        $this->info(sprintf(
+            'Backfilling %d season archives (chunk=%d%s)…',
+            $total,
+            $chunkSize,
+            $dryRun ? ', dry-run' : '',
+        ));
+
+        $bar = $this->output->createProgressBar($total);
+        $bar->start();
+
+        $updated = 0;
+        $unresolved = 0;
+        $empty = 0;
+
+        // select() trims out the heavy JSON columns we don't need (player_season_stats,
+        // season_awards, transfer_activity, transition_log), keeping per-page memory low.
+        $baseQuery
+            ->select(['id', 'final_standings', 'match_results'])
+            ->chunkById($chunkSize, function ($chunk) use (
+                &$updated, &$unresolved, &$empty, $leagueCompetitionIds, $dryRun, $bar
+            ) {
+                foreach ($chunk as $archive) {
+                    $standings = $archive->final_standings ?? [];
+
+                    if (empty($standings)) {
+                        $empty++;
+                        $bar->advance();
+                        continue;
+                    }
+
+                    $leagueId = $this->resolveLeagueId($archive, $leagueCompetitionIds);
+
+                    if (!$leagueId) {
+                        $unresolved++;
+                        $bar->advance();
+                        continue;
+                    }
+
+                    foreach ($standings as &$row) {
+                        $row['competition_id'] = $leagueId;
+                    }
+                    unset($row);
+
+                    if (!$dryRun) {
+                        SeasonArchive::where('id', $archive->id)
+                            ->update(['final_standings' => $standings]);
+                    }
+
+                    $updated++;
+                    $bar->advance();
+                }
+
+                // JSON decoding leaves large transient arrays behind; nudge the
+                // collector between pages so long runs don't fragment memory.
+                unset($chunk);
+                gc_collect_cycles();
+            });
+
+        $bar->finish();
+        $this->newLine(2);
+
+        $this->info(sprintf(
+            'Done. Updated: %d, Unresolved: %d, Empty standings: %d%s',
+            $updated,
+            $unresolved,
+            $empty,
+            $dryRun ? ' (dry-run — no rows written)' : '',
+        ));
+
+        if ($unresolved > 0) {
+            $this->warn('Unresolved archives had no league competition_id in match_results; they may be from pre-league-handler games or lacking match data.');
+        }
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * Find the league competition_id for an archive by scanning its
+     * match_results for the first entry whose competition_id belongs to
+     * a league. Uses a flipped id map for O(1) membership checks.
+     *
+     * @param  \Illuminate\Support\Collection<string, int>  $leagueCompetitionIds
+     */
+    private function resolveLeagueId(SeasonArchive $archive, $leagueCompetitionIds): ?string
+    {
+        foreach ($archive->match_results ?? [] as $match) {
+            $cid = $match['competition_id'] ?? null;
+            if ($cid !== null && $leagueCompetitionIds->has($cid)) {
+                return $cid;
+            }
+        }
+
+        return null;
+    }
+}

--- a/app/Console/Commands/BackfillSeasonArchiveCompetitionIds.php
+++ b/app/Console/Commands/BackfillSeasonArchiveCompetitionIds.php
@@ -5,7 +5,6 @@ namespace App\Console\Commands;
 use App\Models\Competition;
 use App\Models\SeasonArchive;
 use Illuminate\Console\Command;
-use Illuminate\Support\Facades\DB;
 
 /**
  * Writes `competition_id` onto every row in `season_archives.final_standings`

--- a/app/Http/Views/ShowClubReputation.php
+++ b/app/Http/Views/ShowClubReputation.php
@@ -4,6 +4,7 @@ namespace App\Http\Views;
 
 use App\Models\Game;
 use App\Modules\Manager\Services\CareerSummaryService;
+use App\Modules\Manager\Services\PerformanceHistoryService;
 use App\Modules\Reputation\Services\ReputationSummaryService;
 
 class ShowClubReputation
@@ -11,6 +12,7 @@ class ShowClubReputation
     public function __construct(
         private readonly ReputationSummaryService $reputationSummaryService,
         private readonly CareerSummaryService $careerSummaryService,
+        private readonly PerformanceHistoryService $performanceHistoryService,
     ) {}
 
     public function __invoke(string $gameId)
@@ -22,6 +24,7 @@ class ShowClubReputation
             'game' => $game,
             'summary' => $this->reputationSummaryService->build($game),
             'career' => $this->careerSummaryService->build($game, (int) auth()->id()),
+            'history' => $this->performanceHistoryService->build($game),
         ]);
     }
 }

--- a/app/Jobs/DeleteGameJob.php
+++ b/app/Jobs/DeleteGameJob.php
@@ -3,6 +3,7 @@
 namespace App\Jobs;
 
 use App\Models\Game;
+use App\Modules\Manager\Services\PerformanceHistoryService;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
@@ -33,6 +34,7 @@ class DeleteGameJob implements ShouldQueue
         }
 
         Cache::forget("game_owner:{$this->gameId}");
+        PerformanceHistoryService::forget($this->gameId);
 
         // Collect generated player IDs before we delete game_players
         $generatedPlayerIds = DB::table('game_players')

--- a/app/Modules/Manager/Services/PerformanceHistoryService.php
+++ b/app/Modules/Manager/Services/PerformanceHistoryService.php
@@ -36,10 +36,17 @@ class PerformanceHistoryService
             ->orderBy('season')
             ->get();
 
-        // Collect every competition id referenced by any archive's match_results,
-        // plus the game's current competition, so we can resolve tiers in a single query.
+        // Collect every competition id referenced by any archive (final_standings
+        // carries it on backfilled archives; match_results is the fallback for
+        // legacy archives), plus the game's current competition, so we can
+        // resolve tiers in a single query.
         $competitionIds = [];
         foreach ($archives as $archive) {
+            foreach ($archive->final_standings ?? [] as $row) {
+                if (!empty($row['competition_id'])) {
+                    $competitionIds[$row['competition_id']] = true;
+                }
+            }
             foreach ($archive->match_results ?? [] as $match) {
                 if (!empty($match['competition_id'])) {
                     $competitionIds[$match['competition_id']] = true;
@@ -62,7 +69,7 @@ class PerformanceHistoryService
                 continue;
             }
 
-            $leagueCompetition = $this->resolveLeagueCompetition($archive, $competitions);
+            $leagueCompetition = $this->resolveLeagueCompetition($archive, $teamRow, $competitions);
             if (!$leagueCompetition) {
                 continue;
             }
@@ -121,19 +128,32 @@ class PerformanceHistoryService
     }
 
     /**
-     * Find the league competition for a given archive by scanning its
-     * match_results for the first competition_id that resolves to a league.
-     * GameStanding (and therefore final_standings) only exists for the
-     * league tier the user's team played in that season, so any league id
-     * appearing in match_results is the right one.
+     * Resolve the league Competition for a season archive.
      *
+     * Newer archives denormalize `competition_id` onto every final_standings
+     * row (see SeasonArchiveProcessor::captureStandings), so we use the user
+     * team's row directly when available. For legacy archives written before
+     * that change, we fall back to scanning match_results for the first
+     * competition_id that resolves to a league — GameStanding only exists
+     * for the league tier the user's team played, so any league id present
+     * in their match history is the correct one.
+     *
+     * @param  array<string, mixed>  $teamRow
      * @param  \Illuminate\Support\Collection<string, Competition>  $competitions
      */
-    private function resolveLeagueCompetition(SeasonArchive $archive, $competitions): ?Competition
+    private function resolveLeagueCompetition(SeasonArchive $archive, array $teamRow, $competitions): ?Competition
     {
+        $directId = $teamRow['competition_id'] ?? null;
+        if ($directId) {
+            $competition = $competitions->get($directId);
+            if ($competition && $competition->role === Competition::ROLE_LEAGUE) {
+                return $competition;
+            }
+        }
+
         foreach ($archive->match_results ?? [] as $match) {
             $competition = $competitions->get($match['competition_id'] ?? null);
-            if ($competition && $competition->isLeague() && $competition->role === Competition::ROLE_LEAGUE) {
+            if ($competition && $competition->role === Competition::ROLE_LEAGUE) {
                 return $competition;
             }
         }

--- a/app/Modules/Manager/Services/PerformanceHistoryService.php
+++ b/app/Modules/Manager/Services/PerformanceHistoryService.php
@@ -6,15 +6,26 @@ use App\Models\Competition;
 use App\Models\Game;
 use App\Models\GameStanding;
 use App\Models\SeasonArchive;
+use Illuminate\Support\Facades\Cache;
 
 /**
  * Builds the "performance history" strip shown on the Reputation page:
  * one final league position per completed season plus the current season
  * "so far", with the league tier captured so promotion/relegation
  * transitions can be rendered correctly.
+ *
+ * Caching: the archived-seasons portion reads every SeasonArchive row for
+ * the game, which holds large JSON blobs. That portion only changes when
+ * SeasonArchiveProcessor writes a new row at season close, so it is
+ * cached per-game with a long TTL and invalidated explicitly from the
+ * processor (see self::forget). The current in-progress season is
+ * resolved fresh on every call from GameStanding, which is cheap.
  */
 class PerformanceHistoryService
 {
+    /** Long TTL acts as a safety net — primary invalidation is explicit. */
+    private const CACHE_TTL = 604800; // 7 days
+
     /**
      * @return array{
      *   seasons: array<int, array{
@@ -32,14 +43,77 @@ class PerformanceHistoryService
      */
     public function build(Game $game): array
     {
+        $archivedSeasons = $this->getArchivedSeasons($game);
+        $currentSeason = $this->buildCurrentSeason($game);
+
+        $seasons = $currentSeason !== null
+            ? [...$archivedSeasons, $currentSeason]
+            : $archivedSeasons;
+
+        $this->markTierTransitions($seasons);
+
+        $tiersPresent = array_values(array_unique(array_map(
+            fn (array $row) => $row['tier'],
+            $seasons,
+        )));
+        sort($tiersPresent);
+
+        return [
+            'seasons' => $seasons,
+            'tiers_present' => $tiersPresent,
+        ];
+    }
+
+    public static function cacheKey(string $gameId): string
+    {
+        return "performance_history:archived:{$gameId}";
+    }
+
+    /**
+     * Drop the cached archived-seasons shape for a game. Call this after
+     * any write to season_archives for the game (season close, admin
+     * corrections). New archives trigger this from SeasonArchiveProcessor.
+     */
+    public static function forget(string $gameId): void
+    {
+        Cache::forget(self::cacheKey($gameId));
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private function getArchivedSeasons(Game $game): array
+    {
+        return Cache::remember(
+            self::cacheKey($game->id),
+            self::CACHE_TTL,
+            fn () => $this->buildArchivedSeasons($game),
+        );
+    }
+
+    /**
+     * Heavy path: reads every SeasonArchive row for the game, shapes one
+     * entry per archived season. Only runs on cache miss.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    private function buildArchivedSeasons(Game $game): array
+    {
+        // Skip the heavy JSON columns we don't need here
+        // (player_season_stats, season_awards, transfer_activity,
+        // transition_log) so cache misses stay memory-light.
         $archives = SeasonArchive::where('game_id', $game->id)
+            ->select(['id', 'season', 'final_standings', 'match_results'])
             ->orderBy('season')
             ->get();
 
+        if ($archives->isEmpty()) {
+            return [];
+        }
+
         // Collect every competition id referenced by any archive (final_standings
         // carries it on backfilled archives; match_results is the fallback for
-        // legacy archives), plus the game's current competition, so we can
-        // resolve tiers in a single query.
+        // legacy archives) so we can resolve tiers in a single query.
         $competitionIds = [];
         foreach ($archives as $archive) {
             foreach ($archive->final_standings ?? [] as $row) {
@@ -53,14 +127,12 @@ class PerformanceHistoryService
                 }
             }
         }
-        $competitionIds[$game->competition_id] = true;
 
         $competitions = Competition::whereIn('id', array_keys($competitionIds))
             ->get()
             ->keyBy('id');
 
         $seasons = [];
-
         foreach ($archives as $archive) {
             $teamRow = collect($archive->final_standings ?? [])
                 ->firstWhere('team_id', $game->team_id);
@@ -86,44 +158,44 @@ class PerformanceHistoryService
             ];
         }
 
-        // Trailing in-progress season: only include if the current league has
-        // seen a standing row for the user's team (i.e. at least one matchday
-        // has been played — otherwise the point would read as "1st" on day 1).
+        return $seasons;
+    }
+
+    /**
+     * Trailing in-progress season. Cheap (two GameStanding queries + one
+     * Competition lookup), recomputed every call so the point updates as
+     * the user plays matches. Returns null before the first match of the
+     * season is played — otherwise the point would read as "1st" on day 1.
+     */
+    private function buildCurrentSeason(Game $game): ?array
+    {
         $currentStanding = GameStanding::where('game_id', $game->id)
             ->where('competition_id', $game->competition_id)
             ->where('team_id', $game->team_id)
             ->first();
 
-        $currentCompetition = $competitions->get($game->competition_id);
-
-        if ($currentStanding && $currentStanding->played > 0 && $currentCompetition) {
-            $currentTeamCount = GameStanding::where('game_id', $game->id)
-                ->where('competition_id', $game->competition_id)
-                ->count();
-
-            $seasons[] = [
-                'season' => $game->season,
-                'position' => (int) $currentStanding->position,
-                'tier' => (int) $currentCompetition->tier,
-                'team_count' => $currentTeamCount,
-                'league_short_name' => $currentCompetition->shortName(),
-                'promoted' => false,
-                'relegated' => false,
-                'is_current' => true,
-            ];
+        if (!$currentStanding || $currentStanding->played <= 0) {
+            return null;
         }
 
-        $this->markTierTransitions($seasons);
+        $currentCompetition = Competition::find($game->competition_id);
+        if (!$currentCompetition) {
+            return null;
+        }
 
-        $tiersPresent = array_values(array_unique(array_map(
-            fn (array $row) => $row['tier'],
-            $seasons,
-        )));
-        sort($tiersPresent);
+        $currentTeamCount = GameStanding::where('game_id', $game->id)
+            ->where('competition_id', $game->competition_id)
+            ->count();
 
         return [
-            'seasons' => $seasons,
-            'tiers_present' => $tiersPresent,
+            'season' => $game->season,
+            'position' => (int) $currentStanding->position,
+            'tier' => (int) $currentCompetition->tier,
+            'team_count' => $currentTeamCount,
+            'league_short_name' => $currentCompetition->shortName(),
+            'promoted' => false,
+            'relegated' => false,
+            'is_current' => true,
         ];
     }
 

--- a/app/Modules/Manager/Services/PerformanceHistoryService.php
+++ b/app/Modules/Manager/Services/PerformanceHistoryService.php
@@ -1,0 +1,160 @@
+<?php
+
+namespace App\Modules\Manager\Services;
+
+use App\Models\Competition;
+use App\Models\Game;
+use App\Models\GameStanding;
+use App\Models\SeasonArchive;
+
+/**
+ * Builds the "performance history" strip shown on the Reputation page:
+ * one final league position per completed season plus the current season
+ * "so far", with the league tier captured so promotion/relegation
+ * transitions can be rendered correctly.
+ */
+class PerformanceHistoryService
+{
+    /**
+     * @return array{
+     *   seasons: array<int, array{
+     *     season:string,
+     *     position:int,
+     *     tier:int,
+     *     team_count:int,
+     *     league_short_name:string,
+     *     promoted:bool,
+     *     relegated:bool,
+     *     is_current:bool,
+     *   }>,
+     *   tiers_present: array<int, int>,
+     * }
+     */
+    public function build(Game $game): array
+    {
+        $archives = SeasonArchive::where('game_id', $game->id)
+            ->orderBy('season')
+            ->get();
+
+        // Collect every competition id referenced by any archive's match_results,
+        // plus the game's current competition, so we can resolve tiers in a single query.
+        $competitionIds = [];
+        foreach ($archives as $archive) {
+            foreach ($archive->match_results ?? [] as $match) {
+                if (!empty($match['competition_id'])) {
+                    $competitionIds[$match['competition_id']] = true;
+                }
+            }
+        }
+        $competitionIds[$game->competition_id] = true;
+
+        $competitions = Competition::whereIn('id', array_keys($competitionIds))
+            ->get()
+            ->keyBy('id');
+
+        $seasons = [];
+
+        foreach ($archives as $archive) {
+            $teamRow = collect($archive->final_standings ?? [])
+                ->firstWhere('team_id', $game->team_id);
+
+            if (!$teamRow) {
+                continue;
+            }
+
+            $leagueCompetition = $this->resolveLeagueCompetition($archive, $competitions);
+            if (!$leagueCompetition) {
+                continue;
+            }
+
+            $seasons[] = [
+                'season' => $archive->season,
+                'position' => (int) $teamRow['position'],
+                'tier' => (int) $leagueCompetition->tier,
+                'team_count' => count($archive->final_standings ?? []),
+                'league_short_name' => $leagueCompetition->shortName(),
+                'promoted' => false,
+                'relegated' => false,
+                'is_current' => false,
+            ];
+        }
+
+        // Trailing in-progress season: only include if the current league has
+        // seen a standing row for the user's team (i.e. at least one matchday
+        // has been played — otherwise the point would read as "1st" on day 1).
+        $currentStanding = GameStanding::where('game_id', $game->id)
+            ->where('competition_id', $game->competition_id)
+            ->where('team_id', $game->team_id)
+            ->first();
+
+        $currentCompetition = $competitions->get($game->competition_id);
+
+        if ($currentStanding && $currentStanding->played > 0 && $currentCompetition) {
+            $currentTeamCount = GameStanding::where('game_id', $game->id)
+                ->where('competition_id', $game->competition_id)
+                ->count();
+
+            $seasons[] = [
+                'season' => $game->season,
+                'position' => (int) $currentStanding->position,
+                'tier' => (int) $currentCompetition->tier,
+                'team_count' => $currentTeamCount,
+                'league_short_name' => $currentCompetition->shortName(),
+                'promoted' => false,
+                'relegated' => false,
+                'is_current' => true,
+            ];
+        }
+
+        $this->markTierTransitions($seasons);
+
+        $tiersPresent = array_values(array_unique(array_map(
+            fn (array $row) => $row['tier'],
+            $seasons,
+        )));
+        sort($tiersPresent);
+
+        return [
+            'seasons' => $seasons,
+            'tiers_present' => $tiersPresent,
+        ];
+    }
+
+    /**
+     * Find the league competition for a given archive by scanning its
+     * match_results for the first competition_id that resolves to a league.
+     * GameStanding (and therefore final_standings) only exists for the
+     * league tier the user's team played in that season, so any league id
+     * appearing in match_results is the right one.
+     *
+     * @param  \Illuminate\Support\Collection<string, Competition>  $competitions
+     */
+    private function resolveLeagueCompetition(SeasonArchive $archive, $competitions): ?Competition
+    {
+        foreach ($archive->match_results ?? [] as $match) {
+            $competition = $competitions->get($match['competition_id'] ?? null);
+            if ($competition && $competition->isLeague() && $competition->role === Competition::ROLE_LEAGUE) {
+                return $competition;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param  array<int, array<string, mixed>>  $seasons  (by reference)
+     */
+    private function markTierTransitions(array &$seasons): void
+    {
+        for ($i = 1; $i < count($seasons); $i++) {
+            $prevTier = $seasons[$i - 1]['tier'];
+            $currTier = $seasons[$i]['tier'];
+
+            if ($currTier < $prevTier) {
+                $seasons[$i]['promoted'] = true;
+            } elseif ($currTier > $prevTier) {
+                $seasons[$i]['relegated'] = true;
+            }
+        }
+    }
+}

--- a/app/Modules/Season/Processors/SeasonArchiveProcessor.php
+++ b/app/Modules/Season/Processors/SeasonArchiveProcessor.php
@@ -141,6 +141,7 @@ class SeasonArchiveProcessor implements SeasonProcessor
                 return [
                     'team_id' => $standing->team_id,
                     'team_name' => $standing->team->name ?? 'Unknown',
+                    'competition_id' => $standing->competition_id,
                     'position' => $standing->position,
                     'played' => $standing->played,
                     'won' => $standing->won,

--- a/app/Modules/Season/Processors/SeasonArchiveProcessor.php
+++ b/app/Modules/Season/Processors/SeasonArchiveProcessor.php
@@ -5,6 +5,7 @@ namespace App\Modules\Season\Processors;
 use App\Modules\Season\Contracts\SeasonProcessor;
 use App\Modules\Season\DTOs\SeasonTransitionData;
 use App\Modules\Competition\Services\SwissKnockoutGenerator;
+use App\Modules\Manager\Services\PerformanceHistoryService;
 use App\Models\CompetitionEntry;
 use App\Models\CupTie;
 use App\Models\Game;
@@ -73,6 +74,10 @@ class SeasonArchiveProcessor implements SeasonProcessor
             'match_results' => $matchResults,
             'transfer_activity' => $transferActivity,
         ]);
+
+        // Bust the cached archived-seasons shape so the Reputation page
+        // reflects the new season on the next page load.
+        PerformanceHistoryService::forget($game->id);
 
         // Delete archived data to free up space
         $this->deleteArchivedData($game);

--- a/app/Modules/Season/Services/GameDeletionService.php
+++ b/app/Modules/Season/Services/GameDeletionService.php
@@ -4,6 +4,7 @@ namespace App\Modules\Season\Services;
 
 use App\Jobs\DeleteGameJob;
 use App\Models\Game;
+use App\Modules\Manager\Services\PerformanceHistoryService;
 use Illuminate\Support\Facades\Cache;
 
 class GameDeletionService
@@ -15,6 +16,7 @@ class GameDeletionService
         }
 
         Cache::forget("game_owner:{$game->id}");
+        PerformanceHistoryService::forget($game->id);
 
         $game->update(['deleting_at' => now()]);
 

--- a/lang/en/club.php
+++ b/lang/en/club.php
@@ -80,6 +80,17 @@ return [
             'setback' => 'Setback',
         ],
 
+        'history' => [
+            'title' => 'Performance history',
+            'empty' => 'Your performance history will appear at the end of your first season.',
+            'current_suffix' => '(so far)',
+            'promoted' => 'Promotion',
+            'relegated' => 'Relegation',
+            'legend' => [
+                'same_tier' => 'Same tier',
+            ],
+        ],
+
         'impact_title' => 'What reputation means for your club',
         'impact_signings_title' => 'Attracting signings',
         'impact_signings_body' => 'Higher-profile players are more willing to join more reputable clubs. Free agents, transfer targets and rival sellers all weigh your standing before sitting down to negotiate.',

--- a/lang/es/club.php
+++ b/lang/es/club.php
@@ -80,6 +80,17 @@ return [
             'setback' => 'Retroceso',
         ],
 
+        'history' => [
+            'title' => 'Historial de rendimiento',
+            'empty' => 'Tu historial aparecerá al final de la primera temporada.',
+            'current_suffix' => '(en curso)',
+            'promoted' => 'Ascenso',
+            'relegated' => 'Descenso',
+            'legend' => [
+                'same_tier' => 'Misma categoría',
+            ],
+        ],
+
         'impact_title' => 'Qué aporta la reputación a tu club',
         'impact_signings_title' => 'Atraer fichajes',
         'impact_signings_body' => 'Los jugadores de mayor nivel se inclinan por clubes con más reputación. Agentes libres, objetivos de traspaso y clubes rivales valoran tu nivel antes de sentarse a negociar.',

--- a/resources/views/club/reputation.blade.php
+++ b/resources/views/club/reputation.blade.php
@@ -2,6 +2,7 @@
 /** @var App\Models\Game $game */
 /** @var array $summary */
 /** @var array $career */
+/** @var array $history */
 
 $currentLevel = $summary['current_level'];
 $tierIndex = $summary['tier_index'];
@@ -107,6 +108,27 @@ $tierMaintenanceApplies = $summary['tier_maintenance_applies'] ?? false;
                         <p class="text-xs text-text-muted mt-3 leading-relaxed">{{ __('club.reputation.path_also') }}</p>
                         @if($tierMaintenanceApplies)
                             <p class="text-xs text-text-muted mt-1 leading-relaxed">{{ __('club.reputation.maintenance_note') }}</p>
+                        @endif
+                    </div>
+                </x-section-card>
+
+                {{-- Performance history: final league position per season, with tier bands
+                     so promotions and relegations are visually distinct. --}}
+                <x-section-card :title="__('club.reputation.history.title')">
+                    <div class="px-5 py-4">
+                        @if (empty($history['seasons']))
+                            <p class="text-sm text-text-muted leading-relaxed">{{ __('club.reputation.history.empty') }}</p>
+                        @else
+                            <x-performance-history-chart
+                                :seasons="$history['seasons']"
+                                :tiers-present="$history['tiers_present']"
+                            />
+
+                            <div class="flex flex-wrap items-center gap-x-4 gap-y-1 mt-3 text-[11px] text-text-muted">
+                                <span class="flex items-center gap-1.5"><span class="w-2.5 h-2.5 rounded-sm bg-accent-blue"></span>{{ __('club.reputation.history.legend.same_tier') }}</span>
+                                <span class="flex items-center gap-1.5"><span class="w-2.5 h-2.5 rounded-sm bg-accent-green"></span>{{ __('club.reputation.history.promoted') }}</span>
+                                <span class="flex items-center gap-1.5"><span class="w-2.5 h-2.5 rounded-sm bg-accent-red"></span>{{ __('club.reputation.history.relegated') }}</span>
+                            </div>
                         @endif
                     </div>
                 </x-section-card>

--- a/resources/views/components/performance-history-chart.blade.php
+++ b/resources/views/components/performance-history-chart.blade.php
@@ -1,0 +1,232 @@
+@props([
+    'seasons' => [],
+    'tiersPresent' => [],
+])
+
+@php
+    if (empty($seasons) || empty($tiersPresent)) {
+        return;
+    }
+
+    // --- Layout (SVG user units) ---
+    // Width scales to container via viewBox; we give each season a fixed slot
+    // so long histories get a horizontal scroll container rather than cramming.
+    $slotWidth = 56;
+    $leftGutter = 44;   // room for tier labels
+    $rightGutter = 12;
+    $topPadding = 14;
+    $bottomGutter = 22; // room for season labels
+    $bandHeight = 84;
+    $bandGap = 10;
+
+    $bandCount = count($tiersPresent);
+    $plotHeight = $bandCount * $bandHeight + max(0, $bandCount - 1) * $bandGap;
+    $plotWidth = count($seasons) * $slotWidth;
+    $svgWidth = $leftGutter + $plotWidth + $rightGutter;
+    $svgHeight = $topPadding + $plotHeight + $bottomGutter;
+
+    // Map tier -> band top Y coordinate (higher tier = higher on chart = smaller Y).
+    $tiersAsc = $tiersPresent; // already sorted ascending (tier 1 first)
+    $bandTopByTier = [];
+    foreach ($tiersAsc as $idx => $tier) {
+        $bandTopByTier[$tier] = $topPadding + $idx * ($bandHeight + $bandGap);
+    }
+
+    // Convert a (season slot index, position, tier, team_count) into (x, y).
+    $pointFor = function (int $slotIndex, int $position, int $tier, int $teamCount) use (
+        $leftGutter, $slotWidth, $bandTopByTier, $bandHeight
+    ) {
+        $x = $leftGutter + $slotWidth * $slotIndex + $slotWidth / 2;
+        $bandTop = $bandTopByTier[$tier] ?? $bandTopByTier[array_key_first($bandTopByTier)];
+        // Position 1 at top of band, team_count at bottom. Guard div-by-zero.
+        $denominator = max(1, $teamCount - 1);
+        $normalized = max(0, min(1, ($position - 1) / $denominator));
+        $y = $bandTop + $normalized * $bandHeight;
+        return [round($x, 2), round($y, 2)];
+    };
+
+    // Precompute point coords and enrich season rows with an x/y pair for Alpine.
+    $points = [];
+    foreach (array_values($seasons) as $i => $row) {
+        [$x, $y] = $pointFor($i, $row['position'], $row['tier'], $row['team_count']);
+        $points[] = [
+            'x' => $x,
+            'y' => $y,
+            'season' => $row['season'],
+            'position' => $row['position'],
+            'team_count' => $row['team_count'],
+            'league_short_name' => $row['league_short_name'],
+            'promoted' => $row['promoted'],
+            'relegated' => $row['relegated'],
+            'is_current' => $row['is_current'],
+            'tier' => $row['tier'],
+        ];
+    }
+
+    // Segment colour classes by transition type.
+    $segmentStrokeClass = function (array $from, array $to): string {
+        if ($to['promoted']) return 'stroke-accent-green';
+        if ($to['relegated']) return 'stroke-accent-red';
+        return 'stroke-accent-blue';
+    };
+
+    // Spanish has "Liga" / "Liga 2"; English short names fall through from
+    // Competition::shortName(). Band label is the competition short name of
+    // the first season found in that tier (all clubs in that tier share it).
+    $bandLabelByTier = [];
+    foreach ($seasons as $row) {
+        if (!isset($bandLabelByTier[$row['tier']])) {
+            $bandLabelByTier[$row['tier']] = $row['league_short_name'];
+        }
+    }
+@endphp
+
+<div
+    x-data="{ hoveredIndex: null }"
+    class="relative w-full overflow-x-auto"
+>
+    <svg
+        viewBox="0 0 {{ $svgWidth }} {{ $svgHeight }}"
+        preserveAspectRatio="xMidYMid meet"
+        class="block"
+        style="min-width: {{ min(640, $svgWidth) }}px; width: 100%; height: auto;"
+        xmlns="http://www.w3.org/2000/svg"
+    >
+        {{-- Tier bands --}}
+        @foreach ($tiersAsc as $tier)
+            @php $bandTop = $bandTopByTier[$tier]; @endphp
+            <rect
+                x="{{ $leftGutter }}"
+                y="{{ $bandTop }}"
+                width="{{ $plotWidth }}"
+                height="{{ $bandHeight }}"
+                class="fill-surface-700/40 stroke-border-default"
+                stroke-width="0.5"
+                rx="4"
+            />
+            {{-- Top-of-band "1st" guideline --}}
+            <line
+                x1="{{ $leftGutter }}" y1="{{ $bandTop }}"
+                x2="{{ $leftGutter + $plotWidth }}" y2="{{ $bandTop }}"
+                class="stroke-border-default"
+                stroke-width="0.5"
+                stroke-dasharray="2,3"
+            />
+            {{-- Band label (league short name + tier marker) --}}
+            <text
+                x="{{ $leftGutter - 6 }}"
+                y="{{ $bandTop + $bandHeight / 2 }}"
+                text-anchor="end"
+                dominant-baseline="central"
+                class="fill-text-muted font-heading"
+                style="font-size: 9px; letter-spacing: 0.08em;"
+            >{{ strtoupper($bandLabelByTier[$tier] ?? ('T' . $tier)) }}</text>
+            {{-- "1st" hint on the top-left of the band, so readers know
+                 why higher-on-band = better regardless of team count. --}}
+            <text
+                x="{{ $leftGutter - 6 }}"
+                y="{{ $bandTop + 4 }}"
+                text-anchor="end"
+                dominant-baseline="hanging"
+                class="fill-text-faint"
+                style="font-size: 7px;"
+            >1</text>
+        @endforeach
+
+        {{-- Segments connecting consecutive seasons --}}
+        @for ($i = 1; $i < count($points); $i++)
+            @php
+                $from = $points[$i - 1];
+                $to = $points[$i];
+                $class = $segmentStrokeClass($from, $to);
+                $dash = $to['is_current'] ? 'stroke-dasharray="4,3"' : '';
+            @endphp
+            <line
+                x1="{{ $from['x'] }}" y1="{{ $from['y'] }}"
+                x2="{{ $to['x'] }}" y2="{{ $to['y'] }}"
+                class="{{ $class }}"
+                stroke-width="2"
+                stroke-linecap="round"
+                {!! $dash !!}
+            />
+        @endfor
+
+        {{-- Transition markers: small arrow near the tier boundary --}}
+        @foreach ($points as $i => $p)
+            @if ($p['promoted'] || $p['relegated'])
+                @php
+                    $glyph = $p['promoted'] ? '▲' : '▼';
+                    $colorClass = $p['promoted'] ? 'fill-accent-green' : 'fill-accent-red';
+                @endphp
+                <text
+                    x="{{ $p['x'] }}"
+                    y="{{ $p['y'] - 18 }}"
+                    text-anchor="middle"
+                    dominant-baseline="central"
+                    class="{{ $colorClass }}"
+                    style="font-size: 9px;"
+                >{{ $glyph }}</text>
+            @endif
+        @endforeach
+
+        {{-- Data points --}}
+        @foreach ($points as $i => $p)
+            @php
+                $fillClass = $p['is_current'] ? 'fill-surface-800' : 'fill-accent-blue';
+                $strokeClass = 'stroke-accent-blue';
+            @endphp
+            <circle
+                cx="{{ $p['x'] }}"
+                cy="{{ $p['y'] }}"
+                r="4"
+                class="{{ $fillClass }} {{ $strokeClass }} transition-all duration-150 cursor-default"
+                stroke-width="1.8"
+                :r="hoveredIndex === {{ $i }} ? 5.5 : 4"
+                @mouseenter="hoveredIndex = {{ $i }}"
+                @mouseleave="hoveredIndex = null"
+            />
+            {{-- Position label above marker --}}
+            <text
+                x="{{ $p['x'] }}"
+                y="{{ $p['y'] - 8 }}"
+                text-anchor="middle"
+                dominant-baseline="baseline"
+                class="fill-text-primary font-heading font-bold pointer-events-none"
+                style="font-size: 8.5px;"
+            >{{ $p['position'] }}</text>
+        @endforeach
+
+        {{-- Season labels on X axis --}}
+        @foreach ($points as $i => $p)
+            <text
+                x="{{ $p['x'] }}"
+                y="{{ $svgHeight - 6 }}"
+                text-anchor="middle"
+                dominant-baseline="alphabetic"
+                class="fill-text-muted"
+                style="font-size: 8.5px;"
+            >{{ $p['season'] }}</text>
+        @endforeach
+    </svg>
+
+    {{-- One tooltip element per point, toggled via x-show. --}}
+    @foreach ($points as $i => $p)
+        <div
+            x-show="hoveredIndex === {{ $i }}"
+            x-cloak
+            x-transition.opacity.duration.150ms
+            class="absolute left-1/2 -translate-x-1/2 -bottom-1 bg-surface-800/95 border border-border-default text-text-primary text-[10px] px-2.5 py-1.5 rounded-md shadow-lg whitespace-nowrap z-10 flex items-center gap-2"
+        >
+            <span class="font-semibold">
+                {{ $p['season'] }}@if($p['is_current']) {{ __('club.reputation.history.current_suffix') }}@endif
+            </span>
+            <span class="text-text-muted">{{ $p['league_short_name'] }}</span>
+            <span class="text-text-body">{{ $p['position'] }} / {{ $p['team_count'] }}</span>
+            @if ($p['promoted'])
+                <span class="text-accent-green">▲ {{ __('club.reputation.history.promoted') }}</span>
+            @elseif ($p['relegated'])
+                <span class="text-accent-red">▼ {{ __('club.reputation.history.relegated') }}</span>
+            @endif
+        </div>
+    @endforeach
+</div>


### PR DESCRIPTION
## Summary
Adds a visual performance history chart to the club reputation page, displaying the team's final league position for each completed season plus the current season "so far", with tier bands to clearly show promotions and relegations.

## Key Changes

- **New Component**: `performance-history-chart.blade.php` - An SVG-based chart component that:
  - Renders one data point per season showing final league position
  - Organizes seasons into horizontal tier bands (higher tier = higher on chart)
  - Uses color-coded line segments to indicate tier transitions (green for promotion, red for relegation, blue for same tier)
  - Includes interactive tooltips on hover showing season, league, position, and transition status
  - Handles variable team counts per season by normalizing position within each band
  - Supports horizontal scrolling for long histories

- **New Service**: `PerformanceHistoryService` - Builds the performance history data by:
  - Querying `SeasonArchive` records for completed seasons
  - Extracting the team's final position and league tier for each season
  - Including the current in-progress season if at least one matchday has been played
  - Detecting and marking promotion/relegation transitions between consecutive seasons
  - Resolving league competition IDs from archive data

- **New Command**: `BackfillSeasonArchiveCompetitionIds` - Idempotent database migration that:
  - Writes `competition_id` onto every row in `season_archives.final_standings`
  - Enables efficient tier resolution without scanning match_results
  - Uses chunked processing to keep memory bounded on large tables
  - Includes dry-run mode for safe testing

- **Updated Views & Controllers**:
  - Modified `reputation.blade.php` to display the performance history chart with legend
  - Updated `ShowClubReputation` view class to inject history data
  - Modified `SeasonArchiveProcessor` to capture `competition_id` on standings rows

- **Localization**: Added English and Spanish translations for chart labels, legends, and empty state messages

## Implementation Details

- The chart uses SVG with Tailwind styling and Alpine.js for interactivity
- Position normalization accounts for leagues with different team counts (e.g., 20 teams vs 18 teams)
- Tier bands are color-coded with subtle backgrounds and include "1st place" guidelines
- Current season is rendered with a dashed line to distinguish it from completed seasons
- The component gracefully handles empty histories with a user-friendly message

https://claude.ai/code/session_018xJUTTE8kVEg1ysyYgygu4