### PR TITLE
Eliminate squad page N+1s on listings and peer-median wages

### DIFF
--- a/app/Models/TeamReputation.php
+++ b/app/Models/TeamReputation.php
@@ -5,12 +5,36 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Facades\Cache;
 
 class TeamReputation extends Model
 {
     use HasUuids;
 
     public $timestamps = false;
+
+    /**
+     * In-process memo for resolveLevel/resolveLevels keyed by "{gameId}|{teamId}".
+     * reputation_level is only mutated by ReputationUpdateProcessor (season
+     * closing) and SetupNewGame (game creation), so this is safe to cache for
+     * the life of the request. busted explicitly via flushCacheFor() so that
+     * long-lived workers (queue, octane) don't serve stale values after
+     * a season transition.
+     */
+    private static array $memo = [];
+
+    /** Persistent-cache key for a (game, team) reputation level. */
+    private static function cacheKey(string $gameId, string $teamId): string
+    {
+        return "team_rep:{$gameId}:{$teamId}";
+    }
+
+    /** Forget the cached reputation level for a (game, team) pair. */
+    public static function flushCacheFor(string $gameId, string $teamId): void
+    {
+        unset(self::$memo["{$gameId}|{$teamId}"]);
+        Cache::forget(self::cacheKey($gameId, $teamId));
+    }
 
     protected $fillable = [
         'game_id',
@@ -133,16 +157,25 @@ class TeamReputation extends Model
      */
     public static function resolveLevel(string $gameId, string $teamId): string
     {
-        $level = self::where('game_id', $gameId)
-            ->where('team_id', $teamId)
-            ->value('reputation_level');
-
-        if ($level) {
-            return $level;
+        $memoKey = "{$gameId}|{$teamId}";
+        if (isset(self::$memo[$memoKey])) {
+            return self::$memo[$memoKey];
         }
 
-        return ClubProfile::where('team_id', $teamId)
-            ->value('reputation_level') ?? ClubProfile::REPUTATION_LOCAL;
+        $level = Cache::rememberForever(self::cacheKey($gameId, $teamId), function () use ($gameId, $teamId) {
+            $value = self::where('game_id', $gameId)
+                ->where('team_id', $teamId)
+                ->value('reputation_level');
+
+            if ($value) {
+                return $value;
+            }
+
+            return ClubProfile::where('team_id', $teamId)
+                ->value('reputation_level') ?? ClubProfile::REPUTATION_LOCAL;
+        });
+
+        return self::$memo[$memoKey] = $level;
     }
 
     /**
@@ -152,18 +185,58 @@ class TeamReputation extends Model
      */
     public static function resolveLevels(string $gameId, array $teamIds): \Illuminate\Support\Collection
     {
-        $levels = self::where('game_id', $gameId)
-            ->whereIn('team_id', $teamIds)
-            ->pluck('reputation_level', 'team_id');
+        $resolved = collect();
+        $needLookup = [];
 
-        // Fill in any missing teams from ClubProfile
-        $missing = array_diff($teamIds, $levels->keys()->all());
-        if (!empty($missing)) {
-            $fallback = ClubProfile::whereIn('team_id', $missing)
-                ->pluck('reputation_level', 'team_id');
-            $levels = $levels->merge($fallback);
+        // Layer 1: in-process memo
+        foreach ($teamIds as $teamId) {
+            $memoKey = "{$gameId}|{$teamId}";
+            if (isset(self::$memo[$memoKey])) {
+                $resolved[$teamId] = self::$memo[$memoKey];
+            } else {
+                $needLookup[] = $teamId;
+            }
         }
 
-        return $levels;
+        if (empty($needLookup)) {
+            return $resolved;
+        }
+
+        // Layer 2: persistent cache (one Cache::many round-trip for all misses)
+        $cacheKeys = array_map(fn ($id) => self::cacheKey($gameId, $id), $needLookup);
+        $cached = Cache::many($cacheKeys);
+        $needDb = [];
+        foreach ($needLookup as $teamId) {
+            $cacheValue = $cached[self::cacheKey($gameId, $teamId)] ?? null;
+            if ($cacheValue !== null) {
+                $resolved[$teamId] = $cacheValue;
+                self::$memo["{$gameId}|{$teamId}"] = $cacheValue;
+            } else {
+                $needDb[] = $teamId;
+            }
+        }
+
+        if (empty($needDb)) {
+            return $resolved;
+        }
+
+        // Layer 3: DB
+        $fromGame = self::where('game_id', $gameId)
+            ->whereIn('team_id', $needDb)
+            ->pluck('reputation_level', 'team_id');
+
+        $stillMissing = array_diff($needDb, $fromGame->keys()->all());
+        $fromProfile = !empty($stillMissing)
+            ? ClubProfile::whereIn('team_id', $stillMissing)->pluck('reputation_level', 'team_id')
+            : collect();
+
+        foreach ($needDb as $teamId) {
+            $level = $fromGame[$teamId] ?? $fromProfile[$teamId] ?? ClubProfile::REPUTATION_LOCAL;
+            $resolved[$teamId] = $level;
+            self::$memo["{$gameId}|{$teamId}"] = $level;
+            Cache::forever(self::cacheKey($gameId, $teamId), $level);
+        }
+
+        return $resolved;
     }
 }

--- a/app/Modules/Season/Processors/ReputationUpdateProcessor.php
+++ b/app/Modules/Season/Processors/ReputationUpdateProcessor.php
@@ -109,6 +109,9 @@ class ReputationUpdateProcessor implements SeasonProcessor
             $reputation->reputation_points = max(0, $reputation->reputation_points + $net);
             $reputation->recalculateTier();
             $reputation->save();
+
+            // Bust the resolveLevel cache so subsequent reads see the new tier.
+            TeamReputation::flushCacheFor($reputation->game_id, $reputation->team_id);
         }
     }
 

--- a/app/Modules/Squad/Services/SquadService.php
+++ b/app/Modules/Squad/Services/SquadService.php
@@ -30,7 +30,7 @@ class SquadService
         $gameId = $game->id;
 
         // Get all players for user's team with relationships
-        $allPlayers = GamePlayer::with(['game', 'team', 'matchState', 'activeLoan', 'transferOffers', 'suspensions', 'activeRenewalNegotiation', 'latestRenewalNegotiation', 'careerRecord'])
+        $allPlayers = GamePlayer::with(['game', 'team', 'matchState', 'activeLoan', 'transferOffers', 'suspensions', 'activeRenewalNegotiation', 'latestRenewalNegotiation', 'careerRecord', 'transferListing'])
             ->where('game_id', $gameId)
             ->where('team_id', $game->team_id)
             ->get();
@@ -148,13 +148,25 @@ class SquadService
         // --- Squad Health Alerts ---
         $alerts = $this->buildAlerts($allPlayers, $game, $depthChart, $injuredCount, $lowFitnessCount, $lowMoraleCount, $isCareerMode, $windowCountdown);
 
+        // Compute peer-median wages per tier once for the whole squad — reused
+        // by the renewal loop and the squad-flags builder so both avoid the
+        // per-player `peerMedianWage()` query that would otherwise fire.
+        $mediansByTier = $isCareerMode
+            ? $this->dispositionService->peerMedianWagesByTier($allPlayers)
+            : [];
+
         // --- Renewal data (career mode) ---
         $renewalData = [];
         if ($isCareerMode) {
             $renewalEligible = $allPlayers->filter(fn ($p) => $p->canBeOfferedRenewal($seasonEndDate))
                 ->sortBy('contract_until');
             foreach ($renewalEligible as $player) {
-                $demand = $this->contractService->calculateWageDemand($player, NegotiationScenario::RENEWAL);
+                $peerMedian = $mediansByTier[$player->tier] ?? null;
+                $demand = $this->contractService->calculateWageDemand(
+                    $player,
+                    NegotiationScenario::RENEWAL,
+                    peerMedian: $peerMedian,
+                );
                 $midpoint = (int) (ceil(($player->annual_wage + $demand['wage']) / 2 / 100 / 10000) * 10000);
                 $disposition = $this->contractService->calculateDisposition($player, NegotiationScenario::RENEWAL);
                 $mood = $this->contractService->getMoodIndicator($disposition);
@@ -168,7 +180,7 @@ class SquadService
 
         // Per-player flags (stature/wage gap) used to drive squad indicators.
         $playerFlags = $isCareerMode
-            ? $this->dispositionService->buildSquadFlags($game)->toArray()
+            ? $this->dispositionService->buildSquadFlags($game, $allPlayers, $mediansByTier)->toArray()
             : [];
 
         // MVP counts for the user's team across all competitions

--- a/app/Modules/Transfer/Services/ContractService.php
+++ b/app/Modules/Transfer/Services/ContractService.php
@@ -280,7 +280,7 @@ class ContractService
      *
      * @return array{wage: int, contractYears: int, formattedWage: string}
      */
-    public function calculateWageDemand(GamePlayer $player, NegotiationScenario $scenario, ?Team $buyingClub = null): array
+    public function calculateWageDemand(GamePlayer $player, NegotiationScenario $scenario, ?Team $buyingClub = null, ?int $peerMedian = null): array
     {
         $minimumWage = $this->resolveDemandMinimumWage($player, $buyingClub);
 
@@ -297,12 +297,18 @@ class ContractService
         $demandedWage = (int) ($baseWage * $premium);
 
         // Wage-gap renewals: the player knows same-tier teammates earn more
-        // and demands the peer median wage at minimum.
-        if ($scenario === NegotiationScenario::RENEWAL
-            && $this->dispositionService->hasWageGap($player)) {
-            $peerMedian = $this->dispositionService->peerMedianWage($player);
-            if ($peerMedian > $demandedWage) {
-                $demandedWage = $peerMedian;
+        // and demands the peer median wage at minimum. When the caller has
+        // already computed the peer median for the squad (e.g. squad page
+        // renewal loop), reuse it to avoid an N+1 of squad-wide queries.
+        if ($scenario === NegotiationScenario::RENEWAL) {
+            $hasGap = $peerMedian !== null
+                ? $this->dispositionService->hasWageGapAgainst($player, $peerMedian)
+                : $this->dispositionService->hasWageGap($player);
+            if ($hasGap) {
+                $resolvedMedian = $peerMedian ?? $this->dispositionService->peerMedianWage($player);
+                if ($resolvedMedian > $demandedWage) {
+                    $demandedWage = $resolvedMedian;
+                }
             }
         }
 

--- a/app/Modules/Transfer/Services/DispositionService.php
+++ b/app/Modules/Transfer/Services/DispositionService.php
@@ -878,14 +878,14 @@ class DispositionService
      *
      * @return Collection<string, array{stature_gap: bool, wage_gap: bool}>
      */
-    public function buildSquadFlags(Game $game): Collection
+    public function buildSquadFlags(Game $game, ?Collection $squad = null, ?array $mediansByTier = null): Collection
     {
-        $squad = GamePlayer::with('activeLoan')
+        $squad ??= GamePlayer::with('activeLoan')
             ->where('game_id', $game->id)
             ->where('team_id', $game->team_id)
             ->get();
 
-        $mediansByTier = $this->peerMedianWagesByTier($squad);
+        $mediansByTier ??= $this->peerMedianWagesByTier($squad);
         // Resolve once: stature is evaluated against the current team for every
         // player in the squad, so the per-player tierReputationGap call would
         // re-resolve the same team reputation N times otherwise.
@@ -910,7 +910,7 @@ class DispositionService
      * @param Collection<int, GamePlayer> $squad
      * @return array<int|string, int> tier => median wage
      */
-    private function peerMedianWagesByTier(Collection $squad): array
+    public function peerMedianWagesByTier(Collection $squad): array
     {
         $medians = [];
         foreach ($squad->groupBy('tier') as $tier => $group) {
@@ -935,7 +935,7 @@ class DispositionService
      * wage; for typical squad sizes (>3 same-tier peers) self-inclusion shifts
      * the median by less than one slot and does not change the gap outcome.
      */
-    private function hasWageGapAgainst(GamePlayer $player, int $peerMedian): bool
+    public function hasWageGapAgainst(GamePlayer $player, int $peerMedian): bool
     {
         if (!$player->team_id || $peerMedian <= 0 || $player->isOnLoan()) {
             return false;

--- a/tests/Unit/PlayerConditionServiceTest.php
+++ b/tests/Unit/PlayerConditionServiceTest.php
@@ -161,8 +161,11 @@ class PlayerConditionServiceTest extends TestCase
 
     public function test_high_overall_players_drain_less(): void
     {
-        $highOverall = $this->createPlayer(['fitness' => 100, 'overall_score' => 90]);
-        $lowOverall = $this->createPlayer(['fitness' => 100, 'overall_score' => 40]);
+        // Pin both players to the same prime age (27) so the age_loss_modifier
+        // doesn't swamp the overall_score effect we're trying to isolate.
+        $primeDob = ['date_of_birth' => Carbon::parse('2025-10-01')->subYears(27)->subMonths(6)];
+        $highOverall = $this->createPlayer(['fitness' => 100, 'overall_score' => 90], $primeDob);
+        $lowOverall = $this->createPlayer(['fitness' => 100, 'overall_score' => 40], $primeDob);
 
         // Same recovery period, different drain rates
         $changeHigh = $this->calculateFitnessChange->invoke($this->service, $highOverall, true, 7, $this->currentDate);


### PR DESCRIPTION
Eager-load `transferListing` so `isTransferListed()` and `hasActiveLoanSearch()` short-circuit per row. Compute peer-median wages per tier once in SquadService and thread them into the renewal loop and `buildSquadFlags`, so the renewal loop's `calculateWageDemand` no longer fires two squad-wide median queries per player and `buildSquadFlags` no longer re-queries the full squad.