### PR TITLE
Implement domestic cup qualification rules based on league standings

### DIFF
--- a/app/Modules/Competition/Services/CountryConfig.php
+++ b/app/Modules/Competition/Services/CountryConfig.php
@@ -251,6 +251,19 @@ class CountryConfig
     }
 
     /**
+     * Get the cup qualification rule for a specific domestic cup, if defined.
+     *
+     * Describes which teams from the playable tiers qualify for the cup at
+     * the start of the following season. See config/countries.php for shape.
+     *
+     * @return array{auto_qualify_tiers?: int[], top_per_group?: array<int, int>}|null
+     */
+    public function cupQualification(string $countryCode, string $cupId): ?array
+    {
+        return $this->get($countryCode)['cup_qualification'][$cupId] ?? null;
+    }
+
+    /**
      * Get the CompetitionConfig class for a competition ID, checking country configs.
      *
      * @return class-string<CompetitionConfig>|null

--- a/app/Modules/Season/Jobs/SetupNewGame.php
+++ b/app/Modules/Season/Jobs/SetupNewGame.php
@@ -125,10 +125,32 @@ class SetupNewGame implements ShouldQueue, ShouldBeUnique
             return;
         }
 
-        $rows = CompetitionTeam::where('season', $this->season)
+        // Reserve teams (e.g. Real Madrid Castilla, Barcelona Atlètic) never
+        // play in domestic cups. Drop them from those competitions at the
+        // point where per-game entries are first written so no downstream
+        // draw/fixture step can resurface them.
+        $domesticCupIds = [];
+        foreach (app(CountryConfig::class)->allCountryCodes() as $countryCode) {
+            foreach (app(CountryConfig::class)->domesticCupIds($countryCode) as $cupId) {
+                $domesticCupIds[] = $cupId;
+            }
+        }
+
+        $query = CompetitionTeam::where('season', $this->season)
             ->whereNotIn('team_id', function ($query) {
                 $query->select('id')->from('teams')->where('type', 'national');
-            })
+            });
+
+        if (!empty($domesticCupIds)) {
+            $query->where(function ($q) use ($domesticCupIds) {
+                $q->whereNotIn('competition_id', $domesticCupIds)
+                    ->orWhereNotIn('team_id', function ($inner) {
+                        $inner->select('id')->from('teams')->whereNotNull('parent_team_id');
+                    });
+            });
+        }
+
+        $rows = $query
             ->get()
             ->map(fn ($ct) => [
                 'game_id' => $this->gameId,

--- a/app/Modules/Season/Processors/CopaQualificationProcessor.php
+++ b/app/Modules/Season/Processors/CopaQualificationProcessor.php
@@ -27,9 +27,14 @@ use Illuminate\Support\Facades\Log;
  *    (including siblings — e.g. ESP3A and ESP3B) qualify.
  *
  * Reserve teams (Team::parent_team_id is set) never qualify, regardless of
- * finishing position. Teams currently in the cup that are not registered in
- * any playable tier (lower-division seed teams) are left untouched so
- * regional qualifiers keep their cup place.
+ * finishing position. When a reserve occupies a slot in an auto_qualify
+ * tier, its seat cascades to top_per_group: for each ineligible reserve,
+ * one additional pick is made from the groups (distributed round-robin),
+ * so the cup stays at its expected size even as reserves climb divisions.
+ *
+ * Teams currently in the cup that are not registered in any playable tier
+ * (lower-division seed teams) are left untouched so regional qualifiers
+ * keep their cup place.
  */
 class CopaQualificationProcessor implements SeasonProcessor
 {
@@ -81,11 +86,16 @@ class CopaQualificationProcessor implements SeasonProcessor
 
         $reserveLookup = array_flip($reserveTeamIdsForCountry);
         $qualifiers = [];
+        $shortage = 0;
 
         foreach ($rule['auto_qualify_tiers'] ?? [] as $tier) {
             foreach ($this->countryConfig->tierCompetitionIds($countryCode, $tier) as $competitionId) {
                 foreach ($this->teamsInCompetition($game->id, $competitionId) as $teamId) {
                     if (isset($reserveLookup[$teamId])) {
+                        // Reserve team occupies a league slot but can't play
+                        // in the cup — its seat cascades down to the next
+                        // top_per_group pick so the bracket stays full.
+                        $shortage++;
                         continue;
                     }
                     $qualifiers[$teamId] = true;
@@ -93,21 +103,34 @@ class CopaQualificationProcessor implements SeasonProcessor
             }
         }
 
-        // For each group (including siblings), qualify the top N non-reserve
-        // teams — skipping any reserves in higher positions so the group
-        // always contributes exactly N qualifiers when enough are eligible.
+        // Gather every group (primary + siblings) with its base quota so we
+        // can distribute any cascaded seats round-robin across groups.
+        $groups = [];
         foreach ($rule['top_per_group'] ?? [] as $tier => $topN) {
             foreach ($this->countryConfig->tierCompetitionIds($countryCode, $tier) as $competitionId) {
-                $picked = 0;
-                foreach ($this->rankedTeams($game, $competitionId) as $teamId) {
-                    if (isset($reserveLookup[$teamId])) {
-                        continue;
-                    }
-                    $qualifiers[$teamId] = true;
-                    $picked++;
-                    if ($picked >= $topN) {
-                        break;
-                    }
+                $groups[] = ['competition' => $competitionId, 'topN' => $topN];
+            }
+        }
+
+        if (!empty($groups) && $shortage > 0) {
+            for ($i = 0; $i < $shortage; $i++) {
+                $groups[$i % count($groups)]['topN']++;
+            }
+        }
+
+        // For each group, qualify the top N non-reserve teams — skipping any
+        // reserves in higher positions so the group always contributes
+        // exactly N qualifiers when enough are eligible.
+        foreach ($groups as $group) {
+            $picked = 0;
+            foreach ($this->rankedTeams($game, $group['competition']) as $teamId) {
+                if (isset($reserveLookup[$teamId])) {
+                    continue;
+                }
+                $qualifiers[$teamId] = true;
+                $picked++;
+                if ($picked >= $group['topN']) {
+                    break;
                 }
             }
         }

--- a/app/Modules/Season/Processors/CopaQualificationProcessor.php
+++ b/app/Modules/Season/Processors/CopaQualificationProcessor.php
@@ -1,0 +1,212 @@
+<?php
+
+namespace App\Modules\Season\Processors;
+
+use App\Modules\Competition\Services\CountryConfig;
+use App\Modules\Season\Contracts\SeasonProcessor;
+use App\Modules\Season\DTOs\SeasonTransitionData;
+use App\Models\CompetitionEntry;
+use App\Models\Game;
+use App\Models\GameStanding;
+use App\Models\SimulatedSeason;
+use App\Models\Team;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Rebuilds domestic cup participants (e.g. Copa del Rey) at the end of each
+ * season based on the configured qualification rules.
+ *
+ * Runs before PromotionRelegationProcessor (priority 85) so that this
+ * season's CompetitionEntry still reflects this season's divisions and
+ * GameStanding still contains the full final table for every tier.
+ *
+ * Rules live under each country's `cup_qualification` config:
+ *  - auto_qualify_tiers: every team in these tiers qualifies for the next
+ *    season's cup.
+ *  - top_per_group: the top N teams in each competition at this tier
+ *    (including siblings — e.g. ESP3A and ESP3B) qualify.
+ *
+ * Reserve teams (Team::parent_team_id is set) never qualify, regardless of
+ * finishing position. Teams currently in the cup that are not registered in
+ * any playable tier (lower-division seed teams) are left untouched so
+ * regional qualifiers keep their cup place.
+ */
+class CopaQualificationProcessor implements SeasonProcessor
+{
+    public function __construct(
+        private CountryConfig $countryConfig,
+    ) {}
+
+    public function priority(): int
+    {
+        return 82;
+    }
+
+    public function process(Game $game, SeasonTransitionData $data): SeasonTransitionData
+    {
+        foreach ($this->countryConfig->allCountryCodes() as $countryCode) {
+            $reserveTeamIdsForCountry = Team::where('country', $countryCode)
+                ->whereNotNull('parent_team_id')
+                ->pluck('id')
+                ->all();
+
+            foreach ($this->countryConfig->domesticCupIds($countryCode) as $cupId) {
+                $rule = $this->countryConfig->cupQualification($countryCode, $cupId);
+                if (!$rule) {
+                    continue;
+                }
+
+                $this->rebuildCupEntries($game, $countryCode, $cupId, $rule, $reserveTeamIdsForCountry);
+            }
+        }
+
+        return $data;
+    }
+
+    /**
+     * @param  array{auto_qualify_tiers?: int[], top_per_group?: array<int, int>}  $rule
+     * @param  string[]  $reserveTeamIdsForCountry
+     */
+    private function rebuildCupEntries(
+        Game $game,
+        string $countryCode,
+        string $cupId,
+        array $rule,
+        array $reserveTeamIdsForCountry,
+    ): void {
+        $playableTierCompetitions = $this->playableTierCompetitions($countryCode);
+        if (empty($playableTierCompetitions)) {
+            return;
+        }
+
+        $reserveLookup = array_flip($reserveTeamIdsForCountry);
+        $qualifiers = [];
+
+        foreach ($rule['auto_qualify_tiers'] ?? [] as $tier) {
+            foreach ($this->countryConfig->tierCompetitionIds($countryCode, $tier) as $competitionId) {
+                foreach ($this->teamsInCompetition($game->id, $competitionId) as $teamId) {
+                    if (isset($reserveLookup[$teamId])) {
+                        continue;
+                    }
+                    $qualifiers[$teamId] = true;
+                }
+            }
+        }
+
+        // For each group (including siblings), qualify the top N non-reserve
+        // teams — skipping any reserves in higher positions so the group
+        // always contributes exactly N qualifiers when enough are eligible.
+        foreach ($rule['top_per_group'] ?? [] as $tier => $topN) {
+            foreach ($this->countryConfig->tierCompetitionIds($countryCode, $tier) as $competitionId) {
+                $picked = 0;
+                foreach ($this->rankedTeams($game, $competitionId) as $teamId) {
+                    if (isset($reserveLookup[$teamId])) {
+                        continue;
+                    }
+                    $qualifiers[$teamId] = true;
+                    $picked++;
+                    if ($picked >= $topN) {
+                        break;
+                    }
+                }
+            }
+        }
+
+        // Remove existing cup entries for teams that are part of the playable
+        // tier system — we're redeciding qualification for those. Also drop
+        // any reserve teams that may have slipped in previously. Lower-tier
+        // seed teams (not registered in any playable tier) are left alone.
+        $playableTierTeamIds = CompetitionEntry::where('game_id', $game->id)
+            ->whereIn('competition_id', $playableTierCompetitions)
+            ->pluck('team_id')
+            ->unique()
+            ->all();
+
+        $teamIdsToClear = array_unique(array_merge($playableTierTeamIds, $reserveTeamIdsForCountry));
+
+        if (!empty($teamIdsToClear)) {
+            CompetitionEntry::where('game_id', $game->id)
+                ->where('competition_id', $cupId)
+                ->whereIn('team_id', $teamIdsToClear)
+                ->delete();
+        }
+
+        if (empty($qualifiers)) {
+            Log::info("[CopaQualification] {$cupId}: no qualifiers after filtering reserves");
+
+            return;
+        }
+
+        $rows = array_map(fn (string $teamId) => [
+            'game_id' => $game->id,
+            'competition_id' => $cupId,
+            'team_id' => $teamId,
+            'entry_round' => 1,
+        ], array_keys($qualifiers));
+
+        CompetitionEntry::upsert(
+            $rows,
+            ['game_id', 'competition_id', 'team_id'],
+            ['entry_round']
+        );
+
+        Log::info("[CopaQualification] {$cupId}: " . count($rows) . ' qualifiers from playable tiers');
+    }
+
+    /**
+     * @return string[]
+     */
+    private function playableTierCompetitions(string $countryCode): array
+    {
+        $ids = [];
+        foreach (array_keys($this->countryConfig->tiers($countryCode)) as $tier) {
+            foreach ($this->countryConfig->tierCompetitionIds($countryCode, $tier) as $competitionId) {
+                $ids[] = $competitionId;
+            }
+        }
+
+        return $ids;
+    }
+
+    /**
+     * @return string[]
+     */
+    private function teamsInCompetition(string $gameId, string $competitionId): array
+    {
+        return CompetitionEntry::where('game_id', $gameId)
+            ->where('competition_id', $competitionId)
+            ->pluck('team_id')
+            ->all();
+    }
+
+    /**
+     * Full ranked team list for a competition — real standings first, then
+     * simulated season results as fallback. Ordered from 1st position down.
+     *
+     * @return string[]
+     */
+    private function rankedTeams(Game $game, string $competitionId): array
+    {
+        $teams = GameStanding::where('game_id', $game->id)
+            ->where('competition_id', $competitionId)
+            ->where('played', '>', 0)
+            ->orderBy('position')
+            ->pluck('team_id')
+            ->all();
+
+        if (!empty($teams)) {
+            return $teams;
+        }
+
+        $simulated = SimulatedSeason::where('game_id', $game->id)
+            ->where('season', $game->season)
+            ->where('competition_id', $competitionId)
+            ->first();
+
+        if (!$simulated || empty($simulated->results)) {
+            return [];
+        }
+
+        return $simulated->results;
+    }
+}

--- a/app/Modules/Season/Services/SeasonClosingPipeline.php
+++ b/app/Modules/Season/Services/SeasonClosingPipeline.php
@@ -9,6 +9,7 @@ use App\Modules\Season\Processors\AgreedTransferCompletionProcessor;
 use App\Modules\Season\Processors\AIFreeAgentSigningProcessor;
 use App\Modules\Season\Processors\ContractExpirationProcessor;
 use App\Modules\Season\Processors\ContractRenewalProcessor;
+use App\Modules\Season\Processors\CopaQualificationProcessor;
 use App\Modules\Season\Processors\LeaderboardStatsProcessor;
 use App\Modules\Season\Processors\LoanReturnProcessor;
 use App\Modules\Season\Processors\PlayerDevelopmentProcessor;
@@ -57,6 +58,7 @@ class SeasonClosingPipeline
         TransferMarketResetProcessor $transferMarketReset,
         SeasonSimulationProcessor $seasonSimulation,
         SupercupQualificationProcessor $supercupQualification,
+        CopaQualificationProcessor $copaQualification,
         PromotionRelegationProcessor $promotionRelegation,
         ReputationUpdateProcessor $reputationUpdate,
         FanLoyaltyUpdateProcessor $fanLoyaltyUpdate,
@@ -81,6 +83,7 @@ class SeasonClosingPipeline
             $transferMarketReset,
             $seasonSimulation,
             $supercupQualification,
+            $copaQualification,
             $promotionRelegation,
             $reputationUpdate,
             $fanLoyaltyUpdate,

--- a/config/countries.php
+++ b/config/countries.php
@@ -92,6 +92,11 @@ return [
         // - top_per_group: top N teams in each competition at this tier
         //   (including siblings — e.g. ESP3A and ESP3B) qualify.
         //
+        // Reserves occupying auto-qualify slots cascade down: for each
+        // ineligible reserve in an auto_qualify tier, one extra seat is
+        // added to top_per_group, distributed round-robin across groups so
+        // the cup keeps its expected size even as reserves climb divisions.
+        //
         // Teams in ESPCUP that are not registered in any playable tier (the
         // lower-division teams seeded from the data/<season>/ESPCUP/ pool) are
         // left untouched, so regional qualifiers keep their cup place.

--- a/config/countries.php
+++ b/config/countries.php
@@ -84,6 +84,26 @@ return [
             'cup_entry_round' => 3,
         ],
 
+        // Rules for which teams from playable tiers qualify for each domestic
+        // cup at the start of the following season. Reserve teams never
+        // qualify regardless of their finishing position.
+        //
+        // - auto_qualify_tiers: every team currently in these tiers qualifies.
+        // - top_per_group: top N teams in each competition at this tier
+        //   (including siblings — e.g. ESP3A and ESP3B) qualify.
+        //
+        // Teams in ESPCUP that are not registered in any playable tier (the
+        // lower-division teams seeded from the data/<season>/ESPCUP/ pool) are
+        // left untouched, so regional qualifiers keep their cup place.
+        'cup_qualification' => [
+            'ESPCUP' => [
+                'auto_qualify_tiers' => [1, 2],
+                'top_per_group' => [
+                    3 => 5,
+                ],
+            ],
+        ],
+
         'promotions' => [
             [
                 'top_division' => 'ESP1',

--- a/docs/game-systems/season-lifecycle.md
+++ b/docs/game-systems/season-lifecycle.md
@@ -26,7 +26,7 @@ Season transitions run two pipelines sequentially. Each processor implements `Se
 
 **Phase 2 — Squad management** (priority 8-20): Replenish AI squads to minimum roster sizes, apply player development changes, settle finances (actual vs projected), reset stats and transfer market.
 
-**Phase 3 — League simulation & structure** (priority 24-55): Simulate non-played leagues, determine Supercup qualifiers, handle promotion/relegation, update team reputations based on final positions, develop and return academy loans.
+**Phase 3 — League simulation & structure** (priority 24-55): Simulate non-played leagues, determine Supercup qualifiers, rebuild domestic cup participants for the following season (Copa del Rey: all top-two-tier teams plus the top 5 of each Primera Federación group, never reserve teams), handle promotion/relegation, update team reputations based on final positions, develop and return academy loans.
 
 **Phase 4 — Qualification** (priority 105): Determine UEFA competition qualifiers.
 

--- a/tests/Feature/CopaQualificationTest.php
+++ b/tests/Feature/CopaQualificationTest.php
@@ -1,0 +1,263 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Competition;
+use App\Models\CompetitionEntry;
+use App\Models\Game;
+use App\Models\GameStanding;
+use App\Models\SimulatedSeason;
+use App\Models\Team;
+use App\Models\User;
+use App\Modules\Season\DTOs\SeasonTransitionData;
+use App\Modules\Season\Processors\CopaQualificationProcessor;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class CopaQualificationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Game $game;
+
+    /** @var Team[][] keyed by competition id, ordered by position (0-indexed) */
+    private array $teamsByCompetition = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Competition::factory()->league()->create(['id' => 'ESP1', 'country' => 'ES', 'tier' => 1]);
+        Competition::factory()->league()->create([
+            'id' => 'ESP2', 'country' => 'ES', 'tier' => 2, 'handler_type' => 'league_with_playoff',
+        ]);
+        Competition::factory()->league()->create([
+            'id' => 'ESP3A', 'country' => 'ES', 'tier' => 3, 'handler_type' => 'league_with_playoff',
+        ]);
+        Competition::factory()->league()->create([
+            'id' => 'ESP3B', 'country' => 'ES', 'tier' => 3, 'handler_type' => 'league_with_playoff',
+        ]);
+        Competition::factory()->knockoutCup()->create(['id' => 'ESPCUP', 'country' => 'ES']);
+
+        $user = User::factory()->create();
+        $userTeam = Team::factory()->create(['country' => 'ES']);
+        $this->game = Game::factory()->create([
+            'user_id' => $user->id,
+            'team_id' => $userTeam->id,
+            'competition_id' => 'ESP1',
+            'season' => '2025',
+        ]);
+
+        $this->createLeague('ESP1', 20, $userTeam);
+        $this->createLeague('ESP2', 22);
+        $this->createLeague('ESP3A', 20);
+        $this->createLeague('ESP3B', 20);
+    }
+
+    public function test_base_case_qualifies_all_tier_1_and_2_plus_top_5_per_primera_rfef_group(): void
+    {
+        $this->runProcessor();
+
+        $entries = $this->cupEntries();
+
+        $this->assertCount(20 + 22 + 5 + 5, $entries);
+
+        foreach ($this->teamsByCompetition['ESP1'] as $team) {
+            $this->assertContains($team->id, $entries, "ESP1 team {$team->id} should qualify");
+        }
+        foreach ($this->teamsByCompetition['ESP2'] as $team) {
+            $this->assertContains($team->id, $entries, "ESP2 team {$team->id} should qualify");
+        }
+        foreach (['ESP3A', 'ESP3B'] as $group) {
+            foreach (array_slice($this->teamsByCompetition[$group], 0, 5) as $team) {
+                $this->assertContains($team->id, $entries, "Top-5 {$group} team {$team->id} should qualify");
+            }
+            foreach (array_slice($this->teamsByCompetition[$group], 5) as $team) {
+                $this->assertNotContains($team->id, $entries, "Non-top-5 {$group} team {$team->id} should not qualify");
+            }
+        }
+    }
+
+    public function test_reserve_team_in_top_5_is_skipped_and_next_non_reserve_qualifies(): void
+    {
+        // Make position 3 in ESP3A a reserve of an ESP1 team — it must be
+        // skipped and position 6 bumped up into the top 5.
+        $parent = $this->teamsByCompetition['ESP1'][0];
+        $this->teamsByCompetition['ESP3A'][2]->update(['parent_team_id' => $parent->id]);
+
+        $this->runProcessor();
+
+        $entries = $this->cupEntries();
+        $esp3a = $this->teamsByCompetition['ESP3A'];
+
+        $this->assertContains($esp3a[0]->id, $entries, 'pos 1 qualifies');
+        $this->assertContains($esp3a[1]->id, $entries, 'pos 2 qualifies');
+        $this->assertNotContains($esp3a[2]->id, $entries, 'reserve at pos 3 skipped');
+        $this->assertContains($esp3a[3]->id, $entries, 'pos 4 qualifies');
+        $this->assertContains($esp3a[4]->id, $entries, 'pos 5 qualifies');
+        $this->assertContains($esp3a[5]->id, $entries, 'pos 6 bumped into top 5');
+        $this->assertNotContains($esp3a[6]->id, $entries, 'pos 7 does not qualify');
+
+        $esp3aQualifiers = array_values(array_filter(
+            $entries,
+            fn (string $id) => in_array($id, array_map(fn (Team $t) => $t->id, $esp3a), true),
+        ));
+        $this->assertCount(5, $esp3aQualifiers, 'ESP3A still contributes exactly 5 qualifiers');
+    }
+
+    public function test_reserve_in_auto_qualify_tier_cascades_extra_slot_to_primera_rfef_groups(): void
+    {
+        // Three reserves occupying ESP2 slots — cascade should add 3 total
+        // picks across the two groups (round-robin: A=+2, B=+1 → A picks 7,
+        // B picks 6), keeping the cup at 52 qualifiers.
+        $parents = $this->teamsByCompetition['ESP1'];
+        $this->teamsByCompetition['ESP2'][5]->update(['parent_team_id' => $parents[0]->id]);
+        $this->teamsByCompetition['ESP2'][10]->update(['parent_team_id' => $parents[1]->id]);
+        $this->teamsByCompetition['ESP2'][15]->update(['parent_team_id' => $parents[2]->id]);
+
+        $this->runProcessor();
+
+        $entries = $this->cupEntries();
+        $this->assertCount(52, $entries, 'Cup should stay at 52 qualifiers');
+
+        $esp3aIds = array_map(fn (Team $t) => $t->id, $this->teamsByCompetition['ESP3A']);
+        $esp3bIds = array_map(fn (Team $t) => $t->id, $this->teamsByCompetition['ESP3B']);
+
+        $esp3aCount = count(array_intersect($entries, $esp3aIds));
+        $esp3bCount = count(array_intersect($entries, $esp3bIds));
+
+        $this->assertEquals(7, $esp3aCount, 'ESP3A absorbs 2 cascaded seats');
+        $this->assertEquals(6, $esp3bCount, 'ESP3B absorbs 1 cascaded seat');
+
+        // The three reserves themselves never qualify
+        $this->assertNotContains($this->teamsByCompetition['ESP2'][5]->id, $entries);
+        $this->assertNotContains($this->teamsByCompetition['ESP2'][10]->id, $entries);
+        $this->assertNotContains($this->teamsByCompetition['ESP2'][15]->id, $entries);
+    }
+
+    public function test_lower_tier_seed_teams_without_any_playable_tier_entry_are_preserved(): void
+    {
+        // Lower-division "flavour" teams: they sit in ESPCUP but aren't
+        // registered in ESP1/2/3 at all. They should survive the rebuild.
+        $regional1 = Team::factory()->create(['country' => 'ES', 'name' => 'CD Numancia']);
+        $regional2 = Team::factory()->create(['country' => 'ES', 'name' => 'Real Jaén CF']);
+
+        foreach ([$regional1, $regional2] as $team) {
+            CompetitionEntry::create([
+                'game_id' => $this->game->id,
+                'competition_id' => 'ESPCUP',
+                'team_id' => $team->id,
+                'entry_round' => 1,
+            ]);
+        }
+
+        $this->runProcessor();
+
+        $entries = $this->cupEntries();
+
+        $this->assertContains($regional1->id, $entries, 'Lower-tier seed team preserved');
+        $this->assertContains($regional2->id, $entries, 'Lower-tier seed team preserved');
+        $this->assertCount(52 + 2, $entries, 'Qualifiers + preserved seed teams');
+    }
+
+    public function test_reserve_team_previously_in_copa_is_removed_on_rebuild(): void
+    {
+        $parent = $this->teamsByCompetition['ESP1'][0];
+        $strayReserve = Team::factory()->create([
+            'country' => 'ES',
+            'parent_team_id' => $parent->id,
+        ]);
+
+        CompetitionEntry::create([
+            'game_id' => $this->game->id,
+            'competition_id' => 'ESPCUP',
+            'team_id' => $strayReserve->id,
+            'entry_round' => 1,
+        ]);
+
+        $this->runProcessor();
+
+        $this->assertNotContains($strayReserve->id, $this->cupEntries());
+    }
+
+    public function test_falls_back_to_simulated_season_when_standings_are_empty(): void
+    {
+        // Mirror a non-player group where the season was simulated: drop
+        // standings for ESP3B and register results in SimulatedSeason.
+        GameStanding::where('game_id', $this->game->id)
+            ->where('competition_id', 'ESP3B')
+            ->delete();
+
+        SimulatedSeason::create([
+            'game_id' => $this->game->id,
+            'season' => '2025',
+            'competition_id' => 'ESP3B',
+            'results' => array_map(fn (Team $t) => $t->id, $this->teamsByCompetition['ESP3B']),
+        ]);
+
+        $this->runProcessor();
+
+        $entries = $this->cupEntries();
+
+        foreach (array_slice($this->teamsByCompetition['ESP3B'], 0, 5) as $team) {
+            $this->assertContains($team->id, $entries, 'Simulated top-5 ESP3B team qualifies');
+        }
+        foreach (array_slice($this->teamsByCompetition['ESP3B'], 5) as $team) {
+            $this->assertNotContains($team->id, $entries, 'Simulated non-top-5 does not qualify');
+        }
+    }
+
+    private function runProcessor(): void
+    {
+        app(CopaQualificationProcessor::class)->process(
+            $this->game,
+            new SeasonTransitionData(oldSeason: '2025', newSeason: '2026', competitionId: 'ESP1'),
+        );
+    }
+
+    /**
+     * @return string[]
+     */
+    private function cupEntries(): array
+    {
+        return CompetitionEntry::where('game_id', $this->game->id)
+            ->where('competition_id', 'ESPCUP')
+            ->pluck('team_id')
+            ->all();
+    }
+
+    private function createLeague(string $competitionId, int $count, ?Team $firstTeam = null): void
+    {
+        $teams = [];
+        for ($i = 0; $i < $count; $i++) {
+            $team = ($i === 0 && $firstTeam)
+                ? $firstTeam
+                : Team::factory()->create(['country' => 'ES']);
+
+            CompetitionEntry::create([
+                'game_id' => $this->game->id,
+                'competition_id' => $competitionId,
+                'team_id' => $team->id,
+                'entry_round' => 1,
+            ]);
+
+            GameStanding::create([
+                'game_id' => $this->game->id,
+                'competition_id' => $competitionId,
+                'team_id' => $team->id,
+                'position' => $i + 1,
+                'played' => 38,
+                'won' => max(0, 20 - $i),
+                'drawn' => 5,
+                'lost' => max(0, $i - 5),
+                'goals_for' => max(10, 60 - $i * 2),
+                'goals_against' => 20 + $i,
+                'points' => max(0, (20 - $i) * 3 + 5),
+            ]);
+
+            $teams[] = $team;
+        }
+
+        $this->teamsByCompetition[$competitionId] = $teams;
+    }
+}


### PR DESCRIPTION
## Summary
Adds automatic qualification logic for domestic cups (e.g., Copa del Rey) based on configurable rules tied to league tier standings. Teams are qualified at the end of each season according to country-specific rules, with special handling for reserve teams that prevents them from participating in cups.

## Key Changes

- **New `CopaQualificationProcessor`**: Implements the core qualification logic that runs at priority 82 (before promotion/relegation). It:
  - Qualifies all teams from configured auto-qualify tiers
  - Qualifies top N teams from specified tiers via `top_per_group`
  - Handles reserve team cascading: when a reserve occupies an auto-qualify slot, an additional seat is added to `top_per_group` (distributed round-robin) to maintain expected cup size
  - Preserves lower-division seed teams already in the cup (teams not in any playable tier)
  - Falls back to simulated season results when real standings are unavailable

- **Configuration in `config/countries.php`**: Added `cup_qualification` section with rules for Spain's Copa del Rey:
  - `auto_qualify_tiers`: Tiers 1 and 2 (La Liga and Segunda División) auto-qualify all teams
  - `top_per_group`: Top 5 teams from each Tier 3 group (ESP3A, ESP3B) qualify

- **Updated `SetupNewGame.php`**: Filters out reserve teams from domestic cup entries when copying competition teams to a new game, preventing them from being seeded into cups initially

- **Added `CountryConfig::cupQualification()`**: Service method to retrieve cup qualification rules for a specific competition

- **Updated `SeasonClosingPipeline`**: Registered `CopaQualificationProcessor` in the season closing pipeline

- **Documentation**: Updated season lifecycle docs to reflect the new processor in the pipeline

## Implementation Details

- Reserve teams (identified by `parent_team_id` being set) are never eligible for cup qualification regardless of league position
- When reserves occupy auto-qualify slots, their "seats" cascade to the `top_per_group` picks via round-robin distribution across groups to maintain bracket size
- Existing cup entries are cleared only for teams in playable tiers and reserve teams; lower-division seed teams are preserved
- Uses `GameStanding` for real standings, with `SimulatedSeason` as fallback for unplayed competitions

https://claude.ai/code/session_013UeGUm4wAJKJNVCve5Q1F3