### PR TITLE
Implement playoff tiebreaker by regular-season position

### DIFF
--- a/app/Modules/Competition/Playoffs/PrimeraRFEFPlayoffGenerator.php
+++ b/app/Modules/Competition/Playoffs/PrimeraRFEFPlayoffGenerator.php
@@ -26,9 +26,10 @@ use Illuminate\Support\Collection;
  *
  * Format:
  * - 8 qualifying teams: positions 2, 3, 4, 5 from each group.
- * - Two fixed brackets:
- *     Bracket 1 → [A2 vs A5] and [B3 vs B4]
- *     Bracket 2 → [B2 vs B5] and [A3 vs A4]
+ * - Semifinals pair teams from opposite groups: 2nd vs 5th and 3rd vs 4th,
+ *   with each half of the bracket tree hosted by one group's lower seeds.
+ *     Bracket 1 → [B5 vs A2] and [B4 vs A3]
+ *     Bracket 2 → [A5 vs B2] and [A4 vs B3]
  * - Round 1 (Semifinals): 4 two-legged ties, lower seed hosts first leg.
  * - Round 2 (Bracket Finals): the two semifinal winners in each bracket play
  *   a two-legged final. Both bracket winners are promoted to La Liga 2.
@@ -152,9 +153,10 @@ class PrimeraRFEFPlayoffGenerator implements PlayoffGenerator
      * skips reserve teams whose parent already plays in ESP2, populates
      * ESP3PO::CompetitionEntry with the 8 qualified teams, and returns 4 matchups.
      *
-     * Two brackets:
-     *   Bracket 1: (A2 vs A5) and (B3 vs B4)
-     *   Bracket 2: (B2 vs B5) and (A3 vs A4)
+     * Semifinals always pair teams from opposite groups (2nd of one group vs
+     * 5th of the other, 3rd of one vs 4th of the other):
+     *   Bracket 1: (B5 vs A2) and (B4 vs A3)
+     *   Bracket 2: (A5 vs B2) and (A4 vs B3)
      * Lower-seeded team hosts the first leg (matches ESP2PlayoffGenerator's
      * convention so two-leg home/away ordering is consistent across playoffs).
      *
@@ -189,12 +191,13 @@ class PrimeraRFEFPlayoffGenerator implements PlayoffGenerator
         // Lower seed hosts first leg — so the 5th-place team is listed as "home"
         // in the matchup, and the 4th-place team is listed as "home" in the second
         // ESP3PO tie within each bracket. See createTie() which treats the first
-        // slot as first-leg home.
+        // slot as first-leg home. Each semifinal crosses groups so a 2nd-place
+        // team never meets a same-group rival until a bracket final at earliest.
         return [
-            [$a5, $a2, self::BRACKET_A],
-            [$b4, $b3, self::BRACKET_A],
-            [$b5, $b2, self::BRACKET_B],
-            [$a4, $a3, self::BRACKET_B],
+            [$b5, $a2, self::BRACKET_A],
+            [$b4, $a3, self::BRACKET_A],
+            [$a5, $b2, self::BRACKET_B],
+            [$a4, $b3, self::BRACKET_B],
         ];
     }
 

