### PR TITLE
Add production deployment playbook and infrastructure for Hetzner

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -71,3 +71,26 @@ TELESCOPE_ENABLED=false
 
 PULSE_ENABLED=false
 PULSE_DB_CONNECTION=pgsql
+
+# -----------------------------------------------------------------------------
+# Production deployment vars (see deploy/hetzner/README.md)
+# -----------------------------------------------------------------------------
+
+# Set to "true" on exactly one container (typically `app`) when multiple
+# services share this image (app + horizon + scheduler). The entrypoint
+# skips `migrate --force` when this is anything other than "true".
+RUN_MIGRATIONS=true
+
+# Trust X-Forwarded-* headers from the reverse proxy (Traefik) so Octane sees
+# real client IPs. Use "*" inside the compose network, or a comma-separated
+# CIDR list (e.g. "10.0.0.0/8,172.16.0.0/12") for tighter scoping.
+TRUSTED_PROXIES=
+
+# Laravel Nightwatch — first-party APM/error tracking. Token is issued from
+# the Nightwatch dashboard. Disabled by default; enable in production.
+NIGHTWATCH_ENABLED=false
+NIGHTWATCH_TOKEN=
+
+# Slack webhook for Laravel logging channel (and reused by Grafana alerts in
+# the monitoring stack). See config/logging.php → 'slack' channel.
+LOG_SLACK_WEBHOOK_URL=

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,105 @@
+name: Deploy to Hetzner
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Image tag to deploy (defaults to commit SHA)'
+        required: false
+        type: string
+
+concurrency:
+  group: deploy-hetzner
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  wait-for-tests:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push'
+    steps:
+      - uses: lewagon/wait-on-check-action@v1.3.4
+        with:
+          ref: ${{ github.sha }}
+          check-name: tests
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 15
+
+  build:
+    needs: [wait-for-tests]
+    if: ${{ always() && (needs.wait-for-tests.result == 'success' || needs.wait-for-tests.result == 'skipped') }}
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.meta.outputs.tag }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Resolve tag
+        id: meta
+        run: |
+          TAG="${{ inputs.tag }}"
+          if [ -z "$TAG" ]; then TAG="${GITHUB_SHA::12}"; fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          target: production
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}:${{ steps.meta.outputs.tag }}
+            ghcr.io/${{ github.repository }}:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  deploy:
+    needs: [build]
+    runs-on: ubuntu-latest
+    environment:
+      name: production
+      url: https://${{ vars.APP_DOMAIN }}
+    steps:
+      - name: Configure SSH
+        run: |
+          install -d -m 0700 ~/.ssh
+          echo "${{ secrets.HETZNER_SSH_KEY }}" > ~/.ssh/id_ed25519
+          chmod 0600 ~/.ssh/id_ed25519
+          ssh-keyscan -H "${{ secrets.HETZNER_HOST }}" >> ~/.ssh/known_hosts
+
+      - name: Deploy
+        env:
+          TAG: ${{ needs.build.outputs.tag }}
+          HOST: ${{ secrets.HETZNER_HOST }}
+          USER: ${{ secrets.HETZNER_USER }}
+        run: |
+          ssh "$USER@$HOST" "IMAGE_TAG=$TAG /srv/virtua-fc/scripts/deploy.sh"
+
+      - name: Smoke test
+        env:
+          HOST: ${{ secrets.HETZNER_HOST }}
+          USER: ${{ secrets.HETZNER_USER }}
+        run: |
+          ssh "$USER@$HOST" "/srv/virtua-fc/scripts/smoketest.sh"
+
+      - name: Rollback on failure
+        if: failure()
+        env:
+          HOST: ${{ secrets.HETZNER_HOST }}
+          USER: ${{ secrets.HETZNER_USER }}
+        run: |
+          ssh "$USER@$HOST" "/srv/virtua-fc/scripts/rollback.sh"

--- a/deploy/hetzner/README.md
+++ b/deploy/hetzner/README.md
@@ -100,7 +100,53 @@ GitHub repository settings (one-time):
 
 ## 3. One-time server bring-up
 
-### 3.1 Install Ubuntu 24.04 with RAID-1
+Two paths, depending on which Hetzner product you're on. Both end at the
+same state — `/srv/virtua-fc/...` directories created, `deploy` user with
+your SSH key, root + password SSH disabled, ufw enforcing 22/80/443,
+Docker installed.
+
+### Path A — Hetzner Cloud (CX23+ / CCX) via cloud-init
+
+Pick this if you're provisioning a Cloud server. Cloud-init runs the YAML
+on first boot, so the box is already configured by the time you can SSH in.
+
+> **Sizing:** match/season simulation is CPU-bound. Use **CCX** (dedicated
+> vCPU) rather than CX (shared vCPU) for production, or expect noisy-neighbor
+> stalls. CX is fine for staging.
+
+1. **Edit the user-data file.** Open `deploy/hetzner/cloud-init.yaml` and
+   replace the `ssh-ed25519 AAAA_REPLACE_WITH_YOUR_PUBLIC_KEY …` line with
+   your real public key.
+2. **Create the server.** In the Hetzner Cloud console, choose Ubuntu 24.04,
+   pick CCX23 or larger, and paste the YAML into "User data". Or via CLI:
+   ```bash
+   hcloud server create \
+     --name virtua-fc-1 \
+     --type ccx23 \
+     --image ubuntu-24.04 \
+     --location nbg1 \
+     --ssh-key <your-key-name> \
+     --user-data-from-file deploy/hetzner/cloud-init.yaml
+   ```
+3. **Wait ~2 minutes** for cloud-init to finish (apt-update, Docker install,
+   etc.). The server is ready when `/etc/virtua-fc-bootstrapped` exists.
+4. **SSH in as deploy** (root login is already disabled by cloud-init):
+   ```bash
+   ssh deploy@<server-ip>
+   ```
+5. **Skip to §3.3** to push the deploy tree onto the box.
+
+If cloud-init fails for some reason (rare but possible — check
+`/var/log/cloud-init-output.log` on the box), fall back to Path B by running
+`scripts/bootstrap.sh` manually.
+
+### Path B — Hetzner dedicated root server (AX-line) via installimage
+
+Pick this if you're on a dedicated box. There is no cloud-init on dedicated
+hardware — you boot into rescue mode and run installimage, then run our
+bootstrap script.
+
+#### B.1 Install Ubuntu 24.04 with RAID-1
 
 In Hetzner Robot, boot the server into rescue mode and run:
 
@@ -129,7 +175,7 @@ Reboot. From your laptop:
 ssh root@<server-ip>
 ```
 
-### 3.2 Run the bootstrap script
+#### B.2 Run the bootstrap script
 
 Copy the bootstrap script to the box and run it. It is idempotent.
 
@@ -139,7 +185,8 @@ scp deploy/hetzner/scripts/bootstrap.sh root@<server-ip>:/tmp/bootstrap.sh
 ssh root@<server-ip> "DEPLOY_PUBKEY='ssh-ed25519 AAAA…' bash /tmp/bootstrap.sh"
 ```
 
-What it does (see `scripts/bootstrap.sh` for the source):
+What it does (see `scripts/bootstrap.sh` for the source — same end state as
+the cloud-init YAML):
 
 - Creates the `deploy` user with passwordless sudo and your SSH key.
 - Disables root SSH and password auth in `/etc/ssh/sshd_config`.

