### PR TITLE
Allocate promotion slots through one shared walk over standings

### DIFF
--- a/app/Modules/Competition/Configs/LaLiga2Config.php
+++ b/app/Modules/Competition/Configs/LaLiga2Config.php
@@ -121,20 +121,28 @@ class LaLiga2Config implements CompetitionConfig, HasSeasonGoals
 
         $zones = [];
 
-        if ($rule && !empty($rule['direct_promotion_positions'])) {
+        // Zones reflect the *notional* (config-declared) positions a team
+        // would occupy for direct promotion / playoff qualification. The
+        // end-of-season allocator may shift the actual filling down when
+        // reserves cluster at the top, but the standings UI shows the
+        // pristine zone layout — that's what users expect to see.
+        $directCount = (int) ($rule['direct_count'] ?? 0);
+        $playoffCount = (int) ($rule['playoff_count'] ?? 0);
+
+        if ($rule && $directCount > 0) {
             $zones[] = [
-                'minPosition' => min($rule['direct_promotion_positions']),
-                'maxPosition' => max($rule['direct_promotion_positions']),
+                'minPosition' => 1,
+                'maxPosition' => $directCount,
                 'borderColor' => 'green-500',
                 'bgColor' => 'bg-green-500',
                 'label' => 'game.direct_promotion',
             ];
         }
 
-        if ($rule && !empty($rule['playoff_positions'])) {
+        if ($rule && $playoffCount > 0) {
             $zones[] = [
-                'minPosition' => min($rule['playoff_positions']),
-                'maxPosition' => max($rule['playoff_positions']),
+                'minPosition' => $directCount + 1,
+                'maxPosition' => $directCount + $playoffCount,
                 'borderColor' => 'green-300',
                 'bgColor' => 'bg-green-300',
                 'label' => 'game.promotion_playoff',

--- a/app/Modules/Competition/DTOs/PromotionSlotAllocation.php
+++ b/app/Modules/Competition/DTOs/PromotionSlotAllocation.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Modules\Competition\DTOs;
+
+/**
+ * Result of walking a competition's standings (or simulated season) once and
+ * assigning teams to direct-promotion and playoff-bracket slots.
+ *
+ * Both lists are guaranteed disjoint by construction (single sequential walk
+ * with reserve filtering) — the allocator hands the first $directCount eligible
+ * teams to direct promotion, then the next $playoffCount to the bracket. This
+ * is the invariant PromotionRelegationProcessor::validatePlan asserts.
+ *
+ * Each entry carries the team's standings position so callers can reason about
+ * seeding (bracket order) or display (notification text).
+ */
+final class PromotionSlotAllocation
+{
+    /**
+     * @param  array<int, array{teamId: string, position: int, teamName: string}>  $directPromotions
+     *   Ordered by standings position ascending — first entry is the highest finisher
+     *   among eligible teams.
+     * @param  array<int, array{teamId: string, position: int, teamName: string}>  $playoffQualifiers
+     *   Ordered by standings position ascending — bracket seeding follows this order
+     *   (index 0 is the highest seed).
+     */
+    public function __construct(
+        public readonly array $directPromotions,
+        public readonly array $playoffQualifiers,
+    ) {}
+
+    public function isEmpty(): bool
+    {
+        return $this->directPromotions === [] && $this->playoffQualifiers === [];
+    }
+}

--- a/app/Modules/Competition/Playoffs/ESP2PlayoffGenerator.php
+++ b/app/Modules/Competition/Playoffs/ESP2PlayoffGenerator.php
@@ -5,12 +5,11 @@ namespace App\Modules\Competition\Playoffs;
 use App\Modules\Competition\Contracts\PlayoffGenerator;
 use App\Modules\Competition\DTOs\PlayoffRoundConfig;
 use App\Modules\Competition\Enums\PlayoffState;
+use App\Modules\Competition\Promotions\PromotionSlotAllocator;
 use App\Modules\Competition\Services\LeagueFixtureGenerator;
-use App\Modules\Competition\Services\ReserveTeamFilter;
 use App\Models\Competition;
 use App\Models\CupTie;
 use App\Models\Game;
-use App\Models\GameStanding;
 
 /**
  * Playoff generator for a two-round promotion playoff (semifinal + final).
@@ -23,14 +22,22 @@ use App\Models\GameStanding;
  *
  * Originally built for Spanish Segunda División, but parameterized via constructor
  * to support any league with the same playoff format.
+ *
+ * Bracket seeding consults PromotionSlotAllocator so the seeded teams are
+ * guaranteed disjoint from the direct-promotion list. Without this, a reserve
+ * team holding a top-of-table position would push a direct-promotion claimant
+ * down into the bracket's range — and that team would end up both directly
+ * promoted (via standings) and the playoff winner (via the bracket they were
+ * mistakenly seeded into). See PromotionSlotAllocator's class doc for context.
  */
 class ESP2PlayoffGenerator implements PlayoffGenerator
 {
     public function __construct(
         private readonly string $competitionId,
-        private readonly array $qualifyingPositions = [3, 4, 5, 6],
-        private readonly array $directPromotionPositions = [1, 2],
+        private readonly int $directCount = 2,
+        private readonly int $playoffCount = 4,
         private readonly int $triggerMatchday = 42,
+        private readonly ?PromotionSlotAllocator $slotAllocator = null,
     ) {}
 
     public function getCompetitionId(): string
@@ -38,14 +45,23 @@ class ESP2PlayoffGenerator implements PlayoffGenerator
         return $this->competitionId;
     }
 
+    /**
+     * Notional qualifying positions, derived from the slot counts. Used by
+     * in-season UI/notification code (LeaguePlayoffProgressResolver) to show
+     * a user at, say, position 4 a "playoff" notification mid-season. The
+     * actual end-of-season seeding is computed by the allocator and may
+     * include later positions when reserve teams shift slots down.
+     */
     public function getQualifyingPositions(): array
     {
-        return $this->qualifyingPositions;
+        return $this->playoffCount > 0
+            ? range($this->directCount + 1, $this->directCount + $this->playoffCount)
+            : [];
     }
 
     public function getDirectPromotionPositions(): array
     {
-        return $this->directPromotionPositions;
+        return $this->directCount > 0 ? range(1, $this->directCount) : [];
     }
 
     public function getTriggerMatchday(): int
@@ -85,36 +101,33 @@ class ESP2PlayoffGenerator implements PlayoffGenerator
      * Semifinal matchups: highest seed vs lowest, 2nd vs 3rd.
      * Lower-seeded team hosts the first leg.
      *
-     * Reserve teams whose parent club is in the top division are excluded
-     * from playoffs. The next-placed eligible team slides into their spot.
+     * Bracket teams come from PromotionSlotAllocator, which walks standings
+     * once and assigns the first $directCount eligible teams to direct
+     * promotion before handing the next $playoffCount to the bracket. Reserve
+     * teams whose parent club is in the top division are filtered there, so
+     * this method doesn't re-apply the reserve filter.
      */
     private function generateSemifinalMatchups(Game $game): array
     {
-        $requiredCount = count($this->qualifyingPositions);
-        $filter = app(ReserveTeamFilter::class);
+        $allocation = $this->getAllocator()->allocate(
+            $game,
+            $this->competitionId,
+            $this->directCount,
+            $this->playoffCount,
+        );
 
-        // Fetch more standings than needed in case we need to skip reserve teams
-        $maxPosition = max($this->qualifyingPositions) + $requiredCount;
-        $standings = GameStanding::where('game_id', $game->id)
-            ->where('competition_id', $this->competitionId)
-            ->whereBetween('position', [min($this->qualifyingPositions), $maxPosition])
-            ->orderBy('position')
-            ->get();
+        $bracket = $allocation->playoffQualifiers;
 
-        // Filter out ineligible reserve teams
-        $topDivisionTeamIds = $filter->getTopDivisionTeamIds($game, $this->competitionId);
-        $eligible = $standings->filter(
-            fn ($s) => !$filter->isBlockedReserveTeam($s->team_id, $topDivisionTeamIds)
-        )->take($requiredCount);
-
-        if ($eligible->count() < $requiredCount) {
+        if (count($bracket) < $this->playoffCount) {
             throw new \RuntimeException(
-                "Not enough eligible teams for playoffs in {$this->competitionId}: " .
-                "need {$requiredCount}, found {$eligible->count()}"
+                "Not enough eligible teams for playoffs in {$this->competitionId}: "
+                . "need {$this->playoffCount}, found " . count($bracket)
+                . ' (after reserve filtering and direct promotions). Direct promotions '
+                . 'consumed ' . count($allocation->directPromotions) . ' slots.'
             );
         }
 
-        $teamIds = $eligible->pluck('team_id')->values()->toArray();
+        $teamIds = array_column($bracket, 'teamId');
 
         // Last vs first, second-to-last vs second
         return [
@@ -166,5 +179,10 @@ class ESP2PlayoffGenerator implements PlayoffGenerator
             ->exists();
 
         return $anyTieExists ? PlayoffState::InProgress : PlayoffState::NotStarted;
+    }
+
+    private function getAllocator(): PromotionSlotAllocator
+    {
+        return $this->slotAllocator ?? app(PromotionSlotAllocator::class);
     }
 }

--- a/app/Modules/Competition/Playoffs/PlayoffGeneratorFactory.php
+++ b/app/Modules/Competition/Playoffs/PlayoffGeneratorFactory.php
@@ -38,8 +38,8 @@ class PlayoffGeneratorFactory
 
                 $generator = new ($rule['playoff_generator'])(
                     competitionId: $targetCompetitionId,
-                    qualifyingPositions: $rule['playoff_positions'] ?? [],
-                    directPromotionPositions: $rule['direct_promotion_positions'],
+                    directCount: $rule['direct_count'],
+                    playoffCount: $rule['playoff_count'] ?? 0,
                     triggerMatchday: $triggerMatchday,
                 );
 

--- a/app/Modules/Competition/Playoffs/PrimeraRFEFPlayoffGenerator.php
+++ b/app/Modules/Competition/Playoffs/PrimeraRFEFPlayoffGenerator.php
@@ -56,8 +56,8 @@ class PrimeraRFEFPlayoffGenerator implements PlayoffGenerator
 
     public function __construct(
         private readonly string $competitionId = self::PLAYOFF_ID,
-        private readonly array $qualifyingPositions = [2, 3, 4, 5],
-        private readonly array $directPromotionPositions = [1],
+        private readonly int $directCount = 1,
+        private readonly int $playoffCount = 4,
         private readonly int $triggerMatchday = 38,
     ) {}
 
@@ -66,14 +66,23 @@ class PrimeraRFEFPlayoffGenerator implements PlayoffGenerator
         return $this->competitionId;
     }
 
+    /**
+     * Notional qualifying positions per group, derived from the slot counts.
+     * The actual bracket-eligibility logic in eligibleTopTeams() walks each
+     * group's standings sequentially and skips reserve teams; these positions
+     * are exposed only for in-season UI/notification code that highlights
+     * "you'd qualify for the playoff if the season ended now".
+     */
     public function getQualifyingPositions(): array
     {
-        return $this->qualifyingPositions;
+        return $this->playoffCount > 0
+            ? range($this->directCount + 1, $this->directCount + $this->playoffCount)
+            : [];
     }
 
     public function getDirectPromotionPositions(): array
     {
-        return $this->directPromotionPositions;
+        return $this->directCount > 0 ? range(1, $this->directCount) : [];
     }
 
     public function getTriggerMatchday(): int

--- a/app/Modules/Competition/Promotions/ConfigDrivenPromotionRule.php
+++ b/app/Modules/Competition/Promotions/ConfigDrivenPromotionRule.php
@@ -7,19 +7,25 @@ use App\Modules\Competition\Contracts\PromotionRelegationRule;
 use App\Modules\Competition\Enums\PlayoffState;
 use App\Modules\Competition\Exceptions\PlayoffInProgressException;
 use App\Modules\Competition\Services\ReserveTeamFilter;
+use App\Models\CompetitionEntry;
 use App\Models\CupTie;
 use App\Models\Game;
 use App\Models\GameStanding;
 use App\Models\SimulatedSeason;
 use App\Models\Team;
-use Illuminate\Support\Collection;
 
 /**
  * A config-driven promotion/relegation rule.
  *
- * Takes its parameters (divisions, positions, playoff generator) from
+ * Takes its parameters (divisions, slot counts, playoff generator) from
  * config/countries.php rather than hardcoding them. The actual promotion
  * and relegation logic is generic and works for any two-division pair.
+ *
+ * Slot allocation (which teams are direct promotions vs playoff seeds)
+ * is delegated to PromotionSlotAllocator so the bracket generator can
+ * consult the same allocation. This is what prevents a team from appearing
+ * in both lists when reserve filtering shifts the direct-promotion range
+ * down into the bracket's range.
  *
  * This rule branches on PlayoffState to avoid the historical "playoff loser
  * promoted" class of bug — the old implementation conflated "no playoff
@@ -28,20 +34,15 @@ use Illuminate\Support\Collection;
  */
 class ConfigDrivenPromotionRule implements PromotionRelegationRule
 {
-    /**
-     * Extra positions to check beyond the required count when skipping
-     * blocked reserve teams. Covers the unlikely case of multiple
-     * reserve teams clustered at the top of the standings.
-     */
-    private const RESERVE_TEAM_BUFFER = 3;
-
     public function __construct(
         private string $topDivision,
         private string $bottomDivision,
         private array $relegatedPositions,
-        private array $directPromotionPositions,
+        private int $directCount,
+        private int $playoffCount = 0,
         private ?PlayoffGenerator $playoffGenerator = null,
         private ?ReserveTeamFilter $reserveTeamFilter = null,
+        private ?PromotionSlotAllocator $slotAllocator = null,
     ) {}
 
     public function getTopDivision(): string
@@ -59,9 +60,17 @@ class ConfigDrivenPromotionRule implements PromotionRelegationRule
         return $this->relegatedPositions;
     }
 
+    /**
+     * Notional direct-promotion positions, derived from the slot count.
+     * Used by in-season UI/notification code (LeaguePlayoffProgressResolver,
+     * standings-zone coloring) to colour the table by zone. The actual
+     * end-of-season allocation can drift from these positions when reserve
+     * teams hold top-of-table slots — that drift is handled by the slot
+     * allocator, not here.
+     */
     public function getDirectPromotionPositions(): array
     {
-        return $this->directPromotionPositions;
+        return $this->directCount > 0 ? range(1, $this->directCount) : [];
     }
 
     public function getPlayoffGenerator(): ?PlayoffGenerator
@@ -75,12 +84,21 @@ class ConfigDrivenPromotionRule implements PromotionRelegationRule
             return [];
         }
 
-        $expectedCount = count($this->relegatedPositions);
-        $filter = $this->getFilter();
-        $topDivisionTeamIds = $filter->getTopDivisionTeamIds($game, $this->bottomDivision);
-        $this->assertTopDivisionPopulated($topDivisionTeamIds);
+        // Reserve-team filtering needs to know who's in the top division. An
+        // unpopulated top division silently disables the filter, which can
+        // promote a reserve team into the same division as its parent. Fail
+        // loudly upfront rather than producing a corrupt swap.
+        $this->assertTopDivisionPopulated($game);
 
-        $promoted = $this->getDirectPromotions($game, $filter, $topDivisionTeamIds);
+        $expectedCount = count($this->relegatedPositions);
+        $allocation = $this->getAllocator()->allocate(
+            $game,
+            $this->bottomDivision,
+            $this->directCount,
+            $this->playoffCount,
+        );
+
+        $promoted = $allocation->directPromotions;
 
         // With a playoff generator, branch on the playoff's lifecycle state.
         // Without one, direct promotions are all there is.
@@ -90,10 +108,7 @@ class ConfigDrivenPromotionRule implements PromotionRelegationRule
             $promoted = match ($state) {
                 PlayoffState::Completed => array_merge($promoted, [$this->requirePlayoffWinner($game)]),
                 PlayoffState::InProgress => throw PlayoffInProgressException::forCompetition($this->bottomDivision),
-                PlayoffState::NotStarted => array_merge(
-                    $promoted,
-                    $this->playoffStandIn($game, $promoted, $filter, $topDivisionTeamIds),
-                ),
+                PlayoffState::NotStarted => array_merge($promoted, $this->playoffStandIn($allocation)),
             };
         }
 
@@ -153,21 +168,28 @@ class ConfigDrivenPromotionRule implements PromotionRelegationRule
     }
 
     /**
-     * Reserve-team filtering depends on knowing who's currently in the top
-     * division. An empty list means either a config error (no mapping for
-     * this bottom division) or missing CompetitionEntry rows — in either
-     * case, proceeding would silently bypass the filter and could promote
-     * a reserve team whose parent is already in the top division. Fail loudly.
+     * Reserve filtering needs the top division's roster as a reference set —
+     * a team is "blocked" only if its parent club is currently in the top
+     * division. With an empty top-division roster, every reserve team would
+     * pass the filter, and one could end up promoted into its parent's
+     * division. Throwing here catches setup/config problems (missing
+     * CompetitionEntry rows for the top division) before they corrupt swaps.
      */
-    private function assertTopDivisionPopulated(Collection $topDivisionTeamIds): void
+    private function assertTopDivisionPopulated(Game $game): void
     {
-        if ($topDivisionTeamIds->isEmpty()) {
-            throw new \RuntimeException(
-                "Top division {$this->topDivision} has no CompetitionEntry rows for this game. "
-                . "Cannot resolve promotion from {$this->bottomDivision}: reserve-team filtering "
-                . 'requires the top division roster to be populated. This indicates a setup/config problem.'
-            );
+        $populated = CompetitionEntry::where('game_id', $game->id)
+            ->where('competition_id', $this->topDivision)
+            ->exists();
+
+        if ($populated) {
+            return;
         }
+
+        throw new \RuntimeException(
+            "Top division {$this->topDivision} has no CompetitionEntry rows for this game. "
+            . "Cannot resolve promotion from {$this->bottomDivision}: reserve-team filtering "
+            . 'requires the top division roster to be populated. This indicates a setup/config problem.'
+        );
     }
 
     /**
@@ -198,157 +220,18 @@ class ConfigDrivenPromotionRule implements PromotionRelegationRule
     }
 
     /**
-     * Get direct-promotion teams from the bottom division, preferring real
-     * standings and falling back to simulated. Reserve teams whose parent is
-     * in the top division are filtered out; the next eligible team slides in.
-     *
-     * @return array<array{teamId: string, position: int, teamName: string}>
-     */
-    private function getDirectPromotions(Game $game, ReserveTeamFilter $filter, Collection $topDivisionTeamIds): array
-    {
-        $requiredCount = count($this->directPromotionPositions);
-
-        // Real standings path.
-        $maxPosition = max($this->directPromotionPositions) + $requiredCount + self::RESERVE_TEAM_BUFFER;
-        $standings = GameStanding::where('game_id', $game->id)
-            ->where('competition_id', $this->bottomDivision)
-            ->whereBetween('position', [min($this->directPromotionPositions), $maxPosition])
-            ->with('team')
-            ->orderBy('position')
-            ->get();
-
-        if ($standings->isNotEmpty()) {
-            return $this->filterEligibleFromStandings($standings, $filter, $topDivisionTeamIds, $requiredCount);
-        }
-
-        // Simulated path — pull top N + buffer and filter.
-        return $this->filterEligibleFromSimulated(
-            $game,
-            range(1, $requiredCount + self::RESERVE_TEAM_BUFFER),
-            $filter,
-            $topDivisionTeamIds,
-            $requiredCount,
-        );
-    }
-
-    /**
      * Playoff is NotStarted — e.g. simulated non-player league that never ran
      * mid-season brackets. Stand in one team to keep the promoted count balanced:
-     * the next eligible position after the direct promotions.
+     * the highest-seeded entry from the allocator's playoff slots, which is
+     * guaranteed disjoint from the direct promotions.
      *
-     * @param array<array{teamId: string, position: int|string, teamName: string}> $alreadyPromoted
      * @return array<array{teamId: string, position: int|string, teamName: string}>
      */
-    private function playoffStandIn(Game $game, array $alreadyPromoted, ReserveTeamFilter $filter, Collection $topDivisionTeamIds): array
+    private function playoffStandIn(\App\Modules\Competition\DTOs\PromotionSlotAllocation $allocation): array
     {
-        $promotedIds = array_column($alreadyPromoted, 'teamId');
+        $first = $allocation->playoffQualifiers[0] ?? null;
 
-        $nextPosition = max($this->directPromotionPositions) + 1;
-        $maxPosition = $nextPosition + self::RESERVE_TEAM_BUFFER + 1;
-
-        // Real standings path.
-        $standings = GameStanding::where('game_id', $game->id)
-            ->where('competition_id', $this->bottomDivision)
-            ->whereBetween('position', [$nextPosition, $maxPosition])
-            ->with('team')
-            ->orderBy('position')
-            ->get();
-
-        if ($standings->isNotEmpty()) {
-            $teamIds = $standings->pluck('team_id')->all();
-            $parentMap = $filter->loadParentTeamIds($teamIds);
-
-            $eligible = $standings
-                ->filter(fn ($s) => !in_array($s->team_id, $promotedIds, true))
-                ->filter(fn ($s) => !$filter->isBlockedReserveTeam($s->team_id, $topDivisionTeamIds, $parentMap))
-                ->first();
-
-            if (!$eligible) {
-                return [];
-            }
-
-            return [[
-                'teamId' => $eligible->team_id,
-                'position' => $eligible->position,
-                'teamName' => $eligible->team->name ?? 'Unknown',
-            ]];
-        }
-
-        // Simulated path — take the next eligible position after the already-promoted set.
-        $simulated = $this->getSimulatedTeamsByPosition(
-            $game,
-            $this->bottomDivision,
-            range($nextPosition, $maxPosition),
-        );
-
-        $candidateIds = array_column($simulated, 'teamId');
-        $parentMap = $filter->loadParentTeamIds($candidateIds);
-
-        foreach ($simulated as $candidate) {
-            if (in_array($candidate['teamId'], $promotedIds, true)) {
-                continue;
-            }
-            if ($filter->isBlockedReserveTeam($candidate['teamId'], $topDivisionTeamIds, $parentMap)) {
-                continue;
-            }
-            return [$candidate];
-        }
-
-        return [];
-    }
-
-    /**
-     * Filter a collection of GameStanding rows through the reserve-team
-     * filter and return $requiredCount entries in standard shape.
-     *
-     * @param  \Illuminate\Support\Collection<int, GameStanding>  $standings
-     * @return array<array{teamId: string, position: int, teamName: string}>
-     */
-    private function filterEligibleFromStandings(Collection $standings, ReserveTeamFilter $filter, Collection $topDivisionTeamIds, int $requiredCount): array
-    {
-        $teamIds = $standings->pluck('team_id')->all();
-        $parentMap = $filter->loadParentTeamIds($teamIds);
-
-        $eligible = $standings->filter(
-            fn ($s) => !$filter->isBlockedReserveTeam($s->team_id, $topDivisionTeamIds, $parentMap)
-        )->take($requiredCount);
-
-        return $eligible->map(fn ($standing) => [
-            'teamId' => $standing->team_id,
-            'position' => $standing->position,
-            'teamName' => $standing->team->name ?? 'Unknown',
-        ])->values()->toArray();
-    }
-
-    /**
-     * Filter simulated standings through the reserve-team filter and return
-     * $requiredCount entries in standard shape.
-     *
-     * @param  int[]  $positions
-     * @return array<array{teamId: string, position: int, teamName: string}>
-     */
-    private function filterEligibleFromSimulated(Game $game, array $positions, ReserveTeamFilter $filter, Collection $topDivisionTeamIds, int $requiredCount): array
-    {
-        $candidates = $this->getSimulatedTeamsByPosition($game, $this->bottomDivision, $positions);
-        if (empty($candidates)) {
-            return [];
-        }
-
-        $candidateTeamIds = array_column($candidates, 'teamId');
-        $parentMap = $filter->loadParentTeamIds($candidateTeamIds);
-
-        $eligible = [];
-        foreach ($candidates as $candidate) {
-            if ($filter->isBlockedReserveTeam($candidate['teamId'], $topDivisionTeamIds, $parentMap)) {
-                continue;
-            }
-            $eligible[] = $candidate;
-            if (count($eligible) >= $requiredCount) {
-                break;
-            }
-        }
-
-        return $eligible;
+        return $first ? [$first] : [];
     }
 
     /**
@@ -437,8 +320,10 @@ class ConfigDrivenPromotionRule implements PromotionRelegationRule
         ];
     }
 
-    private function getFilter(): ReserveTeamFilter
+    private function getAllocator(): PromotionSlotAllocator
     {
-        return $this->reserveTeamFilter ?? app(ReserveTeamFilter::class);
+        return $this->slotAllocator ??= new PromotionSlotAllocator(
+            $this->reserveTeamFilter ?? app(ReserveTeamFilter::class),
+        );
     }
 }

--- a/app/Modules/Competition/Promotions/PromotionRelegationFactory.php
+++ b/app/Modules/Competition/Promotions/PromotionRelegationFactory.php
@@ -99,8 +99,8 @@ class PromotionRelegationFactory
 
                     $playoffGenerator = new ($promotion['playoff_generator'])(
                         competitionId: $competitionId,
-                        qualifyingPositions: $promotion['playoff_positions'] ?? [],
-                        directPromotionPositions: $promotion['direct_promotion_positions'],
+                        directCount: $promotion['direct_count'],
+                        playoffCount: $promotion['playoff_count'] ?? 0,
                         triggerMatchday: ($teamCount - 1) * 2,
                     );
                 }
@@ -109,7 +109,8 @@ class PromotionRelegationFactory
                     topDivision: $promotion['top_division'],
                     bottomDivision: $promotion['bottom_division'],
                     relegatedPositions: $promotion['relegated_positions'],
-                    directPromotionPositions: $promotion['direct_promotion_positions'],
+                    directCount: $promotion['direct_count'],
+                    playoffCount: $promotion['playoff_count'] ?? 0,
                     playoffGenerator: $playoffGenerator,
                     reserveTeamFilter: $this->reserveTeamFilter,
                 );

--- a/app/Modules/Competition/Promotions/PromotionSlotAllocator.php
+++ b/app/Modules/Competition/Promotions/PromotionSlotAllocator.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace App\Modules\Competition\Promotions;
+
+use App\Modules\Competition\DTOs\PromotionSlotAllocation;
+use App\Modules\Competition\Services\ReserveTeamFilter;
+use App\Models\Game;
+use App\Models\GameStanding;
+use App\Models\SimulatedSeason;
+use App\Models\Team;
+
+/**
+ * Single source of truth for assigning teams to a competition's
+ * direct-promotion and playoff-bracket slots.
+ *
+ * The historical bug this exists to prevent: ConfigDrivenPromotionRule and
+ * ESP2PlayoffGenerator each ran their own reserve-team filter against
+ * overlapping standings ranges. When a reserve team held a direct-promotion
+ * position, the direct list slid down into the bracket's range and the same
+ * team appeared in both — silently corrupting promotion at the array_merge.
+ *
+ * The allocator walks the standings exactly once in position order, skips
+ * blocked reserve teams, and hands out the first $directCount eligible teams
+ * to direct promotion and the next $playoffCount to the bracket. By
+ * construction, no team can appear in both lists.
+ *
+ * The order in $playoffQualifiers preserves standings ranking — bracket
+ * generators consume it as the seeding order (index 0 is the top seed).
+ */
+class PromotionSlotAllocator
+{
+    /**
+     * Extra standings rows to fetch beyond the slot total. Absorbs reserve
+     * clustering at the top of the table without paginating. Sized for the
+     * worst plausible Spanish case (Real Madrid Castilla, Sevilla Atlético,
+     * Atlético Madrileño, Bilbao Athletic… all in ESP2 simultaneously).
+     */
+    private const RESERVE_BUFFER = 10;
+
+    public function __construct(
+        private readonly ReserveTeamFilter $reserveFilter,
+    ) {}
+
+    /**
+     * @param  Game  $game  The game whose standings we're reading.
+     * @param  string  $bottomDivision  Competition ID being walked (e.g., 'ESP2').
+     * @param  int  $directCount  Number of direct-promotion slots to fill.
+     * @param  int  $playoffCount  Number of bracket slots to fill.
+     */
+    public function allocate(
+        Game $game,
+        string $bottomDivision,
+        int $directCount,
+        int $playoffCount,
+    ): PromotionSlotAllocation {
+        $orderedTeams = $this->loadOrderedTeams($game, $bottomDivision, $directCount + $playoffCount);
+
+        if ($orderedTeams === []) {
+            return new PromotionSlotAllocation(directPromotions: [], playoffQualifiers: []);
+        }
+
+        $topDivisionTeamIds = $this->reserveFilter->getTopDivisionTeamIds($game, $bottomDivision);
+        $parentMap = $this->reserveFilter->loadParentTeamIds(
+            array_column($orderedTeams, 'teamId')
+        );
+
+        $eligible = [];
+        foreach ($orderedTeams as $entry) {
+            if ($this->reserveFilter->isBlockedReserveTeam(
+                $entry['teamId'], $topDivisionTeamIds, $parentMap
+            )) {
+                continue;
+            }
+            $eligible[] = $entry;
+        }
+
+        return new PromotionSlotAllocation(
+            directPromotions: array_slice($eligible, 0, $directCount),
+            playoffQualifiers: array_slice($eligible, $directCount, $playoffCount),
+        );
+    }
+
+    /**
+     * Pull the top-of-table teams in position order, preferring real
+     * GameStanding rows and falling back to SimulatedSeason. Returns
+     * standardised entries so the caller doesn't care about the source.
+     *
+     * @return array<int, array{teamId: string, position: int, teamName: string}>
+     */
+    private function loadOrderedTeams(Game $game, string $competitionId, int $needed): array
+    {
+        $fetchCount = $needed + self::RESERVE_BUFFER;
+
+        $standings = GameStanding::where('game_id', $game->id)
+            ->where('competition_id', $competitionId)
+            ->with('team')
+            ->orderBy('position')
+            ->limit($fetchCount)
+            ->get();
+
+        if ($standings->isNotEmpty()) {
+            return $standings->map(fn ($s) => [
+                'teamId' => $s->team_id,
+                'position' => $s->position,
+                'teamName' => $s->team->name ?? 'Unknown',
+            ])->values()->toArray();
+        }
+
+        $simulated = SimulatedSeason::where('game_id', $game->id)
+            ->where('season', $game->season)
+            ->where('competition_id', $competitionId)
+            ->first();
+
+        if (!$simulated || empty($simulated->results)) {
+            return [];
+        }
+
+        $results = array_slice($simulated->results, 0, $fetchCount);
+        $teams = Team::whereIn('id', $results)->get()->keyBy('id');
+
+        $entries = [];
+        foreach ($results as $index => $teamId) {
+            if (!isset($teams[$teamId])) {
+                continue;
+            }
+            $entries[] = [
+                'teamId' => $teamId,
+                'position' => $index + 1,
+                'teamName' => $teams[$teamId]->name,
+            ];
+        }
+
+        return $entries;
+    }
+}

--- a/app/Modules/Competition/Services/CountryConfig.php
+++ b/app/Modules/Competition/Services/CountryConfig.php
@@ -203,7 +203,7 @@ class CountryConfig
     /**
      * Get promotion/relegation rules for a country.
      *
-     * @return array<array{top_division: string, bottom_division: string, relegated_positions: int[], direct_promotion_positions: int[], playoff_positions?: int[], playoff_generator?: class-string}>
+     * @return array<array{top_division: string, bottom_division: string, relegated_positions: int[], direct_count: int, playoff_count?: int, playoff_generator?: class-string}>
      */
     public function promotions(string $countryCode): array
     {

--- a/config/countries.php
+++ b/config/countries.php
@@ -114,8 +114,15 @@ return [
                 'top_division' => 'ESP1',
                 'bottom_division' => 'ESP2',
                 'relegated_positions' => [18, 19, 20],
-                'direct_promotion_positions' => [1, 2],
-                'playoff_positions' => [3, 4, 5, 6],
+                // Slot counts (not positions) — PromotionSlotAllocator walks
+                // standings in order, skipping reserve teams whose parent club
+                // is in the top division, and assigns the first $direct_count
+                // eligible teams to direct promotion before handing the next
+                // $playoff_count to the bracket. This guarantees the two
+                // lists are disjoint even when reserves cluster at the top
+                // and shift the actual filling past the notional positions.
+                'direct_count' => 2,
+                'playoff_count' => 4,
                 'playoff_generator' => \App\Modules\Competition\Playoffs\ESP2PlayoffGenerator::class,
             ],
             [
@@ -128,8 +135,11 @@ return [
                 'top_division' => 'ESP2',
                 'bottom_division' => 'ESP3A',
                 'relegated_positions' => [19, 20, 21, 22],
-                'direct_promotion_positions' => [1],
-                'playoff_positions' => [2, 3, 4, 5],
+                // Per-group counts (1 direct + 4 playoff per ESP3 group);
+                // PrimeraRFEFPlayoffGenerator's bracket walks each group's
+                // standings independently using these counts.
+                'direct_count' => 1,
+                'playoff_count' => 4,
                 'rule_class' => \App\Modules\Competition\Promotions\PrimeraRFEFPromotionRule::class,
                 'playoff_generator' => \App\Modules\Competition\Playoffs\PrimeraRFEFPlayoffGenerator::class,
                 // Register the same playoff generator under both groups so

--- a/tests/Unit/PromotionRelegationValidationTest.php
+++ b/tests/Unit/PromotionRelegationValidationTest.php
@@ -137,7 +137,8 @@ class PromotionRelegationValidationTest extends TestCase
             topDivision: 'ESP1',
             bottomDivision: 'ESP2',
             relegatedPositions: [18, 19, 20],
-            directPromotionPositions: [1, 2],
+            directCount: 2,
+            playoffCount: 4,
             playoffGenerator: null,
         );
 
@@ -153,12 +154,13 @@ class PromotionRelegationValidationTest extends TestCase
     {
         $this->createStandings('ESP2', 22);
 
-        // No playoff generator, but relegatedPositions matches directPromotionPositions count
+        // No playoff generator, but relegatedPositions matches directCount
         $rule = new ConfigDrivenPromotionRule(
             topDivision: 'ESP1',
             bottomDivision: 'ESP2',
             relegatedPositions: [1, 2],
-            directPromotionPositions: [1, 2],
+            directCount: 2,
+            playoffCount: 4,
             playoffGenerator: null,
         );
 
@@ -183,7 +185,8 @@ class PromotionRelegationValidationTest extends TestCase
             topDivision: 'ESP1',
             bottomDivision: 'ESP2',
             relegatedPositions: [18, 19, 20],
-            directPromotionPositions: [1, 2],
+            directCount: 2,
+            playoffCount: 4,
             playoffGenerator: null,
         );
 
@@ -207,7 +210,8 @@ class PromotionRelegationValidationTest extends TestCase
             topDivision: 'ESP1',
             bottomDivision: 'ESP2',
             relegatedPositions: [18, 19, 20],
-            directPromotionPositions: [1, 2],
+            directCount: 2,
+            playoffCount: 4,
         );
 
         $relegated = $rule->getRelegatedTeams($this->game);
@@ -223,7 +227,8 @@ class PromotionRelegationValidationTest extends TestCase
             topDivision: 'ESP1',
             bottomDivision: 'ESP2',
             relegatedPositions: [18, 19, 20],
-            directPromotionPositions: [1, 2],
+            directCount: 2,
+            playoffCount: 4,
         );
 
         // Real standings exist but positions 18-20 are missing
@@ -252,7 +257,8 @@ class PromotionRelegationValidationTest extends TestCase
             topDivision: 'ESP1',
             bottomDivision: 'ESP2',
             relegatedPositions: [18, 19, 20],
-            directPromotionPositions: [1, 2],
+            directCount: 2,
+            playoffCount: 4,
         );
 
         $relegated = $rule->getRelegatedTeams($this->game);
@@ -273,7 +279,8 @@ class PromotionRelegationValidationTest extends TestCase
             topDivision: 'ESP1',
             bottomDivision: 'ESP2',
             relegatedPositions: [18, 19, 20],
-            directPromotionPositions: [1, 2],
+            directCount: 2,
+            playoffCount: 4,
         );
 
         $promoted = $rule->getPromotedTeams($this->game);
