### PR TITLE
Polish reserve squad UI and promotion flow

### DIFF
--- a/app/Http/Actions/NegotiateRenewal.php
+++ b/app/Http/Actions/NegotiateRenewal.php
@@ -37,7 +37,12 @@ class NegotiateRenewal
 
         $player = GamePlayer::with($eagerLoads)
             ->where('game_id', $gameId)
-            ->ownedByTeam($game->team_id)
+            ->where(function ($q) use ($game) {
+                $q->ownedByTeam($game->team_id);
+                if ($game->reserve_team_id) {
+                    $q->orWhere(fn ($sub) => $sub->ownedByTeam($game->reserve_team_id));
+                }
+            })
             ->findOrFail($playerId);
 
         return match ($action) {

--- a/app/Http/Actions/ReleasePlayer.php
+++ b/app/Http/Actions/ReleasePlayer.php
@@ -17,21 +17,25 @@ class ReleasePlayer
     public function __invoke(Request $request, string $gameId, string $playerId): RedirectResponse
     {
         $game = Game::findOrFail($gameId);
+        $allowedTeamIds = array_filter([$game->team_id, $game->reserve_team_id]);
         $player = GamePlayer::where('id', $playerId)
             ->where('game_id', $gameId)
-            ->where('team_id', $game->team_id)
+            ->whereIn('team_id', $allowedTeamIds)
             ->firstOrFail();
+
+        $wasOnReserve = $game->reserve_team_id !== null && $player->team_id === $game->reserve_team_id;
+        $redirectRoute = $wasOnReserve ? 'game.squad.reserve' : 'game.squad';
 
         $result = $this->contractService->releasePlayer($game, $player);
 
         if ($result['error'] ?? false) {
             return redirect()
-                ->route('game.squad', $gameId)
+                ->route($redirectRoute, $gameId)
                 ->with('error', $result['error']);
         }
 
         return redirect()
-            ->route('game.squad', $gameId)
+            ->route($redirectRoute, $gameId)
             ->with('success', __('messages.player_released', [
                 'player' => $result['playerName'],
                 'severance' => $result['formattedSeverance'],

--- a/app/Http/Actions/RequestLoan.php
+++ b/app/Http/Actions/RequestLoan.php
@@ -18,8 +18,10 @@ class RequestLoan
         $game = Game::with(['team', 'finances'])->findOrFail($gameId);
         $player = GamePlayer::where('game_id', $gameId)->with(['player', 'team'])->findOrFail($playerId);
 
-        // Determine if this is loan-in (from scouting) or loan-out (from squad)
-        $isLoanOut = $player->team_id === $game->team_id;
+        // Determine if this is loan-in (from scouting) or loan-out (from squad).
+        // Reserve-team players also belong to the user's club, so loan-out applies.
+        $isLoanOut = $player->team_id === $game->team_id
+            || ($game->reserve_team_id !== null && $player->team_id === $game->reserve_team_id);
 
         if ($isLoanOut) {
             return $this->handleLoanOut($game, $player);

--- a/app/Http/Views/ShowPlayerDetail.php
+++ b/app/Http/Views/ShowPlayerDetail.php
@@ -19,10 +19,20 @@ class ShowPlayerDetail
 
         $allowedTeamIds = array_filter([$game->team_id, $game->reserve_team_id]);
 
-        $gamePlayer = GamePlayer::with(['player', 'careerRecord'])
+        $gamePlayer = GamePlayer::with(['player', 'careerRecord', 'activeLoan'])
             ->where('game_id', $gameId)
             ->whereIn('team_id', $allowedTeamIds)
             ->findOrFail($playerId);
+
+        // Player is "called up" from the filial: currently registered to the
+        // first team via a Loan whose parent is the reserve team. For action
+        // purposes we treat them like a normal first-team player and offer
+        // an additional "send back to filial" button.
+        $isCalledUpFromReserve = $game->reserve_team_id !== null
+            && $gamePlayer->team_id === $game->team_id
+            && $gamePlayer->activeLoan
+            && $gamePlayer->activeLoan->parent_team_id === $game->reserve_team_id
+            && $gamePlayer->activeLoan->loan_team_id === $game->team_id;
 
         $canRenew = $gamePlayer->canBeOfferedRenewal(currentDate: $game->current_date);
         $renewalNegotiation = null;
@@ -38,11 +48,17 @@ class ShowPlayerDetail
             }
         }
 
-        // Release data
+        $isOnReserve = $game->reserve_team_id !== null
+            && $gamePlayer->team_id === $game->reserve_team_id;
+
+        // Release data — allowed for first-team and reserve-team players,
+        // including filial players currently called up via internal loan
+        // (which technically appears as "loaned in" but is treated as
+        // user-owned for management purposes).
         $canRelease = $game->isCareerMode()
-            && $gamePlayer->team_id === $game->team_id
+            && in_array($gamePlayer->team_id, [$game->team_id, $game->reserve_team_id], true)
             && !$gamePlayer->isRetiring()
-            && !$gamePlayer->isLoanedIn($game->team_id)
+            && ($isCalledUpFromReserve || !$gamePlayer->isLoanedIn($game->team_id))
             && !$gamePlayer->isLoanedOut($game->team_id)
             && !$gamePlayer->hasPreContractAgreement()
             && !$gamePlayer->hasRenewalAgreed()
@@ -59,6 +75,8 @@ class ShowPlayerDetail
             'renewalCooldown' => $renewalCooldown,
             'canRelease' => $canRelease,
             'severance' => $severance,
+            'isOnReserve' => $isOnReserve,
+            'isCalledUpFromReserve' => $isCalledUpFromReserve,
         ]);
     }
 }

