### PR TITLE
Squad-minimum guards on roster-removal flows

### DIFF
--- a/app/Http/Actions/AcceptLoanOffer.php
+++ b/app/Http/Actions/AcceptLoanOffer.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Actions;
 
+use App\Modules\Transfer\Exceptions\SquadMinimumException;
 use App\Modules\Transfer\Services\LoanService;
 use App\Models\Game;
 use App\Models\TransferOffer;
@@ -39,7 +40,11 @@ class AcceptLoanOffer
         $team = $offer->offeringTeam;
         $windowOpen = $game->isTransferWindowOpen();
 
-        $this->loanService->acceptLoanOffer($offer, $game);
+        try {
+            $this->loanService->acceptLoanOffer($offer, $game);
+        } catch (SquadMinimumException $e) {
+            return redirect()->back()->with('error', $this->formatBreachMessage($e));
+        }
 
         if ($windowOpen) {
             $message = __('messages.loan_offer_accepted', [
@@ -57,5 +62,17 @@ class AcceptLoanOffer
         return redirect()
             ->route('game.transfers.outgoing', $gameId)
             ->with('success', $message);
+    }
+
+    private function formatBreachMessage(SquadMinimumException $e): string
+    {
+        if ($e->type() === 'too_small') {
+            return __('messages.accept_loan_squad_too_small', ['min' => $e->min()]);
+        }
+
+        return __('messages.accept_loan_position_minimum', [
+            'group' => __('squad.' . strtolower($e->group()) . 's'),
+            'min'   => $e->min(),
+        ]);
     }
 }

--- a/app/Http/Actions/AcceptTransferOffer.php
+++ b/app/Http/Actions/AcceptTransferOffer.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Actions;
 
+use App\Modules\Transfer\Exceptions\SquadMinimumException;
 use App\Modules\Transfer\Services\TransferService;
 use App\Models\Game;
 use App\Models\TransferOffer;
@@ -43,7 +44,11 @@ class AcceptTransferOffer
         $team = $offer->offeringTeam;
         $fee = $offer->formatted_transfer_fee;
 
-        $completedImmediately = $this->transferService->acceptOffer($offer);
+        try {
+            $completedImmediately = $this->transferService->acceptOffer($offer);
+        } catch (SquadMinimumException $e) {
+            return redirect()->back()->with('error', $this->formatBreachMessage($e));
+        }
 
         if ($completedImmediately) {
             $message = __('messages.offer_accepted_sale', [
@@ -64,5 +69,17 @@ class AcceptTransferOffer
         return redirect()
             ->route('game.transfers.outgoing', $gameId)
             ->with('success', $message);
+    }
+
+    private function formatBreachMessage(SquadMinimumException $e): string
+    {
+        if ($e->type() === 'too_small') {
+            return __('messages.accept_offer_squad_too_small', ['min' => $e->min()]);
+        }
+
+        return __('messages.accept_offer_position_minimum', [
+            'group' => __('squad.' . strtolower($e->group()) . 's'),
+            'min'   => $e->min(),
+        ]);
     }
 }

--- a/app/Http/Actions/ListPlayerForTransfer.php
+++ b/app/Http/Actions/ListPlayerForTransfer.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Actions;
 
+use App\Modules\Transfer\Exceptions\SquadMinimumException;
 use App\Modules\Transfer\Services\TransferService;
 use App\Models\Game;
 use App\Models\GamePlayer;
@@ -32,11 +33,26 @@ class ListPlayerForTransfer
             ]));
         }
 
-        // List the player
-        $this->transferService->listPlayer($player);
+        try {
+            $this->transferService->listPlayer($player);
+        } catch (SquadMinimumException $e) {
+            return redirect()->back()->with('error', $this->formatBreachMessage($e));
+        }
 
         return redirect()
             ->back()
             ->with('success', __('messages.player_listed', ['player' => $player->player->name]));
+    }
+
+    private function formatBreachMessage(SquadMinimumException $e): string
+    {
+        if ($e->type() === 'too_small') {
+            return __('messages.list_for_sale_squad_too_small', ['min' => $e->min()]);
+        }
+
+        return __('messages.list_for_sale_position_minimum', [
+            'group' => __('squad.' . strtolower($e->group()) . 's'),
+            'min'   => $e->min(),
+        ]);
     }
 }