--- a/app/Modules/Competition/Services/CountryConfig.php
+++ b/app/Modules/Competition/Services/CountryConfig.php
@@ -211,6 +211,38 @@ class CountryConfig
     }
 
     /**
+     * For a competition that hosts promotion-playoff CupTies, return the
+     * feeder league competition IDs whose regular-season standings decide
+     * tiebreakers when a two-legged tie is level after extra time (higher
+     * finisher wins instead of going to penalties).
+     *
+     * Returns an empty array for competitions that aren't promotion playoffs
+     * (domestic cups, UEFA knockouts, etc.), signalling the default penalty
+     * tiebreaker still applies.
+     *
+     * @return string[]
+     */
+    public function playoffTiebreakerSources(string $competitionId): array
+    {
+        foreach ($this->allCountries() as $config) {
+            foreach ($config['promotions'] ?? [] as $rule) {
+                if (empty($rule['playoff_generator'])) {
+                    continue;
+                }
+
+                $target = $rule['playoff_competition'] ?? $rule['bottom_division'];
+                if ($target !== $competitionId) {
+                    continue;
+                }
+
+                return $rule['playoff_source_divisions'] ?? [$rule['bottom_division']];
+            }
+        }
+
+        return [];
+    }
+
+    /**
      * Get continental qualification slots for a country.
      *
      * @return array<string, array<string, int[]>>

--- a/app/Modules/Competition/Services/PlayoffTiebreakerService.php
+++ b/app/Modules/Competition/Services/PlayoffTiebreakerService.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace App\Modules\Competition\Services;
+
+use App\Models\CupTie;
+use App\Models\Game;
+use App\Models\GameStanding;
+use App\Models\SimulatedSeason;
+
+/**
+ * Resolves promotion-playoff ties that remain level after extra time by
+ * awarding the win to the team that finished higher in its regular-season
+ * table. Applies to Spain's La Liga 2 → La Liga playoff and the Primera
+ * Federación → La Liga 2 bracket; other ties (domestic cups, UEFA) fall
+ * back to penalties.
+ */
+class PlayoffTiebreakerService
+{
+    public function __construct(
+        private readonly CountryConfig $countryConfig,
+    ) {}
+
+    /**
+     * Whether this tie uses the higher-regular-season-finisher rule instead
+     * of penalties when level after extra time.
+     */
+    public function appliesTo(CupTie $tie): bool
+    {
+        return !empty($this->countryConfig->playoffTiebreakerSources($tie->competition_id));
+    }
+
+    /**
+     * Resolve a level tie by regular-season finishing position. Returns the
+     * higher-finishing team's ID, or null if the positions can't be
+     * established (falls back to penalties in that edge case).
+     */
+    public function resolveWinner(CupTie $tie, Game $game): ?string
+    {
+        $sources = $this->countryConfig->playoffTiebreakerSources($tie->competition_id);
+        if (empty($sources)) {
+            return null;
+        }
+
+        $homePos = $this->regularSeasonPosition($game, $tie->home_team_id, $sources);
+        $awayPos = $this->regularSeasonPosition($game, $tie->away_team_id, $sources);
+
+        if ($homePos === null || $awayPos === null || $homePos === $awayPos) {
+            return null;
+        }
+
+        return $homePos < $awayPos ? $tie->home_team_id : $tie->away_team_id;
+    }
+
+    /**
+     * Look up a team's regular-season finishing position in its source
+     * league. Prefers real GameStanding rows; falls back to SimulatedSeason
+     * so sister-group standings (e.g. the group the player isn't in under
+     * Primera RFEF's split format) are still usable.
+     *
+     * @param string[] $sourceCompetitionIds
+     */
+    private function regularSeasonPosition(Game $game, string $teamId, array $sourceCompetitionIds): ?int
+    {
+        foreach ($sourceCompetitionIds as $sourceId) {
+            $standing = GameStanding::where('game_id', $game->id)
+                ->where('competition_id', $sourceId)
+                ->where('team_id', $teamId)
+                ->first();
+
+            if ($standing) {
+                return $standing->position;
+            }
+        }
+
+        foreach ($sourceCompetitionIds as $sourceId) {
+            $sim = SimulatedSeason::where('game_id', $game->id)
+                ->where('competition_id', $sourceId)
+                ->where('season', $game->season)
+                ->first();
+
+            if (!$sim || empty($sim->results)) {
+                continue;
+            }
+
+            $index = array_search($teamId, $sim->results, true);
+            if ($index !== false) {
+                return $index + 1;
+            }
+        }
+
+        return null;
+    }
+}

--- a/app/Modules/Match/Services/CupTieResolver.php
+++ b/app/Modules/Match/Services/CupTieResolver.php
@@ -4,6 +4,7 @@ namespace App\Modules\Match\Services;
 
 use App\Modules\Match\DTOs\MatchResult;
 use App\Modules\Competition\DTOs\PlayoffRoundConfig;
+use App\Modules\Competition\Services\PlayoffTiebreakerService;
 use App\Models\CupTie;
 use App\Models\GameMatch;
 use App\Models\GamePlayer;
