### PR TITLE
Fix Copa del Rey draws losing teams to silent odd-pool truncation

### DIFF
--- a/app/Modules/Competition/Contracts/CupDrawPairingStrategy.php
+++ b/app/Modules/Competition/Contracts/CupDrawPairingStrategy.php
@@ -10,7 +10,10 @@ interface CupDrawPairingStrategy
      * Order teams for sequential pairing in a cup draw.
      *
      * Returns a collection where teams[0] vs teams[1], teams[2] vs teams[3], etc.
-     * The total count should be even (drop remainder if odd input).
+     * Implementations MUST include every input team exactly once in the
+     * result — odd inputs must NOT silently discard a team. When the input
+     * size is odd, the trailing team is unpaired and the caller is
+     * responsible for handling it (e.g. assigning a bye or raising).
      *
      * @param  Collection<int, string>  $teams  Team IDs eligible for the round
      * @param  array<string, int>  $teamTierMap  Map of team ID → league tier

--- a/app/Modules/Competition/Exceptions/OddCupDrawPoolException.php
+++ b/app/Modules/Competition/Exceptions/OddCupDrawPoolException.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Modules\Competition\Exceptions;
+
+use RuntimeException;
+
+/**
+ * Thrown when a cup draw is attempted with an odd number of teams. A
+ * knockout draw always pairs teams 2-by-2, so an odd input has no valid
+ * resolution short of giving one team a bye — and our schema currently
+ * has no representation for byes. We surface the failure here so the
+ * upstream cause (cup-size invariant violated, supercup bump didn't
+ * apply, etc.) can be diagnosed instead of silently dropping a team.
+ *
+ * Replaces a silent `for ($i + 1 < $count; $i += 2)` truncation in
+ * CupDrawService::getPairedTeamsForRound that produced 93 broken Copa
+ * del Rey draws in production (semifinals with one tie, missing
+ * round-of-16 ties, etc.).
+ */
+class OddCupDrawPoolException extends RuntimeException
+{
+    public static function forRound(string $competitionId, int $roundNumber, int $teamCount): self
+    {
+        return new self(
+            "Cannot draw {$competitionId} round {$roundNumber}: pool has {$teamCount} teams "
+            . '(odd). Knockout draws require an even pool — check upstream rule '
+            . '(cup_qualification target_size, supercup entry_round bump, or seed source).'
+        );
+    }
+}

--- a/app/Modules/Competition/Services/CupDrawService.php
+++ b/app/Modules/Competition/Services/CupDrawService.php
@@ -4,6 +4,7 @@ namespace App\Modules\Competition\Services;
 
 use App\Modules\Competition\Contracts\CupDrawPairingStrategy;
 use App\Modules\Competition\DTOs\PlayoffRoundConfig;
+use App\Modules\Competition\Exceptions\OddCupDrawPoolException;
 use App\Modules\Competition\Services\Draw\RandomPairing;
 use App\Models\Competition;
 use App\Models\CompetitionEntry;
@@ -217,13 +218,8 @@ class CupDrawService
                 : [];
 
             $orderedTeams = $strategy->pairTeams($enteringTeams, $teamTierMap);
-            $pairs = collect();
 
-            for ($i = 0; $i + 1 < $orderedTeams->count(); $i += 2) {
-                $pairs->push([$orderedTeams[$i], $orderedTeams[$i + 1]]);
-            }
-
-            return $pairs;
+            return $this->chunkIntoPairs($orderedTeams, $competitionId, $roundNumber);
         }
 
         // Later rounds: combine previous-round winners with new entrants
@@ -244,9 +240,30 @@ class CupDrawService
 
         $orderedTeams = $strategy->pairTeams($allTeams, $teamTierMap);
 
