### PR TITLE
Force FinalVenueResolver injection in CupDrawService

### DIFF
--- a/app/Modules/Competition/Services/CupDrawService.php
+++ b/app/Modules/Competition/Services/CupDrawService.php
@@ -20,7 +20,7 @@ class CupDrawService
 {
     public function __construct(
         private readonly CountryConfig $countryConfig,
-        private readonly ?FinalVenueResolver $finalVenueResolver = null,
+        private readonly FinalVenueResolver $finalVenueResolver,
     ) {}
 
     /**
@@ -142,9 +142,6 @@ class CupDrawService
             }
         }
 
-        // Single-round cups draw their final directly in conductDraw; multi-round
-        // cups rely on CupCompetitionHandler::createTie to set the venue when
-        // the final is drawn later. Keep these two paths symmetric.
         $this->maybeAssignFinalVenues($gameId, $roundConfig, $firstLegRows);
 
         // Return loaded ties
@@ -162,7 +159,7 @@ class CupDrawService
      */
     private function maybeAssignFinalVenues(string $gameId, PlayoffRoundConfig $roundConfig, array $firstLegRows): void
     {
-        if (!$this->finalVenueResolver || $roundConfig->name !== 'cup.final') {
+        if ($roundConfig->name !== 'cup.final') {
             return;
         }
 


### PR DESCRIPTION
Declared as `?FinalVenueResolver = null`, the container treated the default as a signal to skip resolving the class, so the dep was always null in production. maybeAssignFinalVenues short-circuited at its first guard and Copa del Rey finals were saved without `neutral_venue_name`, defeating the La Cartuja rule. Other handlers (Swiss, group-stage) declare the same dep as non-nullable and were unaffected — only the ESPCUP path went through this constructor.

Make the dep required to match the other handlers, and drop the now- dead null guard.