### PR TITLE
Track player origin and per-season career stats

### DIFF
--- a/app/Http/Actions/CallUpReservePlayer.php
+++ b/app/Http/Actions/CallUpReservePlayer.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Http\Actions;
+
+use App\Models\Game;
+use App\Models\GamePlayer;
+use App\Modules\ReserveTeam\Exceptions\FirstTeamSquadFullException;
+use App\Modules\ReserveTeam\Services\ReserveTeamService;
+
+class CallUpReservePlayer
+{
+    public function __construct(
+        private readonly ReserveTeamService $reserveTeamService,
+    ) {}
+
+    public function __invoke(string $gameId, string $playerId)
+    {
+        $game = Game::findOrFail($gameId);
+        abort_if($game->reserve_team_id === null, 404);
+
+        $player = GamePlayer::where('id', $playerId)
+            ->where('game_id', $gameId)
+            ->where('team_id', $game->reserve_team_id)
+            ->with('player')
+            ->firstOrFail();
+
+        $playerName = $player->player->name ?? '';
+
+        try {
+            $this->reserveTeamService->callUpToFirstTeam($player, $game);
+        } catch (FirstTeamSquadFullException $e) {
+            return redirect()->route('game.squad.reserve', $gameId)
+                ->with('error', __('messages.reserve_player_call_up_blocked_full'));
+        }
+
+        return redirect()->route('game.squad.reserve', $gameId)
+            ->with('success', __('messages.reserve_player_called_up', ['player' => $playerName]));
+    }
+}

--- a/app/Http/Actions/SendBackReservePlayer.php
+++ b/app/Http/Actions/SendBackReservePlayer.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Actions;
+
+use App\Models\Game;
+use App\Models\GamePlayer;
+use App\Modules\ReserveTeam\Services\ReserveTeamService;
+
+class SendBackReservePlayer
+{
+    public function __construct(
+        private readonly ReserveTeamService $reserveTeamService,
+    ) {}
+
+    public function __invoke(string $gameId, string $playerId)
+    {
+        $game = Game::findOrFail($gameId);
+        abort_if($game->reserve_team_id === null, 404);
+
+        $player = GamePlayer::where('id', $playerId)
+            ->where('game_id', $gameId)
+            ->where('team_id', $game->team_id)
+            ->whereHas('activeLoan', fn ($q) => $q->where('parent_team_id', $game->reserve_team_id))
+            ->with('player')
+            ->firstOrFail();
+
+        $playerName = $player->player->name ?? '';
+
+        $this->reserveTeamService->sendBackToReserve($player, $game);
+
+        return redirect()->route('game.squad.reserve', $gameId)
+            ->with('success', __('messages.reserve_player_sent_back', ['player' => $playerName]));
+    }
+}

--- a/app/Http/Actions/ToggleShortlist.php
+++ b/app/Http/Actions/ToggleShortlist.php
@@ -19,7 +19,21 @@ class ToggleShortlist
     public function __invoke(Request $request, string $gameId, string $playerId)
     {
         $game = Game::findOrFail($gameId);
-        $gamePlayer = GamePlayer::where('game_id', $gameId)->findOrFail($playerId);
+        $gamePlayer = GamePlayer::where('game_id', $gameId)->with('team')->findOrFail($playerId);
+
+        // Reserve-team (filial) players are not transferable through normal
+        // channels — they belong to the parent club and move only via
+        // call-up / promotion. Block adding them to the shortlist regardless
+        // of which game the user is in.
+        if ($gamePlayer->team && $gamePlayer->team->parent_team_id !== null) {
+            $message = __('messages.shortlist_reserve_blocked');
+
+            if ($request->ajax()) {
+                return response()->json(['success' => false, 'message' => $message], 422);
+            }
+
+            return redirect()->back()->with('error', $message);
+        }
 
         $existing = ShortlistedPlayer::where('game_id', $gameId)
             ->where('game_player_id', $playerId)

--- a/app/Http/Views/ShowPlayerDetail.php
+++ b/app/Http/Views/ShowPlayerDetail.php
@@ -17,9 +17,11 @@ class ShowPlayerDetail
     {
         $game = Game::findOrFail($gameId);
 
+        $allowedTeamIds = array_filter([$game->team_id, $game->reserve_team_id]);
+
         $gamePlayer = GamePlayer::with('player')
             ->where('game_id', $gameId)
-            ->where('team_id', $game->team_id)
+            ->whereIn('team_id', $allowedTeamIds)
             ->findOrFail($playerId);
 
         $canRenew = $gamePlayer->canBeOfferedRenewal(currentDate: $game->current_date);

--- a/app/Http/Views/ShowPlayerDetail.php
+++ b/app/Http/Views/ShowPlayerDetail.php
@@ -19,7 +19,7 @@ class ShowPlayerDetail
 
         $allowedTeamIds = array_filter([$game->team_id, $game->reserve_team_id]);
 
-        $gamePlayer = GamePlayer::with('player')
+        $gamePlayer = GamePlayer::with(['player', 'careerRecord'])
             ->where('game_id', $gameId)
             ->whereIn('team_id', $allowedTeamIds)
             ->findOrFail($playerId);

--- a/app/Http/Views/ShowReserveTeam.php
+++ b/app/Http/Views/ShowReserveTeam.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Http\Views;
+
+use App\Models\Game;
+use App\Modules\ReserveTeam\Services\ReserveTeamService;
+use App\Support\PositionMapper;
+
+class ShowReserveTeam
+{
+    public function __construct(
+        private readonly ReserveTeamService $reserveTeamService,
+    ) {}
+
+    public function __invoke(string $gameId)
+    {
+        $game = Game::with(['team', 'reserveTeam'])->findOrFail($gameId);
+        abort_if($game->isTournamentMode(), 404);
+        abort_if($game->reserve_team_id === null, 404);
+
+        $squad = $this->reserveTeamService->getReserveSquad($game);
+
+        $grouped = $squad
+            ->sortByDesc('overall_score')
+            ->groupBy(fn ($player) => PositionMapper::getPositionGroup($player->position));
+
+        $count = $squad->count();
+        $avgAge = $count > 0 ? round($squad->avg(fn ($p) => $p->age($game->current_date)), 1) : 0;
+        $avgFitness = $count > 0 ? (int) round($squad->avg('fitness')) : 0;
+        $avgMorale = $count > 0 ? (int) round($squad->avg('morale')) : 0;
+        $avgOverall = $count > 0 ? (int) round($squad->avg('overall_score')) : 0;
+
+        return view('squad-reserve', [
+            'game' => $game,
+            'reserveTeam' => $game->reserveTeam,
+            'goalkeepers' => $grouped->get('Goalkeeper', collect()),
+            'defenders' => $grouped->get('Defender', collect()),
+            'midfielders' => $grouped->get('Midfielder', collect()),
+            'forwards' => $grouped->get('Forward', collect()),
+            'reserveCount' => $count,
+            'avgAge' => $avgAge,
+            'avgFitness' => $avgFitness,
+            'avgMorale' => $avgMorale,
+            'avgOverall' => $avgOverall,
+        ]);
+    }
+}

--- a/app/Models/Game.php
+++ b/app/Models/Game.php
@@ -113,6 +113,7 @@ class Game extends Model
         'country',
         'player_name',
         'team_id',
+        'reserve_team_id',
         'competition_id',
         'season',
         'current_date',
@@ -331,6 +332,16 @@ class Game extends Model
     public function team(): BelongsTo
     {
         return $this->belongsTo(Team::class);
+    }
+
+    public function reserveTeam(): BelongsTo
+    {
+        return $this->belongsTo(Team::class, 'reserve_team_id');
+    }
+
+    public function isFilial(): bool
+    {
+        return $this->reserve_team_id !== null;
     }
 
     public function tactics(): HasOne

--- a/app/Models/Game.php
+++ b/app/Models/Game.php
@@ -339,6 +339,19 @@ class Game extends Model
         return $this->belongsTo(Team::class, 'reserve_team_id');
     }
 
+    /**
+     * Whether the given team is owned by the user in this game (first team
+     * or, for parent clubs, the filial reserve team).
+     */
+    public function ownsTeam(?string $teamId): bool
+    {
+        if ($teamId === null) {
+            return false;
+        }
+
+        return $teamId === $this->team_id || $teamId === $this->reserve_team_id;
+    }
+
     public function isFilial(): bool
     {
         return $this->reserve_team_id !== null;

--- a/app/Models/GamePlayer.php
+++ b/app/Models/GamePlayer.php
@@ -238,6 +238,11 @@ class GamePlayer extends Model
         return $this->hasOne(TransferListing::class);
     }
 
+    public function careerRecord(): HasOne
+    {
+        return $this->hasOne(UserSquadCareerRecord::class);
+    }
+
     /**
      * Get the active loan for this player (if any).
      */

--- a/app/Models/GameTransfer.php
+++ b/app/Models/GameTransfer.php
@@ -30,6 +30,7 @@ class GameTransfer extends Model
     public const TYPE_TRANSFER = 'transfer';
     public const TYPE_FREE_AGENT = 'free_agent';
     public const TYPE_LOAN = 'loan';
+    public const TYPE_INTERNAL_PROMOTION = 'internal_promotion';
 
     /**
      * Record a completed transfer in the ledger.

--- a/app/Models/UserSquadCareerRecord.php
+++ b/app/Models/UserSquadCareerRecord.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * Career history for a player currently owned by the user's club.
+ *
+ * Lifecycle:
+ *  - inserted when a GamePlayer becomes user-owned (academy/filial generation,
+ *    transfer in, internal promotion to/within the user's organisation),
+ *  - updated each season-close to append that season's stats to season_stats,
+ *  - deleted when the player ceases to be user-owned (sold, retired, etc.).
+ *
+ * One row per user-owned GamePlayer. AI-vs-AI players have no row.
+ *
+ * @property string $id
+ * @property string $game_player_id
+ * @property string $game_id
+ * @property string $team_id
+ * @property int $joined_season
+ * @property string|null $joined_from   'Academy' sentinel or previous team name snapshot
+ * @property array $season_stats        keyed by season number
+ */
+class UserSquadCareerRecord extends Model
+{
+    use HasFactory, HasUuids;
+
+    public const ORIGIN_ACADEMY = 'Academy';
+
+    public $timestamps = false;
+
+    protected $fillable = [
+        'game_player_id',
+        'game_id',
+        'team_id',
+        'joined_season',
+        'joined_from',
+        'season_stats',
+    ];
+
+    protected $casts = [
+        'joined_season' => 'integer',
+        'season_stats' => 'array',
+    ];
+
+    public function gamePlayer(): BelongsTo
+    {
+        return $this->belongsTo(GamePlayer::class);
+    }
+
+    public function team(): BelongsTo
+    {
+        return $this->belongsTo(Team::class);
+    }
+
+    public function game(): BelongsTo
+    {
+        return $this->belongsTo(Game::class);
+    }
+}

--- a/app/Modules/Academy/Services/YouthAcademyService.php
+++ b/app/Modules/Academy/Services/YouthAcademyService.php
@@ -113,7 +113,11 @@ class YouthAcademyService
     /**
      * Generate a batch of new academy prospects at season start.
      *
-     * @return Collection<int, AcademyPlayer>
+     * For filial games (clubs with a reserve team), prospects are created as
+     * full GamePlayers on the reserve squad — no AcademyPlayer rows. For
+     * non-filial games, prospects land in the AcademyPlayer pool as before.
+     *
+     * @return Collection<int, AcademyPlayer|GamePlayer>
      */
     public function generateSeasonBatch(Game $game): Collection
     {
@@ -127,10 +131,15 @@ class YouthAcademyService
         $excludedNames = $this->getExistingPlayerNames($game);
 
         $prospects = collect();
+        $isFilial = $game->reserve_team_id !== null;
 
         for ($i = 0; $i < $count; $i++) {
-            $prospect = $this->createAcademyProspect($game, $tier, $teamMedianTier, $excludedNames);
-            $excludedNames[] = $prospect->name;
+            $prospect = $isFilial
+                ? $this->createReserveProspect($game, $tier, $teamMedianTier, $excludedNames)
+                : $this->createAcademyProspect($game, $tier, $teamMedianTier, $excludedNames);
+
+            $name = $isFilial ? $prospect->player->name : $prospect->name;
+            $excludedNames[] = $name;
             $prospects->push($prospect);
         }
 
@@ -461,6 +470,71 @@ class YouthAcademyService
             'initial_technical' => $technical,
             'initial_physical' => $physical,
         ]);
