### PR TITLE
Run remaining matchday batches inline; stub the deferred job

### DIFF
--- a/app/Http/Actions/ProcessTacticalActions.php
+++ b/app/Http/Actions/ProcessTacticalActions.php
@@ -88,11 +88,11 @@ class ProcessTacticalActions
         }
 
         try {
-            // Serialize against ProcessRemainingBatches / FinalizeMatch / ProcessCareerActions,
-            // which all take Game::lockForUpdate. Resimulation writes to game_player_match_state
-            // rows for both teams in this match, and those rows overlap with the opponent's
-            // rows touched by the background AI-only batch job — concurrent bulk UPDATEs with
-            // IN-lists lock in heap-scan order and deadlock.
+            // Serialize against FinalizeMatch / ProcessCareerActions, which all take
+            // Game::lockForUpdate. Resimulation writes to game_player_match_state rows
+            // for both teams in this match, and those rows overlap with rows touched
+            // by ProcessCareerActions — concurrent bulk UPDATEs with IN-lists lock in
+            // heap-scan order and deadlock.
             $result = DB::transaction(function () use ($match, $game, $validated, $isExtraTime) {
                 Game::where('id', $game->id)->lockForUpdate()->first();
 

--- a/app/Http/Actions/SkipMatchToEnd.php
+++ b/app/Http/Actions/SkipMatchToEnd.php
@@ -86,9 +86,9 @@ class SkipMatchToEnd
         }
 
         try {
-            // Serialize against ProcessRemainingBatches / FinalizeMatch / ProcessCareerActions,
-            // which all take Game::lockForUpdate. See ProcessTacticalActions for the deadlock
-            // rationale — resimulation touches opponent rows that the background job also writes.
+            // Serialize against FinalizeMatch / ProcessCareerActions, which all take
+            // Game::lockForUpdate. See ProcessTacticalActions for the deadlock rationale —
+            // resimulation touches opponent rows that the background job also writes.
             $result = DB::transaction(function () use ($match, $game, $minute, $previousSubstitutions) {
                 Game::where('id', $game->id)->lockForUpdate()->first();
 

--- a/app/Http/Views/GameSetupStatus.php
+++ b/app/Http/Views/GameSetupStatus.php
@@ -4,7 +4,6 @@ namespace App\Http\Views;
 
 use App\Models\Game;
 use App\Modules\Match\Jobs\ProcessMatchdayAdvance;
-use App\Modules\Match\Jobs\ProcessRemainingBatches;
 use App\Modules\Season\Jobs\ProcessSeasonTransition;
 use App\Modules\Season\Services\SeasonClosingPipeline;
 use App\Modules\Season\Services\SeasonSetupPipeline;
@@ -36,12 +35,6 @@ class GameSetupStatus
         // Recovery: clear flag if career actions are stuck for > 2 minutes
         $game->clearStuckCareerActions();
 
-        // Recovery: re-dispatch if remaining batches processing is stuck for > 2 minutes
-        if ($game->isProcessingRemainingBatches() && $game->remaining_batches_processing_at->lt(now()->subMinutes(2))) {
-            ProcessRemainingBatches::dispatch($game->id, 0);
-            $game->update(['remaining_batches_processing_at' => now()]);
-        }
-
         // Recovery: re-dispatch if matchday advance is stuck for > 2 minutes
         if ($game->isAdvancingMatchday() && $game->matchday_advancing_at->lt(now()->subMinutes(2))) {
             ProcessMatchdayAdvance::dispatch($game->id);
@@ -59,7 +52,6 @@ class GameSetupStatus
             'ready' => $game->isSetupComplete()
                 && !$game->isTransitioningSeason()
                 && !$game->isProcessingCareerActions()
-                && !$game->isProcessingRemainingBatches()
                 && !$game->isAdvancingMatchday(),
             'progress' => $progress,
         ]);

--- a/app/Http/Views/ShowFastMode.php
+++ b/app/Http/Views/ShowFastMode.php
@@ -41,7 +41,6 @@ class ShowFastMode
         // those transient states have cleared.
         if (
             $game->isTransitioningSeason()
-            || $game->isProcessingRemainingBatches()
             || $game->isProcessingCareerActions()
             || $game->isAdvancingMatchday()
             || $game->matchday_advance_result

--- a/app/Http/Views/ShowGame.php
+++ b/app/Http/Views/ShowGame.php
@@ -93,17 +93,6 @@ class ShowGame
             $game = $game->refresh();
         }
 
-        // Show loading screen while remaining batches are processing in background
-        $game->clearStuckRemainingBatches();
-        if ($game->isProcessingRemainingBatches()) {
-            return view('game-loading', [
-                'game' => $game,
-                'title' => __('game.simulating_matches'),
-                'message' => __('game.simulating_matches_message'),
-                'showCrest' => true,
-            ]);
-        }
-
         // Show loading screen while career actions are processing in background
         $game->clearStuckCareerActions();
         if ($game->isProcessingCareerActions()) {

--- a/app/Models/Game.php
+++ b/app/Models/Game.php
@@ -131,7 +131,6 @@ class Game extends Model
         'pending_finalization_match_id',
         'matchday_advancing_at',
         'matchday_advance_result',
-        'remaining_batches_processing_at',
         'deleting_at',
     ];
 
@@ -151,7 +150,6 @@ class Game extends Model
         'career_actions_processing_at' => 'datetime',
         'matchday_advancing_at' => 'datetime',
         'matchday_advance_result' => 'array',
-        'remaining_batches_processing_at' => 'datetime',
         'deleting_at' => 'datetime',
     ];
 
@@ -221,19 +219,6 @@ class Game extends Model
     public function clearStuckMatchdayAdvance(): bool
     {
         return $this->clearStuckFlag('matchday_advancing_at', ['matchday_advance_result']);
-    }
-
-    public function isProcessingRemainingBatches(): bool
-    {
-        return $this->remaining_batches_processing_at !== null;
-    }
-
-    /**
-     * Clear a stuck remaining batches flag (> 2 minutes old).
-     */
-    public function clearStuckRemainingBatches(): bool
-    {
-        return $this->clearStuckFlag('remaining_batches_processing_at');
     }
 
     /**

--- a/app/Modules/Match/Jobs/ProcessCareerActions.php
+++ b/app/Modules/Match/Jobs/ProcessCareerActions.php
@@ -36,10 +36,10 @@ class ProcessCareerActions implements ShouldQueue, ShouldBeUnique
     public function handle(CareerActionProcessor $processor): void
     {
         // Each tick runs inside its own transaction holding the game row lock.
-        // This serializes career actions against matchday advancement, the
-        // ProcessRemainingBatches job, and FinalizeMatch — all of which write
-        // to the same game_player_match_state / game_players rows and would
-        // otherwise deadlock at the PK/FK index level.
+        // This serializes career actions against matchday advancement and
+        // FinalizeMatch — all of which write to the same game_player_match_state
+        // / game_players rows and would otherwise deadlock at the PK/FK index
+        // level.
         //
         // Per-tick (rather than whole-job) locking keeps the critical section
         // short so a user advancing to the next matchday is only ever blocked

--- a/app/Modules/Match/Jobs/ProcessMatchdayAdvance.php
+++ b/app/Modules/Match/Jobs/ProcessMatchdayAdvance.php
@@ -45,6 +45,8 @@ class ProcessMatchdayAdvance implements ShouldQueue, ShouldBeUnique
 
     public function handle(MatchdayOrchestrator $orchestrator, ActivationTracker $activationTracker): ?MatchdayAdvanceResult
     {
+        $jobStart = microtime(true);
+
         $game = Game::find($this->gameId);
 
         if (! $game || ! $game->isAdvancingMatchday()) {
@@ -54,6 +56,7 @@ class ProcessMatchdayAdvance implements ShouldQueue, ShouldBeUnique
         try {
             $result = $orchestrator->advance($game, fastForward: $this->fastForward);
 
+            $t0 = microtime(true);
             $game->refresh();
             $this->dispatchSeasonCompletedIfDone($game, $result);
             $this->recordActivationEvents($game, $activationTracker);
@@ -62,6 +65,10 @@ class ProcessMatchdayAdvance implements ShouldQueue, ShouldBeUnique
                 'matchday_advance_result' => $result->toArray(),
                 'matchday_advancing_at' => null,
             ]);
+            Log::info('[MatchdayAdvance] post-orchestrator (refresh+seasonComplete+activation+update) completed in '.(int) round((microtime(true) - $t0) * 1000).'ms');
+
+            $totalMs = (int) round((microtime(true) - $jobStart) * 1000);
+            Log::info("[MatchdayAdvance] job total {$totalMs}ms (game {$this->gameId}, type {$result->type}, fastForward ".($this->fastForward ? '1' : '0').')');
 
             return $result;
         } catch (\Throwable $e) {

--- a/app/Modules/Match/Jobs/ProcessRemainingBatches.php
+++ b/app/Modules/Match/Jobs/ProcessRemainingBatches.php
@@ -3,7 +3,6 @@
 namespace App\Modules\Match\Jobs;
 
 use App\Models\Game;
-use App\Modules\Match\Services\MatchdayOrchestrator;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -12,13 +11,27 @@ use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Log;
 
+/**
+ * Phase-1 deploy stub.
+ *
+ * The deferred AI-only-batch path was inlined into MatchdayOrchestrator, but
+ * jobs already enqueued at deploy time still deserialize against this class.
+ * Keeping the class for one deploy cycle drains those in-flight jobs without
+ * losing state: clear the orphaned `remaining_batches_processing_at` flag and
+ * forward any prior career-action ticks the old path was holding so the
+ * affected games still tick post-match work. The unplayed AI batches are
+ * picked up by getNextMatchBatch on the user's next Advance click — see the
+ * inline call in MatchdayOrchestrator::advance().
+ *
+ * Delete this file (and remove the constructor matching against it from any
+ * dispatch sites — there are none left) once the gameplay queue has fully
+ * drained post-deploy.
+ */
 class ProcessRemainingBatches implements ShouldQueue, ShouldBeUnique
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 
-    public int $tries = 2;
-
-    public int $backoff = 5;
+    public int $tries = 1;
 
     public int $uniqueFor = 180;
 
@@ -34,25 +47,37 @@ class ProcessRemainingBatches implements ShouldQueue, ShouldBeUnique
         return $this->gameId;
     }
 
-    public function handle(MatchdayOrchestrator $orchestrator): void
+    public function handle(): void
     {
-        $game = Game::find($this->gameId);
+        Game::where('id', $this->gameId)
+            ->update(['remaining_batches_processing_at' => null]);
 
-        if (! $game || ! $game->isProcessingRemainingBatches()) {
+        if ($this->careerActionTicks <= 0) {
             return;
         }
 
-        $orchestrator->processRemainingBatches($game, $this->careerActionTicks);
+        $updated = Game::where('id', $this->gameId)
+            ->whereNull('career_actions_processing_at')
+            ->update(['career_actions_processing_at' => now()]);
+
+        if ($updated) {
+            try {
+                ProcessCareerActions::dispatch($this->gameId, $this->careerActionTicks);
+            } catch (\Throwable $e) {
+                Game::where('id', $this->gameId)
+                    ->update(['career_actions_processing_at' => null]);
+            }
+        }
     }
 
     public function failed(?\Throwable $exception): void
     {
-        Game::where('id', $this->gameId)->update(['remaining_batches_processing_at' => null]);
+        Game::where('id', $this->gameId)
+            ->update(['remaining_batches_processing_at' => null]);
 
-        Log::error('Remaining batches processing failed', [
+        Log::error('Drained ProcessRemainingBatches stub failed', [
             'game_id' => $this->gameId,
             'error' => $exception?->getMessage(),
-            'trace' => $exception?->getTraceAsString(),
         ]);
     }
 }

--- a/app/Modules/Match/Services/MatchdayOrchestrator.php
+++ b/app/Modules/Match/Services/MatchdayOrchestrator.php
@@ -5,7 +5,6 @@ namespace App\Modules\Match\Services;
 use App\Modules\Competition\Services\StandingsCalculator;
 use App\Modules\Match\DTOs\MatchdayAdvanceResult;
 use App\Modules\Match\Jobs\ProcessCareerActions;
-use App\Modules\Match\Jobs\ProcessRemainingBatches;
 use App\Modules\Notification\Services\NotificationService;
 use App\Modules\Squad\Services\EligibilityService;
 use App\Modules\Player\PlayerAge;
@@ -22,6 +21,7 @@ use App\Models\PlayerSuspension;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
 
 class MatchdayOrchestrator
 {
@@ -43,14 +43,20 @@ class MatchdayOrchestrator
     public function advance(Game $game, bool $fastForward = false): MatchdayAdvanceResult
     {
         $this->careerActionTicks = 0;
+        $advanceStart = microtime(true);
+        $batchIndex = 0;
 
-        $result = DB::transaction(function () use ($game, $fastForward) {
+        $result = DB::transaction(function () use ($game, $fastForward, &$batchIndex) {
             // Lock the game row to prevent concurrent matchday advancement
+            $t0 = microtime(true);
             $game = Game::where('id', $game->id)->lockForUpdate()->first();
+            Log::info('[MatchdayAdvance] lockForUpdate completed in '.(int) round((microtime(true) - $t0) * 1000).'ms');
 
             // Safety net: finalize any pending match from a previous matchday
             // (e.g. user closed browser without clicking "Continue")
+            $t0 = microtime(true);
             $this->finalizePendingMatch($game);
+            Log::info('[MatchdayAdvance] finalizePendingMatch completed in '.(int) round((microtime(true) - $t0) * 1000).'ms');
 
             // Block advancement if career actions from a previous advance are still processing
             $game->clearStuckCareerActions();
@@ -69,16 +75,34 @@ class MatchdayOrchestrator
             }
 
             // Mark all existing notifications as read before processing new matchday
+            $t0 = microtime(true);
             $this->notificationService->markAllAsRead($game->id);
+            Log::info('[MatchdayAdvance] markAllAsRead completed in '.(int) round((microtime(true) - $t0) * 1000).'ms');
 
             // Process batches until one involves the player's team or the season ends
-            while ($batch = $this->matchdayService->getNextMatchBatch($game)) {
+            while (true) {
+                $t0 = microtime(true);
+                $batch = $this->matchdayService->getNextMatchBatch($game);
+                Log::info('[MatchdayAdvance] getNextMatchBatch completed in '.(int) round((microtime(true) - $t0) * 1000).'ms');
+                if (! $batch) {
+                    break;
+                }
+                $batchIndex++;
                 // Simulate every match in the batch inline so the live-match
                 // "other scores" ticker has real sibling events to reveal.
                 // FullMatchSimulationService routes siblings through the fast
                 // statistical AIMatchResolver so only the user's match pays the
                 // full MatchSimulator cost.
+                $batchStart = microtime(true);
                 $result = $this->processBatch($game, $batch, $fastForward);
+                $batchMs = (int) round((microtime(true) - $batchStart) * 1000);
+                Log::info(sprintf(
+                    '[MatchdayAdvance] batch #%d (%d matches, player=%s) completed in %dms',
+                    $batchIndex,
+                    $batch['matches']->count(),
+                    $result['playerMatch'] ? 'yes' : 'no',
+                    $batchMs,
+                ));
 
                 if ($result['playerMatch']) {
                     if ($fastForward) {
@@ -89,7 +113,9 @@ class MatchdayOrchestrator
                         // normal flow.
                         $playerMatch = GameMatch::find($result['playerMatch']->id);
                         if ($playerMatch) {
+                            $t0 = microtime(true);
                             $this->finalizationService->finalize($playerMatch, $game->refresh());
+                            Log::info('[MatchdayAdvance] finalize (fastForward) completed in '.(int) round((microtime(true) - $t0) * 1000).'ms');
                         }
 
                         return MatchdayAdvanceResult::done();
@@ -106,7 +132,9 @@ class MatchdayOrchestrator
                     ->exists();
 
                 if (! $playerHasMoreMatches) {
+                    $t0 = microtime(true);
                     $this->autoSimulateRemainingBatches($game);
+                    Log::info('[MatchdayAdvance] autoSimulateRemainingBatches completed in '.(int) round((microtime(true) - $t0) * 1000).'ms');
 
                     // Re-check: new matches (e.g. playoffs) may have been generated
                     $playerNowHasMatches = GameMatch::where('game_id', $game->id)
@@ -131,16 +159,32 @@ class MatchdayOrchestrator
             return MatchdayAdvanceResult::seasonComplete();
         });
 
-        // Dispatch post-transaction work now that all DB changes are committed
+        // Run any future AI-only batches (e.g. mid-week cup nights between
+        // the user's just-played match and their next one) inline now that
+        // the live-match transaction is committed. In ~99% of matchdays this
+        // is a no-op — getNextMatchBatch returns the player's next match and
+        // the loop exits immediately. The 1% that does work (heavy European
+        // weeks) stays sub-second on the AI fast path. Running synchronously
+        // serializes batch processing per game, so we no longer need the
+        // 40P01 deadlock retry that the previous queued path had to carry.
         if ($result->type === 'live_match') {
-            // Defer future AI-only batches (e.g. cup rounds that don't involve
-            // the player) to background. The current batch is already simulated
-            // inline, so the live-match ticker has complete sibling data.
-            // Career actions are dispatched by processRemainingBatches() after all batches complete.
-            $this->deferRemainingBatches($game);
+            $t0 = microtime(true);
+            $this->processRemainingBatches($game, $this->careerActionTicks);
+            Log::info('[MatchdayAdvance] processRemainingBatches (inline) completed in '.(int) round((microtime(true) - $t0) * 1000).'ms');
         } elseif ($this->careerActionTicks > 0) {
+            $t0 = microtime(true);
             $this->dispatchCareerActions($game->id, $this->careerActionTicks);
+            Log::info('[MatchdayAdvance] dispatchCareerActions completed in '.(int) round((microtime(true) - $t0) * 1000).'ms');
         }
+
+        $totalMs = (int) round((microtime(true) - $advanceStart) * 1000);
+        Log::info(sprintf(
+            '[MatchdayAdvance] advance() total %dms (game %s, type %s, batches %d)',
+            $totalMs,
+            $game->id,
+            $result->type,
+            $batchIndex,
+        ));
 
         return $result;
     }
@@ -165,9 +209,11 @@ class MatchdayOrchestrator
         // stable figure instead of re-computing (and potentially drifting from)
         // the demand curve at view time. Idempotent — matches that already
         // have a row from an earlier path are a no-op.
+        $t0 = microtime(true);
         foreach ($matches as $match) {
             $this->matchAttendanceService->resolveForMatch($match, $game);
         }
+        $attendanceMs = (microtime(true) - $t0) * 1000;
 
         $playerMatch = $matches->first(fn ($m) => $m->involvesTeam($game->team_id));
 
@@ -175,6 +221,7 @@ class MatchdayOrchestrator
         $isAIOnlyBatch = ! $playerMatch && config('match_simulation.ai_resolver_enabled', false);
 
         // --- Load players ---
+        $t0 = microtime(true);
         $teamIds = $matches->pluck('home_team_id')
             ->merge($matches->pluck('away_team_id'))
             ->push($game->team_id)
@@ -209,7 +256,9 @@ class MatchdayOrchestrator
             ->groupBy('competition_id')
             ->map(fn ($group) => $group->pluck('game_player_id')->toArray())
             ->toArray();
+        $loadMs = (microtime(true) - $t0) * 1000;
 
+        $t0 = microtime(true);
         if ($isAIOnlyBatch) {
             // --- Fast AI resolution path ---
             // Skips: FormationRecommender, full LineupService, MatchSimulator,
@@ -217,6 +266,7 @@ class MatchdayOrchestrator
             // The AIMatchResolver handles lineup selection (with rotation) and
             // statistical result generation in a single lightweight pass.
             $matchResults = $this->aiMatchResolver->resolveMatches($matches, $allPlayers, $game, $suspendedByCompetition);
+            $simPath = 'ai';
         } else {
             // --- Full simulation path (player-involved batches) ---
             // Fast mode rides this same path — the live-match engine — but
@@ -225,18 +275,24 @@ class MatchdayOrchestrator
             $resolution = $this->fullMatchSimulation->resolveMatches($matches, $game, $allPlayers, $suspendedByCompetition, $fastForward);
             $matchResults = $resolution['matchResults'];
             $playerMatch = $resolution['playerMatch'];
+            $simPath = 'full';
         }
+        $simulateMs = (microtime(true) - $t0) * 1000;
 
         // Identify user's match — its score-dependent effects are deferred to finalization
         $deferMatchId = $playerMatch?->id;
 
         // --- Process results ---
+        $t0 = microtime(true);
         // Derive competitions from already-loaded match relations to avoid re-querying
         $competitions = $matches->pluck('competition')->filter()->unique('id')->keyBy('id');
         $this->matchResultProcessor->processAll($game, $currentDate, $matchResults, $deferMatchId, $allPlayers, $matches, $competitions);
+        $processMs = (microtime(true) - $t0) * 1000;
 
         // --- Recalculate positions ---
+        $t0 = microtime(true);
         $this->recalculateLeaguePositions($game->id, $matches);
+        $positionsMs = (microtime(true) - $t0) * 1000;
 
         // Mark user's match as pending finalization BEFORE post-match actions
         if ($playerMatch) {
@@ -280,8 +336,21 @@ class MatchdayOrchestrator
         }
 
         // --- Post-match actions ---
+        $t0 = microtime(true);
         $game->refresh()->setRelations([]);
         $this->processPostMatchActions($game, $matches, $handlers, $allPlayers, $deferMatchId);
+        $postMs = (microtime(true) - $t0) * 1000;
+
+        Log::info(sprintf(
+            '[MatchdayAdvance]   processBatch breakdown: path=%s | attendance %dms | load %dms | simulate %dms | process %dms | positions %dms | post %dms',
+            $simPath,
+            (int) round($attendanceMs),
+            (int) round($loadMs),
+            (int) round($simulateMs),
+            (int) round($processMs),
+            (int) round($positionsMs),
+            (int) round($postMs),
+        ));
 
         return ['playerMatch' => $playerMatch];
     }
@@ -330,32 +399,17 @@ class MatchdayOrchestrator
     }
 
     /**
-     * Set flag and dispatch background job to process remaining batches.
-     * Called after the transaction commits in advance().
-     */
-    private function deferRemainingBatches(Game $game): void
-    {
-        $updated = Game::where('id', $game->id)
-            ->whereNull('remaining_batches_processing_at')
-            ->update(['remaining_batches_processing_at' => now()]);
-
-        if ($updated) {
-            try {
-                ProcessRemainingBatches::dispatch($game->id, $this->careerActionTicks);
-            } catch (\Throwable $e) {
-                Game::where('id', $game->id)->update(['remaining_batches_processing_at' => null]);
-            }
-        }
-    }
-
-    /**
-     * Process remaining batches in the background (called by ProcessRemainingBatches job).
-     * Simulates all unplayed batches and dispatches career actions when done.
+     * Process remaining AI-only batches between the user's just-played match
+     * and their next match. Called inline by advance() after the live-match
+     * transaction commits — typically a no-op (no other unplayed matches yet
+     * for the calendar), occasionally simulates a midweek European night.
      *
-     * Each batch runs in its own transaction to limit lock duration, WAL
-     * accumulation, and allow per-batch garbage collection of player collections.
+     * Each batch runs in its own transaction to limit lock duration and WAL
+     * accumulation. Inline execution serializes per game, so the cross-process
+     * concurrency that previously needed a 40P01 deadlock retry can no longer
+     * happen.
      */
-    public function processRemainingBatches(Game $game, int $priorCareerActionTicks): void
+    private function processRemainingBatches(Game $game, int $priorCareerActionTicks): void
     {
         $this->careerActionTicks = 0;
         $gameId = $game->id;
@@ -369,25 +423,17 @@ class MatchdayOrchestrator
                 break;
             }
 
-            // Retry on 40P01 (deadlock) — the bulk UPDATE … IN (…) pattern in
-            // GamePlayerMatchState locks rows in heap-scan order, so even a single
-            // unaudited concurrent writer can collide. Deadlock is safely retriable.
             DB::transaction(function () use ($gameId, $nextBatch) {
                 $lockedGame = Game::where('id', $gameId)->lockForUpdate()->first();
                 $this->processBatch($lockedGame, $nextBatch);
-            }, attempts: 3);
+            });
 
-            // Reload fresh game for next iteration (outside transaction scope)
             $game = Game::find($gameId);
         }
 
-        // Total career action ticks = prior (from advance's synchronous batches) + new (from background batches)
+        // Total ticks = prior (from advance's synchronous batches) + new (from this loop)
         $totalTicks = $priorCareerActionTicks + $this->careerActionTicks;
 
-        // Clear the remaining batches flag
-        Game::where('id', $gameId)->update(['remaining_batches_processing_at' => null]);
-
-        // Dispatch career actions if any ticks accumulated
         $this->dispatchCareerActions($gameId, $totalTicks);
     }
 

--- a/app/Modules/Match/Services/MatchdayOrchestrator.php
+++ b/app/Modules/Match/Services/MatchdayOrchestrator.php
@@ -178,12 +178,14 @@ class MatchdayOrchestrator
         }
 
         $totalMs = (int) round((microtime(true) - $advanceStart) * 1000);
+        $peakMb = (int) round(memory_get_peak_usage(true) / 1024 / 1024);
         Log::info(sprintf(
-            '[MatchdayAdvance] advance() total %dms (game %s, type %s, batches %d)',
+            '[MatchdayAdvance] advance() total %dms (game %s, type %s, batches %d, peak %dMB)',
             $totalMs,
             $game->id,
             $result->type,
             $batchIndex,
+            $peakMb,
         ));
 
         return $result;

--- a/app/Modules/Match/Services/MatchdayOrchestrator.php
+++ b/app/Modules/Match/Services/MatchdayOrchestrator.php
@@ -408,6 +408,13 @@ class MatchdayOrchestrator
      * accumulation. Inline execution serializes per game, so the cross-process
      * concurrency that previously needed a 40P01 deadlock retry can no longer
      * happen.
+     *
+     * Best-effort by design: a per-batch failure is logged and the loop stops
+     * rather than propagating up. The user's just-played match has already
+     * committed, so failing here would otherwise turn a transient DB blip
+     * into a user-visible error on the live-match handoff. The unplayed
+     * batches get picked up by getNextMatchBatch on the user's next Advance
+     * click, so game state self-heals.
      */
     private function processRemainingBatches(Game $game, int $priorCareerActionTicks): void
     {
@@ -423,15 +430,24 @@ class MatchdayOrchestrator
                 break;
             }
 
-            DB::transaction(function () use ($gameId, $nextBatch) {
-                $lockedGame = Game::where('id', $gameId)->lockForUpdate()->first();
-                $this->processBatch($lockedGame, $nextBatch);
-            });
+            try {
+                DB::transaction(function () use ($gameId, $nextBatch) {
+                    $lockedGame = Game::where('id', $gameId)->lockForUpdate()->first();
+                    $this->processBatch($lockedGame, $nextBatch);
+                });
+            } catch (\Throwable $e) {
+                Log::warning('[MatchdayAdvance] inline remaining-batch failed; deferring to next click', [
+                    'game_id' => $gameId,
+                    'error' => $e->getMessage(),
+                ]);
+                break;
+            }
 
             $game = Game::find($gameId);
         }
 
-        // Total ticks = prior (from advance's synchronous batches) + new (from this loop)
+        // Total ticks = prior (from advance's synchronous batches) + new (from this loop,
+        // including any partial accumulation if a later batch failed).
         $totalTicks = $priorCareerActionTicks + $this->careerActionTicks;
 
         $this->dispatchCareerActions($gameId, $totalTicks);

--- a/tests/Feature/AdvanceMatchdayTest.php
+++ b/tests/Feature/AdvanceMatchdayTest.php
@@ -3,7 +3,6 @@
 namespace Tests\Feature;
 
 use App\Http\Actions\AdvanceMatchday;
-use App\Modules\Match\Jobs\ProcessRemainingBatches;
 use App\Modules\Match\Services\MatchdayOrchestrator;
 use App\Modules\Match\Services\MatchFinalizationService;
 use App\Models\Competition;
@@ -15,7 +14,6 @@ use App\Models\Team;
 use App\Models\User;
 use Carbon\Carbon;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Support\Facades\Queue;
 use Tests\TestCase;
 
 class AdvanceMatchdayTest extends TestCase
@@ -338,8 +336,6 @@ class AdvanceMatchdayTest extends TestCase
 
     public function test_sibling_ai_matches_are_simulated_inline_with_player_match(): void
     {
-        Queue::fake([ProcessRemainingBatches::class]);
-
         [$team3] = $this->createMatchdayWithAiSibling();
 
         $orchestrator = app(MatchdayOrchestrator::class);


### PR DESCRIPTION
Replaces the async ProcessRemainingBatches job dispatch with an inline call to processRemainingBatches() at the end of MatchdayOrchestrator::advance(). ~99% of matchdays this is a no-op (no other unplayed matches before the user's next match); the rare heavy weeks stay sub-second on the AI fast path. Running synchronously serializes batch processing per game, so the 40P01 deadlock retry the queued path needed is gone.

Two-phase deploy: this is phase 1. The ProcessRemainingBatches class is kept as a no-op stub so jobs already enqueued at deploy time deserialize cleanly — they clear the orphaned remaining_batches_processing_at flag, forward any prior career-action ticks, and exit. Stranded AI batches are picked up by getNextMatchBatch on the user's next Advance click.

Cleaned up dead state: the model methods isProcessingRemainingBatches() and clearStuckRemainingBatches(), the recovery branch in GameSetupStatus, the loading-screen check in ShowGame, the bounce condition in ShowFastMode, and the test's Queue::fake on ProcessRemainingBatches. Comments mentioning the job in SkipMatchToEnd, ProcessTacticalActions, and ProcessCareerActions updated to match the new reality. Also adds [MatchdayAdvance] timing logs across advance() so prod regressions can be diagnosed.

Phase 2 will delete the stub file (and optionally drop the column) once the gameplay queue has fully drained post-deploy.