### PR TITLE
Rename Celta de Vigo to RC Celta across the project

### DIFF
--- a/app/Support/TeamColors/LaLiga.php
+++ b/app/Support/TeamColors/LaLiga.php
@@ -61,7 +61,7 @@ final class LaLiga implements TeamColorProvider
                 'secondary' => 'yellow-400',
                 'number' => 'blue-900',
             ],
-            'Celta de Vigo' => [
+            'RC Celta' => [
                 'pattern' => 'solid',
                 'primary' => 'sky-400',
                 'secondary' => 'sky-400',

--- a/config/countries.php
+++ b/config/countries.php
@@ -124,7 +124,7 @@ return [
             6767 => 418,   // Real Madrid Castilla → Real Madrid
             8516 => 331,   // CA Osasuna Promesas → CA Osasuna
             6688 => 621,   // Bilbao Athletic → Athletic Bilbao
-            8733 => 940,   // RC Celta Fortuna → Celta de Vigo
+            8733 => 940,   // RC Celta Fortuna → RC Celta
             11972 => 1050, // Villarreal CF B → Villarreal CF
             8519 => 368,   // Sevilla Atlético → Sevilla FC
             3679 => 13,    // Atlético Madrileño → Atlético de Madrid

--- a/data/2025/ESP1/teams.json
+++ b/data/2025/ESP1/teams.json
@@ -4924,7 +4924,7 @@
     },
     {
       "image": "https://tmssl.akamaized.net/images/wappen/big/940.png",
-      "name": "Celta de Vigo",
+      "name": "RC Celta",
       "players": [
         {
           "contract": "Jun 30, 2029",

--- a/data/2025/ESPCUP/teams.json
+++ b/data/2025/ESPCUP/teams.json
@@ -13,7 +13,7 @@
         { "id": "418", "name": "Real Madrid" },
         { "id": "1050", "name": "Villarreal CF" },
         { "id": "12321", "name": "Girona FC" },
-        { "id": "940", "name": "Celta de Vigo" },
+        { "id": "940", "name": "RC Celta" },
         { "id": "368", "name": "Sevilla FC" },
         { "id": "714", "name": "RCD Espanyol Barcelona" },
         { "id": "367", "name": "Rayo Vallecano" },

--- a/data/2025/UEL/teams.json
+++ b/data/2025/UEL/teams.json
@@ -34,7 +34,7 @@
         { "id": "417", "name": "OGC Nice", "country": "FR", "pot": 3 },
 
         { "id": "1025", "name": "Bologna FC", "country": "IT", "pot": 4 },
-        { "id": "940", "name": "Celta de Vigo", "country": "ES", "pot": 4 },
+        { "id": "940", "name": "RC Celta", "country": "ES", "pot": 4 },
         { "id": "79", "name": "VfB Stuttgart", "country": "DE", "pot": 4 },
         { "id": "265", "name": "Panathinaikos FC", "country": "GR", "pot": 4 },
         { "id": "496", "name": "Malmö FF", "country": "SE", "pot": 4 },

--- a/database/migrations/2026_04_23_000002_rename_celta_de_vigo_to_rc_celta.php
+++ b/database/migrations/2026_04_23_000002_rename_celta_de_vigo_to_rc_celta.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Rename the club to its official registered name. Keyed by
+     * transfermarkt_id (stable identifier) rather than name, so this migration
+     * is safe to re-run and independent of whichever name the row currently
+     * holds.
+     */
+    public function up(): void
+    {
+        DB::table('teams')
+            ->where('transfermarkt_id', 940)
+            ->update([
+                'name' => 'RC Celta',
+                'slug' => 'rc-celta',
+            ]);
+    }
+
+    public function down(): void
+    {
+        DB::table('teams')
+            ->where('transfermarkt_id', 940)
+            ->update([
+                'name' => 'Celta de Vigo',
+                'slug' => 'celta-de-vigo',
+            ]);
+    }
+};

--- a/database/seeders/ClubProfilesSeeder.php
+++ b/database/seeders/ClubProfilesSeeder.php
@@ -34,7 +34,7 @@ class ClubProfilesSeeder extends Seeder
         // Established - Objetivo: Top 10
         'Valencia CF' => ClubProfile::REPUTATION_ESTABLISHED,
         'RCD Espanyol Barcelona' => ClubProfile::REPUTATION_ESTABLISHED,
-        'Celta de Vigo' => ClubProfile::REPUTATION_ESTABLISHED,
+        'RC Celta' => ClubProfile::REPUTATION_ESTABLISHED,
         'RCD Mallorca' => ClubProfile::REPUTATION_ESTABLISHED,
         'CA Osasuna' => ClubProfile::REPUTATION_ESTABLISHED,
         'Getafe CF' => ClubProfile::REPUTATION_ESTABLISHED,
@@ -340,7 +340,7 @@ class ClubProfilesSeeder extends Seeder
         'Real Sociedad' => 7,            // 78.7%
         'Valencia CF' => 9,              // 89.9%
         'RCD Espanyol Barcelona' => 7,   // 75.7%
-        'Celta de Vigo' => 9,            // 89.0%
+        'RC Celta' => 9,                 // 89.0%
         'RCD Mallorca' => 5,             // 66.8%
         'CA Osasuna' => 8,              // 87.0%
         'Getafe CF' => 3,               // 48.7%

--- a/docs/game-systems/reputation-system.md
+++ b/docs/game-systems/reputation-system.md
@@ -10,7 +10,7 @@ Five tiers, ordered lowest to highest:
 |-------|------|---------------------|
 | 0 | Local | Small/unknown clubs |
 | 1 | Modest | Rayo Vallecano, Girona FC |
-| 2 | Established | Espanyol, Celta de Vigo |
+| 2 | Established | Espanyol, RC Celta |
 | 3 | Continental | Real Betis, Sevilla FC, Atletico |
 | 4 | Elite | Real Madrid, FC Barcelona |
 


### PR DESCRIPTION
Unifies the club name with its official registered form. Updates every data file, seeder, config and doc that referenced "Celta de Vigo". Adds a data migration keyed on transfermarkt_id 940 so in-progress games are updated without a reseed.

https://claude.ai/code/session_01Q79DnfRG4iP7C6jXnrLLhQ