### PR TITLE
Refactor attendance computation to separate persistence from projection

### DIFF
--- a/app/Http/Views/ShowLiveMatch.php
+++ b/app/Http/Views/ShowLiveMatch.php
@@ -17,7 +17,6 @@ use App\Models\MatchAttendance;
 use App\Models\PlayerSuspension;
 use App\Modules\Match\Services\ExtraTimeAndPenaltyService;
 use App\Modules\Match\Services\MatchResimulationService;
-use App\Modules\Stadium\Services\MatchAttendanceService;
 use App\Support\LiveMatchLineupPresenter;
 use App\Support\LiveMatchNarrativeTemplates;
 use App\Support\PitchGrid;
@@ -29,7 +28,6 @@ class ShowLiveMatch
     public function __construct(
         private readonly LineupService $lineupService,
         private readonly ExtraTimeAndPenaltyService $extraTimeService,
-        private readonly MatchAttendanceService $matchAttendanceService,
     ) {}
 
     public function __invoke(string $gameId, string $matchId)
@@ -220,11 +218,9 @@ class ShowLiveMatch
 
         $narrativeTemplates = LiveMatchNarrativeTemplates::build();
 
-        // Resolve attendance for the live-match HUD. The orchestrator's pre-match
-        // hook normally writes the row before this view loads; the defensive
-        // resolveForMatch call covers deep-links and replays (idempotent).
-        $attendanceRow = MatchAttendance::where('game_match_id', $playerMatch->id)->first()
-            ?? $this->matchAttendanceService->resolveForMatch($playerMatch, $game);
+        // MatchdayOrchestrator::processBatch persists the attendance row before
+        // simulating the match, so it's always present when this view loads.
+        $attendanceRow = MatchAttendance::where('game_match_id', $playerMatch->id)->first();
         $attendance = $attendanceRow?->attendance;
         $attendanceCapacity = $attendanceRow?->capacity_at_match;
         $attendancePercent = $attendanceRow?->fillRatePercent();

--- a/app/Http/Views/ShowPreMatchData.php
+++ b/app/Http/Views/ShowPreMatchData.php
@@ -6,7 +6,6 @@ use App\Modules\Lineup\Services\LineupService;
 use App\Modules\Stadium\Services\MatchAttendanceService;
 use App\Models\Game;
 use App\Models\GamePlayer;
-use App\Models\MatchAttendance;
 use App\Models\PlayerSuspension;
 
 class ShowPreMatchData
@@ -81,20 +80,25 @@ class ShowPreMatchData
             return response()->json(['lineupReady' => true]);
         }
 
-        // Resolve attendance ahead of the modal so the user sees the figure
-        // alongside the venue. resolveForMatch is idempotent — the orchestrator
-        // pre-match hook usually wrote the row already.
-        $attendanceRow = MatchAttendance::where('game_match_id', $match->id)->first()
-            ?? $this->matchAttendanceService->resolveForMatch($match, $game);
+        // Show a projected attendance alongside the venue. The modal renders
+        // before advance() runs, so no MatchAttendance row exists yet — the
+        // orchestrator will persist the row (using the same demand curve) at
+        // the start of processBatch when the user commits to the match.
+        $attendance = $this->matchAttendanceService->describeForMatch($match, $game);
+        $attendanceFigure = $attendance['attendance'] ?? null;
+        $attendanceCapacity = $attendance['capacity'] ?? null;
+        $attendancePercent = $attendanceFigure !== null && $attendanceCapacity
+            ? (int) round(($attendanceFigure / $attendanceCapacity) * 100)
+            : null;
 
         return view('partials.pre-match-modal-content', [
             'game' => $game,
             'match' => $match,
             'issueMessage' => $issueMessage,
             'hasIssues' => $hasIssues,
-            'attendance' => $attendanceRow?->attendance,
-            'attendanceCapacity' => $attendanceRow?->capacity_at_match,
-            'attendancePercent' => $attendanceRow?->fillRatePercent(),
+            'attendance' => $attendanceFigure,
+            'attendanceCapacity' => $attendanceCapacity,
+            'attendancePercent' => $attendancePercent,
         ]);
     }
 }

--- a/app/Modules/Match/Listeners/EnsureMatchAttendance.php
+++ b/app/Modules/Match/Listeners/EnsureMatchAttendance.php
@@ -7,11 +7,11 @@ use App\Modules\Stadium\Services\MatchAttendanceService;
 
 /**
  * Safety-net listener that guarantees every finalized match has a
- * MatchAttendance row. The MatchdayOrchestrator pre-match hook normally
- * writes the row before simulation, so under typical flow this is a no-op
- * (the service short-circuits on existing rows). It exists to cover edge
- * paths like MatchFinalizationService::finalizePendingMatch where a match
- * may be finalized without going through the orchestrator batch.
+ * MatchAttendance row. MatchdayOrchestrator::processBatch is the primary
+ * writer (called before simulation for every fixture in the batch), so
+ * under normal flow this is a no-op — resolveForMatch short-circuits on
+ * the existing row. It exists to cover any future path that finalizes a
+ * match without having gone through the orchestrator batch.
  */
 class EnsureMatchAttendance
 {

--- a/app/Modules/Match/Services/MatchdayOrchestrator.php
+++ b/app/Modules/Match/Services/MatchdayOrchestrator.php
@@ -10,6 +10,7 @@ use App\Modules\Notification\Services\NotificationService;
 use App\Modules\Squad\Services\EligibilityService;
 use App\Modules\Player\PlayerAge;
 use App\Modules\Player\Services\InjuryService;
+use App\Modules\Stadium\Services\MatchAttendanceService;
 use App\Models\Competition;
 use App\Models\Game;
 use App\Models\GameMatch;
@@ -35,6 +36,7 @@ class MatchdayOrchestrator
         private readonly NotificationService $notificationService,
         private readonly EligibilityService $eligibilityService,
         private readonly InjuryService $injuryService,
+        private readonly MatchAttendanceService $matchAttendanceService,
         private readonly AIMatchResolver $aiMatchResolver = new AIMatchResolver,
     ) {}
 
