### PR TITLE
Mirror waitlist mode preferences when issuing beta invites

### DIFF
--- a/app/Services/BetaInviteService.php
+++ b/app/Services/BetaInviteService.php
@@ -13,16 +13,14 @@ class BetaInviteService
     public function invite(
         WaitlistEntry $entry,
         ?string $expiresAt = null,
-        bool $grantsCareer = false,
-        bool $grantsTournament = true,
     ): InviteCode {
         $invite = InviteCode::create([
             'code' => $this->generateCode(),
             'email' => strtolower($entry->email),
             'max_uses' => 1,
             'expires_at' => $expiresAt,
-            'grants_career' => $grantsCareer,
-            'grants_tournament' => $grantsTournament,
+            'grants_career' => $entry->wants_career,
+            'grants_tournament' => $entry->wants_tournament,
         ]);
 
         Mail::to($entry->email)->send(new BetaInvite($invite));


### PR DESCRIPTION
Previously BetaInviteService hardcoded grants_career=false / grants_tournament=true,
funnelling every invitee into tournament mode regardless of what they signed up for
on the waitlist. Now the invite mirrors wants_career / wants_tournament from the
waitlist entry so invited users get access to the modes they actually requested.

https://claude.ai/code/session_01J7M3sSaNUrECL8YXnDufkL