@@ -287,7 +294,8 @@ class PromotionRelegationValidationTest extends TestCase
             topDivision: 'ESP1',
             bottomDivision: 'ESP2',
             relegatedPositions: [18, 19, 20],
-            directPromotionPositions: [1, 2],
+            directCount: 2,
+            playoffCount: 4,
         );
 
         $relegated = $rule->getRelegatedTeams($this->game);
@@ -390,7 +398,8 @@ class PromotionRelegationValidationTest extends TestCase
             topDivision: 'ESP1',
             bottomDivision: 'ESP2',
             relegatedPositions: [19, 20],
-            directPromotionPositions: [1, 2],
+            directCount: 2,
+            playoffCount: 4,
         );
 
         $promoted = $rule->getPromotedTeams($this->game);
@@ -640,7 +649,8 @@ class PromotionRelegationValidationTest extends TestCase
             topDivision: 'ESP1',
             bottomDivision: 'ESP2',
             relegatedPositions: [18, 19, 20],
-            directPromotionPositions: [1, 2],
+            directCount: 2,
+            playoffCount: 4,
             playoffGenerator: new FakePlayoffGenerator(PlayoffState::InProgress),
         );
 
@@ -658,7 +668,8 @@ class PromotionRelegationValidationTest extends TestCase
             topDivision: 'ESP1',
             bottomDivision: 'ESP2',
             relegatedPositions: [18, 19, 20],
