### PR TITLE
Open Primera Federación to all users

### DIFF
--- a/app/Http/Views/SelectTeam.php
+++ b/app/Http/Views/SelectTeam.php
@@ -21,14 +21,7 @@ final class SelectTeam
         // Tiers may declare sibling competitions (e.g. Primera RFEF's ESP3A and
         // ESP3B both live at tier 3), so the tiers list is keyed by competition
         // ID rather than tier number to keep every league selectable.
-        //
-        // Tier-3 competitions (Primera RFEF) are gated behind is_admin until
-        // the feature has been validated in production. Remove this gate once
-        // the staged rollout is complete.
-        $isAdmin = $request->user()->is_admin;
-
-        $cacheKey = $isAdmin ? 'career_mode_countries:admin' : 'career_mode_countries';
-        $countries = Cache::remember($cacheKey, 3600, function () use ($countryConfig, $isAdmin) {
+        $countries = Cache::remember('career_mode_countries:v2', 3600, function () use ($countryConfig) {
             $countries = [];
 
             foreach ($countryConfig->playableCountryCodes() as $code) {
@@ -36,11 +29,6 @@ final class SelectTeam
                 $tiers = [];
 
                 foreach ($config['tiers'] as $tier => $tierConfig) {
-                    // Gate tier 3 behind isAdmin for staged rollout
-                    if ($tier >= 3 && !$isAdmin) {
-                        continue;
-                    }
-
                     $entries = [$tierConfig];
                     foreach ($tierConfig['siblings'] ?? [] as $sibling) {
                         $entries[] = $sibling;

--- a/app/Modules/Competition/Promotions/PrimeraRFEFPromotionRule.php
+++ b/app/Modules/Competition/Promotions/PrimeraRFEFPromotionRule.php
@@ -501,11 +501,10 @@ class PrimeraRFEFPromotionRule implements SelfSwappingPromotionRule
     }
 
     /**
-     * Primera RFEF is currently gated to admin-started careers. Games whose
-     * setup skipped tier-3 rosters have no ESP3 CompetitionEntry rows, so this
-     * rule must no-op for them — otherwise ESP2 relegations would have no
-     * matching ESP3 promotions and the processor would error out on the
-     * count-imbalance check. Remove once the gate is lifted globally.
+     * Legacy games created before Primera RFEF was enabled globally may have
+     * no ESP3 CompetitionEntry rows. This rule must no-op for them —
+     * otherwise ESP2 relegations would have no matching ESP3 promotions and
+     * the processor would error out on the count-imbalance check.
      */
     private function isActiveForGame(Game $game): bool
     {

--- a/app/Modules/Season/Jobs/SetupNewGame.php
+++ b/app/Modules/Season/Jobs/SetupNewGame.php
@@ -125,21 +125,7 @@ class SetupNewGame implements ShouldQueue, ShouldBeUnique
             return;
         }
 
-        // Primera RFEF (tier 3) is behind an admin gate in team selection. Only
-        // copy tier-3 competitions into games whose selected team is itself in
-        // tier 3 — i.e. admin-started ESP3 careers. Non-admin games never see
-        // the tier-3 roster in Explore/Transfer/scouting. Remove this filter
-        // once the staged rollout is lifted.
-        $selectedTier = Competition::where('id', $this->competitionId)->value('tier');
-        $excludedCompetitionIds = $selectedTier === 3
-            ? []
-            : Competition::where('tier', 3)->pluck('id')->all();
-
         $rows = CompetitionTeam::where('season', $this->season)
-            ->when(
-                !empty($excludedCompetitionIds),
-                fn ($q) => $q->whereNotIn('competition_id', $excludedCompetitionIds),
-            )
             ->whereNotIn('team_id', function ($query) {
                 $query->select('id')->from('teams')->where('type', 'national');
             })


### PR DESCRIPTION
Lift the admin-only gate on tier-3 (Primera RFEF) career mode. Team
selection now lists ESP3A and ESP3B for every user, and new games of
any tier copy the tier-3 roster into their CompetitionEntry rows so
Explore/Transfer/scouting see the full Spanish pyramid.