### PR TITLE
Filial reserve squad backend

### DIFF
--- a/app/Models/Game.php
+++ b/app/Models/Game.php
@@ -113,6 +113,7 @@ class Game extends Model
         'country',
         'player_name',
         'team_id',
+        'reserve_team_id',
         'competition_id',
         'season',
         'current_date',
@@ -331,6 +332,40 @@ class Game extends Model
     public function team(): BelongsTo
     {
         return $this->belongsTo(Team::class);
+    }
+
+    public function reserveTeam(): BelongsTo
+    {
+        return $this->belongsTo(Team::class, 'reserve_team_id');
+    }
+
+    /**
+     * Whether the given team is owned by the user in this game (first team
+     * or, for parent clubs, the filial reserve team).
+     */
+    public function ownsTeam(?string $teamId): bool
+    {
+        if ($teamId === null) {
+            return false;
+        }
+
+        return $teamId === $this->team_id || $teamId === $this->reserve_team_id;
+    }
+
+    /**
+     * IDs of all teams the user manages in this game (first team, plus the
+     * reserve team for parent clubs). Null entries are filtered out.
+     *
+     * @return array<int, string>
+     */
+    public function userTeamIds(): array
+    {
+        return array_values(array_filter([$this->team_id, $this->reserve_team_id]));
+    }
+
+    public function isFilial(): bool
+    {
+        return $this->reserve_team_id !== null;
     }
 
     public function tactics(): HasOne

--- a/app/Models/GameTransfer.php
+++ b/app/Models/GameTransfer.php
@@ -30,6 +30,7 @@ class GameTransfer extends Model
     public const TYPE_TRANSFER = 'transfer';
     public const TYPE_FREE_AGENT = 'free_agent';
     public const TYPE_LOAN = 'loan';
+    public const TYPE_INTERNAL_PROMOTION = 'internal_promotion';
 
     /**
      * Record a completed transfer in the ledger.

--- a/app/Modules/Academy/Services/YouthAcademyService.php
+++ b/app/Modules/Academy/Services/YouthAcademyService.php
@@ -113,7 +113,11 @@ class YouthAcademyService
     /**
      * Generate a batch of new academy prospects at season start.
      *
-     * @return Collection<int, AcademyPlayer>
+     * For filial games (clubs with a reserve team), prospects are created as
+     * full GamePlayers on the reserve squad — no AcademyPlayer rows. For
+     * non-filial games, prospects land in the AcademyPlayer pool as before.
+     *
+     * @return Collection<int, AcademyPlayer|GamePlayer>
      */
     public function generateSeasonBatch(Game $game): Collection
     {
@@ -127,10 +131,16 @@ class YouthAcademyService
         $excludedNames = $this->getExistingPlayerNames($game);
 
         $prospects = collect();
+        $isFilial = $game->reserve_team_id !== null;
 
         for ($i = 0; $i < $count; $i++) {
-            $prospect = $this->createAcademyProspect($game, $tier, $teamMedianTier, $excludedNames);
-            $excludedNames[] = $prospect->name;
+            $traits = $this->rollProspectTraits($game, $tier, $teamMedianTier, $excludedNames);
+
+            $prospect = $isFilial
+                ? $this->persistAsReservePlayer($game, $traits)
+                : $this->persistAsAcademyPlayer($game, $traits);
+
+            $excludedNames[] = $traits['name'];
             $prospects->push($prospect);
         }
 
@@ -389,24 +399,40 @@ class YouthAcademyService
     ];
 
     /**
-     * Create an academy prospect record.
-     * Quality follows a normal distribution centered on the academy tier's base quality,
-     * adjusted by team context. This produces realistic clustering around the mean
-     * with occasional gems and busts in the tails.
+     * Roll the shared traits for a youth prospect: position, age, abilities,
+     * potential and identity. Quality follows a normal distribution centered
+     * on the academy tier's base quality, adjusted by team context — this
+     * produces realistic clustering with occasional gems and busts in the tails.
+     *
+     * The persistence target (AcademyPlayer pool vs reserve-squad GamePlayer)
+     * is decided by the caller based on whether the game is filial.
+     *
+     * @param  array<int, string>  $excludedNames
+     * @return array{
+     *     position: string,
+     *     age: int,
+     *     dateOfBirth: \Carbon\Carbon,
+     *     technical: int,
+     *     physical: int,
+     *     potential: int,
+     *     potentialLow: int,
+     *     potentialHigh: int,
+     *     name: string,
+     *     nationality: string,
+     * }
      */
