### PR TITLE
Replace tournamentResultType with isFinal flag for champion detection

### DIFF
--- a/app/Http/Views/ShowLiveMatch.php
+++ b/app/Http/Views/ShowLiveMatch.php
@@ -185,6 +185,12 @@ class ShowLiveMatch
             }
         }
 
+        // Final detection works for both career and tournament modes: every cup
+        // schedule labels the title-deciding round 'cup.final'. The summary
+        // generator uses this to fire champion commentary regardless of how
+        // the final was decided (regular time, extra time, penalties).
+        $isFinal = $playerMatch->round_name === 'cup.final';
+
         // User's current instructions
         $prefix = $isUserHome ? 'home' : 'away';
         $userPlayingStyle = $playerMatch->{"{$prefix}_playing_style"} ?? 'balanced';
@@ -263,6 +269,7 @@ class ShowLiveMatch
             'isTournamentKnockout' => $isTournamentKnockout,
             'knockoutRoundNumber' => $knockoutRoundNumber,
             'knockoutRoundName' => $knockoutRoundName,
+            'isFinal' => $isFinal,
             'processingStatusUrl' => $game->isCareerMode()
                 ? route('game.setup-status', $game->id)
                 : null,

--- a/resources/js/live-match.js
+++ b/resources/js/live-match.js
@@ -123,6 +123,7 @@ export default function liveMatch(config) {
         isTournamentKnockout: config.isTournamentKnockout || false,
         knockoutRoundNumber: config.knockoutRoundNumber || null,
         knockoutRoundName: config.knockoutRoundName || '',
+        isFinal: config.isFinal || false,
 
         // Animation state (server-side flag to skip animation on page refresh)
         matchId: config.matchId || '',

--- a/resources/js/modules/atmosphere-glue.js
+++ b/resources/js/modules/atmosphere-glue.js
@@ -97,13 +97,13 @@ export function createAtmosphereGlue(ctx) {
                 isTwoLeggedTie: c.isTwoLeggedTie,
                 isSecondLeg: c.twoLeggedInfo !== null,
                 knockoutRoundNumber: c.knockoutRoundNumber,
+                isFinal: c.isFinal,
                 competitionRole: c.competitionRole,
                 competitionName: c.competitionName,
                 homeForm: c.homeForm,
                 awayForm: c.awayForm,
                 homePosition: c.homePosition,
                 awayPosition: c.awayPosition,
-                tournamentResultType: c.tournamentResultType,
             });
         },
     };

--- a/resources/js/modules/match-summary-generator.js
+++ b/resources/js/modules/match-summary-generator.js
@@ -162,11 +162,11 @@ export function generateMatchSummary(config) {
         isTwoLeggedTie,
         isSecondLeg,
         knockoutRoundNumber,
+        isFinal,
         competitionRole,
         competitionName,
         homeForm, awayForm,
         homePosition, awayPosition,
-        tournamentResultType,
     } = config;
 
     const homeForms = buildTeamForms(homeTeamName, homeArticle);
