### PR TITLE
Cut repeated queries in setup-game flow

### DIFF
--- a/app/Modules/Competition/Services/CupDrawService.php
+++ b/app/Modules/Competition/Services/CupDrawService.php
@@ -414,8 +414,14 @@ class CupDrawService
             return [];
         }
 
-        $gameSeason = Game::where('id', $gameId)->value('season');
+        if (! array_key_exists($gameId, $this->gameSeasonCache)) {
+            $this->gameSeasonCache[$gameId] = Game::where('id', $gameId)->value('season');
+        }
+        $gameSeason = $this->gameSeasonCache[$gameId];
 
         return LeagueFixtureGenerator::loadKnockoutRounds($competitionId, $competition->season, $gameSeason);
     }
+
+    /** @var array<string, ?string> */
+    private array $gameSeasonCache = [];
 }

--- a/app/Modules/Finance/Services/BudgetProjectionService.php
+++ b/app/Modules/Finance/Services/BudgetProjectionService.php
@@ -151,13 +151,17 @@ class BudgetProjectionService
     }
 
     /**
-     * Project matchday revenue by walking the scheduled home fixtures for
-     * the upcoming season and summing per-fixture attendance from the demand
-     * curve. Cup and European home ties add bonus revenue on top of the
-     * league baseline at the same per-seat rate.
+     * Project matchday revenue using the team's season-average attendance
+     * (capacity × base-fill from the demand curve) multiplied by the count
+     * of scheduled home fixtures. Cup and European home ties add bonus
+     * revenue on top of the league baseline at the same per-seat rate.
      *
      * `revenue_per_seat` is a per-seat per-SEASON rate, so we divide by the
-     * league home-game count to derive a per-match rate before summing.
+     * league home-game count to derive a per-match rate. The projection is
+     * intentionally coarse: per-fixture opponent/competition modifiers are
+     * clamped to ±20% and average near 1.0 across a balanced schedule, so
+     * dropping them keeps the estimate within a few percent of a
+     * fixture-by-fixture sum without the per-match queries.
      *
      * Runs at SeasonSetupPipeline priority 107 — after LeagueFixtureProcessor
      * (30) and ContinentalAndCupInitProcessor (106), so the fixture list for
@@ -170,10 +174,13 @@ class BudgetProjectionService
     {
         $reputation = TeamReputation::resolveLevel($game->id, $team->id);
 
-        $leagueHomeMatchCount = GameMatch::where('game_id', $game->id)
-            ->where('competition_id', $game->competition_id)
+        $homeMatchCounts = GameMatch::where('game_id', $game->id)
             ->where('home_team_id', $team->id)
-            ->count();
+            ->selectRaw('COUNT(*) AS total, SUM(CASE WHEN competition_id = ? THEN 1 ELSE 0 END) AS league', [$game->competition_id])
+            ->first();
+
+        $leagueHomeMatchCount = (int) ($homeMatchCounts->league ?? 0);
+        $totalHomeMatchCount = (int) ($homeMatchCounts->total ?? 0);
 
         if ($leagueHomeMatchCount === 0) {
             return 0;
@@ -182,18 +189,8 @@ class BudgetProjectionService
         $perSeatSeasonRate = (int) config("finances.revenue_per_seat.{$reputation}", 15_000);
         $perSeatMatchRate = $perSeatSeasonRate / $leagueHomeMatchCount;
 
-        $homeMatches = GameMatch::where('game_id', $game->id)
-            ->where('home_team_id', $team->id)
-            ->get();
-
-        $total = 0.0;
-        foreach ($homeMatches as $match) {
-            $projection = $this->matchAttendanceService->projectForMatch($match, $game);
-            if ($projection === null) {
-                continue;
-            }
-            $total += $projection['attendance'] * $perSeatMatchRate;
-        }
+        $expectedAttendance = $this->matchAttendanceService->projectBaselineForTeam($game->id, $team);
+        $total = $expectedAttendance * $perSeatMatchRate * $totalHomeMatchCount;
 
         $investment = $game->currentInvestment;
         $facilitiesMultiplier = $investment

--- a/app/Modules/Season/Jobs/SetupNewGame.php
+++ b/app/Modules/Season/Jobs/SetupNewGame.php
@@ -315,7 +315,7 @@ class SetupNewGame implements ShouldQueue, ShouldBeUnique
                 $query->select('id')->from('teams')->where('type', 'national');
             })
             ->orderBy('player_id')
-            ->chunk(200, function ($templates) use ($gameId) {
+            ->chunk(1000, function ($templates) use ($gameId) {
                 $rows = [];
                 $matchStateRows = [];
 

--- a/app/Modules/Season/Services/GameCreationService.php
+++ b/app/Modules/Season/Services/GameCreationService.php
@@ -27,17 +27,16 @@ class GameCreationService
                 ->first()
             ?? CompetitionTeam::where('team_id', $teamId)->first();
 
+        $team = Team::find($teamId);
+
         // Resolve competition ID: use competition_team lookup, fall back to
         // tier 1 of the team's country from config
         $competitionId = $competitionTeam?->competition_id;
         if (!$competitionId) {
-            $team = Team::find($teamId);
             $countryConfig = app(CountryConfig::class);
             $competitionId = $countryConfig->competitionForTier($team->country ?? 'ES', 1);
         }
         $season = $competitionTeam->season ?? '2025';
-
-        $team = Team::find($teamId);
 
         // Create game record (setup not yet complete)
         // current_date and season_goal are set by processors during SetupNewGame

--- a/app/Modules/Season/Services/SeasonInitializationService.php
+++ b/app/Modules/Season/Services/SeasonInitializationService.php
@@ -34,12 +34,24 @@ class SeasonInitializationService
         private CountryConfig $countryConfig,
     ) {}
 
+    /** @var array<string, ?Competition> */
+    private array $competitionCache = [];
+
+    private function findCompetition(string $competitionId): ?Competition
+    {
+        if (! array_key_exists($competitionId, $this->competitionCache)) {
+            $this->competitionCache[$competitionId] = Competition::find($competitionId);
+        }
+
+        return $this->competitionCache[$competitionId];
+    }
+
     /**
      * Generate league fixtures from schedule.json, adjusted for season year.
      */
     public function generateLeagueFixtures(string $gameId, string $competitionId, string $season): void
     {
-        $competition = Competition::find($competitionId);
+        $competition = $this->findCompetition($competitionId);
         if (!$competition || !$competition->isLeague()) {
             return;
         }
@@ -98,7 +110,7 @@ class SeasonInitializationService
             return;
         }
 
