### PR TITLE
Fix TypeError in AI foreign transfer call

### DIFF
--- a/app/Modules/Transfer/Services/AITransferMarketService.php
+++ b/app/Modules/Transfer/Services/AITransferMarketService.php
@@ -557,7 +557,7 @@ class AITransferMarketService
                     $foreignIndex++;
                     $assignedNumber = $this->allocateSquadNumber($takenNumbers, $foreignTeam->id);
 
-                    $this->prepareTransfer($game, $player, $sellerTeamId, $foreignTeam->id, $foreignTeam, $window, $assignedNumber, $playerUpdates, $transferInserts, maxContractYears: 4, buyerReputationIndex: 1);
+                    $this->prepareTransfer($game, $player, $sellerTeamId, $foreignTeam->id, $window, $assignedNumber, $playerUpdates, $transferInserts, maxContractYears: 4, buyerReputationIndex: 1);
                     $count++;
                     $transferredPlayerIds[$player->id] = true;
                     $this->incrementBudget($teamBudgets, $sellerTeamId, 'sells');


### PR DESCRIPTION
The foreign-departure branch passed an extra Team object between
$foreignTeam->id and $window, shifting positional args so $window
was passed where prepareTransfer expects $assignedNumber (int).