### PR TITLE
Fix Swiss R16 error reporting calling count() on raw arrays

### DIFF
--- a/app/Modules/Competition/Services/SwissKnockoutGenerator.php
+++ b/app/Modules/Competition/Services/SwissKnockoutGenerator.php
@@ -163,7 +163,7 @@ class SwissKnockoutGenerator
         }
 
         if (count($matchups) !== 8) {
-            $distribution = collect($bracketWinners)->map->count()->all();
+            $distribution = array_map('count', $bracketWinners);
             throw new \RuntimeException(
                 "R16 generation failed: expected 8 matchups, got " . count($matchups)
                 . ". Completed playoff ties: " . $playoffTies->count()


### PR DESCRIPTION
The diagnostic distribution map was using a higher-order collection proxy
(->map->count()) on $bracketWinners, which holds plain PHP arrays of
winner IDs rather than Collections. That caused the diagnostic itself to
throw "Call to a member function count() on array" and mask the real
"expected 8 matchups" RuntimeException.

https://claude.ai/code/session_01WN4hmjEQEVSwHtvufVpJ4U