### PR TITLE
Add command to backfill player biography into game templates

### DIFF
--- a/app/Console/Commands/BackfillTemplatePlayerBiography.php
+++ b/app/Console/Commands/BackfillTemplatePlayerBiography.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Player;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Phase 2 of the player-data planes refactor: copy biographical columns
+ * (transfermarkt_id, name, date_of_birth, nationality, height, foot) from
+ * the control-plane `players` table into the matching `game_player_templates`
+ * rows added in Phase 1.
+ *
+ * Plane-safe: reads from `pgsql_control` (Player model) and writes to the
+ * default tenant connection in separate queries — no cross-plane JOIN.
+ *
+ * Idempotent: every write is filtered by `name IS NULL`, so re-running the
+ * command after a partial run only touches rows still pending.
+ */
+class BackfillTemplatePlayerBiography extends Command
+{
+    protected $signature = 'app:backfill-template-player-biography
+                            {--chunk=500 : Distinct player_ids to process per batch}
+                            {--limit= : Max distinct player_ids to process this run}
+                            {--dry-run : Report what would be updated without writing}';
+
+    protected $description = 'Copy biographical fields from players (control) into game_player_templates (tenant). Phase 2 of the player-data planes refactor.';
+
+    public function handle(): int
+    {
+        $chunkSize = max(1, (int) $this->option('chunk'));
+        $limit = $this->option('limit') !== null ? (int) $this->option('limit') : null;
+        $dryRun = (bool) $this->option('dry-run');
+
+        $query = DB::table('game_player_templates')
+            ->whereNull('name')
+            ->whereNotNull('player_id')
+            ->select('player_id')
+            ->distinct()
+            ->orderBy('player_id');
+
+        if ($limit !== null) {
+            $query->limit($limit);
+        }
+
+        $playerIds = $query->pluck('player_id');
+
+        $this->info("Distinct players referenced by NULL templates: {$playerIds->count()}");
+
+        $templatesUpdated = 0;
+        $playersBackfilled = 0;
+        $orphanedPlayerIds = 0;
+
+        foreach ($playerIds->chunk($chunkSize) as $chunk) {
+            $players = Player::query()
+                ->whereIn('id', $chunk)
+                ->get(['id', 'transfermarkt_id', 'name', 'date_of_birth', 'nationality', 'height', 'foot'])
+                ->keyBy('id');
+
+            foreach ($chunk as $playerId) {
+                $player = $players->get($playerId);
+
+                if (!$player) {
+                    $orphanedPlayerIds++;
+                    continue;
+                }
+
+                if ($dryRun) {
+                    $playersBackfilled++;
+                    continue;
+                }
+
+                $affected = DB::table('game_player_templates')
+                    ->where('player_id', $playerId)
+                    ->whereNull('name')
+                    ->update([
+                        'transfermarkt_id' => $player->transfermarkt_id,
+                        'name' => $player->name,
+                        'date_of_birth' => $player->date_of_birth?->toDateString(),
+                        'nationality' => $player->nationality !== null
+                            ? json_encode($player->nationality)
+                            : null,
+                        'height' => $player->height,
+                        'foot' => $player->foot,
+                    ]);
+
+                $templatesUpdated += $affected;
+                $playersBackfilled++;
+            }
+        }
+
+        if ($dryRun) {
+            $this->info("DRY RUN — would backfill biography for {$playersBackfilled} player(s).");
+        } else {
+            $this->info("Backfilled biography for {$playersBackfilled} player(s), updating {$templatesUpdated} template row(s).");
+        }
+
+        if ($orphanedPlayerIds > 0) {
+            $this->warn("{$orphanedPlayerIds} template player_id(s) had no matching Player row — left untouched.");
+        }
+
+        $remainingNull = DB::table('game_player_templates')->whereNull('name')->count();
+        if ($remainingNull > 0) {
+            $this->warn("{$remainingNull} template row(s) still have NULL name.");
+        } else {
+            $this->info('All template rows now have populated biography.');
+        }
+
+        return self::SUCCESS;
+    }
+}


### PR DESCRIPTION
## Summary
Adds a new console command `BackfillTemplatePlayerBiography` to support Phase 2 of the player-data planes refactor. This command copies biographical data (transfermarkt_id, name, date_of_birth, nationality, height, foot) from the control-plane `players` table into corresponding `game_player_templates` rows.

## Key Changes
- **New command**: `app:backfill-template-player-biography` with configurable batch processing
- **Plane-safe design**: Reads from `pgsql_control` connection (Player model) and writes to default tenant connection without cross-plane JOINs
- **Idempotent execution**: Filters by `name IS NULL` to safely re-run after partial completion
- **Dry-run support**: `--dry-run` flag to preview changes without writing
- **Configurable processing**: `--chunk` and `--limit` options for batch control
- **Comprehensive reporting**: Tracks updated templates, backfilled players, orphaned references, and remaining NULL rows

## Notable Implementation Details
- Chunks distinct player IDs to manage memory usage during large backfills
- Handles missing Player records gracefully (orphaned player_id references)
- Properly serializes `nationality` as JSON and converts `date_of_birth` to date string format
- Provides detailed console output for monitoring progress and identifying data issues

https://claude.ai/code/session_01BGPcs1cmkJw2QC7DH6EYnq