### PR TITLE
Show just-played competition's standings/bracket in fast mode

### DIFF
--- a/app/Http/Views/ShowFastMode.php
+++ b/app/Http/Views/ShowFastMode.php
@@ -5,6 +5,7 @@ namespace App\Http\Views;
 use App\Modules\Competition\Services\CompetitionViewService;
 use App\Modules\Match\Services\FastModeService;
 use App\Modules\Match\Services\MatchdayService;
+use App\Models\Competition;
 use App\Models\Game;
 use App\Models\GameMatch;
 
@@ -59,15 +60,22 @@ class ShowFastMode
                 : redirect()->route('game.season-end', $gameId);
         }
 
-        $leagueStandings = $this->competitionViewService->getAbridgedLeagueStandings($game);
-        $playerStanding = $leagueStandings->firstWhere('team_id', $game->team_id);
+        // Focus the standings panel on the competition just played; fall
+        // back to the primary league when there's no last match yet.
+        $focalCompetition = $lastMatch?->competition ?? $game->competition;
+        $panelData = $this->buildPanelData($game, $focalCompetition, $lastMatch);
 
         return view('fast-mode', [
             'game' => $game,
             'lastMatch' => $lastMatch,
             'nextMatch' => $nextMatch,
-            'leagueStandings' => $leagueStandings,
-            'playerStanding' => $playerStanding,
+            'focalCompetition' => $focalCompetition,
+            'displayMode' => $panelData['displayMode'],
+            'standings' => $panelData['standings'],
+            'playerStanding' => $panelData['standings']?->firstWhere('team_id', $game->team_id),
+            'rounds' => $panelData['rounds'],
+            'tiesByRound' => $panelData['tiesByRound'],
+            'currentRoundNumber' => $panelData['currentRoundNumber'],
             'pendingAction' => $game->getFirstPendingAction(),
         ]);
     }
@@ -81,5 +89,47 @@ class ShowFastMode
         }
 
         return $match;
+    }
+
+    /**
+     * Prepare standings or condensed-bracket data for the focal competition.
+     * Bracket view triggers when the just-played match was a knockout tie
+     * (covers knockout_cup competitions and the knockout phase of swiss_format
+     * / group_stage_cup / league_with_playoff). Otherwise show abridged
+     * standings.
+     */
+    private function buildPanelData(Game $game, Competition $competition, ?GameMatch $lastMatch): array
+    {
+        $playedKnockoutTie = $lastMatch?->isCupMatch() === true;
+        $isPureKnockout = $competition->handler_type === 'knockout_cup';
+
+        if ($playedKnockoutTie || $isPureKnockout) {
+            $rounds = $this->competitionViewService->getKnockoutRounds($competition, $game->season);
+            $tiesByRound = $this->competitionViewService->getKnockoutTies($game, $competition);
+            $playerTie = $this->competitionViewService->findPlayerTie($rounds, $tiesByRound, $game->team_id);
+
+            // Anchor on the player's most recent tie when available; else
+            // the lowest round_number that already has any ties drawn; else
+            // the first round (draw still pending everywhere).
+            $currentRoundNumber = $playerTie?->round_number
+                ?? $rounds->first(fn ($r) => $tiesByRound->has($r->round))?->round
+                ?? $rounds->first()?->round;
+
+            return [
+                'displayMode' => 'bracket',
+                'standings' => null,
+                'rounds' => $rounds,
+                'tiesByRound' => $tiesByRound,
+                'currentRoundNumber' => $currentRoundNumber,
+            ];
+        }
+
+        return [
+            'displayMode' => 'standings',
+            'standings' => $this->competitionViewService->getAbridgedStandings($game, $competition),
+            'rounds' => null,
+            'tiesByRound' => null,
+            'currentRoundNumber' => null,
+        ];
     }
 }

