### PR TITLE
Expose filial reserve squad UI and player career history

### DIFF
--- a/app/Http/Actions/CallUpReservePlayer.php
+++ b/app/Http/Actions/CallUpReservePlayer.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Http\Actions;
+
+use App\Models\Game;
+use App\Models\GamePlayer;
+use App\Modules\ReserveTeam\Exceptions\FirstTeamSquadFullException;
+use App\Modules\ReserveTeam\Exceptions\ReserveSquadMinimumException;
+use App\Modules\ReserveTeam\Services\ReserveTeamService;
+
+class CallUpReservePlayer
+{
+    public function __construct(
+        private readonly ReserveTeamService $reserveTeamService,
+    ) {}
+
+    public function __invoke(string $gameId, string $playerId)
+    {
+        $game = Game::findOrFail($gameId);
+        abort_if($game->reserve_team_id === null, 404);
+
+        $player = GamePlayer::where('id', $playerId)
+            ->where('game_id', $gameId)
+            ->where('team_id', $game->reserve_team_id)
+            ->with('player')
+            ->firstOrFail();
+
+        $playerName = $player->player->name ?? '';
+
+        try {
+            $this->reserveTeamService->callUpToFirstTeam($player, $game);
+        } catch (FirstTeamSquadFullException $e) {
+            return redirect()->route('game.squad.reserve', $gameId)
+                ->with('error', __('messages.reserve_player_call_up_blocked_full'));
+        } catch (ReserveSquadMinimumException $e) {
+            return redirect()->route('game.squad.reserve', $gameId)
+                ->with('error', $this->formatBreachMessage($e));
+        }
+
+        return redirect()->route('game.squad.reserve', $gameId)
+            ->with('success', __('messages.reserve_player_called_up', ['player' => $playerName]));
+    }
+
+    private function formatBreachMessage(ReserveSquadMinimumException $e): string
+    {
+        if ($e->type() === 'too_small') {
+            return __('messages.promote_squad_too_small', ['min' => $e->min()]);
+        }
+
+        return __('messages.promote_position_minimum', [
+            'group' => __('squad.' . strtolower($e->group()) . 's'),
+            'min'   => $e->min(),
+        ]);
+    }
+}

--- a/app/Http/Actions/ReleasePlayer.php
+++ b/app/Http/Actions/ReleasePlayer.php
@@ -22,16 +22,19 @@ class ReleasePlayer
             ->whereIn('team_id', $game->userTeamIds())
             ->firstOrFail();
 
+        $wasOnReserve = $game->reserve_team_id !== null && $player->team_id === $game->reserve_team_id;
+        $redirectRoute = $wasOnReserve ? 'game.squad.reserve' : 'game.squad';
+
         $result = $this->contractService->releasePlayer($game, $player);
 
         if ($result['error'] ?? false) {
             return redirect()
-                ->route('game.squad', $gameId)
+                ->route($redirectRoute, $gameId)
                 ->with('error', $result['error']);
         }
 
         return redirect()
-            ->route('game.squad', $gameId)
+            ->route($redirectRoute, $gameId)
             ->with('success', __('messages.player_released', [
                 'player' => $result['playerName'],
                 'severance' => $result['formattedSeverance'],

--- a/app/Http/Actions/RequestLoan.php
+++ b/app/Http/Actions/RequestLoan.php
@@ -19,8 +19,10 @@ class RequestLoan
         $game = Game::with(['team', 'finances'])->findOrFail($gameId);
         $player = GamePlayer::where('game_id', $gameId)->with(['player', 'team'])->findOrFail($playerId);
 
-        // Determine if this is loan-in (from scouting) or loan-out (from squad)
-        $isLoanOut = $player->team_id === $game->team_id;
+        // Determine if this is loan-in (from scouting) or loan-out (from squad).
+        // Reserve-team players also belong to the user's club, so loan-out applies.
+        $isLoanOut = $player->team_id === $game->team_id
+            || ($game->reserve_team_id !== null && $player->team_id === $game->reserve_team_id);
 
         if ($isLoanOut) {
             return $this->handleLoanOut($game, $player);

--- a/app/Http/Actions/SendBackReservePlayer.php
+++ b/app/Http/Actions/SendBackReservePlayer.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Http\Actions;
+
+use App\Models\Game;
+use App\Models\GamePlayer;
+use App\Modules\ReserveTeam\Exceptions\FirstTeamSquadMinimumException;
+use App\Modules\ReserveTeam\Services\ReserveTeamService;
+
+class SendBackReservePlayer
+{
+    public function __construct(
+        private readonly ReserveTeamService $reserveTeamService,
+    ) {}
+
+    public function __invoke(string $gameId, string $playerId)
+    {
+        $game = Game::findOrFail($gameId);
+        abort_if($game->reserve_team_id === null, 404);
+
+        $player = GamePlayer::where('id', $playerId)
+            ->where('game_id', $gameId)
+            ->where('team_id', $game->team_id)
+            ->whereHas('activeLoan', fn ($q) => $q->where('parent_team_id', $game->reserve_team_id))
+            ->with('player')
+            ->firstOrFail();
+
+        $playerName = $player->player->name ?? '';
+
+        try {
+            $this->reserveTeamService->sendBackToReserve($player, $game);
+        } catch (FirstTeamSquadMinimumException $e) {
+            return redirect()->route('game.squad.reserve', $gameId)
+                ->with('error', $this->formatBreachMessage($e));
+        }
+
+        return redirect()->route('game.squad.reserve', $gameId)
+            ->with('success', __('messages.reserve_player_sent_back', ['player' => $playerName]));
+    }
+
+    private function formatBreachMessage(FirstTeamSquadMinimumException $e): string
+    {
+        if ($e->type() === 'too_small') {
+            return __('messages.demote_squad_too_small', ['min' => $e->min()]);
+        }
+
+        return __('messages.demote_position_minimum', [
+            'group' => __('squad.' . strtolower($e->group()) . 's'),
+            'min'   => $e->min(),
+        ]);
+    }
+}

--- a/app/Http/Actions/ToggleShortlist.php
+++ b/app/Http/Actions/ToggleShortlist.php
@@ -19,7 +19,21 @@ class ToggleShortlist
     public function __invoke(Request $request, string $gameId, string $playerId)
     {
         $game = Game::findOrFail($gameId);
-        $gamePlayer = GamePlayer::where('game_id', $gameId)->findOrFail($playerId);
+        $gamePlayer = GamePlayer::where('game_id', $gameId)->with('team')->findOrFail($playerId);
+
+        // Reserve-team (filial) players are not transferable through normal
+        // channels — they belong to the parent club and move only via
+        // call-up / promotion. Block adding them to the shortlist regardless
+        // of which game the user is in.
+        if ($gamePlayer->team && $gamePlayer->team->parent_team_id !== null) {
+            $message = __('messages.shortlist_reserve_blocked');
+
+            if ($request->ajax()) {
+                return response()->json(['success' => false, 'message' => $message], 422);
+            }
+
+            return redirect()->back()->with('error', $message);
+        }
 
         $existing = ShortlistedPlayer::where('game_id', $gameId)
             ->where('game_player_id', $playerId)

--- a/app/Http/Views/ShowPlayerDetail.php
+++ b/app/Http/Views/ShowPlayerDetail.php
@@ -17,9 +17,18 @@ class ShowPlayerDetail
     {
         $game = Game::findOrFail($gameId);
 
+        // The modal is reachable from any squad page that lists a player on
+        // the user's roster, including loaned-in players (physically present
+        // but owned by another club). userOwned() would 404 on those, so we
+        // accept "physically here" as well as "owned via active loan-out".
+        $userTeamIds = $game->userTeamIds();
+
         $gamePlayer = GamePlayer::with(['player', 'careerRecord', 'activeLoan'])
             ->where('game_id', $gameId)
-            ->userOwned($game)
+            ->where(function ($q) use ($userTeamIds) {
+                $q->whereIn('team_id', $userTeamIds)
+                    ->orWhereHas('activeLoan', fn ($loan) => $loan->whereIn('parent_team_id', $userTeamIds));
+            })
             ->findOrFail($playerId);
 
         $isCalledUpFromReserve = $gamePlayer->isCalledUpFromReserve($game);

--- a/app/Http/Views/ShowPlayerDetail.php
+++ b/app/Http/Views/ShowPlayerDetail.php
@@ -22,6 +22,8 @@ class ShowPlayerDetail
             ->userOwned($game)
             ->findOrFail($playerId);
 
+        $isCalledUpFromReserve = $gamePlayer->isCalledUpFromReserve($game);
+
         $canRenew = $gamePlayer->canBeOfferedRenewal(currentDate: $game->current_date);
         $renewalNegotiation = null;
         $renewalCooldown = false;
@@ -35,6 +37,9 @@ class ShowPlayerDetail
                 $renewalCooldown = RenewalNegotiation::hasRenewalCooldown($gamePlayer->id, $game->current_date);
             }
         }
+
+        $isOnReserve = $game->reserve_team_id !== null
+            && $gamePlayer->team_id === $game->reserve_team_id;
 
         // Release is permitted for any user-owned player physically present
         // on a user roster (first team or reserve, including filial call-ups
@@ -60,6 +65,8 @@ class ShowPlayerDetail
             'renewalCooldown' => $renewalCooldown,
             'canRelease' => $canRelease,
             'severance' => $severance,
+            'isOnReserve' => $isOnReserve,
+            'isCalledUpFromReserve' => $isCalledUpFromReserve,
         ]);
     }
 }

