### PR TITLE
Phase 1: Add biographical columns to game players and templates

### DIFF
--- a/database/migrations/2026_05_04_000001_add_biography_columns_to_game_players.php
+++ b/database/migrations/2026_05_04_000001_add_biography_columns_to_game_players.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Phase 1 of the player-data planes refactor: add nullable biographical
+     * columns to game_players so each game owns its players' biography
+     * directly, without having to JOIN the control-plane players table.
+     *
+     * Columns are nullable here; backfill and dual-write land in later phases.
+     */
+    public function up(): void
+    {
+        Schema::table('game_players', function (Blueprint $table) {
+            $table->string('transfermarkt_id')->nullable()->after('player_id');
+            $table->string('name')->nullable()->after('transfermarkt_id');
+            $table->date('date_of_birth')->nullable()->after('name');
+            $table->json('nationality')->nullable()->after('date_of_birth');
+            $table->string('height')->nullable()->after('nationality');
+            $table->enum('foot', ['left', 'right', 'both'])->nullable()->after('height');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('game_players', function (Blueprint $table) {
+            $table->dropColumn([
+                'transfermarkt_id',
+                'name',
+                'date_of_birth',
+                'nationality',
+                'height',
+                'foot',
+            ]);
+        });
+    }
+};

--- a/database/migrations/2026_05_04_000002_add_biography_columns_to_game_player_templates.php
+++ b/database/migrations/2026_05_04_000002_add_biography_columns_to_game_player_templates.php
@@ -1,0 +1,42 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Phase 1 of the player-data planes refactor: add nullable biographical
+     * columns to game_player_templates. Once populated, templates become the
+     * canonical real-world roster source and replace the players table
+     * entirely (the table itself moves to the control plane in a later phase).
+     *
+     * Columns are nullable here; backfill from players lands in Phase 2.
+     */
+    public function up(): void
+    {
+        Schema::table('game_player_templates', function (Blueprint $table) {
+            $table->string('transfermarkt_id')->nullable()->after('player_id');
+            $table->string('name')->nullable()->after('transfermarkt_id');
+            $table->date('date_of_birth')->nullable()->after('name');
+            $table->json('nationality')->nullable()->after('date_of_birth');
+            $table->string('height')->nullable()->after('nationality');
+            $table->enum('foot', ['left', 'right', 'both'])->nullable()->after('height');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('game_player_templates', function (Blueprint $table) {
+            $table->dropColumn([
+                'transfermarkt_id',
+                'name',
+                'date_of_birth',
+                'nationality',
+                'height',
+                'foot',
+            ]);
+        });
+    }
+};


### PR DESCRIPTION
## Summary
This PR implements Phase 1 of the player-data planes refactor by adding biographical columns to both the `game_players` and `game_player_templates` tables. This enables games to own player biographical data directly, reducing the need for JOINs with the control-plane players table.

## Key Changes
- **game_players table**: Added 6 nullable biographical columns:
  - `transfermarkt_id` (string)
  - `name` (string)
  - `date_of_birth` (date)
  - `nationality` (JSON)
  - `height` (string)
  - `foot` (enum: left/right/both)

- **game_player_templates table**: Added the same 6 nullable biographical columns with identical structure

## Implementation Details
- All columns are nullable to support a phased rollout approach
- Columns are positioned logically after `player_id` in both tables
- The `nationality` field uses JSON type to support multiple nationalities
- The `foot` field uses an enum constraint for data integrity
- Backfill from the existing players table is deferred to Phase 2
- Dual-write logic will be implemented in subsequent phases
- Both migrations include proper rollback support via the `down()` method

https://claude.ai/code/session_01BGPcs1cmkJw2QC7DH6EYnq