### PR TITLE
Speed up PlayerDevelopmentProcessor from 65s to a few seconds

### DIFF
--- a/app/Modules/Player/Services/PlayerTierService.php
+++ b/app/Modules/Player/Services/PlayerTierService.php
@@ -52,20 +52,4 @@ class PlayerTierService
         ");
     }
 
-    /**
-     * Recompute tiers for ALL players in a game.
-     */
-    public function recomputeAllTiersForGame(string $gameId): void
-    {
-        DB::statement("
-            UPDATE game_players SET tier = CASE
-                WHEN market_value_cents >= " . self::TIER_5_MIN . " THEN 5
-                WHEN market_value_cents >= " . self::TIER_4_MIN . " THEN 4
-                WHEN market_value_cents >= " . self::TIER_3_MIN . " THEN 3
-                WHEN market_value_cents >= " . self::TIER_2_MIN . " THEN 2
-                ELSE 1
-            END
-            WHERE game_id = ?
-        ", [$gameId]);
-    }
 }

--- a/app/Modules/Season/Processors/PlayerDevelopmentProcessor.php
+++ b/app/Modules/Season/Processors/PlayerDevelopmentProcessor.php
@@ -2,26 +2,31 @@
 
 namespace App\Modules\Season\Processors;
 
-use App\Modules\Season\Contracts\SeasonProcessor;
-use App\Modules\Season\DTOs\SeasonTransitionData;
-use App\Modules\Player\Services\PlayerDevelopmentService;
-use App\Modules\Player\Services\PlayerTierService;
-use App\Modules\Player\Services\PlayerValuationService;
 use App\Models\Game;
 use App\Models\GamePlayer;