@@ -16,6 +17,7 @@ class CupTieResolver
     public function __construct(
         private readonly MatchSimulator $matchSimulator,
         private readonly MatchEventRepository $matchEventRepository,
+        private readonly PlayoffTiebreakerService $playoffTiebreakerService,
     ) {}
 
     /**
@@ -217,6 +219,18 @@ class CupTieResolver
                 'aggregate' => "{$homeTotal}-{$awayTotal}",
             ]);
             return $winnerId;
+        }
+
+        // Promotion playoffs (La Liga 2 → La Liga and Primera Federación → La
+        // Liga 2) skip penalties when level after extra time — the side that
+        // finished higher in the regular season goes through instead.
+        $higherSeedWinner = $this->playoffTiebreakerService->resolveWinner($tie, $tie->game);
+        if ($higherSeedWinner !== null) {
+            $this->completeTie($tie, $higherSeedWinner, [
+                'type' => 'higher_seed',
+                'aggregate' => "{$homeTotal}-{$awayTotal}",
+            ]);
+            return $higherSeedWinner;
         }
 
         // Check if penalties were already simulated during the live match

--- a/app/Modules/Match/Services/ExtraTimeAndPenaltyService.php
+++ b/app/Modules/Match/Services/ExtraTimeAndPenaltyService.php
@@ -7,6 +7,7 @@ use App\Models\Game;
 use App\Models\GameMatch;
 use App\Models\GamePlayer;
 use App\Models\MatchEvent;
+use App\Modules\Competition\Services\PlayoffTiebreakerService;
 use App\Modules\Match\DTOs\ExtraTimeProcessResult;
 use App\Modules\Match\DTOs\PenaltyProcessResult;
 use App\Modules\Match\DTOs\TacticalConfig;
@@ -17,6 +18,7 @@ class ExtraTimeAndPenaltyService
     public function __construct(
         private readonly MatchSimulator $matchSimulator,
         private readonly MatchEventRepository $matchEventRepository,
+        private readonly PlayoffTiebreakerService $playoffTiebreakerService,
     ) {}
 
     /**
@@ -203,6 +205,7 @@ class ExtraTimeAndPenaltyService
         $totalHome = $match->home_score + $homeScoreET;
         $totalAway = $match->away_score + $awayScoreET;
 
+        $cupTie = null;
         if ($match->cup_tie_id) {
             $cupTie = CupTie::with('firstLegMatch')->find($match->cup_tie_id);
 
@@ -216,7 +219,17 @@ class ExtraTimeAndPenaltyService
             }
         }
 
-        return $totalHome === $totalAway;
+        if ($totalHome !== $totalAway) {
+            return false;
+        }
+
+        // Promotion-playoff ties are decided by regular-season position when
+        // level after extra time — no penalty shootout.
+        if ($cupTie && $this->playoffTiebreakerService->appliesTo($cupTie)) {
+            return false;
+        }
+
+        return true;
     }
 
     /**

--- a/lang/en/cup.php
+++ b/lang/en/cup.php
@@ -28,6 +28,7 @@ return [
     'pens' => 'Pens:',
     'aet' => 'AET',
     'agg' => 'Agg:',
+    'higher_seed' => 'Higher league finish',
 
     // Legend
     'your_matches' => 'Your matches',

--- a/lang/es/cup.php
+++ b/lang/es/cup.php
@@ -28,6 +28,7 @@ return [
     'pens' => 'Pen:',
     'aet' => 'Prórroga',
     'agg' => 'Agg:',
+    'higher_seed' => 'Mejor clasificación liguera',
 
     // Legend
     'your_matches' => 'Tus partidos',

--- a/resources/views/components/cup-player-tie.blade.php
+++ b/resources/views/components/cup-player-tie.blade.php
@@ -66,6 +66,8 @@
                                 {{ __('cup.pens') }} {{ $tie->resolution['penalties'] }}
                             @elseif($resolutionType === 'extra_time')
                                 {{ __('cup.aet') }}
+                            @elseif($resolutionType === 'higher_seed')
+                                {{ __('cup.higher_seed') }}
                             @elseif($resolutionType === 'aggregate')
                                 {{ __('cup.agg') }} {{ $tie->resolution['aggregate'] }}
                             @endif

--- a/resources/views/components/cup-tie-card.blade.php
+++ b/resources/views/components/cup-tie-card.blade.php
@@ -51,6 +51,8 @@
                 {{ __('cup.pens') }} {{ $tie->resolution['penalties'] }}
             @elseif($tie->resolution['type'] === 'extra_time')
                 {{ __('cup.aet') }}
+            @elseif($tie->resolution['type'] === 'higher_seed')
+                {{ __('cup.higher_seed') }}
             @elseif($tie->resolution['type'] === 'aggregate')
                 {{ __('cup.agg') }} {{ $tie->resolution['aggregate'] }}
             @endif

--- a/tests/Feature/PlayoffTiebreakerTest.php
+++ b/tests/Feature/PlayoffTiebreakerTest.php
@@ -1,0 +1,487 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Competition;
+use App\Models\CupTie;
+use App\Models\Game;
+use App\Models\GameMatch;
+use App\Models\GameStanding;
+use App\Models\SimulatedSeason;
+use App\Models\Team;
+use App\Models\User;
+use App\Modules\Competition\Services\PlayoffTiebreakerService;
+use App\Modules\Match\Services\CupTieResolver;
+use App\Modules\Match\Services\ExtraTimeAndPenaltyService;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Tests for the Spain promotion-playoff tiebreaker: when a two-legged tie is
+ * level after extra time, the higher-regular-season-finishing team goes
+ * through — no penalties. Applies to ESP2 → ESP1 and ESP3 → ESP2 playoffs.
+ * Domestic cups (ESPCUP) and anything else still go to penalties.
+ */
+class PlayoffTiebreakerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Game $game;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Competition::factory()->league()->create([
+            'id' => 'ESP2', 'tier' => 2, 'handler_type' => 'league_with_playoff',
+        ]);
+        Competition::factory()->league()->create([
+            'id' => 'ESP3A', 'tier' => 3, 'handler_type' => 'league_with_playoff',
+        ]);
+        Competition::factory()->league()->create([
+            'id' => 'ESP3B', 'tier' => 3, 'handler_type' => 'league_with_playoff',
+        ]);
+        Competition::factory()->knockoutCup()->create([
+            'id' => 'ESP3PO', 'tier' => 3,
+        ]);
+        Competition::factory()->knockoutCup()->create([
+            'id' => 'ESPCUP', 'tier' => 1,
+        ]);
+
+        $user = User::factory()->create();
+        $this->game = Game::factory()->create([
+            'user_id' => $user->id,
+            'team_id' => Team::factory()->create()->id,
+            'competition_id' => 'ESP2',
+            'season' => '2025',
+            'current_date' => '2026-06-14',
+        ]);
+    }
+
+    // ─────────────────────────────────────────────────
+    // PlayoffTiebreakerService::appliesTo
+    // ─────────────────────────────────────────────────
+
+    public function test_applies_to_esp2_playoff_tie(): void
+    {
+        $tie = $this->makeEmptyTie('ESP2');
+
+        $this->assertTrue(app(PlayoffTiebreakerService::class)->appliesTo($tie));
+    }
+
+    public function test_applies_to_esp3po_playoff_tie(): void
+    {
+        $tie = $this->makeEmptyTie('ESP3PO');
+
+        $this->assertTrue(app(PlayoffTiebreakerService::class)->appliesTo($tie));
+    }
+
+    public function test_does_not_apply_to_espcup_tie(): void
+    {
+        $tie = $this->makeEmptyTie('ESPCUP');
+
+        $this->assertFalse(app(PlayoffTiebreakerService::class)->appliesTo($tie));
+    }
+
+    // ─────────────────────────────────────────────────
+    // PlayoffTiebreakerService::resolveWinner
+    // ─────────────────────────────────────────────────
+
+    public function test_resolve_winner_returns_higher_finisher_in_same_league(): void
+    {
+        $third = Team::factory()->create();
+        $sixth = Team::factory()->create();
+        $this->createStanding('ESP2', $third->id, position: 3);
+        $this->createStanding('ESP2', $sixth->id, position: 6);
+
+        $tie = $this->makeEmptyTie('ESP2', $third, $sixth);
+
+        $this->assertEquals(
+            $third->id,
+            app(PlayoffTiebreakerService::class)->resolveWinner($tie, $this->game),
+        );
+    }
+
+    public function test_resolve_winner_returns_higher_finisher_when_slots_swapped(): void
+    {
+        // Lower seed usually hosts the first leg — i.e. is the tie's home team.
+        // The tiebreaker must still pick the higher seed on the away slot.
+        $sixth = Team::factory()->create();
+        $second = Team::factory()->create();
+        $this->createStanding('ESP2', $sixth->id, position: 6);
+        $this->createStanding('ESP2', $second->id, position: 2);
+
+        $tie = $this->makeEmptyTie('ESP2', $sixth, $second);
+
+        $this->assertEquals(
+            $second->id,
+            app(PlayoffTiebreakerService::class)->resolveWinner($tie, $this->game),
+        );
+    }
+
+    public function test_resolve_winner_handles_esp3po_cross_group_standings(): void
+    {
+        // ESP3PO ties pull from both feeder groups (ESP3A and ESP3B).
+        $a2 = Team::factory()->create();
+        $b5 = Team::factory()->create();
+        $this->createStanding('ESP3A', $a2->id, position: 2);
+        $this->createStanding('ESP3B', $b5->id, position: 5);
+
+        $tie = $this->makeEmptyTie('ESP3PO', $b5, $a2);
+
+        $this->assertEquals(
+            $a2->id,
+            app(PlayoffTiebreakerService::class)->resolveWinner($tie, $this->game),
+        );
+    }
+
+    public function test_resolve_winner_falls_back_to_simulated_season(): void
+    {
+        // ESP3B has no real standings (sister group the player isn't in) —
+        // finishing position must come from SimulatedSeason.results.
+        $a3 = Team::factory()->create();
+        $b4 = Team::factory()->create();
+        $this->createStanding('ESP3A', $a3->id, position: 3);
+
+        $simResults = [];
+        for ($i = 0; $i < 20; $i++) {
+            $simResults[] = $i === 3 ? $b4->id : Team::factory()->create()->id;
+        }
+        SimulatedSeason::create([
+            'game_id' => $this->game->id,
+            'season' => $this->game->season,
+            'competition_id' => 'ESP3B',
+            'results' => $simResults,
+        ]);
+
+        $tie = $this->makeEmptyTie('ESP3PO', $b4, $a3);
+
+        // A3 (position 3) beats B4 (simulated index 3 → position 4).
+        $this->assertEquals(
+            $a3->id,
+            app(PlayoffTiebreakerService::class)->resolveWinner($tie, $this->game),
+        );
+    }
+
+    public function test_resolve_winner_returns_null_for_espcup(): void
+    {
+        $tie = $this->makeEmptyTie('ESPCUP');
+
+        $this->assertNull(
+            app(PlayoffTiebreakerService::class)->resolveWinner($tie, $this->game),
+        );
+    }
+
+    public function test_resolve_winner_returns_null_when_positions_missing(): void
+    {
+        // No GameStanding, no SimulatedSeason — positions can't be determined,
+        // so the caller falls back to penalties.
+        $tie = $this->makeEmptyTie('ESP2');
+
+        $this->assertNull(
+            app(PlayoffTiebreakerService::class)->resolveWinner($tie, $this->game),
+        );
+    }
+
+    // ─────────────────────────────────────────────────
+    // ExtraTimeAndPenaltyService::checkNeedsPenalties
+    // ─────────────────────────────────────────────────
+
+    public function test_check_needs_penalties_false_for_level_esp2_playoff_tie(): void
+    {
+        $higherSeed = Team::factory()->create();
+        $lowerSeed = Team::factory()->create();
+        $this->createStanding('ESP2', $higherSeed->id, position: 3);
+        $this->createStanding('ESP2', $lowerSeed->id, position: 6);
+
+        [, $secondLeg] = $this->makeTwoLeggedTie(
+            'ESP2',
+            tieHomeTeam: $lowerSeed,
+            tieAwayTeam: $higherSeed,
+            firstLegHome: 1,
+            firstLegAway: 1,
+            secondLegHome: 1,
+            secondLegAway: 1,
+        );
+
+        $result = app(ExtraTimeAndPenaltyService::class)
+            ->checkNeedsPenalties($secondLeg, 0, 0);
+
+        $this->assertFalse(
+            $result,
+            'ESP2 playoff ties level after ET must skip penalties in favor of regular-season position',
+        );
+    }
+
+    public function test_check_needs_penalties_true_for_level_espcup_tie(): void
+    {
+        $homeTeam = Team::factory()->create();
+        $awayTeam = Team::factory()->create();
+
+        [, $secondLeg] = $this->makeTwoLeggedTie(
+            'ESPCUP',
+            tieHomeTeam: $homeTeam,
+            tieAwayTeam: $awayTeam,
+            firstLegHome: 1,
+            firstLegAway: 1,
+            secondLegHome: 1,
+            secondLegAway: 1,
+        );
+
+        $result = app(ExtraTimeAndPenaltyService::class)
+            ->checkNeedsPenalties($secondLeg, 0, 0);
+
+        $this->assertTrue(
+            $result,
+            'Domestic cup ties must still go to penalties when level after ET',
+        );
+    }
+
+    public function test_check_needs_penalties_false_when_aggregate_decided(): void
+    {
+        // Guard: even for a playoff tie, an ET result that breaks the
+        // aggregate tie shouldn't touch penalties either way.
+        $higherSeed = Team::factory()->create();
+        $lowerSeed = Team::factory()->create();
+        $this->createStanding('ESP2', $higherSeed->id, position: 3);
+        $this->createStanding('ESP2', $lowerSeed->id, position: 6);
+
+        [, $secondLeg] = $this->makeTwoLeggedTie(
+            'ESP2',
+            tieHomeTeam: $lowerSeed,
+            tieAwayTeam: $higherSeed,
+            firstLegHome: 1,
+            firstLegAway: 1,
+            secondLegHome: 1,
+            secondLegAway: 0,
+        );
+
+        // 2nd leg ET 1-0 for home (lower seed, as 2nd-leg home) → aggregate home 1+0=1, away 1+1+1=3.
+        $result = app(ExtraTimeAndPenaltyService::class)
+            ->checkNeedsPenalties($secondLeg, 1, 0);
+
+        $this->assertFalse($result);
+    }
+
+    // ─────────────────────────────────────────────────
+    // CupTieResolver: full resolution path
+    // ─────────────────────────────────────────────────
+
+    public function test_cup_tie_resolver_awards_higher_seed_when_level_after_et_in_esp2(): void
+    {
+        $higherSeed = Team::factory()->create();
+        $lowerSeed = Team::factory()->create();
+        $this->createStanding('ESP2', $higherSeed->id, position: 3);
+        $this->createStanding('ESP2', $lowerSeed->id, position: 6);
+
+        [$tie, $secondLeg] = $this->makeTwoLeggedTie(
+            'ESP2',
+            tieHomeTeam: $lowerSeed,
+            tieAwayTeam: $higherSeed,
+            firstLegHome: 1,
+            firstLegAway: 1,
+            secondLegHome: 1,
+            secondLegAway: 1,
+            withExtraTime: true,
+        );
+
+        $winnerId = app(CupTieResolver::class)->resolve($tie->fresh(), collect());
+
+        $this->assertEquals($higherSeed->id, $winnerId);
+
+        $tie->refresh();
+        $this->assertTrue($tie->completed);
+        $this->assertEquals($higherSeed->id, $tie->winner_id);
+        $this->assertEquals('higher_seed', $tie->resolution['type']);
+        $this->assertEquals('2-2', $tie->resolution['aggregate']);
+
+        // Penalties must NOT be simulated for a promotion-playoff tie.
+        $secondLeg->refresh();
+        $this->assertNull($secondLeg->home_score_penalties);
+        $this->assertNull($secondLeg->away_score_penalties);
+    }
+
+    public function test_cup_tie_resolver_awards_higher_seed_in_esp3po_cross_group(): void
+    {
+        $a2 = Team::factory()->create(); // Group A, 2nd
+        $b5 = Team::factory()->create(); // Group B, 5th
+        $this->createStanding('ESP3A', $a2->id, position: 2);
+        $this->createStanding('ESP3B', $b5->id, position: 5);
+
+        // B5 hosts the first leg (lower seed convention), so B5 is tie home
+        // team and A2 is tie away team.
+        [$tie, $secondLeg] = $this->makeTwoLeggedTie(
+            'ESP3PO',
+            tieHomeTeam: $b5,
+            tieAwayTeam: $a2,
+            firstLegHome: 2,
+            firstLegAway: 1,
+            secondLegHome: 1,
+            secondLegAway: 2,
+            withExtraTime: true,
+        );
+
+        $winnerId = app(CupTieResolver::class)->resolve($tie->fresh(), collect());
+
+        $this->assertEquals($a2->id, $winnerId);
+        $tie->refresh();
+        $this->assertEquals('higher_seed', $tie->resolution['type']);
+
+        $secondLeg->refresh();
+        $this->assertNull($secondLeg->home_score_penalties);
+    }
+
+    public function test_cup_tie_resolver_uses_penalties_for_espcup(): void
+    {
+        $homeTeam = Team::factory()->create();
+        $awayTeam = Team::factory()->create();
+
+        [$tie, $secondLeg] = $this->makeTwoLeggedTie(
+            'ESPCUP',
+            tieHomeTeam: $homeTeam,
+            tieAwayTeam: $awayTeam,
+            firstLegHome: 1,
+            firstLegAway: 1,
+            secondLegHome: 1,
+            secondLegAway: 1,
+            withExtraTime: true,
+            secondLegRound: 6, // ESPCUP round 6 is the two-legged semi-final
+        );
+
+        // Pre-set penalties so the resolver doesn't try to simulate (which
+        // would need full squads); we only care which branch it takes.
+        $secondLeg->update([
+            'home_score_penalties' => 5,
+            'away_score_penalties' => 3,
+        ]);
+
+        $winnerId = app(CupTieResolver::class)->resolve($tie->fresh(), collect());
+
+        // 2nd-leg home team won on pens → that's the tie's away team.
+        $this->assertEquals($awayTeam->id, $winnerId);
+        $tie->refresh();
+        $this->assertEquals('penalties', $tie->resolution['type']);
+    }
+
+    public function test_cup_tie_resolver_falls_back_to_penalties_when_positions_missing(): void
+    {
+        // Playoff competition but no standings for either team — safe fallback
+        // is penalties rather than arbitrarily picking one side.
+        $homeTeam = Team::factory()->create();
+        $awayTeam = Team::factory()->create();
+
+        [$tie, $secondLeg] = $this->makeTwoLeggedTie(
+            'ESP2',
+            tieHomeTeam: $homeTeam,
+            tieAwayTeam: $awayTeam,
+            firstLegHome: 1,
+            firstLegAway: 1,
+            secondLegHome: 1,
+            secondLegAway: 1,
+            withExtraTime: true,
+        );
+
+        $secondLeg->update([
+            'home_score_penalties' => 4,
+            'away_score_penalties' => 5,
+        ]);
+
+        $winnerId = app(CupTieResolver::class)->resolve($tie->fresh(), collect());
+
+        $this->assertEquals($homeTeam->id, $winnerId);
+        $tie->refresh();
+        $this->assertEquals('penalties', $tie->resolution['type']);
+    }
+
+    // ─────────────────────────────────────────────────
+    // Helpers
+    // ─────────────────────────────────────────────────
+
+    private function makeEmptyTie(string $competitionId, ?Team $home = null, ?Team $away = null): CupTie
+    {
+        return CupTie::factory()
+            ->forGame($this->game)
+            ->between($home ?? Team::factory()->create(), $away ?? Team::factory()->create())
+            ->create(['competition_id' => $competitionId]);
+    }
+
+    /**
+     * @return array{0: CupTie, 1: GameMatch}
+     */
+    private function makeTwoLeggedTie(
+        string $competitionId,
+        Team $tieHomeTeam,
+        Team $tieAwayTeam,
+        int $firstLegHome,
+        int $firstLegAway,
+        int $secondLegHome,
+        int $secondLegAway,
+        bool $withExtraTime = false,
+        int $secondLegRound = 1,
+    ): array {
+        $firstLeg = GameMatch::factory()->create([
+            'game_id' => $this->game->id,
+            'competition_id' => $competitionId,
+            'round_number' => $secondLegRound,
+            'home_team_id' => $tieHomeTeam->id,
+            'away_team_id' => $tieAwayTeam->id,
+            'scheduled_date' => Carbon::parse('2026-06-07'),
+            'played' => true,
+            'home_score' => $firstLegHome,
+            'away_score' => $firstLegAway,
+        ]);
+
+        $tie = CupTie::factory()
+            ->forGame($this->game)
+            ->between($tieHomeTeam, $tieAwayTeam)
+            ->inRound($secondLegRound)
+            ->create([
+                'competition_id' => $competitionId,
+                'first_leg_match_id' => $firstLeg->id,
+            ]);
+
+        $secondLegAttrs = [
+            'game_id' => $this->game->id,
+            'competition_id' => $competitionId,
+            'round_number' => $secondLegRound,
+            // Teams swap on the second leg.
+            'home_team_id' => $tieAwayTeam->id,
+            'away_team_id' => $tieHomeTeam->id,
+            'scheduled_date' => Carbon::parse('2026-06-14'),
+            'played' => true,
+            'home_score' => $secondLegHome,
+            'away_score' => $secondLegAway,
+            'cup_tie_id' => $tie->id,
+        ];
+
+        if ($withExtraTime) {
+            $secondLegAttrs['is_extra_time'] = true;
+            $secondLegAttrs['home_score_et'] = 0;
+            $secondLegAttrs['away_score_et'] = 0;
+        }
+
+        $secondLeg = GameMatch::factory()->create($secondLegAttrs);
+
+        $tie->update(['second_leg_match_id' => $secondLeg->id]);
+
+        return [$tie->fresh(), $secondLeg->fresh()];
+    }
+
+    private function createStanding(string $competitionId, string $teamId, int $position): void
+    {
+        GameStanding::create([
+            'game_id' => $this->game->id,
+            'competition_id' => $competitionId,
+            'team_id' => $teamId,
+            'position' => $position,
+            'played' => 38,
+            'won' => max(0, 25 - $position),
+            'drawn' => 5,
+            'lost' => max(0, $position + 5),
+            'goals_for' => max(10, 80 - $position * 2),
+            'goals_against' => 20 + $position,
+            'points' => max(0, 80 - $position * 3),
+        ]);
+    }
+}

