### PR TITLE
Add player biography backfill job and command

### DIFF
--- a/app/Console/Commands/BackfillPlayerBiography.php
+++ b/app/Console/Commands/BackfillPlayerBiography.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Game;
+use App\Modules\Player\Jobs\BackfillGamePlayerBiography;
+use Illuminate\Console\Command;
+
+class BackfillPlayerBiography extends Command
+{
+    protected $signature = 'app:backfill-player-biography
+                            {--limit= : Max games to dispatch this run (default: all remaining)}
+                            {--queue=cleanup : Queue to dispatch jobs onto}';
+
+    protected $description = 'Dispatch one BackfillGamePlayerBiography job per game with NULL game_players biography rows.';
+
+    public function handle(): int
+    {
+        $limit = $this->option('limit') !== null ? (int) $this->option('limit') : null;
+        $queue = $this->option('queue');
+
+        $query = Game::query()
+            ->select('id')
+            ->whereExists(fn ($q) => $q
+                ->selectRaw(1)
+                ->from('game_players')
+                ->whereColumn('game_players.game_id', 'games.id')
+                ->whereNull('name'))
+            ->orderBy('id');
+
+        if ($limit !== null) {
+            $query->limit($limit);
+        }
+
+        $count = 0;
+        $query->lazyById()->each(function (Game $game) use ($queue, &$count) {
+            BackfillGamePlayerBiography::dispatch($game->id)->onQueue($queue);
+            $count++;
+        });
+
+        $this->info("Dispatched {$count} backfill jobs onto queue '{$queue}'.");
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Modules/Player/Jobs/BackfillGamePlayerBiography.php
+++ b/app/Modules/Player/Jobs/BackfillGamePlayerBiography.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace App\Modules\Player\Jobs;
+
+use App\Models\Player;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Phase 4 of the player-data planes refactor: copy biographical fields
+ * (transfermarkt_id, name, date_of_birth, nationality, height, foot) from
+ * the control-plane `players` table into one game's `game_players` rows.
+ *
+ * Per-game scope: rows for a single game are heap-clustered (inserted
+ * together during game creation), so each UPDATE touches a small,
+ * contiguous slice of the table — same shape that made
+ * BackfillGameOverallScores tractable on Neon's network-storage model.
+ *
+ * Plane-safe: reads Players from `pgsql_control` and writes to the default
+ * tenant connection in separate queries — no cross-plane JOIN. The bulk
+ * UPDATE uses a `VALUES` join rather than a subquery against players.
+ *
+ * Idempotent: every UPDATE filters by `name IS NULL`, so re-dispatch is a
+ * no-op once a game is fully backfilled.
+ */
+class BackfillGamePlayerBiography implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public int $tries = 3;
+    public int $timeout = 300;
+
+    public function __construct(public string $gameId) {}
+
+    public function handle(): int
+    {
+        $playerIds = DB::table('game_players')
+            ->where('game_id', $this->gameId)
+            ->whereNull('name')
+            ->whereNotNull('player_id')
+            ->distinct()
+            ->pluck('player_id');
+
+        if ($playerIds->isEmpty()) {
+            return 0;
+        }
+
+        $players = Player::query()
+            ->whereIn('id', $playerIds)
+            ->get(['id', 'transfermarkt_id', 'name', 'date_of_birth', 'nationality', 'height', 'foot']);
+
+        if ($players->isEmpty()) {
+            return 0;
+        }
+
+        $placeholders = [];
+        $bindings = [];
+        foreach ($players as $player) {
+            $placeholders[] = '(?, ?, ?, ?, ?, ?, ?)';
+            array_push(
+                $bindings,
+                $player->id,
+                $player->transfermarkt_id,
+                $player->name,
+                $player->date_of_birth?->toDateString(),
+                $player->nationality !== null ? json_encode($player->nationality) : null,
+                $player->height,
+                $player->foot,
+            );
+        }
+        $bindings[] = $this->gameId;
+        $values = implode(',', $placeholders);
+
+        return DB::update(
+            "UPDATE game_players gp
+             SET transfermarkt_id = src.transfermarkt_id,
+                 name = src.name,
+                 date_of_birth = src.date_of_birth::date,
+                 nationality = src.nationality::jsonb,
+                 height = src.height,
+                 foot = src.foot
+             FROM (VALUES {$values}) AS src(player_id, transfermarkt_id, name, date_of_birth, nationality, height, foot)
+             WHERE gp.game_id = ?
+               AND gp.player_id = src.player_id::uuid
+               AND gp.name IS NULL",
+            $bindings
+        );
+    }
+}


### PR DESCRIPTION
## Summary
Implements Phase 4 of the player-data planes refactor by adding a queued job and console command to backfill biographical fields from the control plane into game-specific player records.

## Key Changes
- **BackfillGamePlayerBiography job**: A queueable job that copies biographical data (transfermarkt_id, name, date_of_birth, nationality, height, foot) from the `players` table into `game_players` rows for a single game
  - Uses a `VALUES` join pattern to avoid cross-plane subqueries
  - Filters by `name IS NULL` to ensure idempotency
  - Scoped per-game to leverage heap clustering for efficient updates
  - Configurable retry (3 attempts) and timeout (300s) settings

- **BackfillPlayerBiography command**: Console command to dispatch backfill jobs
  - Identifies all games with incomplete player biography data
  - Supports optional `--limit` flag to control batch size
  - Supports optional `--queue` flag to specify target queue (defaults to 'cleanup')
  - Uses lazy loading for memory efficiency with large game counts

## Implementation Details
- Reads from control plane (`pgsql_control`) and writes to tenant connection separately to maintain plane isolation
- Properly handles nullable fields (date_of_birth, nationality) with appropriate casting
- Uses parameterized queries with explicit bindings for security
- Returns count of affected rows for job visibility

https://claude.ai/code/session_01BGPcs1cmkJw2QC7DH6EYnq