### PR TITLE
Filial reserve squad management (Phase 1)

### DIFF
--- a/app/Http/Actions/CallUpReservePlayer.php
+++ b/app/Http/Actions/CallUpReservePlayer.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Http\Actions;
+
+use App\Models\Game;
+use App\Models\GamePlayer;
+use App\Modules\ReserveTeam\Exceptions\FirstTeamSquadFullException;
+use App\Modules\ReserveTeam\Services\ReserveTeamService;
+
+class CallUpReservePlayer
+{
+    public function __construct(
+        private readonly ReserveTeamService $reserveTeamService,
+    ) {}
+
+    public function __invoke(string $gameId, string $playerId)
+    {
+        $game = Game::findOrFail($gameId);
+        abort_if($game->reserve_team_id === null, 404);
+
+        $player = GamePlayer::where('id', $playerId)
+            ->where('game_id', $gameId)
+            ->where('team_id', $game->reserve_team_id)
+            ->with('player')
+            ->firstOrFail();
+
+        $playerName = $player->player->name ?? '';
+
+        try {
+            $this->reserveTeamService->callUpToFirstTeam($player, $game);
+        } catch (FirstTeamSquadFullException $e) {
+            return redirect()->route('game.squad.reserve', $gameId)
+                ->with('error', __('messages.reserve_player_call_up_blocked_full'));
+        }
+
+        return redirect()->route('game.squad.reserve', $gameId)
+            ->with('success', __('messages.reserve_player_called_up', ['player' => $playerName]));
+    }
+}

--- a/app/Http/Actions/SendBackReservePlayer.php
+++ b/app/Http/Actions/SendBackReservePlayer.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Actions;
+
+use App\Models\Game;
+use App\Models\GamePlayer;
+use App\Modules\ReserveTeam\Services\ReserveTeamService;
+
+class SendBackReservePlayer
+{
+    public function __construct(
+        private readonly ReserveTeamService $reserveTeamService,
+    ) {}
+
+    public function __invoke(string $gameId, string $playerId)
+    {
+        $game = Game::findOrFail($gameId);
+        abort_if($game->reserve_team_id === null, 404);
+
+        $player = GamePlayer::where('id', $playerId)
+            ->where('game_id', $gameId)
+            ->where('team_id', $game->team_id)
+            ->whereHas('activeLoan', fn ($q) => $q->where('parent_team_id', $game->reserve_team_id))
+            ->with('player')
+            ->firstOrFail();
+
+        $playerName = $player->player->name ?? '';
+
+        $this->reserveTeamService->sendBackToReserve($player, $game);
+
+        return redirect()->route('game.squad.reserve', $gameId)
+            ->with('success', __('messages.reserve_player_sent_back', ['player' => $playerName]));
+    }
+}

--- a/app/Http/Actions/ToggleShortlist.php
+++ b/app/Http/Actions/ToggleShortlist.php
@@ -21,6 +21,19 @@ class ToggleShortlist
         $game = Game::findOrFail($gameId);
         $gamePlayer = GamePlayer::where('game_id', $gameId)->findOrFail($playerId);
 
+        // Players on the user's own reserve team move via call-up / promotion,
+        // not the transfer market — block shortlisting them. Other clubs'
+        // reserve players are fair game (signable like any other prospect).
+        if ($game->reserve_team_id && $gamePlayer->team_id === $game->reserve_team_id) {
+            $message = __('messages.shortlist_reserve_blocked');
+
+            if ($request->ajax()) {
+                return response()->json(['success' => false, 'message' => $message], 422);
+            }
+
+            return redirect()->back()->with('error', $message);
+        }
+
         $existing = ShortlistedPlayer::where('game_id', $gameId)
             ->where('game_player_id', $playerId)
             ->first();

--- a/app/Http/Views/ShowPlayerDetail.php
+++ b/app/Http/Views/ShowPlayerDetail.php
@@ -17,9 +17,11 @@ class ShowPlayerDetail
     {
         $game = Game::findOrFail($gameId);
 
+        $allowedTeamIds = array_filter([$game->team_id, $game->reserve_team_id]);
+
         $gamePlayer = GamePlayer::with('player')
             ->where('game_id', $gameId)
-            ->where('team_id', $game->team_id)
+            ->whereIn('team_id', $allowedTeamIds)
             ->findOrFail($playerId);
 
         $canRenew = $gamePlayer->canBeOfferedRenewal(currentDate: $game->current_date);

--- a/app/Http/Views/ShowReserveTeam.php
+++ b/app/Http/Views/ShowReserveTeam.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Http\Views;
+
+use App\Models\Game;
+use App\Modules\ReserveTeam\Services\ReserveTeamService;
+use App\Support\PositionMapper;
+
+class ShowReserveTeam
+{
+    public function __construct(
+        private readonly ReserveTeamService $reserveTeamService,
+    ) {}
+
+    public function __invoke(string $gameId)
+    {
+        $game = Game::with(['team', 'reserveTeam'])->findOrFail($gameId);
+        abort_if($game->isTournamentMode(), 404);
+        abort_if($game->reserve_team_id === null, 404);
+
+        $squad = $this->reserveTeamService->getReserveSquad($game);
+
+        $grouped = $squad
+            ->sortByDesc('overall_score')
+            ->groupBy(fn ($player) => PositionMapper::getPositionGroup($player->position));
+
+        $count = $squad->count();
+        $avgAge = $count > 0 ? round($squad->avg(fn ($p) => $p->age($game->current_date)), 1) : 0;
+        $avgFitness = $count > 0 ? (int) round($squad->avg('fitness')) : 0;
+        $avgMorale = $count > 0 ? (int) round($squad->avg('morale')) : 0;
+        $avgOverall = $count > 0 ? (int) round($squad->avg('overall_score')) : 0;
+
+        return view('squad-reserve', [
+            'game' => $game,
+            'reserveTeam' => $game->reserveTeam,
+            'goalkeepers' => $grouped->get('Goalkeeper', collect()),
+            'defenders' => $grouped->get('Defender', collect()),
+            'midfielders' => $grouped->get('Midfielder', collect()),
+            'forwards' => $grouped->get('Forward', collect()),
+            'reserveCount' => $count,
+            'avgAge' => $avgAge,
+            'avgFitness' => $avgFitness,
+            'avgMorale' => $avgMorale,
+            'avgOverall' => $avgOverall,
+        ]);
+    }
+}

--- a/app/Models/Game.php
+++ b/app/Models/Game.php
@@ -113,6 +113,7 @@ class Game extends Model
         'country',
         'player_name',
         'team_id',
+        'reserve_team_id',
         'competition_id',
         'season',
         'current_date',
@@ -331,6 +332,16 @@ class Game extends Model
     public function team(): BelongsTo
     {
         return $this->belongsTo(Team::class);
+    }
+
+    public function reserveTeam(): BelongsTo
+    {
+        return $this->belongsTo(Team::class, 'reserve_team_id');
+    }
+
+    public function isFilial(): bool
+    {
+        return $this->reserve_team_id !== null;
     }
 
     public function tactics(): HasOne

--- a/app/Models/GameTransfer.php
+++ b/app/Models/GameTransfer.php
@@ -30,6 +30,7 @@ class GameTransfer extends Model
     public const TYPE_TRANSFER = 'transfer';
     public const TYPE_FREE_AGENT = 'free_agent';
     public const TYPE_LOAN = 'loan';
+    public const TYPE_INTERNAL_PROMOTION = 'internal_promotion';
 
     /**
      * Record a completed transfer in the ledger.

--- a/app/Modules/Academy/Services/YouthAcademyService.php
+++ b/app/Modules/Academy/Services/YouthAcademyService.php
@@ -113,7 +113,11 @@ class YouthAcademyService
     /**
      * Generate a batch of new academy prospects at season start.
      *
-     * @return Collection<int, AcademyPlayer>
+     * For filial games (clubs with a reserve team), prospects are created as
+     * full GamePlayers on the reserve squad — no AcademyPlayer rows. For
+     * non-filial games, prospects land in the AcademyPlayer pool as before.
+     *
+     * @return Collection<int, AcademyPlayer|GamePlayer>
      */
     public function generateSeasonBatch(Game $game): Collection
     {
@@ -127,10 +131,15 @@ class YouthAcademyService
         $excludedNames = $this->getExistingPlayerNames($game);
 
         $prospects = collect();
+        $isFilial = $game->reserve_team_id !== null;
 
         for ($i = 0; $i < $count; $i++) {
-            $prospect = $this->createAcademyProspect($game, $tier, $teamMedianTier, $excludedNames);
-            $excludedNames[] = $prospect->name;
+            $prospect = $isFilial
+                ? $this->createReserveProspect($game, $tier, $teamMedianTier, $excludedNames)
+                : $this->createAcademyProspect($game, $tier, $teamMedianTier, $excludedNames);
+
+            $name = $isFilial ? $prospect->player->name : $prospect->name;
+            $excludedNames[] = $name;
             $prospects->push($prospect);
         }
 
@@ -461,6 +470,71 @@ class YouthAcademyService
             'initial_technical' => $technical,
             'initial_physical' => $physical,
         ]);