--- a/tests/Feature/PlayoffTiebreakerTest.php
+++ b/tests/Feature/PlayoffTiebreakerTest.php
@@ -309,16 +309,16 @@ class PlayoffTiebreakerTest extends TestCase
         $this->createStanding('ESP3A', $a2->id, position: 2);
         $this->createStanding('ESP3B', $b5->id, position: 5);
 
-        // B5 hosts the first leg (lower seed convention), so B5 is tie home
-        // team and A2 is tie away team.
+        // Both legs 1-1 → aggregate 2-2 after ET, so the tie reaches the
+        // regular-season tiebreaker rather than being decided on aggregate.
         [$tie, $secondLeg] = $this->makeTwoLeggedTie(
             'ESP3PO',
             tieHomeTeam: $b5,
             tieAwayTeam: $a2,
-            firstLegHome: 2,
+            firstLegHome: 1,
             firstLegAway: 1,
             secondLegHome: 1,
-            secondLegAway: 2,
+            secondLegAway: 1,
             withExtraTime: true,
         );
 

--- a/tests/Feature/PrimeraRFEFPromotionTest.php
+++ b/tests/Feature/PrimeraRFEFPromotionTest.php
@@ -119,17 +119,18 @@ class PrimeraRFEFPromotionTest extends TestCase
 
     private function createCompletedSemifinals(array $groupATeams, array $groupBTeams): void
     {
-        // Bracket A: A5 vs A2, B4 vs B3
-        // Bracket B: B5 vs B2, A4 vs A3
+        // Cross-group semifinals: 2nd vs 5th and 3rd vs 4th from opposite groups.
+        // Bracket A: B5 vs A2, B4 vs A3
+        // Bracket B: A5 vs B2, A4 vs B3
         // Index: 2nd=pos2, 3rd=pos3, 4th=pos4, 5th=pos5
 
         $bracketASemiTies = [
-            [$groupATeams[5], $groupATeams[2], PrimeraRFEFPlayoffGenerator::BRACKET_A],
-            [$groupBTeams[4], $groupBTeams[3], PrimeraRFEFPlayoffGenerator::BRACKET_A],
+            [$groupBTeams[5], $groupATeams[2], PrimeraRFEFPlayoffGenerator::BRACKET_A],
+            [$groupBTeams[4], $groupATeams[3], PrimeraRFEFPlayoffGenerator::BRACKET_A],
         ];
         $bracketBSemiTies = [
-            [$groupBTeams[5], $groupBTeams[2], PrimeraRFEFPlayoffGenerator::BRACKET_B],
-            [$groupATeams[4], $groupATeams[3], PrimeraRFEFPlayoffGenerator::BRACKET_B],
+            [$groupATeams[5], $groupBTeams[2], PrimeraRFEFPlayoffGenerator::BRACKET_B],
+            [$groupATeams[4], $groupBTeams[3], PrimeraRFEFPlayoffGenerator::BRACKET_B],
         ];
 
         foreach (array_merge($bracketASemiTies, $bracketBSemiTies) as [$home, $away, $bracket]) {
@@ -182,22 +183,22 @@ class PrimeraRFEFPromotionTest extends TestCase
 
         $this->assertCount(4, $matchups);
 
-        // Bracket A: [A5, A2, 1] and [B4, B3, 1]
-        $this->assertEquals($groupA[5]->id, $matchups[0][0]);
+        // Bracket A: [B5, A2, 1] and [B4, A3, 1] — cross-group
+        $this->assertEquals($groupB[5]->id, $matchups[0][0]);
         $this->assertEquals($groupA[2]->id, $matchups[0][1]);
         $this->assertEquals(PrimeraRFEFPlayoffGenerator::BRACKET_A, $matchups[0][2]);
 
         $this->assertEquals($groupB[4]->id, $matchups[1][0]);
-        $this->assertEquals($groupB[3]->id, $matchups[1][1]);
+        $this->assertEquals($groupA[3]->id, $matchups[1][1]);
         $this->assertEquals(PrimeraRFEFPlayoffGenerator::BRACKET_A, $matchups[1][2]);
 
-        // Bracket B: [B5, B2, 2] and [A4, A3, 2]
-        $this->assertEquals($groupB[5]->id, $matchups[2][0]);
+        // Bracket B: [A5, B2, 2] and [A4, B3, 2] — cross-group
+        $this->assertEquals($groupA[5]->id, $matchups[2][0]);
         $this->assertEquals($groupB[2]->id, $matchups[2][1]);
         $this->assertEquals(PrimeraRFEFPlayoffGenerator::BRACKET_B, $matchups[2][2]);
 
         $this->assertEquals($groupA[4]->id, $matchups[3][0]);
-        $this->assertEquals($groupA[3]->id, $matchups[3][1]);
+        $this->assertEquals($groupB[3]->id, $matchups[3][1]);
         $this->assertEquals(PrimeraRFEFPlayoffGenerator::BRACKET_B, $matchups[3][2]);
     }
 
@@ -228,14 +229,14 @@ class PrimeraRFEFPromotionTest extends TestCase
 
         $this->assertCount(4, $matchups);
 
-        // Group A positions should come from real standings
-        $this->assertEquals($groupA[5]->id, $matchups[0][0]); // A5
-        $this->assertEquals($groupA[2]->id, $matchups[0][1]); // A2
+        // Bracket A semis are cross-group — [B5, A2] and [B4, A3].
+        // B team ids come from the simulated results (index-based),
+        // A team ids come from real standings.
+        $this->assertEquals($simulatedBTeams[4]->id, $matchups[0][0]); // B5 (index 4)
+        $this->assertEquals($groupA[2]->id, $matchups[0][1]);          // A2
 
-        // Group B positions should come from simulated results (index-based).
-        // matchups[1] is the [B4, B3] tie from Bracket A.
         $this->assertEquals($simulatedBTeams[3]->id, $matchups[1][0]); // B4 (index 3)
-        $this->assertEquals($simulatedBTeams[2]->id, $matchups[1][1]); // B3 (index 2)
+        $this->assertEquals($groupA[3]->id, $matchups[1][1]);          // A3
     }
 
     public function test_round_1_skips_reserve_team_and_slides_next_eligible(): void
