### PR TITLE
Send beta invite automatically when a user joins the waitlist

### DIFF
--- a/app/Http/Actions/JoinWaitlist.php
+++ b/app/Http/Actions/JoinWaitlist.php
@@ -3,13 +3,14 @@
 namespace App\Http\Actions;
 
 use App\Models\WaitlistEntry;
+use App\Services\BetaInviteService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Validator;
 
 class JoinWaitlist
 {
-    public function __invoke(Request $request): JsonResponse
+    public function __invoke(Request $request, BetaInviteService $inviteService): JsonResponse
     {
         $validator = Validator::make($request->all(), [
             'name' => 'required|string|max:255',
@@ -37,15 +38,34 @@ class JoinWaitlist
                 'wants_tournament' => $validated['wants_tournament'],
             ]);
 
+            if ($inviteService->hasAlreadyBeenInvited($existing->email)) {
+                return response()->json([
+                    'message' => __('waitlist.already_registered'),
+                ], 200);
+            }
+
+            $this->sendInviteIfBetaEnabled($inviteService, $existing->fresh());
+
             return response()->json([
-                'message' => __('waitlist.already_registered'),
+                'message' => __('waitlist.success'),
             ], 200);
         }
 
-        WaitlistEntry::create($validated);
+        $entry = WaitlistEntry::create($validated);
+
+        $this->sendInviteIfBetaEnabled($inviteService, $entry);
 
         return response()->json([
             'message' => __('waitlist.success'),
         ], 201);
+    }
+
+    private function sendInviteIfBetaEnabled(BetaInviteService $inviteService, WaitlistEntry $entry): void
+    {
+        if (! config('beta.enabled')) {
+            return;
+        }
+
+        $inviteService->invite($entry);
     }
 }

--- a/app/Http/Actions/JoinWaitlist.php
+++ b/app/Http/Actions/JoinWaitlist.php
@@ -44,7 +44,7 @@ class JoinWaitlist
                 ], 200);
             }
 
-            $this->sendInviteIfBetaEnabled($inviteService, $existing->fresh());
+            $inviteService->invite($existing->fresh());
 
             return response()->json([
                 'message' => __('waitlist.success'),
@@ -53,19 +53,10 @@ class JoinWaitlist
 
         $entry = WaitlistEntry::create($validated);
 
-        $this->sendInviteIfBetaEnabled($inviteService, $entry);
+        $inviteService->invite($entry);
 
         return response()->json([
             'message' => __('waitlist.success'),
         ], 201);
-    }
-
-    private function sendInviteIfBetaEnabled(BetaInviteService $inviteService, WaitlistEntry $entry): void
-    {
-        if (! config('beta.enabled')) {
-            return;
-        }
-
-        $inviteService->invite($entry);
     }
 }

--- a/app/Services/BetaInviteService.php
+++ b/app/Services/BetaInviteService.php
@@ -23,7 +23,7 @@ class BetaInviteService
             'grants_tournament' => $entry->wants_tournament,
         ]);
 
-        Mail::to($entry->email)->send(new BetaInvite($invite));
+        Mail::to($entry->email)->queue(new BetaInvite($invite));
 
         $invite->update([
             'invite_sent' => true,

--- a/landing/public/index-en.html
+++ b/landing/public/index-en.html
@@ -390,7 +390,7 @@
                 const data = await res.json();
 
                 if (res.ok) {
-                    formMessage.textContent = "You're on the list! We'll notify you soon.";
+                    formMessage.textContent = "You're on the list! Check your inbox (and spam folder) for your invitation.";
                     formMessage.className = 'text-xs mt-3 text-green-400';
                     formMessage.classList.remove('hidden');
                     form.reset();

--- a/landing/public/index.html
+++ b/landing/public/index.html
@@ -390,7 +390,7 @@
                 const data = await res.json();
 
                 if (res.ok) {
-                    formMessage.textContent = '¡Estás en la lista! Te avisaremos pronto.';
+                    formMessage.textContent = '¡Estás en la lista! Revisa tu bandeja de entrada (y la carpeta de spam) para encontrar tu invitación.';
                     formMessage.className = 'text-xs mt-3 text-green-400';
                     formMessage.classList.remove('hidden');
                     form.reset();

--- a/lang/en/waitlist.php
+++ b/lang/en/waitlist.php
@@ -1,6 +1,6 @@
 <?php
 
 return [
-    'success' => 'You\'re on the list! We\'ll notify you soon.',
+    'success' => 'You\'re on the list! Check your inbox (and spam folder) for your invitation.',
     'already_registered' => 'This email is already registered on the waitlist.',
 ];

--- a/lang/es/waitlist.php
+++ b/lang/es/waitlist.php
@@ -1,6 +1,6 @@
 <?php
 
 return [
-    'success' => '¡Estás en la lista! Te avisaremos pronto.',
+    'success' => '¡Estás en la lista! Revisa tu bandeja de entrada (y la carpeta de spam) para encontrar tu invitación.',
     'already_registered' => 'Este correo ya está registrado en la lista de espera.',
 ];


### PR DESCRIPTION
When beta mode is enabled, JoinWaitlist now triggers BetaInviteService
immediately so signups receive their invitation without admin action.
The existing entry path also sends an invite if one was never issued.
Mail is queued instead of sent synchronously so the API stays responsive.
The success message now points users to their inbox/spam folder.