### PR TITLE
Denormalize player biography to GamePlayer model

### DIFF
--- a/app/Http/Actions/AcceptLoanOffer.php
+++ b/app/Http/Actions/AcceptLoanOffer.php
@@ -36,7 +36,7 @@ class AcceptLoanOffer
             abort(403, 'Cannot accept loan offers for loaned players.');
         }
 
-        $playerName = $offer->gamePlayer->player->name;
+        $playerName = $offer->gamePlayer->name;
         $team = $offer->offeringTeam;
         $windowOpen = $game->isTransferWindowOpen();
 

--- a/app/Http/Actions/AcceptTransferOffer.php
+++ b/app/Http/Actions/AcceptTransferOffer.php
@@ -36,11 +36,11 @@ class AcceptTransferOffer
 
         if ($offer->gamePlayer->joinedInCurrentWindow($game)) {
             return redirect()->back()->with('error', __('messages.cannot_sell_same_window', [
-                'player' => $offer->gamePlayer->player->name,
+                'player' => $offer->gamePlayer->name,
             ]));
         }
 
-        $playerName = $offer->gamePlayer->player->name;
+        $playerName = $offer->gamePlayer->name;
         $team = $offer->offeringTeam;
         $fee = $offer->formatted_transfer_fee;
 

--- a/app/Http/Actions/CallUpReservePlayer.php
+++ b/app/Http/Actions/CallUpReservePlayer.php
@@ -25,7 +25,7 @@ class CallUpReservePlayer
             ->with('player')
             ->firstOrFail();
 
-        $playerName = $player->player->name ?? '';
+        $playerName = $player->name ?? '';
 
         try {
             $this->reserveTeamService->callUpToFirstTeam($player, $game);

--- a/app/Http/Actions/CancelLoanSearch.php
+++ b/app/Http/Actions/CancelLoanSearch.php
@@ -28,6 +28,6 @@ class CancelLoanSearch
 
         return redirect()
             ->route('game.transfers.outgoing', $gameId)
-            ->with('success', __('messages.loan_search_cancelled', ['player' => $player->player->name]));
+            ->with('success', __('messages.loan_search_cancelled', ['player' => $player->name]));
     }
 }

--- a/app/Http/Actions/ListPlayerForTransfer.php
+++ b/app/Http/Actions/ListPlayerForTransfer.php
@@ -29,7 +29,7 @@ class ListPlayerForTransfer
 
         if ($player->joinedInCurrentWindow($game)) {
             return redirect()->back()->with('error', __('messages.cannot_sell_same_window', [
-                'player' => $player->player->name,
+                'player' => $player->name,
             ]));
         }
 
@@ -41,7 +41,7 @@ class ListPlayerForTransfer
 
         return redirect()
             ->back()
-            ->with('success', __('messages.player_listed', ['player' => $player->player->name]));
+            ->with('success', __('messages.player_listed', ['player' => $player->name]));
     }
 
     private function formatBreachMessage(SquadMinimumException $e): string

--- a/app/Http/Actions/RequestLoan.php
+++ b/app/Http/Actions/RequestLoan.php
@@ -44,7 +44,7 @@ class RequestLoan
         $this->loanService->requestLoanIn($game, $player);
 
         return redirect()->back()
-            ->with('success', __('messages.loan_request_submitted', ['player' => $player->player->name]));
+            ->with('success', __('messages.loan_request_submitted', ['player' => $player->name]));
     }
 
     private function handleLoanOut(Game $game, GamePlayer $player)

--- a/app/Http/Actions/SendBackReservePlayer.php
+++ b/app/Http/Actions/SendBackReservePlayer.php
@@ -25,7 +25,7 @@ class SendBackReservePlayer
             ->with('player')
             ->firstOrFail();
 
-        $playerName = $player->player->name ?? '';
+        $playerName = $player->name ?? '';
 
         try {
             $this->reserveTeamService->sendBackToReserve($player, $game);

--- a/app/Http/Actions/UnlistPlayerFromTransfer.php
+++ b/app/Http/Actions/UnlistPlayerFromTransfer.php
@@ -26,6 +26,6 @@ class UnlistPlayerFromTransfer
 
         return redirect()
             ->route('game.transfers.outgoing', $gameId)
-            ->with('success', __('messages.player_unlisted', ['player' => $player->player->name]));
+            ->with('success', __('messages.player_unlisted', ['player' => $player->name]));
     }
 }

--- a/app/Http/Actions/WithdrawTransferOffer.php
+++ b/app/Http/Actions/WithdrawTransferOffer.php
@@ -25,7 +25,7 @@ class WithdrawTransferOffer
             abort(403);
         }
 
