### PR TITLE
Auto-send beta invite when a user joins the waitlist

### DIFF
--- a/app/Http/Actions/JoinWaitlist.php
+++ b/app/Http/Actions/JoinWaitlist.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Actions;
 
+use App\Jobs\SendAutomaticWaitlistInvite;
 use App\Models\WaitlistEntry;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -42,7 +43,9 @@ class JoinWaitlist
             ], 200);
         }
 
-        WaitlistEntry::create($validated);
+        $entry = WaitlistEntry::create($validated);
+
+        SendAutomaticWaitlistInvite::dispatch($entry->id);
 
         return response()->json([
             'message' => __('waitlist.success'),

--- a/app/Jobs/SendAutomaticWaitlistInvite.php
+++ b/app/Jobs/SendAutomaticWaitlistInvite.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\WaitlistEntry;
+use App\Services\BetaInviteService;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+class SendAutomaticWaitlistInvite implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public int $timeout = 60;
+
+    public function __construct(
+        private readonly string $waitlistEntryId,
+    ) {
+        $this->onQueue('mail');
+    }
+
+    public function handle(BetaInviteService $inviteService): void
+    {
+        if (! config('beta.enabled')) {
+            return;
+        }
+
+        $entry = WaitlistEntry::find($this->waitlistEntryId);
+
+        if (! $entry) {
+            return;
+        }
+
+        if ($inviteService->hasAlreadyBeenInvited($entry->email)) {
+            return;
+        }
+
+        $inviteService->invite($entry);
+    }
+}

--- a/landing/public/index-en.html
+++ b/landing/public/index-en.html
@@ -390,7 +390,7 @@
                 const data = await res.json();
 
                 if (res.ok) {
-                    formMessage.textContent = "You're on the list! We'll notify you soon.";
+                    formMessage.textContent = data.message || "You're on the list! Your invitation is on its way — check your inbox (and your spam folder, just in case).";
                     formMessage.className = 'text-xs mt-3 text-green-400';
                     formMessage.classList.remove('hidden');
                     form.reset();

--- a/landing/public/index.html
+++ b/landing/public/index.html
@@ -390,7 +390,7 @@
                 const data = await res.json();
 
                 if (res.ok) {
-                    formMessage.textContent = '¡Estás en la lista! Te avisaremos pronto.';
+                    formMessage.textContent = data.message || '¡Estás en la lista! Tu invitación va de camino: revisa tu bandeja de entrada (y la carpeta de spam, por si acaso).';
                     formMessage.className = 'text-xs mt-3 text-green-400';
                     formMessage.classList.remove('hidden');
                     form.reset();

--- a/lang/en/waitlist.php
+++ b/lang/en/waitlist.php
@@ -1,6 +1,6 @@
 <?php
 
 return [
-    'success' => 'You\'re on the list! We\'ll notify you soon.',
+    'success' => 'You\'re on the list! Your invitation is on its way — check your inbox (and your spam folder, just in case).',
     'already_registered' => 'This email is already registered on the waitlist.',
 ];

--- a/lang/es/waitlist.php
+++ b/lang/es/waitlist.php
@@ -1,6 +1,6 @@
 <?php
 
 return [
-    'success' => '¡Estás en la lista! Te avisaremos pronto.',
+    'success' => '¡Estás en la lista! Tu invitación va de camino: revisa tu bandeja de entrada (y la carpeta de spam, por si acaso).',
     'already_registered' => 'Este correo ya está registrado en la lista de espera.',
 ];


### PR DESCRIPTION
Dispatches SendAutomaticWaitlistInvite onto the mail queue from the
JoinWaitlist action so new signups receive their invitation immediately
instead of waiting for an admin or the daily scheduler. Updates the
waitlist success message (and the landing-page fallbacks) to tell users
to check their inbox or spam folder.