+    }
+
+    /**
+     * Create a reserve-team prospect for filial games. Mirrors the academy
+     * prospect generation (same quality + potential distributions), but
+     * produces a full GamePlayer on the reserve squad instead of an
+     * AcademyPlayer pool entry.
+     */
+    private function createReserveProspect(
+        Game $game,
+        int $academyTier,
+        int $teamMedianTier,
+        array $excludedNames,
+    ): GamePlayer {
+        $position = $this->selectPosition();
+
+        $abilityMean = self::ACADEMY_BASE_QUALITY[$academyTier] + self::TEAM_CONTEXT_BONUS[$teamMedianTier];
+        $age = rand(17, 19);
+        $ageCap = match ($age) {
+            17 => 72,
+            18 => 74,
+            19 => 76,
+            default => 78,
+        };
+        $technical = $this->sampler->sampleAbility($abilityMean, self::ABILITY_STD_DEV, 50, $ageCap);
+        $physical = $this->sampler->sampleAbility($abilityMean, self::ABILITY_STD_DEV, 50, $ageCap);
+
+        $currentBest = max($technical, $physical);
+        $potentialData = $this->sampler->generatePotentialFromAbility(
+            $currentBest,
+            self::POTENTIAL_UPSIDE_MEAN[$academyTier],
+            self::POTENTIAL_UPSIDE_STD_DEV,
+            self::POTENTIAL_FLOOR[$academyTier],
+        );
+
+        $dateOfBirth = $game->current_date->copy()->subYears($age)->subDays(rand(0, 364));
+
+        $teamName = $game->team->name;
+        $nationalityFilter = self::CANTERA_TEAMS[$teamName] ?? null;
+        $teamCountry = $nationalityFilter ? null : $game->team->country;
+        $region = TeamRegionalOrigins::regionFor($teamName);
+        $identity = $this->playerGenerator->pickRandomIdentity(
+            $nationalityFilter,
+            $teamCountry,
+            $excludedNames,
+            $region,
+        );
+
+        return $this->playerGenerator->create($game, new GeneratedPlayerData(
+            teamId: $game->reserve_team_id,
+            position: $position,
+            technical: $technical,
+            physical: $physical,
+            dateOfBirth: $dateOfBirth,
+            contractYears: 2,
+            name: $identity['name'],
+            nationality: $identity['nationality'],
+            potential: $potentialData['potential'],
+            potentialLow: $potentialData['potentialLow'],
+            potentialHigh: $potentialData['potentialHigh'],
+            fitnessMin: 85,
+            fitnessMax: 100,
+            moraleMin: 70,
+            moraleMax: 90,
+        ));
     }
 
     /**

--- a/app/Modules/ReserveTeam/Exceptions/FirstTeamSquadFullException.php
+++ b/app/Modules/ReserveTeam/Exceptions/FirstTeamSquadFullException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Modules\ReserveTeam\Exceptions;
+
+use RuntimeException;
+
+class FirstTeamSquadFullException extends RuntimeException
+{
+}

--- a/app/Modules/ReserveTeam/Services/ReserveTeamService.php
+++ b/app/Modules/ReserveTeam/Services/ReserveTeamService.php
@@ -1,0 +1,212 @@
+<?php
+
+namespace App\Modules\ReserveTeam\Services;
+
+use App\Models\Game;
+use App\Models\GamePlayer;
+use App\Models\GameTransfer;
+use App\Models\Loan;
+use App\Modules\Notification\Services\NotificationService;
+use App\Modules\Player\PlayerAge;
+use App\Modules\ReserveTeam\Exceptions\FirstTeamSquadFullException;
+use App\Modules\Squad\Services\SquadNumberService;
+use App\Modules\Transfer\Enums\TransferWindowType;
+use App\Modules\Transfer\Services\LoanService;
+use Illuminate\Support\Collection;
+
+/**
+ * Filial-aware reserve squad operations: list the reserve squad, call players
+ * up to the first team via Loan, send them back, and auto-promote those who
+ * age past the reserve cutoff at season close.
+ *
+ * Filial semantics: a reserve player belongs to the reserve team. The first
+ * team calls them up via a Loan (parent=reserve, loan=first); ending the loan
+ * sends them back. Age-23 promotion is the one permanent move (one-way
+ * transfer recorded via GameTransfer::TYPE_INTERNAL_PROMOTION).
+ */
+class ReserveTeamService
+{
+    public function __construct(
+        private readonly LoanService $loanService,
+        private readonly SquadNumberService $squadNumberService,
+        private readonly NotificationService $notificationService,
+    ) {}
+
+    /**
+     * Return all GamePlayers who belong to the reserve team — players currently
+     * registered there plus those temporarily called up (active loan with
+     * parent_team_id == reserve_team_id). Empty collection for non-filial games.
+     *
+     * @return Collection<int, GamePlayer>
+     */
+    public function getReserveSquad(Game $game): Collection
+    {
+        if ($game->reserve_team_id === null) {
+            return collect();
+        }
+
+        return GamePlayer::ownedByTeam($game->reserve_team_id)
+            ->where('game_id', $game->id)
+            ->with(['player', 'activeLoan'])
+            ->get();
+    }
+
+    /**
+     * Call a reserve player up to the first team. Creates a Loan
+     * (parent=reserve, loan=first), flips team_id, assigns squad number.
+     *
+     * @throws FirstTeamSquadFullException when no squad number is available
+     */
+    public function callUpToFirstTeam(GamePlayer $player, Game $game): void
+    {
+        $this->assertFilial($game);
+
+        if ($player->team_id !== $game->reserve_team_id) {
+            throw new \DomainException('Player is not currently registered to the reserve team.');
+        }
+
+        $effectiveStart = $game->getLoanEffectiveStartDate();
+        $returnDate = $game->getSeasonEndDateFor($effectiveStart);
+
+        Loan::create([
+            'game_id' => $game->id,
+            'game_player_id' => $player->id,
+            'parent_team_id' => $game->reserve_team_id,
+            'loan_team_id' => $game->team_id,
+            'started_at' => $effectiveStart,
+            'return_at' => $returnDate,
+            'status' => Loan::STATUS_ACTIVE,
+        ]);
+
+        // Move into first team first so SquadNumberService sees the player
+        // among the user's squad while picking a free number. Call-ups are
+        // temporary loans, so force a 26-99 number rather than letting them
+        // claim a permanent first-team slot (1-25).
+        $player->update(['team_id' => $game->team_id]);
+
+        $number = $this->squadNumberService->assignNumberForNewPlayer($game, $player, forceAboveFirstTeamMax: true);
+
+        if ($number === null) {
+            // Roll back the move and the loan.
+            $player->update(['team_id' => $game->reserve_team_id]);
+            Loan::where('game_player_id', $player->id)
+                ->where('status', Loan::STATUS_ACTIVE)
+                ->delete();
+
+            throw new FirstTeamSquadFullException(
+                'First-team squad is full; release a player before calling up another.'
+            );
+        }
+
+        $player->update(['number' => $number]);
+
+        GameTransfer::record(
+            gameId: $game->id,
+            gamePlayerId: $player->id,
+            fromTeamId: $game->reserve_team_id,
+            toTeamId: $game->team_id,
+            transferFee: 0,
+            type: GameTransfer::TYPE_LOAN,
+            season: $game->season,
+            window: TransferWindowType::currentValue($game->current_date),
+        );
+    }
+
+    /**
+     * Send a called-up player back to the reserve team. Ends the active
+     * call-up loan, flips team_id back, nulls squad number.
+     */
+    public function sendBackToReserve(GamePlayer $player, Game $game): void
+    {
+        $this->assertFilial($game);
+
+        $loan = Loan::where('game_player_id', $player->id)
+            ->where('status', Loan::STATUS_ACTIVE)
+            ->where('parent_team_id', $game->reserve_team_id)
+            ->where('loan_team_id', $game->team_id)
+            ->first();
+
+        if ($loan === null) {
+            throw new \DomainException('Player is not currently called up from the reserve team.');
+        }
+
+        // returnLoan handles team_id flip and number reassignment. For loans
+        // returning to the reserve team (not the user's team), it sets number
+        // to null automatically.
+        $this->loanService->returnLoan($loan);
+    }
+
+    /**
+     * At season close, permanently promote any reserve player who has aged
+     * past the reserve cutoff (over 23) to the first team. One-way move,
+     * recorded as a GameTransfer of type INTERNAL_PROMOTION. Any active
+     * call-up loan for the player is closed first.
+     *
+     * Returns the list of promoted players for downstream processors.
+     *
+     * @return Collection<int, GamePlayer>
+     */
+    public function autoPromoteOverageReservePlayers(Game $game): Collection
+    {
+        if ($game->reserve_team_id === null) {
+            return collect();
+        }
+
+        $cutoff = PlayerAge::dateOfBirthCutoff(PlayerAge::YOUNG_END + 1, $game->current_date);
+
+        $candidates = GamePlayer::ownedByTeam($game->reserve_team_id)
+            ->where('game_id', $game->id)
+            ->whereHas('player', fn ($q) => $q->where('date_of_birth', '<=', $cutoff))
+            ->with(['player', 'activeLoan'])
+            ->get();
+
+        $promoted = collect();
+
+        foreach ($candidates as $player) {
+            // Close any active call-up loan first so returnLoan() doesn't
+            // later try to flip the player back to the reserve team.
+            if ($player->activeLoan && $player->activeLoan->parent_team_id === $game->reserve_team_id) {
+                $player->activeLoan->update(['status' => Loan::STATUS_COMPLETED]);
+            }
+
+            // Permanent move to first team.
+            $player->update(['team_id' => $game->team_id]);
+            $number = $this->squadNumberService->assignNumberForNewPlayer($game, $player);
+            if ($number !== null) {
+                $player->update(['number' => $number]);
+            }
+
+            GameTransfer::record(
+                gameId: $game->id,
+                gamePlayerId: $player->id,
+                fromTeamId: $game->reserve_team_id,
+                toTeamId: $game->team_id,
+                transferFee: 0,
+                type: GameTransfer::TYPE_INTERNAL_PROMOTION,
+                season: $game->season,
+                window: TransferWindowType::currentValue($game->current_date),
+            );
+
+            $this->notificationService->create(
+                game: $game,
+                type: \App\Models\GameNotification::TYPE_ACADEMY_PROSPECT,
+                title: __('notifications.reserve_overage_promoted_title'),
+                message: __('notifications.reserve_overage_promoted_message', [
+                    'player' => $player->player->name ?? '',
+                ]),
+                priority: \App\Models\GameNotification::PRIORITY_INFO,
+            );
+
+            $promoted->push($player);
+        }
+
+        return $promoted;
+    }
+
+    private function assertFilial(Game $game): void
+    {
+        if ($game->reserve_team_id === null) {
+            throw new \DomainException('Reserve team operations require a filial game.');
+        }
+    }
+}