--- a/app/Http/Views/ShowReserveTeam.php
+++ b/app/Http/Views/ShowReserveTeam.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Http\Views;
+
+use App\Models\Game;
+use App\Modules\ReserveTeam\Services\ReserveTeamService;
+use App\Support\PositionMapper;
+
+class ShowReserveTeam
+{
+    public function __construct(
+        private readonly ReserveTeamService $reserveTeamService,
+    ) {}
+
+    public function __invoke(string $gameId)
+    {
+        $game = Game::with(['team', 'reserveTeam'])->findOrFail($gameId);
+        abort_if($game->isTournamentMode(), 404);
+        abort_if($game->reserve_team_id === null, 404);
+
+        $squad = $this->reserveTeamService->getReserveSquad($game);
+
+        $grouped = $squad
+            ->sortByDesc('overall_score')
+            ->groupBy(fn ($player) => PositionMapper::getPositionGroup($player->position));
+
+        $count = $squad->count();
+        $avgAge = $count > 0 ? round($squad->avg(fn ($p) => $p->age($game->current_date)), 1) : 0;
+        $avgOverall = $count > 0 ? (int) round($squad->avg('overall_score')) : 0;
+
+        return view('squad-reserve', [
+            'game' => $game,
+            'reserveTeam' => $game->reserveTeam,
+            'goalkeepers' => $grouped->get('Goalkeeper', collect()),
+            'defenders' => $grouped->get('Defender', collect()),
+            'midfielders' => $grouped->get('Midfielder', collect()),
+            'forwards' => $grouped->get('Forward', collect()),
+            'reserveCount' => $count,
+            'avgAge' => $avgAge,
+            'avgOverall' => $avgOverall,
+        ]);
+    }
+}

--- a/app/Modules/ReserveTeam/Services/ReserveTeamService.php
+++ b/app/Modules/ReserveTeam/Services/ReserveTeamService.php
@@ -210,7 +210,6 @@ class ReserveTeamService
                 ],
             );
 
-
             GameTransfer::record(
                 gameId: $game->id,
                 gamePlayerId: $player->id,
@@ -280,7 +279,6 @@ class ReserveTeamService
                     'joined_from' => $reserveTeamName ?? \App\Models\UserSquadCareerRecord::ORIGIN_ACADEMY,
                 ],
             );
-
 
             GameTransfer::record(
                 gameId: $game->id,

--- a/app/Modules/ReserveTeam/Services/ReserveTeamService.php
+++ b/app/Modules/ReserveTeam/Services/ReserveTeamService.php
@@ -210,6 +210,7 @@ class ReserveTeamService
                 ],
             );
 
+
             GameTransfer::record(
                 gameId: $game->id,
                 gamePlayerId: $player->id,
@@ -279,6 +280,7 @@ class ReserveTeamService
                     'joined_from' => $reserveTeamName ?? \App\Models\UserSquadCareerRecord::ORIGIN_ACADEMY,
                 ],
             );
+
 
             GameTransfer::record(
                 gameId: $game->id,

--- a/app/Modules/Season/Services/GameCreationService.php
+++ b/app/Modules/Season/Services/GameCreationService.php
@@ -27,7 +27,7 @@ class GameCreationService
                 ->first()
             ?? CompetitionTeam::where('team_id', $teamId)->first();
 
-        $team = Team::with('reserveTeam')->find($teamId);
+        $team = Team::find($teamId);
 
         // Resolve competition ID: use competition_team lookup, fall back to
         // tier 1 of the team's country from config
@@ -38,10 +38,6 @@ class GameCreationService
         }
         $season = $competitionTeam->season ?? '2025';
 