+    }
+
+    /**
+     * Create a reserve-team prospect for filial games. Mirrors the academy
+     * prospect generation (same quality + potential distributions), but
+     * produces a full GamePlayer on the reserve squad instead of an
+     * AcademyPlayer pool entry.
+     */
+    private function createReserveProspect(
+        Game $game,
+        int $academyTier,
+        int $teamMedianTier,
+        array $excludedNames,
+    ): GamePlayer {
+        $position = $this->selectPosition();
+
+        $abilityMean = self::ACADEMY_BASE_QUALITY[$academyTier] + self::TEAM_CONTEXT_BONUS[$teamMedianTier];
+        $age = rand(17, 19);
+        $ageCap = match ($age) {
+            17 => 72,
+            18 => 74,
+            19 => 76,
+            default => 78,
+        };
+        $technical = $this->sampler->sampleAbility($abilityMean, self::ABILITY_STD_DEV, 50, $ageCap);
+        $physical = $this->sampler->sampleAbility($abilityMean, self::ABILITY_STD_DEV, 50, $ageCap);
+
+        $currentBest = max($technical, $physical);
+        $potentialData = $this->sampler->generatePotentialFromAbility(
+            $currentBest,
+            self::POTENTIAL_UPSIDE_MEAN[$academyTier],
+            self::POTENTIAL_UPSIDE_STD_DEV,
+            self::POTENTIAL_FLOOR[$academyTier],
+        );
+
+        $dateOfBirth = $game->current_date->copy()->subYears($age)->subDays(rand(0, 364));
+
+        $teamName = $game->team->name;
+        $nationalityFilter = self::CANTERA_TEAMS[$teamName] ?? null;
+        $teamCountry = $nationalityFilter ? null : $game->team->country;
+        $region = TeamRegionalOrigins::regionFor($teamName);
+        $identity = $this->playerGenerator->pickRandomIdentity(
+            $nationalityFilter,
+            $teamCountry,
+            $excludedNames,
+            $region,
+        );
+
+        return $this->playerGenerator->create($game, new GeneratedPlayerData(
+            teamId: $game->reserve_team_id,
+            position: $position,
+            technical: $technical,
+            physical: $physical,
+            dateOfBirth: $dateOfBirth,
+            contractYears: 2,
+            name: $identity['name'],
+            nationality: $identity['nationality'],
+            potential: $potentialData['potential'],
+            potentialLow: $potentialData['potentialLow'],
+            potentialHigh: $potentialData['potentialHigh'],
+            fitnessMin: 85,
+            fitnessMax: 100,
+            moraleMin: 70,
+            moraleMax: 90,
+        ));
     }
 
     /**

--- a/app/Modules/Academy/Services/YouthAcademyService.php
+++ b/app/Modules/Academy/Services/YouthAcademyService.php
@@ -306,6 +306,7 @@ class YouthAcademyService
             fitnessMax: 100,
             moraleMin: 70,
             moraleMax: 90,
+            joinedFrom: \App\Models\UserSquadCareerRecord::ORIGIN_ACADEMY,
         ));
 
         $gamePlayer->update([
@@ -534,6 +535,7 @@ class YouthAcademyService
             fitnessMax: 100,
             moraleMin: 70,
             moraleMax: 90,
+            joinedFrom: \App\Models\UserSquadCareerRecord::ORIGIN_ACADEMY,
         ));
     }
 

--- a/app/Modules/ReserveTeam/Exceptions/FirstTeamSquadFullException.php
+++ b/app/Modules/ReserveTeam/Exceptions/FirstTeamSquadFullException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Modules\ReserveTeam\Exceptions;
+
+use RuntimeException;
+
+class FirstTeamSquadFullException extends RuntimeException
+{
+}

--- a/app/Modules/ReserveTeam/Services/ReserveTeamService.php
+++ b/app/Modules/ReserveTeam/Services/ReserveTeamService.php
@@ -47,7 +47,7 @@ class ReserveTeamService
 
         return GamePlayer::ownedByTeam($game->reserve_team_id)
             ->where('game_id', $game->id)
-            ->with(['player', 'activeLoan'])
+            ->with(['player', 'activeLoan', 'careerRecord'])
             ->get();
     }
 
@@ -168,11 +168,22 @@ class ReserveTeamService
             }
 
             // Permanent move to first team.
+            $reserveTeamName = $game->reserveTeam?->name;
             $player->update(['team_id' => $game->team_id]);
             $number = $this->squadNumberService->assignNumberForNewPlayer($game, $player);
             if ($number !== null) {
                 $player->update(['number' => $number]);
             }
+
+            \App\Models\UserSquadCareerRecord::updateOrCreate(
+                ['game_player_id' => $player->id],
+                [
+                    'game_id' => $game->id,
+                    'team_id' => $game->team_id,
+                    'joined_season' => (int) $game->season,
+                    'joined_from' => $reserveTeamName ?? \App\Models\UserSquadCareerRecord::ORIGIN_ACADEMY,
+                ],
+            );
 
             GameTransfer::record(
                 gameId: $game->id,

--- a/app/Modules/ReserveTeam/Services/ReserveTeamService.php
+++ b/app/Modules/ReserveTeam/Services/ReserveTeamService.php
@@ -1,0 +1,210 @@
+<?php
+
+namespace App\Modules\ReserveTeam\Services;
+
+use App\Models\Game;
+use App\Models\GamePlayer;
+use App\Models\GameTransfer;
+use App\Models\Loan;
+use App\Modules\Notification\Services\NotificationService;
+use App\Modules\Player\PlayerAge;
+use App\Modules\ReserveTeam\Exceptions\FirstTeamSquadFullException;
+use App\Modules\Squad\Services\SquadNumberService;
+use App\Modules\Transfer\Enums\TransferWindowType;
+use App\Modules\Transfer\Services\LoanService;
+use Illuminate\Support\Collection;
+
+/**
+ * Filial-aware reserve squad operations: list the reserve squad, call players
+ * up to the first team via Loan, send them back, and auto-promote those who
+ * age past the reserve cutoff at season close.
+ *
+ * Filial semantics: a reserve player belongs to the reserve team. The first
+ * team calls them up via a Loan (parent=reserve, loan=first); ending the loan
+ * sends them back. Age-23 promotion is the one permanent move (one-way
+ * transfer recorded via GameTransfer::TYPE_INTERNAL_PROMOTION).
+ */
+class ReserveTeamService
+{
+    public function __construct(
+        private readonly LoanService $loanService,
+        private readonly SquadNumberService $squadNumberService,
+        private readonly NotificationService $notificationService,
+    ) {}
+
+    /**
+     * Return all GamePlayers who belong to the reserve team — players currently
+     * registered there plus those temporarily called up (active loan with
+     * parent_team_id == reserve_team_id). Empty collection for non-filial games.
+     *
+     * @return Collection<int, GamePlayer>
+     */
+    public function getReserveSquad(Game $game): Collection
+    {
+        if ($game->reserve_team_id === null) {
+            return collect();
+        }
+
+        return GamePlayer::ownedByTeam($game->reserve_team_id)
+            ->where('game_id', $game->id)
+            ->with(['player', 'activeLoan'])
+            ->get();
+    }
+
+    /**
+     * Call a reserve player up to the first team. Creates a Loan
+     * (parent=reserve, loan=first), flips team_id, assigns squad number.
+     *
+     * @throws FirstTeamSquadFullException when no squad number is available
+     */
+    public function callUpToFirstTeam(GamePlayer $player, Game $game): void
+    {
+        $this->assertFilial($game);
+
+        if ($player->team_id !== $game->reserve_team_id) {
+            throw new \DomainException('Player is not currently registered to the reserve team.');
+        }
+
+        $effectiveStart = $game->getLoanEffectiveStartDate();
+        $returnDate = $game->getSeasonEndDateFor($effectiveStart);
+
+        Loan::create([
+            'game_id' => $game->id,
+            'game_player_id' => $player->id,
+            'parent_team_id' => $game->reserve_team_id,
+            'loan_team_id' => $game->team_id,
+            'started_at' => $effectiveStart,
+            'return_at' => $returnDate,
+            'status' => Loan::STATUS_ACTIVE,
+        ]);
+
+        // Move into first team first so SquadNumberService sees the player
+        // among the user's squad while picking a free number.
+        $player->update(['team_id' => $game->team_id]);
+
+        $number = $this->squadNumberService->assignNumberForNewPlayer($game, $player);
+
+        if ($number === null) {
+            // Roll back the move and the loan.
+            $player->update(['team_id' => $game->reserve_team_id]);
+            Loan::where('game_player_id', $player->id)
+                ->where('status', Loan::STATUS_ACTIVE)
+                ->delete();
+
+            throw new FirstTeamSquadFullException(
+                'First-team squad is full; release a player before calling up another.'
+            );
+        }
+
+        $player->update(['number' => $number]);
+
+        GameTransfer::record(
+            gameId: $game->id,
+            gamePlayerId: $player->id,
+            fromTeamId: $game->reserve_team_id,
+            toTeamId: $game->team_id,
+            transferFee: 0,
+            type: GameTransfer::TYPE_LOAN,
+            season: $game->season,
+            window: TransferWindowType::currentValue($game->current_date),
+        );
+    }
+
+    /**
+     * Send a called-up player back to the reserve team. Ends the active
+     * call-up loan, flips team_id back, nulls squad number.
+     */
+    public function sendBackToReserve(GamePlayer $player, Game $game): void
+    {
+        $this->assertFilial($game);
+
+        $loan = Loan::where('game_player_id', $player->id)
+            ->where('status', Loan::STATUS_ACTIVE)
+            ->where('parent_team_id', $game->reserve_team_id)
+            ->where('loan_team_id', $game->team_id)
+            ->first();
+
+        if ($loan === null) {
+            throw new \DomainException('Player is not currently called up from the reserve team.');
+        }
+
+        // returnLoan handles team_id flip and number reassignment. For loans
+        // returning to the reserve team (not the user's team), it sets number
+        // to null automatically.
+        $this->loanService->returnLoan($loan);
+    }
+
+    /**
+     * At season close, permanently promote any reserve player who has aged
+     * past the reserve cutoff (over 23) to the first team. One-way move,
+     * recorded as a GameTransfer of type INTERNAL_PROMOTION. Any active
+     * call-up loan for the player is closed first.
+     *
+     * Returns the list of promoted players for downstream processors.
+     *
+     * @return Collection<int, GamePlayer>
+     */
+    public function autoPromoteOverageReservePlayers(Game $game): Collection
+    {
+        if ($game->reserve_team_id === null) {
+            return collect();
+        }
+
+        $cutoff = PlayerAge::dateOfBirthCutoff(PlayerAge::YOUNG_END + 1, $game->current_date);
+
+        $candidates = GamePlayer::ownedByTeam($game->reserve_team_id)
+            ->where('game_id', $game->id)
+            ->whereHas('player', fn ($q) => $q->where('date_of_birth', '<=', $cutoff))
+            ->with(['player', 'activeLoan'])
+            ->get();
+
+        $promoted = collect();
+
+        foreach ($candidates as $player) {
+            // Close any active call-up loan first so returnLoan() doesn't
+            // later try to flip the player back to the reserve team.
+            if ($player->activeLoan && $player->activeLoan->parent_team_id === $game->reserve_team_id) {
+                $player->activeLoan->update(['status' => Loan::STATUS_COMPLETED]);
+            }
+
+            // Permanent move to first team.
+            $player->update(['team_id' => $game->team_id]);
+            $number = $this->squadNumberService->assignNumberForNewPlayer($game, $player);
+            if ($number !== null) {
+                $player->update(['number' => $number]);
+            }
+
+            GameTransfer::record(
+                gameId: $game->id,
+                gamePlayerId: $player->id,
+                fromTeamId: $game->reserve_team_id,
+                toTeamId: $game->team_id,
+                transferFee: 0,
+                type: GameTransfer::TYPE_INTERNAL_PROMOTION,
+                season: $game->season,
+                window: TransferWindowType::currentValue($game->current_date),
+            );
+
+            $this->notificationService->create(
+                game: $game,
+                type: \App\Models\GameNotification::TYPE_ACADEMY_PROSPECT,
+                title: __('notifications.reserve_overage_promoted_title'),
+                message: __('notifications.reserve_overage_promoted_message', [
+                    'player' => $player->player->name ?? '',
+                ]),
+                priority: \App\Models\GameNotification::PRIORITY_INFO,
+            );
+
+            $promoted->push($player);
+        }
+
+        return $promoted;
+    }
+
+    private function assertFilial(Game $game): void
+    {
+        if ($game->reserve_team_id === null) {
+            throw new \DomainException('Reserve team operations require a filial game.');
+        }
+    }
+}