--- a/app/Http/Actions/NegotiateCounterOffer.php
+++ b/app/Http/Actions/NegotiateCounterOffer.php
@@ -5,6 +5,7 @@ namespace App\Http\Actions;
 use App\Models\Game;
 use App\Models\TransferOffer;
 use App\Modules\Notification\Services\NotificationService;
+use App\Modules\Transfer\Exceptions\SquadMinimumException;
 use App\Modules\Transfer\Services\ContractService;
 use App\Modules\Transfer\Services\ScoutingService;
 use App\Modules\Transfer\Services\TransferService;
@@ -202,7 +203,14 @@ class NegotiateCounterOffer
 
     private function completeSale(TransferOffer $offer, Game $game, $player, string $buyerName): JsonResponse
     {
-        $completedImmediately = $this->transferService->acceptOffer($offer);
+        try {
+            $completedImmediately = $this->transferService->acceptOffer($offer);
+        } catch (SquadMinimumException $e) {
+            return response()->json([
+                'status' => 'error',
+                'message' => $this->formatBreachMessage($e),
+            ], 422);
+        }
 
         if ($completedImmediately) {
             $this->notificationService->notifyTransferComplete($game, $offer->refresh());
@@ -256,5 +264,17 @@ class NegotiateCounterOffer
     private function calculateMidpointInEuros(int $centsA, int $centsB): int
     {
         return (int) (ceil(($centsA + $centsB) / 2 / 100 / 10000) * 10000);
+    }
+
+    private function formatBreachMessage(SquadMinimumException $e): string
+    {
+        if ($e->type() === 'too_small') {
+            return __('messages.accept_offer_squad_too_small', ['min' => $e->min()]);
+        }
+
+        return __('messages.accept_offer_position_minimum', [
+            'group' => __('squad.' . strtolower($e->group()) . 's'),
+            'min'   => $e->min(),
+        ]);
     }
 }

--- a/app/Http/Actions/RequestLoan.php
+++ b/app/Http/Actions/RequestLoan.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Actions;
 
+use App\Modules\Transfer\Exceptions\SquadMinimumException;
 use App\Modules\Transfer\Services\LoanService;
 use App\Models\Game;
 use App\Models\GamePlayer;
@@ -62,9 +63,25 @@ class RequestLoan
                 ->with('error', __('messages.already_on_loan', ['player' => $player->name]));
         }
 
-        $this->loanService->startLoanSearch($game, $player);
+        try {
+            $this->loanService->startLoanSearch($game, $player);
+        } catch (SquadMinimumException $e) {
+            return redirect()->back()->with('error', $this->formatBreachMessage($e));
+        }
 
         return redirect()->back()
             ->with('success', __('messages.loan_search_started', ['player' => $player->name]));
+    }
+
+    private function formatBreachMessage(SquadMinimumException $e): string
+    {
+        if ($e->type() === 'too_small') {
+            return __('messages.list_for_loan_squad_too_small', ['min' => $e->min()]);
+        }
+
+        return __('messages.list_for_loan_position_minimum', [
+            'group' => __('squad.' . strtolower($e->group()) . 's'),
+            'min'   => $e->min(),
+        ]);
     }
 }

--- a/app/Modules/Season/Processors/YouthAcademyPromotionProcessor.php
+++ b/app/Modules/Season/Processors/YouthAcademyPromotionProcessor.php
@@ -7,7 +7,7 @@ use App\Modules\Season\DTOs\SeasonTransitionData;
 use App\Modules\Academy\Services\YouthAcademyService;
 use App\Modules\Notification\Services\NotificationService;
 use App\Modules\Squad\Services\PlayerGeneratorService;
-use App\Modules\Transfer\Services\ContractService;
+use App\Modules\Squad\Services\SquadMinimumService;
 use App\Models\Game;
 use App\Models\GameNotification;
 use App\Models\GamePlayer;
@@ -37,6 +37,7 @@ class YouthAcademyPromotionProcessor implements SeasonProcessor
         private readonly YouthAcademyService $youthAcademyService,
         private readonly NotificationService $notificationService,
         private readonly PlayerGeneratorService $playerGenerator,
+        private readonly SquadMinimumService $squadMinimumService,
     ) {}
 
     public function priority(): int