@@ -206,8 +206,10 @@ export function generateMatchSummary(config) {
     // A knockout match decides progression (single-leg tie, or second leg of
     // a two-legged tie). First legs and Swiss league-phase matches don't.
     const isKnockoutDecisive = !!isKnockout && (!isTwoLeggedTie || !!isSecondLeg);
-    const isHighStakes = isKnockoutDecisive && knockoutRoundNumber && knockoutRoundNumber >= 5;
-    const isChampion = tournamentResultType === 'champion';
+    // High-stakes "advance" wording is reserved for non-final knockout rounds
+    // where progression is the actual outcome. Finals crown a champion, so we
+    // exclude them here and route them to the champion opening below.
+    const isHighStakes = isKnockoutDecisive && knockoutRoundNumber && knockoutRoundNumber >= 5 && !isFinal;
 
     const hatTrick = detectHatTrick(allEvents);
     const lastMinuteGoal = detectLastMinuteGoal(allEvents, homeTeamId);
@@ -259,7 +261,7 @@ export function generateMatchSummary(config) {
 
     sentences.push(buildOpening(t, replacements, {
         isDraw, isGoalless, isBlowout, isNarrowWin,
-        isKnockoutDecisive, isHighStakes, isChampion,
+        isKnockoutDecisive, isHighStakes, isFinal,
         hasExtraTime, penaltyResult,
         winnerId, homeTeamId,
     }));
@@ -325,10 +327,18 @@ export function generateMatchSummary(config) {
 function buildOpening(t, replacements, ctx) {
     const {
         isDraw, isGoalless, isBlowout, isNarrowWin,
-        isKnockoutDecisive, isHighStakes, isChampion,
+        isKnockoutDecisive, isHighStakes, isFinal,
         hasExtraTime, penaltyResult,
         winnerId, homeTeamId,
     } = ctx;
+
+    // Crowning a champion is the headline of a final regardless of how it
+    // was decided (regular time, extra time, penalties), so this check runs
+    // before the penalty/ET openings. The :winner placeholder resolves to
+    // whichever side actually lifted the trophy.
+    if (isFinal && winnerId && t.summaryOpeningHighStakesChampion) {
+        return pickTemplate(t.summaryOpeningHighStakesChampion, replacements);
+    }
 
     if (penaltyResult) {
         return pickTemplate(t.summaryOpeningPenalties, replacements);
@@ -336,10 +346,6 @@ function buildOpening(t, replacements, ctx) {
 
     if (hasExtraTime && winnerId) {
         return pickTemplate(t.summaryOpeningExtraTime, replacements);
-    }
-
-    if (isChampion && t.summaryOpeningHighStakesChampion) {
-        return pickTemplate(t.summaryOpeningHighStakesChampion, replacements);
     }
 
     if (isHighStakes && winnerId && t.summaryOpeningHighStakesWin) {

--- a/resources/views/live-match.blade.php
+++ b/resources/views/live-match.blade.php
@@ -63,6 +63,7 @@
                 isTournamentKnockout: {{ $isTournamentKnockout ? 'true' : 'false' }},
                 knockoutRoundNumber: {{ $knockoutRoundNumber ?? 'null' }},
                 knockoutRoundName: '{{ $knockoutRoundName ?? '' }}',
+                isFinal: {{ $isFinal ? 'true' : 'false' }},
                 processingStatusUrl: {!! $processingStatusUrl ? "'" . $processingStatusUrl . "'" : 'null' !!},
                 homePossession: {{ $homePossession }},
                 awayPossession: {{ $awayPossession }},


### PR DESCRIPTION
## Summary
Refactored the match summary generator to use a dedicated `isFinal` boolean flag instead of the `tournamentResultType` string for detecting championship matches. This simplifies champion commentary logic and ensures finals are properly recognized regardless of how they're decided (regular time, extra time, or penalties).

## Key Changes
- **Replaced `tournamentResultType` with `isFinal`**: Removed the string-based tournament result type check and introduced a cleaner boolean flag that explicitly indicates whether a match is a final
- **Improved final detection logic**: Finals are now detected server-side by checking if `round_name === 'cup.final'`, which works consistently across both career and tournament modes
- **Reordered opening sentence logic**: Moved the final/champion check before penalty and extra-time checks in `buildOpening()`, ensuring champion commentary takes priority as the headline regardless of match circumstances
- **Updated high-stakes logic**: Modified `isHighStakes` calculation to exclude finals (`!isFinal`), reserving "advance" wording for non-final knockout rounds where progression is the actual outcome
- **Propagated flag through layers**: Added `isFinal` parameter through the entire call chain: view → controller → JavaScript config → atmosphere glue → match summary generator

## Implementation Details
- The `isFinal` flag is computed in `ShowLiveMatch.php` by checking the round name against the 'cup.final' label, making it a reliable server-side determination
- Champion commentary now fires for any final match with a winner, regardless of whether it went to extra time or penalties
- The change maintains backward compatibility while simplifying the conditional logic for determining when to use championship-specific opening sentences

https://claude.ai/code/session_01MHUYtQJ5qedr8NGFMGmHYd