--- a/app/Modules/Season/Processors/ReserveOveragePromotionProcessor.php
+++ b/app/Modules/Season/Processors/ReserveOveragePromotionProcessor.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Modules\Season\Processors;
+
+use App\Models\Game;
+use App\Modules\ReserveTeam\Services\ReserveTeamService;
+use App\Modules\Season\Contracts\SeasonProcessor;
+use App\Modules\Season\DTOs\SeasonTransitionData;
+
+/**
+ * For filial games, permanently promotes any reserve player who has aged
+ * past the reserve cutoff (over 23) to the first team.
+ *
+ * Runs before LoanReturnProcessor (priority 5) so age-23 players are settled
+ * permanently in the first team before remaining call-up loans snap back.
+ *
+ * No-op for non-filial games.
+ *
+ * Priority: 4
+ */
+class ReserveOveragePromotionProcessor implements SeasonProcessor
+{
+    public function __construct(
+        private readonly ReserveTeamService $reserveTeamService,
+    ) {}
+
+    public function priority(): int
+    {
+        return 4;
+    }
+
+    public function process(Game $game, SeasonTransitionData $data): SeasonTransitionData
+    {
+        if ($game->reserve_team_id === null) {
+            return $data;
+        }
+
+        $promoted = $this->reserveTeamService->autoPromoteOverageReservePlayers($game);
+
+        if ($promoted->isNotEmpty()) {
+            $data->setMetadata('reserve_overage_promoted', $promoted->count());
+        }
+
+        return $data;
+    }
+}

--- a/app/Modules/Season/Processors/UserSquadCareerSnapshotProcessor.php
+++ b/app/Modules/Season/Processors/UserSquadCareerSnapshotProcessor.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace App\Modules\Season\Processors;
+
+use App\Models\Game;
+use App\Models\UserSquadCareerRecord;
+use App\Modules\Season\Contracts\SeasonProcessor;
+use App\Modules\Season\DTOs\SeasonTransitionData;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Snapshots the just-finished season's match-state stats into each user-owned
+ * career record's season_stats JSON.
+ *
+ * Runs before StatsResetProcessor (priority 65) so the counters on
+ * GamePlayerMatchState are still populated when we read them.
+ */
+class UserSquadCareerSnapshotProcessor implements SeasonProcessor
+{
+    public function priority(): int
+    {
+        return 60;
+    }
+
+    public function process(Game $game, SeasonTransitionData $data): SeasonTransitionData
+    {
+        $seasonKey = (string) (int) $game->season;
+
+        $rows = DB::table('user_squad_career_records as r')
+            ->leftJoin('game_player_match_state as ms', 'ms.game_player_id', '=', 'r.game_player_id')
+            ->leftJoin('game_players as gp', 'gp.id', '=', 'r.game_player_id')
+            ->where('r.game_id', $game->id)
+            ->select([
+                'r.id',
+                'r.season_stats',
+                'gp.team_id',
+                'ms.appearances',
+                'ms.season_appearances',
+                'ms.goals',
+                'ms.own_goals',
+                'ms.assists',
+                'ms.yellow_cards',
+                'ms.red_cards',
+                'ms.goals_conceded',
+                'ms.clean_sheets',
+            ])
+            ->get();
+
+        foreach ($rows as $row) {
+            $stats = is_string($row->season_stats) ? json_decode($row->season_stats, true) : (array) $row->season_stats;
+            if (! is_array($stats)) {
+                $stats = [];
+            }
+
+            $stats[$seasonKey] = [
+                'appearances' => (int) ($row->appearances ?? 0),
+                'season_appearances' => (int) ($row->season_appearances ?? 0),
+                'goals' => (int) ($row->goals ?? 0),
+                'own_goals' => (int) ($row->own_goals ?? 0),
+                'assists' => (int) ($row->assists ?? 0),
+                'yellow_cards' => (int) ($row->yellow_cards ?? 0),
+                'red_cards' => (int) ($row->red_cards ?? 0),
+                'goals_conceded' => (int) ($row->goals_conceded ?? 0),
+                'clean_sheets' => (int) ($row->clean_sheets ?? 0),
+                'team_id' => $row->team_id,
+            ];
+
+            UserSquadCareerRecord::where('id', $row->id)->update([
+                'season_stats' => json_encode($stats),
+            ]);
+        }
+
+        return $data;
+    }
+}