@@ -157,6 +159,15 @@ class MatchdayOrchestrator
 
         // Clear cached match dates from prior batches (played matches changed)
         InjuryService::clearMatchDateCache();
+
+        // Persist MatchAttendance rows for every fixture in the batch before
+        // simulation so the live-match screen and downstream consumers read a
+        // stable figure instead of re-computing (and potentially drifting from)
+        // the demand curve at view time. Idempotent — matches that already
+        // have a row from an earlier path are a no-op.
+        foreach ($matches as $match) {
+            $this->matchAttendanceService->resolveForMatch($match, $game);
+        }
 
         $playerMatch = $matches->first(fn ($m) => $m->involvesTeam($game->team_id));
 

--- a/app/Modules/Stadium/Services/MatchAttendanceService.php
+++ b/app/Modules/Stadium/Services/MatchAttendanceService.php
@@ -46,39 +46,47 @@ class MatchAttendanceService
             return $existing;
         }
 
-        if ($this->isSoldOutRound($match)) {
-            $capacity = $this->soldOutCapacity($match);
-            if ($capacity > 0) {
-                return MatchAttendance::create([
-                    'game_id' => $game->id,
-                    'game_match_id' => $match->id,
-                    'attendance' => $capacity,
-                    'capacity_at_match' => $capacity,
-                ]);
-            }
-        }
-
-        if ($match->isNeutralVenue() && $match->neutral_venue_capacity !== null) {
-            $capacity = (int) $match->neutral_venue_capacity;
-            return MatchAttendance::create([
-                'game_id' => $game->id,
-                'game_match_id' => $match->id,
-                'attendance' => $capacity,
-                'capacity_at_match' => $capacity,
-            ]);
-        }
-
-        $projection = $this->projectForMatch($match, $game);
-        if ($projection === null) {
+        $computed = $this->describeForMatch($match, $game);
+        if ($computed === null) {
             return null;
         }
 
         return MatchAttendance::create([
             'game_id' => $game->id,
             'game_match_id' => $match->id,
-            'attendance' => $projection['attendance'],
-            'capacity_at_match' => $projection['capacity'],
+            'attendance' => $computed['attendance'],
+            'capacity_at_match' => $computed['capacity'],
         ]);
+    }
+
+    /**
+     * Compute the attendance figure for a fixture without persisting it.
+     * Used by views that need to show the number before the orchestrator
+     * has written the row (e.g. the pre-match modal, which renders before
+     * MatchdayOrchestrator::processBatch runs). Covers the same branches
+     * as resolveForMatch: sold-out rounds, explicit neutral venues, and
+     * the general demand-curve projection.
+     *
+     * Differs from projectForMatch(), which intentionally returns null for
+     * neutral venues because BudgetProjectionService doesn't need them.
+     *
+     * @return array{attendance: int, capacity: int}|null
+     */
+    public function describeForMatch(GameMatch $match, Game $game): ?array
+    {
+        if ($this->isSoldOutRound($match)) {
+            $capacity = $this->soldOutCapacity($match);
+            if ($capacity > 0) {
+                return ['attendance' => $capacity, 'capacity' => $capacity];
+            }
+        }
+
+        if ($match->isNeutralVenue() && $match->neutral_venue_capacity !== null) {
+            $capacity = (int) $match->neutral_venue_capacity;
+            return ['attendance' => $capacity, 'capacity' => $capacity];
+        }
+
+        return $this->projectForMatch($match, $game);
     }
 
     /**


### PR DESCRIPTION
## Summary
This PR refactors the match attendance service to separate the computation of attendance figures from their persistence, improving code clarity and enabling attendance projections to be displayed before the orchestrator persists the data.

## Key Changes

- **Extract `describeForMatch()` method**: Created a new public method that computes attendance figures (sold-out rounds, neutral venues, demand curve projections) without persisting them. This allows views to display projected attendance before the MatchAttendance row is written.

- **Refactor `resolveForMatch()`**: Simplified to call `describeForMatch()` for computation, then persist the result. Maintains idempotency by returning early if a row already exists.

- **Move attendance persistence to orchestrator**: Updated `MatchdayOrchestrator::processBatch()` to explicitly persist MatchAttendance rows for all fixtures before simulation, ensuring a stable figure for downstream consumers and the live-match screen.

- **Update pre-match modal**: Modified `ShowPreMatchData` to use `describeForMatch()` directly, computing attendance inline rather than attempting to resolve/persist. This displays projected attendance before the user commits to the match.

- **Simplify live-match view**: Updated `ShowLiveMatch` to assume the MatchAttendance row exists (written by the orchestrator), removing defensive resolution logic.

- **Update safety-net listener**: Clarified `EnsureMatchAttendance` documentation to reflect that the orchestrator is now the primary writer, with this listener serving as a fallback for edge paths.

## Implementation Details

- `describeForMatch()` returns `array{attendance: int, capacity: int}|null` to support both computation and view rendering without database writes.
- The refactoring maintains all existing business logic (sold-out detection, neutral venue handling, demand curve projection).
- All changes are backward compatible; `resolveForMatch()` remains idempotent and can be called multiple times safely.

https://claude.ai/code/session_01PzuhA4xJ94EavraekHE6SQ