-        $playerName = $offer->gamePlayer->player->name;
+        $playerName = $offer->gamePlayer->name;
 
         $offer->update([
             'status' => TransferOffer::STATUS_REJECTED,

--- a/app/Http/Views/ShowLiveMatch.php
+++ b/app/Http/Views/ShowLiveMatch.php
@@ -275,7 +275,7 @@ class ShowLiveMatch
                 : null,
             'homePossession' => $playerMatch->home_possession ?? 50,
             'awayPossession' => $playerMatch->away_possession ?? 50,
-            'mvpPlayerName' => $playerMatch->mvpPlayer?->player?->name,
+            'mvpPlayerName' => $playerMatch->mvpPlayer?->name,
             'mvpPlayerTeamId' => $playerMatch->mvpPlayer?->team_id,
             'homeLineupDisplay' => $homeLineupDisplay,
             'awayLineupDisplay' => $awayLineupDisplay,

--- a/app/Http/Views/ShowSquadRegistration.php
+++ b/app/Http/Views/ShowSquadRegistration.php
@@ -32,7 +32,7 @@ class ShowSquadRegistration
         foreach ($gamePlayers as $gp) {
             $dto = [
                 'id' => $gp->id,
-                'name' => $gp->player->name,
+                'name' => $gp->name,
                 'position' => $gp->position,
                 'position_group' => $gp->position_group,
                 'position_abbreviation' => PositionMapper::toAbbreviation($gp->position),

--- a/app/Models/GamePlayer.php
+++ b/app/Models/GamePlayer.php
@@ -765,23 +765,7 @@ class GamePlayer extends Model
      */
     public function age(Carbon|\DateTimeInterface $currentDate): int
     {
-        return (int) $this->player->date_of_birth->diffInYears($currentDate);
-    }
-
-    /**
-     * Get player's name from the reference Player model.
-     */
-    public function getNameAttribute(): string
-    {
-        return $this->player->name;
-    }
-
-    /**
-     * Get player's nationality from the reference Player model.
-     */
-    public function getNationalityAttribute(): ?array
-    {
-        return $this->player->nationality;
+        return (int) $this->date_of_birth->diffInYears($currentDate);
     }
 
     /**

--- a/app/Models/MatchEvent.php
+++ b/app/Models/MatchEvent.php
@@ -109,7 +109,7 @@ class MatchEvent extends Model
      */
     public function getPlayerNameAttribute(): string
     {
-        return $this->gamePlayer->player->name;
+        return $this->gamePlayer->name;
     }
 
     /**

--- a/app/Modules/Academy/Services/YouthAcademyService.php
+++ b/app/Modules/Academy/Services/YouthAcademyService.php
@@ -7,7 +7,6 @@ use App\Modules\Squad\DTOs\GeneratedPlayerData;
 use App\Models\AcademyPlayer;
 use App\Models\Game;
 use App\Models\GamePlayer;
-use App\Models\Player;
 use App\Modules\Player\PlayerAge;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
@@ -563,13 +562,8 @@ class YouthAcademyService
      */
     private function getExistingPlayerNames(Game $game): array
     {
-        // PLANES-SEAM: cross-plane JOIN. game_players=tenant, players=control.
-        // Restored while both planes share one physical Postgres. Re-split
-        // before the planes are physically separated. See CLAUDE.md →
-        // "Control plane / tenant plane".
-        $playerNames = GamePlayer::where('game_players.game_id', $game->id)
-            ->join('players', 'game_players.player_id', '=', 'players.id')
-            ->pluck('players.name')
+        $playerNames = GamePlayer::where('game_id', $game->id)
+            ->pluck('name')
             ->toArray();
 
         $academyNames = AcademyPlayer::where('game_id', $game->id)

--- a/app/Modules/Lineup/Services/TacticalChangeService.php
+++ b/app/Modules/Lineup/Services/TacticalChangeService.php
@@ -246,8 +246,8 @@ class TacticalChangeService
             $substitutionDetails = array_map(fn ($sub) => [
                 'playerOutId' => $sub['playerOutId'],
                 'playerInId' => $sub['playerInId'],
-                'playerOutName' => $players->get($sub['playerOutId'])?->player->name ?? '',
-                'playerInName' => $players->get($sub['playerInId'])?->player->name ?? '',
+                'playerOutName' => $players->get($sub['playerOutId'])?->name ?? '',
+                'playerInName' => $players->get($sub['playerInId'])?->name ?? '',
                 'minute' => $minute,
                 'teamId' => $game->team_id,
             ], $newSubstitutions);
@@ -259,7 +259,7 @@ class TacticalChangeService
         if ($result->mvpPlayerId) {
             $mvpPlayer = GamePlayer::with('player')->find($result->mvpPlayerId);
             if ($mvpPlayer) {
-                $mvpPlayerName = $mvpPlayer->player->name ?? null;
+                $mvpPlayerName = $mvpPlayer->name ?? null;
                 $mvpPlayerTeamId = $mvpPlayer->team_id;
             }
         }

--- a/app/Modules/Match/Services/MatchResimulationService.php
+++ b/app/Modules/Match/Services/MatchResimulationService.php
@@ -852,7 +852,7 @@ class MatchResimulationService
             $playerInNames = GamePlayer::with('player')
                 ->whereIn('id', $playerInIds)
                 ->get()
-                ->mapWithKeys(fn ($gp) => [$gp->id => $gp->player->name ?? ''])
+                ->mapWithKeys(fn ($gp) => [$gp->id => $gp->name ?? ''])
                 ->all();
         }
 
@@ -862,7 +862,7 @@ class MatchResimulationService
                 $data = [
                     'minute' => $e->minute,
                     'type' => $e->event_type,
-                    'playerName' => $e->gamePlayer->player->name ?? '',
+                    'playerName' => $e->gamePlayer->name ?? '',
                     'teamId' => $e->team_id,
                     'gamePlayerId' => $e->game_player_id,
                     'metadata' => $e->metadata,
@@ -888,7 +888,7 @@ class MatchResimulationService
             if ($event['type'] === 'goal') {
                 $key = $event['minute'].':'.$event['teamId'];
                 if (isset($assists[$key])) {
-                    $event['assistPlayerName'] = $assists[$key]->gamePlayer->player->name ?? null;
+                    $event['assistPlayerName'] = $assists[$key]->gamePlayer->name ?? null;
                     $event['assistPlayerId'] = $assists[$key]->game_player_id;
                 }
             }

--- a/app/Modules/Match/Services/MatchSimulator.php
+++ b/app/Modules/Match/Services/MatchSimulator.php
@@ -2953,7 +2953,7 @@ class MatchSimulator
                 'round' => $round,
                 'side' => 'home',
                 'playerId' => $homeKicker->id,
-                'playerName' => $homeKicker->player->name ?? '',
+                'playerName' => $homeKicker->name ?? '',
                 'scored' => $homeScored,
             ];
             $homeIdx++;
@@ -2971,7 +2971,7 @@ class MatchSimulator
                 'round' => $round,
                 'side' => 'away',
                 'playerId' => $awayKicker->id,
-                'playerName' => $awayKicker->player->name ?? '',
+                'playerName' => $awayKicker->name ?? '',
                 'scored' => $awayScored,
             ];
             $awayIdx++;

--- a/app/Modules/Match/Services/MatchdayOrchestrator.php
+++ b/app/Modules/Match/Services/MatchdayOrchestrator.php
@@ -195,13 +195,11 @@ class MatchdayOrchestrator
 
         $allPlayers = GamePlayer::select([
                 'id', 'game_id', 'player_id', 'team_id', 'number', 'position',
+                'name', 'date_of_birth',
                 'durability',
                 'overall_score',
             ])
-            ->with([
-                'player:id,name,date_of_birth,overall_score',
-                'matchState',
-            ])
+            ->with(['matchState'])
             ->where('game_id', $game->id)
             ->whereIn('team_id', $teamIds)
             ->get();

--- a/app/Modules/Report/Services/TournamentSnapshotService.php
+++ b/app/Modules/Report/Services/TournamentSnapshotService.php
@@ -172,7 +172,7 @@ class TournamentSnapshotService
         }
 
         $finalGoalEvents = $data['finalGoalEvents']->map(function ($event) {
-            $playerName = $event->gamePlayer?->player?->name ?? '?';
+            $playerName = $event->gamePlayer?->name ?? '?';
             $isOwnGoal = $event->event_type === \App\Models\MatchEvent::TYPE_OWN_GOAL;
 
             return [
@@ -185,7 +185,7 @@ class TournamentSnapshotService
 
         $serializePlayerList = fn ($collection, $fields) => $collection->map(function ($gp) use ($fields) {
             $item = ['team_id' => $gp->team_id];
-            $item['player_name'] = $gp->player->name;
+            $item['player_name'] = $gp->name;
             foreach ($fields as $field) {
                 $item[$field] = $gp->{$field};
             }
@@ -197,14 +197,14 @@ class TournamentSnapshotService
         $topGoalkeepers = $serializePlayerList($data['topGoalkeepers'], ['clean_sheets', 'appearances', 'goals_conceded']);
 
         $topMvps = $data['topMvps']->map(fn ($mvp) => [
-            'player_name' => $mvp->gamePlayer->player->name,
+            'player_name' => $mvp->gamePlayer->name,
             'team_id' => $mvp->gamePlayer->team_id,
             'count' => $mvp->count,
         ])->values()->all();
 
         $yourSquadStats = $data['yourSquadStats']->map(fn ($gp) => [
             'player_id' => $gp->player_id,
-            'player_name' => $gp->player->name,
+            'player_name' => $gp->name,
             'position' => $gp->position,
             'appearances' => $gp->appearances,
             'goals' => $gp->goals,

--- a/app/Modules/ReserveTeam/Services/ReserveTeamService.php
+++ b/app/Modules/ReserveTeam/Services/ReserveTeamService.php
@@ -232,7 +232,7 @@ class ReserveTeamService
                 type: \App\Models\GameNotification::TYPE_ACADEMY_PROSPECT,
                 title: __('notifications.reserve_overage_promoted_title'),
                 message: __('notifications.reserve_overage_promoted_message', [
-                    'player' => $player->player->name ?? '',
+                    'player' => $player->name ?? '',
                 ]),
                 priority: \App\Models\GameNotification::PRIORITY_INFO,
             );
@@ -344,7 +344,7 @@ class ReserveTeamService
             type: \App\Models\GameNotification::TYPE_ACADEMY_PROSPECT,
             title: __('notifications.reserve_overage_promoted_title'),
             message: __('notifications.reserve_overage_promoted_message', [
-                'player' => $player->player->name ?? '',
+                'player' => $player->name ?? '',
             ]),
             priority: \App\Models\GameNotification::PRIORITY_INFO,
         );

--- a/app/Modules/Season/Processors/SquadReplenishmentProcessor.php
+++ b/app/Modules/Season/Processors/SquadReplenishmentProcessor.php
@@ -115,21 +115,16 @@ class SquadReplenishmentProcessor implements SeasonProcessor
         $bulkMeta = [];
         $releaseIds = [];
 
-        // PLANES-SEAM: cross-plane JOIN. game_players=tenant, players=control.
-        // Restored while both planes share one physical Postgres. Re-split
-        // before the planes are physically separated. See CLAUDE.md →
-        // "Control plane / tenant plane".
-        $playersByTeam = GamePlayer::where('game_players.game_id', $game->id)
-            ->whereNotNull('game_players.team_id')
-            ->join('players', 'game_players.player_id', '=', 'players.id')
+        $playersByTeam = GamePlayer::where('game_id', $game->id)
+            ->whereNotNull('team_id')
             ->select([
-                'game_players.id',
-                'game_players.team_id',
-                'game_players.position',
-                'game_players.overall_score',
-                'game_players.number',
-                'players.date_of_birth',
-                'players.name as player_name',
+                'id',
+                'team_id',
+                'position',
+                'overall_score',
+                'number',
+                'date_of_birth',
+                'name as player_name',
             ])
             ->get()
             ->groupBy('team_id');

--- a/app/Modules/Season/Processors/YouthAcademyPromotionProcessor.php
+++ b/app/Modules/Season/Processors/YouthAcademyPromotionProcessor.php
@@ -114,7 +114,7 @@ class YouthAcademyPromotionProcessor implements SeasonProcessor
         foreach ($positions as $position) {
             $playerData = $this->playerGenerator->buildReplenishmentPlayerData($game, $game->team_id, $position, $teamAvgAbility);
             $gamePlayer = $this->playerGenerator->create($game, $playerData);
-            $emergencyNames[] = $gamePlayer->player->name;
+            $emergencyNames[] = $gamePlayer->name;
         }
 
         if (! empty($emergencyNames)) {

--- a/app/Modules/Squad/Services/PlayerGeneratorService.php
+++ b/app/Modules/Squad/Services/PlayerGeneratorService.php
@@ -644,13 +644,8 @@ class PlayerGeneratorService
     private function getOrLoadGameNames(string $gameId): array
     {
         if (! isset($this->gameNamesCache[$gameId])) {
-            // PLANES-SEAM: cross-plane JOIN. game_players=tenant, players=control.
-            // Restored while both planes share one physical Postgres. Re-split
-            // before the planes are physically separated. See CLAUDE.md →
-            // "Control plane / tenant plane".
-            $this->gameNamesCache[$gameId] = GamePlayer::where('game_players.game_id', $gameId)
-                ->join('players', 'game_players.player_id', '=', 'players.id')
-                ->pluck('players.name')
+            $this->gameNamesCache[$gameId] = GamePlayer::where('game_id', $gameId)
+                ->pluck('name')
                 ->toArray();
         }
 

--- a/app/Modules/Transfer/Services/AITransferMarketService.php
+++ b/app/Modules/Transfer/Services/AITransferMarketService.php
@@ -6,7 +6,6 @@ use App\Models\ClubProfile;
 use App\Models\Game;
 use App\Models\GamePlayer;
 use App\Models\GameTransfer;
-use App\Models\Player;
 use App\Models\Team;
 use App\Models\TeamReputation;
 use App\Modules\Notification\Services\NotificationService;
@@ -1419,63 +1418,40 @@ class AITransferMarketService
     }
 
     /**
-     * Load game players matching the given filter, with the player's
-     * date_of_birth fetched via a JOIN instead of a separate eager-load
-     * round-trip. Hydrates GamePlayer models and pre-attaches a stub Player
-     * relation so callers using ->age($date) and ->player work unchanged.
-     *
-     * Production profiling showed the eager-load query
-     * `SELECT id, date_of_birth FROM players WHERE id IN (3000)` taking
-     * ~155ms by itself; folding it into a JOIN eliminates that round-trip.
+     * Load game players matching the given filter, hydrating only the
+     * subset of columns this service consumes. date_of_birth is read
+     * directly off game_players (Phase 6) — no Player relation needed.
      */
     private function loadGamePlayersWithPlayerDob(\Closure $applyWhere): Collection
     {
-        // PLANES-SEAM: cross-plane JOIN. game_players=tenant, players=control.
-        // The two-step split was reverted because production profiling already
-        // showed splitting these costs ~155ms per call, and this method is on
-        // multiple AI-transfer hot paths. Re-split before the planes are
-        // physically separated. See CLAUDE.md → "Control plane / tenant plane".
-        $query = DB::table('game_players')
-            ->join('players', 'players.id', '=', 'game_players.player_id');
+        $query = DB::table('game_players');
 
         $applyWhere($query);
 
         $rows = $query->get([
-            'game_players.id',
-            'game_players.game_id',
-            'game_players.player_id',
-            'game_players.team_id',
-            'game_players.position',
-            'game_players.tier',
-            'game_players.market_value_cents',
-            'game_players.overall_score',
-            'game_players.retiring_at_season',
-            'game_players.number',
-            'game_players.contract_until',
-            'game_players.annual_wage',
-            'players.date_of_birth as _player_date_of_birth',
+            'id',
+            'game_id',
+            'player_id',
+            'team_id',
+            'position',
+            'tier',
+            'market_value_cents',
+            'overall_score',
+            'retiring_at_season',
+            'number',
+            'contract_until',
+            'annual_wage',
+            'date_of_birth',
         ]);
 
         if ($rows->isEmpty()) {
             return new Collection();
         }
 
-        $gpAttrs = [];
-        $playerAttrs = [];
-        foreach ($rows as $row) {
-            $arr = (array) $row;
-            $dob = $arr['_player_date_of_birth'];
-            unset($arr['_player_date_of_birth']);
-            $gpAttrs[] = $arr;
-            $playerAttrs[] = ['id' => $arr['player_id'], 'date_of_birth' => $dob];
-        }
-
-        $gamePlayers = GamePlayer::hydrate($gpAttrs);
-        $players = Player::hydrate($playerAttrs);
-
-        foreach ($gamePlayers as $i => $gp) {
-            $gp->setRelation('player', $players[$i]);
-        }
+        $gamePlayers = GamePlayer::hydrate(array_map(
+            fn ($row) => (array) $row,
+            $rows->all(),
+        ));
 
         return $gamePlayers;
     }

--- a/app/Modules/Transfer/Services/AITransferMarketService.php
+++ b/app/Modules/Transfer/Services/AITransferMarketService.php
@@ -1304,7 +1304,7 @@ class AITransferMarketService
 
         $signings[] = [
             'playerId' => $bestAgent->id,
-            'playerName' => $bestAgent->player?->name ?? 'Unknown',
+            'playerName' => $bestAgent->name ?? 'Unknown',
             'position' => $bestAgent->position,
             'teamId' => $teamId,
             'teamName' => $team?->name ?? 'Unknown',

--- a/app/Modules/Transfer/Services/ExploreService.php
+++ b/app/Modules/Transfer/Services/ExploreService.php
@@ -220,21 +220,11 @@ class ExploreService
     public function advancedSearch(Game $game, array $filters): array
     {
         $query = GamePlayer::where('game_id', $game->id)
-            ->with(['player', 'team']);
+            ->with(['team']);
 
-        // PLANES-SEAM: name/age/nationality cross-plane filters.
-        // game_players=tenant, players=control. These were folded into a
-        // single Player::pluck → whereIn split, but for wide ranges that
-        // shipped a list bounded only by the global player pool — the same
-        // OOM trap the ability filter hit. Restored to the pre-split
-        // whereHas / correlated subquery form while both planes share one
-        // physical Postgres. Re-split before the planes are physically
-        // separated. See CLAUDE.md → "Control plane / tenant plane".
         if (!empty($filters['name']) && mb_strlen($filters['name']) >= 2) {
             $needle = mb_strtolower($filters['name']);
-            $query->whereHas('player', function ($q) use ($needle) {
-                $q->whereRaw('LOWER(name) LIKE ?', ['%' . $needle . '%']);
-            });
+            $query->whereRaw('LOWER(game_players.name) LIKE ?', ['%' . $needle . '%']);
         }
 
         if (!empty($filters['position'])) {
@@ -259,7 +249,7 @@ class ExploreService
 
         if (!empty($filters['min_age']) || !empty($filters['max_age'])) {
             $gameDate = $game->current_date->toDateString();
-            $ageExpr = 'EXTRACT(YEAR FROM AGE(?::date, (SELECT date_of_birth FROM players WHERE players.id = game_players.player_id)))';
+            $ageExpr = 'EXTRACT(YEAR FROM AGE(?::date, game_players.date_of_birth))';
             if (!empty($filters['min_age'])) {
                 $query->whereRaw("($ageExpr) >= ?", [$gameDate, (int) $filters['min_age']]);
             }
@@ -269,11 +259,9 @@ class ExploreService
         }
 
         if (!empty($filters['nationality'])) {
-            // players.nationality is stored as a JSON array of country names
-            // (["France", "Spain"]). ?::jsonb matches if the array contains the value.
-            $query->whereHas('player', function ($q) use ($filters) {
-                $q->whereRaw('nationality::jsonb @> ?::jsonb', [json_encode([$filters['nationality']])]);
-            });
+            // nationality is a JSON array of country names (["France", "Spain"]).
+            // ?::jsonb matches if the array contains the value.
+            $query->whereRaw('game_players.nationality::jsonb @> ?::jsonb', [json_encode([$filters['nationality']])]);
         }
 
         if (!empty($filters['competition_id'])) {
@@ -307,21 +295,11 @@ class ExploreService
         }
 
         if (!empty($filters['min_overall']) || !empty($filters['max_overall'])) {
-            // Use the stable overall_score baseline so filter results stay
-            // consistent across matchdays instead of shifting with daily form.
-            //
-            // PLANES-SEAM: cross-plane correlated subquery. game_players=tenant,
-            // players=control. The two-step split version (pluck globally
-            // qualifying player_ids, then OR + whereIn) OOMed PHP when the
-            // ability range was wide. Restored while both planes share one
-            // physical Postgres. Re-split before the planes are physically
-            // separated. See CLAUDE.md → "Control plane / tenant plane".
-            $overallExpr = 'COALESCE(game_players.overall_score, (SELECT overall_score FROM players WHERE players.id = game_players.player_id))';
             if (!empty($filters['min_overall'])) {
-                $query->whereRaw("$overallExpr >= ?", [(int) $filters['min_overall']]);
+                $query->where('overall_score', '>=', (int) $filters['min_overall']);
             }
             if (!empty($filters['max_overall'])) {
-                $query->whereRaw("$overallExpr <= ?", [(int) $filters['max_overall']]);
+                $query->where('overall_score', '<=', (int) $filters['max_overall']);
             }
         }
 

--- a/app/Modules/Transfer/Services/ExploreService.php
+++ b/app/Modules/Transfer/Services/ExploreService.php
@@ -366,25 +366,14 @@ class ExploreService
      * sorted alphabetically. Used to populate the nationality dropdown so the
      * list never contains options that would return zero results.
      *
-     * Uses the DB facade rather than Eloquent because selecting a column
-     * aliased `nationality` through GamePlayer::... triggers the model's
-     * magic getNationalityAttribute() accessor on pluck, which then fails
-     * when the unloaded player relation is null.
-     *
      * @return array<int, string>
      */
     public function getDistinctNationalities(string $gameId): array
     {
-        // PLANES-SEAM: cross-plane JOIN. game_players=tenant, players=control.
-        // The two-step split (pluck player_ids on tenant → query control)
-        // shipped a large IN list per call. Restored while both planes share
-        // one physical Postgres. Re-split before the planes are physically
-        // separated. See CLAUDE.md → "Control plane / tenant plane".
         $rows = DB::table('game_players')
-            ->join('players', 'players.id', '=', 'game_players.player_id')
-            ->where('game_players.game_id', $gameId)
-            ->whereRaw("jsonb_typeof(players.nationality::jsonb) = 'array'")
-            ->selectRaw("DISTINCT players.nationality::jsonb->>0 AS nat")
+            ->where('game_id', $gameId)
+            ->whereRaw("jsonb_typeof(nationality::jsonb) = 'array'")
+            ->selectRaw("DISTINCT nationality::jsonb->>0 AS nat")
             ->pluck('nat')
             ->filter()
             ->unique()

--- a/app/Modules/Transfer/Services/LoanService.php
+++ b/app/Modules/Transfer/Services/LoanService.php
@@ -570,7 +570,7 @@ class LoanService
             category: FinancialTransaction::CATEGORY_LOAN,
             amount: $player->annual_wage,
             description: __('finances.tx_loan_in', [
-                'player' => $player->player->name ?? $player->id,
+                'player' => $player->name ?? $player->id,
                 'team' => $parentTeam->name ?? '',
             ]),
             transactionDate: $game->current_date,

--- a/app/Modules/Transfer/Services/ScoutSearchQueryBuilder.php
+++ b/app/Modules/Transfer/Services/ScoutSearchQueryBuilder.php
@@ -90,16 +90,8 @@ class ScoutSearchQueryBuilder
             return;
         }
 
-        // PLANES-SEAM: cross-plane correlated subquery. game_players=tenant,
-        // players=control. The two-step split (Player::pluck → whereIn)
-        // shipped a list bounded only by the global player pool — the same
-        // OOM trap the ability filter hit. Restored while both planes share
-        // one physical Postgres. Re-split before the planes are physically
-        // separated. See CLAUDE.md → "Control plane / tenant plane".
-        $dobSubquery = '(SELECT date_of_birth FROM players WHERE players.id = game_players.player_id)';
         $gameDate = $game->current_date->toDateString();
-
-        $ageExpr = "EXTRACT(YEAR FROM AGE(?::date, $dobSubquery))";
+        $ageExpr = "EXTRACT(YEAR FROM AGE(?::date, game_players.date_of_birth))";
 
         if (! empty($filters['age_min'])) {
             $query->whereRaw("($ageExpr) >= ?", [$gameDate, (int) $filters['age_min']]);
@@ -115,21 +107,12 @@ class ScoutSearchQueryBuilder
             return;
         }
 
-        // PLANES-SEAM: cross-plane correlated subquery. game_players=tenant,
-        // players=control. The two-step split version OOMed when the
-        // bindings list grew with the global player pool. Restore the
-        // correlated subquery while both planes share one physical Postgres.
-        // Re-split before the planes are physically separated. See CLAUDE.md
-        // → "Control plane / tenant plane".
-        $query->where(function ($q) use ($filters) {
-            $abilityExpr = 'COALESCE(game_players.overall_score, (SELECT overall_score FROM players WHERE players.id = game_players.player_id))';
-            if (! empty($filters['ability_min'])) {
-                $q->whereRaw("$abilityExpr >= ?", [(int) $filters['ability_min']]);
-            }
-            if (! empty($filters['ability_max'])) {
-                $q->whereRaw("$abilityExpr <= ?", [(int) $filters['ability_max']]);
-            }
-        });
+        if (! empty($filters['ability_min'])) {
+            $query->where('overall_score', '>=', (int) $filters['ability_min']);
+        }
+        if (! empty($filters['ability_max'])) {
+            $query->where('overall_score', '<=', (int) $filters['ability_max']);
+        }
     }
 
     private function applyValueFilter(Builder $query, array $filters): void

--- a/app/Modules/Transfer/Services/TransferCompletionService.php
+++ b/app/Modules/Transfer/Services/TransferCompletionService.php
@@ -34,7 +34,7 @@ class TransferCompletionService
     public function completeOutgoingTransfer(TransferOffer $offer, Game $game): void
     {
         $player = $offer->gamePlayer;
-        $playerName = $player->player->name;
+        $playerName = $player->name;
         $buyerName = $offer->offeringTeam->name;
         $isLoan = $offer->offer_type === TransferOffer::TYPE_LOAN_OUT;
 
@@ -108,7 +108,7 @@ class TransferCompletionService
     public function completePreContractTransfer(TransferOffer $offer): void
     {
         $player = $offer->gamePlayer;
-        $playerName = $player->player->name;
+        $playerName = $player->name;
         $buyerName = $offer->offeringTeam->name;
         $game = $player->game;
         $fromTeamId = $player->team_id;
@@ -169,7 +169,7 @@ class TransferCompletionService
         }
 
         $player = $offer->gamePlayer;
-        $playerName = $player->player->name;
+        $playerName = $player->name;
         $sellerName = $offer->sellingTeam->name ?? $player->team->name ?? 'Unknown';
         $fromTeamId = $offer->selling_team_id ?? $player->team_id;
 

--- a/app/Modules/Transfer/Services/TransferMarketService.php
+++ b/app/Modules/Transfer/Services/TransferMarketService.php
@@ -6,7 +6,6 @@ use App\Models\ClubProfile;
 use App\Models\Game;
 use App\Models\GamePlayer;
 use App\Models\GameTransfer;
-use App\Models\Player;
 use App\Models\TeamReputation;
 use App\Models\TransferListing;
 use App\Models\TransferOffer;
@@ -394,14 +393,10 @@ class TransferMarketService
             return collect();
         }
 
-        // PLANES-SEAM: cross-plane JOIN. game_players=tenant, players & teams=control.
-        // The two-step split (Team::pluck → DB::table('game_players') → Player::pluck)
-        // caused timeouts/OOM in production because this is on the AI-transfer hot
-        // path and the JOIN is materially faster while both planes share one
-        // physical Postgres. Re-split before the planes are physically separated.
-        // See CLAUDE.md → "Control plane / tenant plane".
+        // PLANES-SEAM: cross-plane JOIN against teams (for parent_team_id).
+        // game_players biography is read locally post-Phase-6, so the players
+        // join is gone; the teams join remains until that seam is split.
         $rows = DB::table('game_players')
-            ->join('players', 'players.id', '=', 'game_players.player_id')
             ->join('teams', 'teams.id', '=', 'game_players.team_id')
             ->where('game_players.game_id', $game->id)
             ->whereIn('game_players.team_id', $teamIds)
@@ -417,29 +412,17 @@ class TransferMarketService
                 'game_players.retiring_at_season',
                 'game_players.contract_until',
                 'game_players.annual_wage',
-                'players.date_of_birth as _player_date_of_birth',
+                'game_players.date_of_birth',
             ]);
 
         if ($rows->isEmpty()) {
             return collect();
         }
 
-        $gpAttrs = [];
-        $playerAttrs = [];
-        foreach ($rows as $row) {
-            $arr = (array) $row;
-            $dob = $arr['_player_date_of_birth'];
-            unset($arr['_player_date_of_birth']);
-            $gpAttrs[] = $arr;
-            $playerAttrs[] = ['id' => $arr['player_id'], 'date_of_birth' => $dob];
-        }
-
-        $gamePlayers = GamePlayer::hydrate($gpAttrs);
-        $players = Player::hydrate($playerAttrs);
-
-        foreach ($gamePlayers as $i => $gp) {
-            $gp->setRelation('player', $players[$i]);
-        }
+        $gamePlayers = GamePlayer::hydrate(array_map(
+            fn ($row) => (array) $row,
+            $rows->all(),
+        ));
 
         return $gamePlayers->groupBy('team_id');
     }

--- a/app/Support/LiveMatchLineupPresenter.php
+++ b/app/Support/LiveMatchLineupPresenter.php
@@ -105,7 +105,7 @@ class LiveMatchLineupPresenter
             ->get()
             ->map(fn ($p) => [
                 'id' => $p->id,
-                'name' => $p->player->name ?? '',
+                'name' => $p->name ?? '',
                 'positionAbbr' => PositionMapper::toAbbreviation($p->position),
                 'positionGroup' => $p->position_group,
                 'positionSort' => LineupService::positionSortOrder($p->position),
@@ -127,7 +127,7 @@ class LiveMatchLineupPresenter
     ): array {
         $card = [
             'id' => $p->id,
-            'name' => $p->player->name ?? '',
+            'name' => $p->name ?? '',
             'position' => $p->position,
             'positionAbbr' => PositionMapper::toAbbreviation($p->position),
             'positionGroup' => $p->position_group,

--- a/database/factories/GamePlayerFactory.php
+++ b/database/factories/GamePlayerFactory.php
@@ -34,6 +34,16 @@ class GamePlayerFactory extends Factory
             'id' => Str::uuid()->toString(),
             'game_id' => Game::factory(),
             'player_id' => Player::factory(),
+            // Biography lives on game_players directly post-Phase-6. Generate
+            // it inline so factory-built rows match the production reality
+            // where every game_players row carries its own biography copy,
+            // independent of the Player relationship being navigable.
+            'transfermarkt_id' => 'gen-' . Str::uuid()->toString(),
+            'name' => $this->faker->name,
+            'date_of_birth' => $this->faker->dateTimeBetween('-40 years', '-16 years')->format('Y-m-d'),
+            'nationality' => [$this->faker->country],
+            'height' => $this->faker->numberBetween(165, 200) . 'cm',
+            'foot' => $this->faker->randomElement(['left', 'right', 'both']),
             'team_id' => Team::factory(),
             'position' => 'Central Midfield',
             'secondary_positions' => [],
@@ -81,18 +91,6 @@ class GamePlayerFactory extends Factory
             $oid = spl_object_id($player);
             $overrides = self::$pendingOverrides[$oid] ?? [];
             unset(self::$pendingOverrides[$oid]);
-
-            // Mirror biography from the linked Player onto the game_players
-            // row. Production paths set this at insert time (Phase 5);
-            // factories back-fill here so tests reflect the post-Phase-6
-            // schema reality where readers consume the local biography
-            // columns directly.
-            if ($player->name === null && $player->player) {
-                $player->forceFill($player->player->only([
-                    'transfermarkt_id', 'name', 'date_of_birth',
-                    'nationality', 'height', 'foot',
-                ]))->save();
-            }
 
             // Every test-created GamePlayer gets a satellite row by default
             // — tests historically assumed game_players carried fitness etc.,

--- a/database/factories/GamePlayerFactory.php
+++ b/database/factories/GamePlayerFactory.php
@@ -92,6 +92,30 @@ class GamePlayerFactory extends Factory
             $overrides = self::$pendingOverrides[$oid] ?? [];
             unset(self::$pendingOverrides[$oid]);
 
+            // Mirror biography from the linked Player onto the game_players
+            // row. Tests historically set `Player::factory()->age($n)` and
+            // expected `$gp->age()` to reflect it via the relationship;
+            // post-Phase-6 readers consume biography off game_players
+            // directly, so the link has to be carried into the local row.
+            // Any non-null biography column on the Player overrides the
+            // factory's random `definition()` fallback (which still applies
+            // when no Player is attached, or when Player has nulls).
+            $linkedPlayer = $player->player;
+            if ($linkedPlayer !== null) {
+                $bio = array_filter([
+                    'transfermarkt_id' => $linkedPlayer->transfermarkt_id,
+                    'name' => $linkedPlayer->name,
+                    'date_of_birth' => $linkedPlayer->date_of_birth?->toDateString(),
+                    'nationality' => $linkedPlayer->nationality,
+                    'height' => $linkedPlayer->height,
+                    'foot' => $linkedPlayer->foot,
+                ], fn ($v) => $v !== null);
+
+                if (! empty($bio)) {
+                    $player->forceFill($bio)->save();
+                }
+            }
+
             // Every test-created GamePlayer gets a satellite row by default
             // — tests historically assumed game_players carried fitness etc.,
             // and the cheapest fix is to mirror that assumption.

--- a/database/factories/GamePlayerFactory.php
+++ b/database/factories/GamePlayerFactory.php
@@ -82,6 +82,18 @@ class GamePlayerFactory extends Factory
             $overrides = self::$pendingOverrides[$oid] ?? [];
             unset(self::$pendingOverrides[$oid]);
 
+            // Mirror biography from the linked Player onto the game_players
+            // row. Production paths set this at insert time (Phase 5);
+            // factories back-fill here so tests reflect the post-Phase-6
+            // schema reality where readers consume the local biography
+            // columns directly.
+            if ($player->name === null && $player->player) {
+                $player->forceFill($player->player->only([
+                    'transfermarkt_id', 'name', 'date_of_birth',
+                    'nationality', 'height', 'foot',
+                ]))->save();
+            }
+
             // Every test-created GamePlayer gets a satellite row by default
             // — tests historically assumed game_players carried fitness etc.,
             // and the cheapest fix is to mirror that assumption.

--- a/resources/views/components/top-scorers.blade.php
+++ b/resources/views/components/top-scorers.blade.php
@@ -15,7 +15,7 @@
                 <div class="flex items-center gap-2.5 px-4 py-2 text-sm {{ $isPlayerTeam ? 'bg-accent-blue/[0.06] border-l-2 border-l-accent-blue' : '' }}">
                     <span class="w-5 text-[11px] font-heading font-semibold text-text-muted shrink-0">{{ $index + 1 }}</span>
                     <x-team-crest :team="$scorerTeam" class="w-4 h-4 shrink-0" title="{{ $scorerTeam?->name }}" />
-                    <span class="flex-1 truncate text-xs {{ $isPlayerTeam ? 'font-medium text-text-primary' : 'text-text-body' }}">{{ $scorer->player->name }}</span>
+                    <span class="flex-1 truncate text-xs {{ $isPlayerTeam ? 'font-medium text-text-primary' : 'text-text-body' }}">{{ $scorer->name }}</span>
                     <span class="text-[11px] font-semibold text-text-primary shrink-0">{{ $scorer->goals }}</span>
                 </div>
             @endforeach

--- a/resources/views/editor/player-templates/_audit-modal.blade.php
+++ b/resources/views/editor/player-templates/_audit-modal.blade.php
@@ -2,7 +2,7 @@
     <div class="p-6">
         <div class="flex items-center justify-between mb-4">
             <h2 class="font-heading text-lg font-bold uppercase tracking-wide text-text-primary">
-                {{ __('admin.history') }} — {{ $template->player?->name }}
+                {{ __('admin.history') }} — {{ $template->name }}
             </h2>
             <button @click="$dispatch('close-modal', 'audit-{{ $template->id }}')" class="text-text-muted hover:text-text-secondary">
                 <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" /></svg>

--- a/resources/views/editor/player-templates/audit-log.blade.php
+++ b/resources/views/editor/player-templates/audit-log.blade.php
@@ -50,7 +50,7 @@
                                 </span>
                             </td>
                             <td class="px-4 py-3 text-sm text-text-primary">
-                                {{ $audit->template?->player?->name ?? '—' }}
+                                {{ $audit->template?->name ?? '—' }}
                             </td>
                             <td class="px-4 py-3 text-sm text-text-muted hidden md:table-cell">
                                 {{ $audit->template?->team?->name ?? '—' }}

--- a/resources/views/editor/player-templates/squad.blade.php
+++ b/resources/views/editor/player-templates/squad.blade.php
@@ -74,7 +74,7 @@
                                     original: @js($template->toArray()),
                                     form: {
                                         ...@js($template->toArray()),
-                                        nationality: @js(($template->player?->nationality ?? [])[0] ?? ''),
+                                        nationality: @js(($template->nationality ?? [])[0] ?? ''),
                                     },
                                     marketValueEuros: Math.round(@js($template->market_value_cents) / 100),
                                     annualWageEuros: Math.round(@js($template->annual_wage) / 100),
@@ -112,7 +112,7 @@
                                     },
                                     cancel() {
                                         this.form = { ...this.original };
-                                        this.form.nationality = @js(($template->player?->nationality ?? [])[0] ?? '');
+                                        this.form.nationality = @js(($template->nationality ?? [])[0] ?? '');
                                         this.marketValueEuros = Math.round(this.original.market_value_cents / 100);
                                         this.annualWageEuros = Math.round(this.original.annual_wage / 100);
                                         this.editing = false;
@@ -123,7 +123,7 @@
 
                                 {{-- Display mode: proper <td> elements --}}
                                 <td x-show="!editing" class="px-3 py-2.5 text-sm text-text-muted" x-text="original.number || '—'"></td>
-                                <td x-show="!editing" class="px-3 py-2.5 text-sm text-text-primary font-medium truncate">{{ $template->player?->name ?? '—' }}</td>
+                                <td x-show="!editing" class="px-3 py-2.5 text-sm text-text-primary font-medium truncate">{{ $template->name ?? '—' }}</td>
                                 <td x-show="!editing" class="px-3 py-2.5 text-xs text-text-muted hidden md:table-cell" x-text="original.position"></td>
                                 <td x-show="!editing" class="px-3 py-2.5 text-xs text-text-muted text-right hidden md:table-cell">{{ \App\Support\Money::format($template->market_value_cents) }}</td>
                                 <td x-show="!editing" class="px-3 py-2.5 text-sm text-text-primary text-center" x-text="original.overall_score ?? '—'"></td>
@@ -152,7 +152,7 @@
                                 {{-- Edit mode --}}
                                 <td x-show="editing" x-cloak colspan="8" class="p-0">
                                     <div class="p-4 bg-accent-blue/5 border-l-2 border-accent-blue space-y-4">
-                                        <div class="text-sm font-medium text-text-primary">{{ $template->player?->name }}</div>
+                                        <div class="text-sm font-medium text-text-primary">{{ $template->name }}</div>
 
                                         {{-- Error --}}
                                         <div x-show="error" x-text="error" class="text-xs text-accent-red bg-accent-red/10 rounded px-3 py-1.5"></div>

--- a/resources/views/incoming-transfers.blade.php
+++ b/resources/views/incoming-transfers.blade.php
@@ -97,7 +97,7 @@
                                                 @endif
                                                 <div>
                                                     <div class="font-semibold text-text-primary">
-                                                        {{ $offer->gamePlayer->player->name }} &larr; {{ $offer->selling_team_name ?? 'Unknown' }}
+                                                        {{ $offer->gamePlayer->name }} &larr; {{ $offer->selling_team_name ?? 'Unknown' }}
                                                     </div>
                                                     <div class="text-sm text-text-secondary">
                                                         {{ $offer->gamePlayer->position_name }} &middot; {{ $offer->gamePlayer->age($game->current_date) }} {{ __('app.years') }}
@@ -128,7 +128,7 @@
                                                         $gp = $offer->gamePlayer;
                                                         $posDisp = $gp->position_display;
                                                         $negotiationDetail = \Illuminate\Support\Js::from([
-                                                            'playerName' => $gp->player->name,
+                                                            'playerName' => $gp->name,
                                                             'negotiateUrl' => route('game.negotiate.transfer', [$game->id, $gp->id]),
                                                             'mode' => 'transfer_fee',
                                                             'phase' => 'club_fee',
@@ -178,7 +178,7 @@
                                                 @endif
                                                 <div>
                                                     <div class="font-semibold text-text-primary">
-                                                        {{ $transfer->gamePlayer->player->name }} &larr; {{ $transfer->selling_team_name ?? 'Unknown' }}
+                                                        {{ $transfer->gamePlayer->name }} &larr; {{ $transfer->selling_team_name ?? 'Unknown' }}
                                                     </div>
                                                     <div class="text-sm text-text-secondary">
                                                         {{ $transfer->gamePlayer->position_name }} &middot; {{ $transfer->gamePlayer->age($game->current_date) }} {{ __('app.years') }}
@@ -251,7 +251,7 @@
                                                 <x-team-crest :team="$transfer->sellingTeam" class="w-6 h-6 shrink-0" />
                                                 @endif
                                                 <span class="text-text-secondary">
-                                                    {{ $transfer->gamePlayer->player->name }} &larr; {{ $transfer->sellingTeam?->name ?? __('squad.free_transfer') }}
+                                                    {{ $transfer->gamePlayer->name }} &larr; {{ $transfer->sellingTeam?->name ?? __('squad.free_transfer') }}
                                                 </span>
                                             </div>
                                             <div class="flex items-center gap-3 md:text-right">

--- a/resources/views/lineup.blade.php
+++ b/resources/views/lineup.blade.php
@@ -291,7 +291,7 @@
                                                 }"
                                             >
                                                 <div class="flex items-center gap-2.5">
-                                                    <x-player-avatar :name="$player->player->name ?? $player->name" :position-group="$posGroup" :number="$player->number" size="sm" />
+                                                    <x-player-avatar :name="$player->name ?? $player->name" :position-group="$posGroup" :number="$player->number" size="sm" />
                                                     <div class="flex-1 min-w-0">
                                                         <div class="flex items-center gap-1.5">
                                                             <span class="text-xs font-medium text-text-primary truncate">{{ $player->name }}</span>

--- a/resources/views/outgoing-transfers.blade.php
+++ b/resources/views/outgoing-transfers.blade.php
@@ -111,7 +111,7 @@
                                                 <x-team-crest :team="$offer->offeringTeam" class="w-10 h-10 shrink-0" />
                                                 <div>
                                                     <div class="font-semibold text-text-primary">
-                                                        {{ $offer->gamePlayer->player->name }} &larr; {{ $offer->offeringTeam->name }}
+                                                        {{ $offer->gamePlayer->name }} &larr; {{ $offer->offeringTeam->name }}
                                                     </div>
                                                     <div class="text-sm text-text-secondary">
                                                         {{ $offer->gamePlayer->position_name }} &middot; {{ $offer->gamePlayer->age($game->current_date) }} {{ __('app.years') }} &middot;
@@ -129,7 +129,7 @@
                                                         $gp = $offer->gamePlayer;
                                                         $posDisp = $gp->position_display;
                                                         $counterOfferDetail = \Illuminate\Support\Js::from([
-                                                            'playerName' => $gp->player->name,
+                                                            'playerName' => $gp->name,
                                                             'negotiateUrl' => route('game.negotiate.counter-offer', [$game->id, $offer->id]),
                                                             'mode' => 'transfer_fee',
                                                             'phase' => 'counter_offer',
@@ -169,7 +169,7 @@
                                                 <x-team-crest :team="$offer->offeringTeam" class="w-10 h-10 shrink-0" />
                                                 <div>
                                                     <div class="font-semibold text-text-primary">
-                                                        {{ $offer->gamePlayer->player->name }} &larr; {{ $offer->offeringTeam->name }}
+                                                        {{ $offer->gamePlayer->name }} &larr; {{ $offer->offeringTeam->name }}
                                                     </div>
                                                     <div class="text-sm text-text-secondary">
                                                         {{ $offer->gamePlayer->position_name }} &middot; {{ $offer->gamePlayer->age($game->current_date) }} {{ __('app.years') }} &middot;
@@ -233,7 +233,7 @@
                                                 <x-team-crest :team="$offer->offeringTeam" class="w-10 h-10 shrink-0" />
                                                 <div>
                                                     <div class="font-semibold text-text-primary">
-                                                        {{ $offer->gamePlayer->player->name }} &larr; {{ $offer->offeringTeam->name }}
+                                                        {{ $offer->gamePlayer->name }} &larr; {{ $offer->offeringTeam->name }}
                                                     </div>
                                                     <div class="text-sm text-text-secondary">
                                                         {{ $offer->gamePlayer->position_name }} &middot; {{ $offer->gamePlayer->age($game->current_date) }} {{ __('app.years') }} &middot;
@@ -251,7 +251,7 @@
                                                         $gp = $offer->gamePlayer;
                                                         $posDisp = $gp->position_display;
                                                         $counterOfferDetail = \Illuminate\Support\Js::from([
-                                                            'playerName' => $gp->player->name,
+                                                            'playerName' => $gp->name,
                                                             'negotiateUrl' => route('game.negotiate.counter-offer', [$game->id, $offer->id]),
                                                             'mode' => 'transfer_fee',
                                                             'phase' => 'counter_offer',
@@ -291,7 +291,7 @@
                                                 <x-team-crest :team="$transfer->offeringTeam" class="w-10 h-10 shrink-0" />
                                                 <div>
                                                     <div class="font-semibold text-text-primary">
-                                                        {{ $transfer->gamePlayer->player->name }} &rarr; {{ $transfer->offeringTeam->name }}
+                                                        {{ $transfer->gamePlayer->name }} &rarr; {{ $transfer->offeringTeam->name }}
                                                     </div>
                                                     <div class="text-sm text-text-secondary">
                                                         {{ $transfer->gamePlayer->position_name }} &middot; {{ $transfer->gamePlayer->age($game->current_date) }} {{ __('app.years') }}
@@ -322,7 +322,7 @@
                                                 <x-team-crest :team="$transfer->offeringTeam" class="w-10 h-10 shrink-0" />
                                                 <div>
                                                     <div class="font-semibold text-text-primary">
-                                                        {{ $transfer->gamePlayer->player->name }} &rarr; {{ $transfer->offeringTeam->name }}
+                                                        {{ $transfer->gamePlayer->name }} &rarr; {{ $transfer->offeringTeam->name }}
                                                     </div>
                                                     <div class="text-sm text-text-secondary">
                                                         {{ $transfer->gamePlayer->position_name }} &middot; {{ $transfer->gamePlayer->age($game->current_date) }} {{ __('app.years') }}
@@ -353,7 +353,7 @@
                                                 <x-team-crest :team="$offer->offeringTeam" class="w-10 h-10 shrink-0" />
                                                 <div>
                                                     <div class="font-semibold text-text-primary">
-                                                        {{ $offer->gamePlayer->player->name }} &larr; {{ $offer->offeringTeam->name }}
+                                                        {{ $offer->gamePlayer->name }} &larr; {{ $offer->offeringTeam->name }}
                                                     </div>
                                                     <div class="text-sm text-text-secondary">
                                                         {{ $offer->gamePlayer->position_name }} &middot; {{ $offer->gamePlayer->age($game->current_date) }} {{ __('app.years') }} &middot;
@@ -439,7 +439,7 @@
                                                     </svg>
                                                 </div>
                                                 <div>
-                                                    <div class="font-semibold text-text-primary">{{ $player->player->name }}</div>
+                                                    <div class="font-semibold text-text-primary">{{ $player->name }}</div>
                                                     <div class="text-sm text-text-secondary">
                                                         {{ $player->position_name }} &middot; {{ $player->age($game->current_date) }} {{ __('app.years') }} &middot;
                                                         {{ __('app.value') }}: {{ $player->formatted_market_value }}
@@ -470,7 +470,7 @@
                                             <div class="flex items-center gap-3">
                                                 <x-team-crest :team="$transfer->offeringTeam" class="w-6 h-6 shrink-0" />
                                                 <span class="text-text-secondary">
-                                                    {{ $transfer->gamePlayer->player->name }} &rarr; {{ $transfer->offeringTeam->name }}
+                                                    {{ $transfer->gamePlayer->name }} &rarr; {{ $transfer->offeringTeam->name }}
                                                 </span>
                                             </div>
                                             <span class="font-semibold text-accent-green">{{ $transfer->formatted_transfer_fee }}</span>
@@ -535,7 +535,7 @@
                                             </td>
                                             <td class="py-2.5 pl-2 pr-3">
                                                 <div class="flex items-center gap-1.5">
-                                                    <span class="font-medium text-text-primary truncate">{{ $player->player->name }}</span>
+                                                    <span class="font-medium text-text-primary truncate">{{ $player->name }}</span>
                                                     @if($player->contract_expiry_year)
                                                         <span class="text-[10px] tabular-nums shrink-0 {{ $isExpiring ? 'text-accent-red font-medium' : 'text-text-muted' }}">{{ $player->contract_expiry_year }}</span>
                                                     @endif
@@ -560,7 +560,7 @@
                                             </td>
                                             <td class="py-2.5 pl-2 pr-3">
                                                 <div>
-                                                    <span class="font-medium text-text-primary truncate">{{ $player->player->name }}</span>
+                                                    <span class="font-medium text-text-primary truncate">{{ $player->name }}</span>
                                                     <div class="inline-flex items-center gap-1 text-xs text-text-muted">
                                                         <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
                                                         {{ __('transfers.renewal_cooldown_short') }}
@@ -592,7 +592,7 @@
                                         <div class="flex items-center justify-between gap-2">
                                             <div class="flex items-center gap-2 min-w-0">
                                                 <x-position-badge :position="$player->position" size="sm" />
-                                                <span class="text-sm text-text-muted truncate">{{ $player->player->name }}</span>
+                                                <span class="text-sm text-text-muted truncate">{{ $player->name }}</span>
                                             </div>
                                             <form method="post" action="{{ route('game.transfers.reconsider-renewal', [$game->id, $player->id]) }}">
                                                 @csrf
@@ -617,7 +617,7 @@
                                             <svg class="w-4 h-4 text-accent-green shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
                                             </svg>
-                                            <span class="font-medium text-sm text-text-primary truncate">{{ $player->player->name }}</span>
+                                            <span class="font-medium text-sm text-text-primary truncate">{{ $player->name }}</span>
                                         </div>
                                         <div class="text-xs text-text-muted">
                                             {{ $player->formatted_wage }} <span class="text-text-body">&rarr;</span>

--- a/resources/views/partials/player-detail.blade.php
+++ b/resources/views/partials/player-detail.blade.php
@@ -75,7 +75,7 @@
                         {{ $gamePlayer->team->name }}
                     </span>
                 @endif
-                <span>{{ $gamePlayer->age($game->current_date) }} {{ __('app.years') }}@if($gamePlayer->player->height) · {{ $gamePlayer->player->height }}@endif</span>
+                <span>{{ $gamePlayer->age($game->current_date) }} {{ __('app.years') }}@if($gamePlayer->height) · {{ $gamePlayer->height }}@endif</span>
             </div>
             <div class="text-[11px] text-text-faint mt-1">
                 @foreach($gamePlayer->positions as $pos)

--- a/resources/views/results.blade.php
+++ b/resources/views/results.blade.php
@@ -62,7 +62,7 @@
                                 <div class="flex-1 text-right">
                                     @foreach($homeGoals->sortBy('minute') as $event)
                                         <div class="text-text-body">
-                                            {{ $event->gamePlayer->player->name }}
+                                            {{ $event->gamePlayer->name }}
                                             @if($event->event_type === 'own_goal')<span class="text-red-400">({{ __('game.og') }})</span>@endif
                                             <span class="text-text-muted">{{ $event->minute }}'</span>
                                         </div>
@@ -71,7 +71,7 @@
                                 <div class="flex-1">
                                     @foreach($awayGoals->sortBy('minute') as $event)
                                         <div class="text-text-body">
-                                            {{ $event->gamePlayer->player->name }}
+                                            {{ $event->gamePlayer->name }}
                                             @if($event->event_type === 'own_goal')<span class="text-red-400">({{ __('game.og') }})</span>@endif
                                             <span class="text-text-muted">{{ $event->minute }}'</span>
                                         </div>
@@ -92,7 +92,7 @@
                                 <div class="flex-1 text-right">
                                     @foreach($homeCards as $event)
                                         <div class="inline-flex items-center gap-1 justify-end">
-                                            {{ $event->gamePlayer->player->name }} {{ $event->minute }}'
+                                            {{ $event->gamePlayer->name }} {{ $event->minute }}'
                                             @if($event->event_type === 'yellow_card')
                                                 <span class="w-2 h-3 bg-yellow-400 rounded-xs"></span>
                                             @else
@@ -109,7 +109,7 @@
                                             @else
                                                 <span class="w-2 h-3 bg-accent-red rounded-xs"></span>
                                             @endif
-                                            {{ $event->gamePlayer->player->name }} {{ $event->minute }}'
+                                            {{ $event->gamePlayer->name }} {{ $event->minute }}'
                                         </div>
                                     @endforeach
                                 </div>
@@ -123,7 +123,7 @@
                             <div class="flex items-center justify-center gap-2 text-sm">
                                 <span class="text-accent-gold text-base">&#9733;</span>
                                 <span class="text-text-secondary">{{ __('game.mvp') }}</span>
-                                <span class="font-semibold text-text-primary">{{ $playerMatch->mvpPlayer->player->name }}</span>
+                                <span class="font-semibold text-text-primary">{{ $playerMatch->mvpPlayer->name }}</span>
                                 <span class="text-xs px-1.5 py-0.5 rounded bg-surface-700 text-text-muted">
                                     {{ $playerMatch->mvpPlayer->team_id === $playerMatch->home_team_id ? $playerMatch->homeTeam->name : $playerMatch->awayTeam->name }}
                                 </span>

--- a/resources/views/season-end.blade.php
+++ b/resources/views/season-end.blade.php
@@ -41,10 +41,10 @@ $getZoneClass = function($position) use ($standingsZones, $borderColorMap) {
 <x-app-layout :hide-footer="true">
 @php
     $seasonHighlights = collect([
-        $teamTopScorer && $teamTopScorer->goals > 0 ? ['label' => __('season.goals'), 'playerName' => $teamTopScorer->player->name, 'value' => $teamTopScorer->goals] : null,
-        $teamTopAssister && $teamTopAssister->assists > 0 ? ['label' => __('season.assists'), 'playerName' => $teamTopAssister->player->name, 'value' => $teamTopAssister->assists] : null,
-        $teamMostAppearances && $teamMostAppearances->appearances > 0 ? ['label' => __('season.appearances'), 'playerName' => $teamMostAppearances->player->name, 'value' => $teamMostAppearances->appearances] : null,
-        $teamMvpLeader ? ['label' => __('season.mvp_awards'), 'playerName' => $teamMvpLeader->gamePlayer->player->name, 'value' => $teamMvpLeader->count] : null,
+        $teamTopScorer && $teamTopScorer->goals > 0 ? ['label' => __('season.goals'), 'playerName' => $teamTopScorer->name, 'value' => $teamTopScorer->goals] : null,
+        $teamTopAssister && $teamTopAssister->assists > 0 ? ['label' => __('season.assists'), 'playerName' => $teamTopAssister->name, 'value' => $teamTopAssister->assists] : null,
+        $teamMostAppearances && $teamMostAppearances->appearances > 0 ? ['label' => __('season.appearances'), 'playerName' => $teamMostAppearances->name, 'value' => $teamMostAppearances->appearances] : null,
+        $teamMvpLeader ? ['label' => __('season.mvp_awards'), 'playerName' => $teamMvpLeader->gamePlayer->name, 'value' => $teamMvpLeader->count] : null,
     ])->filter()->values()->toArray();
 
     $otherComps = collect($otherCompetitionResults)->map(function ($result) {
@@ -278,7 +278,7 @@ $getZoneClass = function($position) use ($standingsZones, $borderColorMap) {
                                         <div class="flex items-center gap-2 text-sm @if($isPlayerTeam) bg-accent-blue/10 -mx-1 px-1 py-0.5 rounded-sm @endif">
                                             <span class="w-5 text-center text-xs font-bold {{ $index === 0 ? 'text-accent-gold' : 'text-text-secondary' }}">{{ $index + 1 }}</span>
                                             <x-team-crest :team="$scorer->team" class="w-4 h-4 shrink-0" />
-                                            <span class="flex-1 truncate @if($isPlayerTeam) font-medium @endif">{{ $scorer->player->name }}</span>
+                                            <span class="flex-1 truncate @if($isPlayerTeam) font-medium @endif">{{ $scorer->name }}</span>
                                             <span class="font-heading font-bold tabular-nums text-text-primary">{{ $scorer->goals }}</span>
                                         </div>
                                     @endforeach
@@ -302,7 +302,7 @@ $getZoneClass = function($position) use ($standingsZones, $borderColorMap) {
                                     <div class="@if($isPlayerTeam) bg-accent-blue/10 rounded-sm p-2 -m-1 @endif">
                                         <div class="flex items-center gap-2 mb-1.5">
                                             <x-team-crest :team="$bestGoalkeeper->team" class="w-5 h-5 shrink-0" />
-                                            <span class="font-semibold text-sm text-text-primary truncate">{{ $bestGoalkeeper->player->name }}</span>
+                                            <span class="font-semibold text-sm text-text-primary truncate">{{ $bestGoalkeeper->name }}</span>
                                         </div>
                                         <div class="flex items-baseline gap-3 text-xs text-text-muted">
                                             <span><span class="font-heading font-bold text-text-primary text-base tabular-nums">{{ $bestGoalkeeper->clean_sheets }}</span> {{ __('season.clean_sheets') }}</span>
@@ -331,7 +331,7 @@ $getZoneClass = function($position) use ($standingsZones, $borderColorMap) {
                                         <div class="flex items-center gap-2 text-sm @if($isPlayerTeam) bg-accent-blue/10 -mx-1 px-1 py-0.5 rounded-sm @endif">
                                             <span class="w-5 text-center text-xs font-bold {{ $index === 0 ? 'text-accent-gold' : 'text-text-secondary' }}">{{ $index + 1 }}</span>
                                             <x-team-crest :team="$mvp->gamePlayer->team" class="w-4 h-4 shrink-0" />
-                                            <span class="flex-1 truncate @if($isPlayerTeam) font-medium @endif">{{ $mvp->gamePlayer->player->name }}</span>
+                                            <span class="flex-1 truncate @if($isPlayerTeam) font-medium @endif">{{ $mvp->gamePlayer->name }}</span>
                                             <span class="font-heading font-bold tabular-nums text-text-primary">{{ $mvp->count }}</span>
                                         </div>
                                     @endforeach
@@ -470,7 +470,7 @@ $getZoneClass = function($position) use ($standingsZones, $borderColorMap) {
                         <div class="text-[10px] text-accent-gold uppercase tracking-widest font-semibold mb-1.5">{{ __('season.your_top_scorer') }}</div>
                         <div class="flex items-center gap-1.5 mb-1">
                             <x-team-crest :team="$teamTopScorer->team" class="w-4 h-4 shrink-0" />
-                            <span class="text-sm font-medium text-text-primary truncate">{{ $teamTopScorer->player->name }}</span>
+                            <span class="text-sm font-medium text-text-primary truncate">{{ $teamTopScorer->name }}</span>
                         </div>
                         <div class="font-heading text-xl font-bold text-text-primary tabular-nums">{{ $teamTopScorer->goals }}</div>
                         <div class="text-[10px] text-accent-gold/80">{{ __('season.goals') }}</div>
@@ -482,7 +482,7 @@ $getZoneClass = function($position) use ($standingsZones, $borderColorMap) {
                         <div class="text-[10px] text-accent-blue uppercase tracking-widest font-semibold mb-1.5">{{ __('season.your_top_assister') }}</div>
                         <div class="flex items-center gap-1.5 mb-1">
                             <x-team-crest :team="$teamTopAssister->team" class="w-4 h-4 shrink-0" />
-                            <span class="text-sm font-medium text-text-primary truncate">{{ $teamTopAssister->player->name }}</span>
+                            <span class="text-sm font-medium text-text-primary truncate">{{ $teamTopAssister->name }}</span>
                         </div>
                         <div class="font-heading text-xl font-bold text-text-primary tabular-nums">{{ $teamTopAssister->assists }}</div>
                         <div class="text-[10px] text-accent-blue/80">{{ __('season.assists') }}</div>
@@ -494,7 +494,7 @@ $getZoneClass = function($position) use ($standingsZones, $borderColorMap) {
                         <div class="text-[10px] text-accent-green uppercase tracking-widest font-semibold mb-1.5">{{ __('season.most_appearances') }}</div>
                         <div class="flex items-center gap-1.5 mb-1">
                             <x-team-crest :team="$teamMostAppearances->team" class="w-4 h-4 shrink-0" />
-                            <span class="text-sm font-medium text-text-primary truncate">{{ $teamMostAppearances->player->name }}</span>
+                            <span class="text-sm font-medium text-text-primary truncate">{{ $teamMostAppearances->name }}</span>
                         </div>
                         <div class="font-heading text-xl font-bold text-text-primary tabular-nums">{{ $teamMostAppearances->appearances }}</div>
                         <div class="text-[10px] text-accent-green/80">{{ __('season.appearances') }}</div>
@@ -506,7 +506,7 @@ $getZoneClass = function($position) use ($standingsZones, $borderColorMap) {
                         <div class="text-[10px] text-accent-gold uppercase tracking-widest font-semibold mb-1.5">{{ __('season.your_team_mvp') }}</div>
                         <div class="flex items-center gap-1.5 mb-1">
                             <x-team-crest :team="$teamMvpLeader->gamePlayer->team" class="w-4 h-4 shrink-0" />
-                            <span class="text-sm font-medium text-text-primary truncate">{{ $teamMvpLeader->gamePlayer->player->name }}</span>
+                            <span class="text-sm font-medium text-text-primary truncate">{{ $teamMvpLeader->gamePlayer->name }}</span>
                         </div>
                         <div class="font-heading text-xl font-bold text-text-primary tabular-nums">{{ $teamMvpLeader->count }}</div>
                         <div class="text-[10px] text-accent-gold/80">{{ __('season.mvp_awards') }}</div>
@@ -607,7 +607,7 @@ $getZoneClass = function($position) use ($standingsZones, $borderColorMap) {
                         </div>
                         <div class="mt-1.5 space-y-0.5">
                             @foreach($userTeamRetiring as $retiring)
-                                <div class="text-xs text-text-secondary truncate">{{ $retiring->player->name }}</div>
+                                <div class="text-xs text-text-secondary truncate">{{ $retiring->name }}</div>
                             @endforeach
                         </div>
                     </div>

--- a/resources/views/squad-reserve.blade.php
+++ b/resources/views/squad-reserve.blade.php
@@ -103,10 +103,10 @@
                             <div class="md:hidden px-4 py-3 border-b border-border-default {{ $isCalledUp ? 'opacity-60' : '' }}">
                                 <div class="flex items-center gap-3">
                                     <div class="cursor-pointer flex-1 flex items-center gap-3 min-w-0" @click="$dispatch('show-player-detail', '{{ route('game.player.detail', [$game->id, $player->id]) }}')">
-                                        <x-player-avatar :name="$player->player->name" :position-group="\App\Support\PositionMapper::getPositionGroup($player->position)" :position-abbrev="\App\Support\PositionMapper::toAbbreviation($player->position)" />
+                                        <x-player-avatar :name="$player->name" :position-group="\App\Support\PositionMapper::getPositionGroup($player->position)" :position-abbrev="\App\Support\PositionMapper::toAbbreviation($player->position)" />
                                         <div class="flex-1 min-w-0">
                                             <div class="flex items-center gap-2">
-                                                <span class="text-sm font-medium text-text-primary truncate">{{ $player->player->name }}</span>
+                                                <span class="text-sm font-medium text-text-primary truncate">{{ $player->name }}</span>
                                                 <x-origin-badge :player="$player" :current-season="$game->season" />
                                                 <span class="text-[10px] text-text-faint">{{ $age }}</span>
                                                 @if($player->contract_expiry_year)
@@ -143,7 +143,7 @@
                                     @if($player->nationality_flag)
                                         <img src="{{ Storage::disk('assets')->url('flags/' . $player->nationality_flag['code'] . '.svg') }}" class="w-4 h-3 rounded-xs shadow-xs shrink-0" title="{{ $player->nationality_flag['name'] }}">
                                     @endif
-                                    <span class="text-sm font-medium text-text-primary truncate">{{ $player->player->name }}</span>
+                                    <span class="text-sm font-medium text-text-primary truncate">{{ $player->name }}</span>
                                     <x-origin-badge :player="$player" :current-season="$game->season" />
                                     @if($isCalledUp)
                                         <span class="text-[10px] font-semibold bg-accent-blue/10 text-accent-blue px-1.5 py-0.5 rounded-full">{{ __('squad.called_up_indicator') }}</span>

--- a/resources/views/squad.blade.php
+++ b/resources/views/squad.blade.php
@@ -263,12 +263,12 @@
                                     <div class="lg:hidden px-4 py-3 cursor-pointer" @click="$dispatch('show-player-detail', '{{ route('game.player.detail', [$game->id, $gp->id]) }}')">
                                         <div class="flex items-center gap-2.5">
                                             {{-- Avatar --}}
-                                            <x-player-avatar :name="$gp->player->name" :position-group="$groupKey" :number="$gp->number" size="sm" />
+                                            <x-player-avatar :name="$gp->name" :position-group="$groupKey" :number="$gp->number" size="sm" />
 
                                             {{-- Name + details --}}
                                             <div class="flex-1 min-w-0">
                                                 <div class="flex items-center gap-1.5">
-                                                    <span class="text-sm font-medium text-text-primary truncate">{{ $gp->player->name }}</span>
+                                                    <span class="text-sm font-medium text-text-primary truncate">{{ $gp->name }}</span>
                                                     @include('partials.squad.player-status-icon', ['gp' => $gp, 'game' => $game, 'seasonEndDate' => $seasonEndDate, 'playerFlags' => $playerFlags ?? []])
                                                     <x-player-unavailable-icon :player="$gp" :reason="$unavailReason" />
                                                 </div>
@@ -336,10 +336,10 @@
 
                                         {{-- Player name with avatar --}}
                                         <div class="flex items-center gap-3 min-w-0">
-                                            <x-player-avatar :name="$gp->player->name" :position-group="$groupKey" :number="$gp->number" size="sm" />
+                                            <x-player-avatar :name="$gp->name" :position-group="$groupKey" :number="$gp->number" size="sm" />
                                             <div class="min-w-0">
                                                 <div class="flex items-center gap-2">
-                                                    <span class="text-sm font-medium text-text-primary truncate">{{ $gp->player->name }}</span>
+                                                    <span class="text-sm font-medium text-text-primary truncate">{{ $gp->name }}</span>
                                                     @include('partials.squad.player-status-icon', ['gp' => $gp, 'game' => $game, 'seasonEndDate' => $seasonEndDate, 'playerFlags' => $playerFlags ?? []])
                                                     <x-player-unavailable-icon :player="$gp" :reason="$unavailReason" />
                                                 </div>

--- a/resources/views/tournament-end.blade.php
+++ b/resources/views/tournament-end.blade.php
@@ -36,7 +36,7 @@ $homeGoals = collect();
 $awayGoals = collect();
 if ($finalMatch && $finalGoalEvents->isNotEmpty()) {
     foreach ($finalGoalEvents as $event) {
-        $playerName = $event->gamePlayer?->player?->name ?? '?';
+        $playerName = $event->gamePlayer?->name ?? '?';
         $isOwnGoal = $event->event_type === \App\Models\MatchEvent::TYPE_OWN_GOAL;
 
         // For own goals, the scoring team is the OPPOSITE of the event's team
@@ -83,7 +83,7 @@ foreach ($positionGroupOrder as $group) {
     $players = $yourAppearances->filter(fn($gp) => $gp->position_group === $group);
     if ($players->isNotEmpty()) {
         $squadByGroup[$group] = $players->map(fn($gp) => [
-            'name' => $gp->player->name,
+            'name' => $gp->name,
             'appearances' => $gp->appearances,
             'goals' => $gp->goals,
             'assists' => $gp->assists,
@@ -512,7 +512,7 @@ foreach ($positionGroupOrder as $group) {
                                             @foreach($yourAppearances as $gp)
                                             <tr class="{{ $loop->even ? 'bg-surface-700/50' : '' }}">
                                                 <td class="py-1.5 pr-2"><x-position-badge :position="$gp->position" size="sm" /></td>
-                                                <td class="py-1.5 font-medium text-text-primary truncate max-w-[140px]">{{ $gp->player->name }}</td>
+                                                <td class="py-1.5 font-medium text-text-primary truncate max-w-[140px]">{{ $gp->name }}</td>
                                                 <td class="text-center py-1.5 font-semibold text-text-body">{{ $gp->appearances }}</td>
                                                 <td class="text-center py-1.5 {{ $gp->goals > 0 ? 'font-semibold text-text-body' : 'text-text-muted' }}">{{ $gp->goals }}</td>
                                                 <td class="text-center py-1.5 {{ $gp->assists > 0 ? 'font-semibold text-text-body' : 'text-text-muted' }}">{{ $gp->assists }}</td>
@@ -547,7 +547,7 @@ foreach ($positionGroupOrder as $group) {
                             <div class="flex items-center justify-between gap-3">
                                 <div class="flex items-center gap-2 min-w-0">
                                     <x-team-crest :team="$scorer->team" class="w-6 h-6 shrink-0" />
-                                    <span class="font-bold text-text-primary truncate">{{ $scorer->player->name }}</span>
+                                    <span class="font-bold text-text-primary truncate">{{ $scorer->name }}</span>
                                 </div>
                                 <div class="shrink-0 text-right">
                                     <span class="font-heading text-2xl md:text-3xl font-bold text-accent-gold">{{ $scorer->goals }}</span>
@@ -564,7 +564,7 @@ foreach ($positionGroupOrder as $group) {
                             <div class="flex items-center gap-2.5 {{ $scorer->team_id === $game->team_id ? 'bg-accent-gold/10 -mx-2 px-2 rounded-sm' : '' }}">
                                 <span class="w-5 text-center text-xs font-bold text-text-secondary">{{ $loop->iteration + 1 }}</span>
                                 <x-team-crest :team="$scorer->team" class="w-4 h-4 shrink-0" />
-                                <span class="flex-1 text-sm text-text-body truncate">{{ $scorer->player->name }}</span>
+                                <span class="flex-1 text-sm text-text-body truncate">{{ $scorer->name }}</span>
                                 <span class="font-heading text-xs font-semibold text-text-secondary w-10 text-right">{{ $scorer->goals }}</span>
                             </div>
                             @endforeach
@@ -584,7 +584,7 @@ foreach ($positionGroupOrder as $group) {
                             <div class="flex items-center justify-between gap-3">
                                 <div class="flex items-center gap-2 min-w-0">
                                     <x-team-crest :team="$gk->team" class="w-6 h-6 shrink-0" />
-                                    <span class="font-bold text-text-primary truncate">{{ $gk->player->name }}</span>
+                                    <span class="font-bold text-text-primary truncate">{{ $gk->name }}</span>
                                 </div>
                                 <div class="shrink-0 text-right">
                                     <span class="font-heading text-2xl md:text-3xl font-bold text-accent-blue">{{ $gk->clean_sheets }}</span>
@@ -601,7 +601,7 @@ foreach ($positionGroupOrder as $group) {
                             <div class="flex items-center gap-2.5 {{ $gk->team_id === $game->team_id ? 'bg-accent-blue/10 -mx-2 px-2 rounded-sm' : '' }}">
                                 <span class="w-5 text-center text-xs font-bold text-text-secondary">{{ $loop->iteration + 1 }}</span>
                                 <x-team-crest :team="$gk->team" class="w-4 h-4 shrink-0" />
-                                <span class="flex-1 text-sm text-text-body truncate">{{ $gk->player->name }}</span>
+                                <span class="flex-1 text-sm text-text-body truncate">{{ $gk->name }}</span>
                                 <span class="font-heading text-xs font-semibold text-text-secondary w-16 text-right">{{ $gk->clean_sheets }}</span>
                             </div>
                             @endforeach
@@ -621,7 +621,7 @@ foreach ($positionGroupOrder as $group) {
                             <div class="flex items-center justify-between gap-3">
                                 <div class="flex items-center gap-2 min-w-0">
                                     <x-team-crest :team="$assister->team" class="w-6 h-6 shrink-0" />
-                                    <span class="font-bold text-text-primary truncate">{{ $assister->player->name }}</span>
+                                    <span class="font-bold text-text-primary truncate">{{ $assister->name }}</span>
                                 </div>
                                 <div class="shrink-0 text-right">
                                     <span class="font-heading text-2xl md:text-3xl font-bold text-accent-green">{{ $assister->assists }}</span>
@@ -638,7 +638,7 @@ foreach ($positionGroupOrder as $group) {
                             <div class="flex items-center gap-2.5 {{ $assister->team_id === $game->team_id ? 'bg-accent-green/10 -mx-2 px-2 rounded-sm' : '' }}">
                                 <span class="w-5 text-center text-xs font-bold text-text-secondary">{{ $loop->iteration + 1 }}</span>
                                 <x-team-crest :team="$assister->team" class="w-4 h-4 shrink-0" />
-                                <span class="flex-1 text-sm text-text-body truncate">{{ $assister->player->name }}</span>
+                                <span class="flex-1 text-sm text-text-body truncate">{{ $assister->name }}</span>
                                 <span class="font-heading text-xs font-semibold text-text-secondary w-10 text-right">{{ $assister->assists }}</span>
                             </div>
                             @endforeach
@@ -658,7 +658,7 @@ foreach ($positionGroupOrder as $group) {
                             <div class="flex items-center justify-between gap-3">
                                 <div class="flex items-center gap-2 min-w-0">
                                     <x-team-crest :team="$mvpWinner->gamePlayer->team" class="w-6 h-6 shrink-0" />
-                                    <span class="font-bold text-text-primary truncate">{{ $mvpWinner->gamePlayer->player->name }}</span>
+                                    <span class="font-bold text-text-primary truncate">{{ $mvpWinner->gamePlayer->name }}</span>
                                 </div>
                                 <div class="shrink-0 text-right">
                                     <span class="font-heading text-2xl md:text-3xl font-bold text-accent-gold">{{ $mvpWinner->count }}</span>
@@ -675,7 +675,7 @@ foreach ($positionGroupOrder as $group) {
                             <div class="flex items-center gap-2.5 {{ $mvp->gamePlayer->team_id === $game->team_id ? 'bg-accent-gold/10 -mx-2 px-2 rounded-sm' : '' }}">
                                 <span class="w-5 text-center text-xs font-bold text-text-secondary">{{ $loop->iteration + 1 }}</span>
                                 <x-team-crest :team="$mvp->gamePlayer->team" class="w-4 h-4 shrink-0" />
-                                <span class="flex-1 text-sm text-text-body truncate">{{ $mvp->gamePlayer->player->name }}</span>
+                                <span class="flex-1 text-sm text-text-body truncate">{{ $mvp->gamePlayer->name }}</span>
                                 <span class="font-heading text-xs font-semibold text-text-secondary w-10 text-right">{{ $mvp->count }}</span>
                             </div>
                             @endforeach

--- a/tests/Unit/MatchEventFormattingTest.php
+++ b/tests/Unit/MatchEventFormattingTest.php
@@ -59,7 +59,7 @@ class MatchEventFormattingTest extends TestCase
 
         $goalEvent = collect($result)->firstWhere('type', 'goal');
 
-        $this->assertEquals($assister->player->name, $goalEvent['assistPlayerName']);
+        $this->assertEquals($assister->name, $goalEvent['assistPlayerName']);
     }
 
     public function test_assist_not_paired_with_goal_from_different_team(): void
@@ -100,7 +100,7 @@ class MatchEventFormattingTest extends TestCase
         $teamAGoal = $goals->firstWhere('teamId', $teamA->id);
         $teamBGoal = $goals->firstWhere('teamId', $teamB->id);
 
-        $this->assertEquals($assisterA->player->name, $teamAGoal['assistPlayerName']);
+        $this->assertEquals($assisterA->name, $teamAGoal['assistPlayerName']);
         $this->assertArrayNotHasKey('assistPlayerName', $teamBGoal);
     }
 


### PR DESCRIPTION
## Summary
This PR denormalizes player biography fields (name, date_of_birth, nationality, height, foot, transfermarkt_id) from the `Player` model directly onto the `GamePlayer` model. This eliminates the need for eager-loading the `player` relation throughout the codebase and simplifies data access patterns.

## Key Changes

- **Model Changes:**
  - Updated `GamePlayer::age()` to use local `date_of_birth` instead of `$this->player->date_of_birth`
  - Removed `getNameAttribute()` and `getNationalityAttribute()` magic accessors that delegated to the Player relation
  - Factory now back-fills biography columns on GamePlayer from the linked Player model for test compatibility

- **Database Query Optimization:**
  - Simplified `ExploreService::getDistinctNationalities()` to query `game_players.nationality` directly instead of joining to the `players` table
  - Removed cross-plane JOIN logic and associated comments about control/tenant plane separation

- **View Layer Updates:**
  - Replaced all `$gamePlayer->player->name` with `$gamePlayer->name` across multiple views:
    - outgoing-transfers.blade.php
    - incoming-transfers.blade.php
    - season-end.blade.php
    - tournament-end.blade.php
    - results.blade.php
    - squad.blade.php
    - squad-reserve.blade.php
    - lineup.blade.php
    - player-detail.blade.php
    - top-scorers.blade.php
    - editor templates

- **Service Layer Updates:**
  - Updated all service classes to access player name directly from GamePlayer:
    - TacticalChangeService
    - MatchResimulationService
    - TransferCompletionService
    - ReserveTeamService
    - AITransferMarketService
    - LoanService
    - TournamentSnapshotService

- **Action/Controller Updates:**
  - Updated HTTP actions to use `$gamePlayer->name` instead of `$gamePlayer->player->name`
  - Affected: AcceptTransferOffer, ListPlayerForTransfer, AcceptLoanOffer, CallUpReservePlayer, SendBackReservePlayer, WithdrawTransferOffer, and others

- **Test Updates:**
  - Updated MatchEventFormattingTest to use `$assister->name` instead of `$assister->player->name`

## Implementation Details

The denormalization maintains backward compatibility by:
- Keeping the `player` relation intact for cases where full Player model data is needed
- Using the factory to ensure test data reflects the post-Phase-6 schema reality
- Gradually replacing eager-loaded player relations with direct attribute access

This change improves performance by reducing unnecessary relation loads and simplifies the codebase by eliminating the need to traverse the player relation for commonly-accessed biography fields.

https://claude.ai/code/session_01BGPcs1cmkJw2QC7DH6EYnq