### PR TITLE
Upgrade to PHP 8.5

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.4'
+          php-version: '8.5'
           extensions: mbstring, xml, pgsql
           coverage: none
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # =============================================================================
 # Base stage: PHP runtime with extensions (shared by dev and production)
 # =============================================================================
-FROM dunglas/frankenphp:php8.4-alpine AS base
+FROM dunglas/frankenphp:php8.5-alpine AS base
 
 RUN install-php-extensions \
     pdo_pgsql \

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "keywords": ["laravel", "framework"],
     "license": "MIT",
     "require": {
-        "php": "^8.4",
+        "php": "^8.5",
         "fakerphp/faker": "^1.23",
         "jenssegers/agent": "^2.6",
         "laravel/framework": "^12.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9ab021f9c7bd87bc9de7bdcf31600e41",
+    "content-hash": "449ae2f1a673188b033811322fe86432",
     "packages": [
         {
             "name": "brick/math",
@@ -10241,8 +10241,8 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": "^8.4"
+        "php": "^8.5"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -4,6 +4,8 @@ includes:
 
 parameters:
 
+    phpVersion: 80500
+
     paths:
         - app/
 


### PR DESCRIPTION
Bumps composer constraint, FrankenPHP base image, CI matrix, and PHPStan phpVersion. No code changes — all dependencies already declare open ^8.x constraints, no 8.5 deprecations triggered.