### PR TITLE
Implement per-user opt-in migration from beta to production

### DIFF
--- a/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -7,6 +7,7 @@ use App\Models\ActivationEvent;
 use App\Models\InviteCode;
 use App\Models\User;
 use App\Models\WaitlistEntry;
+use App\Modules\Migration\MigrationStatus;
 use App\Modules\Season\Services\ActivationTracker;
 use Illuminate\Auth\Events\Registered;
 use Illuminate\Http\RedirectResponse;
@@ -72,7 +73,10 @@ class RegisteredUserController extends Controller
         ]);
 
         $invite->consume();
-        $user->forceFill(['email_verified_at' => now()])->save();
+        $user->forceFill([
+            'email_verified_at' => now(),
+            ...$this->migrationStatusForNewUser(),
+        ])->save();
 
         event(new Registered($user));
 
@@ -104,6 +108,11 @@ class RegisteredUserController extends Controller
             'has_tournament_access' => true,
         ]);
 
+        $extra = $this->migrationStatusForNewUser();
+        if ($extra !== []) {
+            $user->forceFill($extra)->save();
+        }
+
         event(new Registered($user));
 
         app(ActivationTracker::class)->record($user->id, ActivationEvent::EVENT_REGISTERED);
@@ -111,5 +120,24 @@ class RegisteredUserController extends Controller
         Password::sendResetLink(['email' => $user->email]);
 
         return redirect()->route('activation.sent');
+    }
+
+    /**
+     * Migration-status override for a freshly-created user.
+     *
+     * On the import-side deployment, mark new sign-ups as migration-completed
+     * so RequireMigrationOnImport doesn't trap them on the import page — they
+     * have nothing to migrate. Pre-imported users (control-plane rows copied
+     * from beta) keep the default `pending` and get redirected as expected.
+     *
+     * @return array<string, mixed>
+     */
+    private function migrationStatusForNewUser(): array
+    {
+        if (config('migration.mode') === 'import') {
+            return ['migration_status' => MigrationStatus::COMPLETED];
+        }
+
+        return [];
     }
 }

--- a/app/Http/Middleware/RequireMigrationOnImport.php
+++ b/app/Http/Middleware/RequireMigrationOnImport.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Modules\Migration\MigrationStatus;
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * On the import-side deployment, redirect authenticated users whose
+ * migration_status is `pending` (or `in_progress`) to /migration/import.
+ *
+ * Pre-imported users — those whose control-plane row was bulk-copied from
+ * beta before the cutover — carry that status. The first thing they see
+ * after logging in is the "Copy my data" page; they can't accidentally
+ * play on an empty account.
+ *
+ * No-op outside import mode, for unauthenticated requests, for users with
+ * status `completed`/`failed`, and for migration / logout paths
+ * themselves.
+ */
+class RequireMigrationOnImport
+{
+    /** Paths that stay accessible to pending users (matched via str_starts_with). */
+    private const ALLOWED_PATHS = [
+        '/migration/',
+        '/logout',
+    ];
+
+    public function handle(Request $request, Closure $next): Response
+    {
+        if (config('migration.mode') !== 'import') {
+            return $next($request);
+        }
+
+        $user = $request->user();
+        if ($user === null) {
+            return $next($request);
+        }
+
+        if (! in_array(
+            $user->migration_status,
+            [MigrationStatus::PENDING, MigrationStatus::IN_PROGRESS],
+            true,
+        )) {
+            return $next($request);
+        }
+
+        $path = '/'.ltrim($request->path(), '/');
+        foreach (self::ALLOWED_PATHS as $allowed) {
+            if (str_starts_with($path, $allowed)) {
+                return $next($request);
+            }
+        }
+
+        return redirect()->route('migration.import.show');
+    }
+}

--- a/app/Modules/Migration/Services/UserImporter.php
+++ b/app/Modules/Migration/Services/UserImporter.php
@@ -97,6 +97,15 @@ class UserImporter
                 throw new \RuntimeException("Row in control-plane table {$table} is missing key column {$keyColumn}.");
             }
 
