### PR TITLE
Fix league-wide rating decay over many seasons

### DIFF
--- a/app/Modules/Academy/Services/YouthAcademyService.php
+++ b/app/Modules/Academy/Services/YouthAcademyService.php
@@ -35,8 +35,8 @@ class YouthAcademyService
         0 => 38,   // Minimum: raw, unpolished prospect
         1 => 45,   // Basic: developing players
         2 => 52,   // Good: slightly above developing
-        3 => 62,   // Elite: average-to-good
-        4 => 70,   // World-Class: good, ready to contribute
+        3 => 66,   // Elite: average-to-good
+        4 => 74,   // World-Class: good, ready to contribute
     ];
 
     /**
@@ -64,8 +64,8 @@ class YouthAcademyService
         0 => 12,
         1 => 15,
         2 => 15,
-        3 => 10,
-        4 => 10,
+        3 => 14,
+        4 => 16,
     ];
 
     /**
@@ -82,6 +82,20 @@ class YouthAcademyService
         2 => 50,
         3 => 55,
         4 => 60,
+    ];
+
+    /**
+     * Maximum potential allowed for academy prospects per tier.
+     * Without per-tier caps, world-class academies can never produce
+     * a future elite player above 88 — a ceiling that compounds league-wide
+     * as original-seed elites retire.
+     */
+    private const POTENTIAL_MAX = [
+        0 => 86,
+        1 => 88,
+        2 => 90,
+        3 => 93,
+        4 => 95,
     ];
 
     private const ESTIMATED_MATCHDAYS = 38;
@@ -449,6 +463,7 @@ class YouthAcademyService
             self::POTENTIAL_UPSIDE_MEAN[$academyTier],
             self::POTENTIAL_UPSIDE_STD_DEV,
             self::POTENTIAL_FLOOR[$academyTier],
+            self::POTENTIAL_MAX[$academyTier],
         );
 
         $dateOfBirth = $game->current_date->copy()->subYears($age)->subDays(rand(0, 364));

--- a/app/Modules/Player/Services/DevelopmentCurve.php
+++ b/app/Modules/Player/Services/DevelopmentCurve.php
@@ -7,13 +7,15 @@ namespace App\Modules\Player\Services;
  *
  * Uses direct signed change values per age instead of multipliers.
  * Positive = growth, zero = plateau, negative = decline.
