### PR TITLE
Remove Player model eager loading from GamePlayer queries

### DIFF
--- a/app/Http/Actions/Admin/UpdatePlayerTemplate.php
+++ b/app/Http/Actions/Admin/UpdatePlayerTemplate.php
@@ -56,15 +56,8 @@ class UpdatePlayerTemplate
 
         $service->update($template, $validated, $request->user());
 
-        // Player still mirrors nationality until Phase 7 sunsets the redundant
-        // Player writes — readers haven't fully migrated to the template copy.
-        if ($nationality !== null && $template->player) {
-            $template->player->update(['nationality' => array_filter([$nationality])]);
-        }
-
         if ($request->wantsJson()) {
             $template->refresh();
-            $template->load('player');
             return response()->json([
                 'success' => true,
                 'message' => __('admin.template_updated'),

--- a/app/Http/Actions/CallUpReservePlayer.php
+++ b/app/Http/Actions/CallUpReservePlayer.php
@@ -22,7 +22,7 @@ class CallUpReservePlayer
         $player = GamePlayer::where('id', $playerId)
             ->where('game_id', $gameId)
             ->where('team_id', $game->reserve_team_id)
-            ->with('player')
+            
             ->firstOrFail();
 
         $playerName = $player->name ?? '';

--- a/app/Http/Actions/ComputeSlotAssignments.php
+++ b/app/Http/Actions/ComputeSlotAssignments.php
@@ -53,7 +53,7 @@ class ComputeSlotAssignments
 
         // Load only the requested players, scoped to the user's team in this
         // game. Anything not found is silently dropped by the algorithm.
-        $players = GamePlayer::with('player')
+        $players = GamePlayer::query()
             ->where('game_id', $game->id)
             ->where('team_id', $game->team_id)
             ->whereIn('id', $playerIds)

--- a/app/Http/Actions/NegotiateFreeAgent.php
+++ b/app/Http/Actions/NegotiateFreeAgent.php
@@ -36,7 +36,7 @@ class NegotiateFreeAgent
 
         $game = Game::findOrFail($gameId);
 
-        $player = GamePlayer::with(['player', 'game', 'team'])
+        $player = GamePlayer::with(['game', 'team'])
             ->where('game_id', $gameId)
             ->findOrFail($playerId);
 

--- a/app/Http/Actions/NegotiateLoan.php
+++ b/app/Http/Actions/NegotiateLoan.php
@@ -29,7 +29,7 @@ class NegotiateLoan
 
         $game = Game::findOrFail($gameId);
 
-        $player = GamePlayer::with(['player', 'game', 'team'])
+        $player = GamePlayer::with(['game', 'team'])
             ->where('game_id', $gameId)
             ->findOrFail($playerId);
 

--- a/app/Http/Actions/NegotiatePreContract.php
+++ b/app/Http/Actions/NegotiatePreContract.php
@@ -34,7 +34,7 @@ class NegotiatePreContract
 
         $game = Game::findOrFail($gameId);
 
-        $player = GamePlayer::with(['player', 'game', 'team'])
+        $player = GamePlayer::with(['game', 'team'])
             ->where('game_id', $gameId)
             ->findOrFail($playerId);
 

--- a/app/Http/Actions/NegotiateRenewal.php
+++ b/app/Http/Actions/NegotiateRenewal.php
@@ -32,8 +32,8 @@ class NegotiateRenewal
 
         $action = $request->input('action');
         $eagerLoads = in_array($action, ['start', 'offer'])
-            ? ['player', 'game', 'transferOffers']
-            : ['player', 'game'];
+            ? ['game', 'transferOffers']
+            : ['game'];
 
         $player = GamePlayer::with($eagerLoads)
             ->where('game_id', $gameId)

--- a/app/Http/Actions/NegotiateTransfer.php
+++ b/app/Http/Actions/NegotiateTransfer.php
@@ -39,7 +39,7 @@ class NegotiateTransfer
 
         $game = Game::findOrFail($gameId);
 
-        $player = GamePlayer::with(['player', 'game', 'team'])
+        $player = GamePlayer::with(['game', 'team'])
             ->where('game_id', $gameId)
             ->findOrFail($playerId);
 

--- a/app/Http/Actions/RequestLoan.php
+++ b/app/Http/Actions/RequestLoan.php
@@ -19,7 +19,7 @@ class RequestLoan
     public function __invoke(Request $request, string $gameId, string $playerId)
     {
         $game = Game::with(['team', 'finances'])->findOrFail($gameId);
-        $player = GamePlayer::where('game_id', $gameId)->with(['player', 'team'])->findOrFail($playerId);
+        $player = GamePlayer::where('game_id', $gameId)->with(['team'])->findOrFail($playerId);
 
         // Determine if this is loan-in (from scouting) or loan-out (from squad).
         // Reserve-team players also belong to the user's club, so loan-out applies.

--- a/app/Http/Actions/SaveSquadSelection.php
+++ b/app/Http/Actions/SaveSquadSelection.php
@@ -7,7 +7,7 @@ use App\Modules\Player\Services\PlayerDevelopmentService;
 use App\Models\Game;
 use App\Models\GamePlayer;
 use App\Models\GamePlayerMatchState;
-use App\Models\Player;
+use App\Models\GamePlayerTemplate;
 use Illuminate\Http\Request;
 use Illuminate\Support\Str;
 
@@ -58,13 +58,18 @@ class SaveSquadSelection
 
     public static function createTournamentGamePlayers(string $gameId, string $teamId, array $tmIds, array $positionByTmId): void
     {
-        $playerModels = Player::whereIn('transfermarkt_id', $tmIds)->get()->keyBy('transfermarkt_id');
+        // Templates carry biography directly post-Phase-5 and live on the
+        // control plane alongside the rest of the cross-tenant reference
+        // data. Read from there instead of the now-deprecated Player table.
+        $templates = GamePlayerTemplate::whereIn('transfermarkt_id', $tmIds)
+            ->get()
+            ->keyBy('transfermarkt_id');
 
         $playerRows = [];
         $matchStateRows = [];
         foreach ($tmIds as $tmId) {
-            $player = $playerModels->get($tmId);
-            if (!$player) {
+            $template = $templates->get($tmId);
+            if (!$template) {
                 continue;
             }
 
@@ -73,13 +78,13 @@ class SaveSquadSelection
             $playerRows[] = [
                 'id' => $gamePlayerId,
                 'game_id' => $gameId,
-                'player_id' => $player->id,
-                'transfermarkt_id' => $player->transfermarkt_id,
-                'name' => $player->name,
-                'date_of_birth' => $player->date_of_birth?->toDateString(),
-                'nationality' => $player->nationality !== null ? json_encode($player->nationality) : null,
-                'height' => $player->height,
-                'foot' => $player->foot,
+                'player_id' => $template->player_id,
+                'transfermarkt_id' => $template->transfermarkt_id,
+                'name' => $template->name,
+                'date_of_birth' => $template->date_of_birth?->toDateString(),
+                'nationality' => $template->nationality !== null ? json_encode($template->nationality) : null,
+                'height' => $template->height,
+                'foot' => $template->foot,
                 'team_id' => $teamId,
                 'number' => null,
                 'position' => $positionByTmId[$tmId] ?? 'Central Midfield',
@@ -88,7 +93,7 @@ class SaveSquadSelection
                 'contract_until' => null,
                 'annual_wage' => 0,
                 'durability' => InjuryService::generateDurability(),
-                'overall_score' => $player->overall_score,
+                'overall_score' => $template->overall_score,
             ];
 
             $matchStateRows[] = [

--- a/app/Http/Actions/SendBackReservePlayer.php
+++ b/app/Http/Actions/SendBackReservePlayer.php
@@ -22,7 +22,7 @@ class SendBackReservePlayer
             ->where('game_id', $gameId)
             ->where('team_id', $game->team_id)
             ->whereHas('activeLoan', fn ($q) => $q->where('parent_team_id', $game->reserve_team_id))
-            ->with('player')
+            
             ->firstOrFail();
 
         $playerName = $player->name ?? '';

--- a/app/Http/Actions/SignFreeAgent.php
+++ b/app/Http/Actions/SignFreeAgent.php
@@ -23,7 +23,7 @@ class SignFreeAgent
     public function __invoke(Request $request, string $gameId, string $playerId)
     {
         $game = Game::findOrFail($gameId);
-        $player = GamePlayer::where('game_id', $gameId)->with('player')->findOrFail($playerId);
+        $player = GamePlayer::where('game_id', $gameId)->findOrFail($playerId);
 
         // Must be a free agent
         if ($player->team_id !== null) {

--- a/app/Http/Actions/SubmitPreContractOffer.php
+++ b/app/Http/Actions/SubmitPreContractOffer.php
@@ -16,7 +16,7 @@ class SubmitPreContractOffer
     public function __invoke(Request $request, string $gameId, string $playerId)
     {
         $game = Game::findOrFail($gameId);
-        $player = GamePlayer::where('game_id', $gameId)->with(['player', 'team'])->findOrFail($playerId);
+        $player = GamePlayer::where('game_id', $gameId)->with(['team'])->findOrFail($playerId);
 
         $validated = $request->validate([
             'offered_wage' => 'required|integer|min:0',

--- a/app/Http/Actions/ToggleShortlist.php
+++ b/app/Http/Actions/ToggleShortlist.php
@@ -78,7 +78,7 @@ class ToggleShortlist
 
             if ($action === 'added') {
                 $entry->refresh();
-                $gamePlayer->load(['player', 'team']);
+                $gamePlayer->load(['team']);
                 $positionDisplay = PositionMapper::getPositionDisplay($gamePlayer->position);
 
                 $data['player'] = [

--- a/app/Http/Views/ShowNewSeason.php
+++ b/app/Http/Views/ShowNewSeason.php
@@ -58,7 +58,7 @@ class ShowNewSeason
         // Load squad data for snapshot
         $squad = GamePlayer::where('game_id', $game->id)
             ->where('team_id', $game->team_id)
-            ->with('player')
+            
             ->get();
 
         $squadSnapshot = $this->buildSquadSnapshot($squad, $game->current_date);

--- a/app/Http/Views/ShowOutgoingTransfers.php
+++ b/app/Http/Views/ShowOutgoingTransfers.php
@@ -81,7 +81,7 @@ class ShowOutgoingTransfers
 
         // Get listed players (even those without offers, excluding those with agreed deals)
         $agreedPlayerIds = $agreedTransfers->pluck('game_player_id')->toArray();
-        $listedPlayers = GamePlayer::with(['player'])
+        $listedPlayers = GamePlayer::query()
             ->where('game_id', $gameId)
             ->where('team_id', $game->team_id)
             ->whereHas('transferListing', fn ($q) => $q->where('status', TransferListing::STATUS_LISTED))
@@ -101,7 +101,7 @@ class ShowOutgoingTransfers
         $loans = $this->loanService->getActiveLoans($game);
         $loansOut = $loans['out'];
 
-        $loanSearches = GamePlayer::with(['player'])
+        $loanSearches = GamePlayer::query()
             ->where('game_id', $game->id)
             ->where('team_id', $game->team_id)
             ->whereHas('transferListing', fn ($q) => $q->where('status', TransferListing::STATUS_LOAN_SEARCH))
@@ -140,7 +140,7 @@ class ShowOutgoingTransfers
                 || ($playerFlags[$p->id]['stature_gap'] ?? false)
                 || ($playerFlags[$p->id]['wage_gap'] ?? false)
         )->values();
-        $declinedRenewals = GamePlayer::with(['player', 'latestRenewalNegotiation'])
+        $declinedRenewals = GamePlayer::with(['latestRenewalNegotiation'])
             ->where('game_id', $gameId)
             ->ownedByTeam($game->team_id)
             ->whereHas('latestRenewalNegotiation', fn ($q) => $q->where('status', RenewalNegotiation::STATUS_CLUB_DECLINED))
@@ -156,7 +156,7 @@ class ShowOutgoingTransfers
 
         $cooldownRenewals = collect();
         if (!empty($cooldownPlayerIds)) {
-            $cooldownRenewals = GamePlayer::with(['player'])
+            $cooldownRenewals = GamePlayer::query()
                 ->where('game_id', $gameId)
                 ->ownedByTeam($game->team_id)
                 ->whereIn('id', $cooldownPlayerIds)

--- a/app/Http/Views/ShowPlayerDetail.php
+++ b/app/Http/Views/ShowPlayerDetail.php
@@ -23,7 +23,7 @@ class ShowPlayerDetail
         // accept "physically here" as well as "owned via active loan-out".
         $userTeamIds = $game->userTeamIds();
 
-        $gamePlayer = GamePlayer::with(['player', 'careerRecord', 'activeLoan'])
+        $gamePlayer = GamePlayer::with(['careerRecord', 'activeLoan'])
             ->where('game_id', $gameId)
             ->where(function ($q) use ($userTeamIds) {
                 $q->whereIn('team_id', $userTeamIds)

--- a/app/Http/Views/ShowScoutReportResults.php
+++ b/app/Http/Views/ShowScoutReportResults.php
@@ -33,7 +33,7 @@ class ShowScoutReportResults
         ];
 
         if (!empty($report->player_ids)) {
-            $players = GamePlayer::with(['player', 'team'])
+            $players = GamePlayer::with(['team'])
                 ->whereIn('id', $report->player_ids)
                 ->where(fn ($q) => $q
                     ->whereNull('team_id')

--- a/app/Http/Views/ShowSquadRegistration.php
+++ b/app/Http/Views/ShowSquadRegistration.php
@@ -21,7 +21,7 @@ class ShowSquadRegistration
 
         $gamePlayers = GamePlayer::where('game_id', $gameId)
             ->where('team_id', $game->team_id)
-            ->with('player')
+            
             ->get();
 
         $players = [];

--- a/app/Http/Views/ShowSquadSelection.php
+++ b/app/Http/Views/ShowSquadSelection.php
@@ -4,7 +4,7 @@ namespace App\Http\Views;
 
 use App\Http\Actions\SaveSquadSelection;
 use App\Models\Game;
-use App\Models\Player;
+use App\Models\GamePlayerTemplate;
 use App\Support\PositionMapper;
 
 class ShowSquadSelection
@@ -62,9 +62,13 @@ class ShowSquadSelection
         $data = json_decode(file_get_contents($jsonPath), true);
         $jsonPlayers = $data['players'] ?? [];
 
-        // Get transfermarkt IDs and look up Player models for abilities
+        // Look up the matching templates for biography. Templates are the
+        // canonical roster source post-Phase-3, so abilities and date_of_birth
+        // are read off them instead of the deprecated Player table.
         $tmIds = array_column($jsonPlayers, 'id');
-        $playerModels = Player::whereIn('transfermarkt_id', $tmIds)->get()->keyBy('transfermarkt_id');
+        $templates = GamePlayerTemplate::whereIn('transfermarkt_id', $tmIds)
+            ->get()
+            ->keyBy('transfermarkt_id');
 
         $groups = ['goalkeepers' => [], 'defenders' => [], 'midfielders' => [], 'forwards' => []];
 
@@ -74,26 +78,26 @@ class ShowSquadSelection
                 continue;
             }
 
-            $player = $playerModels->get($tmId);
-            if (!$player) {
+            $template = $templates->get($tmId);
+            if (!$template) {
                 continue;
             }
 
             $position = $jp['position'] ?? 'Central Midfield';
             $positionGroup = PositionMapper::getPositionGroup($position);
             $positionDisplay = PositionMapper::getPositionDisplay($position);
-            $overall = (int) $player->overall_score;
+            $overall = (int) $template->overall_score;
 
             $candidate = [
                 'transfermarkt_id' => (string) $tmId,
-                'player_id' => $player->id,
-                'name' => $player->name,
+                'player_id' => $template->player_id,
+                'name' => $template->name,
                 'position' => $position,
                 'position_group' => $positionGroup,
                 'position_abbreviation' => $positionDisplay['abbreviation'],
                 'position_bg' => $positionDisplay['bg'],
                 'position_text' => $positionDisplay['text'],
-                'age' => $player->date_of_birth->age,
+                'age' => $template->date_of_birth->age,
                 'height' => $jp['height'] ?? null,
                 'overall' => $overall,
             ];

--- a/app/Models/ScoutReport.php
+++ b/app/Models/ScoutReport.php
@@ -83,7 +83,7 @@ class ScoutReport extends Model
             return collect();
         }
 
-        return GamePlayer::with(['player', 'team'])
+        return GamePlayer::with(['team'])
             ->whereIn('id', $this->player_ids)
             ->where('team_id', '!=', $this->game->team_id) // Exclude players now on user's team
             ->get();

--- a/app/Modules/Competition/Services/CompetitionViewService.php
+++ b/app/Modules/Competition/Services/CompetitionViewService.php
@@ -153,7 +153,7 @@ class CompetitionViewService
             return collect();
         }
 
-        $players = GamePlayer::with(['player', 'matchState'])
+        $players = GamePlayer::with(['matchState'])
             ->whereIn('id', $scorerRows->pluck('game_player_id')->unique())
             ->get()
             ->keyBy('id');

--- a/app/Modules/Editor/Services/PlayerTemplateAdminService.php
+++ b/app/Modules/Editor/Services/PlayerTemplateAdminService.php
@@ -50,7 +50,7 @@ class PlayerTemplateAdminService
 
     public function squadForTeam(string $teamId, string $season): Collection
     {
-        $templates = GamePlayerTemplate::with(['player', 'audits.user'])
+        $templates = GamePlayerTemplate::with(['audits.user'])
             ->where('team_id', $teamId)
             ->where('season', $season)
             ->get();
@@ -77,7 +77,7 @@ class PlayerTemplateAdminService
 
     public function find(int $id): GamePlayerTemplate
     {
-        return GamePlayerTemplate::with(['player', 'team', 'audits.user'])->findOrFail($id);
+        return GamePlayerTemplate::with(['team', 'audits.user'])->findOrFail($id);
     }
 
     public function create(array $data, User $user): GamePlayerTemplate
@@ -173,7 +173,7 @@ class PlayerTemplateAdminService
 
     public function recentAudits(int $limit = 50): Collection
     {
-        return GamePlayerTemplateAudit::with(['template.player', 'template.team', 'user'])
+        return GamePlayerTemplateAudit::with(['template.team', 'user'])
             ->orderByDesc('created_at')
             ->limit($limit)
             ->get();

--- a/app/Modules/Lineup/Services/LineupService.php
+++ b/app/Modules/Lineup/Services/LineupService.php
@@ -33,7 +33,7 @@ class LineupService
      */
     public function getAvailablePlayers(string $gameId, string $teamId, Carbon $matchDate, string $competitionId, bool $requireEnrollment = false): Collection
     {
-        $players = GamePlayer::with(['player', 'matchState'])
+        $players = GamePlayer::with(['matchState'])
             ->where('game_id', $gameId)
             ->where('team_id', $teamId)
             ->get();
@@ -64,7 +64,7 @@ class LineupService
      */
     public function getAllPlayers(string $gameId, string $teamId): Collection
     {
-        return GamePlayer::with(['player', 'matchState', 'suspensions', 'transferOffers', 'activeLoan'])
+        return GamePlayer::with(['matchState', 'suspensions', 'transferOffers', 'activeLoan'])
             ->where('game_id', $gameId)
             ->where('team_id', $teamId)
             ->get();
@@ -558,7 +558,7 @@ class LineupService
             return collect();
         }
 
-        return GamePlayer::with(['player', 'matchState'])
+        return GamePlayer::with(['matchState'])
             ->where('game_id', $gameId)
             ->where('team_id', $teamId)
             ->whereIn('id', $playerIds)
@@ -851,7 +851,7 @@ class LineupService
             $availableIds = $availablePlayers->pluck('id')->toArray();
             $allTeamPlayers = $allPlayersGrouped !== null
                 ? $allPlayersGrouped->get($teamId, collect())
-                : GamePlayer::with(['player', 'matchState'])->where('game_id', $game->id)->where('team_id', $teamId)->get();
+                : GamePlayer::with(['matchState'])->where('game_id', $game->id)->where('team_id', $teamId)->get();
             $lineup = $this->selectLineupWithPreferencesFromCollection(
                 $availablePlayers,
                 $allTeamPlayers,

--- a/app/Modules/Lineup/Services/SubstitutionService.php
+++ b/app/Modules/Lineup/Services/SubstitutionService.php
@@ -157,7 +157,7 @@ class SubstitutionService
             $lineupIds[] = $sub['playerInId'];
         }
 
-        return GamePlayer::with(['player', 'matchState'])->whereIn('id', $lineupIds)->get();
+        return GamePlayer::with(['matchState'])->whereIn('id', $lineupIds)->get();
     }
 
     /**
@@ -179,7 +179,7 @@ class SubstitutionService
 
         // Load opponent full squad (1 query) to derive both lineup and bench
         $opponentTeamId = $isUserHome ? $match->away_team_id : $match->home_team_id;
-        $opponentSquad = GamePlayer::with(['player', 'matchState'])
+        $opponentSquad = GamePlayer::with(['matchState'])
             ->where('game_id', $game->id)
             ->where('team_id', $opponentTeamId)
             ->get();
@@ -233,7 +233,7 @@ class SubstitutionService
         // User bench: squad minus active lineup minus subbed-out players minus injured/suspended
         $activeLineupIds = $userLineup->pluck('id')->all();
         $subbedOutIds = array_column($substitutions, 'playerOutId');
-        $userSquad = GamePlayer::with(['player', 'matchState'])
+        $userSquad = GamePlayer::with(['matchState'])
             ->where('game_id', $game->id)
             ->where('team_id', $game->team_id)
             ->get();

--- a/app/Modules/Lineup/Services/TacticalChangeService.php
+++ b/app/Modules/Lineup/Services/TacticalChangeService.php
@@ -242,7 +242,7 @@ class TacticalChangeService
             MatchEvent::insert($eventRows);
 
             // Load player names for response
-            $players = GamePlayer::with('player')->whereIn('id', $playerIds)->get()->keyBy('id');
+            $players = GamePlayer::query()->whereIn('id', $playerIds)->get()->keyBy('id');
             $substitutionDetails = array_map(fn ($sub) => [
                 'playerOutId' => $sub['playerOutId'],
                 'playerInId' => $sub['playerInId'],
@@ -257,7 +257,7 @@ class TacticalChangeService
         $mvpPlayerName = null;
         $mvpPlayerTeamId = null;
         if ($result->mvpPlayerId) {
-            $mvpPlayer = GamePlayer::with('player')->find($result->mvpPlayerId);
+            $mvpPlayer = GamePlayer::query()->find($result->mvpPlayerId);
             if ($mvpPlayer) {
                 $mvpPlayerName = $mvpPlayer->name ?? null;
                 $mvpPlayerTeamId = $mvpPlayer->team_id;

--- a/app/Modules/Match/Services/CareerActionProcessor.php
+++ b/app/Modules/Match/Services/CareerActionProcessor.php
@@ -243,7 +243,7 @@ class CareerActionProcessor
         $currentDate = $game->current_date;
         $sixMonthsOut = $currentDate->copy()->addMonths(6);
 
-        $expiringPlayers = GamePlayer::with('player')
+        $expiringPlayers = GamePlayer::query()
             ->where('game_id', $game->id)
             ->where('team_id', $game->team_id)
             ->whereNull('pending_annual_wage') // not already renewed

--- a/app/Modules/Match/Services/ExtraTimeAndPenaltyService.php
+++ b/app/Modules/Match/Services/ExtraTimeAndPenaltyService.php
@@ -151,7 +151,7 @@ class ExtraTimeAndPenaltyService
         $awayIds = array_values(array_filter($awayIds, fn ($id) => ! in_array($id, $redCardedIds)));
 
         $allIds = array_merge($homeIds, $awayIds);
-        $players = GamePlayer::with(['player', 'matchState'])->whereIn('id', $allIds)->get()->keyBy('id');
+        $players = GamePlayer::with(['matchState'])->whereIn('id', $allIds)->get()->keyBy('id');
 
         return [
             $players->only($homeIds)->values(),

--- a/app/Modules/Match/Services/MatchFinalizationService.php
+++ b/app/Modules/Match/Services/MatchFinalizationService.php
@@ -199,7 +199,7 @@ class MatchFinalizationService
     private function updateConditionsForDeferredMatch(GameMatch $match): void
     {
         $teamIds = [$match->home_team_id, $match->away_team_id];
-        $players = GamePlayer::with(['player', 'matchState'])
+        $players = GamePlayer::with(['matchState'])
             ->where('game_id', $match->game_id)
             ->whereIn('team_id', $teamIds)
             ->get();
@@ -258,7 +258,7 @@ class MatchFinalizationService
 
         // Build players collection for extra time / penalty simulation
         $allLineupIds = array_merge($match->home_lineup ?? [], $match->away_lineup ?? []);
-        $players = GamePlayer::with(['player', 'matchState'])->whereIn('id', $allLineupIds)->get();
+        $players = GamePlayer::with(['matchState'])->whereIn('id', $allLineupIds)->get();
         $allPlayers = collect([
             $match->home_team_id => $players->filter(fn ($p) => $p->team_id === $match->home_team_id),
             $match->away_team_id => $players->filter(fn ($p) => $p->team_id === $match->away_team_id),

--- a/app/Modules/Match/Services/MatchResimulationService.php
+++ b/app/Modules/Match/Services/MatchResimulationService.php
@@ -104,7 +104,7 @@ class MatchResimulationService
             ->all();
 
         if (! empty($autoSubPlayerInIds)) {
-            $autoSubPlayersIn = GamePlayer::with('player')
+            $autoSubPlayersIn = GamePlayer::query()
                 ->whereIn('id', $autoSubPlayerInIds)
                 ->get();
 
@@ -426,7 +426,7 @@ class MatchResimulationService
                 ->all();
 
             if (! empty($autoSubPlayerInIds)) {
-                $autoSubPlayersIn = GamePlayer::with('player')
+                $autoSubPlayersIn = GamePlayer::query()
                     ->whereIn('id', $autoSubPlayerInIds)
                     ->get();
 
@@ -849,7 +849,7 @@ class MatchResimulationService
 
         $playerInNames = [];
         if (! empty($playerInIds)) {
-            $playerInNames = GamePlayer::with('player')
+            $playerInNames = GamePlayer::query()
                 ->whereIn('id', $playerInIds)
                 ->get()
                 ->mapWithKeys(fn ($gp) => [$gp->id => $gp->name ?? ''])

--- a/app/Modules/Match/Services/MatchdayOrchestrator.php
+++ b/app/Modules/Match/Services/MatchdayOrchestrator.php
@@ -17,7 +17,6 @@ use App\Models\GameNotification;
 use App\Models\GamePlayer;
 use App\Models\GamePlayerMatchState;
 use App\Models\GameStanding;
-use App\Models\Player;
 use App\Models\PlayerSuspension;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\Cache;
@@ -277,19 +276,14 @@ class MatchdayOrchestrator
                 $game->endPreSeason();
 
                 if ($game->squad_registration_enabled) {
-                    // Two-step lookup keeps the control/tenant plane boundary intact:
-                    // first resolve qualifying biographical player ids on the control
-                    // plane, then filter game-side rows by player_id.
-                    $registrationEligiblePlayerIds = Player::where(
-                        'date_of_birth',
-                        '<=',
-                        PlayerAge::dateOfBirthCutoff(PlayerAge::YOUNG_END, $game->current_date),
-                    )->pluck('id');
-
                     $unenrolledCount = GamePlayer::where('game_id', $game->id)
                         ->where('team_id', $game->team_id)
                         ->whereNull('number')
-                        ->whereIn('player_id', $registrationEligiblePlayerIds)
+                        ->where(
+                            'date_of_birth',
+                            '<=',
+                            PlayerAge::dateOfBirthCutoff(PlayerAge::YOUNG_END, $game->current_date),
+                        )
                         ->count();
 
                     if ($unenrolledCount > 0) {

--- a/app/Modules/Report/Services/AwardService.php
+++ b/app/Modules/Report/Services/AwardService.php
@@ -13,7 +13,7 @@ class AwardService
      */
     public function getTopScorers(string $gameId, Collection|array|null $teamIds = null, int $limit = 5): Collection
     {
-        return GamePlayer::with(['player', 'team', 'matchState'])
+        return GamePlayer::with(['team', 'matchState'])
             ->joinMatchState()
             ->where('game_players.game_id', $gameId)
             ->when($teamIds, fn ($q) => $q->whereIn('team_id', $teamIds))
@@ -30,7 +30,7 @@ class AwardService
      */
     public function getTopAssisters(string $gameId, Collection|array|null $teamIds = null, int $limit = 5): Collection
     {
-        return GamePlayer::with(['player', 'team', 'matchState'])
+        return GamePlayer::with(['team', 'matchState'])
             ->joinMatchState()
             ->where('game_players.game_id', $gameId)
             ->when($teamIds, fn ($q) => $q->whereIn('team_id', $teamIds))
@@ -46,7 +46,7 @@ class AwardService
      */
     public function getTopGoalkeepers(string $gameId, Collection|array|null $teamIds = null, int $minAppearances = 3, int $limit = 5): Collection
     {
-        return GamePlayer::with(['player', 'team', 'matchState'])
+        return GamePlayer::with(['team', 'matchState'])
             ->joinMatchState()
             ->where('game_players.game_id', $gameId)
             ->when($teamIds, fn ($q) => $q->whereIn('team_id', $teamIds))
@@ -74,7 +74,7 @@ class AwardService
             return [collect(), null, $mvpCounts];
         }
 
-        $players = GamePlayer::with(['player', 'team', 'matchState'])
+        $players = GamePlayer::with(['team', 'matchState'])
             ->whereIn('id', $mvpCounts->keys()->all())
             ->get()
             ->keyBy('id');
@@ -99,7 +99,7 @@ class AwardService
      */
     public function getTeamSquadStats(string $gameId, string $teamId): Collection
     {
-        return GamePlayer::with(['player', 'matchState'])
+        return GamePlayer::with(['matchState'])
             ->leftJoinMatchState()
             ->where('game_players.game_id', $gameId)
             ->where('team_id', $teamId)

--- a/app/Modules/Report/Services/SeasonSummaryService.php
+++ b/app/Modules/Report/Services/SeasonSummaryService.php
@@ -72,7 +72,7 @@ class SeasonSummaryService
         // Team in numbers — eager-load matchState because every aggregation
         // below (top scorer, assists, appearances, cards, clean sheets) reads
         // through the satellite via the GamePlayer accessor delegates.
-        $teamPlayers = GamePlayer::with(['player', 'team', 'matchState'])
+        $teamPlayers = GamePlayer::with(['team', 'matchState'])
             ->where('game_id', $game->id)
             ->where('team_id', $game->team_id)
             ->get();

--- a/app/Modules/ReserveTeam/Services/ReserveTeamService.php
+++ b/app/Modules/ReserveTeam/Services/ReserveTeamService.php
@@ -6,7 +6,6 @@ use App\Models\Game;
 use App\Models\GamePlayer;
 use App\Models\GameTransfer;
 use App\Models\Loan;
-use App\Models\Player;
 use App\Modules\Notification\Services\NotificationService;
 use App\Modules\Player\PlayerAge;
 use App\Modules\ReserveTeam\Exceptions\FirstTeamSquadFullException;
@@ -52,7 +51,7 @@ class ReserveTeamService
 
         return GamePlayer::ownedByTeam($game->reserve_team_id)
             ->where('game_id', $game->id)
-            ->with(['player', 'activeLoan', 'careerRecord'])
+            ->with(['activeLoan', 'careerRecord'])
             ->get();
     }
 
@@ -176,15 +175,10 @@ class ReserveTeamService
 
         $cutoff = PlayerAge::dateOfBirthCutoff(PlayerAge::YOUNG_END + 1, $game->current_date);
 
-        // Resolve overage biographical player ids on the control plane first,
-        // then filter game-side rows by player_id. Avoids a cross-plane
-        // whereHas('player', …) subquery.
-        $overagePlayerIds = Player::where('date_of_birth', '<=', $cutoff)->pluck('id');
-
         $candidates = GamePlayer::ownedByTeam($game->reserve_team_id)
             ->where('game_id', $game->id)
-            ->whereIn('player_id', $overagePlayerIds)
-            ->with(['player', 'activeLoan'])
+            ->where('date_of_birth', '<=', $cutoff)
+            ->with(['activeLoan'])
             ->get();
 
         $promoted = collect();

--- a/app/Modules/Season/Processors/ContractExpirationProcessor.php
+++ b/app/Modules/Season/Processors/ContractExpirationProcessor.php
@@ -8,7 +8,6 @@ use App\Modules\Season\DTOs\SeasonTransitionData;
 use App\Modules\Transfer\Services\ContractService;
 use App\Models\Game;
 use App\Models\GamePlayer;
-use App\Models\Player;
 use App\Models\TransferOffer;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\DB;
@@ -48,47 +47,32 @@ class ContractExpirationProcessor implements SeasonProcessor
         $veteranCutoff = PlayerAge::dateOfBirthCutoff(PlayerAge::PRIME_END + 1, $game->current_date);
         $newContractEnd = Carbon::createFromDate($seasonYear + 3, 6, 30);
 
-        // Resolve eligible biographical player ids on the control plane up
-        // front, then run the set-based UPDATE / SELECT entirely against the
-        // tenant plane. Replaces UPDATE … FROM players and an explicit
-        // ->join('players', …) that crossed the control/tenant boundary.
-        $nonVeteranPlayerIds = Player::where('date_of_birth', '>', $veteranCutoff->toDateString())
-            ->pluck('id')
-            ->all();
-        $veteranPlayerIds = Player::where('date_of_birth', '<=', $veteranCutoff->toDateString())
-            ->pluck('id')
-            ->all();
-
         // AI non-veterans: auto-renew in a single set-based UPDATE. This is
         // ~80% of expired contracts — handling them purely in SQL avoids
         // hydrating hundreds of Eloquent models just to set one column.
         // Filter mirrors the old PHP branch: not user team, contract expired,
-        // no pending wage, player_id corresponds to a non-veteran.
-        $aiAutoRenewedCount = $nonVeteranPlayerIds === []
-            ? 0
-            : DB::table('game_players')
-                ->where('game_id', $game->id)
-                ->whereNotNull('team_id')
-                ->where('team_id', '<>', $game->team_id)
-                ->whereNotNull('contract_until')
-                ->where('contract_until', '<=', $expirationDate)
-                ->whereNull('pending_annual_wage')
-                ->whereIn('player_id', $nonVeteranPlayerIds)
-                ->update(['contract_until' => $newContractEnd->toDateString()]);
+        // no pending wage, player not yet at the veteran cutoff.
+        $aiAutoRenewedCount = DB::table('game_players')
+            ->where('game_id', $game->id)
+            ->whereNotNull('team_id')
+            ->where('team_id', '<>', $game->team_id)
+            ->whereNotNull('contract_until')
+            ->where('contract_until', '<=', $expirationDate)
+            ->whereNull('pending_annual_wage')
+            ->where('date_of_birth', '>', $veteranCutoff->toDateString())
+            ->update(['contract_until' => $newContractEnd->toDateString()]);
 
         // AI veterans: narrow SELECT of just the IDs, then 50% coin flip in
-        // PHP. Typically <30 rows — no hydration, no cross-plane JOIN.
-        $aiVeteranIds = $veteranPlayerIds === []
-            ? collect()
-            : DB::table('game_players')
-                ->where('game_id', $game->id)
-                ->whereNotNull('team_id')
-                ->where('team_id', '<>', $game->team_id)
-                ->whereNotNull('contract_until')
-                ->where('contract_until', '<=', $expirationDate)
-                ->whereNull('pending_annual_wage')
-                ->whereIn('player_id', $veteranPlayerIds)
-                ->pluck('id');
+        // PHP. Typically <30 rows.
+        $aiVeteranIds = DB::table('game_players')
+            ->where('game_id', $game->id)
+            ->whereNotNull('team_id')
+            ->where('team_id', '<>', $game->team_id)
+            ->whereNotNull('contract_until')
+            ->where('contract_until', '<=', $expirationDate)
+            ->whereNull('pending_annual_wage')
+            ->where('date_of_birth', '<=', $veteranCutoff->toDateString())
+            ->pluck('id');
 
         $veteranFreeAgentIds = [];
         $veteranAutoRenewedIds = [];

--- a/app/Modules/Season/Processors/PlayerRetirementProcessor.php
+++ b/app/Modules/Season/Processors/PlayerRetirementProcessor.php
@@ -8,7 +8,6 @@ use App\Modules\Player\PlayerAge;
 use App\Modules\Player\Services\PlayerRetirementService;
 use App\Models\Game;
 use App\Models\GamePlayer;
-use App\Models\Player;
 
 /**
  * Handles player retirements at the end of the season.
@@ -56,7 +55,7 @@ class PlayerRetirementProcessor implements SeasonProcessor
         // while on a team can have their contract expire in the same season closing
         // (ContractExpirationProcessor runs first), leaving team_id null. We still
         // want those players removed from the game.
-        $retiringPlayers = GamePlayer::with(['player', 'team', 'game'])
+        $retiringPlayers = GamePlayer::with(['team', 'game'])
             ->where('game_id', $game->id)
             ->where('retiring_at_season', $data->oldSeason)
             ->get();
@@ -94,19 +93,14 @@ class PlayerRetirementProcessor implements SeasonProcessor
         // set from ~500 to ~20-40 before PHP-side probability evaluation.
         $minRetirementCutoff = PlayerAge::dateOfBirthCutoff(PlayerAge::MIN_RETIREMENT_OUTFIELD, $game->current_date);
 
-        // Resolve eligible biographical players first (control plane), then
-        // filter game-side rows by player_id. Replaces a whereHas('player', …)
-        // subquery that would cross the control/tenant plane boundary.
-        $eligiblePlayerIds = Player::where('date_of_birth', '<=', $minRetirementCutoff)->pluck('id');
-
         // matchState is eager-loaded because shouldRetire() reads
         // fitness/season_appearances via the GamePlayer accessor delegates.
         // Free agents (team_id IS NULL) are included so they also receive
         // retirement announcements on the same cadence as rostered players.
-        $candidates = GamePlayer::with(['player', 'team', 'game', 'matchState'])
+        $candidates = GamePlayer::with(['team', 'game', 'matchState'])
             ->where('game_id', $game->id)
             ->whereNull('retiring_at_season')
-            ->whereIn('player_id', $eligiblePlayerIds)
+            ->where('date_of_birth', '<=', $minRetirementCutoff)
             ->get()
             ->filter(fn (GamePlayer $player) => $this->retirementService->shouldRetire($player));
 

--- a/app/Modules/Squad/Services/SquadNumberService.php
+++ b/app/Modules/Squad/Services/SquadNumberService.php
@@ -51,7 +51,7 @@ class SquadNumberService
             ->where('team_id', $game->team_id)
             ->where('id', '!=', $player->id)
             ->whereNotNull('number')
-            ->with('player')
+            
             ->get();
 
         $takenNumbers = $teamPlayers->pluck('number')->flip();
@@ -123,7 +123,7 @@ class SquadNumberService
     {
         $players = GamePlayer::where('game_id', $game->id)
             ->where('team_id', $game->team_id)
-            ->with('player')
+            
             ->get();
 
         if ($players->isEmpty()) {

--- a/app/Modules/Squad/Services/SquadRegistrationService.php
+++ b/app/Modules/Squad/Services/SquadRegistrationService.php
@@ -4,7 +4,6 @@ namespace App\Modules\Squad\Services;
 
 use App\Models\Game;
 use App\Models\GamePlayer;
-use App\Models\Player;
 use App\Modules\Player\PlayerAge;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
@@ -80,19 +79,14 @@ class SquadRegistrationService
 
         $academyPlayerIds = $academyAssignments->pluck('player_id');
 
-        // Resolve overage biographical player ids on the control plane first,
-        // then filter game-side rows by player_id. Avoids a cross-plane
-        // whereHas('player', …) subquery.
-        $overagePlayerIds = Player::where(
-            'date_of_birth',
-            '<=',
-            PlayerAge::dateOfBirthCutoff(PlayerAge::YOUNG_END + 1, $game->current_date),
-        )->pluck('id');
-
         $overageCount = GamePlayer::where('game_id', $game->id)
             ->where('team_id', $game->team_id)
             ->whereIn('id', $academyPlayerIds)
-            ->whereIn('player_id', $overagePlayerIds)
+            ->where(
+                'date_of_birth',
+                '<=',
+                PlayerAge::dateOfBirthCutoff(PlayerAge::YOUNG_END + 1, $game->current_date),
+            )
             ->count();
 
         if ($overageCount > 0) {

--- a/app/Modules/Squad/Services/SquadService.php
+++ b/app/Modules/Squad/Services/SquadService.php
@@ -30,7 +30,7 @@ class SquadService
         $gameId = $game->id;
 
         // Get all players for user's team with relationships
-        $allPlayers = GamePlayer::with(['player', 'game', 'team', 'matchState', 'activeLoan', 'transferOffers', 'suspensions', 'activeRenewalNegotiation', 'latestRenewalNegotiation', 'careerRecord'])
+        $allPlayers = GamePlayer::with(['game', 'team', 'matchState', 'activeLoan', 'transferOffers', 'suspensions', 'activeRenewalNegotiation', 'latestRenewalNegotiation', 'careerRecord'])
             ->where('game_id', $gameId)
             ->where('team_id', $game->team_id)
             ->get();

--- a/app/Modules/Transfer/Services/ContractService.php
+++ b/app/Modules/Transfer/Services/ContractService.php
@@ -426,7 +426,7 @@ class ContractService
     {
         $seasonEndDate = $game->getSeasonEndDate();
 
-        return GamePlayer::with(['player', 'team', 'game', 'transferOffers', 'latestRenewalNegotiation', 'activeRenewalNegotiation', 'activeLoan'])
+        return GamePlayer::with(['team', 'game', 'transferOffers', 'latestRenewalNegotiation', 'activeRenewalNegotiation', 'activeLoan'])
             ->where('game_id', $game->id)
             ->ownedByTeam($game->team_id)
             ->get()
@@ -442,7 +442,7 @@ class ContractService
      */
     public function getPlayersWithPendingRenewals(Game $game): Collection
     {
-        return GamePlayer::with('player')
+        return GamePlayer::query()
             ->where('game_id', $game->id)
             ->ownedByTeam($game->team_id)
             ->whereNotNull('pending_annual_wage')

--- a/app/Modules/Transfer/Services/ExploreService.php
+++ b/app/Modules/Transfer/Services/ExploreService.php
@@ -135,7 +135,7 @@ class ExploreService
     {
         $players = GamePlayer::where('game_id', $game->id)
             ->where('team_id', $teamId)
-            ->with(['player', 'team'])
+            ->with(['team'])
             ->get();
 
         $playerIds = $players->pluck('id')->toArray();
@@ -166,7 +166,7 @@ class ExploreService
     {
         $query = GamePlayer::where('game_id', $game->id)
             ->whereNull('team_id')
-            ->with('player');
+            ;
 
         $positions = PositionMapper::getPositionsForGroupFilter($positionFilter);
         if ($positions !== null) {

--- a/app/Modules/Transfer/Services/LoanService.php
+++ b/app/Modules/Transfer/Services/LoanService.php
@@ -74,7 +74,7 @@ class LoanService
      */
     public function processLoanSearches(Game $game): array
     {
-        $searching = GamePlayer::with(['player', 'transferListing'])
+        $searching = GamePlayer::with(['transferListing'])
             ->where('game_id', $game->id)
             ->where('team_id', $game->team_id)
             ->whereHas('transferListing', fn ($q) => $q->where('status', TransferListing::STATUS_LOAN_SEARCH))

--- a/app/Modules/Transfer/Services/ScoutSearchQueryBuilder.php
+++ b/app/Modules/Transfer/Services/ScoutSearchQueryBuilder.php
@@ -24,7 +24,7 @@ class ScoutSearchQueryBuilder
      */
     public function buildCandidateQuery(Game $game, array $filters, array $positions): Builder
     {
-        $query = GamePlayer::with(['player', 'team'])
+        $query = GamePlayer::with(['team'])
             ->where('game_id', $game->id)
             ->whereNotNull('team_id')
             ->whereNotIn('team_id', $game->userTeamIds());

--- a/app/Modules/Transfer/Services/ScoutingService.php
+++ b/app/Modules/Transfer/Services/ScoutingService.php
@@ -393,7 +393,7 @@ class ScoutingService
 
         $positionSet = array_flip($positions);
 
-        $squad = GamePlayer::with('player')
+        $squad = GamePlayer::query()
             ->where('game_id', $game->id)
             ->where('team_id', $game->team_id)
             ->get();

--- a/app/Support/LiveMatchLineupPresenter.php
+++ b/app/Support/LiveMatchLineupPresenter.php
@@ -23,7 +23,7 @@ class LiveMatchLineupPresenter
      */
     public static function startingLineup(array $lineupIds, CarbonInterface $currentDate): array
     {
-        return GamePlayer::with(['player', 'matchState'])
+        return GamePlayer::with(['matchState'])
             ->whereIn('id', $lineupIds)
             ->get()
             ->map(fn ($p) => self::fullCard($p, $currentDate, null, 0))
@@ -49,7 +49,7 @@ class LiveMatchLineupPresenter
         CarbonInterface $currentDate,
         array $performances,
     ): array {
-        return GamePlayer::with(['player', 'matchState'])
+        return GamePlayer::with(['matchState'])
             ->where('game_players.game_id', $game->id)
             ->where('team_id', $game->team_id)
             ->whereNotIn('id', $lineupIds)
@@ -100,7 +100,7 @@ class LiveMatchLineupPresenter
      */
     public static function displayRoster(array $lineupIds, array $performances): array
     {
-        return GamePlayer::with(['player', 'matchState'])
+        return GamePlayer::with(['matchState'])
             ->whereIn('id', $lineupIds)
             ->get()
             ->map(fn ($p) => [


### PR DESCRIPTION
## Summary
This PR removes eager loading of the deprecated `Player` model from `GamePlayer` queries across the codebase. The `Player` model is being phased out in favor of `GamePlayerTemplate` for biographical data, and `GamePlayer` now stores biographical fields directly (date_of_birth, nationality, height, foot, etc.).

## Key Changes

- **Removed Player model imports** from multiple service and action classes where they were only used for biographical lookups
- **Replaced Player-based filtering with direct GamePlayer queries** in several processors:
  - `ContractExpirationProcessor`: Changed from pre-fetching player IDs to filtering directly on `game_players.date_of_birth`
  - `MatchdayOrchestrator`: Removed two-step lookup for registration eligibility
  - `SquadRegistrationService`: Removed overage player ID resolution from control plane
  - `ReserveTeamService`: Removed player lookups for overage detection
  - `PlayerRetirementProcessor`: Removed player-based filtering for retirement eligibility

- **Removed `->with('player')` eager loading** from 40+ GamePlayer queries across:
  - HTTP actions and views (squad selection, transfers, negotiations, etc.)
  - Service classes (lineup, substitution, match resimulation, scouting, etc.)
  - Report and competition services
  - Admin and editor services

- **Migrated biographical data sources**:
  - `SaveSquadSelection` and `ShowSquadSelection`: Changed from `Player` to `GamePlayerTemplate` for reading abilities and biographical data
  - `UpdatePlayerTemplate`: Removed redundant Player nationality sync

## Implementation Details

The refactoring maintains the same query semantics while eliminating cross-plane (control/tenant) boundary crossings. Biographical fields are now read directly from `GamePlayer` records or `GamePlayerTemplate` (for canonical roster data), eliminating the need for Player model relationships in most contexts.

Some queries that previously loaded the Player relationship but didn't use it were simplified to `GamePlayer::query()` to avoid unnecessary eager loading overhead.

https://claude.ai/code/session_01BGPcs1cmkJw2QC7DH6EYnq