-    private function createAcademyProspect(
+    private function rollProspectTraits(
         Game $game,
         int $academyTier,
         int $teamMedianTier,
         array $excludedNames,
-    ): AcademyPlayer {
+    ): array {
         $position = $this->selectPosition();
 
         // Ability mean = academy base quality + team context bonus
         $abilityMean = self::ACADEMY_BASE_QUALITY[$academyTier] + self::TEAM_CONTEXT_BONUS[$teamMedianTier];
 
         $age = rand(17, 19);
-
         $ageCap = match ($age) {
             17 => 72,
             18 => 74,
@@ -423,9 +449,6 @@ class YouthAcademyService
             self::POTENTIAL_UPSIDE_STD_DEV,
             self::POTENTIAL_FLOOR[$academyTier],
         );
-        $potential = $potentialData['potential'];
-        $potentialLow = $potentialData['potentialLow'];
-        $potentialHigh = $potentialData['potentialHigh'];
 
         $dateOfBirth = $game->current_date->copy()->subYears($age)->subDays(rand(0, 364));
 
@@ -442,25 +465,74 @@ class YouthAcademyService
             $region,
         );
 
+        return [
+            'position' => $position,
+            'age' => $age,
+            'dateOfBirth' => $dateOfBirth,
+            'technical' => $technical,
+            'physical' => $physical,
+            'potential' => $potentialData['potential'],
+            'potentialLow' => $potentialData['potentialLow'],
+            'potentialHigh' => $potentialData['potentialHigh'],
+            'name' => $identity['name'],
+            'nationality' => $identity['nationality'],
+        ];
+    }
+
+    /**
+     * Persist a rolled prospect as an AcademyPlayer pool entry (non-filial games).
+     *
+     * @param  array<string, mixed>  $traits
+     */
+    private function persistAsAcademyPlayer(Game $game, array $traits): AcademyPlayer
+    {
         return AcademyPlayer::create([
             'id' => Str::uuid()->toString(),
             'game_id' => $game->id,
             'team_id' => $game->team_id,
-            'name' => $identity['name'],
-            'nationality' => $identity['nationality'],
-            'date_of_birth' => $dateOfBirth,
-            'position' => $position,
-            'technical_ability' => $technical,
-            'physical_ability' => $physical,
-            'potential' => $potential,
-            'potential_low' => $potentialLow,
-            'potential_high' => $potentialHigh,
+            'name' => $traits['name'],
+            'nationality' => $traits['nationality'],
+            'date_of_birth' => $traits['dateOfBirth'],
+            'position' => $traits['position'],
+            'technical_ability' => $traits['technical'],
+            'physical_ability' => $traits['physical'],
+            'potential' => $traits['potential'],
+            'potential_low' => $traits['potentialLow'],
+            'potential_high' => $traits['potentialHigh'],
             'appeared_at' => $game->current_date,
             'is_on_loan' => false,
             'joined_season' => (int) $game->season,
-            'initial_technical' => $technical,
-            'initial_physical' => $physical,
+            'initial_technical' => $traits['technical'],
+            'initial_physical' => $traits['physical'],
         ]);
+    }
+
+    /**
+     * Persist a rolled prospect as a full GamePlayer on the reserve squad
+     * (filial games). The reserve squad is the source of truth for filial
+     * players, so prospects skip the AcademyPlayer pool entirely.
+     *
+     * @param  array<string, mixed>  $traits
+     */
+    private function persistAsReservePlayer(Game $game, array $traits): GamePlayer
+    {
+        return $this->playerGenerator->create($game, new GeneratedPlayerData(
+            teamId: $game->reserve_team_id,
+            position: $traits['position'],
+            technical: $traits['technical'],
+            physical: $traits['physical'],
+            dateOfBirth: $traits['dateOfBirth'],
+            contractYears: 2,
+            name: $traits['name'],
+            nationality: $traits['nationality'],
+            potential: $traits['potential'],
+            potentialLow: $traits['potentialLow'],
+            potentialHigh: $traits['potentialHigh'],
+            fitnessMin: 85,
+            fitnessMax: 100,
+            moraleMin: 70,
+            moraleMax: 90,
+        ));
     }
 
     /**

--- a/app/Modules/ReserveTeam/Exceptions/FirstTeamSquadFullException.php
+++ b/app/Modules/ReserveTeam/Exceptions/FirstTeamSquadFullException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Modules\ReserveTeam\Exceptions;
+
+use RuntimeException;
+
+class FirstTeamSquadFullException extends RuntimeException
+{
+}

--- a/app/Modules/ReserveTeam/Exceptions/FirstTeamSquadMinimumException.php
+++ b/app/Modules/ReserveTeam/Exceptions/FirstTeamSquadMinimumException.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Modules\ReserveTeam\Exceptions;
+
+use App\Modules\Squad\Exceptions\SquadMinimumNotMetException;
+
+/**
+ * Sending a called-up player back to the reserve would drop the first
+ * team below its composition minimum. Thrown from
+ * ReserveTeamService::sendBackToReserve.
+ */
+class FirstTeamSquadMinimumException extends SquadMinimumNotMetException
+{
+}