-        $competition = Competition::find($competitionId);
+        $competition = $this->findCompetition($competitionId);
         if (!$competition) {
             Log::warning("[SeasonInit] Competition {$competitionId} not found, skipping Swiss init");
 

--- a/app/Modules/Stadium/Services/DemandCurveService.php
+++ b/app/Modules/Stadium/Services/DemandCurveService.php
@@ -9,8 +9,8 @@ use App\Models\TeamReputation;
 
 /**
  * Pure deterministic demand curve. Given the home team's identity and the
- * match context (opponent reputation, competition, league position),
- * returns an attendance number capped at stadium capacity.
+ * match context (opponent reputation, competition), returns an attendance
+ * number capped at stadium capacity.
  *
  * Loyalty primary, reputation as secondary floor:
  *  - base_fill = FILL_FLOOR + (loyalty_points / 100) × FILL_RANGE.
@@ -18,8 +18,8 @@ use App\Models\TeamReputation;
  *    loyalty-zero club doesn't play to an empty stadium. On top of that,
  *    reputation provides a higher secondary floor for elite/continental
  *    clubs so a marquee brand with crashed loyalty still draws walk-ups.
- *  - Context modifier (opponent reputation, competition weight, home
- *    league position) multiplies on top, clamped to [0.85, 1.20].
+ *  - Context modifier (opponent reputation, competition weight)
+ *    multiplies on top, clamped to [0.85, 1.20].
  *
  * Calibrated against real La Liga / La Liga 2 occupancy data. With
  * average modifiers (~1.0 for mid-table), the formula produces:
@@ -51,7 +51,6 @@ class DemandCurveService
         TeamReputation $homeRep,
         TeamReputation $awayRep,
         Competition $competition,
-        ?int $homePosition = null,
     ): int {
         $capacity = (int) ($home->stadium_seats ?? 0);
         if ($capacity <= 0) {
@@ -62,8 +61,7 @@ class DemandCurveService
 
         $modifier = 1.0
             + $this->opponentDelta($homeRep, $awayRep)
-            + $this->competitionWeight($competition)
-            + $this->positionBoost($competition, $homePosition);
+            + $this->competitionWeight($competition);
 
         $modifier = max(self::MODIFIER_MIN, min(self::MODIFIER_MAX, $modifier));
 
@@ -141,29 +139,5 @@ class DemandCurveService
         }
 
         return 0.0; // ROLE_LEAGUE
-    }
-
-    /**
-     * Top-4 league position pulls a small attendance bump (title/CL chase);
-     * relegation zone drags it down. Only applies in league competitions
-     * where the position number is meaningful.
-     */
-    private function positionBoost(Competition $competition, ?int $homePosition): float
-    {
-        if ($homePosition === null || $competition->role !== Competition::ROLE_LEAGUE) {
-            return 0.0;
-        }
-
-        if ($homePosition <= 4) {
-            return 0.05;
-        }
-
-        // Loose relegation-zone heuristic that works for both 20-team
-        // (La Liga) and 22-team (Segunda) leagues.
-        if ($homePosition >= 18) {
-            return -0.05;
-        }
-
-        return 0.0;
     }
 }