-        // Resolve reserve team (filial) for managers of parent clubs.
-        // The user's club becomes filial if it has a reserve team and isn't itself one.
-        $reserveTeamId = $team->parent_team_id === null ? $team->reserveTeam?->id : null;
-
         // Create game record (setup not yet complete)
         // current_date and season_goal are set by processors during SetupNewGame
         $game = Game::create([
@@ -50,7 +46,6 @@ class GameCreationService
             'game_mode' => $gameMode,
             'country' => $team->country ?? 'ES',
             'team_id' => $teamId,
-            'reserve_team_id' => $reserveTeamId,
             'competition_id' => $competitionId,
             'season' => $season,
             'current_date' => null,

--- a/app/Modules/Season/Services/GameCreationService.php
+++ b/app/Modules/Season/Services/GameCreationService.php
@@ -27,7 +27,7 @@ class GameCreationService
                 ->first()
             ?? CompetitionTeam::where('team_id', $teamId)->first();
 
-        $team = Team::find($teamId);
+        $team = Team::with('reserveTeam')->find($teamId);
 
         // Resolve competition ID: use competition_team lookup, fall back to
         // tier 1 of the team's country from config
@@ -38,6 +38,10 @@ class GameCreationService
         }
         $season = $competitionTeam->season ?? '2025';
 
+        // Resolve reserve team (filial) for managers of parent clubs.
+        // The user's club becomes filial if it has a reserve team and isn't itself one.
+        $reserveTeamId = $team->parent_team_id === null ? $team->reserveTeam?->id : null;
+
         // Create game record (setup not yet complete)
         // current_date and season_goal are set by processors during SetupNewGame
         $game = Game::create([
@@ -46,6 +50,7 @@ class GameCreationService
             'game_mode' => $gameMode,
             'country' => $team->country ?? 'ES',
             'team_id' => $teamId,
+            'reserve_team_id' => $reserveTeamId,
             'competition_id' => $competitionId,
             'season' => $season,
             'current_date' => null,

--- a/app/Modules/Transfer/Services/TransferMarketService.php
+++ b/app/Modules/Transfer/Services/TransferMarketService.php
@@ -359,7 +359,7 @@ class TransferMarketService
             ->where('game_id', $game->id)
             ->whereNotIn('team_id', $game->userTeamIds())
             ->distinct()
-            ->pluck('team_id')
+            ->pluck('competition_entries.team_id')
             ->all();
 
         if (empty($teamIds)) {
@@ -395,6 +395,7 @@ class TransferMarketService
             ])
             ->where('game_id', $game->id)
             ->whereIn('team_id', $teamIds)
+            ->whereHas('team', fn ($q) => $q->whereNull('parent_team_id'))
             ->get()
             ->groupBy('team_id');
     }

--- a/lang/en/messages.php
+++ b/lang/en/messages.php
@@ -91,6 +91,7 @@ return [
 
     // Reserve team (filial)
     'reserve_player_promoted' => ':player has been promoted to the first team.',
+    'shortlist_reserve_blocked' => "Reserve-team players belong to their parent club and aren't transferable.",
 
     // Player release messages
     'player_released' => ':player has been released. Severance paid: :severance.',

--- a/lang/en/messages.php
+++ b/lang/en/messages.php
@@ -90,6 +90,9 @@ return [
     'academy_must_decide_21' => 'Players aged 21+ will be automatically promoted to the first team.',
 
     // Reserve team (filial)
+    'reserve_player_called_up' => ':player has been called up to the first team.',
+    'reserve_player_sent_back' => ':player has been sent back to the reserve team.',
+    'reserve_player_call_up_blocked_full' => 'First-team squad is full. Release a player before calling up another.',
     'reserve_player_promoted' => ':player has been promoted to the first team.',
     'shortlist_reserve_blocked' => "Reserve-team players belong to their parent club and aren't transferable.",
 
@@ -102,7 +105,11 @@ return [
     'release_squad_too_small' => 'Cannot release — your squad must have at least :min players.',
     'release_position_minimum' => 'Cannot release — you need at least :min :group.',
 
-    // Squad-minimum guards on list / accept
+    // Squad-minimum guards on promote / demote / list / accept
+    'promote_squad_too_small' => 'Cannot call up — the reserve squad must have at least :min players.',
+    'promote_position_minimum' => 'Cannot call up — the reserve squad needs at least :min :group.',
+    'demote_squad_too_small' => 'Cannot send back — the first team must have at least :min players.',
+    'demote_position_minimum' => 'Cannot send back — the first team needs at least :min :group.',
     'list_for_sale_squad_too_small' => 'Cannot list for sale — your squad must have at least :min players.',
     'list_for_sale_position_minimum' => 'Cannot list for sale — you need at least :min :group.',
     'list_for_loan_squad_too_small' => 'Cannot loan out — your squad must have at least :min players.',

--- a/lang/en/squad.php
+++ b/lang/en/squad.php
@@ -190,7 +190,7 @@ return [
     'discovered' => 'Discovered',
     'origin' => 'Origin',
     'joined' => 'Joined',
-    'origin_academy' => 'New',
+    'origin_academy' => 'Academy',
     'career_history' => 'Career history',
     'no_career_history' => 'No completed seasons yet.',
 

--- a/lang/en/squad.php
+++ b/lang/en/squad.php
@@ -188,6 +188,11 @@ return [
     'clean_sheets_full' => 'Clean Sheets',
     'goals_conceded_full' => 'Goals Conceded',
     'discovered' => 'Discovered',
+    'origin' => 'Origin',
+    'joined' => 'Joined',
+    'origin_academy' => 'New',
+    'career_history' => 'Career history',
+    'no_career_history' => 'No completed seasons yet.',
 
     // Academy
     'academy' => 'Academy',
@@ -220,6 +225,24 @@ return [
     'academy_tier_3' => 'Elite Academy',
     'academy_tier_4' => 'World-Class Academy',
     'academy_tier_unknown' => 'Unknown',
+
+    // Reserve team (filial)
+    'reserve_team' => 'Reserve Team',
+    'reserve_squad' => 'Reserve squad',
+    'no_reserve_players' => 'No reserve-team players.',
+    'call_up' => 'Call up',
+    'call_up_to_first_team' => 'Call up to first team',
+    'send_back' => 'Send back',
+    'send_back_to_reserve' => 'Send back to reserve',
+    'called_up_indicator' => 'Called up',
+    'homegrown_indicator' => 'Homegrown',
+    'actions' => 'Actions',
+    'reserve_help_toggle' => 'How does the reserve team work?',
+    'reserve_help_development' => 'Your reserve team is your filial — its squad belongs to the reserve, not the first team. New academy prospects arrive here each season based on your academy investment, and develop alongside the existing reserve roster.',
+    'reserve_help_age_rule' => 'Players over 23 are automatically promoted to the first team at season close. The first team can call up reserve players any time during the season.',
+    'reserve_help_actions_title' => 'Available actions',
+    'reserve_help_call_up' => 'Call up - the player joins the first team on a temporary loan and can play first-team matches',
+    'reserve_help_send_back' => 'Send back - returns the called-up player to the reserve squad',
 
     // Lineup help text
     'lineup_help_toggle' => 'How does lineup selection work?',

--- a/lang/es/messages.php
+++ b/lang/es/messages.php
@@ -91,6 +91,7 @@ return [
 
     // Reserve team (filial)
     'reserve_player_promoted' => ':player ha subido al primer equipo.',
+    'shortlist_reserve_blocked' => 'Los jugadores del filial pertenecen al club matriz y no son transferibles.',
 
     // Player release messages
     'player_released' => ':player ha sido liberado. Indemnización pagada: :severance.',

--- a/lang/es/messages.php
+++ b/lang/es/messages.php
@@ -90,6 +90,9 @@ return [
     'academy_must_decide_21' => 'Los jugadores de 21+ años serán promocionados automáticamente al primer equipo.',
 
     // Reserve team (filial)
+    'reserve_player_called_up' => ':player ha sido convocado al primer equipo.',
+    'reserve_player_sent_back' => ':player ha vuelto al filial.',
+    'reserve_player_call_up_blocked_full' => 'La plantilla del primer equipo está completa. Libera un dorsal antes de subir más jugadores.',
     'reserve_player_promoted' => ':player ha subido al primer equipo.',
     'shortlist_reserve_blocked' => 'Los jugadores del filial pertenecen al club matriz y no son transferibles.',
 
@@ -102,7 +105,11 @@ return [
     'release_squad_too_small' => 'No se puede liberar — tu plantilla debe tener al menos :min jugadores.',
     'release_position_minimum' => 'No se puede liberar — necesitas al menos :min :group.',
 
-    // Squad-minimum guards on list / accept
+    // Squad-minimum guards on promote / demote / list / accept
+    'promote_squad_too_small' => 'No se puede subir — el filial debe tener al menos :min jugadores.',
+    'promote_position_minimum' => 'No se puede subir — el filial necesita al menos :min :group.',
+    'demote_squad_too_small' => 'No se puede bajar al filial — el primer equipo debe tener al menos :min jugadores.',
+    'demote_position_minimum' => 'No se puede bajar al filial — el primer equipo necesita al menos :min :group.',
     'list_for_sale_squad_too_small' => 'No se puede poner a la venta — tu plantilla debe tener al menos :min jugadores.',
     'list_for_sale_position_minimum' => 'No se puede poner a la venta — necesitas al menos :min :group.',
     'list_for_loan_squad_too_small' => 'No se puede ceder — tu plantilla debe tener al menos :min jugadores.',

--- a/lang/es/squad.php
+++ b/lang/es/squad.php
@@ -190,7 +190,7 @@ return [
     'discovered' => 'Descubierto',
     'origin' => 'Procedencia',
     'joined' => 'Incorporación',
-    'origin_academy' => 'Nuevo',
+    'origin_academy' => 'Filial',
     'career_history' => 'Trayectoria',
     'no_career_history' => 'Aún no hay temporadas completadas.',
 

--- a/lang/es/squad.php
+++ b/lang/es/squad.php
@@ -188,6 +188,11 @@ return [
     'clean_sheets_full' => 'Porterías a Cero',
     'goals_conceded_full' => 'Goles Encajados',
     'discovered' => 'Descubierto',
+    'origin' => 'Procedencia',
+    'joined' => 'Incorporación',
+    'origin_academy' => 'Nuevo',
+    'career_history' => 'Trayectoria',
+    'no_career_history' => 'Aún no hay temporadas completadas.',
 
     // Academy
     'academy' => 'Cantera',
@@ -220,6 +225,24 @@ return [
     'academy_tier_3' => 'Cantera de Élite',
     'academy_tier_4' => 'Cantera de Clase Mundial',
     'academy_tier_unknown' => 'Desconocido',
+
+    // Reserve team (filial)
+    'reserve_team' => 'Filial',
+    'reserve_squad' => 'Plantilla del filial',
+    'no_reserve_players' => 'No hay jugadores en el filial.',
+    'call_up' => 'Subir',
+    'call_up_to_first_team' => 'Subir al primer equipo',
+    'send_back' => 'Bajar',
+    'send_back_to_reserve' => 'Bajar al filial',
+    'called_up_indicator' => 'En el primer equipo',
+    'homegrown_indicator' => 'Canterano',
+    'actions' => 'Acciones',
+    'reserve_help_toggle' => '¿Cómo funciona el filial?',
+    'reserve_help_development' => 'Tu filial es la cantera oficial — los jugadores pertenecen al filial, no al primer equipo. Cada temporada llegan nuevos canteranos según tu inversión en la cantera, que se desarrollan junto con el resto del filial.',
+    'reserve_help_age_rule' => 'Los jugadores que cumplen 24 años pasan automáticamente al primer equipo al final de la temporada. El primer equipo puede subir jugadores del filial en cualquier momento.',
+    'reserve_help_actions_title' => 'Acciones disponibles',
+    'reserve_help_call_up' => 'Subir - el jugador se incorpora al primer equipo en cesión y puede disputar partidos con el primer equipo',
+    'reserve_help_send_back' => 'Bajar - devuelve al jugador subido al filial',
 
     // Lineup help text
     'lineup_help_toggle' => '¿Cómo funciona la alineación?',

--- a/resources/views/components/origin-badge.blade.php
+++ b/resources/views/components/origin-badge.blade.php
@@ -1,0 +1,26 @@
+@props(['player', 'currentSeason' => null])
+
+@php
+    $record = $player->careerRecord ?? null;
+    $currentSeason = $currentSeason ?? $player->game?->season;
+@endphp
+
+@if($record)
+    @php
+        $isAcademy = $record->joined_from === \App\Models\UserSquadCareerRecord::ORIGIN_ACADEMY;
+        $isCurrentSeason = $currentSeason !== null && (string) $record->joined_season === (string) $currentSeason;
+        $label = $isAcademy
+            ? ($isCurrentSeason ? __('squad.origin_academy') : '')
+            : ($record->joined_from ?? '');
+        $title = trim(($label !== '' ? $label . ' · ' : '') . __('squad.joined') . ' ' . \App\Models\Game::formatSeason((string) $record->joined_season));
+        $classes = $isAcademy
+            ? 'bg-accent-green/10 text-accent-green'
+            : 'bg-accent-blue/10 text-accent-blue';
+    @endphp
+    @if($label !== '')
+        <span class="inline-flex items-center px-1.5 py-0.5 rounded text-[9px] font-semibold uppercase tracking-wide {{ $classes }} shrink-0"
+              title="{{ $title }}">
+            {{ $label }}
+        </span>
+    @endif
+@endif

--- a/resources/views/partials/player-detail.blade.php
+++ b/resources/views/partials/player-detail.blade.php
@@ -4,9 +4,10 @@
 
     $isCareerMode = $game->isCareerMode();
     $isListed = $gamePlayer->isTransferListed();
+    $isCalledUpFromReserve = $isCalledUpFromReserve ?? false;
     $canManage = $isCareerMode
         && !$gamePlayer->isRetiring()
-        && !$gamePlayer->isLoanedIn($game->team_id)
+        && ($isCalledUpFromReserve || !$gamePlayer->isLoanedIn($game->team_id))
         && !$gamePlayer->isLoanedOut($game->team_id)
         && !$gamePlayer->hasPreContractAgreement()
         && !$gamePlayer->hasAgreedTransfer()
@@ -161,6 +162,24 @@
                         <span class="text-xs font-semibold text-text-primary">{{ $gamePlayer->contract_expiry_year }}</span>
                     </div>
                 @endif
+                @if($gamePlayer->careerRecord)
+                    @php
+                        $cr = $gamePlayer->careerRecord;
+                        $originLabel = $cr->joined_from === \App\Models\UserSquadCareerRecord::ORIGIN_ACADEMY
+                            ? __('squad.origin_academy')
+                            : ($cr->joined_from ?? '');
+                    @endphp
+                    @if($originLabel !== '')
+                        <div class="flex items-center justify-between">
+                            <span class="text-[11px] text-text-muted uppercase tracking-wide">{{ __('squad.origin') }}</span>
+                            <span class="text-xs font-semibold text-text-primary">{{ $originLabel }}</span>
+                        </div>
+                    @endif
+                    <div class="flex items-center justify-between">
+                        <span class="text-[11px] text-text-muted uppercase tracking-wide">{{ __('squad.joined') }}</span>
+                        <span class="text-xs font-semibold text-text-primary">{{ \App\Models\Game::formatSeason((string) $cr->joined_season) }}</span>
+                    </div>
+                @endif
             @endif
         </div>
     </div>
@@ -205,10 +224,87 @@
     </div>
 </div>
 
+{{-- Career history --}}
+@if($gamePlayer->careerRecord && !empty($gamePlayer->careerRecord->season_stats))
+    @php
+        $history = collect($gamePlayer->careerRecord->season_stats)
+            ->map(fn ($stats, $season) => array_merge(['season' => $season], (array) $stats))
+            ->sortBy('season')
+            ->values();
+        $isGk = $gamePlayer->position_group === 'Goalkeeper';
+    @endphp
+    <div class="px-5 py-4 border-t border-border-default">
+        <h4 class="font-heading text-[11px] font-semibold uppercase tracking-widest text-text-secondary mb-3">{{ __('squad.career_history') }}</h4>
+        <div class="overflow-x-auto">
+            <table class="w-full text-xs">
+                <thead>
+                    <tr class="text-text-muted uppercase tracking-wide text-[10px]">
+                        <th class="text-left font-semibold py-1.5 pr-3">{{ __('game.season') }}</th>
+                        <th class="text-right font-semibold py-1.5 px-2">{{ __('squad.appearances') }}</th>
+                        @if($isGk)
+                            <th class="text-right font-semibold py-1.5 px-2">{{ __('squad.clean_sheets_full') }}</th>
+                            <th class="text-right font-semibold py-1.5 px-2">{{ __('squad.goals_conceded_full') }}</th>
+                        @else
+                            <th class="text-right font-semibold py-1.5 px-2">{{ __('squad.legend_goals') }}</th>
+                            <th class="text-right font-semibold py-1.5 px-2">{{ __('squad.legend_assists') }}</th>
+                        @endif
+                        <th class="text-right font-semibold py-1.5 pl-2">{{ __('squad.bookings') }}</th>
+                    </tr>
+                </thead>
+                <tbody class="divide-y divide-border-default">
+                    @foreach($history as $row)
+                        <tr>
+                            <td class="py-1.5 pr-3 text-text-primary font-semibold">{{ \App\Models\Game::formatSeason((string) $row['season']) }}</td>
+                            <td class="py-1.5 px-2 text-right text-text-body">{{ $row['appearances'] ?? 0 }}</td>
+                            @if($isGk)
+                                <td class="py-1.5 px-2 text-right text-text-body">{{ $row['clean_sheets'] ?? 0 }}</td>
+                                <td class="py-1.5 px-2 text-right text-text-body">{{ $row['goals_conceded'] ?? 0 }}</td>
+                            @else
+                                <td class="py-1.5 px-2 text-right text-text-body">{{ $row['goals'] ?? 0 }}</td>
+                                <td class="py-1.5 px-2 text-right text-text-body">{{ $row['assists'] ?? 0 }}</td>
+                            @endif
+                            <td class="py-1.5 pl-2 text-right">
+                                <span class="inline-flex items-center gap-1">
+                                    <span class="w-1.5 h-2.5 bg-yellow-400 rounded-xs"></span>
+                                    <span class="text-text-body">{{ $row['yellow_cards'] ?? 0 }}</span>
+                                    <span class="w-1.5 h-2.5 bg-accent-red rounded-xs ml-1"></span>
+                                    <span class="text-text-body">{{ $row['red_cards'] ?? 0 }}</span>
+                                </span>
+                            </td>
+                        </tr>
+                    @endforeach
+                </tbody>
+            </table>
+        </div>
+    </div>
+@endif
+
 {{-- Actions --}}
-@if($showActions || $canRenew || $renewalNegotiation || $renewalCooldown)
+@if($showActions || $canRenew || $renewalNegotiation || $renewalCooldown || ($isOnReserve ?? false) || $isCalledUpFromReserve)
     <div class="px-5 py-4 border-t border-border-default flex flex-wrap items-center gap-2">
-        @if(!$isListed && $canSell)
+        @if(($isOnReserve ?? false) && $isCareerMode)
+            <form method="POST" action="{{ route('game.reserve.call-up', [$game->id, $gamePlayer->id]) }}">
+                @csrf
+                <x-action-button color="blue">
+                    <svg class="w-4 h-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor">
+                        <path fill-rule="evenodd" d="M8 14a.75.75 0 0 1-.75-.75V4.56L4.03 7.78a.75.75 0 0 1-1.06-1.06l4.5-4.5a.75.75 0 0 1 1.06 0l4.5 4.5a.75.75 0 0 1-1.06 1.06L8.75 4.56v8.69A.75.75 0 0 1 8 14Z" clip-rule="evenodd" />
+                    </svg>
+                    {{ __('squad.call_up_to_first_team') }}
+                </x-action-button>
+            </form>
+        @endif
+        @if($isCalledUpFromReserve && $isCareerMode)
+            <form method="POST" action="{{ route('game.reserve.send-back', [$game->id, $gamePlayer->id]) }}">
+                @csrf
+                <x-action-button color="violet">
+                    <svg class="w-4 h-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor">
+                        <path fill-rule="evenodd" d="M8 2a.75.75 0 0 1 .75.75v8.69l3.22-3.22a.75.75 0 1 1 1.06 1.06l-4.5 4.5a.75.75 0 0 1-1.06 0l-4.5-4.5a.75.75 0 0 1 1.06-1.06l3.22 3.22V2.75A.75.75 0 0 1 8 2Z" clip-rule="evenodd" />
+                    </svg>
+                    {{ __('squad.send_back_to_reserve') }}
+                </x-action-button>
+            </form>
+        @endif
+        @if(!$isListed && $canSell && !($isOnReserve ?? false))
             <form method="POST" action="{{ route('game.transfers.list', [$game->id, $gamePlayer->id]) }}">
                 @csrf
                 <x-action-button color="blue">

--- a/resources/views/partials/squad/player-status-icon.blade.php
+++ b/resources/views/partials/squad/player-status-icon.blade.php
@@ -11,6 +11,10 @@
         <svg x-data="" x-tooltip.raw="{{ __('squad.retiring') }}" class="w-4 h-4 text-orange-500 shrink-0 cursor-help" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
             <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 9V5.25A2.25 2.25 0 0 1 10.5 3h6a2.25 2.25 0 0 1 2.25 2.25v13.5A2.25 2.25 0 0 1 16.5 21h-6a2.25 2.25 0 0 1-2.25-2.25V15m-3 0-3-3m0 0 3-3m-3 3H15" />
         </svg>
+    @elseif($gp->isLoanedIn($game->team_id) && $game->reserve_team_id !== null && $gp->activeLoan?->parent_team_id === $game->reserve_team_id)
+        <svg x-data="" x-tooltip.raw="{{ __('squad.homegrown_indicator') }}" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" class="w-4 h-4 text-sky-500 shrink-0 cursor-help" fill="currentColor">
+            <path fill-rule="evenodd" d="M8 14a.75.75 0 0 1-.75-.75V4.56L4.03 7.78a.75.75 0 0 1-1.06-1.06l4.5-4.5a.75.75 0 0 1 1.06 0l4.5 4.5a.75.75 0 0 1-1.06 1.06L8.75 4.56v8.69A.75.75 0 0 1 8 14Z" clip-rule="evenodd" />
+        </svg>
     @elseif($gp->isLoanedIn($game->team_id))
         <svg x-data="" x-tooltip.raw="{{ __('squad.on_loan') }}" class="w-4 h-4 text-sky-500 shrink-0 cursor-help" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
             <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 9V5.25A2.25 2.25 0 0 1 10.5 3h6a2.25 2.25 0 0 1 2.25 2.25v13.5A2.25 2.25 0 0 1 16.5 21h-6a2.25 2.25 0 0 1-2.25-2.25V15M12 9l3 3m0 0-3 3m3-3H2.25" />
@@ -31,17 +35,25 @@
         <svg x-data="" x-tooltip.raw="{{ __('squad.loan_searching') }}" class="w-4 h-4 text-sky-500 shrink-0 cursor-help" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
             <path stroke-linecap="round" stroke-linejoin="round" d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z" />
         </svg>
-    @elseif($gp->isContractExpiring($seasonEndDate ?? $game->getSeasonEndDate()) && !$gp->hasPreContractAgreement() && !$gp->hasRenewalAgreed() && !$gp->isRetiring())
-        <svg x-data="" x-tooltip.raw="{{ __('squad.contract_expiring') }}" class="w-4 h-4 text-amber-500 shrink-0 cursor-help" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m5.231 13.481L15 17.25m-4.5-15H5.625c-.621 0-1.125.504-1.125 1.125v16.5c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Zm3.75 11.625a2.625 2.625 0 1 1-5.25 0 2.625 2.625 0 0 1 5.25 0Z" />
-        </svg>
-    @elseif($gp->isTransferListed())
-        <svg x-data="" x-tooltip.raw="{{ __('squad.listed') }}" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" class="w-4 h-4 text-amber-500 shrink-0 cursor-help" fill="currentColor">
-            <path fill-rule="evenodd" d="M3.396 6.093a2 2 0 0 0 0 3.814 2 2 0 0 0 2.697 2.697 2 2 0 0 0 3.814 0 2.001 2.001 0 0 0 2.698-2.697 2 2 0 0 0-.001-3.814 2.001 2.001 0 0 0-2.697-2.698 2 2 0 0 0-3.814.001 2 2 0 0 0-2.697 2.697ZM6 7a1 1 0 1 0 0-2 1 1 0 0 0 0 2Zm3.47-1.53a.75.75 0 1 1 1.06 1.06l-4 4a.75.75 0 1 1-1.06-1.06l4-4ZM11 10a1 1 0 1 1-2 0 1 1 0 0 1 2 0Z" clip-rule="evenodd" />
-        </svg>
-    @elseif($flags['stature_gap'])
-        <x-warning-triangle :tooltip="__('transfers.player_wont_renew')" class="text-accent-red" />
-    @elseif($flags['wage_gap'])
-        <x-warning-triangle :tooltip="__('transfers.player_wants_raise')" class="text-accent-gold" />
+    @else
+        @php
+            $isExpiring = $gp->isContractExpiring($seasonEndDate ?? $game->getSeasonEndDate());
+            $isListed = $gp->isTransferListed();
+        @endphp
+        @if($isExpiring)
+            <svg x-data="" x-tooltip.raw="{{ __('squad.contract_expiring') }}" class="w-4 h-4 text-amber-500 shrink-0 cursor-help" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m5.231 13.481L15 17.25m-4.5-15H5.625c-.621 0-1.125.504-1.125 1.125v16.5c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Zm3.75 11.625a2.625 2.625 0 1 1-5.25 0 2.625 2.625 0 0 1 5.25 0Z" />
+            </svg>
+        @endif
+        @if($isListed)
+            <svg x-data="" x-tooltip.raw="{{ __('squad.listed') }}" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" class="w-4 h-4 text-amber-500 shrink-0 cursor-help" fill="currentColor">
+                <path fill-rule="evenodd" d="M3.396 6.093a2 2 0 0 0 0 3.814 2 2 0 0 0 2.697 2.697 2 2 0 0 0 3.814 0 2.001 2.001 0 0 0 2.698-2.697 2 2 0 0 0-.001-3.814 2.001 2.001 0 0 0-2.697-2.698 2 2 0 0 0-3.814.001 2 2 0 0 0-2.697 2.697ZM6 7a1 1 0 1 0 0-2 1 1 0 0 0 0 2Zm3.47-1.53a.75.75 0 1 1 1.06 1.06l-4 4a.75.75 0 1 1-1.06-1.06l4-4ZM11 10a1 1 0 1 1-2 0 1 1 0 0 1 2 0Z" clip-rule="evenodd" />
+            </svg>
+        @endif
+        @if(!$isExpiring && !$isListed && $flags['stature_gap'])
+            <x-warning-triangle :tooltip="__('transfers.player_wont_renew')" class="text-accent-red" />
+        @elseif(!$isExpiring && !$isListed && $flags['wage_gap'])
+            <x-warning-triangle :tooltip="__('transfers.player_wants_raise')" class="text-accent-gold" />
+        @endif
     @endif
 @endif

--- a/resources/views/partials/squad/sidebar.blade.php
+++ b/resources/views/partials/squad/sidebar.blade.php
@@ -4,27 +4,6 @@
 @endphp
 
 <div class="space-y-5">
-    {{-- Number Grid (visible only in numbers mode) --}}
-    <div x-show="viewMode === 'numbers'" x-cloak>
-        <h4 class="font-heading text-[11px] font-semibold text-text-muted uppercase tracking-widest pb-2 border-b border-border-default mb-3">{{ __('squad.number_grid') }}</h4>
-        <div class="grid grid-cols-10 gap-1">
-            @for($n = 1; $n <= 99; $n++)
-            <div class="aspect-square flex items-center justify-center rounded-sm text-xs font-medium cursor-default transition-colors"
-                 :class="getNumberOwner({{ $n }}) ? 'bg-accent-blue/10 text-accent-blue border border-accent-blue/20' : 'bg-surface-700/50 text-text-body border border-border-default'"
-                 :title="getNumberOwner({{ $n }})?.name ?? '{{ __('squad.available_number') }}'">
-                <span class="tabular-nums">{{ $n }}</span>
-            </div>
-            @endfor
-        </div>
-        <div class="mt-3 flex items-center gap-3 text-xs text-text-muted">
-            <span class="flex items-center gap-1"><span class="w-3 h-3 rounded-sm bg-accent-blue/10 border border-accent-blue/20"></span> {{ __('squad.assigned') }}</span>
-            <span class="flex items-center gap-1"><span class="w-3 h-3 rounded-sm bg-surface-700/50 border border-border-default"></span> {{ __('squad.available_number') }}</span>
-        </div>
-    </div>
-
-    {{-- Standard sidebar content (hidden in numbers mode) --}}
-    <template x-if="viewMode !== 'numbers'">
-    <div class="space-y-5">
 
     {{-- Alerts --}}
     @if(count($alerts) > 0)
@@ -162,7 +141,4 @@
         </div>
     </div>
     @endif
-
-    </div>
-    </template>
 </div>

--- a/resources/views/squad-academy.blade.php
+++ b/resources/views/squad-academy.blade.php
@@ -8,9 +8,14 @@
     <div class="max-w-7xl mx-auto px-4 pb-8">
 
         {{-- Sub-navigation --}}
+        @php
+            $secondaryItem = $game->isFilial()
+                ? ['href' => route('game.squad.reserve', $game->id), 'label' => __('squad.reserve_team'), 'active' => false]
+                : ['href' => route('game.squad.academy', $game->id), 'label' => __('squad.academy'), 'active' => true];
+        @endphp
         <x-section-nav :items="[
             ['href' => route('game.squad', $game->id), 'label' => __('squad.first_team'), 'active' => false],
-            ['href' => route('game.squad.academy', $game->id), 'label' => __('squad.academy'), 'active' => true],
+            $secondaryItem,
             ['href' => route('game.squad.registration', $game->id), 'label' => __('squad.registration'), 'active' => false],
         ]" />
 

--- a/resources/views/squad-reserve.blade.php
+++ b/resources/views/squad-reserve.blade.php
@@ -1,0 +1,179 @@
+@php /** @var App\Models\Game $game **/ @endphp
+
+<x-app-layout>
+    <x-slot name="header">
+        <x-game-header :game="$game" :next-match="$game->next_match"></x-game-header>
+    </x-slot>
+
+    <div class="max-w-7xl mx-auto px-4 pb-8">
+
+        {{-- Sub-navigation --}}
+        <x-section-nav :items="[
+            ['href' => route('game.squad', $game->id), 'label' => __('squad.first_team'), 'active' => false],
+            ['href' => route('game.squad.reserve', $game->id), 'label' => __('squad.reserve_team'), 'active' => true],
+            ['href' => route('game.squad.registration', $game->id), 'label' => __('squad.registration'), 'active' => false],
+        ]" />
+
+        {{-- Flash Messages --}}
+        <x-flash-message type="success" :message="session('success')" class="mt-4" />
+        <x-flash-message type="error" :message="session('error')" class="mt-4" />
+
+        {{-- Page Title --}}
+        <div class="mt-6 mb-4">
+            <h2 class="font-heading text-2xl lg:text-3xl font-bold uppercase tracking-wide text-text-primary">{{ $reserveTeam->name }}</h2>
+        </div>
+
+        {{-- Summary strip --}}
+        <x-help-disclosure class="mb-6">
+            <x-slot name="trigger">
+                <div class="flex items-center gap-2.5 overflow-x-auto scrollbar-hide pb-1">
+                    <x-summary-card :label="__('squad.squad_size')" :value="$reserveCount" />
+                    <x-summary-card :label="__('squad.avg_age')" :value="$avgAge" />
+                    <x-summary-card :label="__('squad.avg_ovr')" :value="$avgOverall" x-data x-tooltip.raw="{{ __('squad.tooltip_avg_overall') }}" :value-class="$avgOverall >= 75 ? 'text-accent-green' : ($avgOverall >= 65 ? 'text-text-primary' : 'text-amber-500')" />
+                    <div class="ml-auto shrink-0">
+                        <x-help-toggle :label="__('squad.reserve_help_toggle')" />
+                    </div>
+                </div>
+            </x-slot>
+
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-5">
+                <div>
+                    <p class="text-text-secondary mb-3">{{ __('squad.reserve_help_development') }}</p>
+                    <p class="text-text-secondary">{{ __('squad.reserve_help_age_rule') }}</p>
+                </div>
+
+                <div>
+                    <p class="font-semibold text-text-body mb-2">{{ __('squad.reserve_help_actions_title') }}</p>
+                    <ul class="space-y-2">
+                        <li class="flex gap-2">
+                            <span class="text-accent-green shrink-0">↑</span>
+                            <span class="text-text-secondary">{{ __('squad.reserve_help_call_up') }}</span>
+                        </li>
+                        <li class="flex gap-2">
+                            <span class="text-amber-400 shrink-0">↓</span>
+                            <span class="text-text-secondary">{{ __('squad.reserve_help_send_back') }}</span>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </x-help-disclosure>
+
+        @if($reserveCount === 0)
+            <div class="text-center py-16">
+                <div class="inline-flex items-center justify-center w-16 h-16 bg-surface-700 rounded-full mb-4">
+                    <svg class="w-8 h-8 fill-surface-600" stroke="currentColor" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 576 512"><path d="M48 195.8l209.2 86.1c9.8 4 20.2 6.1 30.8 6.1s21-2.1 30.8-6.1l242.4-99.8c9-3.7 14.8-12.4 14.8-22.1s-5.8-18.4-14.8-22.1L318.8 38.1C309 34.1 298.6 32 288 32s-21 2.1-30.8 6.1L14.8 137.9C5.8 141.6 0 150.3 0 160L0 456c0 13.3 10.7 24 24 24s24-10.7 24-24l0-260.2zm48 71.7L96 384c0 53 86 96 192 96s192-43 192-96l0-116.6-142.9 58.9c-15.6 6.4-32.2 9.7-49.1 9.7s-33.5-3.3-49.1-9.7L96 267.4z"/></svg>
+                </div>
+                <p class="text-text-muted text-sm">{{ __('squad.no_reserve_players') }}</p>
+            </div>
+        @else
+            <div x-data class="bg-surface-800 border border-border-default rounded-xl overflow-hidden">
+                {{-- Table header --}}
+                <div class="hidden md:block">
+                    <div class="grid grid-cols-[40px_1fr_48px_56px_48px_48px_56px_56px] gap-1.5 items-center px-4 py-2 bg-surface-700/30 border-b border-border-default text-[10px] text-text-muted uppercase tracking-widest font-semibold">
+                        <span></span>
+                        <span>{{ __('app.name') }}</span>
+                        <span class="text-center">{{ __('app.age') }}</span>
+                        <span class="text-center">{{ __('app.contract') }}</span>
+                        <span class="text-center">{{ __('squad.technical') }}</span>
+                        <span class="text-center">{{ __('squad.physical') }}</span>
+                        <span class="text-center">{{ __('squad.pot') }}</span>
+                        <span class="text-center">{{ __('squad.overall') }}</span>
+                    </div>
+                </div>
+
+                @foreach([
+                    ['name' => __('squad.goalkeepers'), 'players' => $goalkeepers],
+                    ['name' => __('squad.defenders'), 'players' => $defenders],
+                    ['name' => __('squad.midfielders'), 'players' => $midfielders],
+                    ['name' => __('squad.forwards'), 'players' => $forwards],
+                ] as $group)
+                    @if($group['players']->isNotEmpty())
+                        <div class="px-4 py-2 bg-surface-700/30 border-b border-border-default">
+                            <div class="flex items-center justify-between">
+                                <span class="font-heading text-[11px] font-semibold uppercase tracking-widest text-text-muted">{{ $group['name'] }}</span>
+                                <span class="text-[10px] text-text-faint">{{ $group['players']->count() }}</span>
+                            </div>
+                        </div>
+
+                        @foreach($group['players'] as $player)
+                            @php
+                                $isCalledUp = $player->team_id === $game->team_id;
+                                $age = $player->age($game->current_date);
+                            @endphp
+
+                            {{-- Mobile row --}}
+                            <div class="md:hidden px-4 py-3 border-b border-border-default {{ $isCalledUp ? 'opacity-60' : '' }}">
+                                <div class="flex items-center gap-3">
+                                    <div class="cursor-pointer flex-1 flex items-center gap-3 min-w-0" @click="$dispatch('show-player-detail', '{{ route('game.player.detail', [$game->id, $player->id]) }}')">
+                                        <x-player-avatar :name="$player->player->name" :position-group="\App\Support\PositionMapper::getPositionGroup($player->position)" :position-abbrev="\App\Support\PositionMapper::toAbbreviation($player->position)" />
+                                        <div class="flex-1 min-w-0">
+                                            <div class="flex items-center gap-2">
+                                                <span class="text-sm font-medium text-text-primary truncate">{{ $player->player->name }}</span>
+                                                <x-origin-badge :player="$player" :current-season="$game->season" />
+                                                <span class="text-[10px] text-text-faint">{{ $age }}</span>
+                                                @if($player->contract_expiry_year)
+                                                    <span class="text-[10px] tabular-nums @if($player->isContractExpiring($game->getSeasonEndDate())) text-accent-red font-medium @else text-text-faint @endif">{{ __('app.contract') }}: {{ $player->contract_expiry_year }}</span>
+                                                @endif
+                                                @if($isCalledUp)
+                                                    <span class="text-[10px] font-semibold bg-accent-blue/10 text-accent-blue px-1.5 py-0.5 rounded-full">{{ __('squad.called_up_indicator') }}</span>
+                                                @endif
+                                            </div>
+                                        </div>
+                                        <x-rating-badge :value="$player->overall_score" class="shrink-0" />
+                                    </div>
+                                    @if($isCalledUp)
+                                        <form method="POST" action="{{ route('game.reserve.send-back', [$game->id, $player->id]) }}" onsubmit="return confirm('{{ __('squad.send_back_to_reserve') }}?')">
+                                            @csrf
+                                            <button type="submit" class="text-amber-400 hover:text-amber-300 px-2" title="{{ __('squad.send_back_to_reserve') }}">↓</button>
+                                        </form>
+                                    @else
+                                        <form method="POST" action="{{ route('game.reserve.call-up', [$game->id, $player->id]) }}" onsubmit="return confirm('{{ __('squad.call_up_to_first_team') }}?')">
+                                            @csrf
+                                            <button type="submit" class="text-accent-green hover:text-emerald-400 px-2" title="{{ __('squad.call_up_to_first_team') }}">↑</button>
+                                        </form>
+                                    @endif
+                                </div>
+                            </div>
+
+                            {{-- Desktop row --}}
+                            <div class="hidden md:grid grid-cols-[40px_1fr_48px_56px_48px_48px_56px_56px] gap-1.5 items-center px-4 py-2.5 border-b border-border-default hover:bg-surface-700/30 transition-colors cursor-pointer {{ $isCalledUp ? 'opacity-60' : '' }}"
+                                 @click="$dispatch('show-player-detail', '{{ route('game.player.detail', [$game->id, $player->id]) }}')">
+                                <div class="flex justify-center">
+                                    <x-position-badge :position="$player->position" size="sm" :tooltip="\App\Support\PositionMapper::toDisplayName($player->position)" class="cursor-help" />
+                                </div>
+                                <div class="flex items-center gap-2 min-w-0">
+                                    @if($player->nationality_flag)
+                                        <img src="{{ Storage::disk('assets')->url('flags/' . $player->nationality_flag['code'] . '.svg') }}" class="w-4 h-3 rounded-xs shadow-xs shrink-0" title="{{ $player->nationality_flag['name'] }}">
+                                    @endif
+                                    <span class="text-sm font-medium text-text-primary truncate">{{ $player->player->name }}</span>
+                                    <x-origin-badge :player="$player" :current-season="$game->season" />
+                                    @if($isCalledUp)
+                                        <span class="text-[10px] font-semibold bg-accent-blue/10 text-accent-blue px-1.5 py-0.5 rounded-full">{{ __('squad.called_up_indicator') }}</span>
+                                    @endif
+                                </div>
+                                <span class="text-xs text-text-secondary text-center tabular-nums">{{ $age }}</span>
+                                <span class="text-[11px] text-center tabular-nums @if($player->isContractExpiring($game->getSeasonEndDate())) text-accent-red font-medium @else text-text-muted @endif">
+                                    {{ $player->contract_expiry_year ?? '—' }}
+                                </span>
+                                <div class="flex justify-center">
+                                    <span class="text-xs font-medium tabular-nums @if($player->current_technical_ability >= 80) text-accent-green @elseif($player->current_technical_ability >= 70) text-lime-500 @elseif($player->current_technical_ability >= 60) text-text-body @else text-text-secondary @endif">{{ $player->current_technical_ability }}</span>
+                                </div>
+                                <div class="flex justify-center">
+                                    <span class="text-xs font-medium tabular-nums @if($player->current_physical_ability >= 80) text-accent-green @elseif($player->current_physical_ability >= 70) text-lime-500 @elseif($player->current_physical_ability >= 60) text-text-body @else text-text-secondary @endif">{{ $player->current_physical_ability }}</span>
+                                </div>
+                                <span class="text-xs text-center tabular-nums text-text-muted">{{ $player->potential_range }}</span>
+                                <div class="flex justify-center">
+                                    <x-rating-badge :value="$player->overall_score" size="sm" />
+                                </div>
+                            </div>
+                        @endforeach
+                    @endif
+                @endforeach
+            </div>
+        @endif
+
+    </div>
+
+    <x-player-detail-modal />
+    <x-negotiation-chat-modal />
+</x-app-layout>

--- a/resources/views/squad.blade.php
+++ b/resources/views/squad.blade.php
@@ -272,7 +272,6 @@
                                             <div class="flex-1 min-w-0">
                                                 <div class="flex items-center gap-1.5">
                                                     <span class="text-sm font-medium text-text-primary truncate">{{ $gp->player->name }}</span>
-                                                    <x-origin-badge :player="$gp" :current-season="$game->season" />
                                                     @include('partials.squad.player-status-icon', ['gp' => $gp, 'game' => $game, 'seasonEndDate' => $seasonEndDate, 'playerFlags' => $playerFlags ?? []])
                                                     <x-player-unavailable-icon :player="$gp" :reason="$unavailReason" />
                                                 </div>
@@ -344,7 +343,6 @@
                                             <div class="min-w-0">
                                                 <div class="flex items-center gap-2">
                                                     <span class="text-sm font-medium text-text-primary truncate">{{ $gp->player->name }}</span>
-                                                    <x-origin-badge :player="$gp" :current-season="$game->season" />
                                                     @include('partials.squad.player-status-icon', ['gp' => $gp, 'game' => $game, 'seasonEndDate' => $seasonEndDate, 'playerFlags' => $playerFlags ?? []])
                                                     <x-player-unavailable-icon :player="$gp" :reason="$unavailReason" />
                                                 </div>

--- a/resources/views/squad.blade.php
+++ b/resources/views/squad.blade.php
@@ -55,9 +55,12 @@
             {{-- Sub-navigation --}}
             @if($isCareerMode)
                 @php
+                    $secondaryItem = $game->isFilial()
+                        ? ['href' => route('game.squad.reserve', $game->id), 'label' => __('squad.reserve_team'), 'active' => false]
+                        : ['href' => route('game.squad.academy', $game->id), 'label' => __('squad.academy'), 'active' => false];
                     $squadNavItems = [
                         ['href' => route('game.squad', $game->id), 'label' => __('squad.first_team'), 'active' => true],
-                        ['href' => route('game.squad.academy', $game->id), 'label' => __('squad.academy'), 'active' => false],
+                        $secondaryItem,
                         ['href' => route('game.squad.registration', $game->id), 'label' => __('squad.registration'), 'active' => false],
                     ];
                 @endphp
@@ -269,6 +272,7 @@
                                             <div class="flex-1 min-w-0">
                                                 <div class="flex items-center gap-1.5">
                                                     <span class="text-sm font-medium text-text-primary truncate">{{ $gp->player->name }}</span>
+                                                    <x-origin-badge :player="$gp" :current-season="$game->season" />
                                                     @include('partials.squad.player-status-icon', ['gp' => $gp, 'game' => $game, 'seasonEndDate' => $seasonEndDate, 'playerFlags' => $playerFlags ?? []])
                                                     <x-player-unavailable-icon :player="$gp" :reason="$unavailReason" />
                                                 </div>
@@ -340,6 +344,7 @@
                                             <div class="min-w-0">
                                                 <div class="flex items-center gap-2">
                                                     <span class="text-sm font-medium text-text-primary truncate">{{ $gp->player->name }}</span>
+                                                    <x-origin-badge :player="$gp" :current-season="$game->season" />
                                                     @include('partials.squad.player-status-icon', ['gp' => $gp, 'game' => $game, 'seasonEndDate' => $seasonEndDate, 'playerFlags' => $playerFlags ?? []])
                                                     <x-player-unavailable-icon :player="$gp" :reason="$unavailReason" />
                                                 </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -125,6 +125,9 @@ use App\Http\Views\ShowTournamentLeaderboard;
 use App\Http\Views\ShowTournamentSummary;
 use App\Http\Actions\ProcessTacticalActions;
 use App\Http\Actions\PromoteAcademyPlayer;
+use App\Http\Actions\CallUpReservePlayer;
+use App\Http\Actions\SendBackReservePlayer;
+use App\Http\Views\ShowReserveTeam;
 use App\Http\Actions\SkipMatchToEnd;
 use App\Http\Actions\StartNewSeason;
 use Illuminate\Support\Facades\Route;
@@ -167,6 +170,10 @@ Route::middleware('auth')->group(function () {
         Route::post('/game/{gameId}/academy/{playerId}/promote', PromoteAcademyPlayer::class)->name('game.academy.promote');
         Route::post('/game/{gameId}/academy/{playerId}/loan', LoanAcademyPlayer::class)->name('game.academy.loan');
         Route::post('/game/{gameId}/academy/{playerId}/dismiss', DismissAcademyPlayer::class)->name('game.academy.dismiss');
+        // Reserve team (filial games)
+        Route::get('/game/{gameId}/squad/reserve', ShowReserveTeam::class)->name('game.squad.reserve');
+        Route::post('/game/{gameId}/reserve/{playerId}/call-up', CallUpReservePlayer::class)->name('game.reserve.call-up');
+        Route::post('/game/{gameId}/reserve/{playerId}/send-back', SendBackReservePlayer::class)->name('game.reserve.send-back');
         // Club hub — Finances, Stadium, Reputation (and future non-sporting tenants)
         Route::get('/game/{gameId}/club', fn (string $gameId) => redirect()->route('game.club.finances', $gameId))->name('game.club');
         Route::get('/game/{gameId}/club/finances', ShowFinances::class)->name('game.club.finances');


### PR DESCRIPTION
## Summary
Stitches the previous backend PRs into a complete user-facing feature. **This is the only PR in the stack with user-visible changes.** Parent clubs (Real Madrid, Barcelona, Athletic, etc.) get a Reserve Team tab in place of Academy, can call up reserve players and send them back, and see player origin and per-season career history on the player detail card.

**Routes & Actions**
- GET \`/reserve/squad\` → \`ShowReserveTeam\`
- POST \`/reserve/{player}/call-up\` → \`CallUpReservePlayer\` (with squad-minimum check)
- POST \`/reserve/{player}/send-back\` → \`SendBackReservePlayer\` (with squad-minimum check)
- \`RequestLoan\` recognises reserve-team players as user-owned for loan-out
- \`ReleasePlayer\` redirects back to the reserve squad page when releasing a reserve player

**Views**
- \`squad-reserve.blade.php\` — full reserve squad page: contract column, greyed-out called-up rows, homegrown / called-up icons
- \`player-status-icon.blade.php\` — distinct upward-arrow icon for filial loans (with "Canterano" / "Homegrown" tooltip), parallel rendering of contract-expiring + transfer-listed badges
- \`player-detail.blade.php\` — call-up / send-back action buttons for reserve and called-up filial players, plus career-history table fed by \`UserSquadCareerRecord\`
- \`origin-badge.blade.php\` — "Nuevo" / "New" badge for academy and reserve origins, only shown during the joining season
- \`squad.blade.php\` / \`squad-academy.blade.php\` — origin badge integration and nav swap so parent clubs land on Reserve instead of Academy

**Translations**: \`lang/{en,es}/{messages,squad}.php\` for all UI labels, flash messages, and the call-up/send-back flow.

Stacked on \`reserve/04-career-backend\`.

## Test plan
- [ ] Start a new game as Real Madrid / Barcelona / Athletic — Academy tab is replaced by Reserve Team
- [ ] Reserve squad page lists generated youngsters with contract column
- [ ] Call-up: player moves to first team, gets a 26+ shirt number, internal Loan created
- [ ] Send-back: player returns to reserve, shirt number cleared
- [ ] Player detail card on a reserve player shows call-up + renewal + release buttons
- [ ] Renew a reserve-squad player (was previously broken; fixed by ownership refactor PR)
- [ ] Renew a called-up filial player
- [ ] Release a reserve-squad player → flash redirects to reserve squad page
- [ ] Origin badge shows "New" only during the joining season
- [ ] Career history table populates after a season closes
- [ ] Filial loan-ins show the upward-arrow homegrown icon with the right tooltip
- [ ] Existing non-parent-club games continue to use the Academy flow unchanged
- [ ] At season close: an aged-out reserve player is permanently promoted with a career record snapshotted