--- a/app/Modules/ReserveTeam/Exceptions/ReserveSquadMinimumException.php
+++ b/app/Modules/ReserveTeam/Exceptions/ReserveSquadMinimumException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Modules\ReserveTeam\Exceptions;
+
+use App\Modules\Squad\Exceptions\SquadMinimumNotMetException;
+
+/**
+ * Calling up a reserve player would drop the reserve squad below its
+ * composition minimum. Thrown from ReserveTeamService::callUpToFirstTeam.
+ */
+class ReserveSquadMinimumException extends SquadMinimumNotMetException
+{
+}

--- a/app/Modules/ReserveTeam/Services/ReserveTeamService.php
+++ b/app/Modules/ReserveTeam/Services/ReserveTeamService.php
@@ -1,0 +1,294 @@
+<?php
+
+namespace App\Modules\ReserveTeam\Services;
+
+use App\Models\Game;
+use App\Models\GamePlayer;
+use App\Models\GameTransfer;
+use App\Models\Loan;
+use App\Modules\Notification\Services\NotificationService;
+use App\Modules\Player\PlayerAge;
+use App\Modules\ReserveTeam\Exceptions\FirstTeamSquadFullException;
+use App\Modules\ReserveTeam\Exceptions\FirstTeamSquadMinimumException;
+use App\Modules\ReserveTeam\Exceptions\ReserveSquadMinimumException;
+use App\Modules\Squad\Services\SquadMinimumService;
+use App\Modules\Squad\Services\SquadNumberService;
+use App\Modules\Transfer\Enums\TransferWindowType;
+use App\Modules\Transfer\Services\LoanService;
+use Illuminate\Support\Collection;
+
+/**
+ * Filial-aware reserve squad operations: list the reserve squad, call players
+ * up to the first team via Loan, send them back, and auto-promote those who
+ * age past the reserve cutoff at season close.
+ *
+ * Filial semantics: a reserve player belongs to the reserve team. The first
+ * team calls them up via a Loan (parent=reserve, loan=first); ending the loan
+ * sends them back. Age-23 promotion is the one permanent move (one-way
+ * transfer recorded via GameTransfer::TYPE_INTERNAL_PROMOTION).
+ */
+class ReserveTeamService
+{
+    public function __construct(
+        private readonly LoanService $loanService,
+        private readonly SquadNumberService $squadNumberService,
+        private readonly NotificationService $notificationService,
+        private readonly SquadMinimumService $squadMinimumService,
+    ) {}
+
+    /**
+     * Return all GamePlayers who belong to the reserve team — players currently
+     * registered there plus those temporarily called up (active loan with
+     * parent_team_id == reserve_team_id). Empty collection for non-filial games.
+     *
+     * @return Collection<int, GamePlayer>
+     */
+    public function getReserveSquad(Game $game): Collection
+    {
+        if ($game->reserve_team_id === null) {
+            return collect();
+        }
+
+        return GamePlayer::ownedByTeam($game->reserve_team_id)
+            ->where('game_id', $game->id)
+            ->with(['player', 'activeLoan'])
+            ->get();
+    }
+
+    /**
+     * Call a reserve player up to the first team. Creates a Loan
+     * (parent=reserve, loan=first), flips team_id, assigns squad number.
+     *
+     * @throws FirstTeamSquadFullException when no squad number is available
+     * @throws ReserveSquadMinimumException when the reserve would fall below
+     *         its squad-composition minimum after the call-up
+     */
+    public function callUpToFirstTeam(GamePlayer $player, Game $game): void
+    {
+        $this->assertFilial($game);
+
+        if ($player->team_id !== $game->reserve_team_id) {
+            throw new \DomainException('Player is not currently registered to the reserve team.');
+        }
+
+        // Reserve must keep enough players to field a squad after the call-up.
+        $breach = $this->squadMinimumService->validateRemoval($game, $player, $game->reserve_team_id);
+        if ($breach !== null) {
+            throw new ReserveSquadMinimumException($breach);
+        }
+
+        $effectiveStart = $game->getLoanEffectiveStartDate();
+        $returnDate = $game->getSeasonEndDateFor($effectiveStart);
+
+        Loan::create([
+            'game_id' => $game->id,
+            'game_player_id' => $player->id,
+            'parent_team_id' => $game->reserve_team_id,
+            'loan_team_id' => $game->team_id,
+            'started_at' => $effectiveStart,
+            'return_at' => $returnDate,
+            'status' => Loan::STATUS_ACTIVE,
+        ]);
+
+        // Null the reserve number first so flipping team_id can't violate the
+        // (game_id, team_id, number) unique constraint when a first-team
+        // player already wears the same shirt.
+        $previousNumber = $player->number;
+        $player->update(['number' => null, 'team_id' => $game->team_id]);
+
+        $number = $this->squadNumberService->assignAcademyNumberForNewPlayer($game, $player);
+
+        if ($number === null) {
+            // Roll back the move, restore previous number, and drop the loan.
+            $player->update(['team_id' => $game->reserve_team_id, 'number' => $previousNumber]);
+            Loan::where('game_player_id', $player->id)
+                ->where('status', Loan::STATUS_ACTIVE)
+                ->delete();
+
+            throw new FirstTeamSquadFullException(
+                'First-team squad is full; release a player before calling up another.'
+            );
+        }
+
+        $player->update(['number' => $number]);
+
+        GameTransfer::record(
+            gameId: $game->id,
+            gamePlayerId: $player->id,
+            fromTeamId: $game->reserve_team_id,
+            toTeamId: $game->team_id,
+            transferFee: 0,
+            type: GameTransfer::TYPE_LOAN,
+            season: $game->season,
+            window: TransferWindowType::currentValue($game->current_date),
+        );
+    }
+
+    /**
+     * Send a called-up player back to the reserve team. Ends the active
+     * call-up loan, flips team_id back, nulls squad number.
+     *
+     * @throws FirstTeamSquadMinimumException when the first team would fall
+     *         below its squad-composition minimum after the move
+     */
+    public function sendBackToReserve(GamePlayer $player, Game $game): void
+    {
+        $this->assertFilial($game);
+
+        $loan = Loan::where('game_player_id', $player->id)
+            ->where('status', Loan::STATUS_ACTIVE)
+            ->where('parent_team_id', $game->reserve_team_id)
+            ->where('loan_team_id', $game->team_id)
+            ->first();
+
+        if ($loan === null) {
+            throw new \DomainException('Player is not currently called up from the reserve team.');
+        }
+
+        // First team must keep enough players to field a squad after send-back.
+        $breach = $this->squadMinimumService->validateRemoval($game, $player, $game->team_id);
+        if ($breach !== null) {
+            throw new FirstTeamSquadMinimumException($breach);
+        }
+
+        // returnLoan handles team_id flip and number reassignment. For loans
+        // returning to the reserve team (not the user's team), it sets number
+        // to null automatically.
+        $this->loanService->returnLoan($loan);
+    }
+
+    /**
+     * At season close, permanently promote any reserve player who has aged
+     * past the reserve cutoff (over 23) to the first team. One-way move,
+     * recorded as a GameTransfer of type INTERNAL_PROMOTION. Any active
+     * call-up loan for the player is closed first.
+     *
+     * Returns the list of promoted players for downstream processors.
+     *
+     * @return Collection<int, GamePlayer>
+     */
+    public function autoPromoteOverageReservePlayers(Game $game): Collection
+    {
+        if ($game->reserve_team_id === null) {
+            return collect();
+        }
+
+        $cutoff = PlayerAge::dateOfBirthCutoff(PlayerAge::YOUNG_END + 1, $game->current_date);
+
+        $candidates = GamePlayer::ownedByTeam($game->reserve_team_id)
+            ->where('game_id', $game->id)
+            ->whereHas('player', fn ($q) => $q->where('date_of_birth', '<=', $cutoff))
+            ->with(['player', 'activeLoan'])
+            ->get();
+
+        $promoted = collect();
+
+        foreach ($candidates as $player) {
+            // Close any active call-up loan first so returnLoan() doesn't
+            // later try to flip the player back to the reserve team.
+            if ($player->activeLoan && $player->activeLoan->parent_team_id === $game->reserve_team_id) {
+                $player->activeLoan->update(['status' => Loan::STATUS_COMPLETED]);
+            }
+
+            // Permanent move to first team. Null the reserve number first so
+            // the (game_id, team_id, number) unique constraint can't fire on
+            // the team_id flip.
+            $player->update(['number' => null, 'team_id' => $game->team_id]);
+            $number = $this->squadNumberService->assignNumberForNewPlayer($game, $player);
+            if ($number !== null) {
+                $player->update(['number' => $number]);
+            }
+
+            GameTransfer::record(
+                gameId: $game->id,
+                gamePlayerId: $player->id,
+                fromTeamId: $game->reserve_team_id,
+                toTeamId: $game->team_id,
+                transferFee: 0,
+                type: GameTransfer::TYPE_INTERNAL_PROMOTION,
+                season: $game->season,
+                window: TransferWindowType::currentValue($game->current_date),
+            );
+
+            $this->notificationService->create(
+                game: $game,
+                type: \App\Models\GameNotification::TYPE_ACADEMY_PROSPECT,
+                title: __('notifications.reserve_overage_promoted_title'),
+                message: __('notifications.reserve_overage_promoted_message', [
+                    'player' => $player->player->name ?? '',
+                ]),
+                priority: \App\Models\GameNotification::PRIORITY_INFO,
+            );
+
+            $promoted->push($player);
+        }
+
+        return $promoted;
+    }
+
+    /**
+     * At season close, permanently promote any reserve player still on a
+     * call-up loan to the first team. The active call-up loan is closed and
+     * the move is recorded as TYPE_INTERNAL_PROMOTION so the player no longer
+     * snaps back to the reserve team in subsequent seasons. The player keeps
+     * their existing first-team shirt number (assigned on call-up).
+     *
+     * @return Collection<int, GamePlayer>
+     */
+    public function permanentlyPromoteCalledUpPlayers(Game $game): Collection
+    {
+        if ($game->reserve_team_id === null) {
+            return collect();
+        }
+
+        $callUpLoans = Loan::with(['gamePlayer.player'])
+            ->where('game_id', $game->id)
+            ->where('status', Loan::STATUS_ACTIVE)
+            ->where('parent_team_id', $game->reserve_team_id)
+            ->where('loan_team_id', $game->team_id)
+            ->get();
+
+        $promoted = collect();
+
+        foreach ($callUpLoans as $loan) {
+            $player = $loan->gamePlayer;
+            if ($player === null) {
+                continue;
+            }
+
+            $loan->update(['status' => Loan::STATUS_COMPLETED]);
+
+            GameTransfer::record(
+                gameId: $game->id,
+                gamePlayerId: $player->id,
+                fromTeamId: $game->reserve_team_id,
+                toTeamId: $game->team_id,
+                transferFee: 0,
+                type: GameTransfer::TYPE_INTERNAL_PROMOTION,
+                season: $game->season,
+                window: TransferWindowType::currentValue($game->current_date),
+            );
+
+            $this->notificationService->create(
+                game: $game,
+                type: \App\Models\GameNotification::TYPE_ACADEMY_PROSPECT,
+                title: __('notifications.reserve_overage_promoted_title'),
+                message: __('notifications.reserve_overage_promoted_message', [
+                    'player' => $player->player->name ?? '',
+                ]),
+                priority: \App\Models\GameNotification::PRIORITY_INFO,
+            );
+
+            $promoted->push($player);
+        }
+
+        return $promoted;
+    }
+
+    private function assertFilial(Game $game): void
+    {
+        if ($game->reserve_team_id === null) {
+            throw new \DomainException('Reserve team operations require a filial game.');
+        }
+    }
+}

