### PR TITLE
Centralize player-ownership checks across first team and reserve

### DIFF
--- a/app/Http/Actions/NegotiateRenewal.php
+++ b/app/Http/Actions/NegotiateRenewal.php
@@ -37,7 +37,7 @@ class NegotiateRenewal
 
         $player = GamePlayer::with($eagerLoads)
             ->where('game_id', $gameId)
-            ->ownedByTeam($game->team_id)
+            ->userOwned($game)
             ->findOrFail($playerId);
 
         return match ($action) {

--- a/app/Http/Actions/ReleasePlayer.php
+++ b/app/Http/Actions/ReleasePlayer.php
@@ -19,7 +19,7 @@ class ReleasePlayer
         $game = Game::findOrFail($gameId);
         $player = GamePlayer::where('id', $playerId)
             ->where('game_id', $gameId)
-            ->where('team_id', $game->team_id)
+            ->whereIn('team_id', $game->userTeamIds())
             ->firstOrFail();
 
         $result = $this->contractService->releasePlayer($game, $player);

--- a/app/Http/Views/ShowPlayerDetail.php
+++ b/app/Http/Views/ShowPlayerDetail.php
@@ -17,9 +17,9 @@ class ShowPlayerDetail
     {
         $game = Game::findOrFail($gameId);
 
-        $gamePlayer = GamePlayer::with('player')
+        $gamePlayer = GamePlayer::with(['player', 'activeLoan'])
             ->where('game_id', $gameId)
-            ->where('team_id', $game->team_id)
+            ->userOwned($game)
             ->findOrFail($playerId);
 
         $canRenew = $gamePlayer->canBeOfferedRenewal(currentDate: $game->current_date);
@@ -36,12 +36,15 @@ class ShowPlayerDetail
             }
         }
 
-        // Release data
+        // Release is permitted for any user-owned player physically present
+        // on a user roster (first team or reserve, including filial call-ups
+        // who sit on the first team via internal loan). The team_id check
+        // excludes players currently loaned out to a third-party club —
+        // those must wait for the loan to end before they can be released.
         $canRelease = $game->isCareerMode()
-            && $gamePlayer->team_id === $game->team_id
+            && $gamePlayer->isUserOwned($game)
+            && in_array($gamePlayer->team_id, $game->userTeamIds(), true)
             && !$gamePlayer->isRetiring()
-            && !$gamePlayer->isLoanedIn($game->team_id)
-            && !$gamePlayer->isLoanedOut($game->team_id)
             && !$gamePlayer->hasPreContractAgreement()
             && !$gamePlayer->hasRenewalAgreed()
             && !$gamePlayer->hasAgreedTransfer()

--- a/app/Models/GamePlayer.php
+++ b/app/Models/GamePlayer.php
@@ -383,6 +383,77 @@ class GamePlayer extends Model
     }
 
     /**
+     * Limit a query to players owned by the user in the given game — i.e.,
+     * by the first team or the reserve team. Generalizes scopeOwnedByTeam
+     * across the user's whole organization, including filial call-ups (which
+     * appear loaned-in to the first team but are still user-owned through
+     * the reserve as parent).
+     */
+    public function scopeUserOwned($query, Game $game)
+    {
+        $teamIds = $game->userTeamIds();
+
+        if (empty($teamIds)) {
+            return $query->whereRaw('1 = 0');
+        }
+
+        return $query->where(function ($q) use ($teamIds) {
+            $q->where(function ($present) use ($teamIds) {
+                $present->whereIn('team_id', $teamIds)
+                    ->whereDoesntHave('activeLoan');
+            })->orWhereHas('activeLoan', fn ($loanQuery) => $loanQuery->whereIn('parent_team_id', $teamIds));
+        });
+    }
+
+    /**
+     * Whether this player is part of the user's organization in the given
+     * game — owned by the first team or the reserve team, including filial
+     * call-ups loaned internally between them.
+     *
+     * Loaned-out players (gone elsewhere but parent-owned by the user) count.
+     * Loaned-in players from a third-party club do not.
+     */
+    public function isUserOwned(Game $game): bool
+    {
+        $teamIds = $game->userTeamIds();
+
+        if (empty($teamIds)) {
+            return false;
+        }
+
+        $loan = $this->relationLoaded('activeLoan')
+            ? $this->activeLoan
+            : $this->activeLoan()->first();
+
+        if ($loan) {
+            return in_array($loan->parent_team_id, $teamIds, true);
+        }
+
+        return in_array($this->team_id, $teamIds, true);
+    }
+
+    /**
+     * Whether this player is currently called up from the user's reserve team
+     * to the first team via internal loan. The player physically sits on the
+     * first-team roster but is owned by the reserve, so flows like contract
+     * renewal and release must treat them as user-owned.
+     */
+    public function isCalledUpFromReserve(Game $game): bool
+    {
+        if ($game->reserve_team_id === null) {
+            return false;
+        }
+
+        $loan = $this->relationLoaded('activeLoan')
+            ? $this->activeLoan
+            : $this->activeLoan()->first();
+
+        return $loan !== null
+            && $loan->parent_team_id === $game->reserve_team_id
+            && $loan->loan_team_id === $game->team_id;
+    }
+
+    /**
      * Check if player is transfer listed.
      */
     public function isTransferListed(): bool
