### PR TITLE
Prevent selling players acquired in current transfer window

### DIFF
--- a/app/Http/Actions/AcceptTransferOffer.php
+++ b/app/Http/Actions/AcceptTransferOffer.php
@@ -33,6 +33,12 @@ class AcceptTransferOffer
             abort(403, 'Cannot accept offers for loaned players.');
         }
 
+        if ($offer->gamePlayer->joinedInCurrentWindow($game)) {
+            return redirect()->back()->with('error', __('messages.cannot_sell_same_window', [
+                'player' => $offer->gamePlayer->player->name,
+            ]));
+        }
+
         $playerName = $offer->gamePlayer->player->name;
         $team = $offer->offeringTeam;
         $fee = $offer->formatted_transfer_fee;

--- a/app/Http/Actions/ListPlayerForTransfer.php
+++ b/app/Http/Actions/ListPlayerForTransfer.php
@@ -26,6 +26,12 @@ class ListPlayerForTransfer
             abort(403, 'Cannot list a loaned player for transfer.');
         }
 
+        if ($player->joinedInCurrentWindow($game)) {
+            return redirect()->back()->with('error', __('messages.cannot_sell_same_window', [
+                'player' => $player->player->name,
+            ]));
+        }
+
         // List the player
         $this->transferService->listPlayer($player);
 

--- a/app/Models/GamePlayer.php
+++ b/app/Models/GamePlayer.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use App\Modules\Player\PlayerAge;
 use App\Modules\Player\Services\InjuryService;
+use App\Modules\Transfer\Enums\TransferWindowType;
 use App\Support\CountryCodeMapper;
 use App\Support\Money;
 use App\Support\PositionMapper;
@@ -334,6 +335,28 @@ class GamePlayer extends Model
         return Loan::where('game_player_id', $this->id)
             ->where('loan_team_id', $userTeamId)
             ->where('status', Loan::STATUS_ACTIVE)
+            ->exists();
+    }
+
+    /**
+     * True if the player joined their current team during the currently-open
+     * transfer window. Used to prevent flipping a player in the same window
+     * they were acquired.
+     */
+    public function joinedInCurrentWindow(?Game $game = null): bool
+    {
+        $game = $game ?? $this->game;
+
+        if (! $game?->current_date || ! $game->isTransferWindowOpen()) {
+            return false;
+        }
+
+        $currentWindow = TransferWindowType::currentValue($game->current_date);
+
+        return GameTransfer::where('game_player_id', $this->id)
+            ->where('to_team_id', $this->team_id)
+            ->where('window', $currentWindow)
+            ->where('season', $game->season)
             ->exists();
     }
 

--- a/lang/en/messages.php
+++ b/lang/en/messages.php
@@ -7,6 +7,7 @@ return [
     'bid_exceeds_budget' => 'The bid exceeds your transfer budget.',
     'player_listed' => ':player listed for sale. Offers may arrive after the next matchday.',
     'player_unlisted' => ':player removed from the transfer list.',
+    'cannot_sell_same_window' => 'Cannot sell :player — they joined your team in the current transfer window.',
     'offer_rejected' => ':team_de offer rejected.',
     'offer_accepted_sale' => ':player sold :team_a for :fee.',
     'offer_accepted_pre_contract' => 'Deal agreed! :player will sign for :team for :fee when the :window window opens.',

--- a/lang/es/messages.php
+++ b/lang/es/messages.php
@@ -7,6 +7,7 @@ return [
     'bid_exceeds_budget' => 'La oferta supera tu presupuesto de fichajes.',
     'player_listed' => ':player puesto a la venta. Las ofertas pueden llegar tras la próxima jornada.',
     'player_unlisted' => ':player retirado de la lista de fichajes.',
+    'cannot_sell_same_window' => 'No se puede vender a :player — se unió a tu equipo en la ventana de fichajes actual.',
     'offer_rejected' => 'Oferta :team_de rechazada.',
     'offer_accepted_sale' => ':player vendido :team_a por :fee.',
     'offer_accepted_pre_contract' => '¡Acuerdo cerrado! :player fichará por :team por :fee cuando abra la ventana de :window.',

--- a/resources/views/partials/player-detail.blade.php
+++ b/resources/views/partials/player-detail.blade.php
@@ -11,6 +11,7 @@
         && !$gamePlayer->hasPreContractAgreement()
         && !$gamePlayer->hasAgreedTransfer()
         && !$gamePlayer->hasActiveLoanSearch();
+    $canSell = $canManage && !$gamePlayer->joinedInCurrentWindow($game);
     $isTransferWindow = $isCareerMode && $game->isTransferWindowOpen();
     $showActions = $isCareerMode && ($isListed || $canManage);
 
@@ -207,7 +208,7 @@
 {{-- Actions --}}
 @if($showActions || $canRenew || $renewalNegotiation || $renewalCooldown)
     <div class="px-5 py-4 border-t border-border-default flex flex-wrap items-center gap-2">
-        @if(!$isListed && $canManage)
+        @if(!$isListed && $canSell)
             <form method="POST" action="{{ route('game.transfers.list', [$game->id, $gamePlayer->id]) }}">
                 @csrf
                 <x-action-button color="blue">


### PR DESCRIPTION
## Summary
Adds validation to prevent teams from selling players during the same transfer window in which they were acquired. This prevents "flipping" players for quick profit within a single window.

## Key Changes
- **GamePlayer model**: Added `joinedInCurrentWindow()` method to check if a player joined their current team during the currently-open transfer window
- **Transfer actions**: Added validation in `AcceptTransferOffer` and `ListPlayerForTransfer` to reject sales of players acquired in the current window
- **UI**: Updated player detail view to disable the "List for Transfer" button when a player was acquired in the current window
- **Localization**: Added error message in English and Spanish explaining the restriction

## Implementation Details
- The `joinedInCurrentWindow()` method queries `GameTransfer` records to verify if a player was transferred to their current team in the current season's active transfer window
- Uses `TransferWindowType::currentValue()` to determine the active window based on the game's current date
- Validation occurs at both the action level (preventing the operation) and UI level (disabling the button) for better UX
- The check is optional and can accept a `Game` parameter, defaulting to the player's associated game

https://claude.ai/code/session_01QUq9kadArcCS8Em2wyaBxg