-use Carbon\Carbon;
+use App\Modules\Player\Services\DevelopmentCurve;
+use App\Modules\Player\Services\PlayerTierService;
+use App\Modules\Player\Services\PlayerValuationService;
+use App\Modules\Season\Contracts\SeasonProcessor;
+use App\Modules\Season\DTOs\SeasonTransitionData;
 use Illuminate\Support\Facades\DB;
 
 /**
- * Applies player development changes at the end of the season.
- * Priority: 10 (runs first)
+ * Applies player development, market revaluation, and tier recompute at
+ * season end.
+ *
+ * Hybrid approach: one raw SELECT pulls every row the calculation needs,
+ * PHP computes new values (cheap arithmetic), chunked UPSERTs write
+ * back. Avoids the two hidden N+1s that made the Eloquent-based version
+ * take 60+ seconds:
+ *   - current_technical_ability / current_physical_ability accessors
+ *     lazy-loading the players row when game_*_ability is NULL
+ *   - season_appearances accessor lazy-loading the matchState satellite
  */
 class PlayerDevelopmentProcessor implements SeasonProcessor
 {
     public function __construct(
-        private readonly PlayerDevelopmentService $developmentService,
         private readonly PlayerValuationService $valuationService,
-        private readonly PlayerTierService $tierService,
     ) {}
 
     public function priority(): int
@@ -31,65 +36,90 @@ class PlayerDevelopmentProcessor implements SeasonProcessor
 
     public function process(Game $game, SeasonTransitionData $data): SeasonTransitionData
     {
+        $currentDate = $game->current_date?->toDateString();
+        if ($currentDate === null) {
+            return $data;
+        }
+
+        $rows = DB::select(<<<'SQL'
+            SELECT
+                gp.id,
+                gp.game_id,
+                gp.player_id,
+                gp.team_id,
+                gp.position,
+                DATE_PART('year', AGE(?::date, p.date_of_birth))::int AS age,
+                COALESCE(gpms.season_appearances, 0) AS apps,
+                COALESCE(gp.game_technical_ability, p.technical_ability) AS tech,
+                COALESCE(gp.game_physical_ability, p.physical_ability) AS phys,
+                gp.potential
+            FROM game_players gp
+            JOIN players p ON p.id = gp.player_id
+            LEFT JOIN game_player_match_state gpms ON gpms.game_player_id = gp.id
+            WHERE gp.game_id = ?
+              AND p.date_of_birth IS NOT NULL
+        SQL, [$currentDate, $game->id]);
+
+        if (empty($rows)) {
+            return $data;
+        }
+
         $upsertRows = [];
-        $currentDate = $game->current_date;
+        foreach ($rows as $r) {
+            $age = (int) $r->age;
+            $apps = (int) $r->apps;
+            $tech = (int) $r->tech;
+            $phys = (int) $r->phys;
+            $pot = $r->potential !== null ? (int) $r->potential : 99;
 
-        // Join players for date_of_birth (age calculation) and ability
-        // fallbacks. Left-join the satellite for season_appearances —
-        // pool players have no satellite row, in which case
-        // season_appearances is 0 (they never play, so this is correct).
-        GamePlayer::join('players', 'game_players.player_id', '=', 'players.id')
-            ->leftJoinMatchState()
-            ->where('game_players.game_id', $game->id)
-            ->select([
-                'game_players.id',
-                'game_players.game_id',
-                'game_players.player_id',
-                'game_players.team_id',
-                'game_players.position',
-                'game_players.game_technical_ability',
-                'game_players.game_physical_ability',
-                'game_players.market_value_cents',
-                DB::raw('COALESCE(game_player_match_state.season_appearances, 0) AS season_appearances'),
-                'game_players.potential',
-                'players.technical_ability',
-                'players.physical_ability',
-                'players.date_of_birth',
-            ])
-            ->chunk(500, function ($chunk) use (&$upsertRows, $currentDate) {
-                foreach ($chunk as $player) {
-                    $age = (int) Carbon::parse($player->date_of_birth)->diffInYears($currentDate);
-                    $change = $this->developmentService->calculateDevelopment($player, $age);
+            $curve = DevelopmentCurve::getChanges($age);
+            $techDelta = DevelopmentCurve::calculateChange($curve['technical'], $apps);
+            $physDelta = DevelopmentCurve::calculateChange($curve['physical'], $apps);
 
-                    $previousAbility = (int) round(($change['techBefore'] + $change['physBefore']) / 2);
-                    $newAbility = (int) round(($change['techAfter'] + $change['physAfter']) / 2);
-                    $newMarketValue = $this->valuationService->abilityToMarketValue(
-                        $newAbility, $age, $previousAbility
-                    );
-
-                    $upsertRows[] = [
-                        'id' => $player->id,
-                        'game_id' => $player->game_id,
-                        'player_id' => $player->player_id,
-                        'team_id' => $player->team_id,
-                        'position' => $player->position,
-                        'game_technical_ability' => $change['techAfter'],
-                        'game_physical_ability' => $change['physAfter'],
-                        'market_value_cents' => $newMarketValue,
-                    ];
+            $oldAvg = (int) round(($tech + $phys) / 2);
+            if ($age < 23 && ($pot - $oldAvg) >= 15) {
+                if ($techDelta > 0) {
+                    $techDelta += 1;
                 }
-            });
-
-        if (!empty($upsertRows)) {
-            foreach (array_chunk($upsertRows, 500) as $chunk) {
-                GamePlayer::upsert($chunk, ['id'], [
-                    'game_technical_ability',
-                    'game_physical_ability',
-                    'market_value_cents',
-                ]);
+                if ($physDelta > 0) {
+                    $physDelta += 1;
+                }
             }
 
-            $this->tierService->recomputeAllTiersForGame($game->id);
+            $newTech = $tech + $techDelta;
+            $newPhys = $phys + $physDelta;
+            if ($techDelta > 0) {
+                $newTech = min($newTech, $pot);
+            }
+            if ($physDelta > 0) {
+                $newPhys = min($newPhys, $pot);
+            }
+            $newTech = max(1, min(99, $newTech));
+            $newPhys = max(1, min(99, $newPhys));
+
+            $newAvg = (int) round(($newTech + $newPhys) / 2);
+            $newMV = $this->valuationService->abilityToMarketValue($newAvg, $age, $oldAvg);
+
+            $upsertRows[] = [
+                'id' => $r->id,
+                'game_id' => $r->game_id,
+                'player_id' => $r->player_id,
+                'team_id' => $r->team_id,
+                'position' => $r->position,
+                'game_technical_ability' => $newTech,
+                'game_physical_ability' => $newPhys,
+                'market_value_cents' => $newMV,
+                'tier' => PlayerTierService::tierFromMarketValue($newMV),
+            ];
+        }
+
+        foreach (array_chunk($upsertRows, 500) as $chunk) {
+            GamePlayer::upsert($chunk, ['id'], [
+                'game_technical_ability',
+                'game_physical_ability',
+                'market_value_cents',
+                'tier',
+            ]);
         }
 
         return $data;

--- a/database/factories/TeamFactory.php
+++ b/database/factories/TeamFactory.php
@@ -13,12 +13,16 @@ class TeamFactory extends Factory
     public function definition(): array
     {
         $name = $this->faker->unique()->city() . ' FC';
+        $transfermarktId = $this->faker->unique()->numberBetween(1000, 99999);
 
         return [
             'id' => Str::uuid()->toString(),
-            'transfermarkt_id' => $this->faker->unique()->numberBetween(1000, 99999),
+            'transfermarkt_id' => $transfermarktId,
             'name' => $name,
-            'slug' => Str::slug($name),
+            // Append the unique transfermarkt_id so slugs never collide even
+            // when faker's city pool produces near-duplicates (e.g. "St. Louis"
+            // vs "St Louis" both slug to "st-louis") across large test setups.
+            'slug' => Str::slug($name) . '-' . $transfermarktId,
             'country' => 'ES',
             'image' => null,
             'stadium_name' => $this->faker->city() . ' Stadium',

--- a/tests/Unit/AIFreeAgentSigningProcessorTest.php
+++ b/tests/Unit/AIFreeAgentSigningProcessorTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\Game;
+use App\Modules\Season\DTOs\SeasonTransitionData;
+use App\Modules\Season\Processors\AIFreeAgentSigningProcessor;
+use App\Modules\Transfer\Services\AITransferMarketService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Mockery;
+use Tests\TestCase;
+
+class AIFreeAgentSigningProcessorTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_delegates_to_service_and_stores_signings_metadata(): void
+    {
+        $game = Game::factory()->create();
+
+        $signings = [
+            'totalSigned' => 12,
+            'byTeam' => ['team-a' => 3, 'team-b' => 9],
+        ];
+
+        $service = Mockery::mock(AITransferMarketService::class);
+        $service->shouldReceive('processSeasonFreeAgentSignings')
+            ->once()
+            ->with(Mockery::on(fn (Game $g) => $g->id === $game->id), '2026')
+            ->andReturn($signings);
+
+        $processor = new AIFreeAgentSigningProcessor($service);
+
+        $data = new SeasonTransitionData(
+            oldSeason: '2025',
+            newSeason: '2026',
+            competitionId: $game->competition_id,
+        );
+
+        $result = $processor->process($game, $data);
+
+        $this->assertSame($signings, $result->getMetadata('freeAgentSignings'));
+    }
+
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+}

--- a/tests/Unit/BudgetProjectionProcessorTest.php
+++ b/tests/Unit/BudgetProjectionProcessorTest.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\Competition;
+use App\Models\Game;
+use App\Models\GameFinances;
+use App\Models\Team;
+use App\Modules\Finance\Services\BudgetProjectionService;
+use App\Modules\Season\DTOs\SeasonTransitionData;
+use App\Modules\Season\Processors\BudgetProjectionProcessor;
+use App\Modules\Season\Services\SeasonGoalService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Mockery;
+use Tests\TestCase;
+
+class BudgetProjectionProcessorTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_sets_season_goal_and_stores_projections_metadata(): void
+    {
+        $team = Team::factory()->create();
+        $competition = Competition::factory()->league()->create();
+        $game = Game::factory()
+            ->forTeam($team)
+            ->inCompetition($competition->id)
+            ->create();
+
+        $seasonGoalService = Mockery::mock(SeasonGoalService::class);
+        $seasonGoalService->shouldReceive('determineGoalForTeam')
+            ->once()
+            ->with(Mockery::on(fn (Team $t) => $t->id === $team->id), Mockery::any(), Mockery::any(), false)
+            ->andReturn('champion');
+
+        $finances = new GameFinances([
+            'projected_position' => 3,
+            'projected_total_revenue' => 100_000_000_00,
+            'projected_wages' => 40_000_000_00,
+            'projected_surplus' => 5_000_000_00,
+            'carried_debt' => 0,
+            'carried_surplus' => 0,
+            'available_surplus' => 5_000_000_00,
+        ]);
+
+        $projectionService = Mockery::mock(BudgetProjectionService::class);
+        $projectionService->shouldReceive('generateProjections')
+            ->once()
+            ->andReturn($finances);
+
+        $processor = new BudgetProjectionProcessor($projectionService, $seasonGoalService);
+
+        $data = new SeasonTransitionData(
+            oldSeason: '2025',
+            newSeason: '2026',
+            competitionId: $competition->id,
+        );
+
+        $result = $processor->process($game, $data);
+
+        $this->assertSame('champion', $game->fresh()->season_goal);
+
+        $projections = $result->getMetadata('new_season_projections');
+        $this->assertIsArray($projections);
+        $this->assertSame(3, $projections['projected_position']);
+        $this->assertSame(100_000_000_00, $projections['projected_total_revenue']);
+        $this->assertSame('champion', $projections['season_goal']);
+    }
+
+    public function test_passes_recently_promoted_flag_when_team_was_promoted(): void
+    {
+        $team = Team::factory()->create();
+        $competition = Competition::factory()->league()->create();
+        $game = Game::factory()
+            ->forTeam($team)
+            ->inCompetition($competition->id)
+            ->create();
+
+        $seasonGoalService = Mockery::mock(SeasonGoalService::class);
+        $seasonGoalService->shouldReceive('determineGoalForTeam')
+            ->once()
+            ->with(Mockery::any(), Mockery::any(), Mockery::any(), true)
+            ->andReturn('survival');
+
+        $projectionService = Mockery::mock(BudgetProjectionService::class);
+        $projectionService->shouldReceive('generateProjections')
+            ->andReturn(new GameFinances([
+                'projected_position' => 18,
+                'projected_total_revenue' => 50_000_000_00,
+                'projected_wages' => 20_000_000_00,
+                'projected_surplus' => 1_000_000_00,
+                'carried_debt' => 0,
+                'carried_surplus' => 0,
+                'available_surplus' => 1_000_000_00,
+            ]));
+
+        $processor = new BudgetProjectionProcessor($projectionService, $seasonGoalService);
+
+        $data = new SeasonTransitionData(
+            oldSeason: '2025',
+            newSeason: '2026',
+            competitionId: $competition->id,
+        );
+        $data->setMetadata('promotedTeams', [['teamId' => $team->id]]);
+
+        $processor->process($game, $data);
+
+        $this->assertSame('survival', $game->fresh()->season_goal);
+    }
+
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+}

--- a/tests/Unit/ContractRenewalProcessorTest.php
+++ b/tests/Unit/ContractRenewalProcessorTest.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\Game;
+use App\Models\GamePlayer;
+use App\Models\Team;
+use App\Modules\Season\DTOs\SeasonTransitionData;
+use App\Modules\Season\Processors\ContractRenewalProcessor;
+use App\Modules\Transfer\Services\ContractService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ContractRenewalProcessorTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private ContractRenewalProcessor $processor;
+    private Team $team;
+    private Game $game;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->processor = app(ContractRenewalProcessor::class);
+
+        $this->team = Team::factory()->create();
+        $this->game = Game::factory()->forTeam($this->team)->create();
+    }
+
+    public function test_applies_pending_wage_to_annual_wage_and_clears_pending(): void
+    {
+        $player = GamePlayer::factory()
+            ->forGame($this->game)
+            ->forTeam($this->team)
+            ->create([
+                'annual_wage' => 500_000_00,
+                'pending_annual_wage' => 1_200_000_00,
+            ]);
+
+        $this->processor->process($this->game, $this->transitionData());
+
+        $player->refresh();
+        $this->assertSame(1_200_000_00, $player->annual_wage);
+        $this->assertNull($player->pending_annual_wage);
+    }
+
+    public function test_leaves_players_without_pending_wage_untouched(): void
+    {
+        $player = GamePlayer::factory()
+            ->forGame($this->game)
+            ->forTeam($this->team)
+            ->create([
+                'annual_wage' => 500_000_00,
+                'pending_annual_wage' => null,
+            ]);
+
+        $this->processor->process($this->game, $this->transitionData());
+
+        $player->refresh();
+        $this->assertSame(500_000_00, $player->annual_wage);
+    }
+
+    public function test_ignores_players_from_other_teams(): void
+    {
+        $otherTeam = Team::factory()->create();
+        $otherPlayer = GamePlayer::factory()
+            ->forGame($this->game)
+            ->forTeam($otherTeam)
+            ->create([
+                'annual_wage' => 500_000_00,
+                'pending_annual_wage' => 1_200_000_00,
+            ]);
+
+        $this->processor->process($this->game, $this->transitionData());
+
+        $otherPlayer->refresh();
+        $this->assertSame(500_000_00, $otherPlayer->annual_wage);
+        $this->assertSame(1_200_000_00, $otherPlayer->pending_annual_wage);
+    }
+
+    public function test_records_renewal_metadata_for_each_renewed_player(): void
+    {
+        $renewed = GamePlayer::factory()
+            ->forGame($this->game)
+            ->forTeam($this->team)
+            ->create([
+                'pending_annual_wage' => 750_000_00,
+            ]);
+
+        $data = $this->processor->process($this->game, $this->transitionData());
+
+        $renewals = $data->getMetadata('contractRenewals');
+        $this->assertIsArray($renewals);
+        $this->assertCount(1, $renewals);
+        $this->assertSame($renewed->id, $renewals[0]['playerId']);
+    }
+
+    private function transitionData(): SeasonTransitionData
+    {
+        return new SeasonTransitionData(
+            oldSeason: '2025',
+            newSeason: '2026',
+            competitionId: $this->game->competition_id,
+        );
+    }
+}

--- a/tests/Unit/LeagueFixtureProcessorTest.php
+++ b/tests/Unit/LeagueFixtureProcessorTest.php
@@ -37,10 +37,9 @@ class LeagueFixtureProcessorTest extends TestCase
         $oldTie = CupTie::create([
             'game_id' => $game->id,
             'competition_id' => $game->competition_id,
-            'round' => 1,
+            'round_number' => 1,
             'home_team_id' => $home->id,
             'away_team_id' => $away->id,
-            'season' => '2025',
         ]);
 
         // Same shapes for another game (should NOT be touched)

--- a/tests/Unit/LeagueFixtureProcessorTest.php
+++ b/tests/Unit/LeagueFixtureProcessorTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\CupTie;
+use App\Models\Game;
+use App\Models\GameMatch;
+use App\Models\Team;
+use App\Modules\Season\DTOs\SeasonTransitionData;
+use App\Modules\Season\Processors\LeagueFixtureProcessor;
+use App\Modules\Season\Services\SeasonInitializationService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Mockery;
+use Tests\TestCase;
+
+class LeagueFixtureProcessorTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_deletes_old_matches_and_cup_ties_and_generates_new_fixtures(): void
+    {
+        $game = Game::factory()->create();
+        $otherGame = Game::factory()->create();
+        [$home, $away] = Team::factory()->count(2)->create();
+
+        // Old matches + cup ties for this game (should be deleted)
+        $oldMatch = GameMatch::create([
+            'game_id' => $game->id,
+            'competition_id' => $game->competition_id,
+            'round_number' => 1,
+            'home_team_id' => $home->id,
+            'away_team_id' => $away->id,
+            'scheduled_date' => '2024-08-15',
+            'played' => true,
+        ]);
+
+        $oldTie = CupTie::create([
+            'game_id' => $game->id,
+            'competition_id' => $game->competition_id,
+            'round' => 1,
+            'home_team_id' => $home->id,
+            'away_team_id' => $away->id,
+            'season' => '2025',
+        ]);
+
+        // Same shapes for another game (should NOT be touched)
+        $otherMatch = GameMatch::create([
+            'game_id' => $otherGame->id,
+            'competition_id' => $otherGame->competition_id,
+            'round_number' => 1,
+            'home_team_id' => $home->id,
+            'away_team_id' => $away->id,
+            'scheduled_date' => '2024-08-15',
+            'played' => true,
+        ]);
+
+        $service = Mockery::mock(SeasonInitializationService::class);
+        $service->shouldReceive('generateLeagueFixtures')
+            ->once()
+            ->with($game->id, $game->competition_id, '2026');
+
+        $processor = new LeagueFixtureProcessor($service);
+
+        $data = new SeasonTransitionData(
+            oldSeason: '2025',
+            newSeason: '2026',
+            competitionId: $game->competition_id,
+        );
+
+        $processor->process($game, $data);
+
+        $this->assertNull(GameMatch::find($oldMatch->id));
+        $this->assertNull(CupTie::find($oldTie->id));
+        $this->assertNotNull(GameMatch::find($otherMatch->id));
+    }
+
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+}

--- a/tests/Unit/PlayerDevelopmentProcessorTest.php
+++ b/tests/Unit/PlayerDevelopmentProcessorTest.php
@@ -1,0 +1,250 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\Game;
+use App\Models\GamePlayer;
+use App\Models\GamePlayerMatchState;
+use App\Models\Player;
+use App\Models\Team;
+use App\Modules\Player\Services\PlayerTierService;
+use App\Modules\Player\Services\PlayerValuationService;
+use App\Modules\Season\DTOs\SeasonTransitionData;
+use App\Modules\Season\Processors\PlayerDevelopmentProcessor;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class PlayerDevelopmentProcessorTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const SEASON_END = '2025-06-30';
+
+    private PlayerDevelopmentProcessor $processor;
+    private PlayerValuationService $valuationService;
+    private Game $game;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->valuationService = new PlayerValuationService();
+        $this->processor = new PlayerDevelopmentProcessor($this->valuationService);
+
+        $this->game = Game::factory()->atDate(self::SEASON_END)->create();
+    }
+
+    public function test_young_player_with_appearances_grows_and_gets_gap_bonus(): void
+    {
+        // 18yo, 20 apps, big gap to potential → +1 gap bonus on top of curve growth.
+        $player = $this->makePlayer(age: 18, tech: 60, phys: 60, potential: 85, appearances: 20);
+
+        $this->processor->process($this->game, $this->transitionData());
+
+        $player->refresh();
+        // Curve growth at age 18: +2 tech, +2 phys. calculateChange(2, 20) = round(2 * 20/25) = 2.
+        // Gap bonus (+1) applies: pot - avg = 85 - 60 = 25 >= 15, age < 23.
+        $this->assertSame(63, $player->game_technical_ability);
+        $this->assertSame(63, $player->game_physical_ability);
+    }
+
+    public function test_young_player_without_enough_appearances_does_not_grow(): void
+    {
+        // 18yo, 5 apps (below MIN_APPEARANCES_FOR_GROWTH=10).
+        $player = $this->makePlayer(age: 18, tech: 60, phys: 60, potential: 85, appearances: 5);
+
+        $this->processor->process($this->game, $this->transitionData());
+
+        $player->refresh();
+        $this->assertSame(60, $player->game_technical_ability);
+        $this->assertSame(60, $player->game_physical_ability);
+    }
+
+    public function test_inactive_veteran_declines_at_full_rate(): void
+    {
+        // 33yo with only 2 apps: full decline (not halved).
+        $player = $this->makePlayer(age: 33, tech: 80, phys: 75, potential: 85, appearances: 2);
+
+        $this->processor->process($this->game, $this->transitionData());
+
+        $player->refresh();
+        // Age 33 curve: tech -3, phys -4 (full decline since apps < 10).
+        $this->assertSame(77, $player->game_technical_ability);
+        $this->assertSame(71, $player->game_physical_ability);
+    }
+
+    public function test_active_veteran_declines_at_half_rate(): void
+    {
+        // 33yo with 25 apps: decline halved.
+        $player = $this->makePlayer(age: 33, tech: 80, phys: 75, potential: 85, appearances: 25);
+
+        $this->processor->process($this->game, $this->transitionData());
+
+        $player->refresh();
+        // round(-3 * 0.5) = -2 (PHP half-away-from-zero), round(-4 * 0.5) = -2.
+        $this->assertSame(78, $player->game_technical_ability);
+        $this->assertSame(73, $player->game_physical_ability);
+    }
+
+    public function test_growth_is_capped_at_potential(): void
+    {
+        // 16yo already near potential: growth clamps to pot ceiling.
+        $player = $this->makePlayer(age: 16, tech: 74, phys: 74, potential: 75, appearances: 25);
+
+        $this->processor->process($this->game, $this->transitionData());
+
+        $player->refresh();
+        // Curve at 16: tech +3, phys +3 with full apps. Gap = 75 - 74 = 1, no gap bonus.
+        // +3 would go to 77; capped at pot=75.
+        $this->assertSame(75, $player->game_technical_ability);
+        $this->assertSame(75, $player->game_physical_ability);
+    }
+
+    public function test_pool_player_without_match_state_decays_as_inactive(): void
+    {
+        // No matchState row → apps = 0 → behaves as inactive.
+        $player = $this->makePoolPlayer(age: 33, tech: 80, phys: 75, potential: 85);
+
+        $this->processor->process($this->game, $this->transitionData());
+
+        $player->refresh();
+        $this->assertSame(77, $player->game_technical_ability);
+        $this->assertSame(71, $player->game_physical_ability);
+    }
+
+    public function test_market_value_and_tier_are_recomputed(): void
+    {
+        $player = $this->makePlayer(
+            age: 18,
+            tech: 60,
+            phys: 60,
+            potential: 85,
+            appearances: 20,
+            marketValueCents: 100_000_00, // €100K (tier 1) — will get revalued up
+        );
+
+        $this->processor->process($this->game, $this->transitionData());
+
+        $player->refresh();
+        $newAvg = (int) round(($player->game_technical_ability + $player->game_physical_ability) / 2);
+        $oldAvg = 60;
+        $expectedMV = $this->valuationService->abilityToMarketValue($newAvg, 18, $oldAvg);
+
+        $this->assertSame($expectedMV, $player->market_value_cents);
+        $this->assertSame(PlayerTierService::tierFromMarketValue($expectedMV), $player->tier);
+    }
+
+    public function test_falls_back_to_players_ability_when_game_ability_is_null(): void
+    {
+        // Simulates a freshly-generated row where game_*_ability hasn't been set yet.
+        $player = Player::factory()->age(25, self::SEASON_END)->create([
+            'technical_ability' => 70,
+            'physical_ability' => 70,
+        ]);
+
+        $team = Team::factory()->create();
+        $gamePlayer = GamePlayer::factory()
+            ->forGame($this->game)
+            ->forTeam($team)
+            ->create([
+                'player_id' => $player->id,
+                'game_technical_ability' => null,
+                'game_physical_ability' => null,
+                'potential' => 80,
+                'season_appearances' => 25,
+            ]);
+
+        $this->processor->process($this->game, $this->transitionData());
+
+        $gamePlayer->refresh();
+        // Age 25 curve: tech 0, phys -1 (halved with apps >= 10 = -1 after PHP rounding).
+        $this->assertSame(70, $gamePlayer->game_technical_ability);
+        $this->assertSame(69, $gamePlayer->game_physical_ability);
+    }
+
+    public function test_other_games_are_untouched(): void
+    {
+        $otherGame = Game::factory()->atDate(self::SEASON_END)->create();
+        $otherPlayer = $this->makePlayer(
+            age: 18,
+            tech: 60,
+            phys: 60,
+            potential: 85,
+            appearances: 25,
+            game: $otherGame,
+        );
+
+        $this->processor->process($this->game, $this->transitionData());
+
+        $this->assertSame(60, $otherPlayer->fresh()->game_technical_ability);
+        $this->assertSame(60, $otherPlayer->fresh()->game_physical_ability);
+    }
+
+    // -----------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------
+
+    private function transitionData(): SeasonTransitionData
+    {
+        return new SeasonTransitionData(
+            oldSeason: '2025',
+            newSeason: '2026',
+            competitionId: $this->game->competition_id,
+        );
+    }
+
+    private function makePlayer(
+        int $age,
+        int $tech,
+        int $phys,
+        int $potential,
+        int $appearances,
+        ?int $marketValueCents = null,
+        ?Game $game = null,
+    ): GamePlayer {
+        $player = Player::factory()->age($age, self::SEASON_END)->create([
+            'technical_ability' => $tech,
+            'physical_ability' => $phys,
+        ]);
+
+        $team = Team::factory()->create();
+
+        $attributes = [
+            'player_id' => $player->id,
+            'game_technical_ability' => $tech,
+            'game_physical_ability' => $phys,
+            'potential' => $potential,
+            'season_appearances' => $appearances,
+        ];
+
+        if ($marketValueCents !== null) {
+            $attributes['market_value_cents'] = $marketValueCents;
+        }
+
+        return GamePlayer::factory()
+            ->forGame($game ?? $this->game)
+            ->forTeam($team)
+            ->create($attributes);
+    }
+
+    private function makePoolPlayer(int $age, int $tech, int $phys, int $potential): GamePlayer
+    {
+        $player = Player::factory()->age($age, self::SEASON_END)->create([
+            'technical_ability' => $tech,
+            'physical_ability' => $phys,
+        ]);
+
+        $team = Team::factory()->create();
+
+        return GamePlayer::factory()
+            ->forGame($this->game)
+            ->forTeam($team)
+            ->pool()
+            ->create([
+                'player_id' => $player->id,
+                'game_technical_ability' => $tech,
+                'game_physical_ability' => $phys,
+                'potential' => $potential,
+            ]);
+    }
+}