--- a/app/Modules/Stadium/Services/DemandCurveService.php
+++ b/app/Modules/Stadium/Services/DemandCurveService.php
@@ -46,6 +46,28 @@ class DemandCurveService
         ClubProfile::REPUTATION_CONTINENTAL => 0.80,
     ];
 
+    /**
+     * Season-average attendance for a home team, ignoring per-fixture
+     * opponent/competition modifiers. Used by budget projections, which
+     * need a single expected gate across the schedule rather than a
+     * per-match figure. The opponent/competition modifier is clamped to
+     * ±20% and averages near 1.0 across a balanced league schedule, so
+     * dropping it keeps projections within a few percent of the
+     * fixture-by-fixture sum at a fraction of the queries.
+     */
+    public function projectBaseline(Team $home, TeamReputation $homeRep): int
+    {
+        $capacity = (int) ($home->stadium_seats ?? 0);
+        if ($capacity <= 0) {
+            return 0;
+        }
+
+        $attendance = (int) round($capacity * $this->baseFillRate($homeRep));
+        $floor = (int) max(self::ATTENDANCE_FLOOR_ABSOLUTE, $capacity * self::ATTENDANCE_FLOOR_RATIO);
+
+        return max($floor, min($capacity, $attendance));
+    }
+
     public function project(
         Team $home,
         TeamReputation $homeRep,

--- a/app/Modules/Stadium/Services/MatchAttendanceService.php
+++ b/app/Modules/Stadium/Services/MatchAttendanceService.php
@@ -137,6 +137,18 @@ class MatchAttendanceService
         ];
     }
 