-            directPromotionPositions: [1, 2],
+            directCount: 2,
+            playoffCount: 4,
             playoffGenerator: new FakePlayoffGenerator(PlayoffState::Completed),
         );
 
@@ -677,7 +688,8 @@ class PromotionRelegationValidationTest extends TestCase
             topDivision: 'ESP1',
             bottomDivision: 'ESP2',
             relegatedPositions: [18, 19, 20],
-            directPromotionPositions: [1, 2],
+            directCount: 2,
+            playoffCount: 4,
             playoffGenerator: new FakePlayoffGenerator(PlayoffState::NotStarted),
         );
 
@@ -710,7 +722,8 @@ class PromotionRelegationValidationTest extends TestCase
             topDivision: 'ESP1',
             bottomDivision: 'ESP2',
             relegatedPositions: [18, 19, 20],
-            directPromotionPositions: [1, 2],
+            directCount: 2,
+            playoffCount: 4,
             playoffGenerator: new FakePlayoffGenerator(PlayoffState::Completed),
         );
 
@@ -740,7 +753,8 @@ class PromotionRelegationValidationTest extends TestCase
             topDivision: 'ESP1',
             bottomDivision: 'ESP2',
             relegatedPositions: [18, 19, 20],
-            directPromotionPositions: [1, 2],
+            directCount: 2,
+            playoffCount: 4,
         );
 
         $this->expectException(\RuntimeException::class);