--- a/app/Http/Views/ShowReserveTeam.php
+++ b/app/Http/Views/ShowReserveTeam.php
@@ -26,8 +26,6 @@ class ShowReserveTeam
 
         $count = $squad->count();
         $avgAge = $count > 0 ? round($squad->avg(fn ($p) => $p->age($game->current_date)), 1) : 0;
-        $avgFitness = $count > 0 ? (int) round($squad->avg('fitness')) : 0;
-        $avgMorale = $count > 0 ? (int) round($squad->avg('morale')) : 0;
         $avgOverall = $count > 0 ? (int) round($squad->avg('overall_score')) : 0;
 
         return view('squad-reserve', [
@@ -39,8 +37,6 @@ class ShowReserveTeam
             'forwards' => $grouped->get('Forward', collect()),
             'reserveCount' => $count,
             'avgAge' => $avgAge,
-            'avgFitness' => $avgFitness,
-            'avgMorale' => $avgMorale,
             'avgOverall' => $avgOverall,
         ]);
     }

--- a/app/Models/GamePlayer.php
+++ b/app/Models/GamePlayer.php
@@ -539,9 +539,19 @@ class GamePlayer extends Model
         }
 
         // Loaned-in players belong to another club — we can't renew them.
+        // Exception: a player called up from the user's own reserve team
+        // appears as loaned-in to the first team but is still user-owned,
+        // so the user retains contract authority.
         // Loaned-out players (ours, playing elsewhere) can still be renewed.
         if ($this->isLoanedIn($this->game->team_id)) {
-            return false;
+            $reserveTeamId = $this->game->reserve_team_id;
+            $loanedFromOwnReserve = $reserveTeamId !== null
+                && $this->activeLoan
+                && $this->activeLoan->parent_team_id === $reserveTeamId;
+
+            if (!$loanedFromOwnReserve) {
+                return false;
+            }
         }
 
         // Retiring players won't renew

--- a/app/Modules/ReserveTeam/Services/ReserveTeamService.php
+++ b/app/Modules/ReserveTeam/Services/ReserveTeamService.php
@@ -78,15 +78,17 @@ class ReserveTeamService
             'status' => Loan::STATUS_ACTIVE,
         ]);
 
-        // Move into first team first so SquadNumberService sees the player
-        // among the user's squad while picking a free number.
-        $player->update(['team_id' => $game->team_id]);
+        // Null the reserve number first so flipping team_id can't violate the
+        // (game_id, team_id, number) unique constraint when a first-team
+        // player already wears the same shirt.
+        $previousNumber = $player->number;
+        $player->update(['number' => null, 'team_id' => $game->team_id]);
 
-        $number = $this->squadNumberService->assignNumberForNewPlayer($game, $player);
+        $number = $this->squadNumberService->assignAcademyNumberForNewPlayer($game, $player);
 
         if ($number === null) {
-            // Roll back the move and the loan.
-            $player->update(['team_id' => $game->reserve_team_id]);
+            // Roll back the move, restore previous number, and drop the loan.
+            $player->update(['team_id' => $game->reserve_team_id, 'number' => $previousNumber]);
             Loan::where('game_player_id', $player->id)
                 ->where('status', Loan::STATUS_ACTIVE)
                 ->delete();
@@ -167,14 +169,86 @@ class ReserveTeamService
                 $player->activeLoan->update(['status' => Loan::STATUS_COMPLETED]);
             }
 
-            // Permanent move to first team.
+            // Permanent move to first team. Null the reserve number first so
+            // the (game_id, team_id, number) unique constraint can't fire on
+            // the team_id flip.
             $reserveTeamName = $game->reserveTeam?->name;
-            $player->update(['team_id' => $game->team_id]);
+            $player->update(['number' => null, 'team_id' => $game->team_id]);
             $number = $this->squadNumberService->assignNumberForNewPlayer($game, $player);
             if ($number !== null) {
                 $player->update(['number' => $number]);
             }
 