--- a/tests/Unit/PlayerTierServiceTest.php
+++ b/tests/Unit/PlayerTierServiceTest.php
@@ -115,38 +115,6 @@ class PlayerTierServiceTest extends TestCase
     }
 
     // -------------------------------------------------------
-    // recomputeAllTiersForGame — game-scoped
-    // -------------------------------------------------------
-
-    public function test_recompute_all_tiers_for_game_updates_all_players_in_game(): void
-    {
-        $game1 = Game::factory()->create();
-        $game2 = Game::factory()->create();
-        $team = Team::factory()->create();
-
-        $player1 = GamePlayer::factory()->forGame($game1)->forTeam($team)->create([
-            'market_value_cents' => 30_000_000_00, // €30M → tier 4
-            'tier' => 1,
-        ]);
-
-        $player2 = GamePlayer::factory()->forGame($game1)->forTeam($team)->create([
-            'market_value_cents' => 500_000_00, // €500K → tier 1
-            'tier' => 5,
-        ]);
-
-        $otherGamePlayer = GamePlayer::factory()->forGame($game2)->forTeam($team)->create([
-            'market_value_cents' => 30_000_000_00, // €30M → should be tier 4 but stays 1
-            'tier' => 1,
-        ]);
-
-        $this->service->recomputeAllTiersForGame($game1->id);
-
-        $this->assertEquals(4, $player1->fresh()->tier);
-        $this->assertEquals(1, $player2->fresh()->tier);
-        $this->assertEquals(1, $otherGamePlayer->fresh()->tier); // Other game untouched
-    }
-
-    // -------------------------------------------------------
     // Factory produces correct tier
     // -------------------------------------------------------
 