+    /**
+     * Season-average attendance for a team's home fixtures. Skips the
+     * per-fixture queries that projectForMatch() performs — BudgetProjectionService
+     * only needs an expected gate to multiply by the home-match count.
+     */
+    public function projectBaselineForTeam(string $gameId, Team $home): int
+    {
+        $homeRep = $this->loadReputation($gameId, $home->id);
+
+        return $this->demandCurve->projectBaseline($home, $homeRep);
+    }
+
     private function isSoldOutRound(GameMatch $match): bool
     {
         return in_array($match->round_name, self::SOLD_OUT_ROUNDS, true);

--- a/app/Modules/Stadium/Services/MatchAttendanceService.php
+++ b/app/Modules/Stadium/Services/MatchAttendanceService.php
@@ -6,7 +6,6 @@ use App\Models\ClubProfile;
 use App\Models\Competition;
 use App\Models\Game;
 use App\Models\GameMatch;
-use App\Models\GameStanding;
 use App\Models\MatchAttendance;
 use App\Models\Team;
 use App\Models\TeamReputation;
@@ -36,7 +35,6 @@ class MatchAttendanceService
     private array $reputationCache = [];
     private array $clubProfileCache = [];
     private array $teamCache = [];
-    private array $standingPositionCache = [];
 
     /**
      * Return the MatchAttendance for this fixture, computing and persisting
@@ -126,17 +124,11 @@ class MatchAttendanceService
         $homeRep = $this->loadReputation($game->id, $home->id);
         $awayRep = $this->loadReputation($game->id, $match->away_team_id);
 
-        $homePosition = null;
-        if ($competition && $competition->role === Competition::ROLE_LEAGUE) {
-            $homePosition = $this->loadStandingPosition($game->id, $competition->id, $home->id);
-        }
-
         $attendance = $this->demandCurve->project(
             $home,
             $homeRep,
             $awayRep,
             $competition,
-            $homePosition,
         );
 
         return [
@@ -170,20 +162,6 @@ class MatchAttendanceService
         }
 
         return $this->teamCache[$teamId];
-    }
-
-    private function loadStandingPosition(string $gameId, string $competitionId, string $teamId): ?int
-    {
-        $key = "$gameId|$competitionId|$teamId";
-        if (! array_key_exists($key, $this->standingPositionCache)) {
-            $pos = GameStanding::where('game_id', $gameId)
-                ->where('competition_id', $competitionId)
-                ->where('team_id', $teamId)
-                ->value('position');
-            $this->standingPositionCache[$key] = $pos !== null ? (int) $pos : null;
-        }
-
-        return $this->standingPositionCache[$key];
     }
 
     /**

--- a/app/Modules/Stadium/Services/MatchAttendanceService.php
+++ b/app/Modules/Stadium/Services/MatchAttendanceService.php
@@ -32,6 +32,12 @@ class MatchAttendanceService
         private readonly DemandCurveService $demandCurve,
     ) {}
 
+    /** Per-request caches — MatchAttendanceService is resolved fresh per request. */
+    private array $reputationCache = [];
+    private array $clubProfileCache = [];
+    private array $teamCache = [];
+    private array $standingPositionCache = [];
+
     /**
      * Return the MatchAttendance for this fixture, computing and persisting
      * it on first call. For matches at a designated neutral venue (cup
@@ -110,7 +116,7 @@ class MatchAttendanceService
             return null;
         }
 
-        $home = Team::find($match->home_team_id);
+        $home = $this->loadTeam($match->home_team_id);
         if (!$home) {
             return null;
         }
@@ -122,11 +128,7 @@ class MatchAttendanceService
 
         $homePosition = null;
         if ($competition && $competition->role === Competition::ROLE_LEAGUE) {
-            $homePosition = GameStanding::where('game_id', $game->id)
-                ->where('competition_id', $competition->id)
-                ->where('team_id', $home->id)
-                ->value('position');
-            $homePosition = $homePosition !== null ? (int) $homePosition : null;
+            $homePosition = $this->loadStandingPosition($game->id, $competition->id, $home->id);
         }
 
         $attendance = $this->demandCurve->project(
@@ -158,7 +160,30 @@ class MatchAttendanceService
             return (int) $match->neutral_venue_capacity;
         }
 
-        return (int) (Team::find($match->home_team_id)?->stadium_seats ?? 0);
+        return (int) ($this->loadTeam($match->home_team_id)?->stadium_seats ?? 0);
+    }
+
+    private function loadTeam(string $teamId): ?Team
+    {
+        if (! array_key_exists($teamId, $this->teamCache)) {
+            $this->teamCache[$teamId] = Team::find($teamId);
+        }
+
+        return $this->teamCache[$teamId];
+    }
+
+    private function loadStandingPosition(string $gameId, string $competitionId, string $teamId): ?int
+    {
+        $key = "$gameId|$competitionId|$teamId";
+        if (! array_key_exists($key, $this->standingPositionCache)) {
+            $pos = GameStanding::where('game_id', $gameId)
+                ->where('competition_id', $competitionId)
+                ->where('team_id', $teamId)
+                ->value('position');
+            $this->standingPositionCache[$key] = $pos !== null ? (int) $pos : null;
+        }
+
+        return $this->standingPositionCache[$key];
     }
 
     /**
@@ -168,15 +193,23 @@ class MatchAttendanceService
      */
     private function loadReputation(string $gameId, string $teamId): TeamReputation
     {
+        $key = "$gameId|$teamId";
+        if (array_key_exists($key, $this->reputationCache)) {
+            return $this->reputationCache[$key];
+        }
+
         $rep = TeamReputation::where('game_id', $gameId)
             ->where('team_id', $teamId)
             ->first();
 
         if ($rep) {
-            return $rep;
+            return $this->reputationCache[$key] = $rep;
         }
 
-        $profile = ClubProfile::where('team_id', $teamId)->first();
+        if (! array_key_exists($teamId, $this->clubProfileCache)) {
+            $this->clubProfileCache[$teamId] = ClubProfile::where('team_id', $teamId)->first();
+        }
+        $profile = $this->clubProfileCache[$teamId];
         $level = $profile->reputation_level ?? ClubProfile::REPUTATION_LOCAL;
         $anchor = (int) ($profile->fan_loyalty ?? ClubProfile::FAN_LOYALTY_DEFAULT);
         $loyalty = $anchor * 10;
@@ -190,6 +223,6 @@ class MatchAttendanceService
         $synthetic->base_loyalty = $loyalty;
         $synthetic->loyalty_points = $loyalty;
 
-        return $synthetic;
+        return $this->reputationCache[$key] = $synthetic;
     }
 }

