### PR TITLE
Add filial reserve squad management for parent clubs

### DIFF
--- a/app/Http/Actions/AcceptLoanOffer.php
+++ b/app/Http/Actions/AcceptLoanOffer.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Actions;
 
+use App\Modules\Transfer\Exceptions\SquadMinimumException;
 use App\Modules\Transfer\Services\LoanService;
 use App\Models\Game;
 use App\Models\TransferOffer;
@@ -39,7 +40,11 @@ class AcceptLoanOffer
         $team = $offer->offeringTeam;
         $windowOpen = $game->isTransferWindowOpen();
 
-        $this->loanService->acceptLoanOffer($offer, $game);
+        try {
+            $this->loanService->acceptLoanOffer($offer, $game);
+        } catch (SquadMinimumException $e) {
+            return redirect()->back()->with('error', $this->formatBreachMessage($e));
+        }
 
         if ($windowOpen) {
             $message = __('messages.loan_offer_accepted', [
@@ -57,5 +62,17 @@ class AcceptLoanOffer
         return redirect()
             ->route('game.transfers.outgoing', $gameId)
             ->with('success', $message);
+    }
+
+    private function formatBreachMessage(SquadMinimumException $e): string
+    {
+        if ($e->type() === 'too_small') {
+            return __('messages.accept_loan_squad_too_small', ['min' => $e->min()]);
+        }
+
+        return __('messages.accept_loan_position_minimum', [
+            'group' => __('squad.' . strtolower($e->group()) . 's'),
+            'min'   => $e->min(),
+        ]);
     }
 }

--- a/app/Http/Actions/AcceptTransferOffer.php
+++ b/app/Http/Actions/AcceptTransferOffer.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Actions;
 
+use App\Modules\Transfer\Exceptions\SquadMinimumException;
 use App\Modules\Transfer\Services\TransferService;
 use App\Models\Game;
 use App\Models\TransferOffer;
@@ -43,7 +44,11 @@ class AcceptTransferOffer
         $team = $offer->offeringTeam;
         $fee = $offer->formatted_transfer_fee;
 
-        $completedImmediately = $this->transferService->acceptOffer($offer);
+        try {
+            $completedImmediately = $this->transferService->acceptOffer($offer);
+        } catch (SquadMinimumException $e) {
+            return redirect()->back()->with('error', $this->formatBreachMessage($e));
+        }
 
         if ($completedImmediately) {
             $message = __('messages.offer_accepted_sale', [
@@ -64,5 +69,17 @@ class AcceptTransferOffer
         return redirect()
             ->route('game.transfers.outgoing', $gameId)
             ->with('success', $message);
+    }
+
+    private function formatBreachMessage(SquadMinimumException $e): string
+    {
+        if ($e->type() === 'too_small') {
+            return __('messages.accept_offer_squad_too_small', ['min' => $e->min()]);
+        }
+
+        return __('messages.accept_offer_position_minimum', [
+            'group' => __('squad.' . strtolower($e->group()) . 's'),
+            'min'   => $e->min(),
+        ]);
     }
 }

--- a/app/Http/Actions/CallUpReservePlayer.php
+++ b/app/Http/Actions/CallUpReservePlayer.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Http\Actions;
+
+use App\Models\Game;
+use App\Models\GamePlayer;
+use App\Modules\ReserveTeam\Exceptions\FirstTeamSquadFullException;
+use App\Modules\ReserveTeam\Services\ReserveTeamService;
+
+class CallUpReservePlayer
+{
+    public function __construct(
+        private readonly ReserveTeamService $reserveTeamService,
+    ) {}
+
+    public function __invoke(string $gameId, string $playerId)
+    {
+        $game = Game::findOrFail($gameId);
+        abort_if($game->reserve_team_id === null, 404);
+
+        $player = GamePlayer::where('id', $playerId)
+            ->where('game_id', $gameId)
+            ->where('team_id', $game->reserve_team_id)
+            ->with('player')
+            ->firstOrFail();
+
+        $playerName = $player->player->name ?? '';
+
+        try {
+            $this->reserveTeamService->callUpToFirstTeam($player, $game);
+        } catch (FirstTeamSquadFullException $e) {
+            return redirect()->route('game.squad.reserve', $gameId)
+                ->with('error', __('messages.reserve_player_call_up_blocked_full'));
+        }
+
+        return redirect()->route('game.squad.reserve', $gameId)
+            ->with('success', __('messages.reserve_player_called_up', ['player' => $playerName]));
+    }
+}

--- a/app/Http/Actions/CallUpReservePlayer.php
+++ b/app/Http/Actions/CallUpReservePlayer.php
@@ -5,6 +5,7 @@ namespace App\Http\Actions;
 use App\Models\Game;
 use App\Models\GamePlayer;
 use App\Modules\ReserveTeam\Exceptions\FirstTeamSquadFullException;
+use App\Modules\ReserveTeam\Exceptions\ReserveSquadMinimumException;
 use App\Modules\ReserveTeam\Services\ReserveTeamService;
 
 class CallUpReservePlayer
@@ -31,9 +32,24 @@ class CallUpReservePlayer
         } catch (FirstTeamSquadFullException $e) {
             return redirect()->route('game.squad.reserve', $gameId)
                 ->with('error', __('messages.reserve_player_call_up_blocked_full'));
+        } catch (ReserveSquadMinimumException $e) {
+            return redirect()->route('game.squad.reserve', $gameId)
+                ->with('error', $this->formatBreachMessage($e));
         }
 
         return redirect()->route('game.squad.reserve', $gameId)
             ->with('success', __('messages.reserve_player_called_up', ['player' => $playerName]));
+    }
+
+    private function formatBreachMessage(ReserveSquadMinimumException $e): string
+    {
+        if ($e->type() === 'too_small') {
+            return __('messages.promote_squad_too_small', ['min' => $e->min()]);
+        }
+
+        return __('messages.promote_position_minimum', [
+            'group' => __('squad.' . strtolower($e->group()) . 's'),
+            'min'   => $e->min(),
+        ]);
     }
 }

--- a/app/Http/Actions/ListPlayerForTransfer.php
+++ b/app/Http/Actions/ListPlayerForTransfer.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Actions;
 
+use App\Modules\Transfer\Exceptions\SquadMinimumException;
 use App\Modules\Transfer\Services\TransferService;
 use App\Models\Game;
 use App\Models\GamePlayer;
@@ -32,11 +33,26 @@ class ListPlayerForTransfer
             ]));
         }
 
-        // List the player
-        $this->transferService->listPlayer($player);
+        try {
+            $this->transferService->listPlayer($player);
+        } catch (SquadMinimumException $e) {
+            return redirect()->back()->with('error', $this->formatBreachMessage($e));
+        }
 
         return redirect()
             ->back()
             ->with('success', __('messages.player_listed', ['player' => $player->player->name]));
+    }
+
+    private function formatBreachMessage(SquadMinimumException $e): string
+    {
+        if ($e->type() === 'too_small') {
+            return __('messages.list_for_sale_squad_too_small', ['min' => $e->min()]);
+        }
+
+        return __('messages.list_for_sale_position_minimum', [
+            'group' => __('squad.' . strtolower($e->group()) . 's'),
+            'min'   => $e->min(),
+        ]);
     }
 }

--- a/app/Http/Actions/NegotiateCounterOffer.php
+++ b/app/Http/Actions/NegotiateCounterOffer.php
@@ -5,6 +5,7 @@ namespace App\Http\Actions;
 use App\Models\Game;
 use App\Models\TransferOffer;
 use App\Modules\Notification\Services\NotificationService;
+use App\Modules\Transfer\Exceptions\SquadMinimumException;
 use App\Modules\Transfer\Services\ContractService;
 use App\Modules\Transfer\Services\ScoutingService;
 use App\Modules\Transfer\Services\TransferService;
@@ -202,7 +203,14 @@ class NegotiateCounterOffer
 
     private function completeSale(TransferOffer $offer, Game $game, $player, string $buyerName): JsonResponse
     {
-        $completedImmediately = $this->transferService->acceptOffer($offer);
+        try {
+            $completedImmediately = $this->transferService->acceptOffer($offer);
+        } catch (SquadMinimumException $e) {
+            return response()->json([
+                'status' => 'error',
+                'message' => $this->formatBreachMessage($e),
+            ], 422);
+        }
 
         if ($completedImmediately) {
             $this->notificationService->notifyTransferComplete($game, $offer->refresh());
@@ -256,5 +264,17 @@ class NegotiateCounterOffer
     private function calculateMidpointInEuros(int $centsA, int $centsB): int
     {
         return (int) (ceil(($centsA + $centsB) / 2 / 100 / 10000) * 10000);
+    }
+
+    private function formatBreachMessage(SquadMinimumException $e): string
+    {
+        if ($e->type() === 'too_small') {
+            return __('messages.accept_offer_squad_too_small', ['min' => $e->min()]);
+        }
+
+        return __('messages.accept_offer_position_minimum', [
+            'group' => __('squad.' . strtolower($e->group()) . 's'),
+            'min'   => $e->min(),
+        ]);
     }
 }

--- a/app/Http/Actions/NegotiateRenewal.php
+++ b/app/Http/Actions/NegotiateRenewal.php
@@ -37,7 +37,12 @@ class NegotiateRenewal
 
         $player = GamePlayer::with($eagerLoads)
             ->where('game_id', $gameId)
-            ->ownedByTeam($game->team_id)
+            ->where(function ($q) use ($game) {
+                $q->ownedByTeam($game->team_id);
+                if ($game->reserve_team_id) {
+                    $q->orWhere(fn ($sub) => $sub->ownedByTeam($game->reserve_team_id));
+                }
+            })
             ->findOrFail($playerId);
 
         return match ($action) {

--- a/app/Http/Actions/NegotiateRenewal.php
+++ b/app/Http/Actions/NegotiateRenewal.php
@@ -37,12 +37,7 @@ class NegotiateRenewal
 
         $player = GamePlayer::with($eagerLoads)
             ->where('game_id', $gameId)
-            ->where(function ($q) use ($game) {
-                $q->ownedByTeam($game->team_id);
-                if ($game->reserve_team_id) {
-                    $q->orWhere(fn ($sub) => $sub->ownedByTeam($game->reserve_team_id));
-                }
-            })
+            ->userOwned($game)
             ->findOrFail($playerId);
 
         return match ($action) {

--- a/app/Http/Actions/ReleasePlayer.php
+++ b/app/Http/Actions/ReleasePlayer.php
@@ -17,21 +17,25 @@ class ReleasePlayer
     public function __invoke(Request $request, string $gameId, string $playerId): RedirectResponse
     {
         $game = Game::findOrFail($gameId);
+        $allowedTeamIds = array_filter([$game->team_id, $game->reserve_team_id]);
         $player = GamePlayer::where('id', $playerId)
             ->where('game_id', $gameId)
-            ->where('team_id', $game->team_id)
+            ->whereIn('team_id', $allowedTeamIds)
             ->firstOrFail();
+
+        $wasOnReserve = $game->reserve_team_id !== null && $player->team_id === $game->reserve_team_id;
+        $redirectRoute = $wasOnReserve ? 'game.squad.reserve' : 'game.squad';
 
         $result = $this->contractService->releasePlayer($game, $player);
 
         if ($result['error'] ?? false) {
             return redirect()
-                ->route('game.squad', $gameId)
+                ->route($redirectRoute, $gameId)
                 ->with('error', $result['error']);
         }
 
         return redirect()
-            ->route('game.squad', $gameId)
+            ->route($redirectRoute, $gameId)
             ->with('success', __('messages.player_released', [
                 'player' => $result['playerName'],
                 'severance' => $result['formattedSeverance'],

--- a/app/Http/Actions/ReleasePlayer.php
+++ b/app/Http/Actions/ReleasePlayer.php
@@ -17,10 +17,9 @@ class ReleasePlayer
     public function __invoke(Request $request, string $gameId, string $playerId): RedirectResponse
     {
         $game = Game::findOrFail($gameId);
-        $allowedTeamIds = array_filter([$game->team_id, $game->reserve_team_id]);
         $player = GamePlayer::where('id', $playerId)
             ->where('game_id', $gameId)
-            ->whereIn('team_id', $allowedTeamIds)
+            ->whereIn('team_id', $game->userTeamIds())
             ->firstOrFail();
 
         $wasOnReserve = $game->reserve_team_id !== null && $player->team_id === $game->reserve_team_id;

--- a/app/Http/Actions/RequestLoan.php
+++ b/app/Http/Actions/RequestLoan.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Actions;
 
+use App\Modules\Transfer\Exceptions\SquadMinimumException;
 use App\Modules\Transfer\Services\LoanService;
 use App\Models\Game;
 use App\Models\GamePlayer;
@@ -64,9 +65,25 @@ class RequestLoan
                 ->with('error', __('messages.already_on_loan', ['player' => $player->name]));
         }
 
-        $this->loanService->startLoanSearch($game, $player);
+        try {
+            $this->loanService->startLoanSearch($game, $player);
+        } catch (SquadMinimumException $e) {
+            return redirect()->back()->with('error', $this->formatBreachMessage($e));
+        }
 
         return redirect()->back()
             ->with('success', __('messages.loan_search_started', ['player' => $player->name]));
+    }
+
+    private function formatBreachMessage(SquadMinimumException $e): string
+    {
+        if ($e->type() === 'too_small') {
+            return __('messages.list_for_loan_squad_too_small', ['min' => $e->min()]);
+        }
+
+        return __('messages.list_for_loan_position_minimum', [
+            'group' => __('squad.' . strtolower($e->group()) . 's'),
+            'min'   => $e->min(),
+        ]);
     }
 }

--- a/app/Http/Actions/RequestLoan.php
+++ b/app/Http/Actions/RequestLoan.php
@@ -18,8 +18,10 @@ class RequestLoan
         $game = Game::with(['team', 'finances'])->findOrFail($gameId);
         $player = GamePlayer::where('game_id', $gameId)->with(['player', 'team'])->findOrFail($playerId);
 
-        // Determine if this is loan-in (from scouting) or loan-out (from squad)
-        $isLoanOut = $player->team_id === $game->team_id;
+        // Determine if this is loan-in (from scouting) or loan-out (from squad).
+        // Reserve-team players also belong to the user's club, so loan-out applies.
+        $isLoanOut = $player->team_id === $game->team_id
+            || ($game->reserve_team_id !== null && $player->team_id === $game->reserve_team_id);
 
         if ($isLoanOut) {
             return $this->handleLoanOut($game, $player);

--- a/app/Http/Actions/SendBackReservePlayer.php
+++ b/app/Http/Actions/SendBackReservePlayer.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Actions;
+
+use App\Models\Game;
+use App\Models\GamePlayer;
+use App\Modules\ReserveTeam\Services\ReserveTeamService;
+
+class SendBackReservePlayer
+{
+    public function __construct(
+        private readonly ReserveTeamService $reserveTeamService,
+    ) {}
+
+    public function __invoke(string $gameId, string $playerId)
+    {
+        $game = Game::findOrFail($gameId);
+        abort_if($game->reserve_team_id === null, 404);
+
+        $player = GamePlayer::where('id', $playerId)
+            ->where('game_id', $gameId)
+            ->where('team_id', $game->team_id)
+            ->whereHas('activeLoan', fn ($q) => $q->where('parent_team_id', $game->reserve_team_id))
+            ->with('player')
+            ->firstOrFail();
+
+        $playerName = $player->player->name ?? '';
+
+        $this->reserveTeamService->sendBackToReserve($player, $game);
+
+        return redirect()->route('game.squad.reserve', $gameId)
+            ->with('success', __('messages.reserve_player_sent_back', ['player' => $playerName]));
+    }
+}

--- a/app/Http/Actions/SendBackReservePlayer.php
+++ b/app/Http/Actions/SendBackReservePlayer.php
@@ -4,6 +4,7 @@ namespace App\Http\Actions;
 
 use App\Models\Game;
 use App\Models\GamePlayer;
+use App\Modules\ReserveTeam\Exceptions\FirstTeamSquadMinimumException;
 use App\Modules\ReserveTeam\Services\ReserveTeamService;
 
 class SendBackReservePlayer
@@ -26,9 +27,26 @@ class SendBackReservePlayer
 
         $playerName = $player->player->name ?? '';
 
-        $this->reserveTeamService->sendBackToReserve($player, $game);
+        try {
+            $this->reserveTeamService->sendBackToReserve($player, $game);
+        } catch (FirstTeamSquadMinimumException $e) {
+            return redirect()->route('game.squad.reserve', $gameId)
+                ->with('error', $this->formatBreachMessage($e));
+        }
 
         return redirect()->route('game.squad.reserve', $gameId)
             ->with('success', __('messages.reserve_player_sent_back', ['player' => $playerName]));
+    }
+
+    private function formatBreachMessage(FirstTeamSquadMinimumException $e): string
+    {
+        if ($e->type() === 'too_small') {
+            return __('messages.demote_squad_too_small', ['min' => $e->min()]);
+        }
+
+        return __('messages.demote_position_minimum', [
+            'group' => __('squad.' . strtolower($e->group()) . 's'),
+            'min'   => $e->min(),
+        ]);
     }
 }

--- a/app/Http/Actions/ToggleShortlist.php
+++ b/app/Http/Actions/ToggleShortlist.php
@@ -19,7 +19,21 @@ class ToggleShortlist
     public function __invoke(Request $request, string $gameId, string $playerId)
     {
         $game = Game::findOrFail($gameId);
-        $gamePlayer = GamePlayer::where('game_id', $gameId)->findOrFail($playerId);
+        $gamePlayer = GamePlayer::where('game_id', $gameId)->with('team')->findOrFail($playerId);
+
+        // Reserve-team (filial) players are not transferable through normal
+        // channels — they belong to the parent club and move only via
+        // call-up / promotion. Block adding them to the shortlist regardless
+        // of which game the user is in.
+        if ($gamePlayer->team && $gamePlayer->team->parent_team_id !== null) {
+            $message = __('messages.shortlist_reserve_blocked');
+
+            if ($request->ajax()) {
+                return response()->json(['success' => false, 'message' => $message], 422);
+            }
+
+            return redirect()->back()->with('error', $message);
+        }
 
         $existing = ShortlistedPlayer::where('game_id', $gameId)
             ->where('game_player_id', $playerId)

--- a/app/Http/Views/ShowPlayerDetail.php
+++ b/app/Http/Views/ShowPlayerDetail.php
@@ -19,10 +19,20 @@ class ShowPlayerDetail
 
         $allowedTeamIds = array_filter([$game->team_id, $game->reserve_team_id]);
 
-        $gamePlayer = GamePlayer::with(['player', 'careerRecord'])
+        $gamePlayer = GamePlayer::with(['player', 'careerRecord', 'activeLoan'])
             ->where('game_id', $gameId)
             ->whereIn('team_id', $allowedTeamIds)
             ->findOrFail($playerId);
+
+        // Player is "called up" from the filial: currently registered to the
+        // first team via a Loan whose parent is the reserve team. For action
+        // purposes we treat them like a normal first-team player and offer
+        // an additional "send back to filial" button.
+        $isCalledUpFromReserve = $game->reserve_team_id !== null
+            && $gamePlayer->team_id === $game->team_id
+            && $gamePlayer->activeLoan
+            && $gamePlayer->activeLoan->parent_team_id === $game->reserve_team_id
+            && $gamePlayer->activeLoan->loan_team_id === $game->team_id;
 
         $canRenew = $gamePlayer->canBeOfferedRenewal(currentDate: $game->current_date);
         $renewalNegotiation = null;
@@ -38,11 +48,17 @@ class ShowPlayerDetail
             }
         }
 
-        // Release data
+        $isOnReserve = $game->reserve_team_id !== null
+            && $gamePlayer->team_id === $game->reserve_team_id;
+
+        // Release data — allowed for first-team and reserve-team players,
+        // including filial players currently called up via internal loan
+        // (which technically appears as "loaned in" but is treated as
+        // user-owned for management purposes).
         $canRelease = $game->isCareerMode()
-            && $gamePlayer->team_id === $game->team_id
+            && in_array($gamePlayer->team_id, [$game->team_id, $game->reserve_team_id], true)
             && !$gamePlayer->isRetiring()
-            && !$gamePlayer->isLoanedIn($game->team_id)
+            && ($isCalledUpFromReserve || !$gamePlayer->isLoanedIn($game->team_id))
             && !$gamePlayer->isLoanedOut($game->team_id)
             && !$gamePlayer->hasPreContractAgreement()
             && !$gamePlayer->hasRenewalAgreed()
@@ -59,6 +75,8 @@ class ShowPlayerDetail
             'renewalCooldown' => $renewalCooldown,
             'canRelease' => $canRelease,
             'severance' => $severance,
+            'isOnReserve' => $isOnReserve,
+            'isCalledUpFromReserve' => $isCalledUpFromReserve,
         ]);
     }
 }