@@ -285,15 +286,16 @@ class PrimeraRFEFPromotionTest extends TestCase
         $this->assertEquals(PrimeraRFEFPlayoffGenerator::BRACKET_A, $matchups[0][2]);
         $this->assertEquals(PrimeraRFEFPlayoffGenerator::BRACKET_B, $matchups[1][2]);
 
-        // Bracket A winners: A2 (beat A5) and B3 (beat B4)
+        // Bracket A winners: A2 (beat B5) and A3 (beat B4) — cross-group semis
+        // completed via createCompletedSemifinals have away-side teams win.
         $bracketATeamIds = [$matchups[0][0], $matchups[0][1]];
         $this->assertContains($groupA[2]->id, $bracketATeamIds);
-        $this->assertContains($groupB[3]->id, $bracketATeamIds);
+        $this->assertContains($groupA[3]->id, $bracketATeamIds);
 
-        // Bracket B winners: B2 (beat B5) and A3 (beat A4)
+        // Bracket B winners: B2 (beat A5) and B3 (beat A4)
         $bracketBTeamIds = [$matchups[1][0], $matchups[1][1]];
         $this->assertContains($groupB[2]->id, $bracketBTeamIds);
-        $this->assertContains($groupA[3]->id, $bracketBTeamIds);
+        $this->assertContains($groupB[3]->id, $bracketBTeamIds);
     }
 
     // ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