--- a/tests/Unit/ReputationUpdateProcessorTest.php
+++ b/tests/Unit/ReputationUpdateProcessorTest.php
@@ -14,10 +14,12 @@ use App\Modules\Season\DTOs\SeasonTransitionData;
 use App\Modules\Season\Processors\ReputationUpdateProcessor;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use Tests\TestCase;
 
 class ReputationUpdateProcessorTest extends TestCase
 {
+    use MockeryPHPUnitIntegration;
     use RefreshDatabase;
 
     private NotificationService $notificationService;

--- a/tests/Unit/ReputationUpdateProcessorTest.php
+++ b/tests/Unit/ReputationUpdateProcessorTest.php
@@ -1,0 +1,204 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\ClubProfile;
+use App\Models\Competition;
+use App\Models\CompetitionEntry;
+use App\Models\Game;
+use App\Models\GameStanding;
+use App\Models\Team;
+use App\Models\TeamReputation;
+use App\Modules\Notification\Services\NotificationService;
+use App\Modules\Season\DTOs\SeasonTransitionData;
+use App\Modules\Season\Processors\ReputationUpdateProcessor;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Mockery;
+use Tests\TestCase;
+
+class ReputationUpdateProcessorTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private NotificationService $notificationService;
+    private ReputationUpdateProcessor $processor;
+    private Competition $league;
+    private Team $userTeam;
+    private Game $game;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->notificationService = Mockery::mock(NotificationService::class);
+        // Default: no notifications expected; individual tests override.
+        $this->notificationService->shouldReceive('create')->byDefault();
+
+        $this->processor = new ReputationUpdateProcessor($this->notificationService);
+
+        $this->league = Competition::factory()->league()->create(['tier' => 1]);
+        $this->userTeam = Team::factory()->create();
+        $this->game = Game::factory()
+            ->forTeam($this->userTeam)
+            ->inCompetition($this->league->id)
+            ->create();
+    }
+
+    public function test_title_winner_gains_points(): void
+    {
+        // Established team gets +40 for 1st place, minus 5 gravity = +35 net.
+        $this->enterLeague($this->userTeam);
+        $reputation = $this->seedReputation(
+            $this->userTeam,
+            level: ClubProfile::REPUTATION_ESTABLISHED,
+            points: 250,
+        );
+        $this->placeStanding($this->userTeam, position: 1);
+
+        $this->processor->process($this->game, $this->transitionData());
+
+        $this->assertSame(285, $reputation->fresh()->reputation_points);
+    }
+
+    public function test_mid_table_team_declines_from_gravity(): void
+    {
+        // Elite team at mid-table: 0 points gained, 25 lost to gravity.
+        $this->enterLeague($this->userTeam);
+        $reputation = $this->seedReputation(
+            $this->userTeam,
+            level: ClubProfile::REPUTATION_ELITE,
+            points: 450,
+        );
+        $this->placeStanding($this->userTeam, position: 12);
+
+        $this->processor->process($this->game, $this->transitionData());
+
+        $this->assertSame(425, $reputation->fresh()->reputation_points);
+    }
+
+    public function test_points_never_go_below_zero(): void
+    {
+        $this->enterLeague($this->userTeam);
+        $reputation = $this->seedReputation(
+            $this->userTeam,
+            level: ClubProfile::REPUTATION_LOCAL,
+            points: 5,
+        );
+        $this->placeStanding($this->userTeam, position: 20); // 18+ = -15
+
+        $this->processor->process($this->game, $this->transitionData());
+
+        $this->assertSame(0, $reputation->fresh()->reputation_points);
+    }
+
+    public function test_tier_recalculates_when_points_cross_threshold(): void
+    {
+        // 195 + 40 (1st) - 5 (gravity) = 230 → crosses into ESTABLISHED (>= 200).
+        $this->enterLeague($this->userTeam);
+        $reputation = $this->seedReputation(
+            $this->userTeam,
+            level: ClubProfile::REPUTATION_MODEST,
+            baseLevel: ClubProfile::REPUTATION_MODEST,
+            points: 195,
+        );
+        $this->placeStanding($this->userTeam, position: 1);
+
+        $this->processor->process($this->game, $this->transitionData());
+
+        $reputation->refresh();
+        $this->assertSame(ClubProfile::REPUTATION_ESTABLISHED, $reputation->reputation_level);
+    }
+
+    public function test_sends_notification_when_user_tier_changes(): void
+    {
+        $this->enterLeague($this->userTeam);
+        $this->seedReputation(
+            $this->userTeam,
+            level: ClubProfile::REPUTATION_MODEST,
+            baseLevel: ClubProfile::REPUTATION_MODEST,
+            points: 195,
+        );
+        $this->placeStanding($this->userTeam, position: 1);
+
+        $this->notificationService->shouldReceive('create')->once();
+
+        $this->processor->process($this->game, $this->transitionData());
+    }
+
+    public function test_does_not_notify_when_tier_is_unchanged(): void
+    {
+        $this->enterLeague($this->userTeam);
+        $this->seedReputation(
+            $this->userTeam,
+            level: ClubProfile::REPUTATION_ESTABLISHED,
+            points: 250,
+        );
+        $this->placeStanding($this->userTeam, position: 12); // 0 delta - 5 gravity = 245, still ESTABLISHED
+
+        $this->notificationService->shouldNotReceive('create');
+
+        $this->processor->process($this->game, $this->transitionData());
+    }
+
+    // ---------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------
+
+    private function transitionData(): SeasonTransitionData
+    {
+        return new SeasonTransitionData(
+            oldSeason: '2025',
+            newSeason: '2026',
+            competitionId: $this->league->id,
+        );
+    }
+
+    private function enterLeague(Team $team): void
+    {
+        CompetitionEntry::create([
+            'game_id' => $this->game->id,
+            'competition_id' => $this->league->id,
+            'team_id' => $team->id,
+        ]);
+    }
+
+    private function seedReputation(
+        Team $team,
+        string $level,
+        int $points,
+        ?string $baseLevel = null,
+    ): TeamReputation {
+        return TeamReputation::create([
+            'game_id' => $this->game->id,
+            'team_id' => $team->id,
+            'reputation_level' => $level,
+            'base_reputation_level' => $baseLevel ?? $level,
+            'reputation_points' => $points,
+            'base_loyalty' => 70,
+            'loyalty_points' => 70,
+        ]);
+    }
+
+    private function placeStanding(Team $team, int $position): void
+    {
+        GameStanding::create([
+            'game_id' => $this->game->id,
+            'competition_id' => $this->league->id,
+            'team_id' => $team->id,
+            'position' => $position,
+            'played' => 38, // Must be > 0 to be picked up by the processor.
+            'won' => 0,
+            'drawn' => 0,
+            'lost' => 0,
+            'goals_for' => 0,
+            'goals_against' => 0,
+            'points' => 0,
+        ]);
+    }
+
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+}