--- a/app/Http/Views/ShowPlayerDetail.php
+++ b/app/Http/Views/ShowPlayerDetail.php
@@ -17,22 +17,12 @@ class ShowPlayerDetail
     {
         $game = Game::findOrFail($gameId);
 
-        $allowedTeamIds = array_filter([$game->team_id, $game->reserve_team_id]);
-
         $gamePlayer = GamePlayer::with(['player', 'careerRecord', 'activeLoan'])
             ->where('game_id', $gameId)
-            ->whereIn('team_id', $allowedTeamIds)
+            ->userOwned($game)
             ->findOrFail($playerId);
 
-        // Player is "called up" from the filial: currently registered to the
-        // first team via a Loan whose parent is the reserve team. For action
-        // purposes we treat them like a normal first-team player and offer
-        // an additional "send back to filial" button.
-        $isCalledUpFromReserve = $game->reserve_team_id !== null
-            && $gamePlayer->team_id === $game->team_id
-            && $gamePlayer->activeLoan
-            && $gamePlayer->activeLoan->parent_team_id === $game->reserve_team_id
-            && $gamePlayer->activeLoan->loan_team_id === $game->team_id;
+        $isCalledUpFromReserve = $gamePlayer->isCalledUpFromReserve($game);
 
         $canRenew = $gamePlayer->canBeOfferedRenewal(currentDate: $game->current_date);
         $renewalNegotiation = null;
@@ -51,15 +41,15 @@ class ShowPlayerDetail
         $isOnReserve = $game->reserve_team_id !== null
             && $gamePlayer->team_id === $game->reserve_team_id;
 
-        // Release data — allowed for first-team and reserve-team players,
-        // including filial players currently called up via internal loan
-        // (which technically appears as "loaned in" but is treated as
-        // user-owned for management purposes).
+        // Release is permitted for any user-owned player physically present
+        // on a user roster (first team or reserve, including filial call-ups
+        // who sit on the first team via internal loan). The team_id check
+        // excludes players currently loaned out to a third-party club —
+        // those must wait for the loan to end before they can be released.
         $canRelease = $game->isCareerMode()
-            && in_array($gamePlayer->team_id, [$game->team_id, $game->reserve_team_id], true)
+            && $gamePlayer->isUserOwned($game)
+            && in_array($gamePlayer->team_id, $game->userTeamIds(), true)
             && !$gamePlayer->isRetiring()
-            && ($isCalledUpFromReserve || !$gamePlayer->isLoanedIn($game->team_id))
-            && !$gamePlayer->isLoanedOut($game->team_id)
             && !$gamePlayer->hasPreContractAgreement()
             && !$gamePlayer->hasRenewalAgreed()
             && !$gamePlayer->hasAgreedTransfer()

--- a/app/Http/Views/ShowPlayerDetail.php
+++ b/app/Http/Views/ShowPlayerDetail.php
@@ -17,9 +17,11 @@ class ShowPlayerDetail
     {
         $game = Game::findOrFail($gameId);
 
+        $allowedTeamIds = array_filter([$game->team_id, $game->reserve_team_id]);
+
         $gamePlayer = GamePlayer::with('player')
             ->where('game_id', $gameId)
-            ->where('team_id', $game->team_id)
+            ->whereIn('team_id', $allowedTeamIds)
             ->findOrFail($playerId);
 
         $canRenew = $gamePlayer->canBeOfferedRenewal(currentDate: $game->current_date);

--- a/app/Http/Views/ShowPlayerDetail.php
+++ b/app/Http/Views/ShowPlayerDetail.php
@@ -19,7 +19,7 @@ class ShowPlayerDetail
 
         $allowedTeamIds = array_filter([$game->team_id, $game->reserve_team_id]);
 
-        $gamePlayer = GamePlayer::with('player')
+        $gamePlayer = GamePlayer::with(['player', 'careerRecord'])
             ->where('game_id', $gameId)
             ->whereIn('team_id', $allowedTeamIds)
             ->findOrFail($playerId);

--- a/app/Http/Views/ShowReserveTeam.php
+++ b/app/Http/Views/ShowReserveTeam.php
@@ -26,8 +26,6 @@ class ShowReserveTeam
 
         $count = $squad->count();
         $avgAge = $count > 0 ? round($squad->avg(fn ($p) => $p->age($game->current_date)), 1) : 0;
-        $avgFitness = $count > 0 ? (int) round($squad->avg('fitness')) : 0;
-        $avgMorale = $count > 0 ? (int) round($squad->avg('morale')) : 0;
         $avgOverall = $count > 0 ? (int) round($squad->avg('overall_score')) : 0;
 
         return view('squad-reserve', [
@@ -39,8 +37,6 @@ class ShowReserveTeam
             'forwards' => $grouped->get('Forward', collect()),
             'reserveCount' => $count,
             'avgAge' => $avgAge,
-            'avgFitness' => $avgFitness,
-            'avgMorale' => $avgMorale,
             'avgOverall' => $avgOverall,
         ]);
     }

--- a/app/Http/Views/ShowReserveTeam.php
+++ b/app/Http/Views/ShowReserveTeam.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Http\Views;
+
+use App\Models\Game;
+use App\Modules\ReserveTeam\Services\ReserveTeamService;
+use App\Support\PositionMapper;
+
+class ShowReserveTeam
+{
+    public function __construct(
+        private readonly ReserveTeamService $reserveTeamService,
+    ) {}
+
+    public function __invoke(string $gameId)
+    {
+        $game = Game::with(['team', 'reserveTeam'])->findOrFail($gameId);
+        abort_if($game->isTournamentMode(), 404);
+        abort_if($game->reserve_team_id === null, 404);
+
+        $squad = $this->reserveTeamService->getReserveSquad($game);
+
+        $grouped = $squad
+            ->sortByDesc('overall_score')
+            ->groupBy(fn ($player) => PositionMapper::getPositionGroup($player->position));
+
+        $count = $squad->count();
+        $avgAge = $count > 0 ? round($squad->avg(fn ($p) => $p->age($game->current_date)), 1) : 0;
+        $avgFitness = $count > 0 ? (int) round($squad->avg('fitness')) : 0;
+        $avgMorale = $count > 0 ? (int) round($squad->avg('morale')) : 0;
+        $avgOverall = $count > 0 ? (int) round($squad->avg('overall_score')) : 0;
+
+        return view('squad-reserve', [
+            'game' => $game,
+            'reserveTeam' => $game->reserveTeam,
+            'goalkeepers' => $grouped->get('Goalkeeper', collect()),
+            'defenders' => $grouped->get('Defender', collect()),
+            'midfielders' => $grouped->get('Midfielder', collect()),
+            'forwards' => $grouped->get('Forward', collect()),
+            'reserveCount' => $count,
+            'avgAge' => $avgAge,
+            'avgFitness' => $avgFitness,
+            'avgMorale' => $avgMorale,
+            'avgOverall' => $avgOverall,
+        ]);
+    }
+}

--- a/app/Models/Game.php
+++ b/app/Models/Game.php
@@ -113,6 +113,7 @@ class Game extends Model
         'country',
         'player_name',
         'team_id',
+        'reserve_team_id',
         'competition_id',
         'season',
         'current_date',
@@ -331,6 +332,16 @@ class Game extends Model
     public function team(): BelongsTo
     {
         return $this->belongsTo(Team::class);
+    }
+
+    public function reserveTeam(): BelongsTo
+    {
+        return $this->belongsTo(Team::class, 'reserve_team_id');
+    }
+
+    public function isFilial(): bool
+    {
+        return $this->reserve_team_id !== null;
     }
 
     public function tactics(): HasOne

--- a/app/Models/Game.php
+++ b/app/Models/Game.php
@@ -339,6 +339,19 @@ class Game extends Model
         return $this->belongsTo(Team::class, 'reserve_team_id');
     }
 
+    /**
+     * Whether the given team is owned by the user in this game (first team
+     * or, for parent clubs, the filial reserve team).
+     */
+    public function ownsTeam(?string $teamId): bool
+    {
+        if ($teamId === null) {
+            return false;
+        }
+
+        return $teamId === $this->team_id || $teamId === $this->reserve_team_id;
+    }
+
     public function isFilial(): bool
     {
         return $this->reserve_team_id !== null;

--- a/app/Models/Game.php
+++ b/app/Models/Game.php
@@ -352,6 +352,17 @@ class Game extends Model
         return $teamId === $this->team_id || $teamId === $this->reserve_team_id;
     }
 
+    /**
+     * IDs of all teams the user manages in this game (first team, plus the
+     * reserve team for parent clubs). Null entries are filtered out.
+     *
+     * @return array<int, string>
+     */
+    public function userTeamIds(): array
+    {
+        return array_values(array_filter([$this->team_id, $this->reserve_team_id]));
+    }
+
     public function isFilial(): bool
     {
         return $this->reserve_team_id !== null;

--- a/app/Models/GamePlayer.php
+++ b/app/Models/GamePlayer.php
@@ -238,6 +238,11 @@ class GamePlayer extends Model
         return $this->hasOne(TransferListing::class);
     }
 
+    public function careerRecord(): HasOne
+    {
+        return $this->hasOne(UserSquadCareerRecord::class);
+    }
+
     /**
      * Get the active loan for this player (if any).
      */

--- a/app/Models/GamePlayer.php
+++ b/app/Models/GamePlayer.php
@@ -539,9 +539,19 @@ class GamePlayer extends Model
         }
 
         // Loaned-in players belong to another club — we can't renew them.
+        // Exception: a player called up from the user's own reserve team
+        // appears as loaned-in to the first team but is still user-owned,
+        // so the user retains contract authority.
         // Loaned-out players (ours, playing elsewhere) can still be renewed.
         if ($this->isLoanedIn($this->game->team_id)) {
-            return false;
+            $reserveTeamId = $this->game->reserve_team_id;
+            $loanedFromOwnReserve = $reserveTeamId !== null
+                && $this->activeLoan
+                && $this->activeLoan->parent_team_id === $reserveTeamId;
+
+            if (!$loanedFromOwnReserve) {
+                return false;
+            }
         }
 
         // Retiring players won't renew

--- a/app/Models/GamePlayer.php
+++ b/app/Models/GamePlayer.php
@@ -388,6 +388,77 @@ class GamePlayer extends Model
     }
 
     /**
+     * Limit a query to players owned by the user in the given game — i.e.,
+     * by the first team or the reserve team. Generalizes scopeOwnedByTeam
+     * across the user's whole organization, including filial call-ups (which
+     * appear loaned-in to the first team but are still user-owned through
+     * the reserve as parent).
+     */
+    public function scopeUserOwned($query, Game $game)
+    {
+        $teamIds = $game->userTeamIds();
+
+        if (empty($teamIds)) {
+            return $query->whereRaw('1 = 0');
+        }
+
+        return $query->where(function ($q) use ($teamIds) {
+            $q->where(function ($present) use ($teamIds) {
+                $present->whereIn('team_id', $teamIds)
+                    ->whereDoesntHave('activeLoan');
+            })->orWhereHas('activeLoan', fn ($loanQuery) => $loanQuery->whereIn('parent_team_id', $teamIds));
+        });
+    }
+
+    /**
+     * Whether this player is part of the user's organization in the given
+     * game — owned by the first team or the reserve team, including filial
+     * call-ups loaned internally between them.
+     *
+     * Loaned-out players (gone elsewhere but parent-owned by the user) count.
+     * Loaned-in players from a third-party club do not.
+     */
+    public function isUserOwned(Game $game): bool
+    {
+        $teamIds = $game->userTeamIds();
+
+        if (empty($teamIds)) {
+            return false;
+        }
+
+        $loan = $this->relationLoaded('activeLoan')
+            ? $this->activeLoan
+            : $this->activeLoan()->first();
+
+        if ($loan) {
+            return in_array($loan->parent_team_id, $teamIds, true);
+        }
+
+        return in_array($this->team_id, $teamIds, true);
+    }
+
+    /**
+     * Whether this player is currently called up from the user's reserve team
+     * to the first team via internal loan. The player physically sits on the
+     * first-team roster but is owned by the reserve, so flows like contract
+     * renewal and release must treat them as user-owned.
+     */
+    public function isCalledUpFromReserve(Game $game): bool
+    {
+        if ($game->reserve_team_id === null) {
+            return false;
+        }
+
+        $loan = $this->relationLoaded('activeLoan')
+            ? $this->activeLoan
+            : $this->activeLoan()->first();
+
+        return $loan !== null
+            && $loan->parent_team_id === $game->reserve_team_id
+            && $loan->loan_team_id === $game->team_id;
+    }
+
+    /**
      * Check if player is transfer listed.
      */
     public function isTransferListed(): bool
@@ -538,20 +609,12 @@ class GamePlayer extends Model
             return false;
         }
 
-        // Loaned-in players belong to another club — we can't renew them.
-        // Exception: a player called up from the user's own reserve team
-        // appears as loaned-in to the first team but is still user-owned,
-        // so the user retains contract authority.
-        // Loaned-out players (ours, playing elsewhere) can still be renewed.
-        if ($this->isLoanedIn($this->game->team_id)) {
-            $reserveTeamId = $this->game->reserve_team_id;
-            $loanedFromOwnReserve = $reserveTeamId !== null
-                && $this->activeLoan
-                && $this->activeLoan->parent_team_id === $reserveTeamId;
-
-            if (!$loanedFromOwnReserve) {
-                return false;
-            }
+        // Renewal authority follows ownership: any user-owned player counts,
+        // including loaned-out players (parent club retains authority) and
+        // filial call-ups (owned via the reserve team). Players loaned in
+        // from a third-party club are not user-owned and cannot be renewed.
+        if (!$this->isUserOwned($this->game)) {
+            return false;
         }
 
         // Retiring players won't renew

--- a/app/Models/GameTransfer.php
+++ b/app/Models/GameTransfer.php
@@ -30,6 +30,7 @@ class GameTransfer extends Model
     public const TYPE_TRANSFER = 'transfer';
     public const TYPE_FREE_AGENT = 'free_agent';
     public const TYPE_LOAN = 'loan';
+    public const TYPE_INTERNAL_PROMOTION = 'internal_promotion';
 
     /**
      * Record a completed transfer in the ledger.

--- a/app/Models/UserSquadCareerRecord.php
+++ b/app/Models/UserSquadCareerRecord.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * Career history for a player currently owned by the user's club.
+ *
+ * Lifecycle:
+ *  - inserted when a GamePlayer becomes user-owned (academy/filial generation,
+ *    transfer in, internal promotion to/within the user's organisation),
+ *  - updated each season-close to append that season's stats to season_stats,
+ *  - deleted when the player ceases to be user-owned (sold, retired, etc.).
+ *
+ * One row per user-owned GamePlayer. AI-vs-AI players have no row.
+ *
+ * @property string $id
+ * @property string $game_player_id
+ * @property string $game_id
+ * @property string $team_id
+ * @property int $joined_season
+ * @property string|null $joined_from   'Academy' sentinel or previous team name snapshot
+ * @property array $season_stats        keyed by season number
+ */
+class UserSquadCareerRecord extends Model
+{
+    use HasFactory, HasUuids;
+
+    public const ORIGIN_ACADEMY = 'Academy';
+
+    public $timestamps = false;
+
+    protected $fillable = [
+        'game_player_id',
+        'game_id',
+        'team_id',
+        'joined_season',
+        'joined_from',
+        'season_stats',
+    ];
+
+    protected $casts = [
+        'joined_season' => 'integer',
+        'season_stats' => 'array',
+    ];
+
+    public function gamePlayer(): BelongsTo
+    {
+        return $this->belongsTo(GamePlayer::class);
+    }
+
+    public function team(): BelongsTo
+    {
+        return $this->belongsTo(Team::class);
+    }
+
+    public function game(): BelongsTo
+    {
+        return $this->belongsTo(Game::class);
+    }
+}

--- a/app/Modules/Academy/Services/YouthAcademyService.php
+++ b/app/Modules/Academy/Services/YouthAcademyService.php
@@ -113,7 +113,11 @@ class YouthAcademyService
     /**
      * Generate a batch of new academy prospects at season start.
      *
-     * @return Collection<int, AcademyPlayer>
+     * For filial games (clubs with a reserve team), prospects are created as
+     * full GamePlayers on the reserve squad — no AcademyPlayer rows. For
+     * non-filial games, prospects land in the AcademyPlayer pool as before.
+     *
+     * @return Collection<int, AcademyPlayer|GamePlayer>
      */
     public function generateSeasonBatch(Game $game): Collection
     {
@@ -127,10 +131,15 @@ class YouthAcademyService
         $excludedNames = $this->getExistingPlayerNames($game);
 
         $prospects = collect();
+        $isFilial = $game->reserve_team_id !== null;
 
         for ($i = 0; $i < $count; $i++) {
-            $prospect = $this->createAcademyProspect($game, $tier, $teamMedianTier, $excludedNames);
-            $excludedNames[] = $prospect->name;
+            $prospect = $isFilial
+                ? $this->createReserveProspect($game, $tier, $teamMedianTier, $excludedNames)
+                : $this->createAcademyProspect($game, $tier, $teamMedianTier, $excludedNames);
+
+            $name = $isFilial ? $prospect->player->name : $prospect->name;
+            $excludedNames[] = $name;
             $prospects->push($prospect);
         }
 
@@ -461,6 +470,71 @@ class YouthAcademyService
             'initial_technical' => $technical,
             'initial_physical' => $physical,
         ]);
