### PR TITLE
Add squad minimum validation to counter offer acceptance

### DIFF
--- a/app/Http/Actions/NegotiateCounterOffer.php
+++ b/app/Http/Actions/NegotiateCounterOffer.php
@@ -177,7 +177,14 @@ class NegotiateCounterOffer
         $player = $offer->gamePlayer;
         $buyerName = $offer->offeringTeam->name;
 
-        $completedImmediately = $this->transferService->acceptCounterOfferBid($offer);
+        try {
+            $completedImmediately = $this->transferService->acceptCounterOfferBid($offer);
+        } catch (SquadMinimumException $e) {
+            return response()->json([
+                'status' => 'error',
+                'message' => $this->formatBreachMessage($e),
+            ], 422);
+        }
 
         if ($completedImmediately) {
             $this->notificationService->notifyTransferComplete($game, $offer->refresh());


### PR DESCRIPTION
## Summary
Added error handling to the counter offer acceptance flow to validate squad minimum requirements before completing a transfer.

## Key Changes
- Wrapped `acceptCounterOfferBid()` call in try-catch block to handle `SquadMinimumException`
- Returns a 422 Unprocessable Entity response with formatted error message when squad minimum constraint is violated
- Prevents invalid transfers that would breach squad size requirements

## Implementation Details
- Exception is caught at the action level before any transfer completion notifications are sent
- Error response uses the existing `formatBreachMessage()` method to provide consistent error messaging
- Maintains existing behavior for successful counter offer acceptances

https://claude.ai/code/session_019xqYTY9YRYiNZrmsx13m8Z