--- a/app/Http/Views/ShowFastMode.php
+++ b/app/Http/Views/ShowFastMode.php
@@ -106,14 +106,19 @@ class ShowFastMode
         if ($playedKnockoutTie || $isPureKnockout) {
             $rounds = $this->competitionViewService->getKnockoutRounds($competition, $game->season);
             $tiesByRound = $this->competitionViewService->getKnockoutTies($game, $competition);
-            $playerTie = $this->competitionViewService->findPlayerTie($rounds, $tiesByRound, $game->team_id);
 
-            // Anchor on the player's most recent tie when available; else
-            // the lowest round_number that already has any ties drawn; else
-            // the first round (draw still pending everywhere).
-            $currentRoundNumber = $playerTie?->round_number
-                ?? $rounds->first(fn ($r) => $tiesByRound->has($r->round))?->round
-                ?? $rounds->first()?->round;
+            // Anchor on the round of the just-played match when available.
+            // findPlayerTie() returns the player's *latest* tie in the
+            // competition, which is already the next round if the draw for
+            // it has happened — that would skip the round just played.
+            if ($playedKnockoutTie) {
+                $currentRoundNumber = $lastMatch->round_number;
+            } else {
+                $playerTie = $this->competitionViewService->findPlayerTie($rounds, $tiesByRound, $game->team_id);
+                $currentRoundNumber = $playerTie?->round_number
+                    ?? $rounds->first(fn ($r) => $tiesByRound->has($r->round))?->round
+                    ?? $rounds->first()?->round;
+            }
 
             return [
                 'displayMode' => 'bracket',

--- a/app/Modules/Competition/Services/CompetitionViewService.php
+++ b/app/Modules/Competition/Services/CompetitionViewService.php
@@ -27,23 +27,43 @@ class CompetitionViewService
     /**
      * Standings for the user's primary competition, abridged for dashboard
      * widgets: top 3 plus a 5-team window centered on the player's position.
-     * For tournament mode, returns the player's full group instead.
+     * For tournament mode, returns the player's full table (group or flat)
+     * instead of abridging.
      */
     public function getAbridgedLeagueStandings(Game $game): Collection
     {
+        if ($game->isTournamentMode()) {
+            $standings = $this->getStandings($game, $game->competition);
+            $playerGroup = $standings->firstWhere('team_id', $game->team_id)?->group_label;
+
+            return $playerGroup
+                ? $standings->where('group_label', $playerGroup)->values()
+                : $standings;
+        }
+
+        return $this->getAbridgedStandings($game, $game->competition);
+    }
+
+    /**
+     * Abridged standings for any competition the player participates in.
+     * Returns the player's group when standings are grouped (e.g.
+     * group-stage cups); otherwise top 3 + a 5-team window centered on the
+     * player. When the player isn't in this competition, the window centers
+     * on position 1.
+     */
+    public function getAbridgedStandings(Game $game, Competition $competition): Collection
+    {
+        $playerGroupLabel = GameStanding::where('game_id', $game->id)
+            ->where('competition_id', $competition->id)
+            ->where('team_id', $game->team_id)
+            ->value('group_label');
+
         $query = GameStanding::with('team')
             ->where('game_id', $game->id)
-            ->where('competition_id', $game->competition_id);
+            ->where('competition_id', $competition->id);
 
-        if ($game->isTournamentMode()) {
-            $playerGroupLabel = GameStanding::where('game_id', $game->id)
-                ->where('competition_id', $game->competition_id)
-                ->where('team_id', $game->team_id)
-                ->value('group_label');
-
-            if ($playerGroupLabel) {
-                $query->where('group_label', $playerGroupLabel);
-            }
+        if ($playerGroupLabel) {
+            $query->where('group_label', $playerGroupLabel);
         }
 
         $standings = $query->orderBy('position')->get();
@@ -52,7 +72,9 @@ class CompetitionViewService
             return collect();
         }
 
-        if ($game->isTournamentMode()) {
+        // Grouped standings (e.g. World Cup group, or any future grouped
+        // format): show the player's full group rather than abridging.
+        if ($playerGroupLabel) {
             return $standings;
         }
 

--- a/resources/views/fast-mode.blade.php
+++ b/resources/views/fast-mode.blade.php
@@ -2,8 +2,13 @@
     /** @var App\Models\Game $game */
     /** @var App\Models\GameMatch|null $lastMatch */
     /** @var App\Models\GameMatch|null $nextMatch */
-    /** @var \Illuminate\Support\Collection $leagueStandings */
+    /** @var App\Models\Competition $focalCompetition */
+    /** @var string $displayMode */
+    /** @var \Illuminate\Support\Collection|null $standings */
     /** @var App\Models\GameStanding|null $playerStanding */
+    /** @var \Illuminate\Support\Collection|null $rounds */
+    /** @var \Illuminate\Support\Collection|null $tiesByRound */
+    /** @var int|null $currentRoundNumber */
 
     // Last-result summary
     $lastResultLabel = null;
@@ -76,9 +81,25 @@
         );
     }
 
-    $standingsTitle = ($game->isTournamentMode() && $leagueStandings->first()?->group_label)
-        ? __('game.group') . ' ' . $leagueStandings->first()->group_label
-        : __('game.standings');
+    // Title: when the focal competition isn't the player's primary league,
+    // show its name (e.g. "Champions League") so the panel reads in context
+    // with the result above. For grouped standings, append the group label.
+    $isPrimary = $focalCompetition->id === $game->competition_id;
+    if ($displayMode === 'standings' && $standings && $standings->first()?->group_label) {
+        $standingsTitle = $focalCompetition->shortName() . ' · ' . __('game.group') . ' ' . $standings->first()->group_label;
+    } elseif ($isPrimary) {
+        $standingsTitle = __('game.standings');
+    } else {
+        $standingsTitle = $focalCompetition->shortName();
+    }
+
+    // Condensed bracket: the round just played plus the next one.
+    $bracketRounds = collect();
+    if ($displayMode === 'bracket' && $rounds && $currentRoundNumber !== null) {
+        $bracketRounds = $rounds
+            ->filter(fn ($r) => $r->round === $currentRoundNumber || $r->round === $currentRoundNumber + 1)
+            ->values();
+    }
 @endphp
 
 <x-app-layout :hide-footer="true">
@@ -186,21 +207,21 @@
                 </div>
             @endif
 
-            {{-- Compact standings — position / crest / name / GD / Pts.
-                 Drops W/D/L columns and column headers versus the dashboard
-                 sidebar so the block stays light; the "Full table" link
-                 leads to the full view for deeper inspection. --}}
-            @if($leagueStandings->isNotEmpty())
+            {{-- Standings or condensed bracket for the just-played competition.
+                 Standings: top 3 + 5-team window centered on the player (or
+                 full group for grouped formats). Bracket: the round just
+                 played and the next round. --}}
+            @if($displayMode === 'standings' && $standings && $standings->isNotEmpty())
                 <x-section-card :title="$standingsTitle">
                     <x-slot name="badge">
-                        <a href="{{ route('game.competition', [$game->id, $game->competition_id]) }}" class="text-[10px] text-accent-blue hover:text-blue-400 transition-colors">
+                        <a href="{{ route('game.competition', [$game->id, $focalCompetition->id]) }}" class="text-[10px] text-accent-blue hover:text-blue-400 transition-colors">
                             {{ __('game.full_table') }} &rarr;
                         </a>
                     </x-slot>
 
                     <div class="divide-y divide-border-default">
                         @php $prevPosition = 0; @endphp
-                        @foreach($leagueStandings as $standing)
+                        @foreach($standings as $standing)
                             @if($standing->position > $prevPosition + 1)
                                 <div class="px-4 py-0.5 text-center text-text-faint text-[10px]">&middot;&middot;&middot;</div>
                             @endif
@@ -216,6 +237,45 @@
                             </div>
                             @php $prevPosition = $standing->position; @endphp
                         @endforeach
+                    </div>
+                </x-section-card>
+            @elseif($displayMode === 'bracket' && $bracketRounds->isNotEmpty())
+                <x-section-card :title="$standingsTitle">
+                    <x-slot name="badge">
+                        <a href="{{ route('game.competition', [$game->id, $focalCompetition->id]) }}" class="text-[10px] text-accent-blue hover:text-blue-400 transition-colors">
+                            {{ __('cup.bracket') }} &rarr;
+                        </a>
+                    </x-slot>
+
+                    <div class="overflow-x-auto p-3 md:p-4">
+                        <div class="flex gap-3 md:gap-4" style="min-width: fit-content;">
+                            @foreach($bracketRounds as $round)
+                                @php $ties = $tiesByRound->get($round->round, collect()); @endphp
+                                <div class="shrink-0 w-60 md:w-64">
+                                    <div class="text-center mb-3">
+                                        <h4 class="font-heading text-xs font-semibold uppercase tracking-wide text-text-body">{{ __($round->name) }}</h4>
+                                        <div class="text-[10px] text-text-muted mt-0.5">
+                                            {{ $round->firstLegDate->format('d M') }}
+                                            @if($round->twoLegged)
+                                                / {{ $round->secondLegDate->format('d M') }}
+                                            @endif
+                                        </div>
+                                    </div>
+
+                                    @if($ties->isEmpty())
+                                        <div class="p-3 text-center border border-dashed border-border-strong rounded-lg">
+                                            <div class="text-text-muted text-xs">{{ __('cup.draw_pending') }}</div>
+                                        </div>
+                                    @else
+                                        <div class="space-y-2">
+                                            @foreach($ties as $tie)
+                                                <x-cup-tie-card :tie="$tie" :player-team-id="$game->team_id" />
+                                            @endforeach
+                                        </div>
+                                    @endif
+                                </div>
+                            @endforeach
+                        </div>
                     </div>
                 </x-section-card>
             @endif


### PR DESCRIPTION
The fast-mode dashboard always showed the player's primary league standings,
even when the last result was a non-league match. After playing a Champions
League matchday or a Copa del Rey tie, the standings panel was out of context
with the result above it.

The panel now follows the just-played match: abridged standings for league /
Swiss / group-stage formats, and a condensed bracket (current + next round)
for knockout ties. Falls back to the primary league when no last match exists.

Generalizes CompetitionViewService::getAbridgedLeagueStandings into a
getAbridgedStandings(Game, Competition) that any competition can use, and
reuses the existing x-cup-tie-card component for the bracket render.