+            // Local state for migration columns is authoritative — StartImport
+            // has just flipped them to in_progress, and MigrationImportJob will
+            // mark them completed at the end. Importing the export-side values
+            // (still `pending` on beta until the seal call) would briefly bounce
+            // the status back to pending and flicker the import page.
+            if ($table === 'users') {
+                unset($row['migration_status'], $row['migration_completed_at']);
+            }
+
             $existing = DB::connection('pgsql_control')
                 ->table($table)
                 ->where($keyColumn, $key)

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -29,6 +29,7 @@ return Application::configure(basePath: dirname(__DIR__))
         $middleware->web(append: [
             \App\Http\Middleware\SetLocale::class,
             \App\Http\Middleware\BlockMigratedUsersOnExport::class,
+            \App\Http\Middleware\RequireMigrationOnImport::class,
         ]);
 
         $middleware->alias([


### PR DESCRIPTION
## Summary

Implements a complete per-user opt-in migration system that allows users to transfer their account and game data from the legacy beta deployment (Laravel Cloud) to the new production deployment (Hetzner). The system uses HMAC-signed tokens for secure handoff between deployments and a queued job for reliable data import.

## Key Changes

**Core Migration Infrastructure**
- Added `MigrationStatus` enum (pending, in_progress, completed, failed) to track per-user migration state
- Created `SignedHandoff` service for minting and verifying HMAC-SHA256 signed tokens with purpose-specific validation and TTL enforcement
- Implemented `MigrationProgress` cache-backed service for real-time progress tracking during imports
- Added `TableManifest` to define which tables are migrated and in what order (respecting FK dependencies)

**Export Side (Legacy Beta)**
- `StartMigration` action: mints a short-lived handoff token and redirects user to import side
- `ExportUser` API endpoint: returns JSON envelope of user's control-plane and game data
- `SealUser` API endpoint: marks user as completed after successful import
- `BlockMigratedUsersOnExport` middleware: prevents completed users from playing on beta
- Migration banner component showing on export side for pending users

**Import Side (New Production)**
- `LandMigration` action: verifies handoff token, logs user in, redirects to import flow
- `ShowImport` view: renders import page with Alpine.js-driven progress polling
- `StartImport` action: atomically transitions user from pending→in_progress and dispatches job
- `MigrationStatusEndpoint`: provides real-time progress updates to the frontend
- `MigrationImportJob`: queued job that fetches data from export side, imports it locally, and seals the user

**Data Import**
- `UserExporter`: serializes user's control-plane and game data into JSON envelope
- `UserImporter`: deserializes envelope and inserts rows into local database with proper transaction boundaries and progress reporting

**Security & Configuration**
- `VerifyMigrationBearer` middleware: validates server-to-server bearer tokens on export API
- `RequireMigrationMode` middleware: gates routes by deployment role (export/import/off)
- `config/migration.php`: centralized configuration for mode, secrets, TTLs, and peer URLs
- Token purposes (HANDOFF, S2S_EXPORT, S2S_SEAL) prevent token replay attacks

**UI & Localization**
- Import progress page with step-by-step progress bar and error handling
- "You've moved" terminal page on export side for completed users
- English and Spanish translations for all migration flows
- Alpine.js component for client-side polling and state management

**Database**
- Migration adds `migration_status`, `migration_completed_at` columns to users table

**Testing**
- Unit tests for `SignedHandoff` covering token round-trip, purpose validation, signature verification, expiry, and tampering detection

## Notable Implementation Details

- **Idempotency**: The `StartImport` action uses atomic CAS (compare-and-swap) to prevent double-dispatch of the import job
- **Fault tolerance**: Failed imports are retryable; the job logs errors to `MigrationProgress` for frontend display
- **Transaction safety**: Game imports run in tenant transactions; control-plane writes use separate control connection transactions
- **Chunked inserts**: Large tables (match_events, etc.) are inserted in 500-row chunks to keep statement size manageable
- **Progress granularity**: Import reserves 10–95% for game processing, allowing fine-grained progress reporting
- **Session domain**: `.env.example` updated to document `SESSION_DOMAIN` for cross-subdomain session sharing during handoff

https://claude.ai/code/session_019LrTPGVghHVKsAGpxcJLS1