- * Growth requires playing time — no appearances means no growth (stagnation).
+ * Match playing time accelerates growth, but training alone still develops
+ * young players at a reduced rate.
  */
 final class DevelopmentCurve
 {
     /**
-     * Minimum appearances to qualify for any growth at all.
-     * Below this threshold, positive development is zero (stagnation).
+     * Minimum appearances to qualify for full match-driven growth.
+     * Below this threshold, players still develop from training but at a
+     * reduced rate (TRAINING_ONLY_GROWTH_FACTOR).
      */
     public const MIN_APPEARANCES_FOR_GROWTH = 10;
 
@@ -22,6 +24,13 @@ final class DevelopmentCurve
      * Between MIN and this value, growth scales linearly.
      */
     public const FULL_BONUS_APPEARANCES = 25;
+
+    /**
+     * Fraction of base growth applied to bench players (no/few appearances).
+     * Models off-pitch training development. Without this, AI bench prospects
+     * stagnate forever once squads fill up, eroding league strength over time.
+     */
+    public const TRAINING_ONLY_GROWTH_FACTOR = 0.5;
 
     /**
      * Age-based development changes (points per season for a regular starter).
@@ -76,8 +85,8 @@ final class DevelopmentCurve
     /**
      * Calculate development change for a single ability.
      *
-     * Growth (positive baseChange) requires playing time:
-     * - Below MIN_APPEARANCES_FOR_GROWTH: zero growth (stagnation)
+     * Growth (positive baseChange) is driven by playing time:
+     * - Below MIN_APPEARANCES_FOR_GROWTH: training-only rate (TRAINING_ONLY_GROWTH_FACTOR)
      * - Between MIN and FULL_BONUS: scaled growth
      * - At FULL_BONUS+: full growth
      *
@@ -90,9 +99,8 @@ final class DevelopmentCurve
     public static function calculateChange(int $baseChange, int $seasonAppearances): int
     {
         if ($baseChange > 0) {
-            // Growth requires playing time — no play = no growth
             if ($seasonAppearances < self::MIN_APPEARANCES_FOR_GROWTH) {
-                return 0;
+                return (int) round($baseChange * self::TRAINING_ONLY_GROWTH_FACTOR);
             }
 
             $playFactor = min(1.0, $seasonAppearances / self::FULL_BONUS_APPEARANCES);

--- a/app/Modules/Player/Services/PlayerDevelopmentService.php
+++ b/app/Modules/Player/Services/PlayerDevelopmentService.php
@@ -18,7 +18,7 @@ use App\Modules\Player\Services\DevelopmentCurve;
  * Key principles:
  * - Young players with high market value have proven higher potential
  * - Veterans with exceptional market value have proven their quality ceiling
- * - Growth requires playing time — bench players stagnate
+ * - Match playing time accelerates growth; bench players still develop in training at a reduced rate
  * - Physical abilities decline faster than technical abilities
  */
 class PlayerDevelopmentService
@@ -28,7 +28,7 @@ class PlayerDevelopmentService
      *
      * Development is influenced by:
      * - Age (young players grow, veterans decline)
-     * - Playing time (must play to grow; no appearances = stagnation)
+     * - Playing time (full growth at FULL_BONUS_APPEARANCES, training-only rate below MIN_APPEARANCES_FOR_GROWTH)
      * - Quality gap (young players far from potential get +1 bonus)
      * - Potential cap (players can't exceed their ceiling)
      *

--- a/app/Modules/Season/Processors/PlayerDevelopmentProcessor.php
+++ b/app/Modules/Season/Processors/PlayerDevelopmentProcessor.php
@@ -27,8 +27,9 @@ use Illuminate\Support\Facades\DB;
  *
  * Everything else is preserved exactly: AGE_CURVES values, the
  * MIN_APPEARANCES_FOR_GROWTH=10 / FULL_BONUS_APPEARANCES=25 scaling, the
- * +1 quality-gap bonus for late bloomers, the potential cap, and the
- * 1..99 ability bounds.
+ * TRAINING_ONLY_GROWTH_FACTOR=0.5 fallback for bench players, the +1
+ * quality-gap bonus for late bloomers, the potential cap, and the 1..99
+ * ability bounds.
  */
 class PlayerDevelopmentProcessor implements SeasonProcessor
 {
@@ -85,14 +86,14 @@ class PlayerDevelopmentProcessor implements SeasonProcessor
                 SELECT
                     id, age, old_tech, old_phys, pot, old_avg,
                     CASE
-                        WHEN tech_base > 0 AND apps < 10 THEN 0
+                        WHEN tech_base > 0 AND apps < 10 THEN ROUND(tech_base * 0.5)::int
                         WHEN tech_base > 0 THEN ROUND(tech_base * LEAST(1.0, apps::numeric / 25))::int
                         WHEN tech_base < 0 AND apps >= 10 THEN ROUND(tech_base * 0.5)::int
                         WHEN tech_base < 0 THEN tech_base
                         ELSE 0
                     END AS tech_delta_raw,
                     CASE
-                        WHEN phys_base > 0 AND apps < 10 THEN 0
+                        WHEN phys_base > 0 AND apps < 10 THEN ROUND(phys_base * 0.5)::int
                         WHEN phys_base > 0 THEN ROUND(phys_base * LEAST(1.0, apps::numeric / 25))::int
                         WHEN phys_base < 0 AND apps >= 10 THEN ROUND(phys_base * 0.5)::int
                         WHEN phys_base < 0 THEN phys_base

--- a/app/Modules/Squad/Services/PlayerGeneratorService.php
+++ b/app/Modules/Squad/Services/PlayerGeneratorService.php
@@ -365,8 +365,8 @@ class PlayerGeneratorService
         0 => 45,   // local
         1 => 50,   // modest
         2 => 57,   // established
-        3 => 67,   // continental
-        4 => 74,   // elite
+        3 => 70,   // continental
+        4 => 78,   // elite
     ];
 
     private const ABILITY_STD_DEV = 6;
@@ -378,8 +378,8 @@ class PlayerGeneratorService
         0 => 12,
         1 => 12,
         2 => 10,
-        3 => 8,
-        4 => 8,
+        3 => 12,
+        4 => 14,
     ];
 
     private const POTENTIAL_UPSIDE_STD_DEV = 5;
@@ -393,6 +393,20 @@ class PlayerGeneratorService
         2 => 50,
         3 => 55,
         4 => 60,
+    ];
+
+    /**
+     * Maximum potential allowed for AI-generated replenishment players.
+     * Elite clubs can produce future world-class talent; lower tiers cannot.
+     * Without per-tier caps, every replacement player league-wide would clamp
+     * at 88 and erode the league ceiling over many seasons.
+     */
+    private const POTENTIAL_MAX = [
+        0 => 86,
+        1 => 88,
+        2 => 90,
+        3 => 93,
+        4 => 95,
     ];
 
     /**
@@ -420,6 +434,7 @@ class PlayerGeneratorService
             self::POTENTIAL_UPSIDE_MEAN[$reputationIndex],
             self::POTENTIAL_UPSIDE_STD_DEV,
             self::POTENTIAL_FLOOR[$reputationIndex],
+            self::POTENTIAL_MAX[$reputationIndex],
         );
         $potential = $potentialData['potential'];
         $potentialLow = $potentialData['potentialLow'];

--- a/tests/Unit/PlayerDevelopmentProcessorTest.php
+++ b/tests/Unit/PlayerDevelopmentProcessorTest.php
@@ -45,16 +45,18 @@ class PlayerDevelopmentProcessorTest extends TestCase
         $this->assertSame(63, $player->game_physical_ability);
     }
 
-    public function test_young_player_without_enough_appearances_does_not_grow(): void
+    public function test_young_player_without_enough_appearances_grows_at_training_rate(): void
     {
         // 18yo, 5 apps (below MIN_APPEARANCES_FOR_GROWTH=10).
+        // Curve at 18: tech +2, phys +2 → training-only halves it to +1 each.
+        // Gap bonus (+1) still applies when delta > 0 and pot - avg >= 15, age < 23.
         $player = $this->makePlayer(age: 18, tech: 60, phys: 60, potential: 85, appearances: 5);
 
         $this->processor->process($this->game, $this->transitionData());
 
         $player->refresh();
-        $this->assertSame(60, $player->game_technical_ability);
-        $this->assertSame(60, $player->game_physical_ability);
+        $this->assertSame(62, $player->game_technical_ability);
+        $this->assertSame(62, $player->game_physical_ability);
     }
 
     public function test_inactive_veteran_declines_at_full_rate(): void


### PR DESCRIPTION
AI replenishment players and academy graduates were funneled through
PlayerAttributeSampler::generatePotentialFromAbility, whose default
maxPotential of 88 capped every regenerated player league-wide. Original
seed elites (potential 90-95) retired across 10-15 seasons and were
replaced by 88-capped players that ended up at 80-83 overall after
age-related decline, eroding the league ceiling.

- Add tier-aware POTENTIAL_MAX (86/88/90/93/95) for both AI replenishment
  and academy paths so elite clubs can produce future world-class players
- Bump REPUTATION_BASE_QUALITY and POTENTIAL_UPSIDE_MEAN for tiers 3-4 in
  both PlayerGeneratorService and YouthAcademyService
- Replace bench-player stagnation rule with training-only development at
  half rate, mirrored in DevelopmentCurve and PlayerDevelopmentProcessor
  SQL. AI prospects no longer rot on the bench while waiting for minutes.