--- a/app/Modules/Transfer/Services/ScoutingService.php
+++ b/app/Modules/Transfer/Services/ScoutingService.php
@@ -442,10 +442,10 @@ class ScoutingService
     /**
      * Calculate the AI's asking price for a player.
      */
-    public function calculateAskingPrice(GamePlayer $player, Carbon $currentDate): int
+    public function calculateAskingPrice(GamePlayer $player, Carbon $currentDate, ?Collection $teammates = null): int
     {
         $base = $player->market_value_cents;
-        $importance = $this->calculatePlayerImportance($player);
+        $importance = $this->calculatePlayerImportance($player, $teammates);
 
         // Contract leverage: a club can only charge an importance premium if
         // it has leverage to refuse bids. As the contract runs down that

--- a/app/Modules/Transfer/Services/TransferMarketService.php
+++ b/app/Modules/Transfer/Services/TransferMarketService.php
@@ -115,18 +115,25 @@ class TransferMarketService
         // Shuffle for cross-team variety, then take available slots
         $selected = $candidates->shuffle()->take($slotsAvailable);
 
+        $rows = [];
         foreach ($selected as $candidate) {
             $player = $candidate['player'];
-            $askingPrice = $this->scoutingService->calculateAskingPrice($player, $game->current_date);
+            $teammates = $teamRosters->get($player->team_id);
+            $askingPrice = $this->scoutingService->calculateAskingPrice($player, $game->current_date, $teammates);
 
-            TransferListing::create([
+            $rows[] = [
+                'id' => (string) \Illuminate\Support\Str::uuid(),
                 'game_id' => $game->id,
                 'game_player_id' => $player->id,
                 'team_id' => $player->team_id,
                 'status' => TransferListing::STATUS_LISTED,
-                'listed_at' => $game->current_date,
+                'listed_at' => $game->current_date->toDateString(),
                 'asking_price' => $askingPrice,
-            ]);
+            ];
+        }
+
+        if (! empty($rows)) {
+            TransferListing::insert($rows);
         }
     }
 


### PR DESCRIPTION
Telescope showed ~480 queries for a single game creation, dominated by repeated reads rather than the bulk inserts. Four targeted fixes:

- TransferMarketService: thread already-loaded rosters through to ScoutingService::calculateAskingPrice (and on to playerImportance), eliminating a 50x N+1 roster reload. Also batch the per-candidate TransferListing::create calls into a single bulk insert.
- MatchAttendanceService: memoize per-instance lookups for TeamReputation, ClubProfile, Team and GameStanding.position — these were being re-fetched once per fixture during budget projection.
- SeasonInitializationService: cache Competition::find results on the service instance so the same reference row isn't reloaded for every pipeline step.
- CupDrawService: cache game season lookups in getAllRoundConfigs.
- GameCreationService: drop duplicate Team::find (the fallback branch was already loading $team, then the outer scope overwrote it).

No behavior change — all caches are per-request / per-service-instance so stale reads across jobs aren't a concern.