### PR TITLE
Enforce unique squad numbers in game_player_templates

### DIFF
--- a/app/Models/GamePlayerMatchState.php
+++ b/app/Models/GamePlayerMatchState.php
@@ -137,17 +137,7 @@ class GamePlayerMatchState extends Model
         }, $rows);
 
         foreach (array_chunk($prepared, 500) as $chunk) {
-            // Filter to only game_player_ids that actually exist, to avoid
-            // FK violations when a parent insert was partially skipped.
-            $candidateIds = array_column($chunk, 'game_player_id');
-            $existingIds = GamePlayer::whereIn('id', $candidateIds)->pluck('id')->all();
-            $existingSet = array_flip($existingIds);
-
-            $validChunk = array_filter($chunk, fn ($row) => isset($existingSet[$row['game_player_id']]));
-
-            if (! empty($validChunk)) {
-                static::insertOrIgnore(array_values($validChunk));
-            }
+            static::insertOrIgnore($chunk);
         }
     }
 

--- a/data/2025/ESP3B/teams.json
+++ b/data/2025/ESP3B/teams.json
@@ -5105,7 +5105,7 @@
           "nationality": [
             "Zambia"
           ],
-          "number": "6",
+          "number": "8",
           "position": "Central Midfield"
         },
         {

--- a/data/2025/EUR/144.json
+++ b/data/2025/EUR/144.json
@@ -217,7 +217,7 @@
       "nationality": [
         "Croatia"
       ],
-      "number": "24",
+      "number": "21",
       "position": "Defensive Midfield"
     },
     {

--- a/data/2025/EUR/3258.json
+++ b/data/2025/EUR/3258.json
@@ -254,7 +254,7 @@
       "nationality": [
         "Ireland"
       ],
-      "number": "27",
+      "number": "26",
       "position": "Central Midfield"
     },
     {

--- a/data/2025/EUR/3737.json
+++ b/data/2025/EUR/3737.json
@@ -296,7 +296,7 @@
       "nationality": [
         "Iceland"
       ],
-      "number": "13",
+      "number": "22",
       "position": "Right Winger"
     },
     {

--- a/database/migrations/2026_04_24_000001_constrain_template_squad_numbers.php
+++ b/database/migrations/2026_04_24_000001_constrain_template_squad_numbers.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Guard against duplicate squad numbers in game_player_templates.
+ *
+ * The downstream game_players table enforces `(game_id, team_id, number)`
+ * uniqueness, so template dupes cause SetupNewGame's insertOrIgnore to
+ * silently drop rows and then FK-fail on game_player_match_state. The
+ * partial index makes such anomalies fail loudly at ingest time instead.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        DB::statement(<<<'SQL'
+            CREATE UNIQUE INDEX game_player_templates_season_team_number_unique
+            ON game_player_templates (season, team_id, number)
+            WHERE number IS NOT NULL
+        SQL);
+    }
+
+    public function down(): void
+    {
+        DB::statement('DROP INDEX IF EXISTS game_player_templates_season_team_number_unique');
+    }
+};


### PR DESCRIPTION
The downstream game_players table enforces uniqueness on (game_id, team_id, number). When source scrape data contained two players on the same team sharing a number, SetupNewGame's insertOrIgnore silently dropped one and then FK-failed when the game_player_match_state satellite insert referenced the skipped UUID.

- Fix the four affected source rosters (HNK Rijeka, Breidablik, Atlético Sanluqueño, Shamrock Rovers) so numbers are unique per team.
- Add a partial unique index on game_player_templates (season, team_id, number) WHERE number IS NOT NULL — future scrape anomalies will fail loudly at ingest rather than silently during game creation.
- Drop the per-chunk FK pre-check in GamePlayerMatchState::createForPlayers. With the template layer now guaranteeing no silent drops, an FK violation here is a real bug signal, not a tolerable anomaly to swallow.