### PR TITLE
Centralize player-ownership checks across first team and reserve

### DIFF
--- a/app/Http/Actions/NegotiateRenewal.php
+++ b/app/Http/Actions/NegotiateRenewal.php
@@ -37,12 +37,7 @@ class NegotiateRenewal
 
         $player = GamePlayer::with($eagerLoads)
             ->where('game_id', $gameId)
-            ->where(function ($q) use ($game) {
-                $q->ownedByTeam($game->team_id);
-                if ($game->reserve_team_id) {
-                    $q->orWhere(fn ($sub) => $sub->ownedByTeam($game->reserve_team_id));
-                }
-            })
+            ->userOwned($game)
             ->findOrFail($playerId);
 
         return match ($action) {

--- a/app/Http/Actions/ReleasePlayer.php
+++ b/app/Http/Actions/ReleasePlayer.php
@@ -17,10 +17,9 @@ class ReleasePlayer
     public function __invoke(Request $request, string $gameId, string $playerId): RedirectResponse
     {
         $game = Game::findOrFail($gameId);
-        $allowedTeamIds = array_filter([$game->team_id, $game->reserve_team_id]);
         $player = GamePlayer::where('id', $playerId)
             ->where('game_id', $gameId)
-            ->whereIn('team_id', $allowedTeamIds)
+            ->whereIn('team_id', $game->userTeamIds())
             ->firstOrFail();
 
         $wasOnReserve = $game->reserve_team_id !== null && $player->team_id === $game->reserve_team_id;

--- a/app/Http/Views/ShowPlayerDetail.php
+++ b/app/Http/Views/ShowPlayerDetail.php
@@ -17,22 +17,12 @@ class ShowPlayerDetail
     {
         $game = Game::findOrFail($gameId);
 
-        $allowedTeamIds = array_filter([$game->team_id, $game->reserve_team_id]);
-
         $gamePlayer = GamePlayer::with(['player', 'careerRecord', 'activeLoan'])
             ->where('game_id', $gameId)
-            ->whereIn('team_id', $allowedTeamIds)
+            ->userOwned($game)
             ->findOrFail($playerId);
 
-        // Player is "called up" from the filial: currently registered to the
-        // first team via a Loan whose parent is the reserve team. For action
-        // purposes we treat them like a normal first-team player and offer
-        // an additional "send back to filial" button.
-        $isCalledUpFromReserve = $game->reserve_team_id !== null
-            && $gamePlayer->team_id === $game->team_id
-            && $gamePlayer->activeLoan
-            && $gamePlayer->activeLoan->parent_team_id === $game->reserve_team_id
-            && $gamePlayer->activeLoan->loan_team_id === $game->team_id;
+        $isCalledUpFromReserve = $gamePlayer->isCalledUpFromReserve($game);
 
         $canRenew = $gamePlayer->canBeOfferedRenewal(currentDate: $game->current_date);
         $renewalNegotiation = null;
@@ -51,15 +41,15 @@ class ShowPlayerDetail
         $isOnReserve = $game->reserve_team_id !== null
             && $gamePlayer->team_id === $game->reserve_team_id;
 
-        // Release data — allowed for first-team and reserve-team players,
-        // including filial players currently called up via internal loan
-        // (which technically appears as "loaned in" but is treated as
-        // user-owned for management purposes).
+        // Release is permitted for any user-owned player physically present
+        // on a user roster (first team or reserve, including filial call-ups
+        // who sit on the first team via internal loan). The team_id check
+        // excludes players currently loaned out to a third-party club —
+        // those must wait for the loan to end before they can be released.
         $canRelease = $game->isCareerMode()
-            && in_array($gamePlayer->team_id, [$game->team_id, $game->reserve_team_id], true)
+            && $gamePlayer->isUserOwned($game)
+            && in_array($gamePlayer->team_id, $game->userTeamIds(), true)
             && !$gamePlayer->isRetiring()
-            && ($isCalledUpFromReserve || !$gamePlayer->isLoanedIn($game->team_id))
-            && !$gamePlayer->isLoanedOut($game->team_id)
             && !$gamePlayer->hasPreContractAgreement()
             && !$gamePlayer->hasRenewalAgreed()
             && !$gamePlayer->hasAgreedTransfer()

--- a/app/Models/Game.php
+++ b/app/Models/Game.php
@@ -352,6 +352,17 @@ class Game extends Model
         return $teamId === $this->team_id || $teamId === $this->reserve_team_id;
     }
 
+    /**
+     * IDs of all teams the user manages in this game (first team, plus the
+     * reserve team for parent clubs). Null entries are filtered out.
+     *
+     * @return array<int, string>
+     */
+    public function userTeamIds(): array
+    {
+        return array_values(array_filter([$this->team_id, $this->reserve_team_id]));
+    }
+
     public function isFilial(): bool
     {
         return $this->reserve_team_id !== null;

--- a/app/Models/GamePlayer.php
+++ b/app/Models/GamePlayer.php
@@ -388,6 +388,77 @@ class GamePlayer extends Model
     }
 
     /**
+     * Limit a query to players owned by the user in the given game — i.e.,
+     * by the first team or the reserve team. Generalizes scopeOwnedByTeam
+     * across the user's whole organization, including filial call-ups (which
+     * appear loaned-in to the first team but are still user-owned through
+     * the reserve as parent).
+     */
+    public function scopeUserOwned($query, Game $game)
+    {
+        $teamIds = $game->userTeamIds();
+
+        if (empty($teamIds)) {
+            return $query->whereRaw('1 = 0');
+        }
+
+        return $query->where(function ($q) use ($teamIds) {
+            $q->where(function ($present) use ($teamIds) {
+                $present->whereIn('team_id', $teamIds)
+                    ->whereDoesntHave('activeLoan');
+            })->orWhereHas('activeLoan', fn ($loanQuery) => $loanQuery->whereIn('parent_team_id', $teamIds));
+        });
+    }
+
+    /**
+     * Whether this player is part of the user's organization in the given
+     * game — owned by the first team or the reserve team, including filial
+     * call-ups loaned internally between them.
+     *
+     * Loaned-out players (gone elsewhere but parent-owned by the user) count.
+     * Loaned-in players from a third-party club do not.
+     */
+    public function isUserOwned(Game $game): bool
+    {
+        $teamIds = $game->userTeamIds();
+
+        if (empty($teamIds)) {
+            return false;
+        }
+
+        $loan = $this->relationLoaded('activeLoan')
+            ? $this->activeLoan
+            : $this->activeLoan()->first();
+
+        if ($loan) {
+            return in_array($loan->parent_team_id, $teamIds, true);
+        }
+
+        return in_array($this->team_id, $teamIds, true);
+    }
+
+    /**
+     * Whether this player is currently called up from the user's reserve team
+     * to the first team via internal loan. The player physically sits on the
+     * first-team roster but is owned by the reserve, so flows like contract
+     * renewal and release must treat them as user-owned.
+     */
+    public function isCalledUpFromReserve(Game $game): bool
+    {
+        if ($game->reserve_team_id === null) {
+            return false;
+        }
+
+        $loan = $this->relationLoaded('activeLoan')
+            ? $this->activeLoan
+            : $this->activeLoan()->first();
+
+        return $loan !== null
+            && $loan->parent_team_id === $game->reserve_team_id
+            && $loan->loan_team_id === $game->team_id;
+    }
+
+    /**
      * Check if player is transfer listed.
      */
     public function isTransferListed(): bool
@@ -538,20 +609,12 @@ class GamePlayer extends Model
             return false;
         }
 
-        // Loaned-in players belong to another club — we can't renew them.
-        // Exception: a player called up from the user's own reserve team
-        // appears as loaned-in to the first team but is still user-owned,
-        // so the user retains contract authority.
-        // Loaned-out players (ours, playing elsewhere) can still be renewed.
-        if ($this->isLoanedIn($this->game->team_id)) {
-            $reserveTeamId = $this->game->reserve_team_id;
-            $loanedFromOwnReserve = $reserveTeamId !== null
-                && $this->activeLoan
-                && $this->activeLoan->parent_team_id === $reserveTeamId;
-
-            if (!$loanedFromOwnReserve) {
-                return false;
-            }
+        // Renewal authority follows ownership: any user-owned player counts,
+        // including loaned-out players (parent club retains authority) and
+        // filial call-ups (owned via the reserve team). Players loaned in
+        // from a third-party club are not user-owned and cannot be renewed.
+        if (!$this->isUserOwned($this->game)) {
+            return false;
         }
 
         // Retiring players won't renew

--- a/app/Modules/Transfer/Services/ContractService.php
+++ b/app/Modules/Transfer/Services/ContractService.php
@@ -779,15 +779,24 @@ class ContractService
      */
     private function validateRelease(Game $game, GamePlayer $player): ?string
     {
-        // Must belong to the user's team
-        if ($player->team_id !== $game->team_id) {
+        // Must be a user-owned player physically on a user roster. The roster
+        // check rejects players loaned out to a third-party club; the
+        // ownership check rejects players loaned in from a third-party club.
+        if (!in_array($player->team_id, $game->userTeamIds(), true)) {
             return __('messages.release_not_your_player');
         }
 
-        // Cannot release players on loan
-        if ($player->isLoanedOut($game->team_id) || $player->isLoanedIn($game->team_id)) {
+        if (!$player->isUserOwned($game)) {
             return __('messages.release_on_loan');
         }
+
+        // Squad-size and position-group minimums apply to the roster the
+        // player effectively occupies. Filial call-ups sit on the first team
+        // physically but their parent club (and the roster they belong to
+        // for these checks) is the reserve team.
+        $rosterTeamId = $player->isCalledUpFromReserve($game)
+            ? $game->reserve_team_id
+            : $player->team_id;
 
         // Cannot release players with agreed transfers
         if ($player->hasAgreedTransfer()) {
@@ -801,7 +810,7 @@ class ContractService
 
         // Squad size check
         $currentSquadSize = GamePlayer::where('game_id', $game->id)
-            ->where('team_id', $game->team_id)
+            ->where('team_id', $rosterTeamId)
             ->count();
 
         if ($currentSquadSize <= self::MIN_SQUAD_SIZE) {
@@ -814,7 +823,7 @@ class ContractService
 
         if ($groupMinimum > 0) {
             $groupCount = GamePlayer::where('game_id', $game->id)
-                ->where('team_id', $game->team_id)
+                ->where('team_id', $rosterTeamId)
                 ->get()
                 ->filter(fn ($p) => $p->position_group === $positionGroup)
                 ->count();


### PR DESCRIPTION
## Summary
Pure refactor — no behavioral change in the happy path, plus one bug fix as a side effect.

Adds:
- \`Game::userTeamIds()\` returning the user's first-team and reserve-team ids.
- \`GamePlayer::isUserOwned()\`, \`GamePlayer::isCalledUpFromReserve()\`, and a \`userOwned\` query scope.

Collapses duplicated first-team / reserve-team / filial-call-up branching in:
- \`ShowPlayerDetail\`
- \`ReleasePlayer\`
- \`NegotiateRenewal\`
- \`ContractService\`'s release validation
- \`GamePlayer::canBeOfferedRenewal\`

**Side-effect fix**: contract renewal and release now correctly include filial call-ups and reserve-squad players, which previously hit \"loaned-in / not your player\" errors.

Stacked on top of \`reserve/03-ui-polish\`.

## Test plan
- [ ] Renew a reserve-squad player (previously errored)
- [ ] Renew a called-up filial player (previously errored)
- [ ] Release a reserve-squad player
- [ ] Existing first-team renewal / release flows unchanged
- [ ] Existing loaned-in player rejection still works