--- a/app/Modules/Season/Processors/LoanReturnProcessor.php
+++ b/app/Modules/Season/Processors/LoanReturnProcessor.php
@@ -2,6 +2,7 @@
 
 namespace App\Modules\Season\Processors;
 
+use App\Modules\ReserveTeam\Services\ReserveTeamService;
 use App\Modules\Season\Contracts\SeasonProcessor;
 use App\Modules\Season\DTOs\SeasonTransitionData;
 use App\Modules\Transfer\Services\LoanService;
@@ -17,6 +18,7 @@ class LoanReturnProcessor implements SeasonProcessor
     public function __construct(
         private readonly LoanService $loanService,
         private readonly NotificationService $notificationService,
+        private readonly ReserveTeamService $reserveTeamService,
     ) {}
 
     public function priority(): int
@@ -26,6 +28,15 @@ class LoanReturnProcessor implements SeasonProcessor
 
     public function process(Game $game, SeasonTransitionData $data): SeasonTransitionData
     {
+        // Reserve players still called up to the first team at season close
+        // are kept up permanently — closes their call-up loans before the
+        // generic return sweep runs, so they aren't sent back to the filial.
+        $promotedFromReserve = $this->reserveTeamService->permanentlyPromoteCalledUpPlayers($game);
+
+        if ($promotedFromReserve->isNotEmpty()) {
+            $data->setMetadata('reserve_called_up_promoted', $promotedFromReserve->count());
+        }
+
         $returnedLoans = $this->loanService->returnAllLoans($game);
 
         $loanReturns = $returnedLoans->map(fn ($loan) => [

--- a/app/Modules/Season/Processors/ReserveOveragePromotionProcessor.php
+++ b/app/Modules/Season/Processors/ReserveOveragePromotionProcessor.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Modules\Season\Processors;
+
+use App\Models\Game;
+use App\Modules\ReserveTeam\Services\ReserveTeamService;
+use App\Modules\Season\Contracts\SeasonProcessor;
+use App\Modules\Season\DTOs\SeasonTransitionData;
+
+/**
+ * For filial games, permanently promotes any reserve player who has aged
+ * past the reserve cutoff (over 23) to the first team.
+ *
+ * Runs before LoanReturnProcessor (priority 5) so age-23 players are settled
+ * permanently in the first team before remaining call-up loans snap back.
+ *
+ * No-op for non-filial games.
+ *
+ * Priority: 4
+ */
+class ReserveOveragePromotionProcessor implements SeasonProcessor
+{
+    public function __construct(
+        private readonly ReserveTeamService $reserveTeamService,
+    ) {}
+
+    public function priority(): int
+    {
+        return 4;
+    }
+
+    public function process(Game $game, SeasonTransitionData $data): SeasonTransitionData
+    {
+        if ($game->reserve_team_id === null) {
+            return $data;
+        }
+
+        $promoted = $this->reserveTeamService->autoPromoteOverageReservePlayers($game);
+
+        if ($promoted->isNotEmpty()) {
+            $data->setMetadata('reserve_overage_promoted', $promoted->count());
+        }
+
+        return $data;
+    }
+}

--- a/app/Modules/Season/Processors/YouthAcademyClosingProcessor.php
+++ b/app/Modules/Season/Processors/YouthAcademyClosingProcessor.php
@@ -25,6 +25,12 @@ class YouthAcademyClosingProcessor implements SeasonProcessor
 
     public function process(Game $game, SeasonTransitionData $data): SeasonTransitionData
     {
+        // Filial games don't use the AcademyPlayer pool — reserve squads are
+        // GamePlayers handled elsewhere. Skip the academy lifecycle entirely.
+        if ($game->reserve_team_id !== null) {
+            return $data;
+        }
+
         // 1. Develop loaned players at higher rate before returning
         $this->youthAcademyService->developLoanedPlayers($game);
 

--- a/app/Modules/Season/Processors/YouthAcademyPromotionProcessor.php
+++ b/app/Modules/Season/Processors/YouthAcademyPromotionProcessor.php
@@ -47,6 +47,12 @@ class YouthAcademyPromotionProcessor implements SeasonProcessor
 
     public function process(Game $game, SeasonTransitionData $data): SeasonTransitionData
     {
+        // Filial games don't use the AcademyPlayer pool — reserve squad
+        // age-out is handled by ReserveOveragePromotionProcessor instead.
+        if ($game->reserve_team_id !== null) {
+            return $data;
+        }
+
         // Phase 1: Promote overage academy players (mandatory — they must leave)
         $overagePromoted = $this->youthAcademyService->promoteOveragePlayers($game);
 

--- a/app/Modules/Season/Services/SeasonClosingPipeline.php
+++ b/app/Modules/Season/Services/SeasonClosingPipeline.php
@@ -17,6 +17,7 @@ use App\Modules\Season\Processors\PlayerRetirementProcessor;
 use App\Modules\Season\Processors\PreContractTransferProcessor;
 use App\Modules\Season\Processors\PromotionRelegationProcessor;
 use App\Modules\Season\Processors\ReputationUpdateProcessor;
+use App\Modules\Season\Processors\ReserveOveragePromotionProcessor;
 use App\Modules\Season\Processors\SeasonArchiveProcessor;
 use App\Modules\Season\Processors\SeasonSettlementProcessor;
 use App\Modules\Season\Processors\SeasonSimulationProcessor;
@@ -41,6 +42,7 @@ class SeasonClosingPipeline
     private array $processors = [];
 
     public function __construct(
+        ReserveOveragePromotionProcessor $reserveOveragePromotion,
         LoanReturnProcessor $loanReturn,
         TrophyRecordingProcessor $trophyRecording,
         LeaderboardStatsProcessor $leaderboardStats,
@@ -66,6 +68,7 @@ class SeasonClosingPipeline
         UefaQualificationProcessor $uefaQualification,
     ) {
         $this->processors = [
+            $reserveOveragePromotion,
             $loanReturn,
             $trophyRecording,
             $leaderboardStats,

--- a/app/Modules/Squad/Services/SquadNumberService.php
+++ b/app/Modules/Squad/Services/SquadNumberService.php
@@ -91,6 +91,23 @@ class SquadNumberService
     }
 
     /**
+     * Assign the first available academy slot (26-99) for a player joining
+     * the user's team. Used when promoting a reserve-team player up: they
+     * always get a 26+ shirt regardless of age, leaving 1-25 untouched.
+     */
+    public function assignAcademyNumberForNewPlayer(Game $game, GamePlayer $player): ?int
+    {
+        $takenNumbers = GamePlayer::where('game_id', $game->id)
+            ->where('team_id', $game->team_id)
+            ->where('id', '!=', $player->id)
+            ->whereNotNull('number')
+            ->pluck('number')
+            ->flip();
+
+        return $this->firstAvailable(self::FIRST_TEAM_MAX + 1, 99, $takenNumbers);
+    }
+
+    /**
      * Bulk reassign squad numbers for the user's team.
      *
      * Preserves existing numbers where valid. Only moves players when necessary:

--- a/app/Modules/Transfer/Services/LoanService.php
+++ b/app/Modules/Transfer/Services/LoanService.php
@@ -406,7 +406,7 @@ class LoanService
     /**
      * Return a single loan - player goes back to parent team.
      */
-    private function returnLoan(Loan $loan): void
+    public function returnLoan(Loan $loan): void
     {
         $gamePlayer = $loan->gamePlayer;
         $isUserTeam = $loan->parent_team_id === $gamePlayer->game->team_id;

--- a/database/migrations/2026_04_25_000001_add_reserve_team_id_to_games_table.php
+++ b/database/migrations/2026_04_25_000001_add_reserve_team_id_to_games_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('games', function (Blueprint $table) {
+            $table->uuid('reserve_team_id')->nullable()->after('team_id');
+            $table->foreign('reserve_team_id')->references('id')->on('teams')->nullOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('games', function (Blueprint $table) {
+            $table->dropForeign(['reserve_team_id']);
+            $table->dropColumn('reserve_team_id');
+        });
+    }
+};

--- a/lang/en/messages.php
+++ b/lang/en/messages.php
@@ -89,6 +89,9 @@ return [
     'academy_player_loaned' => ':player has been loaned out.',
     'academy_must_decide_21' => 'Players aged 21+ will be automatically promoted to the first team.',
 
+    // Reserve team (filial)
+    'reserve_player_promoted' => ':player has been promoted to the first team.',
+
     // Player release messages
     'player_released' => ':player has been released. Severance paid: :severance.',
     'release_not_your_player' => 'You can only release players from your own team.',

--- a/lang/en/notifications.php
+++ b/lang/en/notifications.php
@@ -89,6 +89,8 @@ return [
     'academy_overage_promoted_message' => ':count academy players aged 21+ have been promoted to the first team.',
     'academy_gap_promoted_title' => 'Academy players promoted',
     'academy_gap_promoted_message' => ':count academy players have been promoted to fill squad gaps.',
+    'reserve_overage_promoted_title' => 'Reserve graduate',
+    'reserve_overage_promoted_message' => ':player has aged out of the reserve team and joined the first team permanently.',
     // Loan request results
     'loan_accepted_title' => 'Loan request for :player accepted',
     'loan_accepted' => ':team have accepted your loan request for :player.',

--- a/lang/es/messages.php
+++ b/lang/es/messages.php
@@ -89,6 +89,9 @@ return [
     'academy_player_loaned' => ':player ha sido cedido.',
     'academy_must_decide_21' => 'Los jugadores de 21+ años serán promocionados automáticamente al primer equipo.',
 
+    // Reserve team (filial)
+    'reserve_player_promoted' => ':player ha subido al primer equipo.',
+
     // Player release messages
     'player_released' => ':player ha sido liberado. Indemnización pagada: :severance.',
     'release_not_your_player' => 'Solo puedes liberar jugadores de tu propio equipo.',

--- a/lang/es/notifications.php
+++ b/lang/es/notifications.php
@@ -89,6 +89,8 @@ return [
     'academy_overage_promoted_message' => ':count canteranos de 21+ años han sido promocionados al primer equipo.',
     'academy_gap_promoted_title' => 'Canteranos promocionados',
     'academy_gap_promoted_message' => ':count canteranos han sido promocionados para cubrir huecos en la plantilla.',
+    'reserve_overage_promoted_title' => 'Graduado del filial',
+    'reserve_overage_promoted_message' => ':player ha superado la edad del filial y se incorpora al primer equipo de forma permanente.',
     // Loan request results
     'loan_accepted_title' => 'Cesión de :player aceptada',
     'loan_accepted' => ':team ha aceptado tu solicitud de cesión por :player.',


### PR DESCRIPTION
## Summary
Adds the backend foundation for parent-club reserve squads (Real Madrid, Barcelona, Athletic, etc.). **Invisible to users** — no routes, Actions, or views ship in this PR. The exposure PR (\`reserve/05-exposure\`) turns this into a complete user-facing feature.

What's wired:
- Migration adding \`games.reserve_team_id\`; \`Game::reserveTeam\`, \`isFilial\`, \`ownsTeam\`, \`userTeamIds\`.
- \`ReserveTeamService\` with \`callUpToFirstTeam\`, \`sendBackToReserve\`, \`autoPromoteOverageReservePlayers\`, \`permanentlyPromoteCalledUpPlayers\` and three exception types (\`FirstTeamSquadFullException\`, \`FirstTeamSquadMinimumException\`, \`ReserveSquadMinimumException\`).
- \`ReserveOveragePromotionProcessor\` wired into \`SeasonClosingPipeline\`.
- \`YouthAcademyService\` routes generation to the reserve squad for filial games (no \`AcademyPlayer\` rows). \`YouthAcademyClosingProcessor\` and \`YouthAcademyPromotionProcessor\` skip filial games.
- \`LoanReturnProcessor\` handles reserve-team loan returns. \`SquadNumberService\` reserves 26+ for called-up reserve players.
- \`GameCreationService\` assigns \`reserve_team_id\` for parent clubs at game creation.
- Defensive filters in \`TransferMarketService\`, \`ScoutSearchQueryBuilder\`, \`ToggleShortlist\`, \`LoanService\` keep reserve players out of AI markets and acquisition surfaces.
- \`GameTransfer::TYPE_INTERNAL_PROMOTION\` for permanent reserve→first-team moves.

Career-record writes are intentionally deferred to \`reserve/04-career-backend\`, which adds the model and snapshot pipeline on top.

Stacked on \`reserve/01-squad-minimums\` — \`ReserveTeamService\` uses the new \`SquadMinimumService\` for the call-up / send-back guards.

## Test plan
- [ ] New game as Real Madrid / Barcelona / Athletic gets a non-null \`reserve_team_id\`
- [ ] Other clubs unchanged (\`reserve_team_id\` is null)
- [ ] Academy generation for a parent club creates GamePlayers on the reserve team (no AcademyPlayer rows)
- [ ] At season close: a 23+ year-old reserve player is permanently promoted via \`INTERNAL_PROMOTION\`
- [ ] Container resolves \`SeasonClosingPipeline\` cleanly (no missing dependencies)