@@ -62,8 +63,8 @@ class YouthAcademyPromotionProcessor implements SeasonProcessor
         }
 
         // Phase 2: If squad is under minimum, promote best academy players to fill
-        $squadCount = ContractService::squadCount($game);
-        $deficit = ContractService::MIN_SQUAD_SIZE - $squadCount;
+        $squadCount = $this->squadMinimumService->squadCount($game, $game->team_id);
+        $deficit = SquadMinimumService::MIN_SQUAD_SIZE - $squadCount;
 
         $gapPromoted = $this->youthAcademyService->promoteBestPlayers($game, $deficit);
 
@@ -80,8 +81,8 @@ class YouthAcademyPromotionProcessor implements SeasonProcessor
         }
 
         // Phase 3: If still under minimum, generate synthetic players
-        $squadCount = ContractService::squadCount($game);
-        $remaining = ContractService::MIN_SQUAD_SIZE - $squadCount;
+        $squadCount = $this->squadMinimumService->squadCount($game, $game->team_id);
+        $remaining = SquadMinimumService::MIN_SQUAD_SIZE - $squadCount;
 
         if ($remaining > 0) {
             $this->generateSyntheticPlayers($game, $remaining, $data);

--- a/app/Modules/Squad/Exceptions/SquadMinimumNotMetException.php
+++ b/app/Modules/Squad/Exceptions/SquadMinimumNotMetException.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Modules\Squad\Exceptions;
+
+use RuntimeException;
+
+/**
+ * Base exception for squad-minimum guard failures. Carries the structured
+ * payload from SquadMinimumService::validateRemoval so the calling Action
+ * can format an action-specific user-facing message.
+ *
+ * Concrete subclasses (one per flow) let callers catch only the relevant
+ * one without false positives from unrelated guards.
+ */
+class SquadMinimumNotMetException extends RuntimeException
+{
+    /**
+     * @param array{type: string, min: int, group?: string} $payload
+     */
+    public function __construct(
+        public readonly array $payload,
+        string $message = 'Squad minimum not met.',
+    ) {
+        parent::__construct($message);
+    }
+
+    public function type(): string
+    {
+        return $this->payload['type'];
+    }
+
+    public function min(): int
+    {
+        return $this->payload['min'];
+    }
+
+    public function group(): ?string
+    {
+        return $this->payload['group'] ?? null;
+    }
+}

--- a/app/Modules/Squad/Services/SquadMinimumService.php
+++ b/app/Modules/Squad/Services/SquadMinimumService.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace App\Modules\Squad\Services;
+
+use App\Models\Game;
+use App\Models\GamePlayer;
+
+/**
+ * Single source of truth for squad-composition minimums (total squad size
+ * and per-position-group floors). Used by every flow that can cause a
+ * user-owned player to leave a roster — release, call-up, send-back,
+ * sale listing, loan-out listing, and offer acceptance — so the same
+ * rule is enforced everywhere.
+ *
+ * Counting is by physical presence (`team_id`) rather than ownership:
+ * the minimum protects the playable roster, so loaned-out players
+ * (still parent-owned but physically away) do not count toward the
+ * source team's minimum.
+ */
+final class SquadMinimumService
+{
+    /**
+     * Absolute minimum players in a squad — flows that would drop the
+     * roster below this are blocked.
+     */
+    public const MIN_SQUAD_SIZE = 20;
+
+    /**
+     * Minimum players per position group. Keys match
+     * GamePlayer::position_group values.
+     */
+    public const POSITION_GROUP_MINIMUMS = [
+        'Goalkeeper' => 2,
+        'Defender'   => 6,
+        'Midfielder' => 6,
+        'Forward'    => 4,
+    ];
+
+    /**
+     * Count physical players on the given team in the given game.
+     */
+    public function squadCount(Game $game, string $teamId): int
+    {
+        return GamePlayer::where('game_id', $game->id)
+            ->where('team_id', $teamId)
+            ->count();
+    }
+
+    /**
+     * Count physical players in a specific position group on the given team.
+     */
+    public function positionGroupCount(Game $game, string $teamId, string $positionGroup): int
+    {
+        return GamePlayer::where('game_id', $game->id)
+            ->where('team_id', $teamId)
+            ->get()
+            ->filter(fn (GamePlayer $p) => $p->position_group === $positionGroup)
+            ->count();
+    }
+
+    /**
+     * Test whether removing $player from $teamId would breach the squad
+     * minimum or position-group minimum on that team.
+     *
+     * Returns null when the removal is allowed, or a structured failure:
+     *   ['type' => 'too_small',         'min' => int]
+     *   ['type' => 'position_minimum',  'min' => int, 'group' => string]
+     *
+     * @return array{type: string, min: int, group?: string}|null
+     */
+    public function validateRemoval(Game $game, GamePlayer $player, string $teamId): ?array
+    {
+        if ($this->squadCount($game, $teamId) <= self::MIN_SQUAD_SIZE) {
+            return ['type' => 'too_small', 'min' => self::MIN_SQUAD_SIZE];
+        }
+
+        $positionGroup = $player->position_group;
+        $groupMinimum = self::POSITION_GROUP_MINIMUMS[$positionGroup] ?? 0;
+
+        if ($groupMinimum > 0
+            && $this->positionGroupCount($game, $teamId, $positionGroup) <= $groupMinimum) {
+            return [
+                'type'  => 'position_minimum',
+                'min'   => $groupMinimum,
+                'group' => $positionGroup,
+            ];
+        }
+
+        return null;
+    }
+}

--- a/app/Modules/Transfer/Exceptions/SquadMinimumException.php
+++ b/app/Modules/Transfer/Exceptions/SquadMinimumException.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Modules\Transfer\Exceptions;
+
+use App\Modules\Squad\Exceptions\SquadMinimumNotMetException;
+
+/**
+ * A transfer/loan flow (listing for sale, listing for loan-out, or
+ * accepting an incoming offer) would drop the player's current squad
+ * below its composition minimum.
+ */
+class SquadMinimumException extends SquadMinimumNotMetException
+{
+}

--- a/app/Modules/Transfer/Services/ContractService.php
+++ b/app/Modules/Transfer/Services/ContractService.php
@@ -15,6 +15,7 @@ use App\Models\Team;
 use App\Models\TransferListing;
 use App\Models\TransferOffer;
 use App\Modules\Notification\Services\NotificationService;
+use App\Modules\Squad\Services\SquadMinimumService;
 use App\Support\Money;
 use Carbon\Carbon;
 use Illuminate\Support\Collection;
@@ -57,6 +58,7 @@ class ContractService
     public function __construct(
         private readonly WageNegotiationEvaluator $wageNegotiationEvaluator,
         private readonly DispositionService $dispositionService,
+        private readonly SquadMinimumService $squadMinimumService,
     ) {}
 
     /**
@@ -689,31 +691,6 @@ class ContractService
     private const SEVERANCE_RATE = 0.50;
 
     /**
-     * Minimum squad size — cannot release if it would drop below this.
-     */
-    public const MIN_SQUAD_SIZE = 20;
-
-    /**
-     * Count first-team players in the user's squad.
-     */
-    public static function squadCount(Game $game): int
-    {
-        return GamePlayer::where('game_id', $game->id)
-            ->where('team_id', $game->team_id)
-            ->count();
-    }
-
-    /**
-     * Minimum players per position group — mirrors SquadReplenishmentProcessor.
-     */
-    private const POSITION_GROUP_MINIMUMS = [
-        'Goalkeeper' => 3,
-        'Defender' => 6,
-        'Midfielder' => 6,
-        'Forward' => 4,
-    ];
-
-    /**
      * Release a player from the user's squad (unilateral contract termination).
      *
      * The player becomes a free agent (team_id = null) and the club pays
@@ -799,32 +776,18 @@ class ContractService
             return __('messages.release_has_pre_contract');
         }
 
-        // Squad size check
-        $currentSquadSize = GamePlayer::where('game_id', $game->id)
-            ->where('team_id', $game->team_id)
-            ->count();
-
-        if ($currentSquadSize <= self::MIN_SQUAD_SIZE) {
-            return __('messages.release_squad_too_small', ['min' => self::MIN_SQUAD_SIZE]);
-        }
-
-        // Position group minimum check
-        $positionGroup = $player->position_group;
-        $groupMinimum = self::POSITION_GROUP_MINIMUMS[$positionGroup] ?? 0;
-
-        if ($groupMinimum > 0) {
-            $groupCount = GamePlayer::where('game_id', $game->id)
-                ->where('team_id', $game->team_id)
-                ->get()
-                ->filter(fn ($p) => $p->position_group === $positionGroup)
-                ->count();
-
-            if ($groupCount <= $groupMinimum) {
-                return __('messages.release_position_minimum', [
-                    'group' => __('squad.' . strtolower($positionGroup) . 's'),
-                    'min' => $groupMinimum,
-                ]);
+        // Squad-composition guard: total squad size and per-position-group
+        // minimums on the team that would lose the player.
+        $breach = $this->squadMinimumService->validateRemoval($game, $player, $game->team_id);
+        if ($breach !== null) {
+            if ($breach['type'] === 'too_small') {
+                return __('messages.release_squad_too_small', ['min' => $breach['min']]);
             }
+
+            return __('messages.release_position_minimum', [
+                'group' => __('squad.' . strtolower($breach['group']) . 's'),
+                'min'   => $breach['min'],
+            ]);
         }
 
         return null;

--- a/app/Modules/Transfer/Services/LoanService.php
+++ b/app/Modules/Transfer/Services/LoanService.php
@@ -14,8 +14,10 @@ use App\Models\Team;
 use App\Models\TeamReputation;
 use App\Models\TransferListing;
 use App\Models\TransferOffer;
+use App\Modules\Squad\Services\SquadMinimumService;
 use App\Modules\Squad\Services\SquadNumberService;
 use App\Modules\Transfer\Enums\TransferWindowType;
+use App\Modules\Transfer\Exceptions\SquadMinimumException;
 use Carbon\Carbon;
 use Illuminate\Support\Collection;
 
@@ -28,13 +30,23 @@ class LoanService
         private readonly DispositionService $dispositionService,
         private readonly SquadNumberService $squadNumberService,
         private readonly AIExclusionList $exclusionList,
+        private readonly SquadMinimumService $squadMinimumService,
     ) {}
 
     /**
      * Start a loan search for a player.
+     *
+     * @throws SquadMinimumException when listing this player would mean the
+     *         squad could fall below its composition minimum if the resulting
+     *         loan offer is accepted.
      */
     public function startLoanSearch(Game $game, GamePlayer $player): void
     {
+        $breach = $this->squadMinimumService->validateRemoval($game, $player, $player->team_id);
+        if ($breach !== null) {
+            throw new SquadMinimumException($breach);
+        }
+
         TransferListing::updateOrCreate(
             ['game_player_id' => $player->id],
             [
@@ -647,6 +659,18 @@ class LoanService
      */
     public function acceptLoanOffer(TransferOffer $offer, Game $game): void
     {
+        // Squad-composition guard: this is the binding moment — once accepted
+        // (or marked agreed), the player is committed to leaving on loan. Block
+        // here so the resulting move can't shrink the squad below minimums,
+        // even if the loan listing itself was OK at the time it was created.
+        $player = $offer->gamePlayer;
+        if ($player !== null) {
+            $breach = $this->squadMinimumService->validateRemoval($game, $player, $player->team_id);
+            if ($breach !== null) {
+                throw new SquadMinimumException($breach);
+            }
+        }
+
         // Reject sibling offers for the same player
         TransferOffer::where('game_id', $game->id)
             ->where('game_player_id', $offer->game_player_id)

--- a/app/Modules/Transfer/Services/TransferService.php
+++ b/app/Modules/Transfer/Services/TransferService.php
@@ -3,8 +3,10 @@
 namespace App\Modules\Transfer\Services;
 
 use App\Modules\Player\PlayerAge;
+use App\Modules\Squad\Services\SquadMinimumService;
 use App\Modules\Squad\Services\SquadNumberService;
 use App\Modules\Transfer\Enums\NegotiationScenario;
+use App\Modules\Transfer\Exceptions\SquadMinimumException;
 use App\Modules\Transfer\Enums\TransferWindowType;
 use App\Modules\Transfer\Services\ContractService;
 use App\Modules\Transfer\Services\LoanService;
@@ -32,6 +34,7 @@ class TransferService
         private readonly ContractService $contractService,
         private readonly DispositionService $dispositionService,
         private readonly SquadNumberService $squadNumberService,
+        private readonly SquadMinimumService $squadMinimumService,
     ) {}
 
     /**
@@ -127,11 +130,24 @@ class TransferService
 
     /**
      * List a player for transfer.
+     *
+     * @throws SquadMinimumException when listing this player would mean the
+     *         squad could fall below its composition minimum if the resulting
+     *         offer is accepted.
      */
     public function listPlayer(GamePlayer $player): void
     {
         if ($player->isOnLoan()) {
             return;
+        }
+
+        $breach = $this->squadMinimumService->validateRemoval(
+            $player->game,
+            $player,
+            $player->team_id,
+        );
+        if ($breach !== null) {
+            throw new SquadMinimumException($breach);
         }
 
         TransferListing::updateOrCreate(
@@ -578,6 +594,15 @@ class TransferService
     {
         $player = $offer->gamePlayer;
         $game = $offer->game;
+
+        // Squad-composition guard: this is the binding moment — once accepted
+        // (or marked agreed), the player is committed to leaving. Block here
+        // so the resulting transfer can't shrink the roster below minimums,
+        // even if the listing itself was OK at the time it was created.
+        $breach = $this->squadMinimumService->validateRemoval($game, $player, $player->team_id);
+        if ($breach !== null) {
+            throw new SquadMinimumException($breach);
+        }
 
         // Reject all other pending offers for this player
         TransferOffer::where('game_player_id', $player->id)

--- a/lang/en/messages.php
+++ b/lang/en/messages.php
@@ -98,6 +98,16 @@ return [
     'release_squad_too_small' => 'Cannot release — your squad must have at least :min players.',
     'release_position_minimum' => 'Cannot release — you need at least :min :group.',
 
+    // Squad-minimum guards on list / accept
+    'list_for_sale_squad_too_small' => 'Cannot list for sale — your squad must have at least :min players.',
+    'list_for_sale_position_minimum' => 'Cannot list for sale — you need at least :min :group.',
+    'list_for_loan_squad_too_small' => 'Cannot loan out — your squad must have at least :min players.',
+    'list_for_loan_position_minimum' => 'Cannot loan out — you need at least :min :group.',
+    'accept_offer_squad_too_small' => 'Cannot accept the offer — your squad must have at least :min players.',
+    'accept_offer_position_minimum' => 'Cannot accept the offer — you need at least :min :group.',
+    'accept_loan_squad_too_small' => 'Cannot accept the loan — your squad must have at least :min players.',
+    'accept_loan_position_minimum' => 'Cannot accept the loan — you need at least :min :group.',
+
     'cannot_loan_free_agent' => 'Cannot loan a free agent. Sign them directly instead.',
 
     // Pending actions

--- a/lang/es/messages.php
+++ b/lang/es/messages.php
@@ -98,6 +98,16 @@ return [
     'release_squad_too_small' => 'No se puede liberar — tu plantilla debe tener al menos :min jugadores.',
     'release_position_minimum' => 'No se puede liberar — necesitas al menos :min :group.',
 
+    // Squad-minimum guards on list / accept
+    'list_for_sale_squad_too_small' => 'No se puede poner a la venta — tu plantilla debe tener al menos :min jugadores.',
+    'list_for_sale_position_minimum' => 'No se puede poner a la venta — necesitas al menos :min :group.',
+    'list_for_loan_squad_too_small' => 'No se puede ceder — tu plantilla debe tener al menos :min jugadores.',
+    'list_for_loan_position_minimum' => 'No se puede ceder — necesitas al menos :min :group.',
+    'accept_offer_squad_too_small' => 'No se puede aceptar la oferta — tu plantilla debe tener al menos :min jugadores.',
+    'accept_offer_position_minimum' => 'No se puede aceptar la oferta — necesitas al menos :min :group.',
+    'accept_loan_squad_too_small' => 'No se puede aceptar la cesión — tu plantilla debe tener al menos :min jugadores.',
+    'accept_loan_position_minimum' => 'No se puede aceptar la cesión — necesitas al menos :min :group.',
+
     'cannot_loan_free_agent' => 'No se puede ceder a un jugador libre. Fíchalo directamente.',
 
     // Pending actions

--- a/tests/Feature/CounterOfferTest.php
+++ b/tests/Feature/CounterOfferTest.php
@@ -56,6 +56,27 @@ class CounterOfferTest extends TestCase
             'contract_until' => '2027-06-30',
         ]);
 
+        // Pad the user roster so SquadMinimumService lets the negotiated
+        // sale proceed. Without this, acceptOffer() would refuse because
+        // the squad would drop below MIN_SQUAD_SIZE / per-position floors.
+        // The main player above (default Central Midfield) counts as the
+        // seventh midfielder.
+        $userSquadFiller = [
+            ['Goalkeeper', 4],
+            ['Centre-Back', 7],
+            ['Central Midfield', 6],
+            ['Centre-Forward', 5],
+        ];
+        foreach ($userSquadFiller as [$position, $count]) {
+            for ($i = 0; $i < $count; $i++) {
+                GamePlayer::factory()->create([
+                    'game_id' => $this->game->id,
+                    'team_id' => $this->userTeam->id,
+                    'position' => $position,
+                ]);
+            }
+        }
+
         // Create buyer team players to give them squad value (€100M total)
         for ($i = 0; $i < 10; $i++) {
             GamePlayer::factory()->create([

--- a/tests/Feature/UnsolicitedRivalExclusionTest.php
+++ b/tests/Feature/UnsolicitedRivalExclusionTest.php
@@ -236,6 +236,13 @@ class UnsolicitedRivalExclusionTest extends TestCase
             'contract_until' => '2027-06-30',
         ]);
 
+        // Pad the user roster so the squad-minimum guard (total >=21,
+        // per-position-group >= floor + 1) lets us list/accept offers on
+        // the main player. The distribution mirrors POSITION_GROUP_MINIMUMS
+        // + 1 each, with the Central Midfielder above counting as the
+        // seventh midfielder.
+        $this->createFillerSquad($game, $userTeam);
+
         // Give the AI team a fat squad so the 15% fee-to-squad-value ratio is
         // never the reason an offer fails to materialise (€400M total).
         for ($i = 0; $i < 10; $i++) {
@@ -247,6 +254,32 @@ class UnsolicitedRivalExclusionTest extends TestCase
         }
 
         return [$game, $player];
+    }
+
+    /**
+     * Build a filler roster that satisfies SquadMinimumService floors when
+     * combined with the test's main player. Every flow that removes a
+     * user-owned player checks this; without padding, listPlayer() and
+     * acceptOffer() would refuse before we can exercise the rival filter.
+     */
+    private function createFillerSquad(Game $game, Team $team): void
+    {
+        $positions = [
+            ['Goalkeeper', 4],
+            ['Centre-Back', 7],
+            ['Central Midfield', 6],
+            ['Centre-Forward', 5],
+        ];
+
+        foreach ($positions as [$position, $count]) {
+            for ($i = 0; $i < $count; $i++) {
+                GamePlayer::factory()->create([
+                    'game_id' => $game->id,
+                    'team_id' => $team->id,
+                    'position' => $position,
+                ]);
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary
Extracts \`MIN_SQUAD_SIZE\` / \`POSITION_GROUP_MINIMUMS\` into a new \`SquadMinimumService\` and applies the same rule everywhere a user-owned player can leave the squad through existing flows: list for sale, list for loan-out, and acceptance of incoming transfer / loan offers (including the in-chat counter-bid acceptance path).

Each flow throws a flow-specific \`SquadMinimumException\` that the calling Action maps to a translated, action-matching error message in both Spanish and English. Release flow refactored onto the same helper. \`ContractService::squadCount\` / \`MIN_SQUAD_SIZE\` / \`POSITION_GROUP_MINIMUMS\` removed; \`YouthAcademyPromotionProcessor\` reads them from the new service.

The season-close auto-promotion paths and AI-side market services remain unaffected by design.

This is the first of a 5-PR stack; it's independent of the reserve-squad work and can ship on its own. See \`reserve/02-reserve-backend\` for the next slice.

## Test plan
- [ ] List a player for sale at minimum squad size — blocked with translated error
- [ ] Loan-list at minimum squad size — blocked
- [ ] Accept incoming transfer offer at minimum squad size — blocked
- [ ] Accept incoming loan offer at minimum squad size — blocked
- [ ] Accept counter-bid in chat at minimum squad size — blocked (returns 422 JSON with translated error)
- [ ] Same for position-group minimums (e.g. dropping below 3 goalkeepers)
- [ ] Existing release flow still blocks below minimums and renders the flow-specific message
- [ ] Season-close auto-promotion is not gated by the new check