+    }
+
+    /**
+     * Create a reserve-team prospect for filial games. Mirrors the academy
+     * prospect generation (same quality + potential distributions), but
+     * produces a full GamePlayer on the reserve squad instead of an
+     * AcademyPlayer pool entry.
+     */
+    private function createReserveProspect(
+        Game $game,
+        int $academyTier,
+        int $teamMedianTier,
+        array $excludedNames,
+    ): GamePlayer {
+        $position = $this->selectPosition();
+
+        $abilityMean = self::ACADEMY_BASE_QUALITY[$academyTier] + self::TEAM_CONTEXT_BONUS[$teamMedianTier];
+        $age = rand(17, 19);
+        $ageCap = match ($age) {
+            17 => 72,
+            18 => 74,
+            19 => 76,
+            default => 78,
+        };
+        $technical = $this->sampler->sampleAbility($abilityMean, self::ABILITY_STD_DEV, 50, $ageCap);
+        $physical = $this->sampler->sampleAbility($abilityMean, self::ABILITY_STD_DEV, 50, $ageCap);
+
+        $currentBest = max($technical, $physical);
+        $potentialData = $this->sampler->generatePotentialFromAbility(
+            $currentBest,
+            self::POTENTIAL_UPSIDE_MEAN[$academyTier],
+            self::POTENTIAL_UPSIDE_STD_DEV,
+            self::POTENTIAL_FLOOR[$academyTier],
+        );
+
+        $dateOfBirth = $game->current_date->copy()->subYears($age)->subDays(rand(0, 364));
+
+        $teamName = $game->team->name;
+        $nationalityFilter = self::CANTERA_TEAMS[$teamName] ?? null;
+        $teamCountry = $nationalityFilter ? null : $game->team->country;
+        $region = TeamRegionalOrigins::regionFor($teamName);
+        $identity = $this->playerGenerator->pickRandomIdentity(
+            $nationalityFilter,
+            $teamCountry,
+            $excludedNames,
+            $region,
+        );
+
+        return $this->playerGenerator->create($game, new GeneratedPlayerData(
+            teamId: $game->reserve_team_id,
+            position: $position,
+            technical: $technical,
+            physical: $physical,
+            dateOfBirth: $dateOfBirth,
+            contractYears: 2,
+            name: $identity['name'],
+            nationality: $identity['nationality'],
+            potential: $potentialData['potential'],
+            potentialLow: $potentialData['potentialLow'],
+            potentialHigh: $potentialData['potentialHigh'],
+            fitnessMin: 85,
+            fitnessMax: 100,
+            moraleMin: 70,
+            moraleMax: 90,
+        ));
     }
 
     /**

--- a/app/Modules/Academy/Services/YouthAcademyService.php
+++ b/app/Modules/Academy/Services/YouthAcademyService.php
@@ -306,6 +306,7 @@ class YouthAcademyService
             fitnessMax: 100,
             moraleMin: 70,
             moraleMax: 90,
+            joinedFrom: \App\Models\UserSquadCareerRecord::ORIGIN_ACADEMY,
         ));
 
         $gamePlayer->update([
@@ -534,6 +535,7 @@ class YouthAcademyService
             fitnessMax: 100,
             moraleMin: 70,
             moraleMax: 90,
+            joinedFrom: \App\Models\UserSquadCareerRecord::ORIGIN_ACADEMY,
         ));
     }
 

--- a/app/Modules/ReserveTeam/Exceptions/FirstTeamSquadFullException.php
+++ b/app/Modules/ReserveTeam/Exceptions/FirstTeamSquadFullException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Modules\ReserveTeam\Exceptions;
+
+use RuntimeException;
+
+class FirstTeamSquadFullException extends RuntimeException
+{
+}

--- a/app/Modules/ReserveTeam/Exceptions/FirstTeamSquadMinimumException.php
+++ b/app/Modules/ReserveTeam/Exceptions/FirstTeamSquadMinimumException.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Modules\ReserveTeam\Exceptions;
+
+use App\Modules\Squad\Exceptions\SquadMinimumNotMetException;
+
+/**
+ * Sending a called-up player back to the reserve would drop the first
+ * team below its composition minimum. Thrown from
+ * ReserveTeamService::sendBackToReserve.
+ */
+class FirstTeamSquadMinimumException extends SquadMinimumNotMetException
+{
+}

--- a/app/Modules/ReserveTeam/Exceptions/ReserveSquadMinimumException.php
+++ b/app/Modules/ReserveTeam/Exceptions/ReserveSquadMinimumException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Modules\ReserveTeam\Exceptions;
+
+use App\Modules\Squad\Exceptions\SquadMinimumNotMetException;
+
+/**
+ * Calling up a reserve player would drop the reserve squad below its
+ * composition minimum. Thrown from ReserveTeamService::callUpToFirstTeam.
+ */
+class ReserveSquadMinimumException extends SquadMinimumNotMetException
+{
+}

--- a/app/Modules/ReserveTeam/Services/ReserveTeamService.php
+++ b/app/Modules/ReserveTeam/Services/ReserveTeamService.php
@@ -78,15 +78,17 @@ class ReserveTeamService
             'status' => Loan::STATUS_ACTIVE,
         ]);
 
-        // Move into first team first so SquadNumberService sees the player
-        // among the user's squad while picking a free number.
-        $player->update(['team_id' => $game->team_id]);
+        // Null the reserve number first so flipping team_id can't violate the
+        // (game_id, team_id, number) unique constraint when a first-team
+        // player already wears the same shirt.
+        $previousNumber = $player->number;
+        $player->update(['number' => null, 'team_id' => $game->team_id]);
 
-        $number = $this->squadNumberService->assignNumberForNewPlayer($game, $player);
+        $number = $this->squadNumberService->assignAcademyNumberForNewPlayer($game, $player);
 
         if ($number === null) {
-            // Roll back the move and the loan.
-            $player->update(['team_id' => $game->reserve_team_id]);
+            // Roll back the move, restore previous number, and drop the loan.
+            $player->update(['team_id' => $game->reserve_team_id, 'number' => $previousNumber]);
             Loan::where('game_player_id', $player->id)
                 ->where('status', Loan::STATUS_ACTIVE)
                 ->delete();
@@ -167,14 +169,86 @@ class ReserveTeamService
                 $player->activeLoan->update(['status' => Loan::STATUS_COMPLETED]);
             }
 
-            // Permanent move to first team.
+            // Permanent move to first team. Null the reserve number first so
+            // the (game_id, team_id, number) unique constraint can't fire on
+            // the team_id flip.
             $reserveTeamName = $game->reserveTeam?->name;
-            $player->update(['team_id' => $game->team_id]);
+            $player->update(['number' => null, 'team_id' => $game->team_id]);
             $number = $this->squadNumberService->assignNumberForNewPlayer($game, $player);
             if ($number !== null) {
                 $player->update(['number' => $number]);
             }
 