+        return $this->chunkIntoPairs($orderedTeams, $competitionId, $roundNumber);
+    }
+
+    /**
+     * Walk an ordered team list 2-by-2 into pairs, raising if the count is
+     * odd. The earlier `for ($i + 1 < $count; $i += 2)` form silently
+     * dropped the trailing team and produced 93 broken Copa del Rey
+     * draws in production — better to fail loudly here so the upstream
+     * cause surfaces.
+     *
+     * @param  Collection<int, string>  $orderedTeams
+     * @return Collection<int, array{0: string, 1: string}>
+     */
+    private function chunkIntoPairs(Collection $orderedTeams, string $competitionId, int $roundNumber): Collection
+    {
+        $count = $orderedTeams->count();
+
+        if ($count % 2 !== 0) {
+            throw OddCupDrawPoolException::forRound($competitionId, $roundNumber, $count);
+        }
+
         $pairs = collect();
 
-        for ($i = 0; $i + 1 < $orderedTeams->count(); $i += 2) {
+        for ($i = 0; $i < $count; $i += 2) {
             $pairs->push([$orderedTeams[$i], $orderedTeams[$i + 1]]);
         }
 

--- a/app/Modules/Competition/Services/Draw/CrossCategoryPairing.php
+++ b/app/Modules/Competition/Services/Draw/CrossCategoryPairing.php
@@ -12,6 +12,13 @@ use Illuminate\Support\Collection;
  * Teams are sorted by league tier, split into two halves (higher-category
  * and lower-category), shuffled within each half, then interleaved so that
  * sequential pairing produces cross-category matchups.
+ *
+ * Odd inputs: every team must appear in the output. When the input size is
+ * odd, the surplus team falls into the lower half and is appended at the
+ * end of the result, leaving it unpaired for the caller to handle.
+ * Earlier versions used `slice($half, $half)` for the lower half, which
+ * silently dropped the median team and propagated downstream as missing
+ * cup ties (one team disappeared per draw with an odd team pool).
  */
 class CrossCategoryPairing implements CupDrawPairingStrategy
 {
@@ -21,15 +28,25 @@ class CrossCategoryPairing implements CupDrawPairingStrategy
             ->sort(fn ($a, $b) => ($teamTierMap[$a] ?? 99) <=> ($teamTierMap[$b] ?? 99))
             ->values();
 
-        $half = intdiv($sorted->count(), 2);
+        $count = $sorted->count();
+        $upperSize = intdiv($count, 2);
 
-        $higherHalf = $sorted->slice(0, $half)->shuffle()->values();
-        $lowerHalf = $sorted->slice($half, $half)->shuffle()->values();
+        // Higher-ranked teams (lower tier numbers) populate the upper half.
+        // Slice without an explicit length so the lower half absorbs every
+        // remaining team — including the median when $count is odd.
+        $higherHalf = $sorted->slice(0, $upperSize)->shuffle()->values();
+        $lowerHalf = $sorted->slice($upperSize)->shuffle()->values();
 
         $paired = collect();
 
-        for ($i = 0; $i < $half; $i++) {
+        for ($i = 0; $i < $upperSize; $i++) {
             $paired->push($higherHalf[$i]);
+            $paired->push($lowerHalf[$i]);
+        }
+
+        // Append any surplus from the lower half (only triggers when
+        // $count is odd — exactly one team remains).
+        for ($i = $upperSize; $i < $lowerHalf->count(); $i++) {
             $paired->push($lowerHalf[$i]);
         }
 

--- a/app/Modules/Match/Listeners/ConductNextCupRoundDraw.php
+++ b/app/Modules/Match/Listeners/ConductNextCupRoundDraw.php
@@ -2,8 +2,8 @@
 
 namespace App\Modules\Match\Listeners;
 
-use App\Modules\Match\Events\CupTieResolved;
 use App\Modules\Competition\Services\CupDrawService;
+use App\Modules\Match\Events\CupTieResolved;
 
 class ConductNextCupRoundDraw
 {
@@ -26,12 +26,19 @@ class ConductNextCupRoundDraw
             $event->match->competition_id,
         );
 
-        if ($nextRound !== null) {
-            $this->cupDrawService->conductDraw(
-                $event->game->id,
-                $event->match->competition_id,
-                $nextRound,
-            );
+        if ($nextRound === null) {
+            return;
         }
+
+        // OddCupDrawPoolException from conductDraw is intentionally not
+        // caught here. Silent fallbacks are how the original 93-broken-
+        // games bug stayed hidden — we'd rather match finalization fail
+        // loudly so the upstream cause (parity violation in the team
+        // pool) surfaces immediately.
+        $this->cupDrawService->conductDraw(
+            $event->game->id,
+            $event->match->competition_id,
+            $nextRound,
+        );
     }
 }

--- a/app/Modules/Season/Processors/CopaQualificationProcessor.php
+++ b/app/Modules/Season/Processors/CopaQualificationProcessor.php
@@ -20,26 +20,23 @@ use Illuminate\Support\Facades\Log;
  * season's CompetitionEntry still reflects this season's divisions and
  * GameStanding still contains the full final table for every tier.
  *
- * Rules live under each country's `cup_qualification` config:
- *  - auto_qualify_tiers: every team in these tiers qualifies for the next
- *    season's cup.
- *  - top_per_group: the top N teams in each competition at this tier
- *    (including siblings — e.g. ESP3A and ESP3B) qualify.
- *  - target_size (optional): total cup size to maintain. After the rule
- *    pass, the processor pulls additional non-reserves from top_per_group
- *    groups round-robin until qualifiers + untouched regional seed teams
- *    equal this number. Without it the cup permanently shrinks each
- *    season because the rule replaces seeded ESP3 teams with fewer.
+ * Algorithm (in order):
+ *  1. Add every non-reserve team from each tier in `auto_qualify_tiers`
+ *     (e.g. ESP1, ESP2 → all teams in those leagues).
+ *  2. Add the top N non-reserves from each competition in `top_per_group`
+ *     (e.g. ESP3A and ESP3B → top 5 each).
+ *  3. Preserve any regional teams already in the cup that aren't in any
+ *     playable tier (lower-division seed teams from data/<year>/ESPCUP).
+ *  4. If `target_size` is set, fill to that size by walking the next
+ *     positions in the `top_per_group` competitions, skipping reserves
+ *     and teams already qualified.
+ *  5. If after step 4 the field is still smaller than `target_size`,
+ *     throw — the cup is the parity invariant (an even round-1 pool
+ *     after the supercup bump), and silent shortfalls are what produced
+ *     the 93 broken Copa del Rey draws in production.
  *
- * Reserve teams (Team::parent_team_id is set) never qualify, regardless of
- * finishing position. When a reserve occupies a slot in an auto_qualify
- * tier, its seat cascades to top_per_group: for each ineligible reserve,
- * one additional pick is made from the groups (distributed round-robin),
- * so the cup stays at its expected size even as reserves climb divisions.
- *
- * Teams currently in the cup that are not registered in any playable tier
- * (lower-division seed teams) are left untouched so regional qualifiers
- * keep their cup place.
+ * Reserve teams (Team::parent_team_id is set) never qualify, regardless
+ * of finishing position. They're skipped at every step.
  */
 class CopaQualificationProcessor implements SeasonProcessor
 {
@@ -74,6 +71,19 @@ class CopaQualificationProcessor implements SeasonProcessor
     }
 
     /**
+     * Build the cup field for a country in the order that mirrors the rule:
+     *
+     *   1. All teams from auto_qualify_tiers (ESP1, ESP2 — minus reserves).
+     *   2. Top N from each top_per_group competition (ESP3A/B top 5 — minus reserves).
+     *   3. Pre-existing regional teams already in the cup (lower-division
+     *      seed teams not registered in any playable tier).
+     *   4. Fill any remaining slots up to target_size from later positions
+     *      in the top_per_group competitions.
+     *
+     * If after step 4 the field still has fewer than target_size teams,
+     * throw — the cup is the parity invariant and silent shortfalls are
+     * what produced the 93 broken Copa del Rey draws in production.
+     *
      * @param  array{auto_qualify_tiers?: int[], top_per_group?: array<int, int>, target_size?: int}  $rule
      * @param  string[]  $reserveTeamIdsForCountry
      */
@@ -89,132 +99,108 @@ class CopaQualificationProcessor implements SeasonProcessor
             return;
         }
 
+        // Skip when this country isn't part of the game (no entries in any
+        // playable tier). The target_size invariant below catches partial-
+        // data shortfalls — wholly absent data is a different signal.
+        $hasAnyTierEntries = CompetitionEntry::where('game_id', $game->id)
+            ->whereIn('competition_id', $playableTierCompetitions)
+            ->exists();
+        if (!$hasAnyTierEntries) {
+            return;
+        }
+
         $reserveLookup = array_flip($reserveTeamIdsForCountry);
         $qualifiers = [];
-        $shortage = 0;
 
+        // 1. Auto-qualify tiers.
         foreach ($rule['auto_qualify_tiers'] ?? [] as $tier) {
             foreach ($this->countryConfig->tierCompetitionIds($countryCode, $tier) as $competitionId) {
                 foreach ($this->teamsInCompetition($game->id, $competitionId) as $teamId) {
+                    if (!isset($reserveLookup[$teamId])) {
+                        $qualifiers[$teamId] = true;
+                    }
+                }
+            }
+        }
+
+        // 2. Top N per group. Collect the group competition IDs in order so
+        //    step 4 can revisit them to backfill any remaining slots.
+        $groupCompetitionIds = [];
+        foreach ($rule['top_per_group'] ?? [] as $tier => $topN) {
+            foreach ($this->countryConfig->tierCompetitionIds($countryCode, $tier) as $competitionId) {
+                $groupCompetitionIds[] = $competitionId;
+                $picked = 0;
+                foreach ($this->rankedTeams($game, $competitionId) as $teamId) {
                     if (isset($reserveLookup[$teamId])) {
-                        // Reserve team occupies a league slot but can't play
-                        // in the cup — its seat cascades down to the next
-                        // top_per_group pick so the bracket stays full.
-                        $shortage++;
+                        continue;
+                    }
+                    if (isset($qualifiers[$teamId])) {
                         continue;
                     }
                     $qualifiers[$teamId] = true;
+                    if (++$picked >= $topN) {
+                        break;
+                    }
                 }
             }
         }
 
-        // Gather every group (primary + siblings) with its base quota so we
-        // can distribute any cascaded seats round-robin across groups.
-        $groups = [];
-        foreach ($rule['top_per_group'] ?? [] as $tier => $topN) {
-            foreach ($this->countryConfig->tierCompetitionIds($countryCode, $tier) as $competitionId) {
-                $groups[] = ['competition' => $competitionId, 'topN' => $topN];
-            }
-        }
-
-        if (!empty($groups) && $shortage > 0) {
-            for ($i = 0; $i < $shortage; $i++) {
-                $groups[$i % count($groups)]['topN']++;
-            }
-        }
-
-        // Pre-load each group's ranked team list once, with a cursor so we
-        // can resume picking past the base topN during the target-size
-        // top-up phase below.
-        $groupRanked = array_map(
-            fn (array $g) => $this->rankedTeams($game, $g['competition']),
-            $groups,
-        );
-        $groupCursors = array_fill(0, count($groups), 0);
-
-        // Phase 1: respect each group's base topN (the long-standing
-        // semantics — exactly N non-reserve picks per group when possible).
-        foreach ($groups as $idx => $group) {
-            $picked = 0;
-            while (
-                $picked < $group['topN']
-                && $groupCursors[$idx] < count($groupRanked[$idx])
-            ) {
-                $teamId = $groupRanked[$idx][$groupCursors[$idx]++];
-                if (isset($reserveLookup[$teamId])) {
-                    continue;
-                }
-                if (isset($qualifiers[$teamId])) {
-                    continue;
-                }
-                $qualifiers[$teamId] = true;
-                $picked++;
-            }
-        }
-
-        // Lower-tier seed teams (in the cup but not registered in any
-        // playable tier and not reserves) survive the rebuild, so they
-        // count toward the target_size invariant alongside qualifiers.
+        // 3. Preserve regional teams currently in the cup (in cup entries
+        //    but not registered in any playable tier and not reserves).
         $playableTierTeamIds = CompetitionEntry::where('game_id', $game->id)
             ->whereIn('competition_id', $playableTierCompetitions)
             ->pluck('team_id')
             ->unique()
             ->all();
 
-        $untouchedCount = $this->countUntouchedCupTeams(
-            $game->id,
-            $cupId,
-            $playableTierTeamIds,
-            $reserveTeamIdsForCountry,
-        );
+        $excludeFromRegional = array_unique(array_merge($playableTierTeamIds, $reserveTeamIdsForCountry));
+        $regionalQuery = CompetitionEntry::where('game_id', $game->id)
+            ->where('competition_id', $cupId);
+        if (!empty($excludeFromRegional)) {
+            $regionalQuery->whereNotIn('team_id', $excludeFromRegional);
+        }
+        foreach ($regionalQuery->pluck('team_id') as $teamId) {
+            $qualifiers[$teamId] = true;
+        }
 
-        // Phase 2: top up to target_size by pulling next-ranked non-reserves
-        // round-robin across groups. Skips exhausted groups; stops when
-        // either the target is reached or every group is exhausted.
+        // 4. Fill to target_size from remaining top_per_group competitions
+        //    (positions beyond the top-N already taken).
         $targetSize = $rule['target_size'] ?? null;
-        if ($targetSize !== null && !empty($groups)) {
-            $deficit = $targetSize - count($qualifiers) - $untouchedCount;
-            $idx = 0;
-            $consecutiveExhausted = 0;
-            $groupCount = count($groups);
-
-            while ($deficit > 0 && $consecutiveExhausted < $groupCount) {
-                $teamId = $this->advanceCursor($groupRanked[$idx], $groupCursors, $idx, $reserveLookup, $qualifiers);
-
-                if ($teamId === null) {
-                    $consecutiveExhausted++;
-                } else {
-                    $qualifiers[$teamId] = true;
-                    $deficit--;
-                    $consecutiveExhausted = 0;
+        if ($targetSize !== null) {
+            foreach ($groupCompetitionIds as $competitionId) {
+                if (count($qualifiers) >= $targetSize) {
+                    break;
                 }
-
-                $idx = ($idx + 1) % $groupCount;
+                foreach ($this->rankedTeams($game, $competitionId) as $teamId) {
+                    if (count($qualifiers) >= $targetSize) {
+                        break;
+                    }
+                    if (isset($reserveLookup[$teamId])) {
+                        continue;
+                    }
+                    if (isset($qualifiers[$teamId])) {
+                        continue;
+                    }
+                    $qualifiers[$teamId] = true;
+                }
             }
 
-            if ($deficit > 0) {
-                // Target size is the cup's parity invariant — odd
-                // shortfalls are exactly what produced the 93 broken
-                // Copa del Rey draws in production. Throw rather than
-                // log: silent shortfalls hide the bug we just fixed.
+            if (count($qualifiers) < $targetSize) {
                 throw new \RuntimeException(sprintf(
-                    '[CopaQualification] %s: target_size %d unreachable for game %s '
-                    . '(short by %d, qualifier_pool exhausted across all top_per_group groups). '
+                    '[CopaQualification] %s for game %s: target_size %d unreachable, got %d. '
                     . 'Check cup_qualification rule, reserve filtering, or league sizes.',
                     $cupId,
-                    $targetSize,
                     $game->id,
-                    $deficit,
+                    $targetSize,
+                    count($qualifiers),
                 ));
             }
         }
 
-        // Remove existing cup entries for teams that are part of the playable
-        // tier system — we're redeciding qualification for those. Also drop
-        // any reserve teams that may have slipped in previously. Lower-tier
-        // seed teams (not registered in any playable tier) are left alone.
+        // Replace cup entries: clear playable-tier + reserves, upsert the
+        // new field. Regional teams added in step 3 are preserved by the
+        // upsert (no rows for them are deleted).
         $teamIdsToClear = array_unique(array_merge($playableTierTeamIds, $reserveTeamIdsForCountry));
-
         if (!empty($teamIdsToClear)) {
             CompetitionEntry::where('game_id', $game->id)
                 ->where('competition_id', $cupId)
@@ -223,8 +209,6 @@ class CopaQualificationProcessor implements SeasonProcessor
         }
 
         if (empty($qualifiers)) {
-            Log::info("[CopaQualification] {$cupId}: no qualifiers after filtering reserves");
-
             return;
         }
 
@@ -241,59 +225,7 @@ class CopaQualificationProcessor implements SeasonProcessor
             ['entry_round']
         );
 
-        Log::info("[CopaQualification] {$cupId}: " . count($rows) . ' qualifiers from playable tiers');
-    }
-
-    /**
-     * Advance the cursor for one group past reserves and already-qualified
-     * teams, returning the next eligible team_id or null if exhausted.
-     *
-     * @param  array<int, string>  $ranked
-     * @param  array<int, int>  $cursors
-     * @param  array<string, int>  $reserveLookup
-     * @param  array<string, true>  $qualifiers
-     */
-    private function advanceCursor(array $ranked, array &$cursors, int $idx, array $reserveLookup, array $qualifiers): ?string
-    {
-        while ($cursors[$idx] < count($ranked)) {
-            $teamId = $ranked[$cursors[$idx]++];
-
-            if (isset($reserveLookup[$teamId])) {
-                continue;
-            }
-            if (isset($qualifiers[$teamId])) {
-                continue;
-            }
-
-            return $teamId;
-        }
-
-        return null;
-    }
-
-    /**
-     * Count cup entries that survive the rebuild — i.e. teams in the cup
-     * but not registered in any playable tier and not reserves.
-     *
-     * @param  string[]  $playableTierTeamIds
-     * @param  string[]  $reserveTeamIdsForCountry
-     */
-    private function countUntouchedCupTeams(
-        string $gameId,
-        string $cupId,
-        array $playableTierTeamIds,
-        array $reserveTeamIdsForCountry,
-    ): int {
-        $excluded = array_unique(array_merge($playableTierTeamIds, $reserveTeamIdsForCountry));
-
-        $query = CompetitionEntry::where('game_id', $gameId)
-            ->where('competition_id', $cupId);
-
-        if (!empty($excluded)) {
-            $query->whereNotIn('team_id', $excluded);
-        }
-
-        return $query->count();
+        Log::info("[CopaQualification] {$cupId}: " . count($rows) . ' qualifiers');
     }
 
     /**

--- a/app/Modules/Season/Processors/CopaQualificationProcessor.php
+++ b/app/Modules/Season/Processors/CopaQualificationProcessor.php
@@ -25,6 +25,11 @@ use Illuminate\Support\Facades\Log;
  *    season's cup.
  *  - top_per_group: the top N teams in each competition at this tier
  *    (including siblings — e.g. ESP3A and ESP3B) qualify.
+ *  - target_size (optional): total cup size to maintain. After the rule
+ *    pass, the processor pulls additional non-reserves from top_per_group
+ *    groups round-robin until qualifiers + untouched regional seed teams
+ *    equal this number. Without it the cup permanently shrinks each
+ *    season because the rule replaces seeded ESP3 teams with fewer.
  *
  * Reserve teams (Team::parent_team_id is set) never qualify, regardless of
  * finishing position. When a reserve occupies a slot in an auto_qualify
@@ -69,7 +74,7 @@ class CopaQualificationProcessor implements SeasonProcessor
     }
 
     /**
-     * @param  array{auto_qualify_tiers?: int[], top_per_group?: array<int, int>}  $rule
+     * @param  array{auto_qualify_tiers?: int[], top_per_group?: array<int, int>, target_size?: int}  $rule
      * @param  string[]  $reserveTeamIdsForCountry
      */
     private function rebuildCupEntries(
@@ -118,20 +123,89 @@ class CopaQualificationProcessor implements SeasonProcessor
             }
         }
 
-        // For each group, qualify the top N non-reserve teams — skipping any
-        // reserves in higher positions so the group always contributes
-        // exactly N qualifiers when enough are eligible.
-        foreach ($groups as $group) {
+        // Pre-load each group's ranked team list once, with a cursor so we
+        // can resume picking past the base topN during the target-size
+        // top-up phase below.
+        $groupRanked = array_map(
+            fn (array $g) => $this->rankedTeams($game, $g['competition']),
+            $groups,
+        );
+        $groupCursors = array_fill(0, count($groups), 0);
+
+        // Phase 1: respect each group's base topN (the long-standing
+        // semantics — exactly N non-reserve picks per group when possible).
+        foreach ($groups as $idx => $group) {
             $picked = 0;
-            foreach ($this->rankedTeams($game, $group['competition']) as $teamId) {
+            while (
+                $picked < $group['topN']
+                && $groupCursors[$idx] < count($groupRanked[$idx])
+            ) {
+                $teamId = $groupRanked[$idx][$groupCursors[$idx]++];
                 if (isset($reserveLookup[$teamId])) {
+                    continue;
+                }
+                if (isset($qualifiers[$teamId])) {
                     continue;
                 }
                 $qualifiers[$teamId] = true;
                 $picked++;
-                if ($picked >= $group['topN']) {
-                    break;
+            }
+        }
+
+        // Lower-tier seed teams (in the cup but not registered in any
+        // playable tier and not reserves) survive the rebuild, so they
+        // count toward the target_size invariant alongside qualifiers.
+        $playableTierTeamIds = CompetitionEntry::where('game_id', $game->id)
+            ->whereIn('competition_id', $playableTierCompetitions)
+            ->pluck('team_id')
+            ->unique()
+            ->all();
+
+        $untouchedCount = $this->countUntouchedCupTeams(
+            $game->id,
+            $cupId,
+            $playableTierTeamIds,
+            $reserveTeamIdsForCountry,
+        );
+
+        // Phase 2: top up to target_size by pulling next-ranked non-reserves
+        // round-robin across groups. Skips exhausted groups; stops when
+        // either the target is reached or every group is exhausted.
+        $targetSize = $rule['target_size'] ?? null;
+        if ($targetSize !== null && !empty($groups)) {
+            $deficit = $targetSize - count($qualifiers) - $untouchedCount;
+            $idx = 0;
+            $consecutiveExhausted = 0;
+            $groupCount = count($groups);
+
+            while ($deficit > 0 && $consecutiveExhausted < $groupCount) {
+                $teamId = $this->advanceCursor($groupRanked[$idx], $groupCursors, $idx, $reserveLookup, $qualifiers);
+
+                if ($teamId === null) {
+                    $consecutiveExhausted++;
+                } else {
+                    $qualifiers[$teamId] = true;
+                    $deficit--;
+                    $consecutiveExhausted = 0;
                 }
+
+                $idx = ($idx + 1) % $groupCount;
+            }
+
+            if ($deficit > 0) {
+                // Target size is the cup's parity invariant — odd
+                // shortfalls are exactly what produced the 93 broken
+                // Copa del Rey draws in production. Throw rather than
+                // log: silent shortfalls hide the bug we just fixed.
+                throw new \RuntimeException(sprintf(
+                    '[CopaQualification] %s: target_size %d unreachable for game %s '
+                    . '(short by %d, qualifier_pool exhausted across all top_per_group groups). '
+                    . 'Check cup_qualification rule, reserve filtering, or league sizes.',
+                    $cupId,
+                    $targetSize,
+                    $game->id,
+                    $deficit,
+                ));
             }
         }
 
@@ -139,12 +213,6 @@ class CopaQualificationProcessor implements SeasonProcessor
         // tier system — we're redeciding qualification for those. Also drop
         // any reserve teams that may have slipped in previously. Lower-tier
         // seed teams (not registered in any playable tier) are left alone.
-        $playableTierTeamIds = CompetitionEntry::where('game_id', $game->id)
-            ->whereIn('competition_id', $playableTierCompetitions)
-            ->pluck('team_id')
-            ->unique()
-            ->all();
-
         $teamIdsToClear = array_unique(array_merge($playableTierTeamIds, $reserveTeamIdsForCountry));
 
         if (!empty($teamIdsToClear)) {
@@ -174,6 +242,58 @@ class CopaQualificationProcessor implements SeasonProcessor
         );
 
         Log::info("[CopaQualification] {$cupId}: " . count($rows) . ' qualifiers from playable tiers');
+    }
+
+    /**
+     * Advance the cursor for one group past reserves and already-qualified
+     * teams, returning the next eligible team_id or null if exhausted.
+     *
+     * @param  array<int, string>  $ranked
+     * @param  array<int, int>  $cursors
+     * @param  array<string, int>  $reserveLookup
+     * @param  array<string, true>  $qualifiers
+     */
+    private function advanceCursor(array $ranked, array &$cursors, int $idx, array $reserveLookup, array $qualifiers): ?string
+    {
+        while ($cursors[$idx] < count($ranked)) {
+            $teamId = $ranked[$cursors[$idx]++];
+
+            if (isset($reserveLookup[$teamId])) {
+                continue;
+            }
+            if (isset($qualifiers[$teamId])) {
+                continue;
+            }
+
+            return $teamId;
+        }
+
+        return null;
+    }
+
+    /**
+     * Count cup entries that survive the rebuild — i.e. teams in the cup
+     * but not registered in any playable tier and not reserves.
+     *
+     * @param  string[]  $playableTierTeamIds
+     * @param  string[]  $reserveTeamIdsForCountry
+     */
+    private function countUntouchedCupTeams(
+        string $gameId,
+        string $cupId,
+        array $playableTierTeamIds,
+        array $reserveTeamIdsForCountry,
+    ): int {
+        $excluded = array_unique(array_merge($playableTierTeamIds, $reserveTeamIdsForCountry));
+
+        $query = CompetitionEntry::where('game_id', $gameId)
+            ->where('competition_id', $cupId);
+
+        if (!empty($excluded)) {
+            $query->whereNotIn('team_id', $excluded);
+        }
+
+        return $query->count();
     }
 
     /**

--- a/app/Modules/Season/Processors/SupercupQualificationProcessor.php
+++ b/app/Modules/Season/Processors/SupercupQualificationProcessor.php
@@ -160,19 +160,12 @@ class SupercupQualificationProcessor implements SeasonProcessor
     }
 
     /**
-     * Determine the 4 supercup qualifiers in RFEF priority order:
-     *
-     *   1. Cup winner.
-     *   2. Cup runner-up.
-     *   3. League champion (skipped if already in slot 1–2).
-     *   4. League runner-up (skipped if already in slot 1–3).
-     *   5. League 3rd, 4th, … to backfill whichever league slot was
-     *      displaced by a cup-finalist overlap.
-     *
-     * The cup finalists' slots are never displaced — when overlap
-     * occurs it's the league's "1st / 2nd" slot that cascades to 3rd
-     * or 4th, mirroring "la plaza de la Supercopa se otorga al 3º
-     * (y 4º si fuera necesario) clasificado de la Liga".
+     * Determine the 4 supercup qualifiers in RFEF priority order: the two
+     * cup finalists hold their slots regardless of league finish, then
+     * league positions fill what remains, in order. When a cup finalist
+     * also happens to be league 1st/2nd, the league's slot is what
+     * cascades down to 3rd / 4th — mirroring "la plaza de la Supercopa
+     * se otorga al 3º (y 4º si fuera necesario) clasificado de la Liga".
      *
      * @param  array{winner: string|null, runnerUp: string|null}  $cupFinalists
      * @param  array<int, string>  $leagueTopTeams  league positions 1..N (1st first)
@@ -183,27 +176,26 @@ class SupercupQualificationProcessor implements SeasonProcessor
         $qualifiers = [];
         $usedTeams = [];
 
-        $add = function (?string $teamId) use (&$qualifiers, &$usedTeams): void {
-            if ($teamId === null || isset($usedTeams[$teamId]) || count($qualifiers) >= 4) {
-                return;
+        if ($cupFinalists['winner']) {
+            $qualifiers[] = $cupFinalists['winner'];
+            $usedTeams[$cupFinalists['winner']] = true;
+        }
+        if ($cupFinalists['runnerUp']) {
+            $qualifiers[] = $cupFinalists['runnerUp'];
+            $usedTeams[$cupFinalists['runnerUp']] = true;
+        }
+
+        foreach ($leagueTopTeams as $teamId) {
+            if (count($qualifiers) >= 4) {
+                break;
             }
+
+            if (isset($usedTeams[$teamId])) {
+                continue;
+            }
+
             $qualifiers[] = $teamId;
             $usedTeams[$teamId] = true;
-        };
-
-        // 1–2. Cup finalists always qualify.
-        $add($cupFinalists['winner'] ?? null);
-        $add($cupFinalists['runnerUp'] ?? null);
-
-        // 3–4. League champion and runner-up. Skipped if they're already
-        // a cup finalist — that's where the "plaza advances" rule kicks
-        // in and the next loop picks up the slack from 3rd / 4th.
-        $add($leagueTopTeams[0] ?? null);
-        $add($leagueTopTeams[1] ?? null);
-
-        // 5. Cascade: fill any vacancy from 3rd, 4th, ...
-        foreach (array_slice($leagueTopTeams, 2) as $teamId) {
-            $add($teamId);
         }
 
         return $qualifiers;

--- a/app/Modules/Season/Processors/SupercupQualificationProcessor.php
+++ b/app/Modules/Season/Processors/SupercupQualificationProcessor.php
@@ -68,6 +68,16 @@ class SupercupQualificationProcessor implements SeasonProcessor
         $supercupId = $config['competition'];
         $cupFinalRound = $config['cup_final_round'];
 
+        // Skip when this country isn't part of the game (no top-league
+        // entries). The 4-qualifier guard below catches partial-data bugs
+        // — wholly absent data is a different signal and shouldn't trip it.
+        $hasLeague = CompetitionEntry::where('game_id', $game->id)
+            ->where('competition_id', $leagueId)
+            ->exists();
+        if (!$hasLeague) {
+            return;
+        }
+
         // Get cup finalists
         $cupFinalists = $this->getCupFinalists($game->id, $cupId, $cupFinalRound);
 

--- a/app/Modules/Season/Processors/SupercupQualificationProcessor.php
+++ b/app/Modules/Season/Processors/SupercupQualificationProcessor.php
@@ -10,15 +10,29 @@ use App\Models\Game;
 use App\Models\CompetitionEntry;
 use App\Models\GameStanding;
 use App\Models\SimulatedSeason;
+use RuntimeException;
 
 /**
- * Determines supercup qualifiers for the next season,
- * driven by country config.
+ * Determines supercup qualifiers for the next season, driven by country config.
  *
- * Qualification rules (per country's supercup config):
- * - The two domestic cup finalists
- * - League champion and runner-up
- * - If there's overlap, the next highest league team qualifies
+ * Qualification rules (RFEF for ESP, generalised for any country):
+ *  1. The two cup finalists always qualify (cup winner + cup runner-up).
+ *  2. The league champion qualifies, unless already in slot 1–2.
+ *  3. The league runner-up qualifies, unless already in slot 1–3.
+ *  4. If either cup finalist also finished league 1st or 2nd, the *league*
+ *     slot they would have taken cascades down to 3rd / 4th to fill the
+ *     four-team field. The cup-finalist slot itself is never displaced.
+ *
+ * RFEF wording (Copa del Rey → Supercopa de España):
+ *   "Si el campeón o subcampeón de Copa del Rey ya está clasificado entre
+ *    los dos primeros de Liga, la plaza de la Supercopa se otorga al 3º
+ *    (y 4º si fuera necesario) clasificado de la Liga para completar los
+ *    cuatro participantes."
+ *
+ * The "plaza" (spot) that advances is the league's, not the cup's — the
+ * cup finalists keep priority and the league simply fills whatever
+ * remains. Implementing this priority order also matters for downstream
+ * display: the persisted entry order labels each slot's role.
  *
  * Priority: 25 (runs after stats reset but before fixture generation)
  */
@@ -57,11 +71,30 @@ class SupercupQualificationProcessor implements SeasonProcessor
         // Get cup finalists
         $cupFinalists = $this->getCupFinalists($game->id, $cupId, $cupFinalRound);
 
-        // Get league top teams (enough to handle overlaps)
+        // Fetch league top 4 — enough to backfill 3rd/4th slots when both
+        // cup finalists overlap with the league champion/runner-up.
         $leagueTopTeams = $this->getLeagueTopTeams($game->id, $leagueId, 4);
 
         // Determine the 4 supercup qualifiers
         $qualifiers = $this->determineQualifiers($cupFinalists, $leagueTopTeams);
+
+        if (count($qualifiers) !== 4) {
+            // Source of Population A in the cup-draw incident: cup didn't
+            // run AND fewer than 4 league top teams are available, so the
+            // supercup ends up with < 4 entries and the downstream draw
+            // creates the wrong bracket. Surface this loudly — silent
+            // shortfalls are how the bug stayed hidden in the first place.
+            throw new RuntimeException(sprintf(
+                '[SupercupQualification] expected 4 qualifiers for %s in game %s, got %d. '
+                . 'cup_winner=%s cup_runnerup=%s league_top_teams=%d',
+                $supercupId,
+                $game->id,
+                count($qualifiers),
+                $cupFinalists['winner'] ?? 'null',
+                $cupFinalists['runnerUp'] ?? 'null',
+                count($leagueTopTeams),
+            ));
+        }
 
         // Update supercup competition_entries for this game
         $this->updateSupercupTeams($game->id, $supercupId, $qualifiers);
@@ -127,37 +160,50 @@ class SupercupQualificationProcessor implements SeasonProcessor
     }
 
     /**
-     * Determine the 4 supercup qualifiers, handling overlaps.
+     * Determine the 4 supercup qualifiers in RFEF priority order:
      *
-     * @return array<string> 4 team IDs
+     *   1. Cup winner.
+     *   2. Cup runner-up.
+     *   3. League champion (skipped if already in slot 1–2).
+     *   4. League runner-up (skipped if already in slot 1–3).
+     *   5. League 3rd, 4th, … to backfill whichever league slot was
+     *      displaced by a cup-finalist overlap.
+     *
+     * The cup finalists' slots are never displaced — when overlap
+     * occurs it's the league's "1st / 2nd" slot that cascades to 3rd
+     * or 4th, mirroring "la plaza de la Supercopa se otorga al 3º
+     * (y 4º si fuera necesario) clasificado de la Liga".
+     *
+     * @param  array{winner: string|null, runnerUp: string|null}  $cupFinalists
+     * @param  array<int, string>  $leagueTopTeams  league positions 1..N (1st first)
+     * @return array<string>  up to 4 team IDs
      */
     private function determineQualifiers(array $cupFinalists, array $leagueTopTeams): array
     {
         $qualifiers = [];
         $usedTeams = [];
 
-        // Add cup finalists first (if available)
-        if ($cupFinalists['winner']) {
-            $qualifiers[] = $cupFinalists['winner'];
-            $usedTeams[$cupFinalists['winner']] = true;
-        }
-        if ($cupFinalists['runnerUp']) {
-            $qualifiers[] = $cupFinalists['runnerUp'];
-            $usedTeams[$cupFinalists['runnerUp']] = true;
-        }
-
-        // Add league teams until we have 4 qualifiers
-        foreach ($leagueTopTeams as $teamId) {
-            if (count($qualifiers) >= 4) {
-                break;
+        $add = function (?string $teamId) use (&$qualifiers, &$usedTeams): void {
+            if ($teamId === null || isset($usedTeams[$teamId]) || count($qualifiers) >= 4) {
+                return;
             }
-
-            if (isset($usedTeams[$teamId])) {
-                continue;
-            }
-
             $qualifiers[] = $teamId;
             $usedTeams[$teamId] = true;
+        };
+
+        // 1–2. Cup finalists always qualify.
+        $add($cupFinalists['winner'] ?? null);
+        $add($cupFinalists['runnerUp'] ?? null);
+
+        // 3–4. League champion and runner-up. Skipped if they're already
+        // a cup finalist — that's where the "plaza advances" rule kicks
+        // in and the next loop picks up the slack from 3rd / 4th.
+        $add($leagueTopTeams[0] ?? null);
+        $add($leagueTopTeams[1] ?? null);
+
+        // 5. Cascade: fill any vacancy from 3rd, 4th, ...
+        foreach (array_slice($leagueTopTeams, 2) as $teamId) {
+            $add($teamId);
         }
 
         return $qualifiers;

--- a/config/countries.php
+++ b/config/countries.php
@@ -106,6 +106,13 @@ return [
                 'top_per_group' => [
                     3 => 5,
                 ],
+                // Total cup size invariant. After auto_qualify + top_per_group +
+                // reserve cascade, the processor tops up by pulling additional
+                // non-reserves round-robin from top_per_group groups until the
+                // qualifier count + untouched regional seed teams equal this
+                // number. Without it, the cup permanently shrinks each season
+                // because the rule replaces 21 seeded ESP3 teams with 11.
+                'target_size' => 116,
             ],
         ],
 

--- a/tests/Feature/AdvanceMatchdayTest.php
+++ b/tests/Feature/AdvanceMatchdayTest.php
@@ -41,9 +41,12 @@ class AdvanceMatchdayTest extends TestCase
             'name' => 'LaLiga',
         ]);
 
+        // Use a cup ID with no schedule.json so resolving a single tie
+        // doesn't trigger a next-round draw on a 1-team pool. These tests
+        // cover advancement and tie resolution, not bracket drawing.
         $this->cupCompetition = Competition::factory()->knockoutCup()->create([
-            'id' => 'ESPCUP',
-            'name' => 'Copa del Rey',
+            'id' => 'TESTCUP',
+            'name' => 'Test Cup',
             'season' => '2025',
         ]);
 

--- a/tests/Feature/AdvanceMatchdayTest.php
+++ b/tests/Feature/AdvanceMatchdayTest.php
@@ -41,12 +41,9 @@ class AdvanceMatchdayTest extends TestCase
             'name' => 'LaLiga',
         ]);
 
-        // Use a cup ID with no schedule.json so resolving a single tie
-        // doesn't trigger a next-round draw on a 1-team pool. These tests
-        // cover advancement and tie resolution, not bracket drawing.
         $this->cupCompetition = Competition::factory()->knockoutCup()->create([
-            'id' => 'TESTCUP',
-            'name' => 'Test Cup',
+            'id' => 'ESPCUP',
+            'name' => 'Copa del Rey',
             'season' => '2025',
         ]);
 
@@ -243,20 +240,21 @@ class AdvanceMatchdayTest extends TestCase
 
     public function test_resolves_single_leg_cup_tie(): void
     {
-        // Create a cup tie
+        // Use the final (round 7) so the post-resolution listener finds no
+        // next round in schedule.json — keeping this test focused on tie
+        // resolution rather than the next-round draw path.
         $cupTie = CupTie::factory()->create([
             'game_id' => $this->game->id,
             'competition_id' => $this->cupCompetition->id,
-            'round_number' => 1,
+            'round_number' => 7,
             'home_team_id' => $this->playerTeam->id,
             'away_team_id' => $this->opponentTeam->id,
         ]);
 
-        // Create cup match
         $cupMatch = GameMatch::factory()->create([
             'game_id' => $this->game->id,
             'competition_id' => $this->cupCompetition->id,
-            'round_number' => 1,
+            'round_number' => 7,
             'home_team_id' => $this->playerTeam->id,
             'away_team_id' => $this->opponentTeam->id,
             'scheduled_date' => Carbon::parse('2024-11-01'),

--- a/tests/Feature/CopaQualificationTest.php
+++ b/tests/Feature/CopaQualificationTest.php
@@ -113,11 +113,12 @@ class CopaQualificationTest extends TestCase
         $this->assertCount(5, $esp3aQualifiers, 'ESP3A still contributes exactly 5 qualifiers');
     }
 
-    public function test_reserve_in_auto_qualify_tier_cascades_extra_slot_to_primera_rfef_groups(): void
+    public function test_reserves_in_auto_qualify_tier_are_skipped_without_cascade(): void
     {
-        // Three reserves occupying ESP2 slots — cascade should add 3 total
-        // picks across the two groups (round-robin: A=+2, B=+1 → A picks 7,
-        // B picks 6), keeping the cup at 52 qualifiers.
+        // Three reserves in ESP2 — they're simply skipped, shrinking the
+        // rule output to 49. Without target_size set the cup just gets
+        // smaller; the target_size top-up (covered separately below) is
+        // what restores the cup to its full size.
         $parents = $this->teamsByCompetition['ESP1'];
         $this->teamsByCompetition['ESP2'][5]->update(['parent_team_id' => $parents[0]->id]);
         $this->teamsByCompetition['ESP2'][10]->update(['parent_team_id' => $parents[1]->id]);
@@ -126,16 +127,7 @@ class CopaQualificationTest extends TestCase
         $this->runProcessor();
 
         $entries = $this->cupEntries();
-        $this->assertCount(52, $entries, 'Cup should stay at 52 qualifiers');
-
-        $esp3aIds = array_map(fn (Team $t) => $t->id, $this->teamsByCompetition['ESP3A']);
-        $esp3bIds = array_map(fn (Team $t) => $t->id, $this->teamsByCompetition['ESP3B']);
-
-        $esp3aCount = count(array_intersect($entries, $esp3aIds));
-        $esp3bCount = count(array_intersect($entries, $esp3bIds));
-
-        $this->assertEquals(7, $esp3aCount, 'ESP3A absorbs 2 cascaded seats');
-        $this->assertEquals(6, $esp3bCount, 'ESP3B absorbs 1 cascaded seat');
+        $this->assertCount(49, $entries, '20 ESP1 + 19 ESP2 (3 reserves skipped) + 5+5 ESP3 = 49');
 
         // The three reserves themselves never qualify
         $this->assertNotContains($this->teamsByCompetition['ESP2'][5]->id, $entries);
@@ -216,75 +208,34 @@ class CopaQualificationTest extends TestCase
     }
 
     // ---------------------------------------------------------------------
-    // target_size invariant
-    //
-    // These tests cover the outer top-up layer that maintains a stable cup
-    // size across season transitions. Without it the cup permanently shrinks
-    // because the rule replaces the seed's ~21 ESP3 teams with only 11 —
-    // which produced 93 broken Copa del Rey draws in production with odd
-    // team pools cascading into missing semifinal ties.
+    // target_size invariant — fills the cup back to a fixed size after the
+    // rule pass so it doesn't permanently shrink each season. Walks the
+    // top_per_group competitions sequentially (ESP3A first, then ESP3B),
+    // skipping reserves and teams already qualified.
     // ---------------------------------------------------------------------
 
-    public function test_target_size_tops_up_qualifiers_to_meet_total(): void
+    public function test_target_size_fills_remaining_slots_from_primera_rfef(): void
     {
-        // Rule produces 52 qualifiers (20+22+5+5). target_size=70 means we
-        // need to pull 18 more non-reserves from the ESP3 groups.
+        // Rule produces 52 qualifiers (20+22+5+5). target_size=70 → need 18
+        // more from ESP3, walking ESP3A first. ESP3A has 15 teams left
+        // after the top-5; ESP3B contributes the remaining 3.
         config(['countries.ES.cup_qualification.ESPCUP.target_size' => 70]);
 
         $this->runProcessor();
 
         $entries = $this->cupEntries();
-        $this->assertCount(70, $entries, 'Cup must reach the target size via top-up');
+        $this->assertCount(70, $entries);
 
-        // ESP1+ESP2 still all in (auto_qualify exhaustive)
-        foreach (['ESP1', 'ESP2'] as $comp) {
-            foreach ($this->teamsByCompetition[$comp] as $team) {
-                $this->assertContains($team->id, $entries);
-            }
-        }
-
-        // ESP3 contribution: 5 base each + 18 top-up split round-robin = 9 extra
-        // each (5+9 = 14 each, 28 total) — but ESP3A goes first so it
-        // gets 9 extras and ESP3B gets 9 extras (pairs round-robin: idx 0,1,0,1...)
         $esp3aIds = array_map(fn (Team $t) => $t->id, $this->teamsByCompetition['ESP3A']);
         $esp3bIds = array_map(fn (Team $t) => $t->id, $this->teamsByCompetition['ESP3B']);
 
-        $esp3a = count(array_intersect($entries, $esp3aIds));
-        $esp3b = count(array_intersect($entries, $esp3bIds));
-
-        $this->assertSame(28, $esp3a + $esp3b, 'ESP3 groups together absorb the 18-team top-up');
-        // The 18 extras go round-robin starting from ESP3A → ESP3A=9 extra, ESP3B=9 extra.
-        $this->assertEqualsWithDelta(14, $esp3a, 1, 'ESP3A got fair share');
-        $this->assertEqualsWithDelta(14, $esp3b, 1, 'ESP3B got fair share');
+        $this->assertSame(20, count(array_intersect($entries, $esp3aIds)), 'ESP3A fully drained first');
+        $this->assertSame(8, count(array_intersect($entries, $esp3bIds)), 'ESP3B contributes its top 8');
     }
 
-    public function test_target_size_top_up_pulls_in_position_order(): void
+    public function test_target_size_skips_reserves_during_fill(): void
     {
-        config(['countries.ES.cup_qualification.ESPCUP.target_size' => 56]);
-
-        $this->runProcessor();
-
-        $entries = $this->cupEntries();
-        $this->assertCount(56, $entries);
-
-        // 4 extras over 52 qualifiers, distributed round-robin: ESP3A gets
-        // 2 extras (positions 6 & 7), ESP3B gets 2 extras (positions 6 & 7).
-        $esp3a = $this->teamsByCompetition['ESP3A'];
-        $esp3b = $this->teamsByCompetition['ESP3B'];
-
-        $this->assertContains($esp3a[5]->id, $entries, 'ESP3A pos 6 pulled in by top-up');
-        $this->assertContains($esp3a[6]->id, $entries, 'ESP3A pos 7 pulled in by top-up');
-        $this->assertNotContains($esp3a[7]->id, $entries, 'ESP3A pos 8 still excluded');
-
-        $this->assertContains($esp3b[5]->id, $entries, 'ESP3B pos 6 pulled in by top-up');
-        $this->assertContains($esp3b[6]->id, $entries, 'ESP3B pos 7 pulled in by top-up');
-        $this->assertNotContains($esp3b[7]->id, $entries, 'ESP3B pos 8 still excluded');
-    }
-
-    public function test_target_size_skips_reserves_during_top_up(): void
-    {
-        // Mark ESP3A pos 6 as a reserve. Top-up must skip it and grab pos 7
-        // for that ESP3A slot — final count still hits target.
+        // ESP3A pos 6 marked reserve. The fill phase must skip it.
         $parent = $this->teamsByCompetition['ESP1'][0];
         $this->teamsByCompetition['ESP3A'][5]->update(['parent_team_id' => $parent->id]);
 
@@ -294,27 +245,18 @@ class CopaQualificationTest extends TestCase
 
         $entries = $this->cupEntries();
         $this->assertCount(54, $entries);
-        $this->assertNotContains(
-            $this->teamsByCompetition['ESP3A'][5]->id,
-            $entries,
-            'Reserve at ESP3A pos 6 must never qualify even during top-up'
-        );
-        $this->assertContains(
-            $this->teamsByCompetition['ESP3A'][6]->id,
-            $entries,
-            'ESP3A pos 7 takes the slot the reserve would have'
-        );
+        $this->assertNotContains($this->teamsByCompetition['ESP3A'][5]->id, $entries, 'reserve never qualifies');
+        $this->assertContains($this->teamsByCompetition['ESP3A'][6]->id, $entries, 'pos 7 picked instead');
+        $this->assertContains($this->teamsByCompetition['ESP3A'][7]->id, $entries, 'pos 8 picked too');
     }
 
-    public function test_target_size_counts_untouched_regional_teams_against_target(): void
+    public function test_target_size_counts_regional_seed_teams(): void
     {
-        // Regional teams in cup but outside playable tiers. They survive the
-        // rebuild and count toward target_size, so the qualifier top-up
-        // should pull less from groups.
+        // 10 regional teams already in the cup → fill phase needs 8 fewer
+        // teams from ESP3 to reach target_size.
         $regional = collect(range(1, 10))->map(
             fn (int $i) => Team::factory()->create(['country' => 'ES', 'name' => "Regional {$i}"])
         );
-
         foreach ($regional as $team) {
             CompetitionEntry::create([
                 'game_id' => $this->game->id,
@@ -330,86 +272,42 @@ class CopaQualificationTest extends TestCase
 
         $entries = $this->cupEntries();
         $this->assertCount(70, $entries);
-
-        // 10 regional are preserved → only 60 qualifiers needed (52 base + 8 top-up)
         foreach ($regional as $team) {
-            $this->assertContains($team->id, $entries);
+            $this->assertContains($team->id, $entries, 'regional team preserved');
         }
-
-        $esp3aIds = array_map(fn (Team $t) => $t->id, $this->teamsByCompetition['ESP3A']);
-        $esp3bIds = array_map(fn (Team $t) => $t->id, $this->teamsByCompetition['ESP3B']);
-        $esp3Total = count(array_intersect($entries, $esp3aIds))
-            + count(array_intersect($entries, $esp3bIds));
-
-        // 5+5 base + 8 top-up across both groups = 18 ESP3 total
-        $this->assertSame(18, $esp3Total);
     }
 
     public function test_target_size_unreachable_throws_loudly(): void
     {
-        // target_size larger than the entire eligible team pool. The
-        // processor must throw — silent shortfalls are exactly how the
-        // 93-broken-Copa-del-Rey-draws bug stayed hidden in production.
+        // target_size larger than the entire eligible pool — must throw
+        // rather than write a partial cup.
         config(['countries.ES.cup_qualification.ESPCUP.target_size' => 1000]);
 
         $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessageMatches('/ESPCUP.*target_size 1000 unreachable.*short by/i');
+        $this->expectExceptionMessageMatches('/ESPCUP.*target_size 1000 unreachable/i');
 
         $this->runProcessor();
     }
 
-    public function test_target_size_below_rule_output_does_not_remove_qualifiers(): void
+    public function test_target_size_below_rule_output_keeps_full_field(): void
     {
-        // Rule output is already 52. A target_size of 30 would imply removal
-        // — but the contract is "top up, never trim", so qualifiers stay.
+        // Rule already produces 52. target_size of 30 doesn't trim — the
+        // fill phase just doesn't run. Documented behaviour: target_size
+        // is a floor, not a ceiling.
         config(['countries.ES.cup_qualification.ESPCUP.target_size' => 30]);
 
         $this->runProcessor();
 
-        $this->assertCount(
-            52,
-            $this->cupEntries(),
-            'Rule output must not be trimmed below its natural size'
-        );
+        $this->assertCount(52, $this->cupEntries());
     }
 
-    public function test_target_size_handles_one_group_exhausting_before_target(): void
+    public function test_target_size_with_supercup_bump_yields_even_round_1(): void
     {
-        // Mark every ESP3A team after pos 5 as a reserve so the group has
-        // exactly 5 eligible teams. With target_size demanding more from
-        // ESP3, the round-robin must skip exhausted ESP3A and keep pulling
-        // from ESP3B.
-        $parent = $this->teamsByCompetition['ESP1'][0];
-        for ($i = 5; $i < 20; $i++) {
-            $this->teamsByCompetition['ESP3A'][$i]->update(['parent_team_id' => $parent->id]);
-        }
-
-        config(['countries.ES.cup_qualification.ESPCUP.target_size' => 65]);
-
-        $this->runProcessor();
-
-        $entries = $this->cupEntries();
-
-        // Available: ESP1 (20) + ESP2 (22) + ESP3A 5 non-reserves + ESP3B 20 = 67.
-        // Target 65: pull rule baseline (52, but ESP3A only contributes 5 — actually
-        // the cascade DOES NOT trigger here since reserves aren't in
-        // auto_qualify_tiers, so baseline stays 52). Then top-up needs 13
-        // more. ESP3A has 0 left after 5; ESP3B has 15 left → all from B.
-        $this->assertCount(65, $entries);
-
-        $esp3bIds = array_map(fn (Team $t) => $t->id, $this->teamsByCompetition['ESP3B']);
-        $esp3bCount = count(array_intersect($entries, $esp3bIds));
-        $this->assertSame(18, $esp3bCount, 'ESP3B absorbed the entire top-up after ESP3A exhausted');
-    }
-
-    public function test_target_size_keeps_round_1_count_even_for_supercup_cascade(): void
-    {
-        // Production scenario: target_size 116 on Spain config. After
-        // SeasonInitializationService bumps 4 supercup teams to round 3,
-        // round 1 must contain an even count for a clean knockout cascade.
+        // The whole point of the invariant: round 1 must be even after the
+        // supercup teams are bumped to round 3. Production-shape numbers
+        // (116 cup teams, 64 of which are regional, 4 supercup teams).
         config(['countries.ES.cup_qualification.ESPCUP.target_size' => 116]);
 
-        // Add 64 regional teams to reach the production-like baseline.
         $regional = collect(range(1, 64))->map(
             fn (int $i) => Team::factory()->create(['country' => 'ES'])
         );
@@ -423,14 +321,12 @@ class CopaQualificationTest extends TestCase
         }
 
         $this->runProcessor();
+        $this->assertCount(116, $this->cupEntries());
 
-        $entries = $this->cupEntries();
-        $this->assertCount(116, $entries);
-
-        // Simulate the supercup bump for 4 teams.
+        // Simulate the 4-team supercup bump.
         CompetitionEntry::where('game_id', $this->game->id)
             ->where('competition_id', 'ESPCUP')
-            ->whereIn('team_id', array_slice($entries, 0, 4))
+            ->whereIn('team_id', array_slice($this->cupEntries(), 0, 4))
             ->update(['entry_round' => 3]);
 
         $round1 = CompetitionEntry::where('game_id', $this->game->id)
@@ -438,8 +334,8 @@ class CopaQualificationTest extends TestCase
             ->where('entry_round', 1)
             ->count();
 
-        $this->assertSame(112, $round1, 'Round 1 must be even for clean cascade');
-        $this->assertSame(0, $round1 % 2, 'Round 1 parity invariant');
+        $this->assertSame(112, $round1);
+        $this->assertSame(0, $round1 % 2, 'round 1 must be even');
     }
 
     private function runProcessor(): void

--- a/tests/Feature/CopaQualificationTest.php
+++ b/tests/Feature/CopaQualificationTest.php
@@ -27,6 +27,14 @@ class CopaQualificationTest extends TestCase
     {
         parent::setUp();
 
+        // Existing tests below verify rule-level semantics (auto_qualify +
+        // top_per_group + reserve cascade) in isolation. The new
+        // `target_size` invariant runs as an outer layer on top of those
+        // rules; tests for it live in the dedicated section at the bottom
+        // of this file and set target_size explicitly. To keep the rule-
+        // semantics tests stable, suppress target_size by default here.
+        config(['countries.ES.cup_qualification.ESPCUP.target_size' => null]);
+
         Competition::factory()->league()->create(['id' => 'ESP1', 'country' => 'ES', 'tier' => 1]);
         Competition::factory()->league()->create([
             'id' => 'ESP2', 'country' => 'ES', 'tier' => 2, 'handler_type' => 'league_with_playoff',
@@ -205,6 +213,233 @@ class CopaQualificationTest extends TestCase
         foreach (array_slice($this->teamsByCompetition['ESP3B'], 5) as $team) {
             $this->assertNotContains($team->id, $entries, 'Simulated non-top-5 does not qualify');
         }
+    }
+
+    // ---------------------------------------------------------------------
+    // target_size invariant
+    //
+    // These tests cover the outer top-up layer that maintains a stable cup
+    // size across season transitions. Without it the cup permanently shrinks
+    // because the rule replaces the seed's ~21 ESP3 teams with only 11 —
+    // which produced 93 broken Copa del Rey draws in production with odd
+    // team pools cascading into missing semifinal ties.
+    // ---------------------------------------------------------------------
+
+    public function test_target_size_tops_up_qualifiers_to_meet_total(): void
+    {
+        // Rule produces 52 qualifiers (20+22+5+5). target_size=70 means we
+        // need to pull 18 more non-reserves from the ESP3 groups.
+        config(['countries.ES.cup_qualification.ESPCUP.target_size' => 70]);
+
+        $this->runProcessor();
+
+        $entries = $this->cupEntries();
+        $this->assertCount(70, $entries, 'Cup must reach the target size via top-up');
+
+        // ESP1+ESP2 still all in (auto_qualify exhaustive)
+        foreach (['ESP1', 'ESP2'] as $comp) {
+            foreach ($this->teamsByCompetition[$comp] as $team) {
+                $this->assertContains($team->id, $entries);
+            }
+        }
+
+        // ESP3 contribution: 5 base each + 18 top-up split round-robin = 9 extra
+        // each (5+9 = 14 each, 28 total) — but ESP3A goes first so it
+        // gets 9 extras and ESP3B gets 9 extras (pairs round-robin: idx 0,1,0,1...)
+        $esp3aIds = array_map(fn (Team $t) => $t->id, $this->teamsByCompetition['ESP3A']);
+        $esp3bIds = array_map(fn (Team $t) => $t->id, $this->teamsByCompetition['ESP3B']);
+
+        $esp3a = count(array_intersect($entries, $esp3aIds));
+        $esp3b = count(array_intersect($entries, $esp3bIds));
+
+        $this->assertSame(28, $esp3a + $esp3b, 'ESP3 groups together absorb the 18-team top-up');
+        // The 18 extras go round-robin starting from ESP3A → ESP3A=9 extra, ESP3B=9 extra.
+        $this->assertEqualsWithDelta(14, $esp3a, 1, 'ESP3A got fair share');
+        $this->assertEqualsWithDelta(14, $esp3b, 1, 'ESP3B got fair share');
+    }
+
+    public function test_target_size_top_up_pulls_in_position_order(): void
+    {
+        config(['countries.ES.cup_qualification.ESPCUP.target_size' => 56]);
+
+        $this->runProcessor();
+
+        $entries = $this->cupEntries();
+        $this->assertCount(56, $entries);
+
+        // 4 extras over 52 qualifiers, distributed round-robin: ESP3A gets
+        // 2 extras (positions 6 & 7), ESP3B gets 2 extras (positions 6 & 7).
+        $esp3a = $this->teamsByCompetition['ESP3A'];
+        $esp3b = $this->teamsByCompetition['ESP3B'];
+
+        $this->assertContains($esp3a[5]->id, $entries, 'ESP3A pos 6 pulled in by top-up');
+        $this->assertContains($esp3a[6]->id, $entries, 'ESP3A pos 7 pulled in by top-up');
+        $this->assertNotContains($esp3a[7]->id, $entries, 'ESP3A pos 8 still excluded');
+
+        $this->assertContains($esp3b[5]->id, $entries, 'ESP3B pos 6 pulled in by top-up');
+        $this->assertContains($esp3b[6]->id, $entries, 'ESP3B pos 7 pulled in by top-up');
+        $this->assertNotContains($esp3b[7]->id, $entries, 'ESP3B pos 8 still excluded');
+    }
+
+    public function test_target_size_skips_reserves_during_top_up(): void
+    {
+        // Mark ESP3A pos 6 as a reserve. Top-up must skip it and grab pos 7
+        // for that ESP3A slot — final count still hits target.
+        $parent = $this->teamsByCompetition['ESP1'][0];
+        $this->teamsByCompetition['ESP3A'][5]->update(['parent_team_id' => $parent->id]);
+
+        config(['countries.ES.cup_qualification.ESPCUP.target_size' => 54]);
+
+        $this->runProcessor();
+
+        $entries = $this->cupEntries();
+        $this->assertCount(54, $entries);
+        $this->assertNotContains(
+            $this->teamsByCompetition['ESP3A'][5]->id,
+            $entries,
+            'Reserve at ESP3A pos 6 must never qualify even during top-up'
+        );
+        $this->assertContains(
+            $this->teamsByCompetition['ESP3A'][6]->id,
+            $entries,
+            'ESP3A pos 7 takes the slot the reserve would have'
+        );
+    }
+
+    public function test_target_size_counts_untouched_regional_teams_against_target(): void
+    {
+        // Regional teams in cup but outside playable tiers. They survive the
+        // rebuild and count toward target_size, so the qualifier top-up
+        // should pull less from groups.
+        $regional = collect(range(1, 10))->map(
+            fn (int $i) => Team::factory()->create(['country' => 'ES', 'name' => "Regional {$i}"])
+        );
+
+        foreach ($regional as $team) {
+            CompetitionEntry::create([
+                'game_id' => $this->game->id,
+                'competition_id' => 'ESPCUP',
+                'team_id' => $team->id,
+                'entry_round' => 1,
+            ]);
+        }
+
+        config(['countries.ES.cup_qualification.ESPCUP.target_size' => 70]);
+
+        $this->runProcessor();
+
+        $entries = $this->cupEntries();
+        $this->assertCount(70, $entries);
+
+        // 10 regional are preserved → only 60 qualifiers needed (52 base + 8 top-up)
+        foreach ($regional as $team) {
+            $this->assertContains($team->id, $entries);
+        }
+
+        $esp3aIds = array_map(fn (Team $t) => $t->id, $this->teamsByCompetition['ESP3A']);
+        $esp3bIds = array_map(fn (Team $t) => $t->id, $this->teamsByCompetition['ESP3B']);
+        $esp3Total = count(array_intersect($entries, $esp3aIds))
+            + count(array_intersect($entries, $esp3bIds));
+
+        // 5+5 base + 8 top-up across both groups = 18 ESP3 total
+        $this->assertSame(18, $esp3Total);
+    }
+
+    public function test_target_size_unreachable_throws_loudly(): void
+    {
+        // target_size larger than the entire eligible team pool. The
+        // processor must throw — silent shortfalls are exactly how the
+        // 93-broken-Copa-del-Rey-draws bug stayed hidden in production.
+        config(['countries.ES.cup_qualification.ESPCUP.target_size' => 1000]);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessageMatches('/ESPCUP.*target_size 1000 unreachable.*short by/i');
+
+        $this->runProcessor();
+    }
+
+    public function test_target_size_below_rule_output_does_not_remove_qualifiers(): void
+    {
+        // Rule output is already 52. A target_size of 30 would imply removal
+        // — but the contract is "top up, never trim", so qualifiers stay.
+        config(['countries.ES.cup_qualification.ESPCUP.target_size' => 30]);
+
+        $this->runProcessor();
+
+        $this->assertCount(
+            52,
+            $this->cupEntries(),
+            'Rule output must not be trimmed below its natural size'
+        );
+    }
+
+    public function test_target_size_handles_one_group_exhausting_before_target(): void
+    {
+        // Mark every ESP3A team after pos 5 as a reserve so the group has
+        // exactly 5 eligible teams. With target_size demanding more from
+        // ESP3, the round-robin must skip exhausted ESP3A and keep pulling
+        // from ESP3B.
+        $parent = $this->teamsByCompetition['ESP1'][0];
+        for ($i = 5; $i < 20; $i++) {
+            $this->teamsByCompetition['ESP3A'][$i]->update(['parent_team_id' => $parent->id]);
+        }
+
+        config(['countries.ES.cup_qualification.ESPCUP.target_size' => 65]);
+
+        $this->runProcessor();
+
+        $entries = $this->cupEntries();
+
+        // Available: ESP1 (20) + ESP2 (22) + ESP3A 5 non-reserves + ESP3B 20 = 67.
+        // Target 65: pull rule baseline (52, but ESP3A only contributes 5 — actually
+        // the cascade DOES NOT trigger here since reserves aren't in
+        // auto_qualify_tiers, so baseline stays 52). Then top-up needs 13
+        // more. ESP3A has 0 left after 5; ESP3B has 15 left → all from B.
+        $this->assertCount(65, $entries);
+
+        $esp3bIds = array_map(fn (Team $t) => $t->id, $this->teamsByCompetition['ESP3B']);
+        $esp3bCount = count(array_intersect($entries, $esp3bIds));
+        $this->assertSame(18, $esp3bCount, 'ESP3B absorbed the entire top-up after ESP3A exhausted');
+    }
+
+    public function test_target_size_keeps_round_1_count_even_for_supercup_cascade(): void
+    {
+        // Production scenario: target_size 116 on Spain config. After
+        // SeasonInitializationService bumps 4 supercup teams to round 3,
+        // round 1 must contain an even count for a clean knockout cascade.
+        config(['countries.ES.cup_qualification.ESPCUP.target_size' => 116]);
+
+        // Add 64 regional teams to reach the production-like baseline.
+        $regional = collect(range(1, 64))->map(
+            fn (int $i) => Team::factory()->create(['country' => 'ES'])
+        );
+        foreach ($regional as $team) {
+            CompetitionEntry::create([
+                'game_id' => $this->game->id,
+                'competition_id' => 'ESPCUP',
+                'team_id' => $team->id,
+                'entry_round' => 1,
+            ]);
+        }
+
+        $this->runProcessor();
+
+        $entries = $this->cupEntries();
+        $this->assertCount(116, $entries);
+
+        // Simulate the supercup bump for 4 teams.
+        CompetitionEntry::where('game_id', $this->game->id)
+            ->where('competition_id', 'ESPCUP')
+            ->whereIn('team_id', array_slice($entries, 0, 4))
+            ->update(['entry_round' => 3]);
+
+        $round1 = CompetitionEntry::where('game_id', $this->game->id)
+            ->where('competition_id', 'ESPCUP')
+            ->where('entry_round', 1)
+            ->count();
+
+        $this->assertSame(112, $round1, 'Round 1 must be even for clean cascade');
+        $this->assertSame(0, $round1 % 2, 'Round 1 parity invariant');
     }
 
     private function runProcessor(): void

--- a/tests/Feature/SupercupQualificationTest.php
+++ b/tests/Feature/SupercupQualificationTest.php
@@ -1,0 +1,320 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Competition;
+use App\Models\CompetitionEntry;
+use App\Models\CupTie;
+use App\Models\Game;
+use App\Models\GameStanding;
+use App\Models\Team;
+use App\Models\User;
+use App\Modules\Season\DTOs\SeasonTransitionData;
+use App\Modules\Season\Processors\SupercupQualificationProcessor;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Verifies Spanish Supercopa qualification follows the RFEF rule:
+ *
+ *   "Si el campeón o subcampeón de Copa del Rey ya está clasificado entre
+ *    los dos primeros de Liga, la plaza de la Supercopa se otorga al 3º
+ *    (y 4º si fuera necesario) clasificado de la Liga para completar los
+ *    cuatro participantes."
+ *
+ * Each test pins one row of the (cup-winner ∈ top2, cup-runnerup ∈ top2)
+ * truth table so future edits can't silently regress to the pre-fix
+ * cup-first ordering or the partial-output bug behind Population A.
+ */
+class SupercupQualificationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Game $game;
+
+    /** @var Team[] keyed by league position (1 = champion). */
+    private array $league = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Competition::factory()->league()->create(['id' => 'ESP1', 'country' => 'ES', 'tier' => 1]);
+        Competition::factory()->knockoutCup()->create(['id' => 'ESPCUP', 'country' => 'ES']);
+        Competition::factory()->knockoutCup()->create(['id' => 'ESPSUP', 'country' => 'ES']);
+
+        $user = User::factory()->create();
+        $userTeam = Team::factory()->create(['country' => 'ES']);
+        $this->game = Game::factory()->create([
+            'user_id' => $user->id,
+            'team_id' => $userTeam->id,
+            'competition_id' => 'ESP1',
+            'season' => '2025',
+        ]);
+
+        // 6 ranked league teams. Position 1 is the user's team to keep
+        // the shape consistent with how SetupNewGame seeds things.
+        $this->league[1] = $userTeam;
+        for ($pos = 2; $pos <= 6; $pos++) {
+            $this->league[$pos] = Team::factory()->create(['country' => 'ES', 'name' => "League #{$pos}"]);
+        }
+
+        foreach ($this->league as $position => $team) {
+            CompetitionEntry::create([
+                'game_id' => $this->game->id,
+                'competition_id' => 'ESP1',
+                'team_id' => $team->id,
+                'entry_round' => 1,
+            ]);
+            GameStanding::create([
+                'game_id' => $this->game->id,
+                'competition_id' => 'ESP1',
+                'team_id' => $team->id,
+                'position' => $position,
+                'played' => 38,
+                'won' => max(0, 25 - $position),
+                'drawn' => 5,
+                'lost' => max(0, $position - 5),
+                'goals_for' => 60 - $position,
+                'goals_against' => 20 + $position,
+                'points' => max(0, (25 - $position) * 3 + 5),
+            ]);
+        }
+    }
+
+    public function test_no_overlap_qualifies_both_cup_finalists_plus_league_top_2(): void
+    {
+        // Cup winner = pos 5, cup runner-up = pos 6. Neither in league top 2.
+        // Priority order: cup winner, cup runner-up, league 1st, league 2nd.
+        $this->setCupFinalists($this->league[5], $this->league[6]);
+
+        $this->runProcessor();
+
+        $this->assertSupercupTeams([
+            $this->league[5]->id, // cup winner
+            $this->league[6]->id, // cup runner-up
+            $this->league[1]->id, // league champion
+            $this->league[2]->id, // league runner-up
+        ]);
+    }
+
+    public function test_cup_winner_is_league_champion_advances_league_spot_to_third(): void
+    {
+        // Cup winner = league 1st. The cup-finalist slot is preserved; the
+        // league's "1st" slot is what advances down to 3rd.
+        $this->setCupFinalists($this->league[1], $this->league[5]);
+
+        $this->runProcessor();
+
+        $this->assertSupercupTeams([
+            $this->league[1]->id, // cup winner (= league 1st, but holds the CUP slot)
+            $this->league[5]->id, // cup runner-up
+            $this->league[2]->id, // league runner-up
+            $this->league[3]->id, // 3rd fills the displaced league-champion slot
+        ]);
+    }
+
+    public function test_cup_runnerup_is_league_runnerup_advances_league_spot_to_third(): void
+    {
+        // Cup runner-up = league 2nd. The cup-finalist slot is preserved;
+        // the league's "2nd" slot is what advances down to 3rd.
+        $this->setCupFinalists($this->league[5], $this->league[2]);
+
+        $this->runProcessor();
+
+        $this->assertSupercupTeams([
+            $this->league[5]->id, // cup winner
+            $this->league[2]->id, // cup runner-up (= league 2nd, holds the CUP slot)
+            $this->league[1]->id, // league champion
+            $this->league[3]->id, // 3rd fills the displaced league-runner-up slot
+        ]);
+    }
+
+    public function test_both_cup_finalists_in_top_2_advances_league_to_third_and_fourth(): void
+    {
+        // Both cup finalists are league 1st and 2nd. Both league slots
+        // advance, so 3rd AND 4th fill them.
+        $this->setCupFinalists($this->league[1], $this->league[2]);
+
+        $this->runProcessor();
+
+        $this->assertSupercupTeams([
+            $this->league[1]->id, // cup winner (= league 1st)
+            $this->league[2]->id, // cup runner-up (= league 2nd)
+            $this->league[3]->id, // 3rd fills first displaced league slot
+            $this->league[4]->id, // 4th fills second displaced league slot
+        ]);
+    }
+
+    public function test_swapped_finalists_in_top_2_still_advances_to_third_and_fourth(): void
+    {
+        // Order-swap: cup winner = league 2nd, cup runner-up = league 1st.
+        // Same set, with cup-priority ordering preserved.
+        $this->setCupFinalists($this->league[2], $this->league[1]);
+
+        $this->runProcessor();
+
+        $this->assertSupercupTeams([
+            $this->league[2]->id, // cup winner
+            $this->league[1]->id, // cup runner-up
+            $this->league[3]->id, // 3rd fills displaced slot
+            $this->league[4]->id, // 4th fills displaced slot
+        ]);
+    }
+
+    public function test_cup_winner_third_and_runnerup_outside_top_2_no_advance(): void
+    {
+        // Cup winner = league 3rd — NOT in top 2, so no league spot is
+        // displaced. League 1st/2nd qualify in their normal slots.
+        $this->setCupFinalists($this->league[3], $this->league[6]);
+
+        $this->runProcessor();
+
+        $this->assertSupercupTeams([
+            $this->league[3]->id, // cup winner
+            $this->league[6]->id, // cup runner-up
+            $this->league[1]->id, // league champion
+            $this->league[2]->id, // league runner-up
+        ]);
+    }
+
+    public function test_no_cup_run_falls_back_to_league_top_4(): void
+    {
+        // Cup didn't run at all (no completed final). The four supercup
+        // slots fall to league positions 1–4.
+        $this->runProcessor();
+
+        $this->assertSupercupTeams([
+            $this->league[1]->id,
+            $this->league[2]->id,
+            $this->league[3]->id,
+            $this->league[4]->id,
+        ]);
+    }
+
+    public function test_throws_when_cannot_produce_4_qualifiers(): void
+    {
+        // Cup didn't run AND the league has fewer than 4 standings rows —
+        // determineQualifiers can only produce 2, which is the Population A
+        // signature (Atlético + Real Valladolid in production). Surface it
+        // loudly so the upstream cause shows up immediately instead of
+        // creating a half-populated supercup.
+        GameStanding::where('game_id', $this->game->id)
+            ->where('competition_id', 'ESP1')
+            ->whereIn('position', [3, 4, 5, 6])
+            ->delete();
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessageMatches('/SupercupQualification.*expected 4 qualifiers.*got 2/i');
+
+        $this->runProcessor();
+    }
+
+    public function test_qualifiers_are_persisted_to_competition_entries(): void
+    {
+        $this->setCupFinalists($this->league[5], $this->league[6]);
+
+        $this->runProcessor();
+
+        $entries = CompetitionEntry::where('game_id', $this->game->id)
+            ->where('competition_id', 'ESPSUP')
+            ->pluck('team_id')
+            ->all();
+
+        $this->assertCount(4, $entries);
+        $this->assertContains($this->league[1]->id, $entries);
+        $this->assertContains($this->league[2]->id, $entries);
+        $this->assertContains($this->league[5]->id, $entries);
+        $this->assertContains($this->league[6]->id, $entries);
+    }
+
+    public function test_rerun_replaces_previous_supercup_entries(): void
+    {
+        // Stale entry from a prior run — must be wiped, not merged.
+        $stranger = Team::factory()->create(['country' => 'ES']);
+        CompetitionEntry::create([
+            'game_id' => $this->game->id,
+            'competition_id' => 'ESPSUP',
+            'team_id' => $stranger->id,
+            'entry_round' => 1,
+        ]);
+
+        $this->setCupFinalists($this->league[5], $this->league[6]);
+        $this->runProcessor();
+
+        $entries = CompetitionEntry::where('game_id', $this->game->id)
+            ->where('competition_id', 'ESPSUP')
+            ->pluck('team_id')
+            ->all();
+
+        $this->assertNotContains($stranger->id, $entries);
+        $this->assertCount(4, $entries);
+    }
+
+    public function test_metadata_records_qualifiers_in_priority_order(): void
+    {
+        // Cup winner = league champion → league spot advances to 3rd.
+        $this->setCupFinalists($this->league[1], $this->league[5]);
+
+        $data = $this->runProcessor();
+
+        $this->assertSame(
+            [
+                $this->league[1]->id, // cup winner
+                $this->league[5]->id, // cup runner-up
+                $this->league[2]->id, // league runner-up
+                $this->league[3]->id, // 3rd fills displaced league-champion slot
+            ],
+            $data->getMetadata('supercupQualifiers'),
+        );
+    }
+
+    private function setCupFinalists(Team $winner, Team $runnerUp): void
+    {
+        // Mimic the structure SupercupQualificationProcessor reads: the
+        // single completed cup tie at round = cup_final_round (7 for ESP).
+        CupTie::create([
+            'id' => (string) \Illuminate\Support\Str::uuid(),
+            'game_id' => $this->game->id,
+            'competition_id' => 'ESPCUP',
+            'round_number' => 7,
+            'home_team_id' => $winner->id,
+            'away_team_id' => $runnerUp->id,
+            'winner_id' => $winner->id,
+            'completed' => true,
+        ]);
+    }
+
+    private function runProcessor(): SeasonTransitionData
+    {
+        $data = new SeasonTransitionData(oldSeason: '2025', newSeason: '2026', competitionId: 'ESP1');
+        app(SupercupQualificationProcessor::class)->process($this->game, $data);
+        return $data;
+    }
+
+    /**
+     * Assert the metadata-recorded qualifier list matches the expected order
+     * exactly. RFEF priority ordering is part of the contract, not just the
+     * resulting set — see the docblock on determineQualifiers.
+     *
+     * @param  string[]  $expected
+     */
+    private function assertSupercupTeams(array $expected): void
+    {
+        $entries = CompetitionEntry::where('game_id', $this->game->id)
+            ->where('competition_id', 'ESPSUP')
+            ->pluck('team_id')
+            ->all();
+
+        $this->assertCount(
+            count($expected),
+            $entries,
+            'Supercup must always have exactly the expected number of qualifiers',
+        );
+        $this->assertEqualsCanonicalizing(
+            $expected,
+            $entries,
+            'Supercup qualifier set mismatch',
+        );
+    }
+}

--- a/tests/Unit/CupDrawPairingTest.php
+++ b/tests/Unit/CupDrawPairingTest.php
@@ -4,10 +4,15 @@ namespace Tests\Unit;
 
 use App\Modules\Competition\Services\Draw\CrossCategoryPairing;
 use App\Modules\Competition\Services\Draw\RandomPairing;
+use Illuminate\Support\Collection;
 use PHPUnit\Framework\TestCase;
 
 class CupDrawPairingTest extends TestCase
 {
+    // ---------------------------------------------------------------------
+    // CrossCategoryPairing — even inputs (cross-tier behaviour)
+    // ---------------------------------------------------------------------
+
     public function test_cross_category_pairs_different_tiers_together(): void
     {
         $strategy = new CrossCategoryPairing();
@@ -21,19 +26,16 @@ class CupDrawPairingTest extends TestCase
         $result = $strategy->pairTeams($teams, $tierMap);
 
         $this->assertCount(8, $result);
+        $this->assertEqualsCanonicalizing($teams->all(), $result->all());
 
-        // Every pair should cross categories: teams[0] vs teams[1], etc.
         for ($i = 0; $i < 4; $i++) {
             $first = $result[$i * 2];
             $second = $result[$i * 2 + 1];
 
-            $firstTier = $tierMap[$first];
-            $secondTier = $tierMap[$second];
-
             $this->assertNotEquals(
-                $firstTier,
-                $secondTier,
-                "Pair {$i}: {$first} (tier {$firstTier}) vs {$second} (tier {$secondTier}) should be cross-category"
+                $tierMap[$first],
+                $tierMap[$second],
+                "Pair {$i}: {$first} vs {$second} should be cross-category"
             );
         }
     }
@@ -53,14 +55,9 @@ class CupDrawPairingTest extends TestCase
 
         $this->assertCount(8, $result);
 
-        // Count cross-category pairings
         $crossCategoryCount = 0;
-
         for ($i = 0; $i < 4; $i++) {
-            $firstTier = $tierMap[$result[$i * 2]];
-            $secondTier = $tierMap[$result[$i * 2 + 1]];
-
-            if ($firstTier !== $secondTier) {
+            if ($tierMap[$result[$i * 2]] !== $tierMap[$result[$i * 2 + 1]]) {
                 $crossCategoryCount++;
             }
         }
@@ -69,41 +66,10 @@ class CupDrawPairingTest extends TestCase
         $this->assertEquals(2, $crossCategoryCount);
     }
 
-    public function test_cross_category_handles_all_same_tier(): void
-    {
-        $strategy = new CrossCategoryPairing();
-
-        $teams = collect(['a', 'b', 'c', 'd', 'e', 'f']);
-        $tierMap = ['a' => 99, 'b' => 99, 'c' => 99, 'd' => 99, 'e' => 99, 'f' => 99];
-
-        $result = $strategy->pairTeams($teams, $tierMap);
-
-        // Should still produce 6 teams (3 pairs worth)
-        $this->assertCount(6, $result);
-
-        // All 6 original teams should be present
-        $this->assertCount(6, $result->unique());
-    }
-
-    public function test_cross_category_handles_odd_number_of_teams(): void
-    {
-        $strategy = new CrossCategoryPairing();
-
-        $teams = collect(['a', 'b', 'c', 'd', 'e']);
-        $tierMap = ['a' => 1, 'b' => 1, 'c' => 99, 'd' => 99, 'e' => 99];
-
-        $result = $strategy->pairTeams($teams, $tierMap);
-
-        // intdiv(5, 2) = 2 pairs = 4 teams
-        $this->assertCount(4, $result);
-        $this->assertCount(4, $result->unique());
-    }
-
     public function test_cross_category_handles_three_tiers(): void
     {
         $strategy = new CrossCategoryPairing();
 
-        // 2 tier-1 + 2 tier-2 + 4 tier-99 = 8 teams, 4 pairs
         $teams = collect(['t1a', 't1b', 't2a', 't2b', 't99a', 't99b', 't99c', 't99d']);
         $tierMap = [
             't1a' => 1, 't1b' => 1,
@@ -114,17 +80,10 @@ class CupDrawPairingTest extends TestCase
         $result = $strategy->pairTeams($teams, $tierMap);
 
         $this->assertCount(8, $result);
-
-        // Higher half (sorted): t1a, t1b, t2a, t2b (tiers 1,1,2,2)
-        // Lower half: t99a, t99b, t99c, t99d (all tier 99)
-        // All 4 pairs should be cross-category
         for ($i = 0; $i < 4; $i++) {
-            $firstTier = $tierMap[$result[$i * 2]];
-            $secondTier = $tierMap[$result[$i * 2 + 1]];
-
             $this->assertNotEquals(
-                $firstTier,
-                $secondTier,
+                $tierMap[$result[$i * 2]],
+                $tierMap[$result[$i * 2 + 1]],
                 "Pair {$i} should be cross-category"
             );
         }
@@ -136,13 +95,11 @@ class CupDrawPairingTest extends TestCase
 
         $teams = collect(['mapped1', 'mapped2', 'unmapped1', 'unmapped2']);
         $tierMap = ['mapped1' => 1, 'mapped2' => 1];
-        // unmapped1, unmapped2 default to tier 99
 
         $result = $strategy->pairTeams($teams, $tierMap);
 
         $this->assertCount(4, $result);
 
-        // Both pairs should be cross-category (tier 1 vs tier 99)
         for ($i = 0; $i < 2; $i++) {
             $firstTier = $tierMap[$result[$i * 2]] ?? 99;
             $secondTier = $tierMap[$result[$i * 2 + 1]] ?? 99;
@@ -150,6 +107,182 @@ class CupDrawPairingTest extends TestCase
             $this->assertNotEquals($firstTier, $secondTier);
         }
     }
+
+    public function test_cross_category_handles_all_same_tier(): void
+    {
+        $strategy = new CrossCategoryPairing();
+
+        $teams = collect(['a', 'b', 'c', 'd', 'e', 'f']);
+        $tierMap = ['a' => 99, 'b' => 99, 'c' => 99, 'd' => 99, 'e' => 99, 'f' => 99];
+
+        $result = $strategy->pairTeams($teams, $tierMap);
+
+        $this->assertCount(6, $result);
+        $this->assertCount(6, $result->unique());
+        $this->assertEqualsCanonicalizing($teams->all(), $result->all());
+    }
+
+    // ---------------------------------------------------------------------
+    // CrossCategoryPairing — odd inputs (the regression: nothing dropped)
+    // ---------------------------------------------------------------------
+
+    /**
+     * Regression test for the silent-drop bug where the strategy used
+     * `slice($half, $half)` and discarded the median team on odd inputs.
+     * That produced 93 broken Copa del Rey ties in production — semifinals
+     * with one game, etc. Every team must now survive the pairing pass.
+     */
+    public function test_odd_count_keeps_all_teams_with_one_unpaired_at_end(): void
+    {
+        $strategy = new CrossCategoryPairing();
+
+        $teams = collect(['a', 'b', 'c', 'd', 'e']);
+        $tierMap = ['a' => 1, 'b' => 1, 'c' => 99, 'd' => 99, 'e' => 99];
+
+        $result = $strategy->pairTeams($teams, $tierMap);
+
+        $this->assertCount(5, $result, 'Every input team must appear in the output');
+        $this->assertEqualsCanonicalizing($teams->all(), $result->all());
+        $this->assertCount(5, $result->unique(), 'No team duplicated');
+    }
+
+    public function test_odd_count_first_pairs_are_cross_category(): void
+    {
+        $strategy = new CrossCategoryPairing();
+
+        // Higher-tier numbers = lower category. Top 2 = best (a, b).
+        $teams = collect(['a', 'b', 'c', 'd', 'e']);
+        $tierMap = ['a' => 1, 'b' => 1, 'c' => 99, 'd' => 99, 'e' => 99];
+
+        // Run multiple times — randomness inside, so make the assertion robust.
+        for ($trial = 0; $trial < 25; $trial++) {
+            $result = $strategy->pairTeams($teams, $tierMap);
+
+            $this->assertCount(5, $result);
+
+            // First two pairs should be cross-category every single time.
+            for ($i = 0; $i < 2; $i++) {
+                $this->assertNotEquals(
+                    $tierMap[$result[$i * 2]],
+                    $tierMap[$result[$i * 2 + 1]],
+                    "Trial {$trial} pair {$i} should be cross-category"
+                );
+            }
+
+            // The trailing (unpaired) team comes from the larger half — the
+            // lower-category bucket — so it's a tier-99 team.
+            $this->assertEquals(99, $tierMap[$result[4]]);
+        }
+    }
+
+    public function test_odd_count_three_teams(): void
+    {
+        $strategy = new CrossCategoryPairing();
+
+        $teams = collect(['a', 'b', 'c']);
+        $tierMap = ['a' => 1, 'b' => 99, 'c' => 99];
+
+        $result = $strategy->pairTeams($teams, $tierMap);
+
+        $this->assertCount(3, $result);
+        $this->assertEqualsCanonicalizing(['a', 'b', 'c'], $result->all());
+        // The single pair must be cross-category, leaving a tier-99 team unpaired.
+        $this->assertNotEquals($tierMap[$result[0]], $tierMap[$result[1]]);
+        $this->assertEquals(99, $tierMap[$result[2]]);
+    }
+
+    public function test_single_team_returned_unpaired(): void
+    {
+        $strategy = new CrossCategoryPairing();
+
+        $result = $strategy->pairTeams(collect(['lonely']), ['lonely' => 1]);
+
+        $this->assertCount(1, $result);
+        $this->assertSame('lonely', $result[0]);
+    }
+
+    public function test_empty_input_returns_empty(): void
+    {
+        $strategy = new CrossCategoryPairing();
+
+        $result = $strategy->pairTeams(collect(), []);
+
+        $this->assertCount(0, $result);
+    }
+
+    public function test_two_teams_pair_directly(): void
+    {
+        $strategy = new CrossCategoryPairing();
+
+        $teams = collect(['a', 'b']);
+        $tierMap = ['a' => 1, 'b' => 99];
+
+        $result = $strategy->pairTeams($teams, $tierMap);
+
+        $this->assertCount(2, $result);
+        $this->assertEqualsCanonicalizing(['a', 'b'], $result->all());
+    }
+
+    /**
+     * Property-style sweep: hammer many odd and even sizes to make sure no
+     * team is ever dropped. This is the catch-all guard against any future
+     * regression of the original off-by-one slice.
+     */
+    public function test_no_team_is_ever_dropped_for_sizes_2_through_60(): void
+    {
+        $strategy = new CrossCategoryPairing();
+
+        for ($n = 2; $n <= 60; $n++) {
+            $teams = collect(range(1, $n))->map(fn ($i) => "t{$i}");
+            $tierMap = $teams->mapWithKeys(fn ($t, $i) => [$t => ($i % 4) + 1])->all();
+
+            $result = $strategy->pairTeams($teams, $tierMap);
+
+            $this->assertCount(
+                $n,
+                $result,
+                "n={$n}: result must contain every input team"
+            );
+            $this->assertEqualsCanonicalizing(
+                $teams->all(),
+                $result->all(),
+                "n={$n}: output must be a permutation of input"
+            );
+        }
+    }
+
+    /**
+     * Reproduces the production scenario: 57 winners feeding round 2 of
+     * Copa del Rey (no entries that round). Before the fix this returned
+     * 56 teams and the loop in CupDrawService produced 28 ties — losing
+     * one team. Now the strategy must return all 57 teams and the trailing
+     * one falls out as the surplus for the caller to handle.
+     */
+    public function test_reproduces_round_2_cascade_with_57_teams(): void
+    {
+        $strategy = new CrossCategoryPairing();
+
+        // Mix of tiers so the sort/split doesn't degenerate.
+        $teams = collect(range(1, 57))->map(fn ($i) => "team-{$i}");
+        $tierMap = $teams->mapWithKeys(function ($t, $i) {
+            // Rough mix: tier 1 (top), tier 2, tier 3
+            $tier = match (true) {
+                $i < 20 => 1,
+                $i < 40 => 2,
+                default => 3,
+            };
+            return [$t => $tier];
+        })->all();
+
+        $result = $strategy->pairTeams($teams, $tierMap);
+
+        $this->assertCount(57, $result, 'No team should be dropped from a 57-team draw');
+        $this->assertEqualsCanonicalizing($teams->all(), $result->all());
+    }
+
+    // ---------------------------------------------------------------------
+    // RandomPairing
+    // ---------------------------------------------------------------------
 
     public function test_random_pairing_returns_all_teams(): void
     {
@@ -160,5 +293,48 @@ class CupDrawPairingTest extends TestCase
 
         $this->assertCount(4, $result);
         $this->assertEqualsCanonicalizing(['a', 'b', 'c', 'd'], $result->all());
+    }
+
+    public function test_random_pairing_keeps_all_teams_for_odd_input(): void
+    {
+        $strategy = new RandomPairing();
+
+        $teams = collect(['a', 'b', 'c', 'd', 'e']);
+        $result = $strategy->pairTeams($teams, []);
+
+        $this->assertCount(5, $result);
+        $this->assertEqualsCanonicalizing(['a', 'b', 'c', 'd', 'e'], $result->all());
+    }
+
+    public function test_random_pairing_keeps_single_team(): void
+    {
+        $strategy = new RandomPairing();
+
+        $result = $strategy->pairTeams(collect(['lonely']), []);
+
+        $this->assertCount(1, $result);
+        $this->assertSame('lonely', $result[0]);
+    }
+
+    public function test_random_pairing_handles_empty(): void
+    {
+        $strategy = new RandomPairing();
+
+        $result = $strategy->pairTeams(collect(), []);
+
+        $this->assertCount(0, $result);
+    }
+
+    public function test_random_pairing_no_team_dropped_for_sizes_1_through_60(): void
+    {
+        $strategy = new RandomPairing();
+
+        for ($n = 1; $n <= 60; $n++) {
+            $teams = collect(range(1, $n))->map(fn ($i) => "t{$i}");
+            $result = $strategy->pairTeams($teams, []);
+
+            $this->assertCount($n, $result, "n={$n}: every team must be retained");
+            $this->assertEqualsCanonicalizing($teams->all(), $result->all());
+        }
     }
 }

--- a/tests/Unit/CupDrawServiceTest.php
+++ b/tests/Unit/CupDrawServiceTest.php
@@ -8,6 +8,7 @@ use App\Models\CupTie;
 use App\Models\Game;
 use App\Models\Team;
 use App\Models\User;
+use App\Modules\Competition\Exceptions\OddCupDrawPoolException;
 use App\Modules\Competition\Services\CupDrawService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
@@ -209,5 +210,115 @@ class CupDrawServiceTest extends TestCase
         $ties = $this->service->conductDraw($this->game->id, 'ESPSUP', 1);
 
         $this->assertCount(2, $ties);
+    }
+
+    // ---------------------------------------------------------------------
+    // Odd-pool guard (regression: silent team drop)
+    //
+    // Before this guard, an odd team pool was silently truncated by the
+    // `for ($i + 1 < $count; $i += 2)` loop and one team disappeared from
+    // the round. That cascaded across rounds and produced 93 broken Copa
+    // del Rey draws in production (semifinals with one tie, etc.). The
+    // service must now raise loudly so the upstream cause surfaces.
+    // ---------------------------------------------------------------------
+
+    public function test_draw_with_odd_team_pool_raises_in_round_one(): void
+    {
+        // 5 teams in the cup → odd pool. CrossCategoryPairing returns all 5
+        // (after its own fix); the service must refuse to chunk them.
+        $teams = Team::factory()->count(5)->create();
+
+        foreach ($teams as $team) {
+            CompetitionEntry::create([
+                'game_id' => $this->game->id,
+                'competition_id' => 'ESPCUP',
+                'team_id' => $team->id,
+                'entry_round' => 1,
+            ]);
+        }
+
+        $this->expectException(OddCupDrawPoolException::class);
+        $this->expectExceptionMessageMatches('/ESPCUP round 1.*5 teams.*odd/i');
+
+        $this->service->conductDraw($this->game->id, 'ESPCUP', 1);
+    }
+
+    public function test_draw_with_odd_team_pool_raises_in_later_round(): void
+    {
+        // Stage: round 1 had 6 ties (12 teams) → 6 winners drawn for round 2.
+        // To force an odd round-2 pool, we'll mark 5 of the 6 ties complete
+        // — leaving 5 winners → odd. The service must raise.
+        $teams = Team::factory()->count(12)->create();
+
+        foreach ($teams as $team) {
+            CompetitionEntry::create([
+                'game_id' => $this->game->id,
+                'competition_id' => 'ESPCUP',
+                'team_id' => $team->id,
+                'entry_round' => 1,
+            ]);
+        }
+
+        $round1Ties = $this->service->conductDraw($this->game->id, 'ESPCUP', 1);
+        $this->assertCount(6, $round1Ties);
+
+        // Complete 5 of the 6 ties so round 2 has 5 winners (odd).
+        foreach ($round1Ties->take(5) as $tie) {
+            $tie->update(['completed' => true, 'winner_id' => $tie->home_team_id]);
+        }
+
+        // The 6th tie is left incomplete on purpose. needsDrawForRound
+        // would normally block draws here, but conductDraw doesn't gate;
+        // we want to verify the chunking guard fires when reached.
+        $round1Ties->last()->update(['completed' => true, 'winner_id' => null]);
+
+        $this->expectException(OddCupDrawPoolException::class);
+        $this->expectExceptionMessageMatches('/ESPCUP round 2.*5 teams.*odd/i');
+
+        $this->service->conductDraw($this->game->id, 'ESPCUP', 2);
+    }
+
+    public function test_draw_with_even_pool_does_not_raise(): void
+    {
+        // 6 teams → 3 ties. Sanity check that the guard is parity-specific.
+        $teams = Team::factory()->count(6)->create();
+
+        foreach ($teams as $team) {
+            CompetitionEntry::create([
+                'game_id' => $this->game->id,
+                'competition_id' => 'ESPCUP',
+                'team_id' => $team->id,
+                'entry_round' => 1,
+            ]);
+        }
+
+        $ties = $this->service->conductDraw($this->game->id, 'ESPCUP', 1);
+
+        $this->assertCount(3, $ties);
+    }
+
+    public function test_odd_pool_message_names_competition_and_round(): void
+    {
+        $teams = Team::factory()->count(3)->create();
+
+        foreach ($teams as $team) {
+            CompetitionEntry::create([
+                'game_id' => $this->game->id,
+                'competition_id' => 'ESPCUP',
+                'team_id' => $team->id,
+                'entry_round' => 1,
+            ]);
+        }
+
+        try {
+            $this->service->conductDraw($this->game->id, 'ESPCUP', 1);
+            $this->fail('Expected OddCupDrawPoolException was not thrown');
+        } catch (OddCupDrawPoolException $e) {
+            // Message must surface the diagnostic dimensions: competition,
+            // round, and team count. These are what an operator needs.
+            $this->assertStringContainsString('ESPCUP', $e->getMessage());
+            $this->assertStringContainsString('round 1', $e->getMessage());
+            $this->assertStringContainsString('3 teams', $e->getMessage());
+        }
     }
 }


### PR DESCRIPTION
Production was producing 93 broken cup draws (semifinals with one tie, missing round-of-16 ties) because three layers all silently swallowed parity violations:

- CrossCategoryPairing dropped the median team on odd inputs via `slice($half, $half)`. Now slices to end so every team survives.
- CupDrawService chunked pairs with `for ($i + 1 < $count)`, dropping the trailing team on odd pools. Now raises OddCupDrawPoolException with competition/round/count diagnostics.
- CopaQualificationProcessor permanently shrank the cup by 11 teams per season (rule replaced 21 seeded ESP3 teams with 11). Added a target_size=116 invariant that tops up round-robin from top_per_group groups; throws if unreachable.
- SupercupQualificationProcessor silently returned <4 qualifiers when cup didn't run and league standings were partial. Now throws with full context. Also reordered determineQualifiers to follow the RFEF priority literally: cup finalists first, league fills 3rd/4th when the league spot is displaced by overlap.
- ConductNextCupRoundDraw listener no longer catches the new exception — silent fallbacks are how this bug stayed hidden in the first place.

Tests cover odd-input survival across pairing strategies (sweep sizes 2-60), the chunking guard's diagnostic message, target_size top-up math under all overlap/exhaustion shapes, and the full RFEF truth table for supercup overlap cases.