--- a/app/Modules/Season/Processors/YouthAcademyClosingProcessor.php
+++ b/app/Modules/Season/Processors/YouthAcademyClosingProcessor.php
@@ -25,6 +25,12 @@ class YouthAcademyClosingProcessor implements SeasonProcessor
 
     public function process(Game $game, SeasonTransitionData $data): SeasonTransitionData
     {
+        // Filial games don't use the AcademyPlayer pool — reserve squads are
+        // GamePlayers handled elsewhere. Skip the academy lifecycle entirely.
+        if ($game->reserve_team_id !== null) {
+            return $data;
+        }
+
         // 1. Develop loaned players at higher rate before returning
         $this->youthAcademyService->developLoanedPlayers($game);
 

--- a/app/Modules/Season/Processors/YouthAcademyPromotionProcessor.php
+++ b/app/Modules/Season/Processors/YouthAcademyPromotionProcessor.php
@@ -46,6 +46,12 @@ class YouthAcademyPromotionProcessor implements SeasonProcessor
 
     public function process(Game $game, SeasonTransitionData $data): SeasonTransitionData
     {
+        // Filial games don't use the AcademyPlayer pool — reserve squad
+        // age-out is handled by ReserveOveragePromotionProcessor instead.
+        if ($game->reserve_team_id !== null) {
+            return $data;
+        }
+
         // Phase 1: Promote overage academy players (mandatory — they must leave)
         $overagePromoted = $this->youthAcademyService->promoteOveragePlayers($game);
 

--- a/app/Modules/Season/Services/GameCreationService.php
+++ b/app/Modules/Season/Services/GameCreationService.php
@@ -27,7 +27,7 @@ class GameCreationService
                 ->first()
             ?? CompetitionTeam::where('team_id', $teamId)->first();
 
-        $team = Team::find($teamId);
+        $team = Team::with('reserveTeam')->find($teamId);
 
         // Resolve competition ID: use competition_team lookup, fall back to
         // tier 1 of the team's country from config
@@ -38,6 +38,10 @@ class GameCreationService
         }
         $season = $competitionTeam->season ?? '2025';
 
+        // Resolve reserve team (filial) for managers of parent clubs.
+        // The user's club becomes filial if it has a reserve team and isn't itself one.
+        $reserveTeamId = $team->parent_team_id === null ? $team->reserveTeam?->id : null;
+
         // Create game record (setup not yet complete)
         // current_date and season_goal are set by processors during SetupNewGame
         $game = Game::create([
@@ -46,6 +50,7 @@ class GameCreationService
             'game_mode' => $gameMode,
             'country' => $team->country ?? 'ES',
             'team_id' => $teamId,
+            'reserve_team_id' => $reserveTeamId,
             'competition_id' => $competitionId,
             'season' => $season,
             'current_date' => null,

--- a/app/Modules/Season/Services/SeasonClosingPipeline.php
+++ b/app/Modules/Season/Services/SeasonClosingPipeline.php
@@ -23,6 +23,7 @@ use App\Modules\Season\Processors\SeasonSettlementProcessor;
 use App\Modules\Season\Processors\SeasonSimulationProcessor;
 use App\Modules\Season\Processors\SquadReplenishmentProcessor;
 use App\Modules\Season\Processors\StatsResetProcessor;
+use App\Modules\Season\Processors\UserSquadCareerSnapshotProcessor;
 use App\Modules\Season\Processors\SupercupQualificationProcessor;
 use App\Modules\Season\Processors\TransferMarketResetProcessor;
 use App\Modules\Season\Processors\UefaQualificationProcessor;
@@ -57,6 +58,7 @@ class SeasonClosingPipeline
         PlayerDevelopmentProcessor $playerDevelopment,
         SeasonSettlementProcessor $seasonSettlement,
         StatsResetProcessor $statsReset,
+        UserSquadCareerSnapshotProcessor $userSquadCareerSnapshot,
         TransferMarketResetProcessor $transferMarketReset,
         SeasonSimulationProcessor $seasonSimulation,
         SupercupQualificationProcessor $supercupQualification,
@@ -82,6 +84,7 @@ class SeasonClosingPipeline
             $aiFreeAgentSigning,
             $playerDevelopment,
             $seasonSettlement,
+            $userSquadCareerSnapshot,
             $statsReset,
             $transferMarketReset,
             $seasonSimulation,

--- a/app/Modules/Season/Services/SeasonClosingPipeline.php
+++ b/app/Modules/Season/Services/SeasonClosingPipeline.php
@@ -17,6 +17,7 @@ use App\Modules\Season\Processors\PlayerRetirementProcessor;
 use App\Modules\Season\Processors\PreContractTransferProcessor;
 use App\Modules\Season\Processors\PromotionRelegationProcessor;
 use App\Modules\Season\Processors\ReputationUpdateProcessor;
+use App\Modules\Season\Processors\ReserveOveragePromotionProcessor;
 use App\Modules\Season\Processors\SeasonArchiveProcessor;
 use App\Modules\Season\Processors\SeasonSettlementProcessor;
 use App\Modules\Season\Processors\SeasonSimulationProcessor;
@@ -41,6 +42,7 @@ class SeasonClosingPipeline
     private array $processors = [];
 
     public function __construct(
+        ReserveOveragePromotionProcessor $reserveOveragePromotion,
         LoanReturnProcessor $loanReturn,
         TrophyRecordingProcessor $trophyRecording,
         LeaderboardStatsProcessor $leaderboardStats,
@@ -66,6 +68,7 @@ class SeasonClosingPipeline
         UefaQualificationProcessor $uefaQualification,
     ) {
         $this->processors = [
+            $reserveOveragePromotion,
             $loanReturn,
             $trophyRecording,
             $leaderboardStats,

--- a/app/Modules/Squad/DTOs/GeneratedPlayerData.php
+++ b/app/Modules/Squad/DTOs/GeneratedPlayerData.php
@@ -30,5 +30,9 @@ final class GeneratedPlayerData
         public readonly int $fitnessMax = 95,
         public readonly int $moraleMin = 65,
         public readonly int $moraleMax = 80,
+        // Origin label persisted on the user-squad career record. Either the
+        // 'Academy' sentinel or the previous team's name. Null skips the record
+        // creation (legacy initial-squad seeding path).
+        public readonly ?string $joinedFrom = null,
     ) {}
 }

--- a/app/Modules/Squad/Services/PlayerGeneratorService.php
+++ b/app/Modules/Squad/Services/PlayerGeneratorService.php
@@ -9,6 +9,7 @@ use App\Models\GamePlayer;
 use App\Models\GamePlayerMatchState;
 use App\Models\Player;
 use App\Models\Team;
+use App\Models\UserSquadCareerRecord;
 use Carbon\Carbon;
 use Illuminate\Support\Str;
 use App\Models\ClubProfile;
@@ -153,6 +154,17 @@ class PlayerGeneratorService
         // attributes via the GamePlayer accessor delegates.
         $gamePlayer->setRelation('player', $player);
         $gamePlayer->setRelation('matchState', $matchState);
+
+        if ($data->joinedFrom !== null && $game->ownsTeam($data->teamId)) {
+            UserSquadCareerRecord::create([
+                'game_player_id' => $gamePlayer->id,
+                'game_id' => $game->id,
+                'team_id' => $data->teamId,
+                'joined_season' => (int) $game->season,
+                'joined_from' => $data->joinedFrom,
+                'season_stats' => [],
+            ]);
+        }
 
         // Update cache with the newly created player so subsequent generations in the
         // same request don't collide with it.

--- a/app/Modules/Squad/Services/SquadService.php
+++ b/app/Modules/Squad/Services/SquadService.php
@@ -30,7 +30,7 @@ class SquadService
         $gameId = $game->id;
 
         // Get all players for user's team with relationships
-        $allPlayers = GamePlayer::with(['player', 'game', 'team', 'matchState', 'activeLoan', 'transferOffers', 'suspensions', 'activeRenewalNegotiation', 'latestRenewalNegotiation'])
+        $allPlayers = GamePlayer::with(['player', 'game', 'team', 'matchState', 'activeLoan', 'transferOffers', 'suspensions', 'activeRenewalNegotiation', 'latestRenewalNegotiation', 'careerRecord'])
             ->where('game_id', $gameId)
             ->where('team_id', $game->team_id)
             ->get();

--- a/app/Modules/Transfer/Services/LoanService.php
+++ b/app/Modules/Transfer/Services/LoanService.php
@@ -394,7 +394,7 @@ class LoanService
     /**
      * Return a single loan - player goes back to parent team.
      */
-    private function returnLoan(Loan $loan): void
+    public function returnLoan(Loan $loan): void
     {
         $gamePlayer = $loan->gamePlayer;
         $isUserTeam = $loan->parent_team_id === $gamePlayer->game->team_id;

--- a/app/Modules/Transfer/Services/ScoutSearchQueryBuilder.php
+++ b/app/Modules/Transfer/Services/ScoutSearchQueryBuilder.php
@@ -27,7 +27,8 @@ class ScoutSearchQueryBuilder
         $query = GamePlayer::with(['player', 'team'])
             ->where('game_id', $game->id)
             ->whereNotNull('team_id')
-            ->where('team_id', '!=', $game->team_id);
+            ->where('team_id', '!=', $game->team_id)
+            ->whereHas('team', fn ($q) => $q->whereNull('parent_team_id'));
 
         $this->applyPositionFilter($query, $positions);
 

--- a/app/Modules/Transfer/Services/TransferCompletionService.php
+++ b/app/Modules/Transfer/Services/TransferCompletionService.php
@@ -10,6 +10,7 @@ use App\Models\Loan;
 use App\Models\ShortlistedPlayer;
 use App\Models\TransferListing;
 use App\Models\TransferOffer;
+use App\Models\UserSquadCareerRecord;
 use App\Modules\Player\PlayerAge;
 use App\Modules\Squad\Services\SquadNumberService;
 use App\Modules\Transfer\Enums\TransferWindowType;
@@ -94,6 +95,11 @@ class TransferCompletionService
         // Remove from shortlist to free up scouting slot
         ShortlistedPlayer::removeForPlayer($game->id, $player->id);
 
+        // Player has left user's club permanently — drop career record.
+        // Loans preserve ownership so the record is left intact.
+        if (! $isLoan) {
+            UserSquadCareerRecord::where('game_player_id', $player->id)->delete();
+        }
     }
 
     /**
@@ -106,6 +112,7 @@ class TransferCompletionService
         $buyerName = $offer->offeringTeam->name;
         $game = $player->game;
         $fromTeamId = $player->team_id;
+        $fromTeamName = $player->team->name ?? null;
 
         // Transfer player to the buying team
         TransferListing::where('game_player_id', $player->id)->delete();
@@ -115,6 +122,13 @@ class TransferCompletionService
             // Extend their contract with the new team
             'contract_until' => Carbon::createFromDate((int) $game->season + rand(2, 4) + 1, 6, 30),
         ]);
+
+        $this->syncCareerRecordOnOwnershipChange(
+            game: $game,
+            player: $player,
+            previousTeamId: $fromTeamId,
+            previousTeamName: $fromTeamName,
+        );
 
         GameTransfer::record(
             gameId: $game->id,
@@ -166,12 +180,20 @@ class TransferCompletionService
         $newContractEnd = Carbon::createFromDate($seasonYear + $contractYears + 1, 6, 30);
 
         TransferListing::where('game_player_id', $player->id)->delete();
+        $previousTeamId = $player->team_id;
         $player->update([
             'team_id' => $game->team_id,
             'number' => $this->squadNumberService->assignNumberForNewPlayer($game, $player),
             'contract_until' => $newContractEnd,
             'annual_wage' => $offer->offered_wage ?? $player->annual_wage,
         ]);
+
+        $this->syncCareerRecordOnOwnershipChange(
+            game: $game,
+            player: $player,
+            previousTeamId: $previousTeamId,
+            previousTeamName: $sellerName,
+        );
 
         GameTransfer::record(
             gameId: $game->id,
@@ -219,12 +241,22 @@ class TransferCompletionService
         $contractYears = $offer->offered_years ?? ($player->age($game->current_date) >= 32 ? 1 : 3);
         $newContractEnd = Carbon::createFromDate($seasonYear + $contractYears + 1, 6, 30);
 
+        $previousTeamId = $player->team_id;
+        $previousTeamName = $player->team->name ?? null;
+
         $player->update([
             'team_id' => $game->team_id,
             'number' => $this->squadNumberService->assignNumberForNewPlayer($game, $player),
             'contract_until' => $newContractEnd,
             'annual_wage' => $offer->offered_wage,
         ]);
+
+        $this->syncCareerRecordOnOwnershipChange(
+            game: $game,
+            player: $player,
+            previousTeamId: $previousTeamId,
+            previousTeamName: $previousTeamName,
+        );
 
         $offer->update([
             'status' => TransferOffer::STATUS_COMPLETED,
@@ -245,4 +277,45 @@ class TransferCompletionService
         ShortlistedPlayer::removeForPlayer($game->id, $player->id);
     }
 
+    /**
+     * Reconcile the user-squad career record after a player's team_id changes.
+     *
+     * - Player moves into a user-owned team and wasn't already user-owned:
+     *   create a record. `joined_from` snapshots the previous team's name.
+     * - Player moves out of a user-owned team to a non-user-owned team:
+     *   delete the record. (We do not retain history for ex-players.)
+     * - Both old and new team are user-owned (e.g., filial → first team):
+     *   update in place; preserve accumulated season_stats.
+     * - Neither side is user-owned: no-op (AI-vs-AI move).
+     */
+    public function syncCareerRecordOnOwnershipChange(
+        Game $game,
+        GamePlayer $player,
+        ?string $previousTeamId,
+        ?string $previousTeamName,
+    ): void {
+        $wasOwned = $game->ownsTeam($previousTeamId);
+        $isOwned = $game->ownsTeam($player->team_id);
+
+        if (! $wasOwned && ! $isOwned) {
+            return;
+        }
+
+        if ($wasOwned && ! $isOwned) {
+            UserSquadCareerRecord::where('game_player_id', $player->id)->delete();
+            return;
+        }
+
+        $origin = $previousTeamName ?? UserSquadCareerRecord::ORIGIN_ACADEMY;
+
+        UserSquadCareerRecord::updateOrCreate(
+            ['game_player_id' => $player->id],
+            [
+                'game_id' => $game->id,
+                'team_id' => $player->team_id,
+                'joined_season' => (int) $game->season,
+                'joined_from' => $origin,
+            ],
+        );
+    }
 }

--- a/app/Modules/Transfer/Services/TransferMarketService.php
+++ b/app/Modules/Transfer/Services/TransferMarketService.php
@@ -181,6 +181,7 @@ class TransferMarketService
         return TransferListing::with(['gamePlayer.player', 'gamePlayer.team'])
             ->where('game_id', $game->id)
             ->where('team_id', '!=', $game->team_id)
+            ->whereHas('team', fn ($q) => $q->whereNull('parent_team_id'))
             ->where('status', TransferListing::STATUS_LISTED)
             ->whereNotNull('asking_price')
             ->whereNotIn('game_player_id', $alreadyAgreedIds)
@@ -356,10 +357,12 @@ class TransferMarketService
     private function sampleAITeams(Game $game, int $sampleSize): array
     {
         $teamIds = DB::table('competition_entries')
-            ->where('game_id', $game->id)
-            ->where('team_id', '!=', $game->team_id)
+            ->join('teams', 'teams.id', '=', 'competition_entries.team_id')
+            ->where('competition_entries.game_id', $game->id)
+            ->where('competition_entries.team_id', '!=', $game->team_id)
+            ->whereNull('teams.parent_team_id')
             ->distinct()
-            ->pluck('team_id')
+            ->pluck('competition_entries.team_id')
             ->all();
 
         if (empty($teamIds)) {
@@ -395,6 +398,7 @@ class TransferMarketService
             ])
             ->where('game_id', $game->id)
             ->whereIn('team_id', $teamIds)
+            ->whereHas('team', fn ($q) => $q->whereNull('parent_team_id'))
             ->get()
             ->groupBy('team_id');
     }

--- a/database/migrations/2026_04_25_000001_add_reserve_team_id_to_games_table.php
+++ b/database/migrations/2026_04_25_000001_add_reserve_team_id_to_games_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('games', function (Blueprint $table) {
+            $table->uuid('reserve_team_id')->nullable()->after('team_id');
+            $table->foreign('reserve_team_id')->references('id')->on('teams')->nullOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('games', function (Blueprint $table) {
+            $table->dropForeign(['reserve_team_id']);
+            $table->dropColumn('reserve_team_id');
+        });
+    }
+};

--- a/database/migrations/2026_04_26_000001_create_user_squad_career_records_table.php
+++ b/database/migrations/2026_04_26_000001_create_user_squad_career_records_table.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('user_squad_career_records', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->uuid('game_player_id');
+            $table->uuid('game_id');
+            $table->uuid('team_id');
+            $table->unsignedSmallInteger('joined_season');
+            $table->string('joined_from')->nullable();
+            $table->jsonb('season_stats')->default('{}');
+
+            $table->unique('game_player_id');
+            $table->index(['game_id', 'team_id']);
+
+            $table->foreign('game_player_id')
+                ->references('id')->on('game_players')
+                ->cascadeOnDelete();
+            $table->foreign('game_id')
+                ->references('id')->on('games')
+                ->cascadeOnDelete();
+            $table->foreign('team_id')
+                ->references('id')->on('teams')
+                ->cascadeOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('user_squad_career_records');
+    }
+};