--- a/app/Modules/Season/Processors/ReserveOveragePromotionProcessor.php
+++ b/app/Modules/Season/Processors/ReserveOveragePromotionProcessor.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Modules\Season\Processors;
+
+use App\Models\Game;
+use App\Modules\ReserveTeam\Services\ReserveTeamService;
+use App\Modules\Season\Contracts\SeasonProcessor;
+use App\Modules\Season\DTOs\SeasonTransitionData;
+
+/**
+ * For filial games, permanently promotes any reserve player who has aged
+ * past the reserve cutoff (over 23) to the first team.
+ *
+ * Runs before LoanReturnProcessor (priority 5) so age-23 players are settled
+ * permanently in the first team before remaining call-up loans snap back.
+ *
+ * No-op for non-filial games.
+ *
+ * Priority: 4
+ */
+class ReserveOveragePromotionProcessor implements SeasonProcessor
+{
+    public function __construct(
+        private readonly ReserveTeamService $reserveTeamService,
+    ) {}
+
+    public function priority(): int
+    {
+        return 4;
+    }
+
+    public function process(Game $game, SeasonTransitionData $data): SeasonTransitionData
+    {
+        if ($game->reserve_team_id === null) {
+            return $data;
+        }
+
+        $promoted = $this->reserveTeamService->autoPromoteOverageReservePlayers($game);
+
+        if ($promoted->isNotEmpty()) {
+            $data->setMetadata('reserve_overage_promoted', $promoted->count());
+        }
+
+        return $data;
+    }
+}