@@ -786,7 +800,8 @@ class PromotionRelegationValidationTest extends TestCase
             topDivision: 'ESP1',
             bottomDivision: 'ESP2',
             relegatedPositions: [1, 2, 3],
-            directPromotionPositions: [1, 2],
+            directCount: 2,
+            playoffCount: 4,
             playoffGenerator: new FakePlayoffGenerator(PlayoffState::NotStarted),
         );
 

--- a/tests/Unit/PromotionSlotAllocatorTest.php
+++ b/tests/Unit/PromotionSlotAllocatorTest.php
@@ -1,0 +1,492 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\Competition;
+use App\Models\CompetitionEntry;
+use App\Models\Game;
+use App\Models\GameStanding;
+use App\Models\SimulatedSeason;
+use App\Models\Team;
+use App\Models\User;
+use App\Modules\Competition\Promotions\PromotionSlotAllocator;
+use App\Modules\Competition\Services\ReserveTeamFilter;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Tests the single-pass slot allocator that prevents the historical
+ * "team appears in both direct-promotion and bracket lists" bug.
+ *
+ * The invariant under test: for any standings layout, directPromotions
+ * and playoffQualifiers are always disjoint, with their counts capped
+ * at the configured slots.
+ */
+class PromotionSlotAllocatorTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const TOP_DIVISION = 'ESP1';
+    private const BOTTOM_DIVISION = 'ESP2';
+
+    private Game $game;
+    /** @var Team[] $topDivisionTeams */
+    private array $topDivisionTeams = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $user = User::factory()->create();
+        Competition::factory()->league()->create(['id' => self::TOP_DIVISION, 'tier' => 1]);
+        Competition::factory()->league()->create(['id' => self::BOTTOM_DIVISION, 'tier' => 2]);
+
+        $userTeam = Team::factory()->create();
+        $this->game = Game::factory()->create([
+            'user_id' => $user->id,
+            'team_id' => $userTeam->id,
+            'competition_id' => self::TOP_DIVISION,
+            'season' => '2025',
+        ]);
+
+        // Seed a 20-team top-division roster so the reserve filter has a
+        // reference set for parent-club lookups. Tests that need a specific
+        // team to be a reserve's parent push their custom team in via
+        // makeReserveParentInTopDivision().
+        for ($i = 0; $i < 20; $i++) {
+            $team = Team::factory()->create();
+            $this->topDivisionTeams[] = $team;
+            CompetitionEntry::create([
+                'game_id' => $this->game->id,
+                'competition_id' => self::TOP_DIVISION,
+                'team_id' => $team->id,
+                'entry_round' => 1,
+            ]);
+        }
+    }
+
+    private function allocator(): PromotionSlotAllocator
+    {
+        return new PromotionSlotAllocator(new ReserveTeamFilter);
+    }
+
+    /**
+     * Place a team at a given standings position in ESP2.
+     */
+    private function placeAtPosition(int $position, Team $team): void
+    {
+        GameStanding::create([
+            'game_id' => $this->game->id,
+            'competition_id' => self::BOTTOM_DIVISION,
+            'team_id' => $team->id,
+            'position' => $position,
+            'played' => 42,
+            'won' => max(0, 25 - $position),
+            'drawn' => 5,
+            'lost' => $position,
+            'goals_for' => max(20, 70 - $position),
+            'goals_against' => 20 + $position,
+            'points' => max(0, (25 - $position) * 3 + 5),
+        ]);
+    }
+
+    /**
+     * Build a 22-team ESP2 standings layout. Returns the teams keyed by
+     * position so individual tests can mark a specific position as a reserve.
+     *
+     * @return array<int, Team> Position (1-indexed) => Team
+     */
+    private function seedFullStandings(): array
+    {
+        $teamsByPosition = [];
+        for ($i = 1; $i <= 22; $i++) {
+            $team = Team::factory()->create();
+            $this->placeAtPosition($i, $team);
+            $teamsByPosition[$i] = $team;
+        }
+        return $teamsByPosition;
+    }
+
+    /**
+     * Make the team at the given position a reserve whose parent club
+     * is in the top division (so the filter blocks it). Replaces the
+     * existing standings row in-place.
+     */
+    private function makeReserve(int $position, array &$teamsByPosition): Team
+    {
+        $parent = $this->topDivisionTeams[0];
+        $reserve = Team::factory()->create(['parent_team_id' => $parent->id]);
+
+        // Replace the existing row at this position
+        GameStanding::where('game_id', $this->game->id)
+            ->where('competition_id', self::BOTTOM_DIVISION)
+            ->where('position', $position)
+            ->delete();
+
+        $this->placeAtPosition($position, $reserve);
+        $teamsByPosition[$position] = $reserve;
+
+        return $reserve;
+    }
+
+    /** Convenience: extract teamIds from a slot list in order. */
+    private function teamIds(array $slots): array
+    {
+        return array_column($slots, 'teamId');
+    }
+
+    // ──────────────────────────────────────────────────
+    // Happy path
+    // ──────────────────────────────────────────────────
+
+    public function test_no_reserves_assigns_top_two_to_direct_and_next_four_to_playoff(): void
+    {
+        $teams = $this->seedFullStandings();
+
+        $allocation = $this->allocator()->allocate($this->game, self::BOTTOM_DIVISION, 2, 4);
+
+        $this->assertSame(
+            [$teams[1]->id, $teams[2]->id],
+            $this->teamIds($allocation->directPromotions),
+        );
+        $this->assertSame(
+            [$teams[3]->id, $teams[4]->id, $teams[5]->id, $teams[6]->id],
+            $this->teamIds($allocation->playoffQualifiers),
+        );
+    }
+
+    // ──────────────────────────────────────────────────
+    // Reserve clustering — the bug class this fix addresses
+    // ──────────────────────────────────────────────────
+
+    /**
+     * The Angel/Pontevedra scenario: ESP2 champion is a reserve (Real Madrid
+     * Castilla). Direct promotions slide to positions 2, 3 — and crucially,
+     * the bracket starts at position 4, not 3. Pre-fix, position 3 was both
+     * directly promoted (post-filter) and seeded into the bracket.
+     */
+    public function test_reserve_at_position_one_shifts_direct_promotions_down_without_collision(): void
+    {
+        $teams = $this->seedFullStandings();
+        $this->makeReserve(1, $teams);
+
+        $allocation = $this->allocator()->allocate($this->game, self::BOTTOM_DIVISION, 2, 4);
+
+        $direct = $this->teamIds($allocation->directPromotions);
+        $playoff = $this->teamIds($allocation->playoffQualifiers);
+
+        $this->assertSame([$teams[2]->id, $teams[3]->id], $direct);
+        $this->assertSame(
+            [$teams[4]->id, $teams[5]->id, $teams[6]->id, $teams[7]->id],
+            $playoff,
+        );
+        $this->assertEmpty(
+            array_intersect($direct, $playoff),
+            'Direct and playoff slots must be disjoint',
+        );
+    }
+
+    public function test_reserve_at_position_two_shifts_only_second_direct_slot_down(): void
+    {
+        $teams = $this->seedFullStandings();
+        $this->makeReserve(2, $teams);
+
+        $allocation = $this->allocator()->allocate($this->game, self::BOTTOM_DIVISION, 2, 4);
+
+        $this->assertSame(
+            [$teams[1]->id, $teams[3]->id],
+            $this->teamIds($allocation->directPromotions),
+        );
+        $this->assertSame(
+            [$teams[4]->id, $teams[5]->id, $teams[6]->id, $teams[7]->id],
+            $this->teamIds($allocation->playoffQualifiers),
+        );
+    }
+
+    public function test_two_reserves_at_top_pushes_both_lists_further_down(): void
+    {
+        $teams = $this->seedFullStandings();
+        $this->makeReserve(1, $teams);
+        $this->makeReserve(2, $teams);
+
+        $allocation = $this->allocator()->allocate($this->game, self::BOTTOM_DIVISION, 2, 4);
+
+        $this->assertSame(
+            [$teams[3]->id, $teams[4]->id],
+            $this->teamIds($allocation->directPromotions),
+        );
+        $this->assertSame(
+            [$teams[5]->id, $teams[6]->id, $teams[7]->id, $teams[8]->id],
+            $this->teamIds($allocation->playoffQualifiers),
+        );
+    }
+
+    public function test_reserve_inside_bracket_range_is_skipped_without_affecting_direct(): void
+    {
+        $teams = $this->seedFullStandings();
+        $this->makeReserve(4, $teams);
+
+        $allocation = $this->allocator()->allocate($this->game, self::BOTTOM_DIVISION, 2, 4);
+
+        $this->assertSame(
+            [$teams[1]->id, $teams[2]->id],
+            $this->teamIds($allocation->directPromotions),
+        );
+        $this->assertSame(
+            [$teams[3]->id, $teams[5]->id, $teams[6]->id, $teams[7]->id],
+            $this->teamIds($allocation->playoffQualifiers),
+        );
+    }
+
+    public function test_reserves_in_both_direct_and_bracket_ranges(): void
+    {
+        $teams = $this->seedFullStandings();
+        $this->makeReserve(1, $teams);
+        $this->makeReserve(5, $teams);
+
+        $allocation = $this->allocator()->allocate($this->game, self::BOTTOM_DIVISION, 2, 4);
+
+        $this->assertSame(
+            [$teams[2]->id, $teams[3]->id],
+            $this->teamIds($allocation->directPromotions),
+        );
+        // Position 5 is skipped, so bracket = [4, 6, 7, 8]
+        $this->assertSame(
+            [$teams[4]->id, $teams[6]->id, $teams[7]->id, $teams[8]->id],
+            $this->teamIds($allocation->playoffQualifiers),
+        );
+    }
+
+    public function test_three_consecutive_reserves_at_top(): void
+    {
+        $teams = $this->seedFullStandings();
+        $this->makeReserve(1, $teams);
+        $this->makeReserve(2, $teams);
+        $this->makeReserve(3, $teams);
+
+        $allocation = $this->allocator()->allocate($this->game, self::BOTTOM_DIVISION, 2, 4);
+
+        $this->assertSame(
+            [$teams[4]->id, $teams[5]->id],
+            $this->teamIds($allocation->directPromotions),
+        );
+        $this->assertSame(
+            [$teams[6]->id, $teams[7]->id, $teams[8]->id, $teams[9]->id],
+            $this->teamIds($allocation->playoffQualifiers),
+        );
+    }
+
+    // ──────────────────────────────────────────────────
+    // Reserve filter scope — only blocks when parent is in top division
+    // ──────────────────────────────────────────────────
+
+    public function test_reserve_whose_parent_is_not_in_top_division_is_eligible(): void
+    {
+        $teams = $this->seedFullStandings();
+
+        // Build a reserve whose parent is *not* in ESP1 — should NOT be filtered.
+        $unrelatedParent = Team::factory()->create();
+        $reserve = Team::factory()->create(['parent_team_id' => $unrelatedParent->id]);
+
+        GameStanding::where('game_id', $this->game->id)
+            ->where('competition_id', self::BOTTOM_DIVISION)
+            ->where('position', 1)
+            ->delete();
+
+        $this->placeAtPosition(1, $reserve);
+
+        $allocation = $this->allocator()->allocate($this->game, self::BOTTOM_DIVISION, 2, 4);
+
+        $this->assertSame($reserve->id, $allocation->directPromotions[0]['teamId']);
+    }
+
+    // ──────────────────────────────────────────────────
+    // Disjointness invariant (defensive)
+    // ──────────────────────────────────────────────────
+
+    /**
+     * Property-style: across many randomised reserve placements, direct and
+     * playoff lists must always be disjoint. This is the load-bearing
+     * invariant that PromotionRelegationProcessor::validatePlan asserts.
+     *
+     * Range tested: 0..3 reserves at random positions in 1..7. Combined
+     * with the 22-team standings, this covers every plausible Spanish layout.
+     *
+     * @dataProvider randomReserveLayouts
+     */
+    public function test_direct_and_playoff_are_always_disjoint(array $reservePositions): void
+    {
+        $teams = $this->seedFullStandings();
+        foreach ($reservePositions as $pos) {
+            $this->makeReserve($pos, $teams);
+        }
+
+        $allocation = $this->allocator()->allocate($this->game, self::BOTTOM_DIVISION, 2, 4);
+
+        $direct = $this->teamIds($allocation->directPromotions);
+        $playoff = $this->teamIds($allocation->playoffQualifiers);
+
+        $this->assertCount(2, $direct, 'Should always fill direct slots');
+        $this->assertCount(4, $playoff, 'Should always fill playoff slots');
+        $this->assertEmpty(
+            array_intersect($direct, $playoff),
+            'Slot lists must be disjoint for any reserve layout. '
+            . 'Reserves at: ' . json_encode($reservePositions),
+        );
+    }
+
+    public static function randomReserveLayouts(): array
+    {
+        return [
+            'no reserves'              => [[]],
+            'reserve at 1'             => [[1]],
+            'reserve at 2'             => [[2]],
+            'reserve at 3'             => [[3]],
+            'reserve at 4'             => [[4]],
+            'reserves at 1,2'          => [[1, 2]],
+            'reserves at 1,3'          => [[1, 3]],
+            'reserves at 1,4'          => [[1, 4]],
+            'reserves at 2,4'          => [[2, 4]],
+            'reserves at 1,2,3'        => [[1, 2, 3]],
+            'reserves at 1,3,5'        => [[1, 3, 5]],
+            'reserves at 2,4,6'        => [[2, 4, 6]],
+        ];
+    }
+
+    // ──────────────────────────────────────────────────
+    // Insufficient eligible teams
+    // ──────────────────────────────────────────────────
+
+    public function test_returns_partial_allocation_when_not_enough_eligible_teams(): void
+    {
+        // Only 4 teams in the standings, all eligible — caller asks for 2+4=6
+        for ($i = 1; $i <= 4; $i++) {
+            $this->placeAtPosition($i, Team::factory()->create());
+        }
+
+        $allocation = $this->allocator()->allocate($this->game, self::BOTTOM_DIVISION, 2, 4);
+
+        // Allocator is non-throwing: it returns what it found and lets the
+        // caller decide whether to fail. Direct fills first.
+        $this->assertCount(2, $allocation->directPromotions);
+        $this->assertCount(2, $allocation->playoffQualifiers);
+    }
+
+    // ──────────────────────────────────────────────────
+    // Simulated standings fallback
+    // ──────────────────────────────────────────────────
+
+    public function test_falls_back_to_simulated_season_when_no_real_standings_exist(): void
+    {
+        $teams = [];
+        for ($i = 0; $i < 22; $i++) {
+            $teams[] = Team::factory()->create();
+        }
+
+        SimulatedSeason::create([
+            'game_id' => $this->game->id,
+            'season' => '2025',
+            'competition_id' => self::BOTTOM_DIVISION,
+            'results' => array_map(fn ($t) => $t->id, $teams),
+        ]);
+
+        $allocation = $this->allocator()->allocate($this->game, self::BOTTOM_DIVISION, 2, 4);
+
+        $this->assertSame(
+            [$teams[0]->id, $teams[1]->id],
+            $this->teamIds($allocation->directPromotions),
+        );
+        $this->assertSame(
+            [$teams[2]->id, $teams[3]->id, $teams[4]->id, $teams[5]->id],
+            $this->teamIds($allocation->playoffQualifiers),
+        );
+    }
+
+    public function test_simulated_path_also_applies_reserve_filter(): void
+    {
+        $parent = $this->topDivisionTeams[0];
+        $reserve = Team::factory()->create(['parent_team_id' => $parent->id]);
+        $regulars = [];
+        for ($i = 0; $i < 21; $i++) {
+            $regulars[] = Team::factory()->create();
+        }
+
+        SimulatedSeason::create([
+            'game_id' => $this->game->id,
+            'season' => '2025',
+            'competition_id' => self::BOTTOM_DIVISION,
+            // Reserve "wins" the simulated league at index 0 (position 1)
+            'results' => array_merge([$reserve->id], array_map(fn ($t) => $t->id, $regulars)),
+        ]);
+
+        $allocation = $this->allocator()->allocate($this->game, self::BOTTOM_DIVISION, 2, 4);
+
+        // Reserve at position 1 is filtered; direct slides to positions 2, 3.
+        $this->assertSame(
+            [$regulars[0]->id, $regulars[1]->id],
+            $this->teamIds($allocation->directPromotions),
+        );
+        $this->assertSame(
+            [$regulars[2]->id, $regulars[3]->id, $regulars[4]->id, $regulars[5]->id],
+            $this->teamIds($allocation->playoffQualifiers),
+        );
+    }
+
+    // ──────────────────────────────────────────────────
+    // No data at all
+    // ──────────────────────────────────────────────────
+
+    public function test_returns_empty_allocation_when_no_data_source_exists(): void
+    {
+        // No standings, no simulated season.
+        $allocation = $this->allocator()->allocate($this->game, self::BOTTOM_DIVISION, 2, 4);
+
+        $this->assertTrue($allocation->isEmpty());
+        $this->assertSame([], $allocation->directPromotions);
+        $this->assertSame([], $allocation->playoffQualifiers);
+    }
+
+    // ──────────────────────────────────────────────────
+    // Slot-count edge cases
+    // ──────────────────────────────────────────────────
+
+    public function test_zero_playoff_slots_returns_only_direct_promotions(): void
+    {
+        $teams = $this->seedFullStandings();
+
+        $allocation = $this->allocator()->allocate($this->game, self::BOTTOM_DIVISION, 2, 0);
+
+        $this->assertCount(2, $allocation->directPromotions);
+        $this->assertCount(0, $allocation->playoffQualifiers);
+    }
+
+    public function test_zero_direct_slots_assigns_everything_to_playoff(): void
+    {
+        $teams = $this->seedFullStandings();
+
+        $allocation = $this->allocator()->allocate($this->game, self::BOTTOM_DIVISION, 0, 4);
+
+        $this->assertCount(0, $allocation->directPromotions);
+        $this->assertSame(
+            [$teams[1]->id, $teams[2]->id, $teams[3]->id, $teams[4]->id],
+            $this->teamIds($allocation->playoffQualifiers),
+        );
+    }
+
+    // ──────────────────────────────────────────────────
+    // Standings-position metadata is preserved
+    // ──────────────────────────────────────────────────
+
+    public function test_each_slot_carries_its_standings_position(): void
+    {
+        $teams = $this->seedFullStandings();
+        $this->makeReserve(1, $teams);
+
+        $allocation = $this->allocator()->allocate($this->game, self::BOTTOM_DIVISION, 2, 4);
+
+        $this->assertSame(2, $allocation->directPromotions[0]['position']);
+        $this->assertSame(3, $allocation->directPromotions[1]['position']);
+        $this->assertSame(4, $allocation->playoffQualifiers[0]['position']);
+        $this->assertSame(7, $allocation->playoffQualifiers[3]['position']);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the `Duplicate team in ESP2→ESP1 promotions` exception that started surfacing after `fdb23835` shipped `validatePlan`. Two affected users in 24h; one game has been deleted, the other (Angel, game `d6eb479f`) confirmed the failure mode.

## Root cause

`ConfigDrivenPromotionRule::getDirectPromotions` and `ESP2PlayoffGenerator::generateSemifinalMatchups` each ran their own reserve-team filter against overlapping standings ranges. When a reserve team held a top-of-table slot (Real Madrid Castilla as ESP2 champion in Angel's game), the direct-promotion list slid down past it, but the bracket kept seeding from the same starting position. The team at standings position 3 ended up in **both** lists — `array_merge` produced a duplicate, and the swap silently no-op'd the second `moveTeam` call, leaving ESP1 short by one team and ESP2 with a phantom seat.

This is not fallout from `8cf33ab` (the orchestrator stale-game bug). It's a separate, pre-existing logic bug that `validatePlan` is now correctly catching.

## Solution

Replace both filters with a single `PromotionSlotAllocator` that walks the standings (or simulated season) once in position order, applies the reserve filter, and assigns the first `directCount` eligible teams to direct promotion before handing the next `playoffCount` to the bracket. By construction the two lists are disjoint — `validatePlan` becomes defense-in-depth rather than the only safeguard.

Config migrates from position arrays to slot counts:

```diff
- 'direct_promotion_positions' => [1, 2],
- 'playoff_positions' => [3, 4, 5, 6],
+ 'direct_count' => 2,
+ 'playoff_count' => 4,
```

In-season UI consumers (`LaLiga2Config::getStandingsZones`, `LeaguePlayoffProgressResolver`) derive notional position ranges from the counts.

## Test plan

- [ ] `php artisan test --filter=PromotionSlotAllocatorTest` — 16 cases including Angel's exact scenario, every reserve clustering at top of table, reserve in bracket range only, simulated-season fallback, slot-count edge cases, and a property-style disjointness check across 12 reserve layouts.
- [ ] `php artisan test --filter=PromotionRelegationValidationTest` — existing tests, updated to new constructor signature; assertions unchanged.
- [ ] Spot-check Spanish standings UI in dev — direct/playoff/relegation zones still colour positions 1-2, 3-6, 19-22 respectively.
- [ ] Trigger an end-of-season transition on a fresh game with a reserve team near the top of ESP2 to confirm the closing pipeline runs cleanly.

## Out of scope

- Data repair for the broken game (per request — second affected game already deleted, Angel's stays as-is).
- The unrelated bug in `PrimeraRFEFPromotionRule::directPromotion` not applying the reserve filter (different shape, lower impact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)