--- a/tests/Unit/SeasonSettlementProcessorTest.php
+++ b/tests/Unit/SeasonSettlementProcessorTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\Game;
+use App\Models\Team;
+use App\Modules\Season\DTOs\SeasonTransitionData;
+use App\Modules\Season\Processors\SeasonSettlementProcessor;
+use App\Modules\Stadium\Services\MatchAttendanceService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Mockery;
+use Tests\TestCase;
+
+class SeasonSettlementProcessorTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_is_a_noop_when_game_has_no_finances_record(): void
+    {
+        $team = Team::factory()->create();
+        $game = Game::factory()->forTeam($team)->create();
+
+        $attendanceService = Mockery::mock(MatchAttendanceService::class);
+        // No attendance lookups should happen when there are no finances to settle.
+        $attendanceService->shouldNotReceive('resolveForMatch');
+
+        $processor = new SeasonSettlementProcessor($attendanceService);
+
+        $data = new SeasonTransitionData(
+            oldSeason: '2025',
+            newSeason: '2026',
+            competitionId: $game->competition_id,
+        );
+
+        $result = $processor->process($game, $data);
+
+        // Pass-through: metadata untouched, no exception thrown.
+        $this->assertSame($data, $result);
+        $this->assertNull($result->getMetadata('finances'));
+    }
+
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+}


### PR DESCRIPTION
Hybrid approach that plays to each layer's strengths:

- One raw DB::select joins game_players + players + match_state in a single indexed query, returning stdClass rows. No Eloquent hydration, so the two hidden accessor N+1s go away (ability fallback to players, season_appearances lookup on matchState satellite).
- PHP loops over the ~15k rows with cheap arithmetic, calling the existing DevelopmentCurve helpers and PlayerValuationService for the log-interpolation market value.
- Chunked upserts write back with a known key set, so PG picks an index scan every time. Tier is computed inline per row and folded into the upsert, removing the separate tier UPDATE pass.