--- a/app/Modules/Season/Processors/YouthAcademyClosingProcessor.php
+++ b/app/Modules/Season/Processors/YouthAcademyClosingProcessor.php
@@ -25,6 +25,12 @@ class YouthAcademyClosingProcessor implements SeasonProcessor
 
     public function process(Game $game, SeasonTransitionData $data): SeasonTransitionData
     {
+        // Filial games don't use the AcademyPlayer pool — reserve squads are
+        // GamePlayers handled elsewhere. Skip the academy lifecycle entirely.
+        if ($game->reserve_team_id !== null) {
+            return $data;
+        }
+
         // 1. Develop loaned players at higher rate before returning
         $this->youthAcademyService->developLoanedPlayers($game);
 

--- a/app/Modules/Season/Processors/YouthAcademyPromotionProcessor.php
+++ b/app/Modules/Season/Processors/YouthAcademyPromotionProcessor.php
@@ -46,6 +46,12 @@ class YouthAcademyPromotionProcessor implements SeasonProcessor
 
     public function process(Game $game, SeasonTransitionData $data): SeasonTransitionData
     {
+        // Filial games don't use the AcademyPlayer pool — reserve squad
+        // age-out is handled by ReserveOveragePromotionProcessor instead.
+        if ($game->reserve_team_id !== null) {
+            return $data;
+        }
+
         // Phase 1: Promote overage academy players (mandatory — they must leave)
         $overagePromoted = $this->youthAcademyService->promoteOveragePlayers($game);
 

--- a/app/Modules/Season/Services/GameCreationService.php
+++ b/app/Modules/Season/Services/GameCreationService.php
@@ -27,7 +27,7 @@ class GameCreationService
                 ->first()
             ?? CompetitionTeam::where('team_id', $teamId)->first();
 
-        $team = Team::find($teamId);
+        $team = Team::with('reserveTeam')->find($teamId);
 
         // Resolve competition ID: use competition_team lookup, fall back to
         // tier 1 of the team's country from config
@@ -38,6 +38,10 @@ class GameCreationService
         }
         $season = $competitionTeam->season ?? '2025';
 
+        // Resolve reserve team (filial) for managers of parent clubs.
+        // The user's club becomes filial if it has a reserve team and isn't itself one.
+        $reserveTeamId = $team->parent_team_id === null ? $team->reserveTeam?->id : null;
+
         // Create game record (setup not yet complete)
         // current_date and season_goal are set by processors during SetupNewGame
         $game = Game::create([
@@ -46,6 +50,7 @@ class GameCreationService
             'game_mode' => $gameMode,
             'country' => $team->country ?? 'ES',
             'team_id' => $teamId,
+            'reserve_team_id' => $reserveTeamId,
             'competition_id' => $competitionId,
             'season' => $season,
             'current_date' => null,

--- a/app/Modules/Season/Services/SeasonClosingPipeline.php
+++ b/app/Modules/Season/Services/SeasonClosingPipeline.php
@@ -17,6 +17,7 @@ use App\Modules\Season\Processors\PlayerRetirementProcessor;
 use App\Modules\Season\Processors\PreContractTransferProcessor;
 use App\Modules\Season\Processors\PromotionRelegationProcessor;
 use App\Modules\Season\Processors\ReputationUpdateProcessor;
+use App\Modules\Season\Processors\ReserveOveragePromotionProcessor;
 use App\Modules\Season\Processors\SeasonArchiveProcessor;
 use App\Modules\Season\Processors\SeasonSettlementProcessor;
 use App\Modules\Season\Processors\SeasonSimulationProcessor;
@@ -41,6 +42,7 @@ class SeasonClosingPipeline
     private array $processors = [];
 
     public function __construct(
+        ReserveOveragePromotionProcessor $reserveOveragePromotion,
         LoanReturnProcessor $loanReturn,
         TrophyRecordingProcessor $trophyRecording,
         LeaderboardStatsProcessor $leaderboardStats,
@@ -66,6 +68,7 @@ class SeasonClosingPipeline
         UefaQualificationProcessor $uefaQualification,
     ) {
         $this->processors = [
+            $reserveOveragePromotion,
             $loanReturn,
             $trophyRecording,
             $leaderboardStats,

--- a/app/Modules/Squad/Services/SquadNumberService.php
+++ b/app/Modules/Squad/Services/SquadNumberService.php
@@ -41,8 +41,12 @@ class SquadNumberService
      * Over-23 players get slots 1-25 (bumping the youngest under-23 if needed).
      * Under-23 players get slots 1-25 if available, otherwise 26-99.
      * Returns null only when there are already 25+ over-23 players (unresolvable).
+     *
+     * When $forceAboveFirstTeamMax is true (e.g. reserve-team call-ups, which
+     * are temporary loans), the player is assigned a 26-99 slot directly and
+     * never claims a permanent first-team number.
      */
-    public function assignNumberForNewPlayer(Game $game, GamePlayer $player): ?int
+    public function assignNumberForNewPlayer(Game $game, GamePlayer $player, bool $forceAboveFirstTeamMax = false): ?int
     {
         $age = $player->age($game->current_date);
         $isYoung = $age <= PlayerAge::YOUNG_END;
@@ -55,6 +59,10 @@ class SquadNumberService
             ->get();
 
         $takenNumbers = $teamPlayers->pluck('number')->flip();
+
+        if ($forceAboveFirstTeamMax) {
+            return $this->firstAvailable(self::FIRST_TEAM_MAX + 1, 99, $takenNumbers);
+        }
 
         if ($isYoung) {
             // Under-23: try preferred numbers in 1-25, then any 1-25, then 26-99

--- a/app/Modules/Transfer/Services/LoanService.php
+++ b/app/Modules/Transfer/Services/LoanService.php
@@ -394,7 +394,7 @@ class LoanService
     /**
      * Return a single loan - player goes back to parent team.
      */
-    private function returnLoan(Loan $loan): void
+    public function returnLoan(Loan $loan): void
     {
         $gamePlayer = $loan->gamePlayer;
         $isUserTeam = $loan->parent_team_id === $gamePlayer->game->team_id;

--- a/app/Modules/Transfer/Services/ScoutSearchQueryBuilder.php
+++ b/app/Modules/Transfer/Services/ScoutSearchQueryBuilder.php
@@ -29,6 +29,10 @@ class ScoutSearchQueryBuilder
             ->whereNotNull('team_id')
             ->where('team_id', '!=', $game->team_id);
 
+        if ($game->reserve_team_id) {
+            $query->where('team_id', '!=', $game->reserve_team_id);
+        }
+
         $this->applyPositionFilter($query, $positions);
 
         $this->applyScopeFilter($query, $game, $filters);

--- a/app/Modules/Transfer/Services/TransferMarketService.php
+++ b/app/Modules/Transfer/Services/TransferMarketService.php
@@ -178,14 +178,18 @@ class TransferMarketService
             ->where('status', TransferOffer::STATUS_AGREED)
             ->pluck('game_player_id');
 
-        return TransferListing::with(['gamePlayer.player', 'gamePlayer.team'])
+        $query = TransferListing::with(['gamePlayer.player', 'gamePlayer.team'])
             ->where('game_id', $game->id)
             ->where('team_id', '!=', $game->team_id)
             ->where('status', TransferListing::STATUS_LISTED)
             ->whereNotNull('asking_price')
-            ->whereNotIn('game_player_id', $alreadyAgreedIds)
-            ->orderByDesc('asking_price')
-            ->get();
+            ->whereNotIn('game_player_id', $alreadyAgreedIds);
+
+        if ($game->reserve_team_id) {
+            $query->where('team_id', '!=', $game->reserve_team_id);
+        }
+
+        return $query->orderByDesc('asking_price')->get();
     }
 
     // ── Private helpers ─────────────────────────────────────────────────
@@ -355,11 +359,17 @@ class TransferMarketService
      */
     private function sampleAITeams(Game $game, int $sampleSize): array
     {
-        $teamIds = DB::table('competition_entries')
-            ->where('game_id', $game->id)
-            ->where('team_id', '!=', $game->team_id)
+        $query = DB::table('competition_entries')
+            ->where('competition_entries.game_id', $game->id)
+            ->where('competition_entries.team_id', '!=', $game->team_id);
+
+        if ($game->reserve_team_id) {
+            $query->where('competition_entries.team_id', '!=', $game->reserve_team_id);
+        }
+
+        $teamIds = $query
             ->distinct()
-            ->pluck('team_id')
+            ->pluck('competition_entries.team_id')
             ->all();
 
         if (empty($teamIds)) {

--- a/database/migrations/2026_04_25_000001_add_reserve_team_id_to_games_table.php
+++ b/database/migrations/2026_04_25_000001_add_reserve_team_id_to_games_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('games', function (Blueprint $table) {
+            $table->uuid('reserve_team_id')->nullable()->after('team_id');
+            $table->foreign('reserve_team_id')->references('id')->on('teams')->nullOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('games', function (Blueprint $table) {
+            $table->dropForeign(['reserve_team_id']);
+            $table->dropColumn('reserve_team_id');
+        });
+    }
+};

--- a/lang/en/messages.php
+++ b/lang/en/messages.php
@@ -89,6 +89,13 @@ return [
     'academy_player_loaned' => ':player has been loaned out.',
     'academy_must_decide_21' => 'Players aged 21+ will be automatically promoted to the first team.',
 
+    // Reserve team (filial)
+    'reserve_player_called_up' => ':player has been called up to the first team.',
+    'reserve_player_sent_back' => ':player has been sent back to the reserve team.',
+    'reserve_player_call_up_blocked_full' => 'First-team squad is full. Release a player before calling up another.',
+    'reserve_player_promoted' => ':player has been promoted to the first team.',
+    'shortlist_reserve_blocked' => "Reserve-team players belong to their parent club and aren't transferable.",
+
     // Player release messages
     'player_released' => ':player has been released. Severance paid: :severance.',
     'release_not_your_player' => 'You can only release players from your own team.',

--- a/lang/en/notifications.php
+++ b/lang/en/notifications.php
@@ -89,6 +89,8 @@ return [
     'academy_overage_promoted_message' => ':count academy players aged 21+ have been promoted to the first team.',
     'academy_gap_promoted_title' => 'Academy players promoted',
     'academy_gap_promoted_message' => ':count academy players have been promoted to fill squad gaps.',
+    'reserve_overage_promoted_title' => 'Reserve graduate',
+    'reserve_overage_promoted_message' => ':player has aged out of the reserve team and joined the first team permanently.',
     // Loan request results
     'loan_accepted_title' => 'Loan request for :player accepted',
     'loan_accepted' => ':team have accepted your loan request for :player.',

--- a/lang/en/squad.php
+++ b/lang/en/squad.php
@@ -221,6 +221,23 @@ return [
     'academy_tier_4' => 'World-Class Academy',
     'academy_tier_unknown' => 'Unknown',
 
+    // Reserve team (filial)
+    'reserve_team' => 'Reserve Team',
+    'reserve_squad' => 'Reserve squad',
+    'no_reserve_players' => 'No reserve-team players.',
+    'call_up' => 'Call up',
+    'call_up_to_first_team' => 'Call up to first team',
+    'send_back' => 'Send back',
+    'send_back_to_reserve' => 'Send back to reserve',
+    'called_up_indicator' => 'Called up',
+    'actions' => 'Actions',
+    'reserve_help_toggle' => 'How does the reserve team work?',
+    'reserve_help_development' => 'Your reserve team is your filial — its squad belongs to the reserve, not the first team. New academy prospects arrive here each season based on your academy investment, and develop alongside the existing reserve roster.',
+    'reserve_help_age_rule' => 'Players over 23 are automatically promoted to the first team at season close. The first team can call up reserve players any time during the season.',
+    'reserve_help_actions_title' => 'Available actions',
+    'reserve_help_call_up' => 'Call up - the player joins the first team on a temporary loan and can play first-team matches',
+    'reserve_help_send_back' => 'Send back - returns the called-up player to the reserve squad',
+
     // Lineup help text
     'lineup_help_toggle' => 'How does lineup selection work?',
     'lineup_help_intro' => 'Choose 11 players for each match. Your formation, player energy, and positional compatibility all affect performance.',

--- a/lang/es/messages.php
+++ b/lang/es/messages.php
@@ -89,6 +89,13 @@ return [
     'academy_player_loaned' => ':player ha sido cedido.',
     'academy_must_decide_21' => 'Los jugadores de 21+ años serán promocionados automáticamente al primer equipo.',
 
+    // Reserve team (filial)
+    'reserve_player_called_up' => ':player ha sido convocado al primer equipo.',
+    'reserve_player_sent_back' => ':player ha vuelto al filial.',
+    'reserve_player_call_up_blocked_full' => 'La plantilla del primer equipo está completa. Libera un dorsal antes de subir más jugadores.',
+    'reserve_player_promoted' => ':player ha subido al primer equipo.',
+    'shortlist_reserve_blocked' => 'Los jugadores del filial pertenecen al club matriz y no son transferibles.',
+
     // Player release messages
     'player_released' => ':player ha sido liberado. Indemnización pagada: :severance.',
     'release_not_your_player' => 'Solo puedes liberar jugadores de tu propio equipo.',

--- a/lang/es/notifications.php
+++ b/lang/es/notifications.php
@@ -89,6 +89,8 @@ return [
     'academy_overage_promoted_message' => ':count canteranos de 21+ años han sido promocionados al primer equipo.',
     'academy_gap_promoted_title' => 'Canteranos promocionados',
     'academy_gap_promoted_message' => ':count canteranos han sido promocionados para cubrir huecos en la plantilla.',
+    'reserve_overage_promoted_title' => 'Graduado del filial',
+    'reserve_overage_promoted_message' => ':player ha superado la edad del filial y se incorpora al primer equipo de forma permanente.',
     // Loan request results
     'loan_accepted_title' => 'Cesión de :player aceptada',
     'loan_accepted' => ':team ha aceptado tu solicitud de cesión por :player.',

--- a/lang/es/squad.php
+++ b/lang/es/squad.php
@@ -221,6 +221,23 @@ return [
     'academy_tier_4' => 'Cantera de Clase Mundial',
     'academy_tier_unknown' => 'Desconocido',
 
+    // Reserve team (filial)
+    'reserve_team' => 'Filial',
+    'reserve_squad' => 'Plantilla del filial',
+    'no_reserve_players' => 'No hay jugadores en el filial.',
+    'call_up' => 'Subir',
+    'call_up_to_first_team' => 'Subir al primer equipo',
+    'send_back' => 'Bajar',
+    'send_back_to_reserve' => 'Bajar al filial',
+    'called_up_indicator' => 'En el primer equipo',
+    'actions' => 'Acciones',
+    'reserve_help_toggle' => '¿Cómo funciona el filial?',
+    'reserve_help_development' => 'Tu filial es la cantera oficial — los jugadores pertenecen al filial, no al primer equipo. Cada temporada llegan nuevos canteranos según tu inversión en la cantera, que se desarrollan junto con el resto del filial.',
+    'reserve_help_age_rule' => 'Los jugadores que cumplen 24 años pasan automáticamente al primer equipo al final de la temporada. El primer equipo puede subir jugadores del filial en cualquier momento.',
+    'reserve_help_actions_title' => 'Acciones disponibles',
+    'reserve_help_call_up' => 'Subir - el jugador se incorpora al primer equipo en cesión y puede disputar partidos con el primer equipo',
+    'reserve_help_send_back' => 'Bajar - devuelve al jugador subido al filial',
+
     // Lineup help text
     'lineup_help_toggle' => '¿Cómo funciona la alineación?',
     'lineup_help_intro' => 'Elige 11 jugadores para cada partido. Tu formación, la energía y la compatibilidad posicional afectan al rendimiento.',

--- a/resources/views/squad-academy.blade.php
+++ b/resources/views/squad-academy.blade.php
@@ -8,9 +8,14 @@
     <div class="max-w-7xl mx-auto px-4 pb-8">
 
         {{-- Sub-navigation --}}
+        @php
+            $secondaryItem = $game->isFilial()
+                ? ['href' => route('game.squad.reserve', $game->id), 'label' => __('squad.reserve_team'), 'active' => false]
+                : ['href' => route('game.squad.academy', $game->id), 'label' => __('squad.academy'), 'active' => true];
+        @endphp
         <x-section-nav :items="[
             ['href' => route('game.squad', $game->id), 'label' => __('squad.first_team'), 'active' => false],
-            ['href' => route('game.squad.academy', $game->id), 'label' => __('squad.academy'), 'active' => true],
+            $secondaryItem,
             ['href' => route('game.squad.registration', $game->id), 'label' => __('squad.registration'), 'active' => false],
         ]" />
 

--- a/resources/views/squad-reserve.blade.php
+++ b/resources/views/squad-reserve.blade.php
@@ -1,0 +1,194 @@
+@php /** @var App\Models\Game $game **/ @endphp
+
+<x-app-layout>
+    <x-slot name="header">
+        <x-game-header :game="$game" :next-match="$game->next_match"></x-game-header>
+    </x-slot>
+
+    <div class="max-w-7xl mx-auto px-4 pb-8">
+
+        {{-- Sub-navigation --}}
+        <x-section-nav :items="[
+            ['href' => route('game.squad', $game->id), 'label' => __('squad.first_team'), 'active' => false],
+            ['href' => route('game.squad.reserve', $game->id), 'label' => __('squad.reserve_team'), 'active' => true],
+            ['href' => route('game.squad.registration', $game->id), 'label' => __('squad.registration'), 'active' => false],
+        ]" />
+
+        {{-- Flash Messages --}}
+        <x-flash-message type="success" :message="session('success')" class="mt-4" />
+        <x-flash-message type="error" :message="session('error')" class="mt-4" />
+
+        {{-- Page Title --}}
+        <div class="mt-6 mb-4 flex items-center gap-3">
+            @if($reserveTeam->image)
+                <img src="{{ $reserveTeam->image }}" alt="{{ $reserveTeam->name }}" class="w-10 h-10 object-contain shrink-0" />
+            @endif
+            <div>
+                <h2 class="font-heading text-2xl lg:text-3xl font-bold uppercase tracking-wide text-text-primary">{{ $reserveTeam->name }}</h2>
+                <p class="text-xs text-text-muted">{{ __('squad.reserve_team') }}</p>
+            </div>
+        </div>
+
+        {{-- Summary strip --}}
+        <x-help-disclosure class="mb-6">
+            <x-slot name="trigger">
+                <div class="flex items-center gap-2.5 overflow-x-auto scrollbar-hide pb-1">
+                    <x-summary-card :label="__('squad.squad_size')" :value="$reserveCount" />
+                    <x-summary-card :label="__('squad.avg_age')" :value="$avgAge" />
+                    <x-summary-card :label="__('squad.fitness_full')" :value="$avgFitness . '%'" x-data x-tooltip.raw="{{ __('squad.tooltip_fitness') }}" :value-class="$avgFitness >= 85 ? 'text-accent-green' : ($avgFitness >= 70 ? 'text-text-primary' : 'text-amber-500')" />
+                    <x-summary-card :label="__('squad.morale_full')" :value="$avgMorale" x-data x-tooltip.raw="{{ __('squad.tooltip_morale') }}" :value-class="$avgMorale >= 80 ? 'text-accent-green' : ($avgMorale >= 65 ? 'text-text-primary' : 'text-amber-500')" />
+                    <x-summary-card :label="__('squad.avg_ovr')" :value="$avgOverall" x-data x-tooltip.raw="{{ __('squad.tooltip_avg_overall') }}" :value-class="$avgOverall >= 75 ? 'text-accent-green' : ($avgOverall >= 65 ? 'text-text-primary' : 'text-amber-500')" />
+                    <div class="ml-auto shrink-0">
+                        <x-help-toggle :label="__('squad.reserve_help_toggle')" />
+                    </div>
+                </div>
+            </x-slot>
+
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-5">
+                <div>
+                    <p class="text-text-secondary mb-3">{{ __('squad.reserve_help_development') }}</p>
+                    <p class="text-text-secondary">{{ __('squad.reserve_help_age_rule') }}</p>
+                </div>
+
+                <div>
+                    <p class="font-semibold text-text-body mb-2">{{ __('squad.reserve_help_actions_title') }}</p>
+                    <ul class="space-y-2">
+                        <li class="flex gap-2">
+                            <span class="text-accent-green shrink-0">↑</span>
+                            <span class="text-text-secondary">{{ __('squad.reserve_help_call_up') }}</span>
+                        </li>
+                        <li class="flex gap-2">
+                            <span class="text-amber-400 shrink-0">↓</span>
+                            <span class="text-text-secondary">{{ __('squad.reserve_help_send_back') }}</span>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </x-help-disclosure>
+
+        @if($reserveCount === 0)
+            <div class="text-center py-16">
+                <div class="inline-flex items-center justify-center w-16 h-16 bg-surface-700 rounded-full mb-4">
+                    <svg class="w-8 h-8 fill-surface-600" stroke="currentColor" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 576 512"><path d="M48 195.8l209.2 86.1c9.8 4 20.2 6.1 30.8 6.1s21-2.1 30.8-6.1l242.4-99.8c9-3.7 14.8-12.4 14.8-22.1s-5.8-18.4-14.8-22.1L318.8 38.1C309 34.1 298.6 32 288 32s-21 2.1-30.8 6.1L14.8 137.9C5.8 141.6 0 150.3 0 160L0 456c0 13.3 10.7 24 24 24s24-10.7 24-24l0-260.2zm48 71.7L96 384c0 53 86 96 192 96s192-43 192-96l0-116.6-142.9 58.9c-15.6 6.4-32.2 9.7-49.1 9.7s-33.5-3.3-49.1-9.7L96 267.4z"/></svg>
+                </div>
+                <p class="text-text-muted text-sm">{{ __('squad.no_reserve_players') }}</p>
+            </div>
+        @else
+            <div x-data class="bg-surface-800 border border-border-default rounded-xl overflow-hidden">
+                {{-- Table header --}}
+                <div class="hidden md:block">
+                    <div class="grid grid-cols-[40px_1fr_48px_48px_48px_56px_56px_120px] gap-1.5 items-center px-4 py-2 bg-surface-700/30 border-b border-border-default text-[10px] text-text-muted uppercase tracking-widest font-semibold">
+                        <span></span>
+                        <span>{{ __('app.name') }}</span>
+                        <span class="text-center">{{ __('app.age') }}</span>
+                        <span class="text-center">{{ __('squad.technical') }}</span>
+                        <span class="text-center">{{ __('squad.physical') }}</span>
+                        <span class="text-center">{{ __('squad.pot') }}</span>
+                        <span class="text-center">{{ __('squad.overall') }}</span>
+                        <span class="text-right">{{ __('squad.actions') }}</span>
+                    </div>
+                </div>
+
+                @foreach([
+                    ['name' => __('squad.goalkeepers'), 'players' => $goalkeepers],
+                    ['name' => __('squad.defenders'), 'players' => $defenders],
+                    ['name' => __('squad.midfielders'), 'players' => $midfielders],
+                    ['name' => __('squad.forwards'), 'players' => $forwards],
+                ] as $group)
+                    @if($group['players']->isNotEmpty())
+                        <div class="px-4 py-2 bg-surface-700/30 border-b border-border-default">
+                            <div class="flex items-center justify-between">
+                                <span class="font-heading text-[11px] font-semibold uppercase tracking-widest text-text-muted">{{ $group['name'] }}</span>
+                                <span class="text-[10px] text-text-faint">{{ $group['players']->count() }}</span>
+                            </div>
+                        </div>
+
+                        @foreach($group['players'] as $player)
+                            @php
+                                $isCalledUp = $player->team_id === $game->team_id;
+                                $age = $player->age($game->current_date);
+                            @endphp
+
+                            {{-- Mobile row --}}
+                            <div class="md:hidden px-4 py-3 border-b border-border-default">
+                                <div class="flex items-center gap-3">
+                                    <div class="cursor-pointer flex-1 flex items-center gap-3 min-w-0" @click="$dispatch('show-player-detail', '{{ route('game.player.detail', [$game->id, $player->id]) }}')">
+                                        <x-player-avatar :name="$player->player->name" :position-group="\App\Support\PositionMapper::getPositionGroup($player->position)" :position-abbrev="\App\Support\PositionMapper::toAbbreviation($player->position)" />
+                                        <div class="flex-1 min-w-0">
+                                            <div class="flex items-center gap-2">
+                                                <span class="text-sm font-medium text-text-primary truncate">{{ $player->player->name }}</span>
+                                                <span class="text-[10px] text-text-faint">{{ $age }}</span>
+                                                @if($isCalledUp)
+                                                    <span class="text-[10px] font-semibold bg-accent-blue/10 text-accent-blue px-1.5 py-0.5 rounded-full">{{ __('squad.called_up_indicator') }}</span>
+                                                @endif
+                                            </div>
+                                        </div>
+                                        <x-rating-badge :value="$player->overall_score" class="shrink-0" />
+                                    </div>
+                                    @if($isCalledUp)
+                                        <form method="POST" action="{{ route('game.reserve.send-back', [$game->id, $player->id]) }}" onsubmit="return confirm('{{ __('squad.send_back_to_reserve') }}?')">
+                                            @csrf
+                                            <button type="submit" class="text-amber-400 hover:text-amber-300 px-2" title="{{ __('squad.send_back_to_reserve') }}">↓</button>
+                                        </form>
+                                    @else
+                                        <form method="POST" action="{{ route('game.reserve.call-up', [$game->id, $player->id]) }}" onsubmit="return confirm('{{ __('squad.call_up_to_first_team') }}?')">
+                                            @csrf
+                                            <button type="submit" class="text-accent-green hover:text-emerald-400 px-2" title="{{ __('squad.call_up_to_first_team') }}">↑</button>
+                                        </form>
+                                    @endif
+                                </div>
+                            </div>
+
+                            {{-- Desktop row --}}
+                            <div class="hidden md:grid grid-cols-[40px_1fr_48px_48px_48px_56px_56px_120px] gap-1.5 items-center px-4 py-2.5 border-b border-border-default hover:bg-surface-700/30 transition-colors">
+                                <div class="flex justify-center cursor-pointer" @click="$dispatch('show-player-detail', '{{ route('game.player.detail', [$game->id, $player->id]) }}')">
+                                    <x-position-badge :position="$player->position" size="sm" :tooltip="\App\Support\PositionMapper::toDisplayName($player->position)" class="cursor-help" />
+                                </div>
+                                <div class="flex items-center gap-2 min-w-0 cursor-pointer" @click="$dispatch('show-player-detail', '{{ route('game.player.detail', [$game->id, $player->id]) }}')">
+                                    @if($player->nationality_flag)
+                                        <img src="{{ Storage::disk('assets')->url('flags/' . $player->nationality_flag['code'] . '.svg') }}" class="w-4 h-3 rounded-xs shadow-xs shrink-0" title="{{ $player->nationality_flag['name'] }}">
+                                    @endif
+                                    <span class="text-sm font-medium text-text-primary truncate">{{ $player->player->name }}</span>
+                                    @if($isCalledUp)
+                                        <span class="text-[10px] font-semibold bg-accent-blue/10 text-accent-blue px-1.5 py-0.5 rounded-full">{{ __('squad.called_up_indicator') }}</span>
+                                    @endif
+                                </div>
+                                <span class="text-xs text-text-secondary text-center tabular-nums">{{ $age }}</span>
+                                <div class="flex justify-center">
+                                    <span class="text-xs font-medium tabular-nums @if($player->current_technical_ability >= 80) text-accent-green @elseif($player->current_technical_ability >= 70) text-lime-500 @elseif($player->current_technical_ability >= 60) text-text-body @else text-text-secondary @endif">{{ $player->current_technical_ability }}</span>
+                                </div>
+                                <div class="flex justify-center">
+                                    <span class="text-xs font-medium tabular-nums @if($player->current_physical_ability >= 80) text-accent-green @elseif($player->current_physical_ability >= 70) text-lime-500 @elseif($player->current_physical_ability >= 60) text-text-body @else text-text-secondary @endif">{{ $player->current_physical_ability }}</span>
+                                </div>
+                                <span class="text-xs text-center tabular-nums text-text-muted">{{ $player->potential_range }}</span>
+                                <div class="flex justify-center">
+                                    <x-rating-badge :value="$player->overall_score" size="sm" />
+                                </div>
+                                <div class="flex justify-end">
+                                    @if($isCalledUp)
+                                        <form method="POST" action="{{ route('game.reserve.send-back', [$game->id, $player->id]) }}" onsubmit="return confirm('{{ __('squad.send_back_to_reserve') }}?')">
+                                            @csrf
+                                            <x-ghost-button color="slate" size="xs" type="submit" title="{{ __('squad.send_back_to_reserve') }}">
+                                                ↓ {{ __('squad.send_back') }}
+                                            </x-ghost-button>
+                                        </form>
+                                    @else
+                                        <form method="POST" action="{{ route('game.reserve.call-up', [$game->id, $player->id]) }}" onsubmit="return confirm('{{ __('squad.call_up_to_first_team') }}?')">
+                                            @csrf
+                                            <x-ghost-button color="green" size="xs" type="submit" title="{{ __('squad.call_up_to_first_team') }}">
+                                                ↑ {{ __('squad.call_up') }}
+                                            </x-ghost-button>
+                                        </form>
+                                    @endif
+                                </div>
+                            </div>
+                        @endforeach
+                    @endif
+                @endforeach
+            </div>
+        @endif
+
+    </div>
+
+    <x-player-detail-modal />
+</x-app-layout>

--- a/resources/views/squad.blade.php
+++ b/resources/views/squad.blade.php
@@ -55,9 +55,12 @@
             {{-- Sub-navigation --}}
             @if($isCareerMode)
                 @php
+                    $secondaryItem = $game->isFilial()
+                        ? ['href' => route('game.squad.reserve', $game->id), 'label' => __('squad.reserve_team'), 'active' => false]
+                        : ['href' => route('game.squad.academy', $game->id), 'label' => __('squad.academy'), 'active' => false];
                     $squadNavItems = [
                         ['href' => route('game.squad', $game->id), 'label' => __('squad.first_team'), 'active' => true],
-                        ['href' => route('game.squad.academy', $game->id), 'label' => __('squad.academy'), 'active' => false],
+                        $secondaryItem,
                         ['href' => route('game.squad.registration', $game->id), 'label' => __('squad.registration'), 'active' => false],
                     ];
                 @endphp

--- a/routes/web.php
+++ b/routes/web.php
@@ -125,6 +125,9 @@ use App\Http\Views\ShowTournamentLeaderboard;
 use App\Http\Views\ShowTournamentSummary;
 use App\Http\Actions\ProcessTacticalActions;
 use App\Http\Actions\PromoteAcademyPlayer;
+use App\Http\Actions\CallUpReservePlayer;
+use App\Http\Actions\SendBackReservePlayer;
+use App\Http\Views\ShowReserveTeam;
 use App\Http\Actions\SkipMatchToEnd;
 use App\Http\Actions\StartNewSeason;
 use Illuminate\Support\Facades\Route;
@@ -167,6 +170,10 @@ Route::middleware('auth')->group(function () {
         Route::post('/game/{gameId}/academy/{playerId}/promote', PromoteAcademyPlayer::class)->name('game.academy.promote');
         Route::post('/game/{gameId}/academy/{playerId}/loan', LoanAcademyPlayer::class)->name('game.academy.loan');
         Route::post('/game/{gameId}/academy/{playerId}/dismiss', DismissAcademyPlayer::class)->name('game.academy.dismiss');
+        // Reserve team (filial games)
+        Route::get('/game/{gameId}/squad/reserve', ShowReserveTeam::class)->name('game.squad.reserve');
+        Route::post('/game/{gameId}/reserve/{playerId}/call-up', CallUpReservePlayer::class)->name('game.reserve.call-up');
+        Route::post('/game/{gameId}/reserve/{playerId}/send-back', SendBackReservePlayer::class)->name('game.reserve.send-back');
         // Club hub — Finances, Stadium, Reputation (and future non-sporting tenants)
         Route::get('/game/{gameId}/club', fn (string $gameId) => redirect()->route('game.club.finances', $gameId))->name('game.club');
         Route::get('/game/{gameId}/club/finances', ShowFinances::class)->name('game.club.finances');


### PR DESCRIPTION
## Summary
Spanish parent clubs (Real Madrid, Barcelona, Athletic, etc.) can now manage their reserve team in place of the Academy tab. Reserve players belong to the reserve squad and the first team calls them up via internal loans (parent=reserve, loan=first team); ending the loan sends them back. At season close, players who age past 23 are permanently promoted via a new `GameTransfer` type `INTERNAL_PROMOTION`.

- Adds `reserve_team_id` to games and assigns it for parent clubs at game creation.
- Academy generation for parent clubs creates `GamePlayer`s directly on the reserve team (no `AcademyPlayer` rows). Other clubs keep the existing Academy flow untouched.
- Reserve-team players are excluded from scouting, AI transfer listings, and shortlist actions so they can't be acquired through normal channels.
- New `ShowReserveTeam` view, `CallUpReservePlayer` / `SendBackReservePlayer` actions, `ReserveTeamService`, and `ReserveOveragePromotionProcessor`.

Phase 2 (reserve-league standings, fixtures, lazy match resolution) is intentionally deferred — this PR ships the squad-management slice on its own.

This is the foundation PR in a stack of 5 — see \`reserve/02-career-tracking\` next.

## Test plan
- [ ] Start a new game as Real Madrid / Barcelona / Athletic and verify the Academy tab is replaced by Reserve Team
- [ ] Reserve squad page lists generated youngsters
- [ ] Call-up moves player to first team via internal loan; send-back reverses it
- [ ] Season close: a 23-year-old reserve player is permanently promoted to first team
- [ ] Existing non-parent-club games continue to use the Academy flow unchanged