--- a/lang/en/messages.php
+++ b/lang/en/messages.php
@@ -89,6 +89,13 @@ return [
     'academy_player_loaned' => ':player has been loaned out.',
     'academy_must_decide_21' => 'Players aged 21+ will be automatically promoted to the first team.',
 
+    // Reserve team (filial)
+    'reserve_player_called_up' => ':player has been called up to the first team.',
+    'reserve_player_sent_back' => ':player has been sent back to the reserve team.',
+    'reserve_player_call_up_blocked_full' => 'First-team squad is full. Release a player before calling up another.',
+    'reserve_player_promoted' => ':player has been promoted to the first team.',
+    'shortlist_reserve_blocked' => "Reserve-team players belong to their parent club and aren't transferable.",
+
     // Player release messages
     'player_released' => ':player has been released. Severance paid: :severance.',
     'release_not_your_player' => 'You can only release players from your own team.',

--- a/lang/en/notifications.php
+++ b/lang/en/notifications.php
@@ -89,6 +89,8 @@ return [
     'academy_overage_promoted_message' => ':count academy players aged 21+ have been promoted to the first team.',
     'academy_gap_promoted_title' => 'Academy players promoted',
     'academy_gap_promoted_message' => ':count academy players have been promoted to fill squad gaps.',
+    'reserve_overage_promoted_title' => 'Reserve graduate',
+    'reserve_overage_promoted_message' => ':player has aged out of the reserve team and joined the first team permanently.',
     // Loan request results
     'loan_accepted_title' => 'Loan request for :player accepted',
     'loan_accepted' => ':team have accepted your loan request for :player.',

--- a/lang/en/squad.php
+++ b/lang/en/squad.php
@@ -188,6 +188,11 @@ return [
     'clean_sheets_full' => 'Clean Sheets',
     'goals_conceded_full' => 'Goals Conceded',
     'discovered' => 'Discovered',
+    'origin' => 'Origin',
+    'joined' => 'Joined',
+    'origin_academy' => 'Academy',
+    'career_history' => 'Career history',
+    'no_career_history' => 'No completed seasons yet.',
 
     // Academy
     'academy' => 'Academy',

--- a/lang/en/squad.php
+++ b/lang/en/squad.php
@@ -221,6 +221,23 @@ return [
     'academy_tier_4' => 'World-Class Academy',
     'academy_tier_unknown' => 'Unknown',
 
+    // Reserve team (filial)
+    'reserve_team' => 'Reserve Team',
+    'reserve_squad' => 'Reserve squad',
+    'no_reserve_players' => 'No reserve-team players.',
+    'call_up' => 'Call up',
+    'call_up_to_first_team' => 'Call up to first team',
+    'send_back' => 'Send back',
+    'send_back_to_reserve' => 'Send back to reserve',
+    'called_up_indicator' => 'Called up',
+    'actions' => 'Actions',
+    'reserve_help_toggle' => 'How does the reserve team work?',
+    'reserve_help_development' => 'Your reserve team is your filial — its squad belongs to the reserve, not the first team. New academy prospects arrive here each season based on your academy investment, and develop alongside the existing reserve roster.',
+    'reserve_help_age_rule' => 'Players over 23 are automatically promoted to the first team at season close. The first team can call up reserve players any time during the season.',
+    'reserve_help_actions_title' => 'Available actions',
+    'reserve_help_call_up' => 'Call up - the player joins the first team on a temporary loan and can play first-team matches',
+    'reserve_help_send_back' => 'Send back - returns the called-up player to the reserve squad',
+
     // Lineup help text
     'lineup_help_toggle' => 'How does lineup selection work?',
     'lineup_help_intro' => 'Choose 11 players for each match. Your formation, player energy, and positional compatibility all affect performance.',

--- a/lang/es/messages.php
+++ b/lang/es/messages.php
@@ -89,6 +89,13 @@ return [
     'academy_player_loaned' => ':player ha sido cedido.',
     'academy_must_decide_21' => 'Los jugadores de 21+ años serán promocionados automáticamente al primer equipo.',
 
+    // Reserve team (filial)
+    'reserve_player_called_up' => ':player ha sido convocado al primer equipo.',
+    'reserve_player_sent_back' => ':player ha vuelto al filial.',
+    'reserve_player_call_up_blocked_full' => 'La plantilla del primer equipo está completa. Libera un dorsal antes de subir más jugadores.',
+    'reserve_player_promoted' => ':player ha subido al primer equipo.',
+    'shortlist_reserve_blocked' => 'Los jugadores del filial pertenecen al club matriz y no son transferibles.',
+
     // Player release messages
     'player_released' => ':player ha sido liberado. Indemnización pagada: :severance.',
     'release_not_your_player' => 'Solo puedes liberar jugadores de tu propio equipo.',

--- a/lang/es/notifications.php
+++ b/lang/es/notifications.php
@@ -89,6 +89,8 @@ return [
     'academy_overage_promoted_message' => ':count canteranos de 21+ años han sido promocionados al primer equipo.',
     'academy_gap_promoted_title' => 'Canteranos promocionados',
     'academy_gap_promoted_message' => ':count canteranos han sido promocionados para cubrir huecos en la plantilla.',
+    'reserve_overage_promoted_title' => 'Graduado del filial',
+    'reserve_overage_promoted_message' => ':player ha superado la edad del filial y se incorpora al primer equipo de forma permanente.',
     // Loan request results
     'loan_accepted_title' => 'Cesión de :player aceptada',
     'loan_accepted' => ':team ha aceptado tu solicitud de cesión por :player.',

--- a/lang/es/squad.php
+++ b/lang/es/squad.php
@@ -188,6 +188,11 @@ return [
     'clean_sheets_full' => 'Porterías a Cero',
     'goals_conceded_full' => 'Goles Encajados',
     'discovered' => 'Descubierto',
+    'origin' => 'Procedencia',
+    'joined' => 'Incorporación',
+    'origin_academy' => 'Cantera',
+    'career_history' => 'Trayectoria',
+    'no_career_history' => 'Aún no hay temporadas completadas.',
 
     // Academy
     'academy' => 'Cantera',

--- a/lang/es/squad.php
+++ b/lang/es/squad.php
@@ -221,6 +221,23 @@ return [
     'academy_tier_4' => 'Cantera de Clase Mundial',
     'academy_tier_unknown' => 'Desconocido',
 
+    // Reserve team (filial)
+    'reserve_team' => 'Filial',
+    'reserve_squad' => 'Plantilla del filial',
+    'no_reserve_players' => 'No hay jugadores en el filial.',
+    'call_up' => 'Subir',
+    'call_up_to_first_team' => 'Subir al primer equipo',
+    'send_back' => 'Bajar',
+    'send_back_to_reserve' => 'Bajar al filial',
+    'called_up_indicator' => 'En el primer equipo',
+    'actions' => 'Acciones',
+    'reserve_help_toggle' => '¿Cómo funciona el filial?',
+    'reserve_help_development' => 'Tu filial es la cantera oficial — los jugadores pertenecen al filial, no al primer equipo. Cada temporada llegan nuevos canteranos según tu inversión en la cantera, que se desarrollan junto con el resto del filial.',
+    'reserve_help_age_rule' => 'Los jugadores que cumplen 24 años pasan automáticamente al primer equipo al final de la temporada. El primer equipo puede subir jugadores del filial en cualquier momento.',
+    'reserve_help_actions_title' => 'Acciones disponibles',
+    'reserve_help_call_up' => 'Subir - el jugador se incorpora al primer equipo en cesión y puede disputar partidos con el primer equipo',
+    'reserve_help_send_back' => 'Bajar - devuelve al jugador subido al filial',
+
     // Lineup help text
     'lineup_help_toggle' => '¿Cómo funciona la alineación?',
     'lineup_help_intro' => 'Elige 11 jugadores para cada partido. Tu formación, la energía y la compatibilidad posicional afectan al rendimiento.',

--- a/resources/views/components/origin-badge.blade.php
+++ b/resources/views/components/origin-badge.blade.php
@@ -1,0 +1,24 @@
+@props(['player'])
+
+@php
+    $record = $player->careerRecord ?? null;
+@endphp
+
+@if($record)
+    @php
+        $isAcademy = $record->joined_from === \App\Models\UserSquadCareerRecord::ORIGIN_ACADEMY;
+        $label = $isAcademy
+            ? __('squad.origin_academy')
+            : ($record->joined_from ?? '');
+        $title = trim(($label !== '' ? $label . ' · ' : '') . __('squad.joined') . ' ' . \App\Models\Game::formatSeason((string) $record->joined_season));
+        $classes = $isAcademy
+            ? 'bg-accent-green/10 text-accent-green'
+            : 'bg-accent-blue/10 text-accent-blue';
+    @endphp
+    @if($label !== '')
+        <span class="inline-flex items-center px-1.5 py-0.5 rounded text-[9px] font-semibold uppercase tracking-wide {{ $classes }} shrink-0"
+              title="{{ $title }}">
+            {{ $label }}
+        </span>
+    @endif
+@endif

--- a/resources/views/partials/player-detail.blade.php
+++ b/resources/views/partials/player-detail.blade.php
@@ -161,6 +161,24 @@
                         <span class="text-xs font-semibold text-text-primary">{{ $gamePlayer->contract_expiry_year }}</span>
                     </div>
                 @endif
+                @if($gamePlayer->careerRecord)
+                    @php
+                        $cr = $gamePlayer->careerRecord;
+                        $originLabel = $cr->joined_from === \App\Models\UserSquadCareerRecord::ORIGIN_ACADEMY
+                            ? __('squad.origin_academy')
+                            : ($cr->joined_from ?? '');
+                    @endphp
+                    @if($originLabel !== '')
+                        <div class="flex items-center justify-between">
+                            <span class="text-[11px] text-text-muted uppercase tracking-wide">{{ __('squad.origin') }}</span>
+                            <span class="text-xs font-semibold text-text-primary">{{ $originLabel }}</span>
+                        </div>
+                    @endif
+                    <div class="flex items-center justify-between">
+                        <span class="text-[11px] text-text-muted uppercase tracking-wide">{{ __('squad.joined') }}</span>
+                        <span class="text-xs font-semibold text-text-primary">{{ \App\Models\Game::formatSeason((string) $cr->joined_season) }}</span>
+                    </div>
+                @endif
             @endif
         </div>
     </div>
@@ -204,6 +222,61 @@
         </div>
     </div>
 </div>
+
+{{-- Career history --}}
+@if($gamePlayer->careerRecord && !empty($gamePlayer->careerRecord->season_stats))
+    @php
+        $history = collect($gamePlayer->careerRecord->season_stats)
+            ->map(fn ($stats, $season) => array_merge(['season' => $season], (array) $stats))
+            ->sortBy('season')
+            ->values();
+        $isGk = $gamePlayer->position_group === 'Goalkeeper';
+    @endphp
+    <div class="px-5 py-4 border-t border-border-default">
+        <h4 class="font-heading text-[11px] font-semibold uppercase tracking-widest text-text-secondary mb-3">{{ __('squad.career_history') }}</h4>
+        <div class="overflow-x-auto">
+            <table class="w-full text-xs">
+                <thead>
+                    <tr class="text-text-muted uppercase tracking-wide text-[10px]">
+                        <th class="text-left font-semibold py-1.5 pr-3">{{ __('game.season') }}</th>
+                        <th class="text-right font-semibold py-1.5 px-2">{{ __('squad.appearances') }}</th>
+                        @if($isGk)
+                            <th class="text-right font-semibold py-1.5 px-2">{{ __('squad.clean_sheets_full') }}</th>
+                            <th class="text-right font-semibold py-1.5 px-2">{{ __('squad.goals_conceded_full') }}</th>
+                        @else
+                            <th class="text-right font-semibold py-1.5 px-2">{{ __('squad.legend_goals') }}</th>
+                            <th class="text-right font-semibold py-1.5 px-2">{{ __('squad.legend_assists') }}</th>
+                        @endif
+                        <th class="text-right font-semibold py-1.5 pl-2">{{ __('squad.bookings') }}</th>
+                    </tr>
+                </thead>
+                <tbody class="divide-y divide-border-default">
+                    @foreach($history as $row)
+                        <tr>
+                            <td class="py-1.5 pr-3 text-text-primary font-semibold">{{ \App\Models\Game::formatSeason((string) $row['season']) }}</td>
+                            <td class="py-1.5 px-2 text-right text-text-body">{{ $row['appearances'] ?? 0 }}</td>
+                            @if($isGk)
+                                <td class="py-1.5 px-2 text-right text-text-body">{{ $row['clean_sheets'] ?? 0 }}</td>
+                                <td class="py-1.5 px-2 text-right text-text-body">{{ $row['goals_conceded'] ?? 0 }}</td>
+                            @else
+                                <td class="py-1.5 px-2 text-right text-text-body">{{ $row['goals'] ?? 0 }}</td>
+                                <td class="py-1.5 px-2 text-right text-text-body">{{ $row['assists'] ?? 0 }}</td>
+                            @endif
+                            <td class="py-1.5 pl-2 text-right">
+                                <span class="inline-flex items-center gap-1">
+                                    <span class="w-1.5 h-2.5 bg-yellow-400 rounded-xs"></span>
+                                    <span class="text-text-body">{{ $row['yellow_cards'] ?? 0 }}</span>
+                                    <span class="w-1.5 h-2.5 bg-accent-red rounded-xs ml-1"></span>
+                                    <span class="text-text-body">{{ $row['red_cards'] ?? 0 }}</span>
+                                </span>
+                            </td>
+                        </tr>
+                    @endforeach
+                </tbody>
+            </table>
+        </div>
+    </div>
+@endif
 
 {{-- Actions --}}
 @if($showActions || $canRenew || $renewalNegotiation || $renewalCooldown)

--- a/resources/views/squad-academy.blade.php
+++ b/resources/views/squad-academy.blade.php
@@ -8,9 +8,14 @@
     <div class="max-w-7xl mx-auto px-4 pb-8">
 
         {{-- Sub-navigation --}}
+        @php
+            $secondaryItem = $game->isFilial()
+                ? ['href' => route('game.squad.reserve', $game->id), 'label' => __('squad.reserve_team'), 'active' => false]
+                : ['href' => route('game.squad.academy', $game->id), 'label' => __('squad.academy'), 'active' => true];
+        @endphp
         <x-section-nav :items="[
             ['href' => route('game.squad', $game->id), 'label' => __('squad.first_team'), 'active' => false],
-            ['href' => route('game.squad.academy', $game->id), 'label' => __('squad.academy'), 'active' => true],
+            $secondaryItem,
             ['href' => route('game.squad.registration', $game->id), 'label' => __('squad.registration'), 'active' => false],
         ]" />
 

--- a/resources/views/squad-reserve.blade.php
+++ b/resources/views/squad-reserve.blade.php
@@ -117,6 +117,7 @@
                                         <div class="flex-1 min-w-0">
                                             <div class="flex items-center gap-2">
                                                 <span class="text-sm font-medium text-text-primary truncate">{{ $player->player->name }}</span>
+                                                <x-origin-badge :player="$player" />
                                                 <span class="text-[10px] text-text-faint">{{ $age }}</span>
                                                 @if($isCalledUp)
                                                     <span class="text-[10px] font-semibold bg-accent-blue/10 text-accent-blue px-1.5 py-0.5 rounded-full">{{ __('squad.called_up_indicator') }}</span>
@@ -149,6 +150,7 @@
                                         <img src="{{ Storage::disk('assets')->url('flags/' . $player->nationality_flag['code'] . '.svg') }}" class="w-4 h-3 rounded-xs shadow-xs shrink-0" title="{{ $player->nationality_flag['name'] }}">
                                     @endif
                                     <span class="text-sm font-medium text-text-primary truncate">{{ $player->player->name }}</span>
+                                    <x-origin-badge :player="$player" />
                                     @if($isCalledUp)
                                         <span class="text-[10px] font-semibold bg-accent-blue/10 text-accent-blue px-1.5 py-0.5 rounded-full">{{ __('squad.called_up_indicator') }}</span>
                                     @endif

--- a/resources/views/squad-reserve.blade.php
+++ b/resources/views/squad-reserve.blade.php
@@ -1,0 +1,194 @@
+@php /** @var App\Models\Game $game **/ @endphp
+
+<x-app-layout>
+    <x-slot name="header">
+        <x-game-header :game="$game" :next-match="$game->next_match"></x-game-header>
+    </x-slot>
+
+    <div class="max-w-7xl mx-auto px-4 pb-8">
+
+        {{-- Sub-navigation --}}
+        <x-section-nav :items="[
+            ['href' => route('game.squad', $game->id), 'label' => __('squad.first_team'), 'active' => false],
+            ['href' => route('game.squad.reserve', $game->id), 'label' => __('squad.reserve_team'), 'active' => true],
+            ['href' => route('game.squad.registration', $game->id), 'label' => __('squad.registration'), 'active' => false],
+        ]" />
+
+        {{-- Flash Messages --}}
+        <x-flash-message type="success" :message="session('success')" class="mt-4" />
+        <x-flash-message type="error" :message="session('error')" class="mt-4" />
+
+        {{-- Page Title --}}
+        <div class="mt-6 mb-4 flex items-center gap-3">
+            @if($reserveTeam->image)
+                <img src="{{ $reserveTeam->image }}" alt="{{ $reserveTeam->name }}" class="w-10 h-10 object-contain shrink-0" />
+            @endif
+            <div>
+                <h2 class="font-heading text-2xl lg:text-3xl font-bold uppercase tracking-wide text-text-primary">{{ $reserveTeam->name }}</h2>
+                <p class="text-xs text-text-muted">{{ __('squad.reserve_team') }}</p>
+            </div>
+        </div>
+
+        {{-- Summary strip --}}
+        <x-help-disclosure class="mb-6">
+            <x-slot name="trigger">
+                <div class="flex items-center gap-2.5 overflow-x-auto scrollbar-hide pb-1">
+                    <x-summary-card :label="__('squad.squad_size')" :value="$reserveCount" />
+                    <x-summary-card :label="__('squad.avg_age')" :value="$avgAge" />
+                    <x-summary-card :label="__('squad.fitness_full')" :value="$avgFitness . '%'" x-data x-tooltip.raw="{{ __('squad.tooltip_fitness') }}" :value-class="$avgFitness >= 85 ? 'text-accent-green' : ($avgFitness >= 70 ? 'text-text-primary' : 'text-amber-500')" />
+                    <x-summary-card :label="__('squad.morale_full')" :value="$avgMorale" x-data x-tooltip.raw="{{ __('squad.tooltip_morale') }}" :value-class="$avgMorale >= 80 ? 'text-accent-green' : ($avgMorale >= 65 ? 'text-text-primary' : 'text-amber-500')" />
+                    <x-summary-card :label="__('squad.avg_ovr')" :value="$avgOverall" x-data x-tooltip.raw="{{ __('squad.tooltip_avg_overall') }}" :value-class="$avgOverall >= 75 ? 'text-accent-green' : ($avgOverall >= 65 ? 'text-text-primary' : 'text-amber-500')" />
+                    <div class="ml-auto shrink-0">
+                        <x-help-toggle :label="__('squad.reserve_help_toggle')" />
+                    </div>
+                </div>
+            </x-slot>
+
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-5">
+                <div>
+                    <p class="text-text-secondary mb-3">{{ __('squad.reserve_help_development') }}</p>
+                    <p class="text-text-secondary">{{ __('squad.reserve_help_age_rule') }}</p>
+                </div>
+
+                <div>
+                    <p class="font-semibold text-text-body mb-2">{{ __('squad.reserve_help_actions_title') }}</p>
+                    <ul class="space-y-2">
+                        <li class="flex gap-2">
+                            <span class="text-accent-green shrink-0">↑</span>
+                            <span class="text-text-secondary">{{ __('squad.reserve_help_call_up') }}</span>
+                        </li>
+                        <li class="flex gap-2">
+                            <span class="text-amber-400 shrink-0">↓</span>
+                            <span class="text-text-secondary">{{ __('squad.reserve_help_send_back') }}</span>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </x-help-disclosure>
+
+        @if($reserveCount === 0)
+            <div class="text-center py-16">
+                <div class="inline-flex items-center justify-center w-16 h-16 bg-surface-700 rounded-full mb-4">
+                    <svg class="w-8 h-8 fill-surface-600" stroke="currentColor" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 576 512"><path d="M48 195.8l209.2 86.1c9.8 4 20.2 6.1 30.8 6.1s21-2.1 30.8-6.1l242.4-99.8c9-3.7 14.8-12.4 14.8-22.1s-5.8-18.4-14.8-22.1L318.8 38.1C309 34.1 298.6 32 288 32s-21 2.1-30.8 6.1L14.8 137.9C5.8 141.6 0 150.3 0 160L0 456c0 13.3 10.7 24 24 24s24-10.7 24-24l0-260.2zm48 71.7L96 384c0 53 86 96 192 96s192-43 192-96l0-116.6-142.9 58.9c-15.6 6.4-32.2 9.7-49.1 9.7s-33.5-3.3-49.1-9.7L96 267.4z"/></svg>
+                </div>
+                <p class="text-text-muted text-sm">{{ __('squad.no_reserve_players') }}</p>
+            </div>
+        @else
+            <div x-data class="bg-surface-800 border border-border-default rounded-xl overflow-hidden">
+                {{-- Table header --}}
+                <div class="hidden md:block">
+                    <div class="grid grid-cols-[40px_1fr_48px_48px_48px_56px_56px_120px] gap-1.5 items-center px-4 py-2 bg-surface-700/30 border-b border-border-default text-[10px] text-text-muted uppercase tracking-widest font-semibold">
+                        <span></span>
+                        <span>{{ __('app.name') }}</span>
+                        <span class="text-center">{{ __('app.age') }}</span>
+                        <span class="text-center">{{ __('squad.technical') }}</span>
+                        <span class="text-center">{{ __('squad.physical') }}</span>
+                        <span class="text-center">{{ __('squad.pot') }}</span>
+                        <span class="text-center">{{ __('squad.overall') }}</span>
+                        <span class="text-right">{{ __('squad.actions') }}</span>
+                    </div>
+                </div>
+
+                @foreach([
+                    ['name' => __('squad.goalkeepers'), 'players' => $goalkeepers],
+                    ['name' => __('squad.defenders'), 'players' => $defenders],
+                    ['name' => __('squad.midfielders'), 'players' => $midfielders],
+                    ['name' => __('squad.forwards'), 'players' => $forwards],
+                ] as $group)
+                    @if($group['players']->isNotEmpty())
+                        <div class="px-4 py-2 bg-surface-700/30 border-b border-border-default">
+                            <div class="flex items-center justify-between">
+                                <span class="font-heading text-[11px] font-semibold uppercase tracking-widest text-text-muted">{{ $group['name'] }}</span>
+                                <span class="text-[10px] text-text-faint">{{ $group['players']->count() }}</span>
+                            </div>
+                        </div>
+
+                        @foreach($group['players'] as $player)
+                            @php
+                                $isCalledUp = $player->team_id === $game->team_id;
+                                $age = $player->age($game->current_date);
+                            @endphp
+
+                            {{-- Mobile row --}}
+                            <div class="md:hidden px-4 py-3 border-b border-border-default">
+                                <div class="flex items-center gap-3">
+                                    <div class="cursor-pointer flex-1 flex items-center gap-3 min-w-0" @click="$dispatch('show-player-detail', '{{ route('game.player.detail', [$game->id, $player->id]) }}')">
+                                        <x-player-avatar :name="$player->player->name" :position-group="\App\Support\PositionMapper::getPositionGroup($player->position)" :position-abbrev="\App\Support\PositionMapper::toAbbreviation($player->position)" />
+                                        <div class="flex-1 min-w-0">
+                                            <div class="flex items-center gap-2">
+                                                <span class="text-sm font-medium text-text-primary truncate">{{ $player->player->name }}</span>
+                                                <span class="text-[10px] text-text-faint">{{ $age }}</span>
+                                                @if($isCalledUp)
+                                                    <span class="text-[10px] font-semibold bg-accent-blue/10 text-accent-blue px-1.5 py-0.5 rounded-full">{{ __('squad.called_up_indicator') }}</span>
+                                                @endif
+                                            </div>
+                                        </div>
+                                        <x-rating-badge :value="$player->overall_score" class="shrink-0" />
+                                    </div>
+                                    @if($isCalledUp)
+                                        <form method="POST" action="{{ route('game.reserve.send-back', [$game->id, $player->id]) }}" onsubmit="return confirm('{{ __('squad.send_back_to_reserve') }}?')">
+                                            @csrf
+                                            <button type="submit" class="text-amber-400 hover:text-amber-300 px-2" title="{{ __('squad.send_back_to_reserve') }}">↓</button>
+                                        </form>
+                                    @else
+                                        <form method="POST" action="{{ route('game.reserve.call-up', [$game->id, $player->id]) }}" onsubmit="return confirm('{{ __('squad.call_up_to_first_team') }}?')">
+                                            @csrf
+                                            <button type="submit" class="text-accent-green hover:text-emerald-400 px-2" title="{{ __('squad.call_up_to_first_team') }}">↑</button>
+                                        </form>
+                                    @endif
+                                </div>
+                            </div>
+
+                            {{-- Desktop row --}}
+                            <div class="hidden md:grid grid-cols-[40px_1fr_48px_48px_48px_56px_56px_120px] gap-1.5 items-center px-4 py-2.5 border-b border-border-default hover:bg-surface-700/30 transition-colors">
+                                <div class="flex justify-center cursor-pointer" @click="$dispatch('show-player-detail', '{{ route('game.player.detail', [$game->id, $player->id]) }}')">
+                                    <x-position-badge :position="$player->position" size="sm" :tooltip="\App\Support\PositionMapper::toDisplayName($player->position)" class="cursor-help" />
+                                </div>
+                                <div class="flex items-center gap-2 min-w-0 cursor-pointer" @click="$dispatch('show-player-detail', '{{ route('game.player.detail', [$game->id, $player->id]) }}')">
+                                    @if($player->nationality_flag)
+                                        <img src="{{ Storage::disk('assets')->url('flags/' . $player->nationality_flag['code'] . '.svg') }}" class="w-4 h-3 rounded-xs shadow-xs shrink-0" title="{{ $player->nationality_flag['name'] }}">
+                                    @endif
+                                    <span class="text-sm font-medium text-text-primary truncate">{{ $player->player->name }}</span>
+                                    @if($isCalledUp)
+                                        <span class="text-[10px] font-semibold bg-accent-blue/10 text-accent-blue px-1.5 py-0.5 rounded-full">{{ __('squad.called_up_indicator') }}</span>
+                                    @endif
+                                </div>
+                                <span class="text-xs text-text-secondary text-center tabular-nums">{{ $age }}</span>
+                                <div class="flex justify-center">
+                                    <span class="text-xs font-medium tabular-nums @if($player->current_technical_ability >= 80) text-accent-green @elseif($player->current_technical_ability >= 70) text-lime-500 @elseif($player->current_technical_ability >= 60) text-text-body @else text-text-secondary @endif">{{ $player->current_technical_ability }}</span>
+                                </div>
+                                <div class="flex justify-center">
+                                    <span class="text-xs font-medium tabular-nums @if($player->current_physical_ability >= 80) text-accent-green @elseif($player->current_physical_ability >= 70) text-lime-500 @elseif($player->current_physical_ability >= 60) text-text-body @else text-text-secondary @endif">{{ $player->current_physical_ability }}</span>
+                                </div>
+                                <span class="text-xs text-center tabular-nums text-text-muted">{{ $player->potential_range }}</span>
+                                <div class="flex justify-center">
+                                    <x-rating-badge :value="$player->overall_score" size="sm" />
+                                </div>
+                                <div class="flex justify-end">
+                                    @if($isCalledUp)
+                                        <form method="POST" action="{{ route('game.reserve.send-back', [$game->id, $player->id]) }}" onsubmit="return confirm('{{ __('squad.send_back_to_reserve') }}?')">
+                                            @csrf
+                                            <x-ghost-button color="slate" size="xs" type="submit" title="{{ __('squad.send_back_to_reserve') }}">
+                                                ↓ {{ __('squad.send_back') }}
+                                            </x-ghost-button>
+                                        </form>
+                                    @else
+                                        <form method="POST" action="{{ route('game.reserve.call-up', [$game->id, $player->id]) }}" onsubmit="return confirm('{{ __('squad.call_up_to_first_team') }}?')">
+                                            @csrf
+                                            <x-ghost-button color="green" size="xs" type="submit" title="{{ __('squad.call_up_to_first_team') }}">
+                                                ↑ {{ __('squad.call_up') }}
+                                            </x-ghost-button>
+                                        </form>
+                                    @endif
+                                </div>
+                            </div>
+                        @endforeach
+                    @endif
+                @endforeach
+            </div>
+        @endif
+
+    </div>
+
+    <x-player-detail-modal />
+</x-app-layout>

--- a/resources/views/squad.blade.php
+++ b/resources/views/squad.blade.php
@@ -55,9 +55,12 @@
             {{-- Sub-navigation --}}
             @if($isCareerMode)
                 @php
+                    $secondaryItem = $game->isFilial()
+                        ? ['href' => route('game.squad.reserve', $game->id), 'label' => __('squad.reserve_team'), 'active' => false]
+                        : ['href' => route('game.squad.academy', $game->id), 'label' => __('squad.academy'), 'active' => false];
                     $squadNavItems = [
                         ['href' => route('game.squad', $game->id), 'label' => __('squad.first_team'), 'active' => true],
-                        ['href' => route('game.squad.academy', $game->id), 'label' => __('squad.academy'), 'active' => false],
+                        $secondaryItem,
                         ['href' => route('game.squad.registration', $game->id), 'label' => __('squad.registration'), 'active' => false],
                     ];
                 @endphp

--- a/resources/views/squad.blade.php
+++ b/resources/views/squad.blade.php
@@ -272,6 +272,7 @@
                                             <div class="flex-1 min-w-0">
                                                 <div class="flex items-center gap-1.5">
                                                     <span class="text-sm font-medium text-text-primary truncate">{{ $gp->player->name }}</span>
+                                                    <x-origin-badge :player="$gp" />
                                                     @include('partials.squad.player-status-icon', ['gp' => $gp, 'game' => $game, 'seasonEndDate' => $seasonEndDate, 'playerFlags' => $playerFlags ?? []])
                                                     <x-player-unavailable-icon :player="$gp" :reason="$unavailReason" />
                                                 </div>
@@ -343,6 +344,7 @@
                                             <div class="min-w-0">
                                                 <div class="flex items-center gap-2">
                                                     <span class="text-sm font-medium text-text-primary truncate">{{ $gp->player->name }}</span>
+                                                    <x-origin-badge :player="$gp" />
                                                     @include('partials.squad.player-status-icon', ['gp' => $gp, 'game' => $game, 'seasonEndDate' => $seasonEndDate, 'playerFlags' => $playerFlags ?? []])
                                                     <x-player-unavailable-icon :player="$gp" :reason="$unavailReason" />
                                                 </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -125,6 +125,9 @@ use App\Http\Views\ShowTournamentLeaderboard;
 use App\Http\Views\ShowTournamentSummary;
 use App\Http\Actions\ProcessTacticalActions;
 use App\Http\Actions\PromoteAcademyPlayer;
+use App\Http\Actions\CallUpReservePlayer;
+use App\Http\Actions\SendBackReservePlayer;
+use App\Http\Views\ShowReserveTeam;
 use App\Http\Actions\SkipMatchToEnd;
 use App\Http\Actions\StartNewSeason;
 use Illuminate\Support\Facades\Route;
@@ -167,6 +170,10 @@ Route::middleware('auth')->group(function () {
         Route::post('/game/{gameId}/academy/{playerId}/promote', PromoteAcademyPlayer::class)->name('game.academy.promote');
         Route::post('/game/{gameId}/academy/{playerId}/loan', LoanAcademyPlayer::class)->name('game.academy.loan');
         Route::post('/game/{gameId}/academy/{playerId}/dismiss', DismissAcademyPlayer::class)->name('game.academy.dismiss');
+        // Reserve team (filial games)
+        Route::get('/game/{gameId}/squad/reserve', ShowReserveTeam::class)->name('game.squad.reserve');
+        Route::post('/game/{gameId}/reserve/{playerId}/call-up', CallUpReservePlayer::class)->name('game.reserve.call-up');
+        Route::post('/game/{gameId}/reserve/{playerId}/send-back', SendBackReservePlayer::class)->name('game.reserve.send-back');
         // Club hub — Finances, Stadium, Reputation (and future non-sporting tenants)
         Route::get('/game/{gameId}/club', fn (string $gameId) => redirect()->route('game.club.finances', $gameId))->name('game.club');
         Route::get('/game/{gameId}/club/finances', ShowFinances::class)->name('game.club.finances');


### PR DESCRIPTION
## Summary
Adds a per-game-player career record (1:1 with each user-owned `GamePlayer`) that captures where the player came from — \`Academy\` for youth/filial generation, the previous club name for transfers — and the season they joined.

- New \`UserSquadCareerRecord\` model + migration.
- \`UserSquadCareerSnapshotProcessor\` snapshots match-state stats into a JSON column at season close so historical seasons survive the \`StatsResetProcessor\`.
- \`TransferCompletionService\` records origin on transfers; Academy and ReserveTeam paths record origin on generation.
- Origin shown as a badge on the squad and reserve squad lists; player detail modal renders a career history table.

Stacked on top of \`reserve/01-foundation\`. Merge that one first.

## Test plan
- [ ] New academy / filial player gets a career record with origin = \`Academy\`
- [ ] Player signed via transfer gets a career record with origin = previous club name
- [ ] Origin badge renders on squad and reserve-squad pages
- [ ] Player detail shows career history table
- [ ] Season close snapshots stats into JSON; rolling over preserves history