+            \App\Models\UserSquadCareerRecord::updateOrCreate(
+                ['game_player_id' => $player->id],
+                [
+                    'game_id' => $game->id,
+                    'team_id' => $game->team_id,
+                    'joined_season' => (int) $game->season,
+                    'joined_from' => $reserveTeamName ?? \App\Models\UserSquadCareerRecord::ORIGIN_ACADEMY,
+                ],
+            );
+
+            GameTransfer::record(
+                gameId: $game->id,
+                gamePlayerId: $player->id,
+                fromTeamId: $game->reserve_team_id,
+                toTeamId: $game->team_id,
+                transferFee: 0,
+                type: GameTransfer::TYPE_INTERNAL_PROMOTION,
+                season: $game->season,
+                window: TransferWindowType::currentValue($game->current_date),
+            );
+
+            $this->notificationService->create(
+                game: $game,
+                type: \App\Models\GameNotification::TYPE_ACADEMY_PROSPECT,
+                title: __('notifications.reserve_overage_promoted_title'),
+                message: __('notifications.reserve_overage_promoted_message', [
+                    'player' => $player->player->name ?? '',
+                ]),
+                priority: \App\Models\GameNotification::PRIORITY_INFO,
+            );
+
+            $promoted->push($player);
+        }
+
+        return $promoted;
+    }
+
+    /**
+     * At season close, permanently promote any reserve player still on a
+     * call-up loan to the first team. The active call-up loan is closed and
+     * the move is recorded as TYPE_INTERNAL_PROMOTION so the player no longer
+     * snaps back to the reserve team in subsequent seasons. The player keeps
+     * their existing first-team shirt number (assigned on call-up).
+     *
+     * @return Collection<int, GamePlayer>
+     */
+    public function permanentlyPromoteCalledUpPlayers(Game $game): Collection
+    {
+        if ($game->reserve_team_id === null) {
+            return collect();
+        }
+
+        $callUpLoans = Loan::with(['gamePlayer.player'])
+            ->where('game_id', $game->id)
+            ->where('status', Loan::STATUS_ACTIVE)
+            ->where('parent_team_id', $game->reserve_team_id)
+            ->where('loan_team_id', $game->team_id)
+            ->get();
+
+        $promoted = collect();
+
+        foreach ($callUpLoans as $loan) {
+            $player = $loan->gamePlayer;
+            if ($player === null) {
+                continue;
+            }
+
+            $loan->update(['status' => Loan::STATUS_COMPLETED]);
+
+            $reserveTeamName = $game->reserveTeam?->name;
             \App\Models\UserSquadCareerRecord::updateOrCreate(
                 ['game_player_id' => $player->id],
                 [

--- a/app/Modules/ReserveTeam/Services/ReserveTeamService.php
+++ b/app/Modules/ReserveTeam/Services/ReserveTeamService.php
@@ -47,7 +47,7 @@ class ReserveTeamService
 
         return GamePlayer::ownedByTeam($game->reserve_team_id)
             ->where('game_id', $game->id)
-            ->with(['player', 'activeLoan'])
+            ->with(['player', 'activeLoan', 'careerRecord'])
             ->get();
     }
 
@@ -168,11 +168,22 @@ class ReserveTeamService
             }
 
             // Permanent move to first team.
+            $reserveTeamName = $game->reserveTeam?->name;
             $player->update(['team_id' => $game->team_id]);
             $number = $this->squadNumberService->assignNumberForNewPlayer($game, $player);
             if ($number !== null) {
                 $player->update(['number' => $number]);
             }
+
+            \App\Models\UserSquadCareerRecord::updateOrCreate(
+                ['game_player_id' => $player->id],
+                [
+                    'game_id' => $game->id,
+                    'team_id' => $game->team_id,
+                    'joined_season' => (int) $game->season,
+                    'joined_from' => $reserveTeamName ?? \App\Models\UserSquadCareerRecord::ORIGIN_ACADEMY,
+                ],
+            );
 
             GameTransfer::record(
                 gameId: $game->id,

--- a/app/Modules/ReserveTeam/Services/ReserveTeamService.php
+++ b/app/Modules/ReserveTeam/Services/ReserveTeamService.php
@@ -1,0 +1,210 @@
+<?php
+
+namespace App\Modules\ReserveTeam\Services;
+
+use App\Models\Game;
+use App\Models\GamePlayer;
+use App\Models\GameTransfer;
+use App\Models\Loan;
+use App\Modules\Notification\Services\NotificationService;
+use App\Modules\Player\PlayerAge;
+use App\Modules\ReserveTeam\Exceptions\FirstTeamSquadFullException;
+use App\Modules\Squad\Services\SquadNumberService;
+use App\Modules\Transfer\Enums\TransferWindowType;
+use App\Modules\Transfer\Services\LoanService;
+use Illuminate\Support\Collection;
+
+/**
+ * Filial-aware reserve squad operations: list the reserve squad, call players
+ * up to the first team via Loan, send them back, and auto-promote those who
+ * age past the reserve cutoff at season close.
+ *
+ * Filial semantics: a reserve player belongs to the reserve team. The first
+ * team calls them up via a Loan (parent=reserve, loan=first); ending the loan
+ * sends them back. Age-23 promotion is the one permanent move (one-way
+ * transfer recorded via GameTransfer::TYPE_INTERNAL_PROMOTION).
+ */
+class ReserveTeamService
+{
+    public function __construct(
+        private readonly LoanService $loanService,
+        private readonly SquadNumberService $squadNumberService,
+        private readonly NotificationService $notificationService,
+    ) {}
+
+    /**
+     * Return all GamePlayers who belong to the reserve team — players currently
+     * registered there plus those temporarily called up (active loan with
+     * parent_team_id == reserve_team_id). Empty collection for non-filial games.
+     *
+     * @return Collection<int, GamePlayer>
+     */
+    public function getReserveSquad(Game $game): Collection
+    {
+        if ($game->reserve_team_id === null) {
+            return collect();
+        }
+
+        return GamePlayer::ownedByTeam($game->reserve_team_id)
+            ->where('game_id', $game->id)
+            ->with(['player', 'activeLoan'])
+            ->get();
+    }
+
+    /**
+     * Call a reserve player up to the first team. Creates a Loan
+     * (parent=reserve, loan=first), flips team_id, assigns squad number.
+     *
+     * @throws FirstTeamSquadFullException when no squad number is available
+     */
+    public function callUpToFirstTeam(GamePlayer $player, Game $game): void
+    {
+        $this->assertFilial($game);
+
+        if ($player->team_id !== $game->reserve_team_id) {
+            throw new \DomainException('Player is not currently registered to the reserve team.');
+        }
+
+        $effectiveStart = $game->getLoanEffectiveStartDate();
+        $returnDate = $game->getSeasonEndDateFor($effectiveStart);
+
+        Loan::create([
+            'game_id' => $game->id,
+            'game_player_id' => $player->id,
+            'parent_team_id' => $game->reserve_team_id,
+            'loan_team_id' => $game->team_id,
+            'started_at' => $effectiveStart,
+            'return_at' => $returnDate,
+            'status' => Loan::STATUS_ACTIVE,
+        ]);
+
+        // Move into first team first so SquadNumberService sees the player
+        // among the user's squad while picking a free number.
+        $player->update(['team_id' => $game->team_id]);
+
+        $number = $this->squadNumberService->assignNumberForNewPlayer($game, $player);
+
+        if ($number === null) {
+            // Roll back the move and the loan.
+            $player->update(['team_id' => $game->reserve_team_id]);
+            Loan::where('game_player_id', $player->id)
+                ->where('status', Loan::STATUS_ACTIVE)
+                ->delete();
+
+            throw new FirstTeamSquadFullException(
+                'First-team squad is full; release a player before calling up another.'
+            );
+        }
+
+        $player->update(['number' => $number]);
+
+        GameTransfer::record(
+            gameId: $game->id,
+            gamePlayerId: $player->id,
+            fromTeamId: $game->reserve_team_id,
+            toTeamId: $game->team_id,
+            transferFee: 0,
+            type: GameTransfer::TYPE_LOAN,
+            season: $game->season,
+            window: TransferWindowType::currentValue($game->current_date),
+        );
+    }
+
+    /**
+     * Send a called-up player back to the reserve team. Ends the active
+     * call-up loan, flips team_id back, nulls squad number.
+     */
+    public function sendBackToReserve(GamePlayer $player, Game $game): void
+    {
+        $this->assertFilial($game);
+
+        $loan = Loan::where('game_player_id', $player->id)
+            ->where('status', Loan::STATUS_ACTIVE)
+            ->where('parent_team_id', $game->reserve_team_id)
+            ->where('loan_team_id', $game->team_id)
+            ->first();
+
+        if ($loan === null) {
+            throw new \DomainException('Player is not currently called up from the reserve team.');
+        }
+
+        // returnLoan handles team_id flip and number reassignment. For loans
+        // returning to the reserve team (not the user's team), it sets number
+        // to null automatically.
+        $this->loanService->returnLoan($loan);
+    }
+
+    /**
+     * At season close, permanently promote any reserve player who has aged
+     * past the reserve cutoff (over 23) to the first team. One-way move,
+     * recorded as a GameTransfer of type INTERNAL_PROMOTION. Any active
+     * call-up loan for the player is closed first.
+     *
+     * Returns the list of promoted players for downstream processors.
+     *
+     * @return Collection<int, GamePlayer>
+     */
+    public function autoPromoteOverageReservePlayers(Game $game): Collection
+    {
+        if ($game->reserve_team_id === null) {
+            return collect();
+        }
+
+        $cutoff = PlayerAge::dateOfBirthCutoff(PlayerAge::YOUNG_END + 1, $game->current_date);
+
+        $candidates = GamePlayer::ownedByTeam($game->reserve_team_id)
+            ->where('game_id', $game->id)
+            ->whereHas('player', fn ($q) => $q->where('date_of_birth', '<=', $cutoff))
+            ->with(['player', 'activeLoan'])
+            ->get();
+
+        $promoted = collect();
+
+        foreach ($candidates as $player) {
+            // Close any active call-up loan first so returnLoan() doesn't
+            // later try to flip the player back to the reserve team.
+            if ($player->activeLoan && $player->activeLoan->parent_team_id === $game->reserve_team_id) {
+                $player->activeLoan->update(['status' => Loan::STATUS_COMPLETED]);
+            }
+
+            // Permanent move to first team.
+            $player->update(['team_id' => $game->team_id]);
+            $number = $this->squadNumberService->assignNumberForNewPlayer($game, $player);
+            if ($number !== null) {
+                $player->update(['number' => $number]);
+            }
+
+            GameTransfer::record(
+                gameId: $game->id,
+                gamePlayerId: $player->id,
+                fromTeamId: $game->reserve_team_id,
+                toTeamId: $game->team_id,
+                transferFee: 0,
+                type: GameTransfer::TYPE_INTERNAL_PROMOTION,
+                season: $game->season,
+                window: TransferWindowType::currentValue($game->current_date),
+            );
+
+            $this->notificationService->create(
+                game: $game,
+                type: \App\Models\GameNotification::TYPE_ACADEMY_PROSPECT,
+                title: __('notifications.reserve_overage_promoted_title'),
+                message: __('notifications.reserve_overage_promoted_message', [
+                    'player' => $player->player->name ?? '',
+                ]),
+                priority: \App\Models\GameNotification::PRIORITY_INFO,
+            );
+
+            $promoted->push($player);
+        }
+
+        return $promoted;
+    }
+
+    private function assertFilial(Game $game): void
+    {
+        if ($game->reserve_team_id === null) {
+            throw new \DomainException('Reserve team operations require a filial game.');
+        }
+    }
+}

--- a/app/Modules/ReserveTeam/Services/ReserveTeamService.php
+++ b/app/Modules/ReserveTeam/Services/ReserveTeamService.php
@@ -9,6 +9,9 @@ use App\Models\Loan;
 use App\Modules\Notification\Services\NotificationService;
 use App\Modules\Player\PlayerAge;
 use App\Modules\ReserveTeam\Exceptions\FirstTeamSquadFullException;
+use App\Modules\ReserveTeam\Exceptions\FirstTeamSquadMinimumException;
+use App\Modules\ReserveTeam\Exceptions\ReserveSquadMinimumException;
+use App\Modules\Squad\Services\SquadMinimumService;
 use App\Modules\Squad\Services\SquadNumberService;
 use App\Modules\Transfer\Enums\TransferWindowType;
 use App\Modules\Transfer\Services\LoanService;
@@ -30,6 +33,7 @@ class ReserveTeamService
         private readonly LoanService $loanService,
         private readonly SquadNumberService $squadNumberService,
         private readonly NotificationService $notificationService,
+        private readonly SquadMinimumService $squadMinimumService,
     ) {}
 
     /**
@@ -56,6 +60,8 @@ class ReserveTeamService
      * (parent=reserve, loan=first), flips team_id, assigns squad number.
      *
      * @throws FirstTeamSquadFullException when no squad number is available
+     * @throws ReserveSquadMinimumException when the reserve would fall below
+     *         its squad-composition minimum after the call-up
      */
     public function callUpToFirstTeam(GamePlayer $player, Game $game): void
     {
@@ -63,6 +69,12 @@ class ReserveTeamService
 
         if ($player->team_id !== $game->reserve_team_id) {
             throw new \DomainException('Player is not currently registered to the reserve team.');
+        }
+
+        // Reserve must keep enough players to field a squad after the call-up.
+        $breach = $this->squadMinimumService->validateRemoval($game, $player, $game->reserve_team_id);
+        if ($breach !== null) {
+            throw new ReserveSquadMinimumException($breach);
         }
 
         $effectiveStart = $game->getLoanEffectiveStartDate();
@@ -115,6 +127,9 @@ class ReserveTeamService
     /**
      * Send a called-up player back to the reserve team. Ends the active
      * call-up loan, flips team_id back, nulls squad number.
+     *
+     * @throws FirstTeamSquadMinimumException when the first team would fall
+     *         below its squad-composition minimum after the move
      */
     public function sendBackToReserve(GamePlayer $player, Game $game): void
     {
@@ -128,6 +143,12 @@ class ReserveTeamService
 
         if ($loan === null) {
             throw new \DomainException('Player is not currently called up from the reserve team.');
+        }
+
+        // First team must keep enough players to field a squad after send-back.
+        $breach = $this->squadMinimumService->validateRemoval($game, $player, $game->team_id);
+        if ($breach !== null) {
+            throw new FirstTeamSquadMinimumException($breach);
         }
 
         // returnLoan handles team_id flip and number reassignment. For loans

--- a/app/Modules/Season/Processors/LoanReturnProcessor.php
+++ b/app/Modules/Season/Processors/LoanReturnProcessor.php
@@ -2,6 +2,7 @@
 
 namespace App\Modules\Season\Processors;
 
+use App\Modules\ReserveTeam\Services\ReserveTeamService;
 use App\Modules\Season\Contracts\SeasonProcessor;
 use App\Modules\Season\DTOs\SeasonTransitionData;
 use App\Modules\Transfer\Services\LoanService;
@@ -17,6 +18,7 @@ class LoanReturnProcessor implements SeasonProcessor
     public function __construct(
         private readonly LoanService $loanService,
         private readonly NotificationService $notificationService,
+        private readonly ReserveTeamService $reserveTeamService,
     ) {}
 
     public function priority(): int
@@ -26,6 +28,15 @@ class LoanReturnProcessor implements SeasonProcessor
 
     public function process(Game $game, SeasonTransitionData $data): SeasonTransitionData
     {
+        // Reserve players still called up to the first team at season close
+        // are kept up permanently — closes their call-up loans before the
+        // generic return sweep runs, so they aren't sent back to the filial.
+        $promotedFromReserve = $this->reserveTeamService->permanentlyPromoteCalledUpPlayers($game);
+
+        if ($promotedFromReserve->isNotEmpty()) {
+            $data->setMetadata('reserve_called_up_promoted', $promotedFromReserve->count());
+        }
+
         $returnedLoans = $this->loanService->returnAllLoans($game);
 
         $loanReturns = $returnedLoans->map(fn ($loan) => [

--- a/app/Modules/Season/Processors/ReserveOveragePromotionProcessor.php
+++ b/app/Modules/Season/Processors/ReserveOveragePromotionProcessor.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Modules\Season\Processors;
+
+use App\Models\Game;
+use App\Modules\ReserveTeam\Services\ReserveTeamService;
+use App\Modules\Season\Contracts\SeasonProcessor;
+use App\Modules\Season\DTOs\SeasonTransitionData;
+
+/**
+ * For filial games, permanently promotes any reserve player who has aged
+ * past the reserve cutoff (over 23) to the first team.
+ *
+ * Runs before LoanReturnProcessor (priority 5) so age-23 players are settled
+ * permanently in the first team before remaining call-up loans snap back.
+ *
+ * No-op for non-filial games.
+ *
+ * Priority: 4
+ */
+class ReserveOveragePromotionProcessor implements SeasonProcessor
+{
+    public function __construct(
+        private readonly ReserveTeamService $reserveTeamService,
+    ) {}
+
+    public function priority(): int
+    {
+        return 4;
+    }
+
+    public function process(Game $game, SeasonTransitionData $data): SeasonTransitionData
+    {
+        if ($game->reserve_team_id === null) {
+            return $data;
+        }
+
+        $promoted = $this->reserveTeamService->autoPromoteOverageReservePlayers($game);
+
+        if ($promoted->isNotEmpty()) {
+            $data->setMetadata('reserve_overage_promoted', $promoted->count());
+        }
+
+        return $data;
+    }
+}

--- a/app/Modules/Season/Processors/UserSquadCareerSnapshotProcessor.php
+++ b/app/Modules/Season/Processors/UserSquadCareerSnapshotProcessor.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace App\Modules\Season\Processors;
+
+use App\Models\Game;
+use App\Models\UserSquadCareerRecord;
+use App\Modules\Season\Contracts\SeasonProcessor;
+use App\Modules\Season\DTOs\SeasonTransitionData;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Snapshots the just-finished season's match-state stats into each user-owned
+ * career record's season_stats JSON.
+ *
+ * Runs before StatsResetProcessor (priority 65) so the counters on
+ * GamePlayerMatchState are still populated when we read them.
+ */
+class UserSquadCareerSnapshotProcessor implements SeasonProcessor
+{
+    public function priority(): int
+    {
+        return 60;
+    }
+
+    public function process(Game $game, SeasonTransitionData $data): SeasonTransitionData
+    {
+        $seasonKey = (string) (int) $game->season;
+
+        $rows = DB::table('user_squad_career_records as r')
+            ->leftJoin('game_player_match_state as ms', 'ms.game_player_id', '=', 'r.game_player_id')
+            ->leftJoin('game_players as gp', 'gp.id', '=', 'r.game_player_id')
+            ->where('r.game_id', $game->id)
+            ->select([
+                'r.id',
+                'r.season_stats',
+                'gp.team_id',
+                'ms.appearances',
+                'ms.season_appearances',
+                'ms.goals',
+                'ms.own_goals',
+                'ms.assists',
+                'ms.yellow_cards',
+                'ms.red_cards',
+                'ms.goals_conceded',
+                'ms.clean_sheets',
+            ])
+            ->get();
+
+        foreach ($rows as $row) {
+            $stats = is_string($row->season_stats) ? json_decode($row->season_stats, true) : (array) $row->season_stats;
+            if (! is_array($stats)) {
+                $stats = [];
+            }
+
+            $stats[$seasonKey] = [
+                'appearances' => (int) ($row->appearances ?? 0),
+                'season_appearances' => (int) ($row->season_appearances ?? 0),
+                'goals' => (int) ($row->goals ?? 0),
+                'own_goals' => (int) ($row->own_goals ?? 0),
+                'assists' => (int) ($row->assists ?? 0),
+                'yellow_cards' => (int) ($row->yellow_cards ?? 0),
+                'red_cards' => (int) ($row->red_cards ?? 0),
+                'goals_conceded' => (int) ($row->goals_conceded ?? 0),
+                'clean_sheets' => (int) ($row->clean_sheets ?? 0),
+                'team_id' => $row->team_id,
+            ];
+
+            UserSquadCareerRecord::where('id', $row->id)->update([
+                'season_stats' => json_encode($stats),
+            ]);
+        }
+
+        return $data;
+    }
+}

--- a/app/Modules/Season/Processors/YouthAcademyClosingProcessor.php
+++ b/app/Modules/Season/Processors/YouthAcademyClosingProcessor.php
@@ -25,6 +25,12 @@ class YouthAcademyClosingProcessor implements SeasonProcessor
 
     public function process(Game $game, SeasonTransitionData $data): SeasonTransitionData
     {
+        // Filial games don't use the AcademyPlayer pool — reserve squads are
+        // GamePlayers handled elsewhere. Skip the academy lifecycle entirely.
+        if ($game->reserve_team_id !== null) {
+            return $data;
+        }
+
         // 1. Develop loaned players at higher rate before returning
         $this->youthAcademyService->developLoanedPlayers($game);
 

--- a/app/Modules/Season/Processors/YouthAcademyPromotionProcessor.php
+++ b/app/Modules/Season/Processors/YouthAcademyPromotionProcessor.php
@@ -7,7 +7,7 @@ use App\Modules\Season\DTOs\SeasonTransitionData;
 use App\Modules\Academy\Services\YouthAcademyService;
 use App\Modules\Notification\Services\NotificationService;
 use App\Modules\Squad\Services\PlayerGeneratorService;
-use App\Modules\Transfer\Services\ContractService;
+use App\Modules\Squad\Services\SquadMinimumService;
 use App\Models\Game;
 use App\Models\GameNotification;
 use App\Models\GamePlayer;
@@ -37,6 +37,7 @@ class YouthAcademyPromotionProcessor implements SeasonProcessor
         private readonly YouthAcademyService $youthAcademyService,
         private readonly NotificationService $notificationService,
         private readonly PlayerGeneratorService $playerGenerator,
+        private readonly SquadMinimumService $squadMinimumService,
     ) {}
 
     public function priority(): int
@@ -68,8 +69,8 @@ class YouthAcademyPromotionProcessor implements SeasonProcessor
         }
 
         // Phase 2: If squad is under minimum, promote best academy players to fill
-        $squadCount = ContractService::squadCount($game);
-        $deficit = ContractService::MIN_SQUAD_SIZE - $squadCount;
+        $squadCount = $this->squadMinimumService->squadCount($game, $game->team_id);
+        $deficit = SquadMinimumService::MIN_SQUAD_SIZE - $squadCount;
 
         $gapPromoted = $this->youthAcademyService->promoteBestPlayers($game, $deficit);
 
@@ -86,8 +87,8 @@ class YouthAcademyPromotionProcessor implements SeasonProcessor
         }
 
         // Phase 3: If still under minimum, generate synthetic players
-        $squadCount = ContractService::squadCount($game);
-        $remaining = ContractService::MIN_SQUAD_SIZE - $squadCount;
+        $squadCount = $this->squadMinimumService->squadCount($game, $game->team_id);
+        $remaining = SquadMinimumService::MIN_SQUAD_SIZE - $squadCount;
 
         if ($remaining > 0) {
             $this->generateSyntheticPlayers($game, $remaining, $data);

--- a/app/Modules/Season/Processors/YouthAcademyPromotionProcessor.php
+++ b/app/Modules/Season/Processors/YouthAcademyPromotionProcessor.php
@@ -46,6 +46,12 @@ class YouthAcademyPromotionProcessor implements SeasonProcessor
 
     public function process(Game $game, SeasonTransitionData $data): SeasonTransitionData
     {
+        // Filial games don't use the AcademyPlayer pool — reserve squad
+        // age-out is handled by ReserveOveragePromotionProcessor instead.
+        if ($game->reserve_team_id !== null) {
+            return $data;
+        }
+
         // Phase 1: Promote overage academy players (mandatory — they must leave)
         $overagePromoted = $this->youthAcademyService->promoteOveragePlayers($game);
 

--- a/app/Modules/Season/Services/GameCreationService.php
+++ b/app/Modules/Season/Services/GameCreationService.php
@@ -27,7 +27,7 @@ class GameCreationService
                 ->first()
             ?? CompetitionTeam::where('team_id', $teamId)->first();
 
-        $team = Team::find($teamId);
+        $team = Team::with('reserveTeam')->find($teamId);
 
         // Resolve competition ID: use competition_team lookup, fall back to
         // tier 1 of the team's country from config
@@ -38,6 +38,10 @@ class GameCreationService
         }
         $season = $competitionTeam->season ?? '2025';
 
+        // Resolve reserve team (filial) for managers of parent clubs.
+        // The user's club becomes filial if it has a reserve team and isn't itself one.
+        $reserveTeamId = $team->parent_team_id === null ? $team->reserveTeam?->id : null;
+
         // Create game record (setup not yet complete)
         // current_date and season_goal are set by processors during SetupNewGame
         $game = Game::create([
@@ -46,6 +50,7 @@ class GameCreationService
             'game_mode' => $gameMode,
             'country' => $team->country ?? 'ES',
             'team_id' => $teamId,
+            'reserve_team_id' => $reserveTeamId,
             'competition_id' => $competitionId,
             'season' => $season,
             'current_date' => null,

--- a/app/Modules/Season/Services/SeasonClosingPipeline.php
+++ b/app/Modules/Season/Services/SeasonClosingPipeline.php
@@ -23,6 +23,7 @@ use App\Modules\Season\Processors\SeasonSettlementProcessor;
 use App\Modules\Season\Processors\SeasonSimulationProcessor;
 use App\Modules\Season\Processors\SquadReplenishmentProcessor;
 use App\Modules\Season\Processors\StatsResetProcessor;
+use App\Modules\Season\Processors\UserSquadCareerSnapshotProcessor;
 use App\Modules\Season\Processors\SupercupQualificationProcessor;
 use App\Modules\Season\Processors\TransferMarketResetProcessor;
 use App\Modules\Season\Processors\UefaQualificationProcessor;
@@ -57,6 +58,7 @@ class SeasonClosingPipeline
         PlayerDevelopmentProcessor $playerDevelopment,
         SeasonSettlementProcessor $seasonSettlement,
         StatsResetProcessor $statsReset,
+        UserSquadCareerSnapshotProcessor $userSquadCareerSnapshot,
         TransferMarketResetProcessor $transferMarketReset,
         SeasonSimulationProcessor $seasonSimulation,
         SupercupQualificationProcessor $supercupQualification,
@@ -82,6 +84,7 @@ class SeasonClosingPipeline
             $aiFreeAgentSigning,
             $playerDevelopment,
             $seasonSettlement,
+            $userSquadCareerSnapshot,
             $statsReset,
             $transferMarketReset,
             $seasonSimulation,

--- a/app/Modules/Season/Services/SeasonClosingPipeline.php
+++ b/app/Modules/Season/Services/SeasonClosingPipeline.php
@@ -17,6 +17,7 @@ use App\Modules\Season\Processors\PlayerRetirementProcessor;
 use App\Modules\Season\Processors\PreContractTransferProcessor;
 use App\Modules\Season\Processors\PromotionRelegationProcessor;
 use App\Modules\Season\Processors\ReputationUpdateProcessor;
+use App\Modules\Season\Processors\ReserveOveragePromotionProcessor;
 use App\Modules\Season\Processors\SeasonArchiveProcessor;
 use App\Modules\Season\Processors\SeasonSettlementProcessor;
 use App\Modules\Season\Processors\SeasonSimulationProcessor;
@@ -41,6 +42,7 @@ class SeasonClosingPipeline
     private array $processors = [];
 
     public function __construct(
+        ReserveOveragePromotionProcessor $reserveOveragePromotion,
         LoanReturnProcessor $loanReturn,
         TrophyRecordingProcessor $trophyRecording,
         LeaderboardStatsProcessor $leaderboardStats,
@@ -66,6 +68,7 @@ class SeasonClosingPipeline
         UefaQualificationProcessor $uefaQualification,
     ) {
         $this->processors = [
+            $reserveOveragePromotion,
             $loanReturn,
             $trophyRecording,
             $leaderboardStats,

--- a/app/Modules/Squad/DTOs/GeneratedPlayerData.php
+++ b/app/Modules/Squad/DTOs/GeneratedPlayerData.php
@@ -30,5 +30,9 @@ final class GeneratedPlayerData
         public readonly int $fitnessMax = 95,
         public readonly int $moraleMin = 65,
         public readonly int $moraleMax = 80,
+        // Origin label persisted on the user-squad career record. Either the
+        // 'Academy' sentinel or the previous team's name. Null skips the record
+        // creation (legacy initial-squad seeding path).
+        public readonly ?string $joinedFrom = null,
     ) {}
 }

--- a/app/Modules/Squad/Exceptions/SquadMinimumNotMetException.php
+++ b/app/Modules/Squad/Exceptions/SquadMinimumNotMetException.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Modules\Squad\Exceptions;
+
+use RuntimeException;
+
+/**
+ * Base exception for squad-minimum guard failures. Carries the structured
+ * payload from SquadMinimumService::validateRemoval so the calling Action
+ * can format an action-specific user-facing message.
+ *
+ * Concrete subclasses (one per flow) let callers catch only the relevant
+ * one without false positives from unrelated guards.
+ */
+class SquadMinimumNotMetException extends RuntimeException
+{
+    /**
+     * @param array{type: string, min: int, group?: string} $payload
+     */
+    public function __construct(
+        public readonly array $payload,
+        string $message = 'Squad minimum not met.',
+    ) {
+        parent::__construct($message);
+    }
+
+    public function type(): string
+    {
+        return $this->payload['type'];
+    }
+
+    public function min(): int
+    {
+        return $this->payload['min'];
+    }
+
+    public function group(): ?string
+    {
+        return $this->payload['group'] ?? null;
+    }
+}

--- a/app/Modules/Squad/Services/PlayerGeneratorService.php
+++ b/app/Modules/Squad/Services/PlayerGeneratorService.php
@@ -9,6 +9,7 @@ use App\Models\GamePlayer;
 use App\Models\GamePlayerMatchState;
 use App\Models\Player;
 use App\Models\Team;
+use App\Models\UserSquadCareerRecord;
 use Carbon\Carbon;
 use Illuminate\Support\Str;
 use App\Models\ClubProfile;
@@ -153,6 +154,17 @@ class PlayerGeneratorService
         // attributes via the GamePlayer accessor delegates.
         $gamePlayer->setRelation('player', $player);
         $gamePlayer->setRelation('matchState', $matchState);
+
+        if ($data->joinedFrom !== null && $game->ownsTeam($data->teamId)) {
+            UserSquadCareerRecord::create([
+                'game_player_id' => $gamePlayer->id,
+                'game_id' => $game->id,
+                'team_id' => $data->teamId,
+                'joined_season' => (int) $game->season,
+                'joined_from' => $data->joinedFrom,
+                'season_stats' => [],
+            ]);
+        }
 
         // Update cache with the newly created player so subsequent generations in the
         // same request don't collide with it.

--- a/app/Modules/Squad/Services/SquadMinimumService.php
+++ b/app/Modules/Squad/Services/SquadMinimumService.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace App\Modules\Squad\Services;
+
+use App\Models\Game;
+use App\Models\GamePlayer;
+
+/**
+ * Single source of truth for squad-composition minimums (total squad size
+ * and per-position-group floors). Used by every flow that can cause a
+ * user-owned player to leave a roster — release, call-up, send-back,
+ * sale listing, loan-out listing, and offer acceptance — so the same
+ * rule is enforced everywhere.
+ *
+ * Counting is by physical presence (`team_id`) rather than ownership:
+ * the minimum protects the playable roster, so loaned-out players
+ * (still parent-owned but physically away) do not count toward the
+ * source team's minimum.
+ */
+final class SquadMinimumService
+{
+    /**
+     * Absolute minimum players in a squad — flows that would drop the
+     * roster below this are blocked.
+     */
+    public const MIN_SQUAD_SIZE = 20;
+
+    /**
+     * Minimum players per position group. Keys match
+     * GamePlayer::position_group values.
+     */
+    public const POSITION_GROUP_MINIMUMS = [
+        'Goalkeeper' => 3,
+        'Defender'   => 6,
+        'Midfielder' => 6,
+        'Forward'    => 4,
+    ];
+
+    /**
+     * Count physical players on the given team in the given game.
+     */
+    public function squadCount(Game $game, string $teamId): int
+    {
+        return GamePlayer::where('game_id', $game->id)
+            ->where('team_id', $teamId)
+            ->count();
+    }
+
+    /**
+     * Count physical players in a specific position group on the given team.
+     */
+    public function positionGroupCount(Game $game, string $teamId, string $positionGroup): int
+    {
+        return GamePlayer::where('game_id', $game->id)
+            ->where('team_id', $teamId)
+            ->get()
+            ->filter(fn (GamePlayer $p) => $p->position_group === $positionGroup)
+            ->count();
+    }
+
+    /**
+     * Test whether removing $player from $teamId would breach the squad
+     * minimum or position-group minimum on that team.
+     *
+     * Returns null when the removal is allowed, or a structured failure:
+     *   ['type' => 'too_small',         'min' => int]
+     *   ['type' => 'position_minimum',  'min' => int, 'group' => string]
+     *
+     * @return array{type: string, min: int, group?: string}|null
+     */
+    public function validateRemoval(Game $game, GamePlayer $player, string $teamId): ?array
+    {
+        if ($this->squadCount($game, $teamId) <= self::MIN_SQUAD_SIZE) {
+            return ['type' => 'too_small', 'min' => self::MIN_SQUAD_SIZE];
+        }
+
+        $positionGroup = $player->position_group;
+        $groupMinimum = self::POSITION_GROUP_MINIMUMS[$positionGroup] ?? 0;
+
+        if ($groupMinimum > 0
+            && $this->positionGroupCount($game, $teamId, $positionGroup) <= $groupMinimum) {
+            return [
+                'type'  => 'position_minimum',
+                'min'   => $groupMinimum,
+                'group' => $positionGroup,
+            ];
+        }
+
+        return null;
+    }
+}

--- a/app/Modules/Squad/Services/SquadNumberService.php
+++ b/app/Modules/Squad/Services/SquadNumberService.php
@@ -91,6 +91,23 @@ class SquadNumberService
     }
 
     /**
+     * Assign the first available academy slot (26-99) for a player joining
+     * the user's team. Used when promoting a reserve-team player up: they
+     * always get a 26+ shirt regardless of age, leaving 1-25 untouched.
+     */
+    public function assignAcademyNumberForNewPlayer(Game $game, GamePlayer $player): ?int
+    {
+        $takenNumbers = GamePlayer::where('game_id', $game->id)
+            ->where('team_id', $game->team_id)
+            ->where('id', '!=', $player->id)
+            ->whereNotNull('number')
+            ->pluck('number')
+            ->flip();
+
+        return $this->firstAvailable(self::FIRST_TEAM_MAX + 1, 99, $takenNumbers);
+    }
+
+    /**
      * Bulk reassign squad numbers for the user's team.
      *
      * Preserves existing numbers where valid. Only moves players when necessary:

--- a/app/Modules/Squad/Services/SquadService.php
+++ b/app/Modules/Squad/Services/SquadService.php
@@ -30,7 +30,7 @@ class SquadService
         $gameId = $game->id;
 
         // Get all players for user's team with relationships
-        $allPlayers = GamePlayer::with(['player', 'game', 'team', 'matchState', 'activeLoan', 'transferOffers', 'suspensions', 'activeRenewalNegotiation', 'latestRenewalNegotiation'])
+        $allPlayers = GamePlayer::with(['player', 'game', 'team', 'matchState', 'activeLoan', 'transferOffers', 'suspensions', 'activeRenewalNegotiation', 'latestRenewalNegotiation', 'careerRecord'])
             ->where('game_id', $gameId)
             ->where('team_id', $game->team_id)
             ->get();

--- a/app/Modules/Transfer/Exceptions/SquadMinimumException.php
+++ b/app/Modules/Transfer/Exceptions/SquadMinimumException.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Modules\Transfer\Exceptions;
+
+use App\Modules\Squad\Exceptions\SquadMinimumNotMetException;
+
+/**
+ * A transfer/loan flow (listing for sale, listing for loan-out, or
+ * accepting an incoming offer) would drop the player's current squad
+ * below its composition minimum.
+ */
+class SquadMinimumException extends SquadMinimumNotMetException
+{
+}

--- a/app/Modules/Transfer/Services/ContractService.php
+++ b/app/Modules/Transfer/Services/ContractService.php
@@ -15,6 +15,7 @@ use App\Models\Team;
 use App\Models\TransferListing;
 use App\Models\TransferOffer;
 use App\Modules\Notification\Services\NotificationService;
+use App\Modules\Squad\Services\SquadMinimumService;
 use App\Support\Money;
 use Carbon\Carbon;
 use Illuminate\Support\Collection;
@@ -57,6 +58,7 @@ class ContractService
     public function __construct(
         private readonly WageNegotiationEvaluator $wageNegotiationEvaluator,
         private readonly DispositionService $dispositionService,
+        private readonly SquadMinimumService $squadMinimumService,
     ) {}
 
     /**
@@ -689,31 +691,6 @@ class ContractService
     private const SEVERANCE_RATE = 0.50;
 
     /**
-     * Minimum squad size — cannot release if it would drop below this.
-     */
-    public const MIN_SQUAD_SIZE = 20;
-
-    /**
-     * Count first-team players in the user's squad.
-     */
-    public static function squadCount(Game $game): int
-    {
-        return GamePlayer::where('game_id', $game->id)
-            ->where('team_id', $game->team_id)
-            ->count();
-    }
-
-    /**
-     * Minimum players per position group — mirrors SquadReplenishmentProcessor.
-     */
-    private const POSITION_GROUP_MINIMUMS = [
-        'Goalkeeper' => 3,
-        'Defender' => 6,
-        'Midfielder' => 6,
-        'Forward' => 4,
-    ];
-
-    /**
      * Release a player from the user's squad (unilateral contract termination).
      *
      * The player becomes a free agent (team_id = null) and the club pays
@@ -808,32 +785,18 @@ class ContractService
             return __('messages.release_has_pre_contract');
         }
 
-        // Squad size check
-        $currentSquadSize = GamePlayer::where('game_id', $game->id)
-            ->where('team_id', $rosterTeamId)
-            ->count();
-
-        if ($currentSquadSize <= self::MIN_SQUAD_SIZE) {
-            return __('messages.release_squad_too_small', ['min' => self::MIN_SQUAD_SIZE]);
-        }
-
-        // Position group minimum check
-        $positionGroup = $player->position_group;
-        $groupMinimum = self::POSITION_GROUP_MINIMUMS[$positionGroup] ?? 0;
-
-        if ($groupMinimum > 0) {
-            $groupCount = GamePlayer::where('game_id', $game->id)
-                ->where('team_id', $rosterTeamId)
-                ->get()
-                ->filter(fn ($p) => $p->position_group === $positionGroup)
-                ->count();
-
-            if ($groupCount <= $groupMinimum) {
-                return __('messages.release_position_minimum', [
-                    'group' => __('squad.' . strtolower($positionGroup) . 's'),
-                    'min' => $groupMinimum,
-                ]);
+        // Squad-composition guard: total roster size and per-position-group
+        // minimums on the team that would lose the player.
+        $breach = $this->squadMinimumService->validateRemoval($game, $player, $rosterTeamId);
+        if ($breach !== null) {
+            if ($breach['type'] === 'too_small') {
+                return __('messages.release_squad_too_small', ['min' => $breach['min']]);
             }
+
+            return __('messages.release_position_minimum', [
+                'group' => __('squad.' . strtolower($breach['group']) . 's'),
+                'min'   => $breach['min'],
+            ]);
         }
 
         return null;

--- a/app/Modules/Transfer/Services/ContractService.php
+++ b/app/Modules/Transfer/Services/ContractService.php
@@ -779,15 +779,24 @@ class ContractService
      */
     private function validateRelease(Game $game, GamePlayer $player): ?string
     {
-        // Must belong to the user's team
-        if ($player->team_id !== $game->team_id) {
+        // Must be a user-owned player physically on a user roster. The roster
+        // check rejects players loaned out to a third-party club; the
+        // ownership check rejects players loaned in from a third-party club.
+        if (!in_array($player->team_id, $game->userTeamIds(), true)) {
             return __('messages.release_not_your_player');
         }
 
-        // Cannot release players on loan
-        if ($player->isLoanedOut($game->team_id) || $player->isLoanedIn($game->team_id)) {
+        if (!$player->isUserOwned($game)) {
             return __('messages.release_on_loan');
         }
+
+        // Squad-size and position-group minimums apply to the roster the
+        // player effectively occupies. Filial call-ups sit on the first team
+        // physically but their parent club (and the roster they belong to
+        // for these checks) is the reserve team.
+        $rosterTeamId = $player->isCalledUpFromReserve($game)
+            ? $game->reserve_team_id
+            : $player->team_id;
 
         // Cannot release players with agreed transfers
         if ($player->hasAgreedTransfer()) {
@@ -801,7 +810,7 @@ class ContractService
 
         // Squad size check
         $currentSquadSize = GamePlayer::where('game_id', $game->id)
-            ->where('team_id', $game->team_id)
+            ->where('team_id', $rosterTeamId)
             ->count();
 
         if ($currentSquadSize <= self::MIN_SQUAD_SIZE) {
@@ -814,7 +823,7 @@ class ContractService
 
         if ($groupMinimum > 0) {
             $groupCount = GamePlayer::where('game_id', $game->id)
-                ->where('team_id', $game->team_id)
+                ->where('team_id', $rosterTeamId)
                 ->get()
                 ->filter(fn ($p) => $p->position_group === $positionGroup)
                 ->count();

--- a/app/Modules/Transfer/Services/LoanService.php
+++ b/app/Modules/Transfer/Services/LoanService.php
@@ -394,7 +394,7 @@ class LoanService
     /**
      * Return a single loan - player goes back to parent team.
      */
-    private function returnLoan(Loan $loan): void
+    public function returnLoan(Loan $loan): void
     {
         $gamePlayer = $loan->gamePlayer;
         $isUserTeam = $loan->parent_team_id === $gamePlayer->game->team_id;

--- a/app/Modules/Transfer/Services/LoanService.php
+++ b/app/Modules/Transfer/Services/LoanService.php
@@ -14,8 +14,10 @@ use App\Models\Team;
 use App\Models\TeamReputation;
 use App\Models\TransferListing;
 use App\Models\TransferOffer;
+use App\Modules\Squad\Services\SquadMinimumService;
 use App\Modules\Squad\Services\SquadNumberService;
 use App\Modules\Transfer\Enums\TransferWindowType;
+use App\Modules\Transfer\Exceptions\SquadMinimumException;
 use Carbon\Carbon;
 use Illuminate\Support\Collection;
 
@@ -28,13 +30,23 @@ class LoanService
         private readonly DispositionService $dispositionService,
         private readonly SquadNumberService $squadNumberService,
         private readonly AIExclusionList $exclusionList,
+        private readonly SquadMinimumService $squadMinimumService,
     ) {}
 
     /**
      * Start a loan search for a player.
+     *
+     * @throws SquadMinimumException when listing this player would mean the
+     *         squad could fall below its composition minimum if the resulting
+     *         loan offer is accepted.
      */
     public function startLoanSearch(Game $game, GamePlayer $player): void
     {
+        $breach = $this->squadMinimumService->validateRemoval($game, $player, $player->team_id);
+        if ($breach !== null) {
+            throw new SquadMinimumException($breach);
+        }
+
         TransferListing::updateOrCreate(
             ['game_player_id' => $player->id],
             [
@@ -647,6 +659,18 @@ class LoanService
      */
     public function acceptLoanOffer(TransferOffer $offer, Game $game): void
     {
+        // Squad-composition guard: this is the binding moment — once accepted
+        // (or marked agreed), the player is committed to leaving on loan. Block
+        // here so the resulting move can't shrink the squad below minimums,
+        // even if the loan listing itself was OK at the time it was created.
+        $player = $offer->gamePlayer;
+        if ($player !== null) {
+            $breach = $this->squadMinimumService->validateRemoval($game, $player, $player->team_id);
+            if ($breach !== null) {
+                throw new SquadMinimumException($breach);
+            }
+        }
+
         // Reject sibling offers for the same player
         TransferOffer::where('game_id', $game->id)
             ->where('game_player_id', $offer->game_player_id)

--- a/app/Modules/Transfer/Services/ScoutSearchQueryBuilder.php
+++ b/app/Modules/Transfer/Services/ScoutSearchQueryBuilder.php
@@ -27,7 +27,8 @@ class ScoutSearchQueryBuilder
         $query = GamePlayer::with(['player', 'team'])
             ->where('game_id', $game->id)
             ->whereNotNull('team_id')
-            ->where('team_id', '!=', $game->team_id);
+            ->where('team_id', '!=', $game->team_id)
+            ->whereHas('team', fn ($q) => $q->whereNull('parent_team_id'));
 
         $this->applyPositionFilter($query, $positions);
 

--- a/app/Modules/Transfer/Services/TransferCompletionService.php
+++ b/app/Modules/Transfer/Services/TransferCompletionService.php
@@ -10,6 +10,7 @@ use App\Models\Loan;
 use App\Models\ShortlistedPlayer;
 use App\Models\TransferListing;
 use App\Models\TransferOffer;
+use App\Models\UserSquadCareerRecord;
 use App\Modules\Player\PlayerAge;
 use App\Modules\Squad\Services\SquadNumberService;
 use App\Modules\Transfer\Enums\TransferWindowType;
@@ -94,6 +95,11 @@ class TransferCompletionService
         // Remove from shortlist to free up scouting slot
         ShortlistedPlayer::removeForPlayer($game->id, $player->id);
 
+        // Player has left user's club permanently — drop career record.
+        // Loans preserve ownership so the record is left intact.
+        if (! $isLoan) {
+            UserSquadCareerRecord::where('game_player_id', $player->id)->delete();
+        }
     }
 
     /**
@@ -106,6 +112,7 @@ class TransferCompletionService
         $buyerName = $offer->offeringTeam->name;
         $game = $player->game;
         $fromTeamId = $player->team_id;
+        $fromTeamName = $player->team->name ?? null;
 
         // Transfer player to the buying team
         TransferListing::where('game_player_id', $player->id)->delete();
@@ -115,6 +122,13 @@ class TransferCompletionService
             // Extend their contract with the new team
             'contract_until' => Carbon::createFromDate((int) $game->season + rand(2, 4) + 1, 6, 30),
         ]);
+
+        $this->syncCareerRecordOnOwnershipChange(
+            game: $game,
+            player: $player,
+            previousTeamId: $fromTeamId,
+            previousTeamName: $fromTeamName,
+        );
 
         GameTransfer::record(
             gameId: $game->id,
@@ -166,12 +180,20 @@ class TransferCompletionService
         $newContractEnd = Carbon::createFromDate($seasonYear + $contractYears + 1, 6, 30);
 
         TransferListing::where('game_player_id', $player->id)->delete();
+        $previousTeamId = $player->team_id;
         $player->update([
             'team_id' => $game->team_id,
             'number' => $this->squadNumberService->assignNumberForNewPlayer($game, $player),
             'contract_until' => $newContractEnd,
             'annual_wage' => $offer->offered_wage ?? $player->annual_wage,
         ]);
+
+        $this->syncCareerRecordOnOwnershipChange(
+            game: $game,
+            player: $player,
+            previousTeamId: $previousTeamId,
+            previousTeamName: $sellerName,
+        );
 
         GameTransfer::record(
             gameId: $game->id,
@@ -219,12 +241,22 @@ class TransferCompletionService
         $contractYears = $offer->offered_years ?? ($player->age($game->current_date) >= 32 ? 1 : 3);
         $newContractEnd = Carbon::createFromDate($seasonYear + $contractYears + 1, 6, 30);
 
+        $previousTeamId = $player->team_id;
+        $previousTeamName = $player->team->name ?? null;
+
         $player->update([
             'team_id' => $game->team_id,
             'number' => $this->squadNumberService->assignNumberForNewPlayer($game, $player),
             'contract_until' => $newContractEnd,
             'annual_wage' => $offer->offered_wage,
         ]);
+
+        $this->syncCareerRecordOnOwnershipChange(
+            game: $game,
+            player: $player,
+            previousTeamId: $previousTeamId,
+            previousTeamName: $previousTeamName,
+        );
 
         $offer->update([
             'status' => TransferOffer::STATUS_COMPLETED,
@@ -245,4 +277,45 @@ class TransferCompletionService
         ShortlistedPlayer::removeForPlayer($game->id, $player->id);
     }
 
+    /**
+     * Reconcile the user-squad career record after a player's team_id changes.
+     *
+     * - Player moves into a user-owned team and wasn't already user-owned:
+     *   create a record. `joined_from` snapshots the previous team's name.
+     * - Player moves out of a user-owned team to a non-user-owned team:
+     *   delete the record. (We do not retain history for ex-players.)
+     * - Both old and new team are user-owned (e.g., filial → first team):
+     *   update in place; preserve accumulated season_stats.
+     * - Neither side is user-owned: no-op (AI-vs-AI move).
+     */
+    public function syncCareerRecordOnOwnershipChange(
+        Game $game,
+        GamePlayer $player,
+        ?string $previousTeamId,
+        ?string $previousTeamName,
+    ): void {
+        $wasOwned = $game->ownsTeam($previousTeamId);
+        $isOwned = $game->ownsTeam($player->team_id);
+
+        if (! $wasOwned && ! $isOwned) {
+            return;
+        }
+
+        if ($wasOwned && ! $isOwned) {
+            UserSquadCareerRecord::where('game_player_id', $player->id)->delete();
+            return;
+        }
+
+        $origin = $previousTeamName ?? UserSquadCareerRecord::ORIGIN_ACADEMY;
+
+        UserSquadCareerRecord::updateOrCreate(
+            ['game_player_id' => $player->id],
+            [
+                'game_id' => $game->id,
+                'team_id' => $player->team_id,
+                'joined_season' => (int) $game->season,
+                'joined_from' => $origin,
+            ],
+        );
+    }
 }

--- a/app/Modules/Transfer/Services/TransferMarketService.php
+++ b/app/Modules/Transfer/Services/TransferMarketService.php
@@ -181,6 +181,7 @@ class TransferMarketService
         return TransferListing::with(['gamePlayer.player', 'gamePlayer.team'])
             ->where('game_id', $game->id)
             ->where('team_id', '!=', $game->team_id)
+            ->whereHas('team', fn ($q) => $q->whereNull('parent_team_id'))
             ->where('status', TransferListing::STATUS_LISTED)
             ->whereNotNull('asking_price')
             ->whereNotIn('game_player_id', $alreadyAgreedIds)
@@ -356,10 +357,12 @@ class TransferMarketService
     private function sampleAITeams(Game $game, int $sampleSize): array
     {
         $teamIds = DB::table('competition_entries')
-            ->where('game_id', $game->id)
-            ->where('team_id', '!=', $game->team_id)
+            ->join('teams', 'teams.id', '=', 'competition_entries.team_id')
+            ->where('competition_entries.game_id', $game->id)
+            ->where('competition_entries.team_id', '!=', $game->team_id)
+            ->whereNull('teams.parent_team_id')
             ->distinct()
-            ->pluck('team_id')
+            ->pluck('competition_entries.team_id')
             ->all();
 
         if (empty($teamIds)) {
@@ -395,6 +398,7 @@ class TransferMarketService
             ])
             ->where('game_id', $game->id)
             ->whereIn('team_id', $teamIds)
+            ->whereHas('team', fn ($q) => $q->whereNull('parent_team_id'))
             ->get()
             ->groupBy('team_id');
     }

--- a/app/Modules/Transfer/Services/TransferService.php
+++ b/app/Modules/Transfer/Services/TransferService.php
@@ -3,8 +3,10 @@
 namespace App\Modules\Transfer\Services;
 
 use App\Modules\Player\PlayerAge;
+use App\Modules\Squad\Services\SquadMinimumService;
 use App\Modules\Squad\Services\SquadNumberService;
 use App\Modules\Transfer\Enums\NegotiationScenario;
+use App\Modules\Transfer\Exceptions\SquadMinimumException;
 use App\Modules\Transfer\Enums\TransferWindowType;
 use App\Modules\Transfer\Services\ContractService;
 use App\Modules\Transfer\Services\LoanService;
@@ -32,6 +34,7 @@ class TransferService
         private readonly ContractService $contractService,
         private readonly DispositionService $dispositionService,
         private readonly SquadNumberService $squadNumberService,
+        private readonly SquadMinimumService $squadMinimumService,
     ) {}
 
     /**
@@ -127,11 +130,24 @@ class TransferService
 
     /**
      * List a player for transfer.
+     *
+     * @throws SquadMinimumException when listing this player would mean the
+     *         squad could fall below its composition minimum if the resulting
+     *         offer is accepted.
      */
     public function listPlayer(GamePlayer $player): void
     {
         if ($player->isOnLoan()) {
             return;
+        }
+
+        $breach = $this->squadMinimumService->validateRemoval(
+            $player->game,
+            $player,
+            $player->team_id,
+        );
+        if ($breach !== null) {
+            throw new SquadMinimumException($breach);
         }
 
         TransferListing::updateOrCreate(
@@ -578,6 +594,15 @@ class TransferService
     {
         $player = $offer->gamePlayer;
         $game = $offer->game;
+
+        // Squad-composition guard: this is the binding moment — once accepted
+        // (or marked agreed), the player is committed to leaving. Block here
+        // so the resulting transfer can't shrink the roster below minimums,
+        // even if the listing itself was OK at the time it was created.
+        $breach = $this->squadMinimumService->validateRemoval($game, $player, $player->team_id);
+        if ($breach !== null) {
+            throw new SquadMinimumException($breach);
+        }
 
         // Reject all other pending offers for this player
         TransferOffer::where('game_player_id', $player->id)

--- a/database/migrations/2026_04_25_000001_add_reserve_team_id_to_games_table.php
+++ b/database/migrations/2026_04_25_000001_add_reserve_team_id_to_games_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('games', function (Blueprint $table) {
+            $table->uuid('reserve_team_id')->nullable()->after('team_id');
+            $table->foreign('reserve_team_id')->references('id')->on('teams')->nullOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('games', function (Blueprint $table) {
+            $table->dropForeign(['reserve_team_id']);
+            $table->dropColumn('reserve_team_id');
+        });
+    }
+};

--- a/database/migrations/2026_04_26_000001_create_user_squad_career_records_table.php
+++ b/database/migrations/2026_04_26_000001_create_user_squad_career_records_table.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('user_squad_career_records', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->uuid('game_player_id');
+            $table->uuid('game_id');
+            $table->uuid('team_id');
+            $table->unsignedSmallInteger('joined_season');
+            $table->string('joined_from')->nullable();
+            $table->jsonb('season_stats')->default('{}');
+
+            $table->unique('game_player_id');
+            $table->index(['game_id', 'team_id']);
+
+            $table->foreign('game_player_id')
+                ->references('id')->on('game_players')
+                ->cascadeOnDelete();
+            $table->foreign('game_id')
+                ->references('id')->on('games')
+                ->cascadeOnDelete();
+            $table->foreign('team_id')
+                ->references('id')->on('teams')
+                ->cascadeOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('user_squad_career_records');
+    }
+};

--- a/lang/en/messages.php
+++ b/lang/en/messages.php
@@ -105,6 +105,20 @@ return [
     'release_squad_too_small' => 'Cannot release — your squad must have at least :min players.',
     'release_position_minimum' => 'Cannot release — you need at least :min :group.',
 
+    // Squad-minimum guards on promote / demote / list / accept
+    'promote_squad_too_small' => 'Cannot call up — the reserve squad must have at least :min players.',
+    'promote_position_minimum' => 'Cannot call up — the reserve squad needs at least :min :group.',
+    'demote_squad_too_small' => 'Cannot send back — the first team must have at least :min players.',
+    'demote_position_minimum' => 'Cannot send back — the first team needs at least :min :group.',
+    'list_for_sale_squad_too_small' => 'Cannot list for sale — your squad must have at least :min players.',
+    'list_for_sale_position_minimum' => 'Cannot list for sale — you need at least :min :group.',
+    'list_for_loan_squad_too_small' => 'Cannot loan out — your squad must have at least :min players.',
+    'list_for_loan_position_minimum' => 'Cannot loan out — you need at least :min :group.',
+    'accept_offer_squad_too_small' => 'Cannot accept the offer — your squad must have at least :min players.',
+    'accept_offer_position_minimum' => 'Cannot accept the offer — you need at least :min :group.',
+    'accept_loan_squad_too_small' => 'Cannot accept the loan — your squad must have at least :min players.',
+    'accept_loan_position_minimum' => 'Cannot accept the loan — you need at least :min :group.',
+
     'cannot_loan_free_agent' => 'Cannot loan a free agent. Sign them directly instead.',
 
     // Pending actions

--- a/lang/en/messages.php
+++ b/lang/en/messages.php
@@ -89,6 +89,13 @@ return [
     'academy_player_loaned' => ':player has been loaned out.',
     'academy_must_decide_21' => 'Players aged 21+ will be automatically promoted to the first team.',
 
+    // Reserve team (filial)
+    'reserve_player_called_up' => ':player has been called up to the first team.',
+    'reserve_player_sent_back' => ':player has been sent back to the reserve team.',
+    'reserve_player_call_up_blocked_full' => 'First-team squad is full. Release a player before calling up another.',
+    'reserve_player_promoted' => ':player has been promoted to the first team.',
+    'shortlist_reserve_blocked' => "Reserve-team players belong to their parent club and aren't transferable.",
+
     // Player release messages
     'player_released' => ':player has been released. Severance paid: :severance.',
     'release_not_your_player' => 'You can only release players from your own team.',

--- a/lang/en/notifications.php
+++ b/lang/en/notifications.php
@@ -89,6 +89,8 @@ return [
     'academy_overage_promoted_message' => ':count academy players aged 21+ have been promoted to the first team.',
     'academy_gap_promoted_title' => 'Academy players promoted',
     'academy_gap_promoted_message' => ':count academy players have been promoted to fill squad gaps.',
+    'reserve_overage_promoted_title' => 'Reserve graduate',
+    'reserve_overage_promoted_message' => ':player has aged out of the reserve team and joined the first team permanently.',
     // Loan request results
     'loan_accepted_title' => 'Loan request for :player accepted',
     'loan_accepted' => ':team have accepted your loan request for :player.',

--- a/lang/en/squad.php
+++ b/lang/en/squad.php
@@ -190,7 +190,7 @@ return [
     'discovered' => 'Discovered',
     'origin' => 'Origin',
     'joined' => 'Joined',
-    'origin_academy' => 'Academy',
+    'origin_academy' => 'New',
     'career_history' => 'Career history',
     'no_career_history' => 'No completed seasons yet.',
 
@@ -235,6 +235,7 @@ return [
     'send_back' => 'Send back',
     'send_back_to_reserve' => 'Send back to reserve',
     'called_up_indicator' => 'Called up',
+    'homegrown_indicator' => 'Homegrown',
     'actions' => 'Actions',
     'reserve_help_toggle' => 'How does the reserve team work?',
     'reserve_help_development' => 'Your reserve team is your filial — its squad belongs to the reserve, not the first team. New academy prospects arrive here each season based on your academy investment, and develop alongside the existing reserve roster.',

--- a/lang/en/squad.php
+++ b/lang/en/squad.php
@@ -188,6 +188,11 @@ return [
     'clean_sheets_full' => 'Clean Sheets',
     'goals_conceded_full' => 'Goals Conceded',
     'discovered' => 'Discovered',
+    'origin' => 'Origin',
+    'joined' => 'Joined',
+    'origin_academy' => 'Academy',
+    'career_history' => 'Career history',
+    'no_career_history' => 'No completed seasons yet.',
 
     // Academy
     'academy' => 'Academy',

--- a/lang/en/squad.php
+++ b/lang/en/squad.php
@@ -221,6 +221,23 @@ return [
     'academy_tier_4' => 'World-Class Academy',
     'academy_tier_unknown' => 'Unknown',
 
+    // Reserve team (filial)
+    'reserve_team' => 'Reserve Team',
+    'reserve_squad' => 'Reserve squad',
+    'no_reserve_players' => 'No reserve-team players.',
+    'call_up' => 'Call up',
+    'call_up_to_first_team' => 'Call up to first team',
+    'send_back' => 'Send back',
+    'send_back_to_reserve' => 'Send back to reserve',
+    'called_up_indicator' => 'Called up',
+    'actions' => 'Actions',
+    'reserve_help_toggle' => 'How does the reserve team work?',
+    'reserve_help_development' => 'Your reserve team is your filial — its squad belongs to the reserve, not the first team. New academy prospects arrive here each season based on your academy investment, and develop alongside the existing reserve roster.',
+    'reserve_help_age_rule' => 'Players over 23 are automatically promoted to the first team at season close. The first team can call up reserve players any time during the season.',
+    'reserve_help_actions_title' => 'Available actions',
+    'reserve_help_call_up' => 'Call up - the player joins the first team on a temporary loan and can play first-team matches',
+    'reserve_help_send_back' => 'Send back - returns the called-up player to the reserve squad',
+
     // Lineup help text
     'lineup_help_toggle' => 'How does lineup selection work?',
     'lineup_help_intro' => 'Choose 11 players for each match. Your formation, player energy, and positional compatibility all affect performance.',

--- a/lang/es/messages.php
+++ b/lang/es/messages.php
@@ -89,6 +89,13 @@ return [
     'academy_player_loaned' => ':player ha sido cedido.',
     'academy_must_decide_21' => 'Los jugadores de 21+ años serán promocionados automáticamente al primer equipo.',
 
+    // Reserve team (filial)
+    'reserve_player_called_up' => ':player ha sido convocado al primer equipo.',
+    'reserve_player_sent_back' => ':player ha vuelto al filial.',
+    'reserve_player_call_up_blocked_full' => 'La plantilla del primer equipo está completa. Libera un dorsal antes de subir más jugadores.',
+    'reserve_player_promoted' => ':player ha subido al primer equipo.',
+    'shortlist_reserve_blocked' => 'Los jugadores del filial pertenecen al club matriz y no son transferibles.',
+
     // Player release messages
     'player_released' => ':player ha sido liberado. Indemnización pagada: :severance.',
     'release_not_your_player' => 'Solo puedes liberar jugadores de tu propio equipo.',

--- a/lang/es/messages.php
+++ b/lang/es/messages.php
@@ -105,6 +105,20 @@ return [
     'release_squad_too_small' => 'No se puede liberar — tu plantilla debe tener al menos :min jugadores.',
     'release_position_minimum' => 'No se puede liberar — necesitas al menos :min :group.',
 
+    // Squad-minimum guards on promote / demote / list / accept
+    'promote_squad_too_small' => 'No se puede subir — el filial debe tener al menos :min jugadores.',
+    'promote_position_minimum' => 'No se puede subir — el filial necesita al menos :min :group.',
+    'demote_squad_too_small' => 'No se puede bajar al filial — el primer equipo debe tener al menos :min jugadores.',
+    'demote_position_minimum' => 'No se puede bajar al filial — el primer equipo necesita al menos :min :group.',
+    'list_for_sale_squad_too_small' => 'No se puede poner a la venta — tu plantilla debe tener al menos :min jugadores.',
+    'list_for_sale_position_minimum' => 'No se puede poner a la venta — necesitas al menos :min :group.',
+    'list_for_loan_squad_too_small' => 'No se puede ceder — tu plantilla debe tener al menos :min jugadores.',
+    'list_for_loan_position_minimum' => 'No se puede ceder — necesitas al menos :min :group.',
+    'accept_offer_squad_too_small' => 'No se puede aceptar la oferta — tu plantilla debe tener al menos :min jugadores.',
+    'accept_offer_position_minimum' => 'No se puede aceptar la oferta — necesitas al menos :min :group.',
+    'accept_loan_squad_too_small' => 'No se puede aceptar la cesión — tu plantilla debe tener al menos :min jugadores.',
+    'accept_loan_position_minimum' => 'No se puede aceptar la cesión — necesitas al menos :min :group.',
+
     'cannot_loan_free_agent' => 'No se puede ceder a un jugador libre. Fíchalo directamente.',
 
     // Pending actions

--- a/lang/es/notifications.php
+++ b/lang/es/notifications.php
@@ -89,6 +89,8 @@ return [
     'academy_overage_promoted_message' => ':count canteranos de 21+ años han sido promocionados al primer equipo.',
     'academy_gap_promoted_title' => 'Canteranos promocionados',
     'academy_gap_promoted_message' => ':count canteranos han sido promocionados para cubrir huecos en la plantilla.',
+    'reserve_overage_promoted_title' => 'Graduado del filial',
+    'reserve_overage_promoted_message' => ':player ha superado la edad del filial y se incorpora al primer equipo de forma permanente.',
     // Loan request results
     'loan_accepted_title' => 'Cesión de :player aceptada',
     'loan_accepted' => ':team ha aceptado tu solicitud de cesión por :player.',

--- a/lang/es/squad.php
+++ b/lang/es/squad.php
@@ -188,6 +188,11 @@ return [
     'clean_sheets_full' => 'Porterías a Cero',
     'goals_conceded_full' => 'Goles Encajados',
     'discovered' => 'Descubierto',
+    'origin' => 'Procedencia',
+    'joined' => 'Incorporación',
+    'origin_academy' => 'Cantera',
+    'career_history' => 'Trayectoria',
+    'no_career_history' => 'Aún no hay temporadas completadas.',
 
     // Academy
     'academy' => 'Cantera',

--- a/lang/es/squad.php
+++ b/lang/es/squad.php
@@ -221,6 +221,23 @@ return [
     'academy_tier_4' => 'Cantera de Clase Mundial',
     'academy_tier_unknown' => 'Desconocido',
 
+    // Reserve team (filial)
+    'reserve_team' => 'Filial',
+    'reserve_squad' => 'Plantilla del filial',
+    'no_reserve_players' => 'No hay jugadores en el filial.',
+    'call_up' => 'Subir',
+    'call_up_to_first_team' => 'Subir al primer equipo',
+    'send_back' => 'Bajar',
+    'send_back_to_reserve' => 'Bajar al filial',
+    'called_up_indicator' => 'En el primer equipo',
+    'actions' => 'Acciones',
+    'reserve_help_toggle' => '¿Cómo funciona el filial?',
+    'reserve_help_development' => 'Tu filial es la cantera oficial — los jugadores pertenecen al filial, no al primer equipo. Cada temporada llegan nuevos canteranos según tu inversión en la cantera, que se desarrollan junto con el resto del filial.',
+    'reserve_help_age_rule' => 'Los jugadores que cumplen 24 años pasan automáticamente al primer equipo al final de la temporada. El primer equipo puede subir jugadores del filial en cualquier momento.',
+    'reserve_help_actions_title' => 'Acciones disponibles',
+    'reserve_help_call_up' => 'Subir - el jugador se incorpora al primer equipo en cesión y puede disputar partidos con el primer equipo',
+    'reserve_help_send_back' => 'Bajar - devuelve al jugador subido al filial',
+
     // Lineup help text
     'lineup_help_toggle' => '¿Cómo funciona la alineación?',
     'lineup_help_intro' => 'Elige 11 jugadores para cada partido. Tu formación, la energía y la compatibilidad posicional afectan al rendimiento.',

--- a/lang/es/squad.php
+++ b/lang/es/squad.php
@@ -190,7 +190,7 @@ return [
     'discovered' => 'Descubierto',
     'origin' => 'Procedencia',
     'joined' => 'Incorporación',
-    'origin_academy' => 'Cantera',
+    'origin_academy' => 'Nuevo',
     'career_history' => 'Trayectoria',
     'no_career_history' => 'Aún no hay temporadas completadas.',
 
@@ -235,6 +235,7 @@ return [
     'send_back' => 'Bajar',
     'send_back_to_reserve' => 'Bajar al filial',
     'called_up_indicator' => 'En el primer equipo',
+    'homegrown_indicator' => 'Canterano',
     'actions' => 'Acciones',
     'reserve_help_toggle' => '¿Cómo funciona el filial?',
     'reserve_help_development' => 'Tu filial es la cantera oficial — los jugadores pertenecen al filial, no al primer equipo. Cada temporada llegan nuevos canteranos según tu inversión en la cantera, que se desarrollan junto con el resto del filial.',

--- a/resources/views/components/origin-badge.blade.php
+++ b/resources/views/components/origin-badge.blade.php
@@ -1,0 +1,24 @@
+@props(['player'])
+
+@php
+    $record = $player->careerRecord ?? null;
+@endphp
+
+@if($record)
+    @php
+        $isAcademy = $record->joined_from === \App\Models\UserSquadCareerRecord::ORIGIN_ACADEMY;
+        $label = $isAcademy
+            ? __('squad.origin_academy')
+            : ($record->joined_from ?? '');
+        $title = trim(($label !== '' ? $label . ' · ' : '') . __('squad.joined') . ' ' . \App\Models\Game::formatSeason((string) $record->joined_season));
+        $classes = $isAcademy
+            ? 'bg-accent-green/10 text-accent-green'
+            : 'bg-accent-blue/10 text-accent-blue';
+    @endphp
+    @if($label !== '')
+        <span class="inline-flex items-center px-1.5 py-0.5 rounded text-[9px] font-semibold uppercase tracking-wide {{ $classes }} shrink-0"
+              title="{{ $title }}">
+            {{ $label }}
+        </span>
+    @endif
+@endif

--- a/resources/views/components/origin-badge.blade.php
+++ b/resources/views/components/origin-badge.blade.php
@@ -1,14 +1,16 @@
-@props(['player'])
+@props(['player', 'currentSeason' => null])
 
 @php
     $record = $player->careerRecord ?? null;
+    $currentSeason = $currentSeason ?? $player->game?->season;
 @endphp
 
 @if($record)
     @php
         $isAcademy = $record->joined_from === \App\Models\UserSquadCareerRecord::ORIGIN_ACADEMY;
+        $isCurrentSeason = $currentSeason !== null && (string) $record->joined_season === (string) $currentSeason;
         $label = $isAcademy
-            ? __('squad.origin_academy')
+            ? ($isCurrentSeason ? __('squad.origin_academy') : '')
             : ($record->joined_from ?? '');
         $title = trim(($label !== '' ? $label . ' · ' : '') . __('squad.joined') . ' ' . \App\Models\Game::formatSeason((string) $record->joined_season));
         $classes = $isAcademy

--- a/resources/views/partials/player-detail.blade.php
+++ b/resources/views/partials/player-detail.blade.php
@@ -4,9 +4,10 @@
 
     $isCareerMode = $game->isCareerMode();
     $isListed = $gamePlayer->isTransferListed();
+    $isCalledUpFromReserve = $isCalledUpFromReserve ?? false;
     $canManage = $isCareerMode
         && !$gamePlayer->isRetiring()
-        && !$gamePlayer->isLoanedIn($game->team_id)
+        && ($isCalledUpFromReserve || !$gamePlayer->isLoanedIn($game->team_id))
         && !$gamePlayer->isLoanedOut($game->team_id)
         && !$gamePlayer->hasPreContractAgreement()
         && !$gamePlayer->hasAgreedTransfer()
@@ -279,9 +280,31 @@
 @endif
 
 {{-- Actions --}}
-@if($showActions || $canRenew || $renewalNegotiation || $renewalCooldown)
+@if($showActions || $canRenew || $renewalNegotiation || $renewalCooldown || ($isOnReserve ?? false) || $isCalledUpFromReserve)
     <div class="px-5 py-4 border-t border-border-default flex flex-wrap items-center gap-2">
-        @if(!$isListed && $canSell)
+        @if(($isOnReserve ?? false) && $isCareerMode)
+            <form method="POST" action="{{ route('game.reserve.call-up', [$game->id, $gamePlayer->id]) }}">
+                @csrf
+                <x-action-button color="blue">
+                    <svg class="w-4 h-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor">
+                        <path fill-rule="evenodd" d="M8 14a.75.75 0 0 1-.75-.75V4.56L4.03 7.78a.75.75 0 0 1-1.06-1.06l4.5-4.5a.75.75 0 0 1 1.06 0l4.5 4.5a.75.75 0 0 1-1.06 1.06L8.75 4.56v8.69A.75.75 0 0 1 8 14Z" clip-rule="evenodd" />
+                    </svg>
+                    {{ __('squad.call_up_to_first_team') }}
+                </x-action-button>
+            </form>
+        @endif
+        @if($isCalledUpFromReserve && $isCareerMode)
+            <form method="POST" action="{{ route('game.reserve.send-back', [$game->id, $gamePlayer->id]) }}">
+                @csrf
+                <x-action-button color="violet">
+                    <svg class="w-4 h-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor">
+                        <path fill-rule="evenodd" d="M8 2a.75.75 0 0 1 .75.75v8.69l3.22-3.22a.75.75 0 1 1 1.06 1.06l-4.5 4.5a.75.75 0 0 1-1.06 0l-4.5-4.5a.75.75 0 0 1 1.06-1.06l3.22 3.22V2.75A.75.75 0 0 1 8 2Z" clip-rule="evenodd" />
+                    </svg>
+                    {{ __('squad.send_back_to_reserve') }}
+                </x-action-button>
+            </form>
+        @endif
+        @if(!$isListed && $canSell && !($isOnReserve ?? false))
             <form method="POST" action="{{ route('game.transfers.list', [$game->id, $gamePlayer->id]) }}">
                 @csrf
                 <x-action-button color="blue">

--- a/resources/views/partials/player-detail.blade.php
+++ b/resources/views/partials/player-detail.blade.php
@@ -161,6 +161,24 @@
                         <span class="text-xs font-semibold text-text-primary">{{ $gamePlayer->contract_expiry_year }}</span>
                     </div>
                 @endif
+                @if($gamePlayer->careerRecord)
+                    @php
+                        $cr = $gamePlayer->careerRecord;
+                        $originLabel = $cr->joined_from === \App\Models\UserSquadCareerRecord::ORIGIN_ACADEMY
+                            ? __('squad.origin_academy')
+                            : ($cr->joined_from ?? '');
+                    @endphp
+                    @if($originLabel !== '')
+                        <div class="flex items-center justify-between">
+                            <span class="text-[11px] text-text-muted uppercase tracking-wide">{{ __('squad.origin') }}</span>
+                            <span class="text-xs font-semibold text-text-primary">{{ $originLabel }}</span>
+                        </div>
+                    @endif
+                    <div class="flex items-center justify-between">
+                        <span class="text-[11px] text-text-muted uppercase tracking-wide">{{ __('squad.joined') }}</span>
+                        <span class="text-xs font-semibold text-text-primary">{{ \App\Models\Game::formatSeason((string) $cr->joined_season) }}</span>
+                    </div>
+                @endif
             @endif
         </div>
     </div>
@@ -204,6 +222,61 @@
         </div>
     </div>
 </div>
+
+{{-- Career history --}}
+@if($gamePlayer->careerRecord && !empty($gamePlayer->careerRecord->season_stats))
+    @php
+        $history = collect($gamePlayer->careerRecord->season_stats)
+            ->map(fn ($stats, $season) => array_merge(['season' => $season], (array) $stats))
+            ->sortBy('season')
+            ->values();
+        $isGk = $gamePlayer->position_group === 'Goalkeeper';
+    @endphp
+    <div class="px-5 py-4 border-t border-border-default">
+        <h4 class="font-heading text-[11px] font-semibold uppercase tracking-widest text-text-secondary mb-3">{{ __('squad.career_history') }}</h4>
+        <div class="overflow-x-auto">
+            <table class="w-full text-xs">
+                <thead>
+                    <tr class="text-text-muted uppercase tracking-wide text-[10px]">
+                        <th class="text-left font-semibold py-1.5 pr-3">{{ __('game.season') }}</th>
+                        <th class="text-right font-semibold py-1.5 px-2">{{ __('squad.appearances') }}</th>
+                        @if($isGk)
+                            <th class="text-right font-semibold py-1.5 px-2">{{ __('squad.clean_sheets_full') }}</th>
+                            <th class="text-right font-semibold py-1.5 px-2">{{ __('squad.goals_conceded_full') }}</th>
+                        @else
+                            <th class="text-right font-semibold py-1.5 px-2">{{ __('squad.legend_goals') }}</th>
+                            <th class="text-right font-semibold py-1.5 px-2">{{ __('squad.legend_assists') }}</th>
+                        @endif
+                        <th class="text-right font-semibold py-1.5 pl-2">{{ __('squad.bookings') }}</th>
+                    </tr>
+                </thead>
+                <tbody class="divide-y divide-border-default">
+                    @foreach($history as $row)
+                        <tr>
+                            <td class="py-1.5 pr-3 text-text-primary font-semibold">{{ \App\Models\Game::formatSeason((string) $row['season']) }}</td>
+                            <td class="py-1.5 px-2 text-right text-text-body">{{ $row['appearances'] ?? 0 }}</td>
+                            @if($isGk)
+                                <td class="py-1.5 px-2 text-right text-text-body">{{ $row['clean_sheets'] ?? 0 }}</td>
+                                <td class="py-1.5 px-2 text-right text-text-body">{{ $row['goals_conceded'] ?? 0 }}</td>
+                            @else
+                                <td class="py-1.5 px-2 text-right text-text-body">{{ $row['goals'] ?? 0 }}</td>
+                                <td class="py-1.5 px-2 text-right text-text-body">{{ $row['assists'] ?? 0 }}</td>
+                            @endif
+                            <td class="py-1.5 pl-2 text-right">
+                                <span class="inline-flex items-center gap-1">
+                                    <span class="w-1.5 h-2.5 bg-yellow-400 rounded-xs"></span>
+                                    <span class="text-text-body">{{ $row['yellow_cards'] ?? 0 }}</span>
+                                    <span class="w-1.5 h-2.5 bg-accent-red rounded-xs ml-1"></span>
+                                    <span class="text-text-body">{{ $row['red_cards'] ?? 0 }}</span>
+                                </span>
+                            </td>
+                        </tr>
+                    @endforeach
+                </tbody>
+            </table>
+        </div>
+    </div>
+@endif
 
 {{-- Actions --}}
 @if($showActions || $canRenew || $renewalNegotiation || $renewalCooldown)

--- a/resources/views/partials/squad/player-status-icon.blade.php
+++ b/resources/views/partials/squad/player-status-icon.blade.php
@@ -11,6 +11,10 @@
         <svg x-data="" x-tooltip.raw="{{ __('squad.retiring') }}" class="w-4 h-4 text-orange-500 shrink-0 cursor-help" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
             <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 9V5.25A2.25 2.25 0 0 1 10.5 3h6a2.25 2.25 0 0 1 2.25 2.25v13.5A2.25 2.25 0 0 1 16.5 21h-6a2.25 2.25 0 0 1-2.25-2.25V15m-3 0-3-3m0 0 3-3m-3 3H15" />
         </svg>
+    @elseif($gp->isLoanedIn($game->team_id) && $game->reserve_team_id !== null && $gp->activeLoan?->parent_team_id === $game->reserve_team_id)
+        <svg x-data="" x-tooltip.raw="{{ __('squad.homegrown_indicator') }}" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" class="w-4 h-4 text-sky-500 shrink-0 cursor-help" fill="currentColor">
+            <path fill-rule="evenodd" d="M8 14a.75.75 0 0 1-.75-.75V4.56L4.03 7.78a.75.75 0 0 1-1.06-1.06l4.5-4.5a.75.75 0 0 1 1.06 0l4.5 4.5a.75.75 0 0 1-1.06 1.06L8.75 4.56v8.69A.75.75 0 0 1 8 14Z" clip-rule="evenodd" />
+        </svg>
     @elseif($gp->isLoanedIn($game->team_id))
         <svg x-data="" x-tooltip.raw="{{ __('squad.on_loan') }}" class="w-4 h-4 text-sky-500 shrink-0 cursor-help" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
             <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 9V5.25A2.25 2.25 0 0 1 10.5 3h6a2.25 2.25 0 0 1 2.25 2.25v13.5A2.25 2.25 0 0 1 16.5 21h-6a2.25 2.25 0 0 1-2.25-2.25V15M12 9l3 3m0 0-3 3m3-3H2.25" />
@@ -31,17 +35,25 @@
         <svg x-data="" x-tooltip.raw="{{ __('squad.loan_searching') }}" class="w-4 h-4 text-sky-500 shrink-0 cursor-help" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
             <path stroke-linecap="round" stroke-linejoin="round" d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z" />
         </svg>
-    @elseif($gp->isContractExpiring($seasonEndDate ?? $game->getSeasonEndDate()) && !$gp->hasPreContractAgreement() && !$gp->hasRenewalAgreed() && !$gp->isRetiring())
-        <svg x-data="" x-tooltip.raw="{{ __('squad.contract_expiring') }}" class="w-4 h-4 text-amber-500 shrink-0 cursor-help" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m5.231 13.481L15 17.25m-4.5-15H5.625c-.621 0-1.125.504-1.125 1.125v16.5c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Zm3.75 11.625a2.625 2.625 0 1 1-5.25 0 2.625 2.625 0 0 1 5.25 0Z" />
-        </svg>
-    @elseif($gp->isTransferListed())
-        <svg x-data="" x-tooltip.raw="{{ __('squad.listed') }}" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" class="w-4 h-4 text-amber-500 shrink-0 cursor-help" fill="currentColor">
-            <path fill-rule="evenodd" d="M3.396 6.093a2 2 0 0 0 0 3.814 2 2 0 0 0 2.697 2.697 2 2 0 0 0 3.814 0 2.001 2.001 0 0 0 2.698-2.697 2 2 0 0 0-.001-3.814 2.001 2.001 0 0 0-2.697-2.698 2 2 0 0 0-3.814.001 2 2 0 0 0-2.697 2.697ZM6 7a1 1 0 1 0 0-2 1 1 0 0 0 0 2Zm3.47-1.53a.75.75 0 1 1 1.06 1.06l-4 4a.75.75 0 1 1-1.06-1.06l4-4ZM11 10a1 1 0 1 1-2 0 1 1 0 0 1 2 0Z" clip-rule="evenodd" />
-        </svg>
-    @elseif($flags['stature_gap'])
-        <x-warning-triangle :tooltip="__('transfers.player_wont_renew')" class="text-accent-red" />
-    @elseif($flags['wage_gap'])
-        <x-warning-triangle :tooltip="__('transfers.player_wants_raise')" class="text-accent-gold" />
+    @else
+        @php
+            $isExpiring = $gp->isContractExpiring($seasonEndDate ?? $game->getSeasonEndDate());
+            $isListed = $gp->isTransferListed();
+        @endphp
+        @if($isExpiring)
+            <svg x-data="" x-tooltip.raw="{{ __('squad.contract_expiring') }}" class="w-4 h-4 text-amber-500 shrink-0 cursor-help" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m5.231 13.481L15 17.25m-4.5-15H5.625c-.621 0-1.125.504-1.125 1.125v16.5c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Zm3.75 11.625a2.625 2.625 0 1 1-5.25 0 2.625 2.625 0 0 1 5.25 0Z" />
+            </svg>
+        @endif
+        @if($isListed)
+            <svg x-data="" x-tooltip.raw="{{ __('squad.listed') }}" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" class="w-4 h-4 text-amber-500 shrink-0 cursor-help" fill="currentColor">
+                <path fill-rule="evenodd" d="M3.396 6.093a2 2 0 0 0 0 3.814 2 2 0 0 0 2.697 2.697 2 2 0 0 0 3.814 0 2.001 2.001 0 0 0 2.698-2.697 2 2 0 0 0-.001-3.814 2.001 2.001 0 0 0-2.697-2.698 2 2 0 0 0-3.814.001 2 2 0 0 0-2.697 2.697ZM6 7a1 1 0 1 0 0-2 1 1 0 0 0 0 2Zm3.47-1.53a.75.75 0 1 1 1.06 1.06l-4 4a.75.75 0 1 1-1.06-1.06l4-4ZM11 10a1 1 0 1 1-2 0 1 1 0 0 1 2 0Z" clip-rule="evenodd" />
+            </svg>
+        @endif
+        @if(!$isExpiring && !$isListed && $flags['stature_gap'])
+            <x-warning-triangle :tooltip="__('transfers.player_wont_renew')" class="text-accent-red" />
+        @elseif(!$isExpiring && !$isListed && $flags['wage_gap'])
+            <x-warning-triangle :tooltip="__('transfers.player_wants_raise')" class="text-accent-gold" />
+        @endif
     @endif
 @endif

--- a/resources/views/squad-academy.blade.php
+++ b/resources/views/squad-academy.blade.php
@@ -8,9 +8,14 @@
     <div class="max-w-7xl mx-auto px-4 pb-8">
 
         {{-- Sub-navigation --}}
+        @php
+            $secondaryItem = $game->isFilial()
+                ? ['href' => route('game.squad.reserve', $game->id), 'label' => __('squad.reserve_team'), 'active' => false]
+                : ['href' => route('game.squad.academy', $game->id), 'label' => __('squad.academy'), 'active' => true];
+        @endphp
         <x-section-nav :items="[
             ['href' => route('game.squad', $game->id), 'label' => __('squad.first_team'), 'active' => false],
-            ['href' => route('game.squad.academy', $game->id), 'label' => __('squad.academy'), 'active' => true],
+            $secondaryItem,
             ['href' => route('game.squad.registration', $game->id), 'label' => __('squad.registration'), 'active' => false],
         ]" />
 

--- a/resources/views/squad-reserve.blade.php
+++ b/resources/views/squad-reserve.blade.php
@@ -117,6 +117,7 @@
                                         <div class="flex-1 min-w-0">
                                             <div class="flex items-center gap-2">
                                                 <span class="text-sm font-medium text-text-primary truncate">{{ $player->player->name }}</span>
+                                                <x-origin-badge :player="$player" />
                                                 <span class="text-[10px] text-text-faint">{{ $age }}</span>
                                                 @if($isCalledUp)
                                                     <span class="text-[10px] font-semibold bg-accent-blue/10 text-accent-blue px-1.5 py-0.5 rounded-full">{{ __('squad.called_up_indicator') }}</span>
@@ -149,6 +150,7 @@
                                         <img src="{{ Storage::disk('assets')->url('flags/' . $player->nationality_flag['code'] . '.svg') }}" class="w-4 h-3 rounded-xs shadow-xs shrink-0" title="{{ $player->nationality_flag['name'] }}">
                                     @endif
                                     <span class="text-sm font-medium text-text-primary truncate">{{ $player->player->name }}</span>
+                                    <x-origin-badge :player="$player" />
                                     @if($isCalledUp)
                                         <span class="text-[10px] font-semibold bg-accent-blue/10 text-accent-blue px-1.5 py-0.5 rounded-full">{{ __('squad.called_up_indicator') }}</span>
                                     @endif

--- a/resources/views/squad-reserve.blade.php
+++ b/resources/views/squad-reserve.blade.php
@@ -1,0 +1,194 @@
+@php /** @var App\Models\Game $game **/ @endphp
+
+<x-app-layout>
+    <x-slot name="header">
+        <x-game-header :game="$game" :next-match="$game->next_match"></x-game-header>
+    </x-slot>
+
+    <div class="max-w-7xl mx-auto px-4 pb-8">
+
+        {{-- Sub-navigation --}}
+        <x-section-nav :items="[
+            ['href' => route('game.squad', $game->id), 'label' => __('squad.first_team'), 'active' => false],
+            ['href' => route('game.squad.reserve', $game->id), 'label' => __('squad.reserve_team'), 'active' => true],
+            ['href' => route('game.squad.registration', $game->id), 'label' => __('squad.registration'), 'active' => false],
+        ]" />
+
+        {{-- Flash Messages --}}
+        <x-flash-message type="success" :message="session('success')" class="mt-4" />
+        <x-flash-message type="error" :message="session('error')" class="mt-4" />
+
+        {{-- Page Title --}}
+        <div class="mt-6 mb-4 flex items-center gap-3">
+            @if($reserveTeam->image)
+                <img src="{{ $reserveTeam->image }}" alt="{{ $reserveTeam->name }}" class="w-10 h-10 object-contain shrink-0" />
+            @endif
+            <div>
+                <h2 class="font-heading text-2xl lg:text-3xl font-bold uppercase tracking-wide text-text-primary">{{ $reserveTeam->name }}</h2>
+                <p class="text-xs text-text-muted">{{ __('squad.reserve_team') }}</p>
+            </div>
+        </div>
+
+        {{-- Summary strip --}}
+        <x-help-disclosure class="mb-6">
+            <x-slot name="trigger">
+                <div class="flex items-center gap-2.5 overflow-x-auto scrollbar-hide pb-1">
+                    <x-summary-card :label="__('squad.squad_size')" :value="$reserveCount" />
+                    <x-summary-card :label="__('squad.avg_age')" :value="$avgAge" />
+                    <x-summary-card :label="__('squad.fitness_full')" :value="$avgFitness . '%'" x-data x-tooltip.raw="{{ __('squad.tooltip_fitness') }}" :value-class="$avgFitness >= 85 ? 'text-accent-green' : ($avgFitness >= 70 ? 'text-text-primary' : 'text-amber-500')" />
+                    <x-summary-card :label="__('squad.morale_full')" :value="$avgMorale" x-data x-tooltip.raw="{{ __('squad.tooltip_morale') }}" :value-class="$avgMorale >= 80 ? 'text-accent-green' : ($avgMorale >= 65 ? 'text-text-primary' : 'text-amber-500')" />
+                    <x-summary-card :label="__('squad.avg_ovr')" :value="$avgOverall" x-data x-tooltip.raw="{{ __('squad.tooltip_avg_overall') }}" :value-class="$avgOverall >= 75 ? 'text-accent-green' : ($avgOverall >= 65 ? 'text-text-primary' : 'text-amber-500')" />
+                    <div class="ml-auto shrink-0">
+                        <x-help-toggle :label="__('squad.reserve_help_toggle')" />
+                    </div>
+                </div>
+            </x-slot>
+
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-5">
+                <div>
+                    <p class="text-text-secondary mb-3">{{ __('squad.reserve_help_development') }}</p>
+                    <p class="text-text-secondary">{{ __('squad.reserve_help_age_rule') }}</p>
+                </div>
+
+                <div>
+                    <p class="font-semibold text-text-body mb-2">{{ __('squad.reserve_help_actions_title') }}</p>
+                    <ul class="space-y-2">
+                        <li class="flex gap-2">
+                            <span class="text-accent-green shrink-0">↑</span>
+                            <span class="text-text-secondary">{{ __('squad.reserve_help_call_up') }}</span>
+                        </li>
+                        <li class="flex gap-2">
+                            <span class="text-amber-400 shrink-0">↓</span>
+                            <span class="text-text-secondary">{{ __('squad.reserve_help_send_back') }}</span>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </x-help-disclosure>
+
+        @if($reserveCount === 0)
+            <div class="text-center py-16">
+                <div class="inline-flex items-center justify-center w-16 h-16 bg-surface-700 rounded-full mb-4">
+                    <svg class="w-8 h-8 fill-surface-600" stroke="currentColor" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 576 512"><path d="M48 195.8l209.2 86.1c9.8 4 20.2 6.1 30.8 6.1s21-2.1 30.8-6.1l242.4-99.8c9-3.7 14.8-12.4 14.8-22.1s-5.8-18.4-14.8-22.1L318.8 38.1C309 34.1 298.6 32 288 32s-21 2.1-30.8 6.1L14.8 137.9C5.8 141.6 0 150.3 0 160L0 456c0 13.3 10.7 24 24 24s24-10.7 24-24l0-260.2zm48 71.7L96 384c0 53 86 96 192 96s192-43 192-96l0-116.6-142.9 58.9c-15.6 6.4-32.2 9.7-49.1 9.7s-33.5-3.3-49.1-9.7L96 267.4z"/></svg>
+                </div>
+                <p class="text-text-muted text-sm">{{ __('squad.no_reserve_players') }}</p>
+            </div>
+        @else
+            <div x-data class="bg-surface-800 border border-border-default rounded-xl overflow-hidden">
+                {{-- Table header --}}
+                <div class="hidden md:block">
+                    <div class="grid grid-cols-[40px_1fr_48px_48px_48px_56px_56px_120px] gap-1.5 items-center px-4 py-2 bg-surface-700/30 border-b border-border-default text-[10px] text-text-muted uppercase tracking-widest font-semibold">
+                        <span></span>
+                        <span>{{ __('app.name') }}</span>
+                        <span class="text-center">{{ __('app.age') }}</span>
+                        <span class="text-center">{{ __('squad.technical') }}</span>
+                        <span class="text-center">{{ __('squad.physical') }}</span>
+                        <span class="text-center">{{ __('squad.pot') }}</span>
+                        <span class="text-center">{{ __('squad.overall') }}</span>
+                        <span class="text-right">{{ __('squad.actions') }}</span>
+                    </div>
+                </div>
+
+                @foreach([
+                    ['name' => __('squad.goalkeepers'), 'players' => $goalkeepers],
+                    ['name' => __('squad.defenders'), 'players' => $defenders],
+                    ['name' => __('squad.midfielders'), 'players' => $midfielders],
+                    ['name' => __('squad.forwards'), 'players' => $forwards],
+                ] as $group)
+                    @if($group['players']->isNotEmpty())
+                        <div class="px-4 py-2 bg-surface-700/30 border-b border-border-default">
+                            <div class="flex items-center justify-between">
+                                <span class="font-heading text-[11px] font-semibold uppercase tracking-widest text-text-muted">{{ $group['name'] }}</span>
+                                <span class="text-[10px] text-text-faint">{{ $group['players']->count() }}</span>
+                            </div>
+                        </div>
+
+                        @foreach($group['players'] as $player)
+                            @php
+                                $isCalledUp = $player->team_id === $game->team_id;
+                                $age = $player->age($game->current_date);
+                            @endphp
+
+                            {{-- Mobile row --}}
+                            <div class="md:hidden px-4 py-3 border-b border-border-default">
+                                <div class="flex items-center gap-3">
+                                    <div class="cursor-pointer flex-1 flex items-center gap-3 min-w-0" @click="$dispatch('show-player-detail', '{{ route('game.player.detail', [$game->id, $player->id]) }}')">
+                                        <x-player-avatar :name="$player->player->name" :position-group="\App\Support\PositionMapper::getPositionGroup($player->position)" :position-abbrev="\App\Support\PositionMapper::toAbbreviation($player->position)" />
+                                        <div class="flex-1 min-w-0">
+                                            <div class="flex items-center gap-2">
+                                                <span class="text-sm font-medium text-text-primary truncate">{{ $player->player->name }}</span>
+                                                <span class="text-[10px] text-text-faint">{{ $age }}</span>
+                                                @if($isCalledUp)
+                                                    <span class="text-[10px] font-semibold bg-accent-blue/10 text-accent-blue px-1.5 py-0.5 rounded-full">{{ __('squad.called_up_indicator') }}</span>
+                                                @endif
+                                            </div>
+                                        </div>
+                                        <x-rating-badge :value="$player->overall_score" class="shrink-0" />
+                                    </div>
+                                    @if($isCalledUp)
+                                        <form method="POST" action="{{ route('game.reserve.send-back', [$game->id, $player->id]) }}" onsubmit="return confirm('{{ __('squad.send_back_to_reserve') }}?')">
+                                            @csrf
+                                            <button type="submit" class="text-amber-400 hover:text-amber-300 px-2" title="{{ __('squad.send_back_to_reserve') }}">↓</button>
+                                        </form>
+                                    @else
+                                        <form method="POST" action="{{ route('game.reserve.call-up', [$game->id, $player->id]) }}" onsubmit="return confirm('{{ __('squad.call_up_to_first_team') }}?')">
+                                            @csrf
+                                            <button type="submit" class="text-accent-green hover:text-emerald-400 px-2" title="{{ __('squad.call_up_to_first_team') }}">↑</button>
+                                        </form>
+                                    @endif
+                                </div>
+                            </div>
+
+                            {{-- Desktop row --}}
+                            <div class="hidden md:grid grid-cols-[40px_1fr_48px_48px_48px_56px_56px_120px] gap-1.5 items-center px-4 py-2.5 border-b border-border-default hover:bg-surface-700/30 transition-colors">
+                                <div class="flex justify-center cursor-pointer" @click="$dispatch('show-player-detail', '{{ route('game.player.detail', [$game->id, $player->id]) }}')">
+                                    <x-position-badge :position="$player->position" size="sm" :tooltip="\App\Support\PositionMapper::toDisplayName($player->position)" class="cursor-help" />
+                                </div>
+                                <div class="flex items-center gap-2 min-w-0 cursor-pointer" @click="$dispatch('show-player-detail', '{{ route('game.player.detail', [$game->id, $player->id]) }}')">
+                                    @if($player->nationality_flag)
+                                        <img src="{{ Storage::disk('assets')->url('flags/' . $player->nationality_flag['code'] . '.svg') }}" class="w-4 h-3 rounded-xs shadow-xs shrink-0" title="{{ $player->nationality_flag['name'] }}">
+                                    @endif
+                                    <span class="text-sm font-medium text-text-primary truncate">{{ $player->player->name }}</span>
+                                    @if($isCalledUp)
+                                        <span class="text-[10px] font-semibold bg-accent-blue/10 text-accent-blue px-1.5 py-0.5 rounded-full">{{ __('squad.called_up_indicator') }}</span>
+                                    @endif
+                                </div>
+                                <span class="text-xs text-text-secondary text-center tabular-nums">{{ $age }}</span>
+                                <div class="flex justify-center">
+                                    <span class="text-xs font-medium tabular-nums @if($player->current_technical_ability >= 80) text-accent-green @elseif($player->current_technical_ability >= 70) text-lime-500 @elseif($player->current_technical_ability >= 60) text-text-body @else text-text-secondary @endif">{{ $player->current_technical_ability }}</span>
+                                </div>
+                                <div class="flex justify-center">
+                                    <span class="text-xs font-medium tabular-nums @if($player->current_physical_ability >= 80) text-accent-green @elseif($player->current_physical_ability >= 70) text-lime-500 @elseif($player->current_physical_ability >= 60) text-text-body @else text-text-secondary @endif">{{ $player->current_physical_ability }}</span>
+                                </div>
+                                <span class="text-xs text-center tabular-nums text-text-muted">{{ $player->potential_range }}</span>
+                                <div class="flex justify-center">
+                                    <x-rating-badge :value="$player->overall_score" size="sm" />
+                                </div>
+                                <div class="flex justify-end">
+                                    @if($isCalledUp)
+                                        <form method="POST" action="{{ route('game.reserve.send-back', [$game->id, $player->id]) }}" onsubmit="return confirm('{{ __('squad.send_back_to_reserve') }}?')">
+                                            @csrf
+                                            <x-ghost-button color="slate" size="xs" type="submit" title="{{ __('squad.send_back_to_reserve') }}">
+                                                ↓ {{ __('squad.send_back') }}
+                                            </x-ghost-button>
+                                        </form>
+                                    @else
+                                        <form method="POST" action="{{ route('game.reserve.call-up', [$game->id, $player->id]) }}" onsubmit="return confirm('{{ __('squad.call_up_to_first_team') }}?')">
+                                            @csrf
+                                            <x-ghost-button color="green" size="xs" type="submit" title="{{ __('squad.call_up_to_first_team') }}">
+                                                ↑ {{ __('squad.call_up') }}
+                                            </x-ghost-button>
+                                        </form>
+                                    @endif
+                                </div>
+                            </div>
+                        @endforeach
+                    @endif
+                @endforeach
+            </div>
+        @endif
+
+    </div>
+
+    <x-player-detail-modal />
+</x-app-layout>

--- a/resources/views/squad-reserve.blade.php
+++ b/resources/views/squad-reserve.blade.php
@@ -19,14 +19,8 @@
         <x-flash-message type="error" :message="session('error')" class="mt-4" />
 
         {{-- Page Title --}}
-        <div class="mt-6 mb-4 flex items-center gap-3">
-            @if($reserveTeam->image)
-                <img src="{{ $reserveTeam->image }}" alt="{{ $reserveTeam->name }}" class="w-10 h-10 object-contain shrink-0" />
-            @endif
-            <div>
-                <h2 class="font-heading text-2xl lg:text-3xl font-bold uppercase tracking-wide text-text-primary">{{ $reserveTeam->name }}</h2>
-                <p class="text-xs text-text-muted">{{ __('squad.reserve_team') }}</p>
-            </div>
+        <div class="mt-6 mb-4">
+            <h2 class="font-heading text-2xl lg:text-3xl font-bold uppercase tracking-wide text-text-primary">{{ $reserveTeam->name }}</h2>
         </div>
 
         {{-- Summary strip --}}
@@ -35,8 +29,6 @@
                 <div class="flex items-center gap-2.5 overflow-x-auto scrollbar-hide pb-1">
                     <x-summary-card :label="__('squad.squad_size')" :value="$reserveCount" />
                     <x-summary-card :label="__('squad.avg_age')" :value="$avgAge" />
-                    <x-summary-card :label="__('squad.fitness_full')" :value="$avgFitness . '%'" x-data x-tooltip.raw="{{ __('squad.tooltip_fitness') }}" :value-class="$avgFitness >= 85 ? 'text-accent-green' : ($avgFitness >= 70 ? 'text-text-primary' : 'text-amber-500')" />
-                    <x-summary-card :label="__('squad.morale_full')" :value="$avgMorale" x-data x-tooltip.raw="{{ __('squad.tooltip_morale') }}" :value-class="$avgMorale >= 80 ? 'text-accent-green' : ($avgMorale >= 65 ? 'text-text-primary' : 'text-amber-500')" />
                     <x-summary-card :label="__('squad.avg_ovr')" :value="$avgOverall" x-data x-tooltip.raw="{{ __('squad.tooltip_avg_overall') }}" :value-class="$avgOverall >= 75 ? 'text-accent-green' : ($avgOverall >= 65 ? 'text-text-primary' : 'text-amber-500')" />
                     <div class="ml-auto shrink-0">
                         <x-help-toggle :label="__('squad.reserve_help_toggle')" />
@@ -77,15 +69,15 @@
             <div x-data class="bg-surface-800 border border-border-default rounded-xl overflow-hidden">
                 {{-- Table header --}}
                 <div class="hidden md:block">
-                    <div class="grid grid-cols-[40px_1fr_48px_48px_48px_56px_56px_120px] gap-1.5 items-center px-4 py-2 bg-surface-700/30 border-b border-border-default text-[10px] text-text-muted uppercase tracking-widest font-semibold">
+                    <div class="grid grid-cols-[40px_1fr_48px_56px_48px_48px_56px_56px] gap-1.5 items-center px-4 py-2 bg-surface-700/30 border-b border-border-default text-[10px] text-text-muted uppercase tracking-widest font-semibold">
                         <span></span>
                         <span>{{ __('app.name') }}</span>
                         <span class="text-center">{{ __('app.age') }}</span>
+                        <span class="text-center">{{ __('app.contract') }}</span>
                         <span class="text-center">{{ __('squad.technical') }}</span>
                         <span class="text-center">{{ __('squad.physical') }}</span>
                         <span class="text-center">{{ __('squad.pot') }}</span>
                         <span class="text-center">{{ __('squad.overall') }}</span>
-                        <span class="text-right">{{ __('squad.actions') }}</span>
                     </div>
                 </div>
 
@@ -110,15 +102,18 @@
                             @endphp
 
                             {{-- Mobile row --}}
-                            <div class="md:hidden px-4 py-3 border-b border-border-default">
+                            <div class="md:hidden px-4 py-3 border-b border-border-default {{ $isCalledUp ? 'opacity-60' : '' }}">
                                 <div class="flex items-center gap-3">
                                     <div class="cursor-pointer flex-1 flex items-center gap-3 min-w-0" @click="$dispatch('show-player-detail', '{{ route('game.player.detail', [$game->id, $player->id]) }}')">
                                         <x-player-avatar :name="$player->player->name" :position-group="\App\Support\PositionMapper::getPositionGroup($player->position)" :position-abbrev="\App\Support\PositionMapper::toAbbreviation($player->position)" />
                                         <div class="flex-1 min-w-0">
                                             <div class="flex items-center gap-2">
                                                 <span class="text-sm font-medium text-text-primary truncate">{{ $player->player->name }}</span>
-                                                <x-origin-badge :player="$player" />
+                                                <x-origin-badge :player="$player" :current-season="$game->season" />
                                                 <span class="text-[10px] text-text-faint">{{ $age }}</span>
+                                                @if($player->contract_expiry_year)
+                                                    <span class="text-[10px] tabular-nums @if($player->isContractExpiring($game->getSeasonEndDate())) text-accent-red font-medium @else text-text-faint @endif">{{ __('app.contract') }}: {{ $player->contract_expiry_year }}</span>
+                                                @endif
                                                 @if($isCalledUp)
                                                     <span class="text-[10px] font-semibold bg-accent-blue/10 text-accent-blue px-1.5 py-0.5 rounded-full">{{ __('squad.called_up_indicator') }}</span>
                                                 @endif
@@ -141,21 +136,25 @@
                             </div>
 
                             {{-- Desktop row --}}
-                            <div class="hidden md:grid grid-cols-[40px_1fr_48px_48px_48px_56px_56px_120px] gap-1.5 items-center px-4 py-2.5 border-b border-border-default hover:bg-surface-700/30 transition-colors">
-                                <div class="flex justify-center cursor-pointer" @click="$dispatch('show-player-detail', '{{ route('game.player.detail', [$game->id, $player->id]) }}')">
+                            <div class="hidden md:grid grid-cols-[40px_1fr_48px_56px_48px_48px_56px_56px] gap-1.5 items-center px-4 py-2.5 border-b border-border-default hover:bg-surface-700/30 transition-colors cursor-pointer {{ $isCalledUp ? 'opacity-60' : '' }}"
+                                 @click="$dispatch('show-player-detail', '{{ route('game.player.detail', [$game->id, $player->id]) }}')">
+                                <div class="flex justify-center">
                                     <x-position-badge :position="$player->position" size="sm" :tooltip="\App\Support\PositionMapper::toDisplayName($player->position)" class="cursor-help" />
                                 </div>
-                                <div class="flex items-center gap-2 min-w-0 cursor-pointer" @click="$dispatch('show-player-detail', '{{ route('game.player.detail', [$game->id, $player->id]) }}')">
+                                <div class="flex items-center gap-2 min-w-0">
                                     @if($player->nationality_flag)
                                         <img src="{{ Storage::disk('assets')->url('flags/' . $player->nationality_flag['code'] . '.svg') }}" class="w-4 h-3 rounded-xs shadow-xs shrink-0" title="{{ $player->nationality_flag['name'] }}">
                                     @endif
                                     <span class="text-sm font-medium text-text-primary truncate">{{ $player->player->name }}</span>
-                                    <x-origin-badge :player="$player" />
+                                    <x-origin-badge :player="$player" :current-season="$game->season" />
                                     @if($isCalledUp)
                                         <span class="text-[10px] font-semibold bg-accent-blue/10 text-accent-blue px-1.5 py-0.5 rounded-full">{{ __('squad.called_up_indicator') }}</span>
                                     @endif
                                 </div>
                                 <span class="text-xs text-text-secondary text-center tabular-nums">{{ $age }}</span>
+                                <span class="text-[11px] text-center tabular-nums @if($player->isContractExpiring($game->getSeasonEndDate())) text-accent-red font-medium @else text-text-muted @endif">
+                                    {{ $player->contract_expiry_year ?? '—' }}
+                                </span>
                                 <div class="flex justify-center">
                                     <span class="text-xs font-medium tabular-nums @if($player->current_technical_ability >= 80) text-accent-green @elseif($player->current_technical_ability >= 70) text-lime-500 @elseif($player->current_technical_ability >= 60) text-text-body @else text-text-secondary @endif">{{ $player->current_technical_ability }}</span>
                                 </div>
@@ -165,23 +164,6 @@
                                 <span class="text-xs text-center tabular-nums text-text-muted">{{ $player->potential_range }}</span>
                                 <div class="flex justify-center">
                                     <x-rating-badge :value="$player->overall_score" size="sm" />
-                                </div>
-                                <div class="flex justify-end">
-                                    @if($isCalledUp)
-                                        <form method="POST" action="{{ route('game.reserve.send-back', [$game->id, $player->id]) }}" onsubmit="return confirm('{{ __('squad.send_back_to_reserve') }}?')">
-                                            @csrf
-                                            <x-ghost-button color="slate" size="xs" type="submit" title="{{ __('squad.send_back_to_reserve') }}">
-                                                ↓ {{ __('squad.send_back') }}
-                                            </x-ghost-button>
-                                        </form>
-                                    @else
-                                        <form method="POST" action="{{ route('game.reserve.call-up', [$game->id, $player->id]) }}" onsubmit="return confirm('{{ __('squad.call_up_to_first_team') }}?')">
-                                            @csrf
-                                            <x-ghost-button color="green" size="xs" type="submit" title="{{ __('squad.call_up_to_first_team') }}">
-                                                ↑ {{ __('squad.call_up') }}
-                                            </x-ghost-button>
-                                        </form>
-                                    @endif
                                 </div>
                             </div>
                         @endforeach
@@ -193,4 +175,5 @@
     </div>
 
     <x-player-detail-modal />
+    <x-negotiation-chat-modal />
 </x-app-layout>

--- a/resources/views/squad.blade.php
+++ b/resources/views/squad.blade.php
@@ -55,9 +55,12 @@
             {{-- Sub-navigation --}}
             @if($isCareerMode)
                 @php
+                    $secondaryItem = $game->isFilial()
+                        ? ['href' => route('game.squad.reserve', $game->id), 'label' => __('squad.reserve_team'), 'active' => false]
+                        : ['href' => route('game.squad.academy', $game->id), 'label' => __('squad.academy'), 'active' => false];
                     $squadNavItems = [
                         ['href' => route('game.squad', $game->id), 'label' => __('squad.first_team'), 'active' => true],
-                        ['href' => route('game.squad.academy', $game->id), 'label' => __('squad.academy'), 'active' => false],
+                        $secondaryItem,
                         ['href' => route('game.squad.registration', $game->id), 'label' => __('squad.registration'), 'active' => false],
                     ];
                 @endphp

--- a/resources/views/squad.blade.php
+++ b/resources/views/squad.blade.php
@@ -272,6 +272,7 @@
                                             <div class="flex-1 min-w-0">
                                                 <div class="flex items-center gap-1.5">
                                                     <span class="text-sm font-medium text-text-primary truncate">{{ $gp->player->name }}</span>
+                                                    <x-origin-badge :player="$gp" />
                                                     @include('partials.squad.player-status-icon', ['gp' => $gp, 'game' => $game, 'seasonEndDate' => $seasonEndDate, 'playerFlags' => $playerFlags ?? []])
                                                     <x-player-unavailable-icon :player="$gp" :reason="$unavailReason" />
                                                 </div>
@@ -343,6 +344,7 @@
                                             <div class="min-w-0">
                                                 <div class="flex items-center gap-2">
                                                     <span class="text-sm font-medium text-text-primary truncate">{{ $gp->player->name }}</span>
+                                                    <x-origin-badge :player="$gp" />
                                                     @include('partials.squad.player-status-icon', ['gp' => $gp, 'game' => $game, 'seasonEndDate' => $seasonEndDate, 'playerFlags' => $playerFlags ?? []])
                                                     <x-player-unavailable-icon :player="$gp" :reason="$unavailReason" />
                                                 </div>

--- a/resources/views/squad.blade.php
+++ b/resources/views/squad.blade.php
@@ -272,7 +272,7 @@
                                             <div class="flex-1 min-w-0">
                                                 <div class="flex items-center gap-1.5">
                                                     <span class="text-sm font-medium text-text-primary truncate">{{ $gp->player->name }}</span>
-                                                    <x-origin-badge :player="$gp" />
+                                                    <x-origin-badge :player="$gp" :current-season="$game->season" />
                                                     @include('partials.squad.player-status-icon', ['gp' => $gp, 'game' => $game, 'seasonEndDate' => $seasonEndDate, 'playerFlags' => $playerFlags ?? []])
                                                     <x-player-unavailable-icon :player="$gp" :reason="$unavailReason" />
                                                 </div>
@@ -344,7 +344,7 @@
                                             <div class="min-w-0">
                                                 <div class="flex items-center gap-2">
                                                     <span class="text-sm font-medium text-text-primary truncate">{{ $gp->player->name }}</span>
-                                                    <x-origin-badge :player="$gp" />
+                                                    <x-origin-badge :player="$gp" :current-season="$game->season" />
                                                     @include('partials.squad.player-status-icon', ['gp' => $gp, 'game' => $game, 'seasonEndDate' => $seasonEndDate, 'playerFlags' => $playerFlags ?? []])
                                                     <x-player-unavailable-icon :player="$gp" :reason="$unavailReason" />
                                                 </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -125,6 +125,9 @@ use App\Http\Views\ShowTournamentLeaderboard;
 use App\Http\Views\ShowTournamentSummary;
 use App\Http\Actions\ProcessTacticalActions;
 use App\Http\Actions\PromoteAcademyPlayer;
+use App\Http\Actions\CallUpReservePlayer;
+use App\Http\Actions\SendBackReservePlayer;
+use App\Http\Views\ShowReserveTeam;
 use App\Http\Actions\SkipMatchToEnd;
 use App\Http\Actions\StartNewSeason;
 use Illuminate\Support\Facades\Route;
@@ -167,6 +170,10 @@ Route::middleware('auth')->group(function () {
         Route::post('/game/{gameId}/academy/{playerId}/promote', PromoteAcademyPlayer::class)->name('game.academy.promote');
         Route::post('/game/{gameId}/academy/{playerId}/loan', LoanAcademyPlayer::class)->name('game.academy.loan');
         Route::post('/game/{gameId}/academy/{playerId}/dismiss', DismissAcademyPlayer::class)->name('game.academy.dismiss');
+        // Reserve team (filial games)
+        Route::get('/game/{gameId}/squad/reserve', ShowReserveTeam::class)->name('game.squad.reserve');
+        Route::post('/game/{gameId}/reserve/{playerId}/call-up', CallUpReservePlayer::class)->name('game.reserve.call-up');
+        Route::post('/game/{gameId}/reserve/{playerId}/send-back', SendBackReservePlayer::class)->name('game.reserve.send-back');
         // Club hub — Finances, Stadium, Reputation (and future non-sporting tenants)
         Route::get('/game/{gameId}/club', fn (string $gameId) => redirect()->route('game.club.finances', $gameId))->name('game.club');
         Route::get('/game/{gameId}/club/finances', ShowFinances::class)->name('game.club.finances');


### PR DESCRIPTION
Spanish parent clubs (Real Madrid, Barcelona, Athletic, etc.) now manage their reserve team in place of the Academy tab. Reserve players belong to the reserve squad and the first team calls them up via internal Loans (parent=reserve, loan=first team); ending the loan sends them back. At season close, players who age past 23 are permanently promoted via a new GameTransfer type INTERNAL_PROMOTION.

Academy generation for these clubs creates GamePlayers directly on the reserve team (no AcademyPlayer rows). Other clubs keep the existing Academy flow untouched.

Reserve-team players are excluded from scouting, AI transfer listings, and shortlist actions so they can't be acquired through normal channels.

Phase 2 (reserve-league standings, fixtures, and lazy match resolution) is intentionally deferred — this commit ships the squad-management slice on its own.