+            \App\Models\UserSquadCareerRecord::updateOrCreate(
+                ['game_player_id' => $player->id],
+                [
+                    'game_id' => $game->id,
+                    'team_id' => $game->team_id,
+                    'joined_season' => (int) $game->season,
+                    'joined_from' => $reserveTeamName ?? \App\Models\UserSquadCareerRecord::ORIGIN_ACADEMY,
+                ],
+            );
+
+            GameTransfer::record(
+                gameId: $game->id,
+                gamePlayerId: $player->id,
+                fromTeamId: $game->reserve_team_id,
+                toTeamId: $game->team_id,
+                transferFee: 0,
+                type: GameTransfer::TYPE_INTERNAL_PROMOTION,
+                season: $game->season,
+                window: TransferWindowType::currentValue($game->current_date),
+            );
+
+            $this->notificationService->create(
+                game: $game,
+                type: \App\Models\GameNotification::TYPE_ACADEMY_PROSPECT,
+                title: __('notifications.reserve_overage_promoted_title'),
+                message: __('notifications.reserve_overage_promoted_message', [
+                    'player' => $player->player->name ?? '',
+                ]),
+                priority: \App\Models\GameNotification::PRIORITY_INFO,
+            );
+
+            $promoted->push($player);
+        }
+
+        return $promoted;
+    }
+
+    /**
+     * At season close, permanently promote any reserve player still on a
+     * call-up loan to the first team. The active call-up loan is closed and
+     * the move is recorded as TYPE_INTERNAL_PROMOTION so the player no longer
+     * snaps back to the reserve team in subsequent seasons. The player keeps
+     * their existing first-team shirt number (assigned on call-up).
+     *
+     * @return Collection<int, GamePlayer>
+     */
+    public function permanentlyPromoteCalledUpPlayers(Game $game): Collection
+    {
+        if ($game->reserve_team_id === null) {
+            return collect();
+        }
+
+        $callUpLoans = Loan::with(['gamePlayer.player'])
+            ->where('game_id', $game->id)
+            ->where('status', Loan::STATUS_ACTIVE)
+            ->where('parent_team_id', $game->reserve_team_id)
+            ->where('loan_team_id', $game->team_id)
+            ->get();
+
+        $promoted = collect();
+
+        foreach ($callUpLoans as $loan) {
+            $player = $loan->gamePlayer;
+            if ($player === null) {
+                continue;
+            }
+
+            $loan->update(['status' => Loan::STATUS_COMPLETED]);
+
+            $reserveTeamName = $game->reserveTeam?->name;
             \App\Models\UserSquadCareerRecord::updateOrCreate(
                 ['game_player_id' => $player->id],
                 [

--- a/app/Modules/Season/Processors/LoanReturnProcessor.php
+++ b/app/Modules/Season/Processors/LoanReturnProcessor.php
@@ -2,6 +2,7 @@
 
 namespace App\Modules\Season\Processors;
 
+use App\Modules\ReserveTeam\Services\ReserveTeamService;
 use App\Modules\Season\Contracts\SeasonProcessor;
 use App\Modules\Season\DTOs\SeasonTransitionData;
 use App\Modules\Transfer\Services\LoanService;
@@ -17,6 +18,7 @@ class LoanReturnProcessor implements SeasonProcessor
     public function __construct(
         private readonly LoanService $loanService,
         private readonly NotificationService $notificationService,
+        private readonly ReserveTeamService $reserveTeamService,
     ) {}
 
     public function priority(): int
@@ -26,6 +28,15 @@ class LoanReturnProcessor implements SeasonProcessor
 
     public function process(Game $game, SeasonTransitionData $data): SeasonTransitionData
     {
+        // Reserve players still called up to the first team at season close
+        // are kept up permanently — closes their call-up loans before the
+        // generic return sweep runs, so they aren't sent back to the filial.
+        $promotedFromReserve = $this->reserveTeamService->permanentlyPromoteCalledUpPlayers($game);
+
+        if ($promotedFromReserve->isNotEmpty()) {
+            $data->setMetadata('reserve_called_up_promoted', $promotedFromReserve->count());
+        }
+
         $returnedLoans = $this->loanService->returnAllLoans($game);
 
         $loanReturns = $returnedLoans->map(fn ($loan) => [

--- a/app/Modules/Squad/Services/SquadNumberService.php
+++ b/app/Modules/Squad/Services/SquadNumberService.php
@@ -91,6 +91,23 @@ class SquadNumberService
     }
 
     /**
+     * Assign the first available academy slot (26-99) for a player joining
+     * the user's team. Used when promoting a reserve-team player up: they
+     * always get a 26+ shirt regardless of age, leaving 1-25 untouched.
+     */
+    public function assignAcademyNumberForNewPlayer(Game $game, GamePlayer $player): ?int
+    {
+        $takenNumbers = GamePlayer::where('game_id', $game->id)
+            ->where('team_id', $game->team_id)
+            ->where('id', '!=', $player->id)
+            ->whereNotNull('number')
+            ->pluck('number')
+            ->flip();
+
+        return $this->firstAvailable(self::FIRST_TEAM_MAX + 1, 99, $takenNumbers);
+    }
+
+    /**
      * Bulk reassign squad numbers for the user's team.
      *
      * Preserves existing numbers where valid. Only moves players when necessary:

--- a/lang/en/squad.php
+++ b/lang/en/squad.php
@@ -190,7 +190,7 @@ return [
     'discovered' => 'Discovered',
     'origin' => 'Origin',
     'joined' => 'Joined',
-    'origin_academy' => 'Academy',
+    'origin_academy' => 'New',
     'career_history' => 'Career history',
     'no_career_history' => 'No completed seasons yet.',
 
@@ -235,6 +235,7 @@ return [
     'send_back' => 'Send back',
     'send_back_to_reserve' => 'Send back to reserve',
     'called_up_indicator' => 'Called up',
+    'homegrown_indicator' => 'Homegrown',
     'actions' => 'Actions',
     'reserve_help_toggle' => 'How does the reserve team work?',
     'reserve_help_development' => 'Your reserve team is your filial — its squad belongs to the reserve, not the first team. New academy prospects arrive here each season based on your academy investment, and develop alongside the existing reserve roster.',

--- a/lang/es/squad.php
+++ b/lang/es/squad.php
@@ -190,7 +190,7 @@ return [
     'discovered' => 'Descubierto',
     'origin' => 'Procedencia',
     'joined' => 'Incorporación',
-    'origin_academy' => 'Cantera',
+    'origin_academy' => 'Nuevo',
     'career_history' => 'Trayectoria',
     'no_career_history' => 'Aún no hay temporadas completadas.',
 
@@ -235,6 +235,7 @@ return [
     'send_back' => 'Bajar',
     'send_back_to_reserve' => 'Bajar al filial',
     'called_up_indicator' => 'En el primer equipo',
+    'homegrown_indicator' => 'Canterano',
     'actions' => 'Acciones',
     'reserve_help_toggle' => '¿Cómo funciona el filial?',
     'reserve_help_development' => 'Tu filial es la cantera oficial — los jugadores pertenecen al filial, no al primer equipo. Cada temporada llegan nuevos canteranos según tu inversión en la cantera, que se desarrollan junto con el resto del filial.',

--- a/resources/views/components/origin-badge.blade.php
+++ b/resources/views/components/origin-badge.blade.php
@@ -1,14 +1,16 @@
-@props(['player'])
+@props(['player', 'currentSeason' => null])
 
 @php
     $record = $player->careerRecord ?? null;
+    $currentSeason = $currentSeason ?? $player->game?->season;
 @endphp
 
 @if($record)
     @php
         $isAcademy = $record->joined_from === \App\Models\UserSquadCareerRecord::ORIGIN_ACADEMY;
+        $isCurrentSeason = $currentSeason !== null && (string) $record->joined_season === (string) $currentSeason;
         $label = $isAcademy
-            ? __('squad.origin_academy')
+            ? ($isCurrentSeason ? __('squad.origin_academy') : '')
             : ($record->joined_from ?? '');
         $title = trim(($label !== '' ? $label . ' · ' : '') . __('squad.joined') . ' ' . \App\Models\Game::formatSeason((string) $record->joined_season));
         $classes = $isAcademy

--- a/resources/views/partials/player-detail.blade.php
+++ b/resources/views/partials/player-detail.blade.php
@@ -4,9 +4,10 @@
 
     $isCareerMode = $game->isCareerMode();
     $isListed = $gamePlayer->isTransferListed();
+    $isCalledUpFromReserve = $isCalledUpFromReserve ?? false;
     $canManage = $isCareerMode
         && !$gamePlayer->isRetiring()
-        && !$gamePlayer->isLoanedIn($game->team_id)
+        && ($isCalledUpFromReserve || !$gamePlayer->isLoanedIn($game->team_id))
         && !$gamePlayer->isLoanedOut($game->team_id)
         && !$gamePlayer->hasPreContractAgreement()
         && !$gamePlayer->hasAgreedTransfer()
@@ -279,9 +280,31 @@
 @endif
 
 {{-- Actions --}}
-@if($showActions || $canRenew || $renewalNegotiation || $renewalCooldown)
+@if($showActions || $canRenew || $renewalNegotiation || $renewalCooldown || ($isOnReserve ?? false) || $isCalledUpFromReserve)
     <div class="px-5 py-4 border-t border-border-default flex flex-wrap items-center gap-2">
-        @if(!$isListed && $canSell)
+        @if(($isOnReserve ?? false) && $isCareerMode)
+            <form method="POST" action="{{ route('game.reserve.call-up', [$game->id, $gamePlayer->id]) }}">
+                @csrf
+                <x-action-button color="blue">
+                    <svg class="w-4 h-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor">
+                        <path fill-rule="evenodd" d="M8 14a.75.75 0 0 1-.75-.75V4.56L4.03 7.78a.75.75 0 0 1-1.06-1.06l4.5-4.5a.75.75 0 0 1 1.06 0l4.5 4.5a.75.75 0 0 1-1.06 1.06L8.75 4.56v8.69A.75.75 0 0 1 8 14Z" clip-rule="evenodd" />
+                    </svg>
+                    {{ __('squad.call_up_to_first_team') }}
+                </x-action-button>
+            </form>
+        @endif
+        @if($isCalledUpFromReserve && $isCareerMode)
+            <form method="POST" action="{{ route('game.reserve.send-back', [$game->id, $gamePlayer->id]) }}">
+                @csrf
+                <x-action-button color="violet">
+                    <svg class="w-4 h-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor">
+                        <path fill-rule="evenodd" d="M8 2a.75.75 0 0 1 .75.75v8.69l3.22-3.22a.75.75 0 1 1 1.06 1.06l-4.5 4.5a.75.75 0 0 1-1.06 0l-4.5-4.5a.75.75 0 0 1 1.06-1.06l3.22 3.22V2.75A.75.75 0 0 1 8 2Z" clip-rule="evenodd" />
+                    </svg>
+                    {{ __('squad.send_back_to_reserve') }}
+                </x-action-button>
+            </form>
+        @endif
+        @if(!$isListed && $canSell && !($isOnReserve ?? false))
             <form method="POST" action="{{ route('game.transfers.list', [$game->id, $gamePlayer->id]) }}">
                 @csrf
                 <x-action-button color="blue">

--- a/resources/views/partials/squad/player-status-icon.blade.php
+++ b/resources/views/partials/squad/player-status-icon.blade.php
@@ -11,6 +11,10 @@
         <svg x-data="" x-tooltip.raw="{{ __('squad.retiring') }}" class="w-4 h-4 text-orange-500 shrink-0 cursor-help" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
             <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 9V5.25A2.25 2.25 0 0 1 10.5 3h6a2.25 2.25 0 0 1 2.25 2.25v13.5A2.25 2.25 0 0 1 16.5 21h-6a2.25 2.25 0 0 1-2.25-2.25V15m-3 0-3-3m0 0 3-3m-3 3H15" />
         </svg>
+    @elseif($gp->isLoanedIn($game->team_id) && $game->reserve_team_id !== null && $gp->activeLoan?->parent_team_id === $game->reserve_team_id)
+        <svg x-data="" x-tooltip.raw="{{ __('squad.homegrown_indicator') }}" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" class="w-4 h-4 text-sky-500 shrink-0 cursor-help" fill="currentColor">
+            <path fill-rule="evenodd" d="M8 14a.75.75 0 0 1-.75-.75V4.56L4.03 7.78a.75.75 0 0 1-1.06-1.06l4.5-4.5a.75.75 0 0 1 1.06 0l4.5 4.5a.75.75 0 0 1-1.06 1.06L8.75 4.56v8.69A.75.75 0 0 1 8 14Z" clip-rule="evenodd" />
+        </svg>
     @elseif($gp->isLoanedIn($game->team_id))
         <svg x-data="" x-tooltip.raw="{{ __('squad.on_loan') }}" class="w-4 h-4 text-sky-500 shrink-0 cursor-help" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
             <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 9V5.25A2.25 2.25 0 0 1 10.5 3h6a2.25 2.25 0 0 1 2.25 2.25v13.5A2.25 2.25 0 0 1 16.5 21h-6a2.25 2.25 0 0 1-2.25-2.25V15M12 9l3 3m0 0-3 3m3-3H2.25" />
@@ -31,17 +35,25 @@
         <svg x-data="" x-tooltip.raw="{{ __('squad.loan_searching') }}" class="w-4 h-4 text-sky-500 shrink-0 cursor-help" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
             <path stroke-linecap="round" stroke-linejoin="round" d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z" />
         </svg>
-    @elseif($gp->isContractExpiring($seasonEndDate ?? $game->getSeasonEndDate()) && !$gp->hasPreContractAgreement() && !$gp->hasRenewalAgreed() && !$gp->isRetiring())
-        <svg x-data="" x-tooltip.raw="{{ __('squad.contract_expiring') }}" class="w-4 h-4 text-amber-500 shrink-0 cursor-help" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m5.231 13.481L15 17.25m-4.5-15H5.625c-.621 0-1.125.504-1.125 1.125v16.5c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Zm3.75 11.625a2.625 2.625 0 1 1-5.25 0 2.625 2.625 0 0 1 5.25 0Z" />
-        </svg>
-    @elseif($gp->isTransferListed())
-        <svg x-data="" x-tooltip.raw="{{ __('squad.listed') }}" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" class="w-4 h-4 text-amber-500 shrink-0 cursor-help" fill="currentColor">
-            <path fill-rule="evenodd" d="M3.396 6.093a2 2 0 0 0 0 3.814 2 2 0 0 0 2.697 2.697 2 2 0 0 0 3.814 0 2.001 2.001 0 0 0 2.698-2.697 2 2 0 0 0-.001-3.814 2.001 2.001 0 0 0-2.697-2.698 2 2 0 0 0-3.814.001 2 2 0 0 0-2.697 2.697ZM6 7a1 1 0 1 0 0-2 1 1 0 0 0 0 2Zm3.47-1.53a.75.75 0 1 1 1.06 1.06l-4 4a.75.75 0 1 1-1.06-1.06l4-4ZM11 10a1 1 0 1 1-2 0 1 1 0 0 1 2 0Z" clip-rule="evenodd" />
-        </svg>
-    @elseif($flags['stature_gap'])
-        <x-warning-triangle :tooltip="__('transfers.player_wont_renew')" class="text-accent-red" />
-    @elseif($flags['wage_gap'])
-        <x-warning-triangle :tooltip="__('transfers.player_wants_raise')" class="text-accent-gold" />
+    @else
+        @php
+            $isExpiring = $gp->isContractExpiring($seasonEndDate ?? $game->getSeasonEndDate());
+            $isListed = $gp->isTransferListed();
+        @endphp
+        @if($isExpiring)
+            <svg x-data="" x-tooltip.raw="{{ __('squad.contract_expiring') }}" class="w-4 h-4 text-amber-500 shrink-0 cursor-help" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m5.231 13.481L15 17.25m-4.5-15H5.625c-.621 0-1.125.504-1.125 1.125v16.5c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Zm3.75 11.625a2.625 2.625 0 1 1-5.25 0 2.625 2.625 0 0 1 5.25 0Z" />
+            </svg>
+        @endif
+        @if($isListed)
+            <svg x-data="" x-tooltip.raw="{{ __('squad.listed') }}" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" class="w-4 h-4 text-amber-500 shrink-0 cursor-help" fill="currentColor">
+                <path fill-rule="evenodd" d="M3.396 6.093a2 2 0 0 0 0 3.814 2 2 0 0 0 2.697 2.697 2 2 0 0 0 3.814 0 2.001 2.001 0 0 0 2.698-2.697 2 2 0 0 0-.001-3.814 2.001 2.001 0 0 0-2.697-2.698 2 2 0 0 0-3.814.001 2 2 0 0 0-2.697 2.697ZM6 7a1 1 0 1 0 0-2 1 1 0 0 0 0 2Zm3.47-1.53a.75.75 0 1 1 1.06 1.06l-4 4a.75.75 0 1 1-1.06-1.06l4-4ZM11 10a1 1 0 1 1-2 0 1 1 0 0 1 2 0Z" clip-rule="evenodd" />
+            </svg>
+        @endif
+        @if(!$isExpiring && !$isListed && $flags['stature_gap'])
+            <x-warning-triangle :tooltip="__('transfers.player_wont_renew')" class="text-accent-red" />
+        @elseif(!$isExpiring && !$isListed && $flags['wage_gap'])
+            <x-warning-triangle :tooltip="__('transfers.player_wants_raise')" class="text-accent-gold" />
+        @endif
     @endif
 @endif

--- a/resources/views/squad-reserve.blade.php
+++ b/resources/views/squad-reserve.blade.php
@@ -19,14 +19,8 @@
         <x-flash-message type="error" :message="session('error')" class="mt-4" />
 
         {{-- Page Title --}}
-        <div class="mt-6 mb-4 flex items-center gap-3">
-            @if($reserveTeam->image)
-                <img src="{{ $reserveTeam->image }}" alt="{{ $reserveTeam->name }}" class="w-10 h-10 object-contain shrink-0" />
-            @endif
-            <div>
-                <h2 class="font-heading text-2xl lg:text-3xl font-bold uppercase tracking-wide text-text-primary">{{ $reserveTeam->name }}</h2>
-                <p class="text-xs text-text-muted">{{ __('squad.reserve_team') }}</p>
-            </div>
+        <div class="mt-6 mb-4">
+            <h2 class="font-heading text-2xl lg:text-3xl font-bold uppercase tracking-wide text-text-primary">{{ $reserveTeam->name }}</h2>
         </div>
 
         {{-- Summary strip --}}
@@ -35,8 +29,6 @@
                 <div class="flex items-center gap-2.5 overflow-x-auto scrollbar-hide pb-1">
                     <x-summary-card :label="__('squad.squad_size')" :value="$reserveCount" />
                     <x-summary-card :label="__('squad.avg_age')" :value="$avgAge" />
-                    <x-summary-card :label="__('squad.fitness_full')" :value="$avgFitness . '%'" x-data x-tooltip.raw="{{ __('squad.tooltip_fitness') }}" :value-class="$avgFitness >= 85 ? 'text-accent-green' : ($avgFitness >= 70 ? 'text-text-primary' : 'text-amber-500')" />
-                    <x-summary-card :label="__('squad.morale_full')" :value="$avgMorale" x-data x-tooltip.raw="{{ __('squad.tooltip_morale') }}" :value-class="$avgMorale >= 80 ? 'text-accent-green' : ($avgMorale >= 65 ? 'text-text-primary' : 'text-amber-500')" />
                     <x-summary-card :label="__('squad.avg_ovr')" :value="$avgOverall" x-data x-tooltip.raw="{{ __('squad.tooltip_avg_overall') }}" :value-class="$avgOverall >= 75 ? 'text-accent-green' : ($avgOverall >= 65 ? 'text-text-primary' : 'text-amber-500')" />
                     <div class="ml-auto shrink-0">
                         <x-help-toggle :label="__('squad.reserve_help_toggle')" />
@@ -77,15 +69,15 @@
             <div x-data class="bg-surface-800 border border-border-default rounded-xl overflow-hidden">
                 {{-- Table header --}}
                 <div class="hidden md:block">
-                    <div class="grid grid-cols-[40px_1fr_48px_48px_48px_56px_56px_120px] gap-1.5 items-center px-4 py-2 bg-surface-700/30 border-b border-border-default text-[10px] text-text-muted uppercase tracking-widest font-semibold">
+                    <div class="grid grid-cols-[40px_1fr_48px_56px_48px_48px_56px_56px] gap-1.5 items-center px-4 py-2 bg-surface-700/30 border-b border-border-default text-[10px] text-text-muted uppercase tracking-widest font-semibold">
                         <span></span>
                         <span>{{ __('app.name') }}</span>
                         <span class="text-center">{{ __('app.age') }}</span>
+                        <span class="text-center">{{ __('app.contract') }}</span>
                         <span class="text-center">{{ __('squad.technical') }}</span>
                         <span class="text-center">{{ __('squad.physical') }}</span>
                         <span class="text-center">{{ __('squad.pot') }}</span>
                         <span class="text-center">{{ __('squad.overall') }}</span>
-                        <span class="text-right">{{ __('squad.actions') }}</span>
                     </div>
                 </div>
 
@@ -110,15 +102,18 @@
                             @endphp
 
                             {{-- Mobile row --}}
-                            <div class="md:hidden px-4 py-3 border-b border-border-default">
+                            <div class="md:hidden px-4 py-3 border-b border-border-default {{ $isCalledUp ? 'opacity-60' : '' }}">
                                 <div class="flex items-center gap-3">
                                     <div class="cursor-pointer flex-1 flex items-center gap-3 min-w-0" @click="$dispatch('show-player-detail', '{{ route('game.player.detail', [$game->id, $player->id]) }}')">
                                         <x-player-avatar :name="$player->player->name" :position-group="\App\Support\PositionMapper::getPositionGroup($player->position)" :position-abbrev="\App\Support\PositionMapper::toAbbreviation($player->position)" />
                                         <div class="flex-1 min-w-0">
                                             <div class="flex items-center gap-2">
                                                 <span class="text-sm font-medium text-text-primary truncate">{{ $player->player->name }}</span>
-                                                <x-origin-badge :player="$player" />
+                                                <x-origin-badge :player="$player" :current-season="$game->season" />
                                                 <span class="text-[10px] text-text-faint">{{ $age }}</span>
+                                                @if($player->contract_expiry_year)
+                                                    <span class="text-[10px] tabular-nums @if($player->isContractExpiring($game->getSeasonEndDate())) text-accent-red font-medium @else text-text-faint @endif">{{ __('app.contract') }}: {{ $player->contract_expiry_year }}</span>
+                                                @endif
                                                 @if($isCalledUp)
                                                     <span class="text-[10px] font-semibold bg-accent-blue/10 text-accent-blue px-1.5 py-0.5 rounded-full">{{ __('squad.called_up_indicator') }}</span>
                                                 @endif
@@ -141,21 +136,25 @@
                             </div>
 
                             {{-- Desktop row --}}
-                            <div class="hidden md:grid grid-cols-[40px_1fr_48px_48px_48px_56px_56px_120px] gap-1.5 items-center px-4 py-2.5 border-b border-border-default hover:bg-surface-700/30 transition-colors">
-                                <div class="flex justify-center cursor-pointer" @click="$dispatch('show-player-detail', '{{ route('game.player.detail', [$game->id, $player->id]) }}')">
+                            <div class="hidden md:grid grid-cols-[40px_1fr_48px_56px_48px_48px_56px_56px] gap-1.5 items-center px-4 py-2.5 border-b border-border-default hover:bg-surface-700/30 transition-colors cursor-pointer {{ $isCalledUp ? 'opacity-60' : '' }}"
+                                 @click="$dispatch('show-player-detail', '{{ route('game.player.detail', [$game->id, $player->id]) }}')">
+                                <div class="flex justify-center">
                                     <x-position-badge :position="$player->position" size="sm" :tooltip="\App\Support\PositionMapper::toDisplayName($player->position)" class="cursor-help" />
                                 </div>
-                                <div class="flex items-center gap-2 min-w-0 cursor-pointer" @click="$dispatch('show-player-detail', '{{ route('game.player.detail', [$game->id, $player->id]) }}')">
+                                <div class="flex items-center gap-2 min-w-0">
                                     @if($player->nationality_flag)
                                         <img src="{{ Storage::disk('assets')->url('flags/' . $player->nationality_flag['code'] . '.svg') }}" class="w-4 h-3 rounded-xs shadow-xs shrink-0" title="{{ $player->nationality_flag['name'] }}">
                                     @endif
                                     <span class="text-sm font-medium text-text-primary truncate">{{ $player->player->name }}</span>
-                                    <x-origin-badge :player="$player" />
+                                    <x-origin-badge :player="$player" :current-season="$game->season" />
                                     @if($isCalledUp)
                                         <span class="text-[10px] font-semibold bg-accent-blue/10 text-accent-blue px-1.5 py-0.5 rounded-full">{{ __('squad.called_up_indicator') }}</span>
                                     @endif
                                 </div>
                                 <span class="text-xs text-text-secondary text-center tabular-nums">{{ $age }}</span>
+                                <span class="text-[11px] text-center tabular-nums @if($player->isContractExpiring($game->getSeasonEndDate())) text-accent-red font-medium @else text-text-muted @endif">
+                                    {{ $player->contract_expiry_year ?? '—' }}
+                                </span>
                                 <div class="flex justify-center">
                                     <span class="text-xs font-medium tabular-nums @if($player->current_technical_ability >= 80) text-accent-green @elseif($player->current_technical_ability >= 70) text-lime-500 @elseif($player->current_technical_ability >= 60) text-text-body @else text-text-secondary @endif">{{ $player->current_technical_ability }}</span>
                                 </div>
@@ -165,23 +164,6 @@
                                 <span class="text-xs text-center tabular-nums text-text-muted">{{ $player->potential_range }}</span>
                                 <div class="flex justify-center">
                                     <x-rating-badge :value="$player->overall_score" size="sm" />
-                                </div>
-                                <div class="flex justify-end">
-                                    @if($isCalledUp)
-                                        <form method="POST" action="{{ route('game.reserve.send-back', [$game->id, $player->id]) }}" onsubmit="return confirm('{{ __('squad.send_back_to_reserve') }}?')">
-                                            @csrf
-                                            <x-ghost-button color="slate" size="xs" type="submit" title="{{ __('squad.send_back_to_reserve') }}">
-                                                ↓ {{ __('squad.send_back') }}
-                                            </x-ghost-button>
-                                        </form>
-                                    @else
-                                        <form method="POST" action="{{ route('game.reserve.call-up', [$game->id, $player->id]) }}" onsubmit="return confirm('{{ __('squad.call_up_to_first_team') }}?')">
-                                            @csrf
-                                            <x-ghost-button color="green" size="xs" type="submit" title="{{ __('squad.call_up_to_first_team') }}">
-                                                ↑ {{ __('squad.call_up') }}
-                                            </x-ghost-button>
-                                        </form>
-                                    @endif
                                 </div>
                             </div>
                         @endforeach
@@ -193,4 +175,5 @@
     </div>
 
     <x-player-detail-modal />
+    <x-negotiation-chat-modal />
 </x-app-layout>

--- a/resources/views/squad.blade.php
+++ b/resources/views/squad.blade.php
@@ -272,7 +272,7 @@
                                             <div class="flex-1 min-w-0">
                                                 <div class="flex items-center gap-1.5">
                                                     <span class="text-sm font-medium text-text-primary truncate">{{ $gp->player->name }}</span>
-                                                    <x-origin-badge :player="$gp" />
+                                                    <x-origin-badge :player="$gp" :current-season="$game->season" />
                                                     @include('partials.squad.player-status-icon', ['gp' => $gp, 'game' => $game, 'seasonEndDate' => $seasonEndDate, 'playerFlags' => $playerFlags ?? []])
                                                     <x-player-unavailable-icon :player="$gp" :reason="$unavailReason" />
                                                 </div>
@@ -344,7 +344,7 @@
                                             <div class="min-w-0">
                                                 <div class="flex items-center gap-2">
                                                     <span class="text-sm font-medium text-text-primary truncate">{{ $gp->player->name }}</span>
-                                                    <x-origin-badge :player="$gp" />
+                                                    <x-origin-badge :player="$gp" :current-season="$game->season" />
                                                     @include('partials.squad.player-status-icon', ['gp' => $gp, 'game' => $game, 'seasonEndDate' => $seasonEndDate, 'playerFlags' => $playerFlags ?? []])
                                                     <x-player-unavailable-icon :player="$gp" :reason="$unavailReason" />
                                                 </div>


### PR DESCRIPTION
## Summary
UI polish and promotion-flow correctness on top of Phase 1.

**Player detail card** now exposes the right actions for both reserve and called-up filial players: call-up from reserve, send-back to filial when on internal loan, plus renewal and the standard release / loan-out / list-for-sale flow.

**Reserve squad page**:
- Adds a contract column next to age, drops the now-unused actions column, drops unused fitness/morale summary cards.
- Greys out players currently called up to the first team.
- Distinct upward-arrow icon (with \"Canterano\" / \"Homegrown\" tooltip) for filial loans, differentiating them from external loan-ins.

**Promotion flow**: called-up reserve players get 26+ shirt numbers on call-up and are permanently promoted at season close instead of having the internal loan returned. Call-up nulls the squad number before flipping \`team_id\` so the unique constraint can't trip.

**Misc UI**: contract-expiring and transfer-listed icons render in parallel; origin badge labeled \"Nuevo\" / \"New\" and only shown during the joining season; small color tweak on the player detail card.

Stacked on top of \`reserve/02-career-tracking\`.

## Test plan
- [ ] Player detail card shows the correct actions for first-team / reserve / called-up filial players
- [ ] Renew action available for reserve-squad players
- [ ] Reserve squad page shows contract column and greyed-out called-up rows
- [ ] Filial loan-ins show the upward-arrow icon with the right tooltip
- [ ] Called-up player keeps a 26+ shirt number, gets permanently promoted at season close
- [ ] \"Nuevo\" badge only visible during the joining season; disappears next season