Adds support for resolving promotion-playoff ties by regular-season finishing position instead of penalties when matches are level after extra time. This applies to Spain's La Liga 2 → La Liga and Primera Federación → La Liga 2 promotion playoffs.

## Key Changes

- **New `PlayoffTiebreakerService`**: Determines whether a tie uses the higher-regular-season-finisher rule and resolves winners by looking up team positions in `GameStanding` or `SimulatedSeason` records. Handles edge cases like sister-group standings in split formats.

- **Updated `CountryConfig.playoffTiebreakerSources()`**: New method that returns feeder league competition IDs for a given playoff competition, enabling the tiebreaker logic to find the correct source standings.

- **Modified `ExtraTimeAndPenaltyService`**: Skips penalty shootout logic when a promotion-playoff tie is level after extra time, deferring to the tiebreaker service instead.

- **Modified `CupTieResolver`**: Applies the playoff tiebreaker rule before falling back to penalties, recording the resolution type as `'higher_seed'`.

- **Fixed `PrimeraRFEFPlayoffGenerator`**: Corrected semifinal bracket structure to pair teams from opposite groups (2nd vs 5th, 3rd vs 4th cross-group) rather than same-group matchups. Updated documentation and test expectations accordingly.

- **UI & Localization**: Added `'higher_seed'` resolution type display in cup tie components and translations (English: "Higher league finish", Spanish: "Mejor clasificación liguera").

## Implementation Details

- The tiebreaker service prefers real `GameStanding` records but falls back to `SimulatedSeason` results (index-based) to support sister-group standings in split league formats.
- Null position lookups gracefully fall back to penalties, handling edge cases where standings data is unavailable.
- The Primera RFEF playoff bracket structure now correctly implements cross-group semifinals, ensuring same-group rivals don't meet until bracket finals.

https://claude.ai/code/session_01M763j8QtnfC5MZxB5sWWdt