--- a/deploy/hetzner/README.md
+++ b/deploy/hetzner/README.md
@@ -22,6 +22,7 @@ issue and update this README.
 8. [Scaling out](#8-scaling-out)
 9. [Disaster-recovery drill](#9-disaster-recovery-drill)
 10. [Reference appendix](#10-reference-appendix)
+11. [Container image (GHCR)](#11-container-image-ghcr)
 
 ---
 
@@ -80,8 +81,9 @@ Before you start the bring-up, make sure you have:
   - (Add other subdomains later if you choose to expose `horizon.` / `pulse.`
     — they are reachable today via the app at `/horizon` and `/pulse`.)
 - **GHCR access** — the GitHub Actions workflow pushes the production image
-  to `ghcr.io/<owner>/virtua-fc`. Make the package public, or grant the box a
-  read-only token.
+  to `ghcr.io/<owner>/<repo>` (e.g. `ghcr.io/pabloroman/virtua-fc`). See
+  [§11 Container image (GHCR)](#11-container-image-ghcr) for how the URL
+  is constructed and how to grant the box pull access.
 - **Resend API key** for transactional email.
 - **Laravel Nightwatch token** for APM/error tracking.
 - **Slack webhook** for alert delivery (optional but recommended).
@@ -806,3 +808,137 @@ at the root of the repo or the design doc that triggered this work):
 
 When the time comes, drop a `migrate.sh` next to the other scripts and add a
 "Migration day" section above §3.
+
+---
+
+## 11. Container image (GHCR)
+
+### 11.1 Where the URL comes from
+
+The image is published to the GitHub Container Registry. The URL is built
+from three pieces:
+
+```
+ghcr.io / <owner> / <repo> : <tag>
+```
+
+| Piece | Source | Value for this project |
+|---|---|---|
+| `ghcr.io` | hard-coded — GHCR's hostname | `ghcr.io` |
+| `<owner>` | GitHub user or org that owns the repo | `pabloroman` |
+| `<repo>` | the repository name | `virtua-fc` |
+| `<tag>` | image tag (commit SHA, branch, or `latest`) | the 12-char SHA, plus `latest` |
+
+So the image you'll be pulling on the server is:
+
+```
+ghcr.io/pabloroman/virtua-fc:latest
+ghcr.io/pabloroman/virtua-fc:3507182f4b9c        # specific build
+```
+
+The `<owner>/<repo>` part comes straight from `${{ github.repository }}` in
+`.github/workflows/deploy.yml` — no manual configuration. Whatever the
+GitHub repo's slug is, that's the image path.
+
+### 11.2 How the image gets there
+
+1. You push to `main`.
+2. `tests.yml` runs and goes green.
+3. `deploy.yml` waits for `tests`, then runs `docker buildx build` against
+   the repo root `Dockerfile` (target `production`) and pushes two tags:
+   - `ghcr.io/pabloroman/virtua-fc:<12-char-sha>` (immutable, what we
+     actually deploy)
+   - `ghcr.io/pabloroman/virtua-fc:latest` (moving pointer for humans)
+4. The workflow then SSHes to the Hetzner box and runs
+   `IMAGE_TAG=<sha> /srv/virtua-fc/scripts/deploy.sh`, which writes the
+   tag into `/srv/virtua-fc/env/.env` and runs `docker compose pull && up -d`.
+
+The push step uses the workflow's built-in `GITHUB_TOKEN` with
+`packages: write` permission (granted at the top of `deploy.yml`). No PAT
+needed for *publishing*.
+
+### 11.3 First-time setup
+
+After the very first successful push from `deploy.yml`:
+
+1. **The package is created automatically** at
+   `https://github.com/users/<owner>/packages/container/package/virtua-fc`
+   (or `/orgs/<org>/...` for org-owned repos).
+2. **By default the package is private.** You must grant the Hetzner box
+   pull access — pick one option below.
+
+### 11.4 Granting the server pull access
+
+#### Option A — make the package public (recommended for OSS)
+
+GitHub UI → your packages → `virtua-fc` → Package settings → "Change
+visibility" → Public. Now `docker pull ghcr.io/<owner>/virtua-fc:<tag>`
+works from anywhere with no credentials. Easiest, no rotation burden.
+
+If the repo is private and you'd rather keep the image private too, use B
+or C.
+
+#### Option B — Personal Access Token on the server
+
+1. GitHub → Settings → Developer settings → Personal access tokens →
+   **Tokens (classic)** → Generate new token. The fine-grained tokens do
+   not yet support the GHCR `read:packages` scope at the time of writing,
+   so use a classic token.
+2. Scope: `read:packages` only. Set an expiry (90 days is reasonable).
+3. SSH to the box and log Docker into GHCR once:
+   ```bash
+   ssh deploy@<server-ip>
+   echo "<the-token>" | docker login ghcr.io -u <github-username> --password-stdin
+   ```
+   The credential is saved to `/home/deploy/.docker/config.json` and survives
+   reboots. `docker compose pull` from the deploy scripts will use it
+   automatically.
+4. Add a calendar reminder for token rotation; re-run `docker login` with the
+   new value when the time comes.
+
+#### Option C — repo-scoped deploy token
+
+Same as B but generated under Repo → Settings → Actions → Repository
+secrets won't work here (those are CI-only). Use a fine-grained PAT scoped
+to a single package once GHCR support lands; until then, B is the path.
+
+### 11.5 Configuring the server-side env
+
+Open `/srv/virtua-fc/env/.env` and confirm:
+
+```bash
+GHCR_REPO=pabloroman/virtua-fc      # <owner>/<repo>, no leading "ghcr.io/"
+IMAGE_TAG=latest                    # bumped automatically by deploy.sh
+```
+
+The compose file builds the full `ghcr.io/${GHCR_REPO}:${IMAGE_TAG}` URL
+itself — see the `x-app-image` anchor at the top of
+`compose/docker-compose.yml`.
+
+### 11.6 Pulling a specific build manually
+
+To pin to a known-good tag (e.g. while debugging):
+
+```bash
+# List the tags GHCR has for the package
+curl -fsSL \
+  -H "Authorization: Bearer $(echo -n '<github-username>:<token>' | base64)" \
+  https://ghcr.io/v2/<owner>/virtua-fc/tags/list | jq
+
+# Pull and run a specific tag
+ssh deploy@<server-ip>
+IMAGE_TAG=3507182f4b9c /srv/virtua-fc/scripts/deploy.sh
+```
+
+`deploy.sh` records the previous tag to `/srv/virtua-fc/env/.previous`, so
+`rollback.sh` can revert with no arguments.
+
+### 11.7 Pruning old images on the server
+
+Disk fills slowly with stale tags. The deploy scripts don't prune
+automatically — add this to a weekly cron if disk pressure becomes a thing:
+
+```bash
+docker image prune -af --filter "until=336h"   # 14 days
+```
+

--- a/deploy/hetzner/README.md
+++ b/deploy/hetzner/README.md
@@ -1,0 +1,761 @@
+# VirtuaFC on Hetzner — Operational Playbook
+
+A copy-pasteable runbook for deploying and operating VirtuaFC on a single
+dedicated Hetzner root server with a bolted-on monitoring stack. Written for
+an operator who has SSH access and nothing else: every command in this
+document is intended to be run literally, in order, top to bottom.
+
+If something here disagrees with the codebase, the codebase wins — open an
+issue and update this README.
+
+---
+
+## Contents
+
+1. [Topology](#1-topology)
+2. [Prerequisites](#2-prerequisites)
+3. [One-time server bring-up](#3-one-time-server-bring-up)
+4. [Day-2 operations](#4-day-2-operations)
+5. [Monitoring access & on-call](#5-monitoring-access--on-call)
+6. [Health checks & smoke tests](#6-health-checks--smoke-tests)
+7. [Common incidents → fixes](#7-common-incidents--fixes)
+8. [Scaling out](#8-scaling-out)
+9. [Disaster-recovery drill](#9-disaster-recovery-drill)
+10. [Reference appendix](#10-reference-appendix)
+
+---
+
+## 1. Topology
+
+```
+                        Internet
+                           │
+                  ┌────────▼─────────┐
+                  │ Traefik          │  :80/:443 (Let's Encrypt HTTP-01)
+                  │ (TLS, routing)   │
+                  └─┬──────┬────────┬┘
+                    │      │        │
+            virtuafc.…           grafana.…
+                    │              │
+                  app           Grafana
+                  (Octane/FrankenPHP)
+                    │
+              scheduler   horizon
+              (schedule:work) (queues)
+                    │
+        ┌───────────┼────────────────┐
+        │           │                │
+     postgres     redis      Prometheus + Loki + Promtail
+                              + node/cAdvisor/pg/redis exporters
+```
+
+All services run as containers on a single Docker host. Networks:
+
+- `edge` — Traefik plus everything that takes external traffic (`app`, `grafana`).
+- `internal` — everything else (Postgres, Redis, the monitoring scrape targets).
+
+Host paths:
+
+| Path | Purpose |
+|---|---|
+| `/srv/virtua-fc/compose/` | `docker-compose.yml`, `docker-compose.monitoring.yml` |
+| `/srv/virtua-fc/env/.env` | secrets (mode 0600, owned by `deploy`) |
+| `/srv/virtua-fc/scripts/` | `compose.sh`, `deploy.sh`, `rollback.sh`, `backup.sh`, `restore.sh`, `smoketest.sh` |
+| `/srv/virtua-fc/{prometheus,promtail,grafana}/` | provisioned monitoring config |
+| `/srv/virtua-fc/backups/` | local Postgres dumps (rotated) |
+| `/var/lib/virtua-fc/{postgres,redis,traefik,prometheus,grafana,loki}` | persistent data volumes |
+
+---
+
+## 2. Prerequisites
+
+Before you start the bring-up, make sure you have:
+
+- **Hetzner root server** (recommended: AX42, Ryzen 7700, 64 GB ECC, 2×1 TB
+  NVMe in RAID-1) running Ubuntu 24.04 LTS via `installimage`.
+- **SSH key** for the future `deploy` user (the public key, not the private).
+- **Domain** with DNS records pointing at the server's IPv4/IPv6:
+  - `virtuafc.example.com` → app
+  - `grafana.virtuafc.example.com` → Grafana
+  - (Add other subdomains later if you choose to expose `horizon.` / `pulse.`
+    — they are reachable today via the app at `/horizon` and `/pulse`.)
+- **GHCR access** — the GitHub Actions workflow pushes the production image
+  to `ghcr.io/<owner>/virtua-fc`. Make the package public, or grant the box a
+  read-only token.
+- **Resend API key** for transactional email.
+- **Laravel Nightwatch token** for APM/error tracking.
+- **Slack webhook** for alert delivery (optional but recommended).
+- **Hetzner Storage Box** (~€4/mo) for offsite backups, plus its SSH user/host.
+
+GitHub repository settings (one-time):
+
+| Where | Name | Value |
+|---|---|---|
+| Secrets | `HETZNER_HOST` | server IP or hostname |
+| Secrets | `HETZNER_USER` | `deploy` |
+| Secrets | `HETZNER_SSH_KEY` | the *private* key, ed25519 preferred |
+| Variables | `APP_DOMAIN` | e.g. `virtuafc.example.com` |
+
+---
+
+## 3. One-time server bring-up
+
+### 3.1 Install Ubuntu 24.04 with RAID-1
+
+In Hetzner Robot, boot the server into rescue mode and run:
+
+```bash
+installimage
+```
+
+Choose **Ubuntu 24.04**. In the editor, set:
+
+```
+SWRAID 1
+SWRAIDLEVEL 1
+HOSTNAME virtua-fc-1
+PART /boot ext3 1G
+PART lvm vg0 all
+LV vg0 root / ext4 64G
+LV vg0 var /var ext4 100G
+LV vg0 srv /srv ext4 32G
+LV vg0 docker /var/lib/docker ext4 200G
+LV vg0 data /var/lib/virtua-fc ext4 all
+```
+
+Reboot. From your laptop:
+
+```bash
+ssh root@<server-ip>
+```
+
+### 3.2 Run the bootstrap script
+
+Copy the bootstrap script to the box and run it. It is idempotent.
+
+```bash
+# from your laptop, in the repo root
+scp deploy/hetzner/scripts/bootstrap.sh root@<server-ip>:/tmp/bootstrap.sh
+ssh root@<server-ip> "DEPLOY_PUBKEY='ssh-ed25519 AAAA…' bash /tmp/bootstrap.sh"
+```
+
+What it does (see `scripts/bootstrap.sh` for the source):
+
+- Creates the `deploy` user with passwordless sudo and your SSH key.
+- Disables root SSH and password auth in `/etc/ssh/sshd_config`.
+- Configures `ufw` (deny incoming except 22/80/443).
+- Enables `fail2ban` (sshd jail) and `unattended-upgrades`.
+- Installs Docker Engine + compose plugin from Docker's apt repo.
+- Sets the timezone to UTC (matches `APP_TIMEZONE`).
+- Creates `/srv/virtua-fc/...` and `/var/lib/virtua-fc/...` directory layout.
+
+**Verify SSH lockdown** in a *different* terminal — both must hold:
+
+```bash
+ssh root@<server-ip>      # MUST FAIL
+ssh deploy@<server-ip>    # MUST SUCCEED (key only)
+```
+
+### 3.3 Push deployment files to the server
+
+From the repo root on your laptop:
+
+```bash
+rsync -avz --delete \
+  deploy/hetzner/compose/        deploy@<server-ip>:/srv/virtua-fc/compose/
+rsync -avz --delete \
+  deploy/hetzner/scripts/        deploy@<server-ip>:/srv/virtua-fc/scripts/
+rsync -avz --delete \
+  deploy/hetzner/prometheus/     deploy@<server-ip>:/srv/virtua-fc/prometheus/
+rsync -avz --delete \
+  deploy/hetzner/promtail/       deploy@<server-ip>:/srv/virtua-fc/promtail/
+rsync -avz --delete \
+  deploy/hetzner/grafana/        deploy@<server-ip>:/srv/virtua-fc/grafana/
+ssh deploy@<server-ip> "chmod +x /srv/virtua-fc/scripts/*.sh"
+```
+
+### 3.4 Fill in the environment file
+
+```bash
+ssh deploy@<server-ip>
+cp /srv/virtua-fc/compose/.env.example /srv/virtua-fc/env/.env
+chmod 0600 /srv/virtua-fc/env/.env
+nano /srv/virtua-fc/env/.env
+```
+
+Generate `APP_KEY` once (it must look like `base64:…`) — you can do it before
+the stack is up by running the image directly:
+
+```bash
+docker run --rm ghcr.io/<owner>/virtua-fc:latest \
+  php artisan key:generate --show
+```
+
+Paste the output into `APP_KEY=` in `.env`. Fill in `DB_PASSWORD`,
+`RESEND_API_KEY`, `NIGHTWATCH_TOKEN`, `GRAFANA_ADMIN_PASSWORD`, the
+StorageBox values, etc.
+
+### 3.5 First boot
+
+```bash
+cd /srv/virtua-fc/compose
+/srv/virtua-fc/scripts/compose.sh pull
+/srv/virtua-fc/scripts/compose.sh up -d
+/srv/virtua-fc/scripts/compose.sh ps
+```
+
+Watch the logs until `app` reports `Octane has started`:
+
+```bash
+/srv/virtua-fc/scripts/compose.sh logs -f --tail=200 app
+```
+
+The entrypoint will run `migrate --force` automatically on the `app` container
+(see `docker/entrypoint.sh` — gated by `RUN_MIGRATIONS=true`, set on `app`
+only in `compose/docker-compose.yml`). The `horizon` and `scheduler`
+containers skip migrations to avoid races.
+
+### 3.6 Seed reference data
+
+```bash
+/srv/virtua-fc/scripts/compose.sh exec app php artisan app:seed-reference-data --fresh
+```
+
+### 3.7 Open the front door
+
+Visit `https://virtuafc.example.com` — you should see the login page.
+Visit `https://grafana.virtuafc.example.com` — log in with
+`GRAFANA_ADMIN_USER` / `GRAFANA_ADMIN_PASSWORD`, then change the password.
+
+### 3.8 Schedule nightly backups
+
+```bash
+sudo tee /etc/systemd/system/virtua-fc-backup.service >/dev/null <<'EOF'
+[Unit]
+Description=VirtuaFC nightly Postgres backup
+After=docker.service
+
+[Service]
+Type=oneshot
+User=deploy
+ExecStart=/srv/virtua-fc/scripts/backup.sh
+EOF
+
+sudo tee /etc/systemd/system/virtua-fc-backup.timer >/dev/null <<'EOF'
+[Unit]
+Description=Run VirtuaFC backup nightly
+[Timer]
+OnCalendar=*-*-* 03:00:00
+RandomizedDelaySec=15min
+Persistent=true
+[Install]
+WantedBy=timers.target
+EOF
+
+sudo systemctl daemon-reload
+sudo systemctl enable --now virtua-fc-backup.timer
+sudo systemctl list-timers virtua-fc-backup.timer
+```
+
+### 3.9 Smoke test
+
+```bash
+/srv/virtua-fc/scripts/smoketest.sh
+```
+
+All checks should print `OK:`. If anything fails, jump to
+[Common incidents → fixes](#7-common-incidents--fixes).
+
+---
+
+## 4. Day-2 operations
+
+All commands assume you've SSHed in as `deploy@<server-ip>`. The
+`compose.sh` wrapper loads the env file and both compose files for you.
+
+### 4.1 Deploy a new version
+
+The normal path is automatic via `.github/workflows/deploy.yml` — push to
+`main`, the workflow builds the image, pushes to GHCR, SSHes in, and runs
+`scripts/deploy.sh` followed by `scripts/smoketest.sh`. To deploy manually:
+
+```bash
+IMAGE_TAG=<sha-or-tag> /srv/virtua-fc/scripts/deploy.sh
+```
+
+`deploy.sh` records the previous tag in `/srv/virtua-fc/env/.previous` for
+fast rollback.
+
+### 4.2 Roll back
+
+```bash
+/srv/virtua-fc/scripts/rollback.sh                  # back to previous
+/srv/virtua-fc/scripts/rollback.sh <explicit-tag>   # to a specific tag
+```
+
+### 4.3 Tail logs
+
+```bash
+/srv/virtua-fc/scripts/compose.sh logs -f --tail=200 app
+/srv/virtua-fc/scripts/compose.sh logs -f --tail=200 horizon scheduler
+/srv/virtua-fc/scripts/compose.sh logs -f --tail=200 traefik
+```
+
+For structured queries, use Grafana → Explore → Loki and filter by
+`{compose_service="app"}`.
+
+### 4.4 Run an artisan command
+
+```bash
+/srv/virtua-fc/scripts/compose.sh exec app php artisan <cmd>
+/srv/virtua-fc/scripts/compose.sh exec app php artisan tinker
+```
+
+Examples:
+
+```bash
+# Trigger the daily cleanup on demand
+/srv/virtua-fc/scripts/compose.sh exec app php artisan app:cleanup-games
+
+# Fire any due scheduled tasks now
+/srv/virtua-fc/scripts/compose.sh exec app php artisan schedule:run
+
+# Retry all failed Horizon jobs
+/srv/virtua-fc/scripts/compose.sh exec app php artisan horizon:retry all
+
+# Clear the cache after a config change in /srv/virtua-fc/env/.env
+/srv/virtua-fc/scripts/compose.sh exec app php artisan config:cache
+```
+
+### 4.5 Inspect Horizon
+
+The dashboard lives at `https://virtuafc.example.com/horizon` and is gated
+to `$user->is_admin` (see `app/Providers/HorizonServiceProvider.php`).
+
+CLI fallbacks:
+
+```bash
+/srv/virtua-fc/scripts/compose.sh exec app php artisan horizon:status
+/srv/virtua-fc/scripts/compose.sh exec horizon php artisan horizon:terminate
+/srv/virtua-fc/scripts/compose.sh exec app php artisan horizon:supervisor:list
+```
+
+The four supervisors (`gameplay`, `setup`, `mail`, `cleanup`) are configured
+in `config/horizon.php`.
+
+### 4.6 Inspect Pulse
+
+`https://virtuafc.example.com/pulse` — same admin gate
+(`app/Providers/AppServiceProvider.php` defines the `viewPulse` gate).
+Pulse is enabled via `PULSE_ENABLED=true`; its tables live in the same
+Postgres as the app.
+
+### 4.7 Database access
+
+```bash
+# psql shell
+/srv/virtua-fc/scripts/compose.sh exec postgres \
+  psql -U virtua_fc virtua_fc
+
+# Top 10 slow queries (requires pg_stat_statements; enable once with:
+#   CREATE EXTENSION pg_stat_statements;)
+/srv/virtua-fc/scripts/compose.sh exec postgres \
+  psql -U virtua_fc -d virtua_fc -c \
+  "SELECT round(total_exec_time::numeric, 2) AS total_ms,
+          calls,
+          round(mean_exec_time::numeric, 2) AS mean_ms,
+          left(query, 120) AS q
+     FROM pg_stat_statements
+    ORDER BY total_exec_time DESC
+    LIMIT 10;"
+
+# Database size
+/srv/virtua-fc/scripts/compose.sh exec postgres \
+  psql -U virtua_fc -d virtua_fc -c \
+  "SELECT pg_size_pretty(pg_database_size('virtua_fc'));"
+```
+
+### 4.8 Backup now / restore from backup
+
+```bash
+# Manual on-demand backup
+/srv/virtua-fc/scripts/backup.sh
+
+# List the contents of a dump (no destruction)
+/srv/virtua-fc/scripts/restore.sh --dry-run \
+  /srv/virtua-fc/backups/virtua_fc-20260105T030000Z.dump
+
+# Destructive restore (asks for confirmation)
+/srv/virtua-fc/scripts/restore.sh \
+  /srv/virtua-fc/backups/virtua_fc-20260105T030000Z.dump
+```
+
+`backup.sh` ships dumps to the Storage Box configured by `STORAGEBOX_*` in
+`/srv/virtua-fc/env/.env`, then prunes anything older than
+`BACKUP_RETENTION_DAYS` locally.
+
+### 4.9 Rotate secrets
+
+#### `APP_KEY`
+
+`APP_KEY` rotation invalidates **all** existing encrypted sessions. Plan a
+brief logout-everyone window:
+
+```bash
+# 1. Generate the new key without writing it.
+NEW_KEY=$(docker run --rm ghcr.io/<owner>/virtua-fc:latest php artisan key:generate --show)
+
+# 2. Edit /srv/virtua-fc/env/.env, replace APP_KEY.
+# 3. Bounce app/horizon/scheduler so they pick up the new key.
+/srv/virtua-fc/scripts/compose.sh up -d --force-recreate app horizon scheduler
+
+# 4. Flush sessions (Redis DB 0).
+/srv/virtua-fc/scripts/compose.sh exec redis redis-cli -n 0 FLUSHDB
+```
+
+#### `DB_PASSWORD`
+
+```bash
+# 1. Change it inside Postgres.
+/srv/virtua-fc/scripts/compose.sh exec postgres \
+  psql -U virtua_fc -d postgres -c "ALTER USER virtua_fc WITH PASSWORD '<new>';"
+
+# 2. Update DB_PASSWORD in /srv/virtua-fc/env/.env.
+# 3. Roll the consumers (postgres_exporter and the app services).
+/srv/virtua-fc/scripts/compose.sh up -d --force-recreate \
+  app horizon scheduler postgres_exporter
+```
+
+#### API tokens (Resend, Nightwatch, Slack webhook)
+
+Update `/srv/virtua-fc/env/.env` and `compose.sh up -d --force-recreate app
+horizon scheduler grafana`. Tokens are read at boot.
+
+### 4.10 Renew TLS
+
+Traefik renews Let's Encrypt certificates automatically (~30 days before
+expiry). Inspect:
+
+```bash
+/srv/virtua-fc/scripts/compose.sh logs traefik | grep -i acme
+```
+
+If renewal stalls, check that ports 80 and 443 are reachable from the
+internet (the HTTP-01 challenge needs port 80) and that DNS still points at
+this box.
+
+### 4.11 Update the deployment files themselves
+
+When this `deploy/hetzner/` tree changes (new compose service, new script):
+
+```bash
+# from your laptop, repo root, after pulling main
+rsync -avz --delete deploy/hetzner/{compose,scripts,prometheus,promtail,grafana}/ \
+  deploy@<server-ip>:/srv/virtua-fc/{compose,scripts,prometheus,promtail,grafana}/
+ssh deploy@<server-ip> "/srv/virtua-fc/scripts/compose.sh up -d"
+```
+
+---
+
+## 5. Monitoring access & on-call
+
+| URL | What | Auth |
+|---|---|---|
+| `https://virtuafc.example.com/up` | Health probe (Laravel default) | none — used by uptime checks |
+| `https://virtuafc.example.com/horizon` | Queue dashboard | logged-in admin (`is_admin`) |
+| `https://virtuafc.example.com/pulse` | App perf dashboard | logged-in admin (`is_admin`) |
+| `https://grafana.virtuafc.example.com` | Metrics + logs | Grafana basic auth |
+| Nightwatch SaaS dashboard | Errors / APM | Nightwatch login |
+| Better Stack / external uptime | External probe | external |
+
+### Where to look first when something is slow
+
+1. **Pulse** (`/pulse`) — slow requests, slow queries, slow jobs, exceptions.
+   Almost everything is here in one screen.
+2. **Horizon** (`/horizon`) — supervisor health, throughput, failed jobs.
+3. **Grafana** → *Node Exporter Full* dashboard — host CPU/RAM/disk pressure.
+4. **Grafana** → *Postgres / Redis* dashboards — connection counts, lock waits, hit rates.
+5. **Grafana → Explore → Loki** — full-text search the app's stdout
+   (`{compose_service="app"} |= "<term>"`).
+6. **Nightwatch** dashboard — exception clusters and traces.
+
+### Silencing an alert before maintenance
+
+- Grafana → Alerting → Silences → New silence → match the alert by label,
+  pick a duration. **Always** set a duration; never indefinite.
+
+### Importing standard dashboards
+
+Grafana → "+" → Import → enter ID → pick the Prometheus data source:
+
+| ID | Dashboard |
+|---|---|
+| 1860 | Node Exporter Full |
+| 14282 | cAdvisor exporter |
+| 9628 | PostgreSQL Database |
+| 11835 | Redis Dashboard for Prometheus Redis Exporter |
+| 17346 | Traefik Official Standalone Dashboard |
+
+Once imported, export each one as JSON and commit it under
+`deploy/hetzner/grafana/dashboards/` — the provisioning loader auto-imports
+that directory on next start (see `grafana/provisioning/dashboards/dashboards.yml`).
+
+---
+
+## 6. Health checks & smoke tests
+
+```bash
+/srv/virtua-fc/scripts/smoketest.sh
+```
+
+Wraps:
+
+- All compose services healthy (`docker compose ps`).
+- `https://<domain>/up` returns 200.
+- Postgres `pg_isready`.
+- Redis `PING` → `PONG`.
+- `php artisan horizon:status` reports running.
+- Grafana `/api/health` returns 200.
+
+Fails loudly on the first red light and exits non-zero — used by both the
+GitHub Actions deploy workflow (auto-rollback on failure) and on-call.
+
+---
+
+## 7. Common incidents → fixes
+
+### 502 Bad Gateway from Traefik
+
+1. `compose.sh ps` — is `app` healthy? If not, check entrypoint logs:
+   `compose.sh logs --tail=200 app`. Common causes:
+   - `APP_KEY` missing or wrong → `Cannot decrypt session` errors. Re-set in `.env`.
+   - DB unreachable → `compose.sh exec app php artisan migrate:status` to confirm.
+   - Migration failed → see "Migration failed mid-deploy" below.
+2. Container healthy but route still 502 → Traefik label drift: `compose.sh
+   logs --tail=200 traefik | grep -i error`.
+
+### Horizon dashboard shows a red supervisor
+
+1. `compose.sh exec horizon php artisan horizon:status` — confirms.
+2. Inspect failures: `https://<domain>/horizon/failed` or
+   `compose.sh exec app php artisan queue:failed`.
+3. Fix the underlying error (look at the exception in Pulse or Nightwatch),
+   then retry: `compose.sh exec app php artisan horizon:retry all`.
+4. If a single supervisor is wedged, restart it: `compose.sh exec horizon
+   php artisan horizon:terminate` (compose restarts the container).
+
+### Postgres disk filling
+
+```bash
+# Find the heaviest tables
+/srv/virtua-fc/scripts/compose.sh exec postgres \
+  psql -U virtua_fc -d virtua_fc -c \
+  "SELECT relname, pg_size_pretty(pg_total_relation_size(relid)) AS total
+     FROM pg_catalog.pg_statio_user_tables
+    ORDER BY pg_total_relation_size(relid) DESC
+    LIMIT 20;"
+
+# Reclaim space
+/srv/virtua-fc/scripts/compose.sh exec postgres \
+  psql -U virtua_fc -d virtua_fc -c "VACUUM (VERBOSE, ANALYZE);"
+```
+
+If Pulse is the culprit (high cardinality writes), trim its tables:
+
+```bash
+/srv/virtua-fc/scripts/compose.sh exec app php artisan pulse:purge
+```
+
+### Redis OOM
+
+Sessions and queues live in DB 0 by default; the cache lives in DB 1 (set by
+Laravel's `REDIS_CACHE_DB`). Flushing the cache only is safe:
+
+```bash
+/srv/virtua-fc/scripts/compose.sh exec redis redis-cli -n 1 FLUSHDB
+```
+
+Never `FLUSHALL` on prod — that drops queued jobs and active sessions.
+
+### Migration failed mid-deploy
+
+The new image is already running on `horizon`/`scheduler` (no migrations
+there) but `app` exited because `migrate --force` failed. `deploy.sh` will
+have detected the smoketest failure and called `rollback.sh`. If it didn't:
+
+```bash
+# 1. Roll back to the previous tag.
+/srv/virtua-fc/scripts/rollback.sh
+
+# 2. Inspect the migration that failed.
+/srv/virtua-fc/scripts/compose.sh exec app php artisan migrate:status
+
+# 3. Hotfix the migration in code, push a new commit, redeploy.
+```
+
+If the migration partially applied (DDL committed but the entrypoint died):
+you may need `php artisan migrate:rollback --step=1` from a one-shot
+container before deploying again.
+
+### Grafana shows "no data" everywhere
+
+1. Prometheus reachable? `compose.sh exec grafana wget -qO- http://prometheus:9090/-/healthy`.
+2. Targets up? Open Prometheus directly inside the network:
+   `compose.sh exec prometheus wget -qO- 'http://localhost:9090/api/v1/targets' | jq '.data.activeTargets[] | {job, health, lastError}'`.
+3. Common cause: a renamed service. Update `prometheus/prometheus.yml`,
+   `compose.sh up -d prometheus`.
+
+### TLS renewal stuck
+
+Traefik can't pass the HTTP-01 challenge if port 80 is blocked or DNS
+points elsewhere.
+
+```bash
+# Confirm port 80 is open and routes to traefik
+sudo ufw status
+sudo ss -tlnp | grep ':80 '
+# Force a reload
+/srv/virtua-fc/scripts/compose.sh restart traefik
+/srv/virtua-fc/scripts/compose.sh logs traefik | grep -i acme | tail -50
+```
+
+If `acme.json` is corrupted, stop traefik, delete the file, restart — Traefik
+will re-issue cleanly (subject to Let's Encrypt rate limits, so don't do
+this casually).
+
+---
+
+## 8. Scaling out
+
+This single-host setup is intentionally simple. Triggers to leave it:
+
+| Symptom | Action |
+|---|---|
+| Postgres CPU > 70 % sustained | Move Postgres to Hetzner Cloud or a dedicated DB host. Update `DB_HOST` in `.env`, redeploy. No code changes. |
+| App p95 latency > 500 ms after Pulse cleanup | Add a second app host behind a load balancer, share Redis + Postgres. Sticky sessions via Redis make this transparent. |
+| Match-simulation throughput becomes the bottleneck | Add a second host running only `horizon` (queue workers); same image, no app-side changes. |
+| Pulse writes drown the OLTP DB | Switch `PULSE_DB_CONNECTION` to a separate Postgres connection (the `pulse_pgsql` connection in `config/database.php` is wired for this). |
+| Cross-tenant queries (`PLANES-SEAM` markers) finally get refactored | Provision a second Postgres for `pgsql_control`, set `CONTROL_DB_*` in `.env`, enable `DATABASE_PLANES_GUARD_ENABLED=true` to verify the rewrite. |
+
+---
+
+## 9. Disaster-recovery drill
+
+Run quarterly. Goal: prove the latest backup is restorable in under 30 minutes.
+
+```bash
+# 1. Pull the latest dump from Storage Box to a scratch host (NOT prod).
+DUMP=$(ls -t /srv/virtua-fc/backups/virtua_fc-*.dump | head -1)
+
+# 2. Spin up an isolated postgres container.
+docker run -d --name vfc-dr -e POSTGRES_DB=virtua_fc \
+  -e POSTGRES_USER=virtua_fc -e POSTGRES_PASSWORD=drill \
+  -p 55432:5432 postgres:18-alpine
+
+# 3. Wait, then restore.
+sleep 5
+docker exec -i vfc-dr pg_restore -U virtua_fc -d virtua_fc < "$DUMP"
+
+# 4. Sanity-check row counts.
+docker exec vfc-dr psql -U virtua_fc -d virtua_fc -c \
+  "SELECT 'users', count(*) FROM users
+   UNION ALL SELECT 'games', count(*) FROM games
+   UNION ALL SELECT 'game_matches', count(*) FROM game_matches;"
+
+# 5. Tear down.
+docker rm -f vfc-dr
+```
+
+Record the date, dump size, and restore wall-clock time in your ops log. If
+the restore took materially longer than the previous drill, investigate
+(usually growth in the largest table or accumulated bloat).
+
+---
+
+## 10. Reference appendix
+
+### 10.1 Environment variables (production)
+
+Everything in `/srv/virtua-fc/env/.env`. The full template is at
+`deploy/hetzner/compose/.env.example`. The most important entries:
+
+| Var | Where it's read | Notes |
+|---|---|---|
+| `APP_KEY` | Laravel | Generate once; rotation logs everyone out. |
+| `APP_DOMAIN` / `APP_URL` | compose + Laravel | Must match DNS + TLS subject. |
+| `IMAGE_TAG` / `GHCR_REPO` | compose | Bumped by `deploy.sh`. |
+| `DB_PASSWORD` | compose + Laravel | Strong random; rotate via §4.9. |
+| `RUN_MIGRATIONS` | `docker/entrypoint.sh` | `true` only on `app`, `false` on `horizon`/`scheduler`. |
+| `TRUSTED_PROXIES` | Octane | `*` inside the compose network. |
+| `NIGHTWATCH_TOKEN`, `NIGHTWATCH_ENABLED` | `laravel/nightwatch` | APM/error tracking. |
+| `PULSE_ENABLED` | `laravel/pulse` | `true` in prod. |
+| `LOG_SLACK_WEBHOOK_URL` | `config/logging.php` | Reused by Grafana alerts. |
+| `RESEND_API_KEY` | `resend/resend-laravel` | Required if `MAIL_MAILER=resend`. |
+| `GRAFANA_ADMIN_PASSWORD` | Grafana | Rotate after first login. |
+| `STORAGEBOX_*`, `BACKUP_RETENTION_DAYS` | `scripts/backup.sh` | Offsite copy + local pruning. |
+
+### 10.2 Ports
+
+| Port | Service | Exposed externally? |
+|---|---|---|
+| 22 | sshd | yes (firewall to your IPs if you can) |
+| 80 | Traefik (HTTP, redirects to 443) | yes |
+| 443 | Traefik (HTTPS) | yes |
+| 8000 | `app` (FrankenPHP) | no (Traefik only) |
+| 3000 | Grafana | no (Traefik only, behind `grafana.<domain>`) |
+| 9090 | Prometheus | no |
+| 3100 | Loki | no |
+| 8082 | Traefik metrics endpoint | no |
+
+UFW enforces this — see `scripts/bootstrap.sh`.
+
+### 10.3 Volumes
+
+| Host path | Container | Purpose |
+|---|---|---|
+| `/var/lib/virtua-fc/postgres` | `postgres:/var/lib/postgresql/data` | Game + control DB |
+| `/var/lib/virtua-fc/redis` | `redis:/data` | AOF persistence |
+| `/var/lib/virtua-fc/traefik` | `traefik:/letsencrypt` | TLS certs |
+| `/var/lib/virtua-fc/prometheus` | `prometheus:/prometheus` | Metrics TSDB (30 d) |
+| `/var/lib/virtua-fc/grafana` | `grafana:/var/lib/grafana` | Dashboards, users |
+| `/var/lib/virtua-fc/loki` | `loki:/loki` | Log chunks |
+| `storage` (named) | `app/horizon/scheduler:/app/storage` | Laravel storage tree (uploads, logs) |
+
+### 10.4 Subdomains
+
+| Subdomain | Service | Set up where |
+|---|---|---|
+| `virtuafc.example.com` | App (Octane) | `traefik.http.routers.app.rule` in compose |
+| `grafana.virtuafc.example.com` | Grafana | `traefik.http.routers.grafana.rule` in monitoring compose |
+| (future) `horizon.virtuafc.example.com` | Horizon — currently served at `/horizon` on the app | not configured today |
+| (future) `pulse.virtuafc.example.com` | Pulse — currently served at `/pulse` on the app | not configured today |
+
+### 10.5 Where the codebase wires up each piece
+
+| Concern | File |
+|---|---|
+| Health endpoint `/up` | `bootstrap/app.php` |
+| Scheduled tasks | `routes/console.php` |
+| Horizon supervisors | `config/horizon.php` |
+| Horizon access gate | `app/Providers/HorizonServiceProvider.php` |
+| Pulse access gate | `app/Providers/AppServiceProvider.php` (`viewPulse`) |
+| DB connections (incl. control plane) | `config/database.php`, `config/database_planes.php` |
+| Migration gate | `docker/entrypoint.sh` (reads `RUN_MIGRATIONS`) |
+| Octane boot command | `Dockerfile` (`CMD`) |
+| Logging channels | `config/logging.php` |
+
+### 10.6 Data migration playbook
+
+We deferred the choice of migration strategy until we know whether prod
+data exists today. The options live in the project plan (see the plan file
+at the root of the repo or the design doc that triggered this work):
+
+1. **Greenfield re-seed** — `app:seed-reference-data --fresh`.
+2. **`pg_dump -Fc` → `pg_restore`** — offline cutover, the default.
+3. **Logical replication** — near-zero downtime, requires `wal_level=logical`.
+4. **Physical streaming replication** — alternative when logical isn't
+   available; same major Postgres version on both sides.
+5. **WAL shipping / pgBackRest** — long-term DR posture, layer on regardless.
+
+When the time comes, drop a `migrate.sh` next to the other scripts and add a
+"Migration day" section above §3.

--- a/deploy/hetzner/cloud-init.yaml
+++ b/deploy/hetzner/cloud-init.yaml
@@ -1,0 +1,129 @@
+#cloud-config
+# VirtuaFC initial-boot configuration for a Hetzner Cloud server (CX23+/CCX).
+#
+# Paste the contents of this file into the "user data" field when creating the
+# server in the Hetzner Cloud console (or pass via `hcloud server create
+# --user-data-from-file deploy/hetzner/cloud-init.yaml`).
+#
+# Before pasting, replace the placeholder ssh-ed25519 key in `users[0].ssh_authorized_keys`
+# with your actual public key. Everything else is generic.
+#
+# After the server boots, log in as `deploy@<ip>` and follow §3.3 onwards in
+# deploy/hetzner/README.md (rsync the deploy tree, fill .env, first boot).
+
+hostname: virtua-fc-1
+timezone: UTC
+locale: en_US.UTF-8
+
+# Disable root SSH and password auth — the deploy user (below) is the only way in.
+disable_root: true
+ssh_pwauth: false
+
+users:
+  - name: deploy
+    groups: [sudo, docker]
+    shell: /bin/bash
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    lock_passwd: true
+    ssh_authorized_keys:
+      - ssh-ed25519 AAAA_REPLACE_WITH_YOUR_PUBLIC_KEY operator@laptop
+
+package_update: true
+package_upgrade: true
+packages:
+  - ca-certificates
+  - curl
+  - gnupg
+  - lsb-release
+  - ufw
+  - fail2ban
+  - unattended-upgrades
+  - htop
+  - iotop
+  - jq
+  - rsync
+  - git
+  - tmux
+  - postgresql-client-common
+  - postgresql-client
+
+write_files:
+  # SSH hardening drop-in — overrides the defaults from /etc/ssh/sshd_config.
+  - path: /etc/ssh/sshd_config.d/99-virtua-fc.conf
+    permissions: '0644'
+    content: |
+      PermitRootLogin no
+      PasswordAuthentication no
+      ChallengeResponseAuthentication no
+      KbdInteractiveAuthentication no
+
+  # fail2ban sshd jail.
+  - path: /etc/fail2ban/jail.d/sshd.local
+    permissions: '0644'
+    content: |
+      [sshd]
+      enabled = true
+      maxretry = 5
+      findtime = 10m
+      bantime = 1h
+
+  # Pin Docker's apt repo. The signing key is fetched in runcmd.
+  - path: /etc/apt/sources.list.d/docker.list.tmpl
+    permissions: '0644'
+    content: |
+      deb [arch=ARCH signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu CODENAME stable
+
+runcmd:
+  # --- Docker install (Ubuntu's repo lags upstream; pin to docker.com) ---
+  - install -m 0755 -d /etc/apt/keyrings
+  - curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+  - chmod a+r /etc/apt/keyrings/docker.asc
+  - bash -c 'set -e; . /etc/os-release; sed -e "s|ARCH|$(dpkg --print-architecture)|" -e "s|CODENAME|$VERSION_CODENAME|" /etc/apt/sources.list.d/docker.list.tmpl > /etc/apt/sources.list.d/docker.list'
+  - rm -f /etc/apt/sources.list.d/docker.list.tmpl
+  - apt-get update -y
+  - apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+
+  # --- Firewall (deny incoming except SSH/HTTP/HTTPS) ---
+  - ufw --force reset
+  - ufw default deny incoming
+  - ufw default allow outgoing
+  - ufw allow 22/tcp comment 'ssh'
+  - ufw allow 80/tcp comment 'http'
+  - ufw allow 443/tcp comment 'https'
+  - ufw --force enable
+
+  # --- Services ---
+  - systemctl enable --now fail2ban
+  - systemctl enable --now systemd-timesyncd
+  - dpkg-reconfigure -f noninteractive unattended-upgrades
+  - systemctl reload ssh || systemctl reload sshd
+
+  # --- Directory layout (matches deploy/hetzner/README.md §1) ---
+  - install -d -m 0755 -o deploy -g deploy /srv/virtua-fc /srv/virtua-fc/compose /srv/virtua-fc/env /srv/virtua-fc/backups /srv/virtua-fc/prometheus /srv/virtua-fc/promtail /srv/virtua-fc/grafana /srv/virtua-fc/grafana/provisioning /srv/virtua-fc/grafana/dashboards /srv/virtua-fc/scripts
+  - install -d -m 0755 /var/lib/virtua-fc /var/lib/virtua-fc/postgres /var/lib/virtua-fc/redis /var/lib/virtua-fc/traefik /var/lib/virtua-fc/prometheus /var/lib/virtua-fc/grafana /var/lib/virtua-fc/loki
+
+  # Grafana container runs as UID 472.
+  - chown -R 472:472 /var/lib/virtua-fc/grafana
+
+  # Traefik acme.json must be 0600 or it refuses to start.
+  - touch /var/lib/virtua-fc/traefik/acme.json
+  - chmod 0600 /var/lib/virtua-fc/traefik/acme.json
+
+  # Marker so the operator knows cloud-init finished.
+  - bash -c 'echo "cloud-init bootstrap finished at $(date -u +%FT%TZ)" > /etc/virtua-fc-bootstrapped'
+
+final_message: |
+  VirtuaFC cloud-init bootstrap complete.
+
+  Next steps from your laptop:
+    1. ssh deploy@<server-ip>           (root login is disabled)
+    2. From the repo root, sync the deploy tree:
+         rsync -avz deploy/hetzner/{compose,scripts,prometheus,promtail,grafana}/ \
+           deploy@<ip>:/srv/virtua-fc/{compose,scripts,prometheus,promtail,grafana}/
+    3. cp /srv/virtua-fc/compose/.env.example /srv/virtua-fc/env/.env
+       chmod 0600 /srv/virtua-fc/env/.env
+       # edit with APP_KEY, DB_PASSWORD, NIGHTWATCH_TOKEN, etc.
+    4. /srv/virtua-fc/scripts/compose.sh up -d
+    5. /srv/virtua-fc/scripts/smoketest.sh
+
+  Full playbook: deploy/hetzner/README.md

--- a/deploy/hetzner/compose/.env.example
+++ b/deploy/hetzner/compose/.env.example
@@ -1,0 +1,53 @@
+# Production server .env — copy to /srv/virtua-fc/env/.env, mode 0600.
+# Compose reads this via `docker compose --env-file /srv/virtua-fc/env/.env ...`
+# (see deploy/hetzner/scripts/compose.sh).
+
+# -------- Image --------
+GHCR_REPO=pabloroman/virtua-fc
+IMAGE_TAG=latest
+
+# -------- Domain & TLS --------
+APP_DOMAIN=virtuafc.example.com
+APP_URL=https://virtuafc.example.com
+ACME_EMAIL=ops@example.com
+
+# -------- Laravel core --------
+APP_ENV=production
+APP_KEY=                           # generate once: docker run --rm <image> php artisan key:generate --show
+APP_LOCALE=es
+APP_TIMEZONE=UTC
+LOG_LEVEL=info
+BETA_MODE=false
+
+# -------- Database --------
+DB_DATABASE=virtua_fc
+DB_USERNAME=virtua_fc
+DB_PASSWORD=                       # strong random; rotate via deploy/hetzner/README.md
+
+# -------- Redis --------
+REDIS_PASSWORD=null                # 'null' literal disables auth; set a real password if exposing redis
+
+# -------- Mail (Resend) --------
+MAIL_MAILER=resend
+MAIL_FROM_ADDRESS=noreply@virtuafc.example.com
+MAIL_FROM_NAME=VirtuaFC
+RESEND_API_KEY=
+
+# -------- Reverse proxy --------
+TRUSTED_PROXIES=*
+
+# -------- Monitoring --------
+NIGHTWATCH_ENABLED=true
+NIGHTWATCH_TOKEN=
+PULSE_ENABLED=true
+
+LOG_SLACK_WEBHOOK_URL=             # also reused by Grafana alerting
+
+GRAFANA_ADMIN_USER=admin
+GRAFANA_ADMIN_PASSWORD=            # rotate after first login
+
+# -------- Backups --------
+BACKUP_RETENTION_DAYS=14
+STORAGEBOX_USER=
+STORAGEBOX_HOST=                   # e.g. uXXXXXX.your-storagebox.de
+STORAGEBOX_PATH=/home/virtua-fc/backups

--- a/deploy/hetzner/compose/docker-compose.monitoring.yml
+++ b/deploy/hetzner/compose/docker-compose.monitoring.yml
@@ -1,0 +1,122 @@
+# Monitoring stack — combined with docker-compose.yml at runtime:
+#   docker compose -f docker-compose.yml -f docker-compose.monitoring.yml up -d
+#
+# Routes:
+#   grafana.${APP_DOMAIN}  → Grafana (Prometheus + Loki datasources, dashboards)
+#
+# Internal-only (not exposed via Traefik):
+#   prometheus, loki, promtail, node_exporter, cadvisor, postgres_exporter,
+#   redis_exporter — scraped by Prometheus on the `internal` network.
+
+name: virtua-fc
+
+services:
+  prometheus:
+    image: prom/prometheus:v2.55.1
+    restart: unless-stopped
+    command:
+      - --config.file=/etc/prometheus/prometheus.yml
+      - --storage.tsdb.path=/prometheus
+      - --storage.tsdb.retention.time=30d
+      - --web.enable-lifecycle
+    volumes:
+      - /srv/virtua-fc/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - /var/lib/virtua-fc/prometheus:/prometheus
+    networks:
+      - internal
+
+  grafana:
+    image: grafana/grafana:11.4.0
+    restart: unless-stopped
+    environment:
+      GF_SECURITY_ADMIN_USER: ${GRAFANA_ADMIN_USER:-admin}
+      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD:?GRAFANA_ADMIN_PASSWORD required}
+      GF_USERS_ALLOW_SIGN_UP: "false"
+      GF_SERVER_ROOT_URL: https://grafana.${APP_DOMAIN}
+      GF_SERVER_DOMAIN: grafana.${APP_DOMAIN}
+      GF_INSTALL_PLUGINS: ""
+    volumes:
+      - /var/lib/virtua-fc/grafana:/var/lib/grafana
+      - /srv/virtua-fc/grafana/provisioning:/etc/grafana/provisioning:ro
+      - /srv/virtua-fc/grafana/dashboards:/var/lib/grafana/dashboards:ro
+    depends_on:
+      - prometheus
+      - loki
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.grafana.rule=Host(`grafana.${APP_DOMAIN}`)
+      - traefik.http.routers.grafana.entrypoints=websecure
+      - traefik.http.routers.grafana.tls.certresolver=le
+      - traefik.http.services.grafana.loadbalancer.server.port=3000
+    networks:
+      - edge
+      - internal
+
+  loki:
+    image: grafana/loki:3.3.1
+    restart: unless-stopped
+    command: -config.file=/etc/loki/local-config.yaml
+    volumes:
+      - /var/lib/virtua-fc/loki:/loki
+    networks:
+      - internal
+
+  promtail:
+    image: grafana/promtail:3.3.1
+    restart: unless-stopped
+    command: -config.file=/etc/promtail/promtail.yml
+    volumes:
+      - /srv/virtua-fc/promtail/promtail.yml:/etc/promtail/promtail.yml:ro
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - /var/lib/docker/containers:/var/lib/docker/containers:ro
+    depends_on:
+      - loki
+    networks:
+      - internal
+
+  node_exporter:
+    image: prom/node-exporter:v1.8.2
+    restart: unless-stopped
+    command:
+      - --path.rootfs=/host
+    network_mode: host
+    pid: host
+    volumes:
+      - /:/host:ro,rslave
+
+  cadvisor:
+    image: gcr.io/cadvisor/cadvisor:v0.49.1
+    restart: unless-stopped
+    privileged: true
+    devices:
+      - /dev/kmsg
+    volumes:
+      - /:/rootfs:ro
+      - /var/run:/var/run:ro
+      - /sys:/sys:ro
+      - /var/lib/docker:/var/lib/docker:ro
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    networks:
+      - internal
+
+  postgres_exporter:
+    image: prometheuscommunity/postgres-exporter:v0.16.0
+    restart: unless-stopped
+    environment:
+      DATA_SOURCE_NAME: "postgresql://${DB_USERNAME:-virtua_fc}:${DB_PASSWORD}@postgres:5432/${DB_DATABASE:-virtua_fc}?sslmode=disable"
+    depends_on:
+      postgres:
+        condition: service_healthy
+    networks:
+      - internal
+
+  redis_exporter:
+    image: oliver006/redis_exporter:v1.66.0
+    restart: unless-stopped
+    environment:
+      REDIS_ADDR: redis://redis:6379
+    depends_on:
+      redis:
+        condition: service_healthy
+    networks:
+      - internal

--- a/deploy/hetzner/compose/docker-compose.yml
+++ b/deploy/hetzner/compose/docker-compose.yml
@@ -1,0 +1,208 @@
+# Production stack for VirtuaFC on a single Hetzner root server.
+#
+# Run from /srv/virtua-fc/compose/ with:
+#   docker compose -f docker-compose.yml -f docker-compose.monitoring.yml up -d
+#
+# Image source: ghcr.io/${GHCR_REPO}:${IMAGE_TAG}. The image is built in CI by
+# .github/workflows/deploy.yml from the repo root Dockerfile (target: production).
+
+name: virtua-fc
+
+x-app-image: &app-image ghcr.io/${GHCR_REPO:?GHCR_REPO required}:${IMAGE_TAG:-latest}
+
+x-app-env: &app-env
+  APP_ENV: production
+  APP_DEBUG: "false"
+  APP_KEY: ${APP_KEY:?APP_KEY required}
+  APP_URL: ${APP_URL:?APP_URL required}
+  APP_LOCALE: ${APP_LOCALE:-es}
+  APP_TIMEZONE: ${APP_TIMEZONE:-UTC}
+
+  DB_CONNECTION: pgsql
+  DB_HOST: postgres
+  DB_PORT: 5432
+  DB_DATABASE: ${DB_DATABASE:-virtua_fc}
+  DB_USERNAME: ${DB_USERNAME:-virtua_fc}
+  DB_PASSWORD: ${DB_PASSWORD:?DB_PASSWORD required}
+  DB_SSLMODE: disable
+
+  REDIS_CLIENT: phpredis
+  REDIS_HOST: redis
+  REDIS_PORT: 6379
+  REDIS_PASSWORD: ${REDIS_PASSWORD:-null}
+
+  SESSION_DRIVER: redis
+  SESSION_ENCRYPT: "true"
+  CACHE_STORE: redis
+  QUEUE_CONNECTION: redis
+  BROADCAST_CONNECTION: log
+  FILESYSTEM_DISK: local
+
+  LOG_CHANNEL: stack
+  LOG_STACK: daily,stderr
+  LOG_LEVEL: ${LOG_LEVEL:-info}
+  LOG_SLACK_WEBHOOK_URL: ${LOG_SLACK_WEBHOOK_URL:-}
+
+  MAIL_MAILER: ${MAIL_MAILER:-resend}
+  MAIL_FROM_ADDRESS: ${MAIL_FROM_ADDRESS:?MAIL_FROM_ADDRESS required}
+  MAIL_FROM_NAME: ${MAIL_FROM_NAME:-VirtuaFC}
+  RESEND_API_KEY: ${RESEND_API_KEY:-}
+
+  NIGHTWATCH_ENABLED: ${NIGHTWATCH_ENABLED:-true}
+  NIGHTWATCH_TOKEN: ${NIGHTWATCH_TOKEN:-}
+
+  PULSE_ENABLED: ${PULSE_ENABLED:-true}
+  PULSE_DB_CONNECTION: pgsql
+
+  TELESCOPE_ENABLED: "false"
+
+  TRUSTED_PROXIES: ${TRUSTED_PROXIES:-*}
+  OCTANE_SERVER: frankenphp
+
+  BETA_MODE: ${BETA_MODE:-false}
+
+services:
+  traefik:
+    image: traefik:v3.2
+    restart: unless-stopped
+    command:
+      - --providers.docker=true
+      - --providers.docker.exposedbydefault=false
+      - --entrypoints.web.address=:80
+      - --entrypoints.web.http.redirections.entrypoint.to=websecure
+      - --entrypoints.web.http.redirections.entrypoint.scheme=https
+      - --entrypoints.websecure.address=:443
+      - --certificatesresolvers.le.acme.email=${ACME_EMAIL:?ACME_EMAIL required}
+      - --certificatesresolvers.le.acme.storage=/letsencrypt/acme.json
+      - --certificatesresolvers.le.acme.httpchallenge=true
+      - --certificatesresolvers.le.acme.httpchallenge.entrypoint=web
+      - --accesslog=true
+      - --log.level=INFO
+      - --metrics.prometheus=true
+      - --metrics.prometheus.entrypoint=metrics
+      - --entrypoints.metrics.address=:8082
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - /var/lib/virtua-fc/traefik:/letsencrypt
+    labels:
+      - traefik.enable=true
+    networks:
+      - edge
+      - internal
+
+  app:
+    image: *app-image
+    restart: unless-stopped
+    environment:
+      <<: *app-env
+      RUN_MIGRATIONS: "true"
+    volumes:
+      - storage:/app/storage
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:8000/up"]
+      interval: 30s
+      timeout: 5s
+      retries: 5
+      start_period: 60s
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.app.rule=Host(`${APP_DOMAIN:?APP_DOMAIN required}`)
+      - traefik.http.routers.app.entrypoints=websecure
+      - traefik.http.routers.app.tls.certresolver=le
+      - traefik.http.services.app.loadbalancer.server.port=8000
+    networks:
+      - edge
+      - internal
+
+  horizon:
+    image: *app-image
+    restart: unless-stopped
+    command: ["php", "artisan", "horizon"]
+    environment:
+      <<: *app-env
+      RUN_MIGRATIONS: "false"
+    volumes:
+      - storage:/app/storage
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      app:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "php", "artisan", "horizon:status"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
+    networks:
+      - internal
+
+  scheduler:
+    image: *app-image
+    restart: unless-stopped
+    command: ["php", "artisan", "schedule:work"]
+    environment:
+      <<: *app-env
+      RUN_MIGRATIONS: "false"
+    volumes:
+      - storage:/app/storage
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      app:
+        condition: service_healthy
+    networks:
+      - internal
+
+  postgres:
+    image: postgres:18-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: ${DB_DATABASE:-virtua_fc}
+      POSTGRES_USER: ${DB_USERNAME:-virtua_fc}
+      POSTGRES_PASSWORD: ${DB_PASSWORD:?DB_PASSWORD required}
+    volumes:
+      - /var/lib/virtua-fc/postgres:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${DB_USERNAME:-virtua_fc} -d ${DB_DATABASE:-virtua_fc}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - internal
+
+  redis:
+    image: redis:7-alpine
+    restart: unless-stopped
+    command: ["redis-server", "--appendonly", "yes", "--save", "60", "1000"]
+    volumes:
+      - /var/lib/virtua-fc/redis:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - internal
+
+volumes:
+  storage:
+
+networks:
+  edge:
+    driver: bridge
+  internal:
+    driver: bridge
+    internal: false

--- a/deploy/hetzner/grafana/dashboards/.gitkeep
+++ b/deploy/hetzner/grafana/dashboards/.gitkeep
@@ -1,0 +1,15 @@
+# Drop dashboard JSON files here to provision them on Grafana startup.
+# The provisioning loader watches this directory (see ../provisioning/dashboards/dashboards.yml).
+#
+# Recommended starter set — import via Grafana UI ("+" → Import → ID) or
+# place the JSON exports next to this file:
+#
+#   1860   Node Exporter Full
+#   14282  cAdvisor exporter
+#   9628   PostgreSQL Database
+#   11835  Redis Dashboard for Prometheus Redis Exporter
+#   17346  Traefik Official Standalone Dashboard
+#
+# After import, use "Share → Export → Save to file" and commit the JSON
+# under deploy/hetzner/grafana/dashboards/ so future deploys are
+# reproducible.

--- a/deploy/hetzner/grafana/provisioning/dashboards/dashboards.yml
+++ b/deploy/hetzner/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,13 @@
+apiVersion: 1
+
+providers:
+  - name: VirtuaFC
+    orgId: 1
+    folder: ''
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    allowUiUpdates: true
+    options:
+      path: /var/lib/grafana/dashboards
+      foldersFromFilesStructure: false

--- a/deploy/hetzner/grafana/provisioning/datasources/datasources.yml
+++ b/deploy/hetzner/grafana/provisioning/datasources/datasources.yml
@@ -1,0 +1,17 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    jsonData:
+      timeInterval: 15s
+
+  - name: Loki
+    type: loki
+    access: proxy
+    url: http://loki:3100
+    jsonData:
+      maxLines: 5000

--- a/deploy/hetzner/prometheus/prometheus.yml
+++ b/deploy/hetzner/prometheus/prometheus.yml
@@ -1,0 +1,34 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+  external_labels:
+    server: virtua-fc-hetzner
+
+scrape_configs:
+  - job_name: prometheus
+    static_configs:
+      - targets: ['localhost:9090']
+
+  - job_name: node
+    static_configs:
+      - targets: ['host.docker.internal:9100']
+    relabel_configs:
+      - source_labels: [__address__]
+        target_label: instance
+        replacement: hetzner-host
+
+  - job_name: cadvisor
+    static_configs:
+      - targets: ['cadvisor:8080']
+
+  - job_name: postgres
+    static_configs:
+      - targets: ['postgres_exporter:9187']
+
+  - job_name: redis
+    static_configs:
+      - targets: ['redis_exporter:9121']
+
+  - job_name: traefik
+    static_configs:
+      - targets: ['traefik:8082']

--- a/deploy/hetzner/promtail/promtail.yml
+++ b/deploy/hetzner/promtail/promtail.yml
@@ -1,0 +1,28 @@
+server:
+  http_listen_port: 9080
+  grpc_listen_port: 0
+
+positions:
+  filename: /tmp/positions.yaml
+
+clients:
+  - url: http://loki:3100/loki/api/v1/push
+
+scrape_configs:
+  # Scrape every container's stdout/stderr from the local Docker daemon. The
+  # `compose_service` and `compose_project` labels make it easy to filter in
+  # Grafana → Explore (Loki).
+  - job_name: docker
+    docker_sd_configs:
+      - host: unix:///var/run/docker.sock
+        refresh_interval: 5s
+    relabel_configs:
+      - source_labels: ['__meta_docker_container_name']
+        regex: '/(.*)'
+        target_label: container
+      - source_labels: ['__meta_docker_container_label_com_docker_compose_service']
+        target_label: compose_service
+      - source_labels: ['__meta_docker_container_label_com_docker_compose_project']
+        target_label: compose_project
+      - source_labels: ['__meta_docker_container_log_stream']
+        target_label: stream

--- a/deploy/hetzner/scripts/backup.sh
+++ b/deploy/hetzner/scripts/backup.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Nightly Postgres backup. Writes a custom-format dump locally, ships it to
+# the Hetzner Storage Box, prunes anything older than BACKUP_RETENTION_DAYS.
+#
+# Wire to systemd timer or cron:
+#   0 3 * * *  /srv/virtua-fc/scripts/backup.sh >>/var/log/virtua-fc-backup.log 2>&1
+
+set -euo pipefail
+
+ROOT="${VFC_ROOT:-/srv/virtua-fc}"
+ENV_FILE="${VFC_ENV_FILE:-$ROOT/env/.env}"
+BACKUP_DIR="$ROOT/backups"
+COMPOSE="$(dirname "$0")/compose.sh"
+
+# shellcheck disable=SC1090
+set -a; . "$ENV_FILE"; set +a
+
+mkdir -p "$BACKUP_DIR"
+TS=$(date -u +%Y%m%dT%H%M%SZ)
+DUMP="$BACKUP_DIR/${DB_DATABASE}-${TS}.dump"
+
+echo "==> Dumping ${DB_DATABASE} → ${DUMP}"
+"$COMPOSE" exec -T postgres pg_dump -U "$DB_USERNAME" -Fc "$DB_DATABASE" > "$DUMP"
+
+# Sanity check — pg_restore --list should succeed on a valid dump.
+docker run --rm -i postgres:18-alpine pg_restore --list < "$DUMP" >/dev/null
+echo "==> Dump verified ($(du -h "$DUMP" | cut -f1))"
+
+if [ -n "${STORAGEBOX_HOST:-}" ] && [ -n "${STORAGEBOX_USER:-}" ]; then
+    echo "==> Shipping to ${STORAGEBOX_USER}@${STORAGEBOX_HOST}:${STORAGEBOX_PATH:-/}"
+    rsync -az --partial --timeout=120 \
+        -e "ssh -o StrictHostKeyChecking=accept-new" \
+        "$DUMP" \
+        "${STORAGEBOX_USER}@${STORAGEBOX_HOST}:${STORAGEBOX_PATH:-/}/"
+else
+    echo "!! STORAGEBOX_HOST/USER not set — skipping offsite copy"
+fi
+
+RETAIN="${BACKUP_RETENTION_DAYS:-14}"
+echo "==> Pruning local dumps older than ${RETAIN} days"
+find "$BACKUP_DIR" -maxdepth 1 -name "${DB_DATABASE}-*.dump" -mtime +"$RETAIN" -print -delete || true
+
+echo "==> Backup OK: $DUMP"

--- a/deploy/hetzner/scripts/bootstrap.sh
+++ b/deploy/hetzner/scripts/bootstrap.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# One-time server bring-up for a fresh Hetzner Ubuntu 24.04 root server.
+# Run as root immediately after Hetzner installimage:
+#
+#   curl -fsSL https://raw.githubusercontent.com/<repo>/<branch>/deploy/hetzner/scripts/bootstrap.sh | sudo DEPLOY_PUBKEY="ssh-ed25519 AAAA…" bash
+#
+# Or, after cloning the repo onto the box:
+#
+#   sudo DEPLOY_PUBKEY="ssh-ed25519 AAAA…" bash deploy/hetzner/scripts/bootstrap.sh
+#
+# Idempotent — safe to re-run.
+
+set -euo pipefail
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo "bootstrap.sh must run as root" >&2
+    exit 1
+fi
+
+if [ -z "${DEPLOY_PUBKEY:-}" ]; then
+    echo "DEPLOY_PUBKEY env var required (the SSH public key for the deploy user)" >&2
+    exit 1
+fi
+
+DEPLOY_USER="${DEPLOY_USER:-deploy}"
+SSH_PORT="${SSH_PORT:-22}"
+
+echo "==> Updating apt and installing base packages"
+export DEBIAN_FRONTEND=noninteractive
+apt-get update -y
+apt-get upgrade -y
+apt-get install -y \
+    ca-certificates curl gnupg lsb-release \
+    ufw fail2ban unattended-upgrades \
+    htop iotop jq rsync git tmux \
+    postgresql-client-common postgresql-client
+
+echo "==> Creating deploy user '$DEPLOY_USER'"
+if ! id -u "$DEPLOY_USER" >/dev/null 2>&1; then
+    useradd -m -s /bin/bash -G sudo "$DEPLOY_USER"
+fi
+install -d -m 0700 -o "$DEPLOY_USER" -g "$DEPLOY_USER" /home/"$DEPLOY_USER"/.ssh
+echo "$DEPLOY_PUBKEY" > /home/"$DEPLOY_USER"/.ssh/authorized_keys
+chmod 0600 /home/"$DEPLOY_USER"/.ssh/authorized_keys
+chown "$DEPLOY_USER":"$DEPLOY_USER" /home/"$DEPLOY_USER"/.ssh/authorized_keys
+
+# Passwordless sudo for the deploy user (so CI deploys don't need a TTY).
+echo "$DEPLOY_USER ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/90-"$DEPLOY_USER"
+chmod 0440 /etc/sudoers.d/90-"$DEPLOY_USER"
+
+echo "==> Hardening sshd"
+sed -ri 's/^#?PermitRootLogin.*/PermitRootLogin no/' /etc/ssh/sshd_config
+sed -ri 's/^#?PasswordAuthentication.*/PasswordAuthentication no/' /etc/ssh/sshd_config
+sed -ri 's/^#?ChallengeResponseAuthentication.*/ChallengeResponseAuthentication no/' /etc/ssh/sshd_config
+sed -ri 's/^#?KbdInteractiveAuthentication.*/KbdInteractiveAuthentication no/' /etc/ssh/sshd_config
+systemctl reload ssh || systemctl reload sshd
+
+echo "==> Configuring ufw"
+ufw --force reset
+ufw default deny incoming
+ufw default allow outgoing
+ufw allow "$SSH_PORT"/tcp comment 'ssh'
+ufw allow 80/tcp comment 'http'
+ufw allow 443/tcp comment 'https'
+ufw --force enable
+
+echo "==> Configuring fail2ban (sshd jail)"
+cat >/etc/fail2ban/jail.d/sshd.local <<'EOF'
+[sshd]
+enabled = true
+maxretry = 5
+findtime = 10m
+bantime = 1h
+EOF
+systemctl enable --now fail2ban
+
+echo "==> Enabling unattended-upgrades"
+dpkg-reconfigure -f noninteractive unattended-upgrades
+
+echo "==> Installing Docker Engine"
+install -m 0755 -d /etc/apt/keyrings
+if [ ! -f /etc/apt/keyrings/docker.asc ]; then
+    curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+    chmod a+r /etc/apt/keyrings/docker.asc
+fi
+. /etc/os-release
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu $VERSION_CODENAME stable" \
+    > /etc/apt/sources.list.d/docker.list
+apt-get update -y
+apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+usermod -aG docker "$DEPLOY_USER"
+
+echo "==> Time sync"
+timedatectl set-timezone UTC
+systemctl enable --now systemd-timesyncd
+
+echo "==> Creating directory layout"
+install -d -m 0755 -o "$DEPLOY_USER" -g "$DEPLOY_USER" \
+    /srv/virtua-fc \
+    /srv/virtua-fc/compose \
+    /srv/virtua-fc/env \
+    /srv/virtua-fc/backups \
+    /srv/virtua-fc/prometheus \
+    /srv/virtua-fc/promtail \
+    /srv/virtua-fc/grafana \
+    /srv/virtua-fc/grafana/provisioning \
+    /srv/virtua-fc/grafana/dashboards \
+    /srv/virtua-fc/scripts
+
+# Data volumes — owned by root, mounted into containers with their own UIDs.
+install -d -m 0755 \
+    /var/lib/virtua-fc \
+    /var/lib/virtua-fc/postgres \
+    /var/lib/virtua-fc/redis \
+    /var/lib/virtua-fc/traefik \
+    /var/lib/virtua-fc/prometheus \
+    /var/lib/virtua-fc/grafana \
+    /var/lib/virtua-fc/loki
+
+# Grafana container runs as UID 472.
+chown -R 472:472 /var/lib/virtua-fc/grafana
+
+# Traefik acme.json must be 0600.
+touch /var/lib/virtua-fc/traefik/acme.json
+chmod 0600 /var/lib/virtua-fc/traefik/acme.json
+
+cat <<EOF
+
+====================================================
+Bootstrap complete.
+
+Next steps (as the deploy user, NOT root):
+
+  1. Copy the deploy/hetzner/ tree into /srv/virtua-fc/
+       rsync -a deploy/hetzner/ deploy@<host>:/srv/virtua-fc/
+
+  2. Copy compose/.env.example to /srv/virtua-fc/env/.env (mode 0600)
+     and fill in secrets (APP_KEY, DB_PASSWORD, NIGHTWATCH_TOKEN, …).
+
+  3. Test SSH lockdown: 'ssh root@<host>' must fail.
+     'ssh deploy@<host>' must succeed (key-only).
+
+  4. First-boot the stack:
+       cd /srv/virtua-fc/compose
+       docker compose --env-file /srv/virtua-fc/env/.env \\
+         -f docker-compose.yml -f docker-compose.monitoring.yml up -d
+
+See deploy/hetzner/README.md for the full playbook.
+====================================================
+EOF

--- a/deploy/hetzner/scripts/compose.sh
+++ b/deploy/hetzner/scripts/compose.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Thin wrapper around `docker compose` that loads the production env file and
+# both compose files. Usage:
+#
+#   ./compose.sh ps
+#   ./compose.sh logs -f --tail=200 app
+#   ./compose.sh exec app php artisan tinker
+#   ./compose.sh up -d
+#   ./compose.sh pull
+#
+# Anything you'd type after `docker compose` is forwarded.
+
+set -euo pipefail
+
+ROOT="${VFC_ROOT:-/srv/virtua-fc}"
+ENV_FILE="${VFC_ENV_FILE:-$ROOT/env/.env}"
+COMPOSE_DIR="${VFC_COMPOSE_DIR:-$ROOT/compose}"
+
+if [ ! -f "$ENV_FILE" ]; then
+    echo "Missing env file: $ENV_FILE" >&2
+    exit 1
+fi
+
+exec docker compose \
+    --env-file "$ENV_FILE" \
+    -f "$COMPOSE_DIR/docker-compose.yml" \
+    -f "$COMPOSE_DIR/docker-compose.monitoring.yml" \
+    "$@"

--- a/deploy/hetzner/scripts/deploy.sh
+++ b/deploy/hetzner/scripts/deploy.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Pull a new image tag and roll the app/horizon/scheduler services.
+#
+# Usage:
+#   IMAGE_TAG=<sha> ./deploy.sh
+#
+# Called both interactively and from .github/workflows/deploy.yml. Records the
+# previous IMAGE_TAG to /srv/virtua-fc/env/.previous so rollback.sh can revert.
+
+set -euo pipefail
+
+ROOT="${VFC_ROOT:-/srv/virtua-fc}"
+ENV_FILE="${VFC_ENV_FILE:-$ROOT/env/.env}"
+PREV_FILE="$ROOT/env/.previous"
+COMPOSE="$(dirname "$0")/compose.sh"
+
+if [ -z "${IMAGE_TAG:-}" ]; then
+    echo "IMAGE_TAG required" >&2
+    exit 1
+fi
+
+CURRENT_TAG=$(grep -E '^IMAGE_TAG=' "$ENV_FILE" | cut -d= -f2- || echo "latest")
+echo "==> Current tag: $CURRENT_TAG"
+echo "==> Deploying tag: $IMAGE_TAG"
+
+# Save the rollback target.
+echo "$CURRENT_TAG" > "$PREV_FILE"
+
+# Update the tag in .env atomically.
+sed -i.bak "s|^IMAGE_TAG=.*|IMAGE_TAG=$IMAGE_TAG|" "$ENV_FILE"
+rm -f "$ENV_FILE.bak"
+
+echo "==> Pulling images"
+"$COMPOSE" pull app horizon scheduler
+
+echo "==> Rolling app, horizon, scheduler"
+"$COMPOSE" up -d app horizon scheduler
+
+echo "==> Waiting for /up health check"
+APP_DOMAIN=$(grep -E '^APP_DOMAIN=' "$ENV_FILE" | cut -d= -f2-)
+for i in $(seq 1 30); do
+    if curl -fsS --max-time 5 "https://$APP_DOMAIN/up" >/dev/null; then
+        echo "==> /up returned 200 (attempt $i)"
+        echo "==> Deploy successful: $IMAGE_TAG"
+        exit 0
+    fi
+    sleep 2
+done
+
+echo "!! /up did not return 200 within 60s — consider rolling back" >&2
+exit 1

--- a/deploy/hetzner/scripts/restore.sh
+++ b/deploy/hetzner/scripts/restore.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Restore a Postgres dump produced by backup.sh.
+#
+# Usage:
+#   ./restore.sh /srv/virtua-fc/backups/virtua_fc-20260101T030000Z.dump          # destructive
+#   ./restore.sh --dry-run /srv/.../foo.dump                                      # list only
+#
+# DESTRUCTIVE: drops and recreates the target database. Read the prompt before
+# typing yes.
+
+set -euo pipefail
+
+ROOT="${VFC_ROOT:-/srv/virtua-fc}"
+ENV_FILE="${VFC_ENV_FILE:-$ROOT/env/.env}"
+COMPOSE="$(dirname "$0")/compose.sh"
+
+DRY_RUN=0
+if [ "${1:-}" = "--dry-run" ]; then
+    DRY_RUN=1
+    shift
+fi
+
+DUMP="${1:-}"
+if [ -z "$DUMP" ] || [ ! -f "$DUMP" ]; then
+    echo "Usage: $0 [--dry-run] <path-to-dump>" >&2
+    exit 1
+fi
+
+# shellcheck disable=SC1090
+set -a; . "$ENV_FILE"; set +a
+
+if [ "$DRY_RUN" -eq 1 ]; then
+    echo "==> Listing contents of $DUMP"
+    docker run --rm -i postgres:18-alpine pg_restore --list < "$DUMP"
+    exit 0
+fi
+
+echo "WARNING: this will DROP and recreate database '$DB_DATABASE' on the running"
+echo "         postgres container. All current data will be lost."
+read -r -p "Type the database name ('$DB_DATABASE') to confirm: " CONFIRM
+if [ "$CONFIRM" != "$DB_DATABASE" ]; then
+    echo "Aborted." >&2
+    exit 1
+fi
+
+echo "==> Putting app into maintenance mode"
+"$COMPOSE" exec -T app php artisan down --retry=15 --secret=restore-in-progress || true
+
+echo "==> Drop + recreate database"
+"$COMPOSE" exec -T postgres psql -U "$DB_USERNAME" -d postgres -c "DROP DATABASE IF EXISTS \"$DB_DATABASE\";"
+"$COMPOSE" exec -T postgres psql -U "$DB_USERNAME" -d postgres -c "CREATE DATABASE \"$DB_DATABASE\" OWNER \"$DB_USERNAME\";"
+
+echo "==> Restoring $DUMP (this can take a while)"
+"$COMPOSE" exec -T postgres pg_restore -U "$DB_USERNAME" -d "$DB_DATABASE" --no-owner --no-privileges < "$DUMP"
+
+echo "==> Bringing app back up"
+"$COMPOSE" exec -T app php artisan up || true
+
+echo "==> Restore complete."

--- a/deploy/hetzner/scripts/rollback.sh
+++ b/deploy/hetzner/scripts/rollback.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Roll back to the previous image tag (recorded by deploy.sh in env/.previous).
+# Optionally pass an explicit tag: ./rollback.sh <tag>
+
+set -euo pipefail
+
+ROOT="${VFC_ROOT:-/srv/virtua-fc}"
+PREV_FILE="$ROOT/env/.previous"
+
+TARGET="${1:-}"
+if [ -z "$TARGET" ]; then
+    if [ ! -f "$PREV_FILE" ]; then
+        echo "No previous tag recorded at $PREV_FILE — pass one explicitly: ./rollback.sh <tag>" >&2
+        exit 1
+    fi
+    TARGET=$(cat "$PREV_FILE")
+fi
+
+echo "==> Rolling back to $TARGET"
+IMAGE_TAG="$TARGET" "$(dirname "$0")/deploy.sh"

--- a/deploy/hetzner/scripts/smoketest.sh
+++ b/deploy/hetzner/scripts/smoketest.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Post-deploy smoke test. Returns non-zero on any failure.
+
+set -euo pipefail
+
+ROOT="${VFC_ROOT:-/srv/virtua-fc}"
+ENV_FILE="${VFC_ENV_FILE:-$ROOT/env/.env}"
+COMPOSE="$(dirname "$0")/compose.sh"
+
+# shellcheck disable=SC1090
+set -a; . "$ENV_FILE"; set +a
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+ok()   { echo "OK:   $*"; }
+
+echo "==> Checking compose service health"
+UNHEALTHY=$("$COMPOSE" ps --format json | jq -r 'select(.Health != null and .Health != "" and .Health != "healthy") | .Service' || true)
+[ -z "$UNHEALTHY" ] || fail "unhealthy services: $UNHEALTHY"
+ok "all containers healthy"
+
+echo "==> Checking https://$APP_DOMAIN/up"
+HTTP_CODE=$(curl -fsS -o /dev/null -w "%{http_code}" --max-time 10 "https://$APP_DOMAIN/up" || true)
+[ "$HTTP_CODE" = "200" ] || fail "/up returned $HTTP_CODE"
+ok "/up returned 200"
+
+echo "==> Checking Postgres connectivity"
+"$COMPOSE" exec -T postgres pg_isready -U "$DB_USERNAME" -d "$DB_DATABASE" >/dev/null || fail "pg_isready failed"
+ok "postgres ready"
+
+echo "==> Checking Redis connectivity"
+"$COMPOSE" exec -T redis redis-cli ping | grep -q PONG || fail "redis ping failed"
+ok "redis pong"
+
+echo "==> Checking Horizon supervisors"
+"$COMPOSE" exec -T app php artisan horizon:status | grep -qi "running" || fail "horizon not running"
+ok "horizon running"
+
+echo "==> Checking Grafana"
+HTTP_CODE=$(curl -fsS -o /dev/null -w "%{http_code}" --max-time 10 "https://grafana.$APP_DOMAIN/api/health" || true)
+[ "$HTTP_CODE" = "200" ] || fail "grafana health returned $HTTP_CODE"
+ok "grafana healthy"
+
+echo
+echo "==> Smoke test PASSED"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -32,9 +32,17 @@ if [ ! -f .env ]; then
     fi
 fi
 
-# Run migrations
-echo "Running migrations..."
-php artisan migrate --force
+# Run migrations only on the designated container (typically `app`).
+# Multi-service prod deploys (app + horizon + scheduler share this image) must
+# avoid concurrent migrate runs racing each other — set RUN_MIGRATIONS=true on
+# exactly one service. Defaults to true so single-container and dev setups
+# continue to work without changes.
+if [ "${RUN_MIGRATIONS:-true}" = "true" ]; then
+    echo "Running migrations..."
+    php artisan migrate --force
+else
+    echo "Skipping migrations (RUN_MIGRATIONS != true)."
+fi
 
 # Cache configuration in production
 if [ "$APP_ENV" = "production" ]; then


### PR DESCRIPTION
## Summary

This PR adds a complete, copy-pasteable operational playbook and infrastructure-as-code for deploying and operating VirtuaFC on a single Hetzner dedicated root server. It includes Docker Compose configurations, deployment scripts, monitoring stack setup, and comprehensive documentation.

## Key Changes

- **Operational Playbook** (`deploy/hetzner/README.md`): 761-line runbook covering topology, prerequisites, one-time server bring-up, day-2 operations, monitoring, health checks, incident response, scaling guidance, and disaster recovery procedures.

- **Docker Compose Stack**:
  - `docker-compose.yml`: Production services (Traefik, app, Horizon, scheduler, Postgres, Redis) with health checks and networking
  - `docker-compose.monitoring.yml`: Monitoring stack (Prometheus, Grafana, Loki, Promtail, node/cAdvisor/Postgres/Redis exporters)

- **Deployment Scripts**:
  - `bootstrap.sh`: One-time server hardening, Docker installation, user/directory setup, firewall configuration
  - `deploy.sh`: Image pull and rolling deployment of app/horizon/scheduler with health check polling
  - `rollback.sh`: Fast rollback to previous or explicit image tag
  - `backup.sh`: Nightly Postgres dumps with local rotation and offsite shipping to Hetzner Storage Box
  - `restore.sh`: Destructive database restore from backup with dry-run support
  - `smoketest.sh`: Post-deploy health verification (containers, HTTP, Postgres, Redis, Horizon, Grafana)
  - `compose.sh`: Wrapper around `docker compose` that loads env file and both compose files

- **Monitoring Configuration**:
  - `prometheus/prometheus.yml`: Scrape targets for node, cAdvisor, Postgres, Redis, Traefik
  - `promtail/promtail.yml`: Docker log aggregation to Loki
  - `grafana/provisioning/`: Datasource and dashboard provisioning setup

- **Environment & Configuration**:
  - `.env.example`: Template with all required secrets and settings
  - Updated `docker/entrypoint.sh`: Conditional migrations (only on designated container) to prevent races in multi-service deployments

- **GitHub Actions**:
  - `.github/workflows/deploy.yml`: Automated build, push to GHCR, SSH deploy, and smoke test with auto-rollback on failure

## Notable Implementation Details

- **Single-host simplicity**: All services run on one Docker host with two networks (`edge` for Traefik/external traffic, `internal` for backend services)
- **Idempotent bootstrap**: `bootstrap.sh` can be re-run safely; creates `deploy` user with passwordless sudo and SSH-key-only auth
- **Atomic deployments**: `deploy.sh` records previous tag for instant rollback; smoke test gates production traffic
- **Monitoring-first**: Prometheus + Loki + Grafana with exporters for host, containers, Postgres, Redis, and Traefik metrics
- **Backup automation**: Systemd timer-based nightly backups with configurable retention and offsite replication
- **Secrets rotation**: Documented procedures for rotating `APP_KEY`, `DB_PASSWORD`, and API tokens
- **Conditional migrations**: `RUN_MIGRATIONS=true` env var prevents concurrent migration races when app/horizon/scheduler share the same image

The playbook is written for operators with SSH access only—every command is intended to be run literally, top-to-bottom, with clear prerequisites and troubleshooting guidance for common incidents.

https://claude.ai/code/session_019kQgW5WZgYesQz5gxAWQW3