### PR TITLE
Remove physical-ability factor from inter-match recovery

### DIFF
--- a/app/Modules/Player/Services/PlayerConditionService.php
+++ b/app/Modules/Player/Services/PlayerConditionService.php
@@ -115,7 +115,7 @@ class PlayerConditionService
      * - Weekly matches: full recovery to 100
      * - Congested periods (3 days): stabilize around 75-80 starting energy
      *
-     * Formula: recoveryRate = base × physicalMod × (1 + scaling × (100 − postMatchEnergy) / 100)
+     * Formula: recoveryRate = base × (1 + scaling × (100 − postMatchEnergy) / 100)
      */
     private function calculateFitnessChange(GamePlayer $player, bool $playedMatch, int $daysSinceLastMatch, Carbon $currentDate): int
     {
@@ -126,8 +126,6 @@ class PlayerConditionService
         $baseRecovery = $config['base_recovery_per_day'];
         $scaling = $config['recovery_scaling'];
         $maxRecoveryDays = $config['max_recovery_days'];
-        $physicalModifier = $this->getPhysicalRecoveryModifier($player, $config);
-        $effectiveBase = $baseRecovery * $physicalModifier;
 
         $recoveryDays = min($daysSinceLastMatch, $maxRecoveryDays);
 
@@ -156,14 +154,14 @@ class PlayerConditionService
             // After playing, the player is at low energy and recovers faster from there.
             // This correctly models: play match → drop to ~60% → recover over N days.
             $estimatedPostMatch = max(self::MIN_FITNESS, $currentFitness - $loss);
-            $recoveryRate = $effectiveBase * (1 + $scaling * (self::MAX_FITNESS - $estimatedPostMatch) / 100);
+            $recoveryRate = $baseRecovery * (1 + $scaling * (self::MAX_FITNESS - $estimatedPostMatch) / 100);
             $recovery = (int) round($recoveryRate * $recoveryDays);
 
             return $recovery - $loss;
         }
 
         // Non-playing players: recovery only, based on current fitness
-        $recoveryRate = $effectiveBase * (1 + $scaling * (self::MAX_FITNESS - $currentFitness) / 100);
+        $recoveryRate = $baseRecovery * (1 + $scaling * (self::MAX_FITNESS - $currentFitness) / 100);
         $recovery = (int) round($recoveryRate * $recoveryDays);
 
         return $recovery;
@@ -181,21 +179,6 @@ class PlayerConditionService
             $age <= PlayerAge::YOUNG_END => $ageMod['young'],
             $age < PlayerAge::MIN_RETIREMENT_OUTFIELD => $ageMod['prime'],
             default => $ageMod['veteran'],
-        };
-    }
-
-    /**
-     * Get physical ability modifier for recovery rate (fitter players recover faster).
-     */
-    private function getPhysicalRecoveryModifier(GamePlayer $player, array $config): float
-    {
-        $physical = $player->current_physical_ability;
-        $physMod = $config['physical_recovery_modifier'];
-
-        return match (true) {
-            $physical >= $physMod['high_threshold'] => $physMod['high'],
-            $physical >= $physMod['low_threshold'] => $physMod['medium'],
-            default => $physMod['low'],
         };
     }
 

--- a/config/player.php
+++ b/config/player.php
@@ -15,7 +15,7 @@ return [
     | A typical outfielder at fitness 100 ends a match at ~60 energy.
     |
     | Recovery formula:
-    |   recoveryRate = base × physicalMod × (1 + scaling × (100 − fitness) / 100)
+    |   recoveryRate = base × (1 + scaling × (100 − fitness) / 100)
     |
     | Weekly matches: stabilize around 88-92 starting energy (not full 100),
     | so even normal schedules reward rotation.
@@ -23,7 +23,8 @@ return [
     | forcing squad rotation for optimal performance.
     |
     | Age modifies energy loss per match (veterans lose more).
-    | Physical ability modifies both drain rate AND recovery speed.
+    | Physical ability modifies drain rate during the match only; recovery
+    | between matches is the same for all players.
     |
     */
     'condition' => [
@@ -35,14 +36,6 @@ return [
             'young' => 0.92,                    // <= YOUNG_END: less fatigue per match
             'prime' => 1.0,                     // YOUNG_END+1 to MIN_RETIREMENT_OUTFIELD-1: baseline
             'veteran' => 1.12,                  // >= MIN_RETIREMENT_OUTFIELD: noticeably more
-        ],
-
-        'physical_recovery_modifier' => [       // multiplier on base recovery rate
-            'high_threshold' => 80,
-            'low_threshold' => 60,
-            'high' => 1.05,                     // physical >= 80: faster recovery
-            'medium' => 1.0,                    // 60-79: baseline
-            'low' => 0.95,                      // < 60: slower recovery
         ],
 
         'ai_rotation_threshold' => 70,          // AI benches players below this energy

--- a/tests/Unit/PlayerConditionServiceTest.php
+++ b/tests/Unit/PlayerConditionServiceTest.php
@@ -197,21 +197,6 @@ class PlayerConditionServiceTest extends TestCase
     }
 
     // -------------------------------------------------------
-    // Physical ability modifiers
-    // -------------------------------------------------------
-
-    public function test_high_physical_players_recover_faster(): void
-    {
-        $highPhys = $this->createPlayer(['fitness' => 60, 'game_physical_ability' => 85]);
-        $lowPhys = $this->createPlayer(['fitness' => 60, 'game_physical_ability' => 50]);
-
-        $recoveryHigh = $this->calculateFitnessChange->invoke($this->service, $highPhys, false, 5, $this->currentDate);
-        $recoveryLow = $this->calculateFitnessChange->invoke($this->service, $lowPhys, false, 5, $this->currentDate);
-
-        $this->assertGreaterThan($recoveryLow, $recoveryHigh, 'High physical player should recover faster');
-    }
-
-    // -------------------------------------------------------
     // Proportional drain (unified energy model)
     // -------------------------------------------------------
 


### PR DESCRIPTION
Low-physical players were being penalized twice: once via slower per-minute
energy drain in EnergyCalculator (which is realistic and stays), and again
via a stepped recovery-rate multiplier between matches. The second penalty
made low-physical players feel sluggish to bounce back.

Drop the recovery multiplier so all players recover at the same per-day
rate; the existing nonlinear scaling already gives tired players a bigger
recovery boost. In-match drain is unchanged.