### PR TITLE
Force-include supercup qualifiers in cup rebuild to maintain round 1 parity

### DIFF
--- a/app/Modules/Season/Processors/CopaQualificationProcessor.php
+++ b/app/Modules/Season/Processors/CopaQualificationProcessor.php
@@ -27,6 +27,11 @@ use Illuminate\Support\Facades\Log;
  *     (e.g. ESP3A and ESP3B → top 5 each).
  *  3. Preserve any regional teams already in the cup that aren't in any
  *     playable tier (lower-division seed teams from data/<year>/ESPCUP).
+ *  3b. Force-include any team in this country's supercup field. The
+ *      downstream setup pipeline bumps these teams to a later entry_round
+ *      via an UPDATE — if a supercup-qualifying cup finalist (e.g. a
+ *      tier-3 cup winner outside its group's top 5) isn't in this rebuilt
+ *      cup field, the bump silently misses it and round 1 ends up odd.
  *  4. If `target_size` is set, fill to that size by walking the next
  *     positions in the `top_per_group` competitions, skipping reserves
  *     and teams already qualified.
@@ -77,6 +82,8 @@ class CopaQualificationProcessor implements SeasonProcessor
      *   2. Top N from each top_per_group competition (ESP3A/B top 5 — minus reserves).
      *   3. Pre-existing regional teams already in the cup (lower-division
      *      seed teams not registered in any playable tier).
+     *   3b. Force-include the country's supercup-qualifying teams (so the
+     *       downstream entry_round bump always finds them and round 1 stays even).
      *   4. Fill any remaining slots up to target_size from later positions
      *      in the top_per_group competitions.
      *
@@ -161,6 +168,31 @@ class CopaQualificationProcessor implements SeasonProcessor
         }
         foreach ($regionalQuery->pluck('team_id') as $teamId) {
             $qualifiers[$teamId] = true;
+        }
+
+        // 3b. Force-include the supercup-qualifying teams. The supercup
+        //     processor (priority 80) ran before us and persisted the new
+        //     season's supercup field; downstream the setup pipeline bumps
+        //     these teams from cup round 1 to a later entry_round so the
+        //     supercup field skips the early rounds. That bump is an
+        //     UPDATE on existing rows — if a supercup team isn't in this
+        //     cup field, it silently isn't bumped, and round 1 ends up
+        //     odd (the OddCupDrawPoolException case). League top 1–2 are
+        //     always ESP1/auto-qualify, but cup finalists can be anyone:
+        //     a tier-3 cup winner outside its group's top 5 falls through
+        //     steps 1-3 and may not be reached by step 4. Pull them in
+        //     explicitly so the parity invariant holds.
+        $supercupConfig = $this->countryConfig->supercup($countryCode);
+        if ($supercupConfig && ($supercupConfig['cup'] ?? null) === $cupId) {
+            $supercupTeamIds = CompetitionEntry::where('game_id', $game->id)
+                ->where('competition_id', $supercupConfig['competition'])
+                ->pluck('team_id');
+            foreach ($supercupTeamIds as $teamId) {
+                if (isset($reserveLookup[$teamId])) {
+                    continue;
+                }
+                $qualifiers[$teamId] = true;
+            }
         }
 
         // 4. Fill to target_size from remaining top_per_group competitions

--- a/tests/Feature/CopaQualificationTest.php
+++ b/tests/Feature/CopaQualificationTest.php
@@ -301,6 +301,49 @@ class CopaQualificationTest extends TestCase
         $this->assertCount(52, $this->cupEntries());
     }
 
+    public function test_supercup_qualifier_outside_top_5_is_force_included(): void
+    {
+        // Reproduces the OddCupDrawPoolException scenario from production:
+        // a tier-3 cup finalist (e.g. SD Ponferradina at ESP3A pos 12, or
+        // Juventud Torremolinos at ESP3B pos 8) qualifies for the supercup
+        // by winning/runner-up of the cup, but lives outside its group's
+        // top 5 and outside the range step 4 reaches when filling
+        // target_size. Without 3b it never enters the rebuilt cup, the
+        // entry_round bump silently misses it, and round 1 ends up odd.
+        Competition::factory()->knockoutCup()->create(['id' => 'ESPSUP', 'country' => 'ES']);
+
+        // 4 supercup qualifiers: 2 ESP1 leaders (always in step 1) plus the
+        // two cup finalists from outside the auto-qualifying tiers.
+        $supercupQualifiers = [
+            $this->teamsByCompetition['ESP1'][0]->id,
+            $this->teamsByCompetition['ESP1'][1]->id,
+            $this->teamsByCompetition['ESP3A'][11]->id, // pos 12, beyond step 4's reach with target=70
+            $this->teamsByCompetition['ESP3B'][7]->id,  // pos 8, beyond step 4's reach with target=70
+        ];
+        foreach ($supercupQualifiers as $teamId) {
+            CompetitionEntry::create([
+                'game_id' => $this->game->id,
+                'competition_id' => 'ESPSUP',
+                'team_id' => $teamId,
+                'entry_round' => 1,
+            ]);
+        }
+
+        // Step 4 with target=70 fills only ESP3A pos 6-20 + ESP3B pos 6-8 —
+        // misses ESP3B pos 8 if 3b doesn't pull it in. Note: with the fix
+        // active, the supercup teams take some of those fill slots, so
+        // step 4 reaches further into ESP3B than it otherwise would.
+        config(['countries.ES.cup_qualification.ESPCUP.target_size' => 70]);
+
+        $this->runProcessor();
+
+        $entries = $this->cupEntries();
+        foreach ($supercupQualifiers as $teamId) {
+            $this->assertContains($teamId, $entries, "supercup team {$teamId} must be in cup");
+        }
+        $this->assertCount(70, $entries, 'cup field still hits target_size');
+    }
+
     public function test_target_size_with_supercup_bump_yields_even_round_1(): void
     {
         // The whole point of the invariant: round 1 must be even after the


### PR DESCRIPTION
## Summary
Fixes an issue where cup finalists qualifying for the supercup but falling outside the auto-qualifying tiers could be silently missed during cup field reconstruction, resulting in an odd number of teams in round 1.

## Changes
- **CopaQualificationProcessor**: Added step 3b to explicitly force-include all supercup-qualifying teams when rebuilding the cup entry field
  - Retrieves the supercup field from the persisted competition entries
  - Adds each supercup team to the qualifiers set (unless they're reserves)
  - Ensures these teams are present before the downstream entry_round bump occurs
  
- **Test coverage**: Added `test_supercup_qualifier_outside_top_5_is_force_included()` to reproduce and verify the fix
  - Tests the scenario where tier-3 cup finalists (e.g., position 12 in ESP3A, position 8 in ESP3B) qualify for the supercup
  - Verifies they are included in the rebuilt cup field even when beyond step 4's reach with `target_size=70`
  - Confirms the cup field still hits the target size and maintains parity

## Implementation Details
The fix addresses a critical gap in the qualification pipeline: the supercup processor runs before cup qualification and persists the supercup field, but if a supercup-qualifying team isn't in the rebuilt cup field, the downstream entry_round bump (which updates existing rows) silently misses it. By force-including supercup teams in step 3b—after auto-qualifiers and pre-existing regional teams but before the fill-to-target step—we ensure the parity invariant holds and round 1 remains even.

https://claude.ai/code/session_01NGpJJUAjKBX6h6DGN5b7Go