@@ -533,9 +604,11 @@ class GamePlayer extends Model
             return false;
         }
 
-        // Loaned-in players belong to another club — we can't renew them.
-        // Loaned-out players (ours, playing elsewhere) can still be renewed.
-        if ($this->isLoanedIn($this->game->team_id)) {
+        // Renewal authority follows ownership: any user-owned player counts,
+        // including loaned-out players (parent club retains authority) and
+        // filial call-ups (owned via the reserve team). Players loaned in
+        // from a third-party club are not user-owned and cannot be renewed.
+        if (!$this->isUserOwned($this->game)) {
             return false;
         }
 

--- a/app/Modules/Season/Services/GameCreationService.php
+++ b/app/Modules/Season/Services/GameCreationService.php
@@ -27,7 +27,7 @@ class GameCreationService
                 ->first()
             ?? CompetitionTeam::where('team_id', $teamId)->first();
 
-        $team = Team::with('reserveTeam')->find($teamId);
+        $team = Team::find($teamId);
 
         // Resolve competition ID: use competition_team lookup, fall back to
         // tier 1 of the team's country from config
@@ -38,10 +38,6 @@ class GameCreationService
         }
         $season = $competitionTeam->season ?? '2025';
 
-        // Resolve reserve team (filial) for managers of parent clubs.
-        // The user's club becomes filial if it has a reserve team and isn't itself one.
-        $reserveTeamId = $team->parent_team_id === null ? $team->reserveTeam?->id : null;
-
         // Create game record (setup not yet complete)
         // current_date and season_goal are set by processors during SetupNewGame
         $game = Game::create([
@@ -50,7 +46,6 @@ class GameCreationService
             'game_mode' => $gameMode,
             'country' => $team->country ?? 'ES',
             'team_id' => $teamId,
-            'reserve_team_id' => $reserveTeamId,
             'competition_id' => $competitionId,
             'season' => $season,
             'current_date' => null,

--- a/app/Modules/Season/Services/GameCreationService.php
+++ b/app/Modules/Season/Services/GameCreationService.php
@@ -27,7 +27,7 @@ class GameCreationService
                 ->first()
             ?? CompetitionTeam::where('team_id', $teamId)->first();
 
-        $team = Team::find($teamId);
+        $team = Team::with('reserveTeam')->find($teamId);
 
         // Resolve competition ID: use competition_team lookup, fall back to
         // tier 1 of the team's country from config
@@ -38,6 +38,10 @@ class GameCreationService
         }
         $season = $competitionTeam->season ?? '2025';
 
+        // Resolve reserve team (filial) for managers of parent clubs.
+        // The user's club becomes filial if it has a reserve team and isn't itself one.
+        $reserveTeamId = $team->parent_team_id === null ? $team->reserveTeam?->id : null;
+
         // Create game record (setup not yet complete)
         // current_date and season_goal are set by processors during SetupNewGame
         $game = Game::create([
@@ -46,6 +50,7 @@ class GameCreationService
             'game_mode' => $gameMode,
             'country' => $team->country ?? 'ES',
             'team_id' => $teamId,
+            'reserve_team_id' => $reserveTeamId,
             'competition_id' => $competitionId,
             'season' => $season,
             'current_date' => null,

--- a/app/Modules/Transfer/Services/ContractService.php
+++ b/app/Modules/Transfer/Services/ContractService.php
@@ -756,15 +756,24 @@ class ContractService
      */
     private function validateRelease(Game $game, GamePlayer $player): ?string
     {
-        // Must belong to the user's team
-        if ($player->team_id !== $game->team_id) {
+        // Must be a user-owned player physically on a user roster. The roster
+        // check rejects players loaned out to a third-party club; the
+        // ownership check rejects players loaned in from a third-party club.
+        if (!in_array($player->team_id, $game->userTeamIds(), true)) {
             return __('messages.release_not_your_player');
         }
 
-        // Cannot release players on loan
-        if ($player->isLoanedOut($game->team_id) || $player->isLoanedIn($game->team_id)) {
+        if (!$player->isUserOwned($game)) {
             return __('messages.release_on_loan');
         }
+
+        // Squad-size and position-group minimums apply to the roster the
+        // player effectively occupies. Filial call-ups sit on the first team
+        // physically but their parent club (and the roster they belong to
+        // for these checks) is the reserve team.
+        $rosterTeamId = $player->isCalledUpFromReserve($game)
+            ? $game->reserve_team_id
+            : $player->team_id;
 
         // Cannot release players with agreed transfers
         if ($player->hasAgreedTransfer()) {
@@ -776,9 +785,9 @@ class ContractService
             return __('messages.release_has_pre_contract');
         }
 
-        // Squad-composition guard: total squad size and per-position-group
+        // Squad-composition guard: total roster size and per-position-group
         // minimums on the team that would lose the player.
-        $breach = $this->squadMinimumService->validateRemoval($game, $player, $game->team_id);
+        $breach = $this->squadMinimumService->validateRemoval($game, $player, $rosterTeamId);
         if ($breach !== null) {
             if ($breach['type'] === 'too_small') {
                 return __('messages.release_squad_too_small', ['min' => $breach['min']]);

--- a/app/Modules/Transfer/Services/ScoutSearchQueryBuilder.php
+++ b/app/Modules/Transfer/Services/ScoutSearchQueryBuilder.php
@@ -27,7 +27,7 @@ class ScoutSearchQueryBuilder
         $query = GamePlayer::with(['player', 'team'])
             ->where('game_id', $game->id)
             ->whereNotNull('team_id')
-            ->where('team_id', '!=', $game->team_id);
+            ->whereNotIn('team_id', $game->userTeamIds());
 
         $this->applyPositionFilter($query, $positions);
 

--- a/app/Modules/Transfer/Services/TransferMarketService.php
+++ b/app/Modules/Transfer/Services/TransferMarketService.php
@@ -89,7 +89,7 @@ class TransferMarketService
 
         // Count current AI listings
         $currentCount = TransferListing::where('game_id', $game->id)
-            ->where('team_id', '!=', $game->team_id)
+            ->whereNotIn('team_id', $game->userTeamIds())
             ->where('status', TransferListing::STATUS_LISTED)
             ->whereNotNull('asking_price')
             ->count();
@@ -180,7 +180,7 @@ class TransferMarketService
 
         return TransferListing::with(['gamePlayer.player', 'gamePlayer.team'])
             ->where('game_id', $game->id)
-            ->where('team_id', '!=', $game->team_id)
+            ->whereNotIn('team_id', $game->userTeamIds())
             ->where('status', TransferListing::STATUS_LISTED)
             ->whereNotNull('asking_price')
             ->whereNotIn('game_player_id', $alreadyAgreedIds)
@@ -357,7 +357,7 @@ class TransferMarketService
     {
         $teamIds = DB::table('competition_entries')
             ->where('game_id', $game->id)
-            ->where('team_id', '!=', $game->team_id)
+            ->whereNotIn('team_id', $game->userTeamIds())
             ->distinct()
             ->pluck('team_id')
             ->all();


### PR DESCRIPTION
## Summary
Pure refactor on top of the reserve backend. **No user-visible changes** in this PR: existing first-team flows behave identically; the side-effect bug fix (renewal/release for reserve and called-up filial players) is invisible until the exposure PR adds the buttons.

Adds \`GamePlayer::scopeUserOwned\`, \`isUserOwned\`, and \`isCalledUpFromReserve\` on top of the \`Game::userTeamIds()\` introduced with the reserve backend, and collapses the duplicated first-team / reserve-team / filial-call-up branching in:
- \`ShowPlayerDetail\`
- \`ReleasePlayer\`
- \`NegotiateRenewal\`
- \`ContractService::validateRelease\`
- \`GamePlayer::canBeOfferedRenewal\`

\`validateRelease\` additionally runs the squad-minimum check against the roster the player effectively occupies — first team for normal players, reserve team for filial call-ups — so a call-up's release is gated by the reserve squad's minimums, not the first team's.

Stacked on \`reserve/02-reserve-backend\`.

## Test plan
- [ ] Existing first-team renewal / release flows unchanged
- [ ] Loaned-in player rejection still works
- [ ] Loaned-out player can still be renewed (parent club retains authority)
- [ ] Container resolves \`ContractService\` and consumers cleanly
- [ ] Behavioral verification of the bug fix happens in the exposure PR (where the buttons appear)