### PR TITLE
Add pre-match opponent scouting report

### DIFF
--- a/app/Http/Views/ShowLiveMatch.php
+++ b/app/Http/Views/ShowLiveMatch.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Views;
 
+use App\Modules\Coaching\Services\HalfTimeAdvisorService;
 use App\Modules\Lineup\Enums\DefensiveLineHeight;
 use App\Modules\Lineup\Enums\Formation;
 use App\Modules\Lineup\Enums\Mentality;
@@ -28,6 +29,7 @@ class ShowLiveMatch
     public function __construct(
         private readonly LineupService $lineupService,
         private readonly ExtraTimeAndPenaltyService $extraTimeService,
+        private readonly HalfTimeAdvisorService $halfTimeAdvisor,
     ) {}
 
     public function __invoke(string $gameId, string $matchId)
@@ -224,6 +226,14 @@ class ShowLiveMatch
 
         $narrativeTemplates = LiveMatchNarrativeTemplates::build();
 
+        // Pre-compute half-time tactical tips. The match is already simulated
+        // when this view loads, so we can read first-half state directly off
+        // the events collection — no extra queries, single pass over events.
+        $halfTimeTips = array_map(
+            fn ($tip) => $tip->toArray(),
+            $this->halfTimeAdvisor->buildTips($playerMatch, $game),
+        );
+
         // MatchdayOrchestrator::processBatch persists the attendance row before
         // simulating the match, so it's always present when this view loads.
         $attendanceRow = MatchAttendance::where('game_match_id', $playerMatch->id)->first();
@@ -304,6 +314,7 @@ class ShowLiveMatch
             'awayPosition' => $awayStanding?->position,
             'competitionRole' => $playerMatch->competition->role,
             'competitionName' => __($playerMatch->competition->name),
+            'halfTimeTips' => $halfTimeTips,
         ]);
     }
 

--- a/app/Modules/Coaching/DTOs/CoachingTip.php
+++ b/app/Modules/Coaching/DTOs/CoachingTip.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Modules\Coaching\DTOs;
+
+/**
+ * A single half-time recommendation from the coaching staff.
+ *
+ * `headline` and `rationale` are pre-translated. When `tacticalChange` is
+ * non-null, the UI exposes an "Apply" button that submits the payload to the
+ * existing tactical-actions endpoint; advisory-only tips set it to null.
+ *
+ * Tips are precomputed server-side in {@see \App\Http\Views\ShowLiveMatch}
+ * and passed into the Alpine half-time block as a static array — no extra
+ * round-trips during the live match flow.
+ */
+final class CoachingTip
+{
+    /**
+     * @param  array<string, string>|null  $tacticalChange
+     *     Subset of {mentality, playing_style, pressing, defensive_line}
+     *     keyed by the same field names accepted by ProcessTacticalActions.
+     */
+    public function __construct(
+        public readonly string $id,
+        public readonly string $headline,
+        public readonly string $rationale,
+        public readonly ?array $tacticalChange,
+        public readonly string $tone,
+        public readonly Confidence $confidence,
+    ) {}
+
+    public const TONE_INFO = 'info';
+    public const TONE_WARNING = 'warning';
+    public const TONE_OPPORTUNITY = 'opportunity';
+
+    /**
+     * Blade-friendly array form. Used to hand the payload to Alpine via Js::from().
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'id' => $this->id,
+            'headline' => $this->headline,
+            'rationale' => $this->rationale,
+            'tacticalChange' => $this->tacticalChange,
+            'tone' => $this->tone,
+            'confidence' => $this->confidence->value,
+        ];
+    }
+}

--- a/app/Modules/Coaching/DTOs/Confidence.php
+++ b/app/Modules/Coaching/DTOs/Confidence.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Modules\Coaching\DTOs;
+
+/**
+ * Confidence level attached to each coaching insight.
+ *
+ * Phase 1 derives confidence from how strong the underlying signal is.
+ * A later phase can scale confidence by an assistant's quality once a
+ * staff hiring layer lands.
+ */
+enum Confidence: string
+{
+    case HIGH = 'high';
+    case MEDIUM = 'medium';
+    case LOW = 'low';
+
+    public function translationKey(): string
+    {
+        return 'coaching.confidence_'.$this->value;
+    }
+}

--- a/app/Modules/Coaching/Services/HalfTimeAdvisorService.php
+++ b/app/Modules/Coaching/Services/HalfTimeAdvisorService.php
@@ -1,0 +1,323 @@
+<?php
+
+namespace App\Modules\Coaching\Services;
+
+use App\Models\Game;
+use App\Models\GameMatch;
+use App\Models\MatchEvent;
+use App\Modules\Coaching\DTOs\CoachingTip;
+use App\Modules\Coaching\DTOs\Confidence;
+use App\Modules\Lineup\Enums\DefensiveLineHeight;
+use App\Modules\Lineup\Enums\Mentality;
+use App\Modules\Lineup\Enums\PlayingStyle;
+use App\Modules\Lineup\Enums\PressingIntensity;
+use Illuminate\Support\Collection;
+
+/**
+ * Computes half-time tactical recommendations for the user.
+ *
+ * Pure read service: inspects the first-half events of an already-simulated
+ * match plus both teams' current tactics, and emits 0-3 advisory tips. When
+ * a tip carries a `tacticalChange` payload, the UI's "Apply" button reuses
+ * the existing /tactical-actions endpoint — no new write paths.
+ *
+ * Only invoked from the live-match view (the user's match), so the AI-vs-AI
+ * fast-resolver path is untouched.
+ */
+class HalfTimeAdvisorService
+{
+    /** Minute at which the half-time read happens. Mirrors the live-match phase. */
+    private const HALF_TIME_MINUTE = 45;
+
+    /** Yellow cards on user players that trigger the discipline tip. */
+    private const YELLOW_CARD_RISK_THRESHOLD = 2;
+
+    /** Cap on the number of tips returned. Keeps the half-time UI scannable. */
+    private const MAX_TIPS = 3;
+
+    /**
+     * Build half-time tips for the user's side of a match.
+     *
+     * @return array<int, CoachingTip>
+     */
+    public function buildTips(GameMatch $match, Game $game): array
+    {
+        $isUserHome = $match->isHomeTeam($game->team_id);
+        $userTeamId = $game->team_id;
+        $opponentTeamId = $isUserHome ? $match->away_team_id : $match->home_team_id;
+
+        $firstHalfEvents = $match->events
+            ->filter(fn (MatchEvent $e) => $e->minute <= self::HALF_TIME_MINUTE);
+
+        $userScore = $this->scoreFor($firstHalfEvents, $userTeamId, $opponentTeamId);
+        $opponentScore = $this->scoreFor($firstHalfEvents, $opponentTeamId, $userTeamId);
+
+        $diff = $userScore - $opponentScore;
+
+        $userTactics = $this->extractTactics($match, $isUserHome ? 'home' : 'away');
+        $opponentTactics = $this->extractTactics($match, $isUserHome ? 'away' : 'home');
+
+        $tips = [];
+
+        $resultTip = $this->buildResultTip($diff, $userTactics);
+        if ($resultTip !== null) {
+            $tips[] = $resultTip;
+        }
+
+        $matchupTip = $this->buildMatchupTip($userTactics, $opponentTactics);
+        if ($matchupTip !== null) {
+            $tips[] = $matchupTip;
+        }
+
+        $disciplineTip = $this->buildDisciplineTip($firstHalfEvents, $userTeamId);
+        if ($disciplineTip !== null) {
+            $tips[] = $disciplineTip;
+        }
+
+        // If nothing notable surfaced, give the user one neutral read so the
+        // panel never feels broken.
+        if ($tips === []) {
+            $tips[] = $this->buildBalancedTip();
+        }
+
+        return array_slice($tips, 0, self::MAX_TIPS);
+    }
+
+    /**
+     * Goals scored by $teamId in the given event collection, accounting for
+     * own goals (which credit the opposing team).
+     */
+    private function scoreFor(Collection $events, string $teamId, string $oppTeamId): int
+    {
+        return $events->reduce(function (int $carry, MatchEvent $event) use ($teamId, $oppTeamId): int {
+            if ($event->event_type === MatchEvent::TYPE_GOAL && $event->team_id === $teamId) {
+                return $carry + 1;
+            }
+            if ($event->event_type === MatchEvent::TYPE_OWN_GOAL && $event->team_id === $oppTeamId) {
+                return $carry + 1;
+            }
+
+            return $carry;
+        }, 0);
+    }
+
+    /**
+     * Result-driven tip: respond to the scoreline.
+     *
+     * @param  array{mentality: string, playing_style: string, pressing: string, defensive_line: string}  $userTactics
+     */
+    private function buildResultTip(int $diff, array $userTactics): ?CoachingTip
+    {
+        // Heavy deficit: chase the game.
+        if ($diff <= -2) {
+            return $this->makeTip(
+                id: 'result_chasing',
+                headlineKey: 'coaching.tip_chasing_headline',
+                rationaleKey: 'coaching.tip_chasing_rationale',
+                tone: CoachingTip::TONE_WARNING,
+                confidence: Confidence::HIGH,
+                change: [
+                    'mentality' => Mentality::ATTACKING->value,
+                    'pressing' => PressingIntensity::HIGH_PRESS->value,
+                    'defensive_line' => DefensiveLineHeight::HIGH_LINE->value,
+                ],
+            );
+        }
+
+        // One-goal deficit: measured push.
+        if ($diff === -1) {
+            $change = [];
+            if ($userTactics['mentality'] !== Mentality::ATTACKING->value) {
+                $change['mentality'] = Mentality::ATTACKING->value;
+            }
+            if ($userTactics['playing_style'] === PlayingStyle::COUNTER_ATTACK->value) {
+                $change['playing_style'] = PlayingStyle::BALANCED->value;
+            }
+
+            return $this->makeTip(
+                id: 'result_trailing_one',
+                headlineKey: 'coaching.tip_trailing_one_headline',
+                rationaleKey: 'coaching.tip_trailing_one_rationale',
+                tone: CoachingTip::TONE_WARNING,
+                confidence: Confidence::MEDIUM,
+                change: $change ?: null,
+            );
+        }
+
+        // Two-goal cushion: protect.
+        if ($diff >= 2) {
+            $change = [];
+            if ($userTactics['mentality'] === Mentality::ATTACKING->value) {
+                $change['mentality'] = Mentality::BALANCED->value;
+            }
+            if ($userTactics['pressing'] === PressingIntensity::HIGH_PRESS->value) {
+                $change['pressing'] = PressingIntensity::STANDARD->value;
+            }
+            if ($userTactics['defensive_line'] === DefensiveLineHeight::HIGH_LINE->value) {
+                $change['defensive_line'] = DefensiveLineHeight::NORMAL->value;
+            }
+
+            return $this->makeTip(
+                id: 'result_two_goal_lead',
+                headlineKey: 'coaching.tip_protecting_lead_headline',
+                rationaleKey: 'coaching.tip_protecting_lead_rationale',
+                tone: CoachingTip::TONE_OPPORTUNITY,
+                confidence: Confidence::HIGH,
+                change: $change ?: null,
+            );
+        }
+
+        // One-goal cushion: stay disciplined; only intervene if currently aggressive.
+        if ($diff === 1) {
+            if ($userTactics['mentality'] === Mentality::ATTACKING->value) {
+                return $this->makeTip(
+                    id: 'result_one_goal_lead_attacking',
+                    headlineKey: 'coaching.tip_one_goal_lead_headline',
+                    rationaleKey: 'coaching.tip_one_goal_lead_rationale',
+                    tone: CoachingTip::TONE_INFO,
+                    confidence: Confidence::MEDIUM,
+                    change: ['mentality' => Mentality::BALANCED->value],
+                );
+            }
+
+            return null;
+        }
+
+        // Drawing: no automatic result tip — the matchup tip handles the rest.
+        return null;
+    }
+
+    /**
+     * Tactical-matchup tip: respond to the opponent's setup independent of score.
+     *
+     * @param  array{mentality: string, playing_style: string, pressing: string, defensive_line: string}  $userTactics
+     * @param  array{mentality: string, playing_style: string, pressing: string, defensive_line: string}  $opponentTactics
+     */
+    private function buildMatchupTip(array $userTactics, array $opponentTactics): ?CoachingTip
+    {
+        // Opponent high-pressing AND our line is high → invert: drop deeper to release pressure.
+        if ($opponentTactics['pressing'] === PressingIntensity::HIGH_PRESS->value
+            && $userTactics['defensive_line'] === DefensiveLineHeight::HIGH_LINE->value) {
+            return $this->makeTip(
+                id: 'matchup_release_press',
+                headlineKey: 'coaching.tip_release_press_headline',
+                rationaleKey: 'coaching.tip_release_press_rationale',
+                tone: CoachingTip::TONE_WARNING,
+                confidence: Confidence::HIGH,
+                change: [
+                    'defensive_line' => DefensiveLineHeight::NORMAL->value,
+                    'playing_style' => PlayingStyle::DIRECT->value,
+                ],
+            );
+        }
+
+        // Opponent sitting low-block + we're not in possession → switch to possession.
+        if ($opponentTactics['pressing'] === PressingIntensity::LOW_BLOCK->value
+            && $userTactics['playing_style'] !== PlayingStyle::POSSESSION->value) {
+            return $this->makeTip(
+                id: 'matchup_break_low_block',
+                headlineKey: 'coaching.tip_break_low_block_headline',
+                rationaleKey: 'coaching.tip_break_low_block_rationale',
+                tone: CoachingTip::TONE_OPPORTUNITY,
+                confidence: Confidence::MEDIUM,
+                change: ['playing_style' => PlayingStyle::POSSESSION->value],
+            );
+        }
+
+        // Opponent attacking + high line → counter-attack opportunity.
+        if ($opponentTactics['mentality'] === Mentality::ATTACKING->value
+            && $opponentTactics['defensive_line'] === DefensiveLineHeight::HIGH_LINE->value
+            && $userTactics['playing_style'] !== PlayingStyle::COUNTER_ATTACK->value) {
+            return $this->makeTip(
+                id: 'matchup_counter_high_line',
+                headlineKey: 'coaching.tip_counter_high_line_headline',
+                rationaleKey: 'coaching.tip_counter_high_line_rationale',
+                tone: CoachingTip::TONE_OPPORTUNITY,
+                confidence: Confidence::MEDIUM,
+                change: ['playing_style' => PlayingStyle::COUNTER_ATTACK->value],
+            );
+        }
+
+        return null;
+    }
+
+    /**
+     * Discipline tip: flag yellow-card risk on user players. Advisory only —
+     * substitutions are out of scope for the apply flow at this stage.
+     */
+    private function buildDisciplineTip(Collection $firstHalfEvents, string $userTeamId): ?CoachingTip
+    {
+        $yellowCards = $firstHalfEvents
+            ->filter(fn (MatchEvent $e) => $e->event_type === MatchEvent::TYPE_YELLOW_CARD
+                && $e->team_id === $userTeamId)
+            ->count();
+
+        if ($yellowCards < self::YELLOW_CARD_RISK_THRESHOLD) {
+            return null;
+        }
+
+        return $this->makeTip(
+            id: 'discipline_card_risk',
+            headlineKey: 'coaching.tip_card_risk_headline',
+            rationaleKey: 'coaching.tip_card_risk_rationale',
+            tone: CoachingTip::TONE_WARNING,
+            confidence: Confidence::HIGH,
+            change: null,
+            replacements: ['count' => $yellowCards],
+        );
+    }
+
+    /**
+     * Fallback tip when nothing notable surfaced.
+     */
+    private function buildBalancedTip(): CoachingTip
+    {
+        return $this->makeTip(
+            id: 'balanced_general',
+            headlineKey: 'coaching.tip_balanced_headline',
+            rationaleKey: 'coaching.tip_balanced_rationale',
+            tone: CoachingTip::TONE_INFO,
+            confidence: Confidence::LOW,
+            change: null,
+        );
+    }
+
+    /**
+     * Read the current tactics for one side of the match, falling back to
+     * the engine's defaults so callers never have to handle null.
+     *
+     * @return array{mentality: string, playing_style: string, pressing: string, defensive_line: string}
+     */
+    private function extractTactics(GameMatch $match, string $prefix): array
+    {
+        return [
+            'mentality' => $match->{"{$prefix}_mentality"} ?? Mentality::BALANCED->value,
+            'playing_style' => $match->{"{$prefix}_playing_style"} ?? PlayingStyle::BALANCED->value,
+            'pressing' => $match->{"{$prefix}_pressing"} ?? PressingIntensity::STANDARD->value,
+            'defensive_line' => $match->{"{$prefix}_defensive_line"} ?? DefensiveLineHeight::NORMAL->value,
+        ];
+    }
+
+    /**
+     * @param  array<string, string>|null  $change
+     * @param  array<string, mixed>  $replacements
+     */
+    private function makeTip(
+        string $id,
+        string $headlineKey,
+        string $rationaleKey,
+        string $tone,
+        Confidence $confidence,
+        ?array $change,
+        array $replacements = [],
+    ): CoachingTip {
+        return new CoachingTip(
+            id: $id,
+            headline: __($headlineKey, $replacements),
+            rationale: __($rationaleKey, $replacements),
+            tacticalChange: $change,
+            tone: $tone,
+            confidence: $confidence,
+        );
+    }
+}

--- a/lang/en/coaching.php
+++ b/lang/en/coaching.php
@@ -1,0 +1,53 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Coaching Module — Half-time Advisor
+    |--------------------------------------------------------------------------
+    |
+    | Strings used by the coaching staff layer's half-time tactical advisor.
+    | The advisor inspects first-half state and emits 1-3 tips, each shown
+    | inside the live-match half-time pause block with optional one-click
+    | apply via the existing tactical-actions endpoint.
+    |
+    */
+
+    // Confidence labels attached to each tip.
+    'confidence_high' => 'High',
+    'confidence_medium' => 'Medium',
+    'confidence_low' => 'Low',
+
+    // Half-time advisor panel header.
+    'advisor_title' => 'Coach\'s read',
+    'advisor_apply' => 'Apply',
+    'advisor_dismiss' => 'Dismiss',
+    'advisor_all_dismissed' => 'All tips dismissed.',
+
+    // Result-driven tips (responding to the scoreline at HT).
+    'tip_chasing_headline' => 'We\'re chasing this — push everything forward',
+    'tip_chasing_rationale' => 'Two goals down at the break. Go attacking, press high, and squeeze the field.',
+    'tip_trailing_one_headline' => 'One down — time to take more risks',
+    'tip_trailing_one_rationale' => 'A measured push: more bodies forward, but keep our shape.',
+    'tip_protecting_lead_headline' => 'Protect the cushion',
+    'tip_protecting_lead_rationale' => 'Two-goal lead. Drop the line, ease off the press, and manage the second half.',
+    'tip_one_goal_lead_headline' => 'Don\'t over-commit',
+    'tip_one_goal_lead_rationale' => 'A one-goal lead is fragile. Drop to balanced and keep our shape.',
+
+    // Matchup tips (responding to the opponent's setup).
+    'tip_release_press_headline' => 'They\'re pressing — release the pressure',
+    'tip_release_press_rationale' => 'Drop the line and play more direct to bypass their press.',
+    'tip_break_low_block_headline' => 'They\'re sitting deep — keep the ball',
+    'tip_break_low_block_rationale' => 'Switch to possession to drag them out of shape.',
+    'tip_counter_high_line_headline' => 'Their line is high — hit them on the break',
+    'tip_counter_high_line_rationale' => 'Switch to counter-attack to exploit the space behind their defenders.',
+
+    // Discipline tip (advisory only).
+    'tip_card_risk_headline' => ':count yellows already — careful with challenges',
+    'tip_card_risk_rationale' => 'Consider subbing the booked players if they\'re leading the count.',
+
+    // Fallback tip when nothing notable surfaced.
+    'tip_balanced_headline' => 'No big issues — stay the course',
+    'tip_balanced_rationale' => 'Setup is working. Trust the plan and re-evaluate if the second half changes.',
+];

--- a/lang/es/coaching.php
+++ b/lang/es/coaching.php
@@ -1,0 +1,53 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Módulo de Coaching — Asesor al descanso
+    |--------------------------------------------------------------------------
+    |
+    | Cadenas usadas por el asesor táctico al descanso. El asesor lee el
+    | estado de la primera parte y emite 1-3 consejos que se muestran en el
+    | bloque de pausa del descanso con opción de aplicar en un clic vía el
+    | endpoint de acciones tácticas ya existente.
+    |
+    */
+
+    // Niveles de confianza asociados a cada consejo.
+    'confidence_high' => 'Alta',
+    'confidence_medium' => 'Media',
+    'confidence_low' => 'Baja',
+
+    // Cabecera del panel.
+    'advisor_title' => 'Lectura del segundo entrenador',
+    'advisor_apply' => 'Aplicar',
+    'advisor_dismiss' => 'Descartar',
+    'advisor_all_dismissed' => 'Todos los consejos descartados.',
+
+    // Consejos según resultado al descanso.
+    'tip_chasing_headline' => 'Vamos a remolque — todo hacia delante',
+    'tip_chasing_rationale' => 'Dos goles abajo al descanso. Ofensivo, presión alta y línea adelantada.',
+    'tip_trailing_one_headline' => 'A uno — toca asumir más riesgos',
+    'tip_trailing_one_rationale' => 'Empuje moderado: más gente arriba, pero sin perder la forma.',
+    'tip_protecting_lead_headline' => 'Proteger la renta',
+    'tip_protecting_lead_rationale' => 'Dos goles arriba. Baja la línea, suelta la presión y gestiona la segunda parte.',
+    'tip_one_goal_lead_headline' => 'No te sobreexpongas',
+    'tip_one_goal_lead_rationale' => 'Una renta de un gol es frágil. Equilibrado y mantener la forma.',
+
+    // Consejos por planteamiento del rival.
+    'tip_release_press_headline' => 'Están presionando — libera presión',
+    'tip_release_press_rationale' => 'Baja la línea y juega más directo para superar su presión.',
+    'tip_break_low_block_headline' => 'Se cierran atrás — guarda el balón',
+    'tip_break_low_block_rationale' => 'Pasa a posesión para sacarlos de su bloque.',
+    'tip_counter_high_line_headline' => 'Línea alta — castígalos a la contra',
+    'tip_counter_high_line_rationale' => 'Cambia a contraataque para aprovechar el espacio a su espalda.',
+
+    // Consejo de disciplina (solo informativo).
+    'tip_card_risk_headline' => ':count amarillas ya — cuidado con las entradas',
+    'tip_card_risk_rationale' => 'Plantéate cambiar a los amonestados si lideran las faltas.',
+
+    // Fallback cuando no destaca nada.
+    'tip_balanced_headline' => 'Sin alarmas — mantén el plan',
+    'tip_balanced_rationale' => 'El planteamiento funciona. Confía y revalúa si cambia la segunda parte.',
+];

--- a/resources/js/live-match.js
+++ b/resources/js/live-match.js
@@ -24,6 +24,7 @@ import { createMatchStats } from './modules/match-stats.js';
 import { createAtmosphereGlue } from './modules/atmosphere-glue.js';
 import { createTacticalPanel } from './modules/tactical-panel.js';
 import { createTacticalSubmission } from './modules/tactical-submission.js';
+import { createHalfTimeAdvisor } from './modules/half-time-advisor.js';
 import { createPitchLayout } from './modules/pitch-layout.js';
 import { mixinModule } from './modules/_mixin.js';
 import {
@@ -58,6 +59,7 @@ export default function liveMatch(config) {
     const atmosphere = createAtmosphereGlue(ctx);
     const tacticalPanel = createTacticalPanel(ctx);
     const tacticalSubmission = createTacticalSubmission(ctx);
+    const halfTimeAdvisor = createHalfTimeAdvisor(ctx);
     const pitchLayout = createPitchLayout(ctx);
 
     const component = {
@@ -156,6 +158,10 @@ export default function liveMatch(config) {
         awayPosition: config.awayPosition || null,
         competitionRole: config.competitionRole || 'league',
         competitionName: config.competitionName || '',
+
+        // Half-time advisor: tips precomputed server-side, dismissals tracked client-side.
+        halfTimeTips: config.halfTimeTips || [],
+        halfTimeTipsDismissed: [],
 
         // Pitch visualization config
         formationSlots: config.formationSlots || {},
@@ -827,6 +833,7 @@ export default function liveMatch(config) {
     mixinModule(component, atmosphere);
     mixinModule(component, tacticalPanel);
     mixinModule(component, tacticalSubmission);
+    mixinModule(component, halfTimeAdvisor);
     mixinModule(component, pitchLayout);
 
     return component;

--- a/resources/js/modules/half-time-advisor.js
+++ b/resources/js/modules/half-time-advisor.js
@@ -1,0 +1,50 @@
+/**
+ * Half-time advisor module.
+ *
+ * Wires the "Apply" / "Dismiss" buttons in the half-time tip panel into the
+ * existing tactical-actions pipeline. A tip's `tacticalChange` payload is
+ * staged into the same `pending*` slots the tactical panel uses, then
+ * confirmAllChanges() (from tactical-submission.js) submits to the existing
+ * /tactical-actions endpoint — no new endpoints, no new write paths.
+ */
+export function createHalfTimeAdvisor(ctx) {
+    return {
+        /**
+         * Stage a tip's tactical changes into the same pending slots used by
+         * the tactical panel, then submit through the standard pipeline.
+         * Dismisses the tip on success so it can't be re-applied accidentally.
+         */
+        async applyHalfTimeTip(tip) {
+            const c = ctx();
+
+            if (!tip || !tip.tacticalChange || c.applyingChanges) {
+                return;
+            }
+
+            const change = tip.tacticalChange;
+
+            // Stage each field on the matching pending slot. Fields the tip
+            // doesn't mention stay null so confirmAllChanges() leaves them alone.
+            if (change.mentality !== undefined) c.pendingMentality = change.mentality;
+            if (change.playing_style !== undefined) c.pendingPlayingStyle = change.playing_style;
+            if (change.pressing !== undefined) c.pendingPressing = change.pressing;
+            if (change.defensive_line !== undefined) c.pendingDefLine = change.defensive_line;
+
+            await c.confirmAllChanges();
+
+            // Dismiss only after a successful submission (applyingChanges resets to
+            // false in confirmAllChanges' finally block; tacticalError signals failure).
+            if (!c.tacticalError) {
+                this.dismissHalfTimeTip(tip);
+            }
+        },
+
+        dismissHalfTimeTip(tip) {
+            const c = ctx();
+            if (!tip || !tip.id) return;
+            if (c.halfTimeTipsDismissed.includes(tip.id)) return;
+
+            c.halfTimeTipsDismissed = [...c.halfTimeTipsDismissed, tip.id];
+        },
+    };
+}

--- a/resources/views/components/coaching/half-time-advisor.blade.php
+++ b/resources/views/components/coaching/half-time-advisor.blade.php
@@ -1,0 +1,66 @@
+{{--
+    Half-time advisor panel.
+
+    Reads `halfTimeTips` and `halfTimeTipsDismissed` from the live-match Alpine
+    component. Each tip's "Apply" button stages the recommended tactical change
+    via existing pending-state slots and submits through the standard
+    /tactical-actions pipeline (confirmAllChanges in tactical-submission.js) —
+    no new endpoints, no new write paths.
+--}}
+<div class="px-3 pb-3" x-cloak>
+    <template x-if="halfTimeTips && halfTimeTips.length > 0">
+        <div class="rounded-xl border border-border-default bg-surface-800 overflow-hidden">
+            <div class="px-3 py-2 border-b border-border-default flex items-center gap-2">
+                <span class="w-1.5 h-1.5 rounded-full bg-accent-gold"></span>
+                <span class="text-[10px] font-semibold uppercase tracking-widest text-text-secondary">
+                    {{ __('coaching.advisor_title') }}
+                </span>
+            </div>
+            <ul class="divide-y divide-border-default">
+                <template x-for="tip in halfTimeTips.filter(t => !halfTimeTipsDismissed.includes(t.id))" :key="tip.id">
+                    <li class="px-3 py-2.5">
+                        <div class="flex items-start gap-2.5">
+                            <span
+                                class="w-1.5 h-1.5 rounded-full mt-1.5 shrink-0"
+                                :class="{
+                                    'bg-amber-400': tip.tone === 'warning',
+                                    'bg-accent-green': tip.tone === 'opportunity',
+                                    'bg-sky-400': tip.tone === 'info',
+                                }"
+                            ></span>
+                            <div class="min-w-0 flex-1">
+                                <p class="text-xs font-semibold text-text-body leading-snug" x-text="tip.headline"></p>
+                                <p class="text-[11px] text-text-secondary leading-relaxed mt-0.5" x-text="tip.rationale"></p>
+                                <div class="flex items-center gap-2 mt-2">
+                                    <template x-if="tip.tacticalChange">
+                                        <button
+                                            type="button"
+                                            @click="applyHalfTimeTip(tip)"
+                                            x-bind:disabled="applyingChanges"
+                                            class="text-[10px] font-semibold px-2.5 py-1 rounded-md bg-accent-blue/15 text-accent-blue hover:bg-accent-blue/25 transition disabled:opacity-50"
+                                        >
+                                            {{ __('coaching.advisor_apply') }}
+                                        </button>
+                                    </template>
+                                    <button
+                                        type="button"
+                                        @click="dismissHalfTimeTip(tip)"
+                                        class="text-[10px] font-medium px-2.5 py-1 rounded-md text-text-muted hover:text-text-secondary transition"
+                                    >
+                                        {{ __('coaching.advisor_dismiss') }}
+                                    </button>
+                                </div>
+                            </div>
+                        </div>
+                    </li>
+                </template>
+            </ul>
+            {{-- Empty state once everything is dismissed --}}
+            <template x-if="halfTimeTips.every(t => halfTimeTipsDismissed.includes(t.id))">
+                <p class="px-3 py-3 text-[11px] text-text-muted italic text-center">
+                    {{ __('coaching.advisor_all_dismissed') }}
+                </p>
+            </template>
+        </div>
+    </template>
+</div>

--- a/resources/views/live-match.blade.php
+++ b/resources/views/live-match.blade.php
@@ -97,6 +97,7 @@
                 awayPosition: @js($awayPosition),
                 competitionRole: @js($competitionRole),
                 competitionName: @js($competitionName),
+                halfTimeTips: @js($halfTimeTips),
                 translations: {
                     unsavedTacticalChanges: {!! Js::from(__('game.tactical_unsaved_changes')) !!},
                     extraTime: {!! Js::from(__('game.live_extra_time')) !!},
@@ -369,6 +370,13 @@
                                 <path d="M2.53 3.956A1 1 0 0 0 1 4.804v6.392a1 1 0 0 0 1.53.848l5.113-3.196c.16-.1.279-.233.357-.383v2.73a1 1 0 0 0 1.53.849l5.113-3.196a1 1 0 0 0 0-1.696L9.53 3.956A1 1 0 0 0 8 4.804v2.731a.992.992 0 0 0-.357-.383L2.53 3.956Z" />
                             </svg>
                         </x-secondary-button>
+                    </div>
+
+                    {{-- Half-time advisor: tactical tips with one-click apply.
+                         Sits above the existing half-time control row so the
+                         user reads the assistant before deciding what to do. --}}
+                    <div x-show="phase === 'half_time'">
+                        <x-coaching.half-time-advisor />
                     </div>
 
                     {{-- Half-time pause controls --}}

--- a/tests/Unit/HalfTimeAdvisorServiceTest.php
+++ b/tests/Unit/HalfTimeAdvisorServiceTest.php
@@ -1,0 +1,310 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\Game;
+use App\Models\GameMatch;
+use App\Models\MatchEvent;
+use App\Models\Team;
+use App\Modules\Coaching\DTOs\CoachingTip;
+use App\Modules\Coaching\DTOs\Confidence;
+use App\Modules\Coaching\Services\HalfTimeAdvisorService;
+use App\Modules\Lineup\Enums\DefensiveLineHeight;
+use App\Modules\Lineup\Enums\Mentality;
+use App\Modules\Lineup\Enums\PlayingStyle;
+use App\Modules\Lineup\Enums\PressingIntensity;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+class HalfTimeAdvisorServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private HalfTimeAdvisorService $service;
+
+    private Game $game;
+
+    private Team $userTeam;
+
+    private Team $opponent;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->service = $this->app->make(HalfTimeAdvisorService::class);
+        $this->userTeam = Team::factory()->create();
+        $this->opponent = Team::factory()->create();
+        $this->game = Game::factory()->forTeam($this->userTeam)->create();
+    }
+
+    public function test_returns_chasing_tip_when_two_goals_down(): void
+    {
+        $match = $this->makeMatch(
+            events: [
+                ['minute' => 20, 'type' => MatchEvent::TYPE_GOAL, 'team_id' => $this->opponent->id],
+                ['minute' => 35, 'type' => MatchEvent::TYPE_GOAL, 'team_id' => $this->opponent->id],
+            ],
+        );
+
+        $tipById = $this->indexById($this->service->buildTips($match, $this->game));
+
+        $this->assertArrayHasKey('result_chasing', $tipById);
+        $this->assertEquals(Confidence::HIGH, $tipById['result_chasing']->confidence);
+        $this->assertEquals(Mentality::ATTACKING->value, $tipById['result_chasing']->tacticalChange['mentality']);
+        $this->assertEquals(PressingIntensity::HIGH_PRESS->value, $tipById['result_chasing']->tacticalChange['pressing']);
+    }
+
+    public function test_returns_protecting_lead_tip_when_two_goals_up(): void
+    {
+        $match = $this->makeMatch(
+            userTactics: [
+                'mentality' => Mentality::ATTACKING->value,
+                'pressing' => PressingIntensity::HIGH_PRESS->value,
+                'defensive_line' => DefensiveLineHeight::HIGH_LINE->value,
+            ],
+            events: [
+                ['minute' => 10, 'type' => MatchEvent::TYPE_GOAL, 'team_id' => $this->userTeam->id],
+                ['minute' => 30, 'type' => MatchEvent::TYPE_GOAL, 'team_id' => $this->userTeam->id],
+            ],
+        );
+
+        $tipById = $this->indexById($this->service->buildTips($match, $this->game));
+
+        $this->assertArrayHasKey('result_two_goal_lead', $tipById);
+        $change = $tipById['result_two_goal_lead']->tacticalChange;
+        $this->assertEquals(Mentality::BALANCED->value, $change['mentality']);
+        $this->assertEquals(PressingIntensity::STANDARD->value, $change['pressing']);
+        $this->assertEquals(DefensiveLineHeight::NORMAL->value, $change['defensive_line']);
+    }
+
+    public function test_one_goal_lead_only_intervenes_when_currently_attacking(): void
+    {
+        $matchBalanced = $this->makeMatch(
+            userTactics: ['mentality' => Mentality::BALANCED->value],
+            events: [
+                ['minute' => 20, 'type' => MatchEvent::TYPE_GOAL, 'team_id' => $this->userTeam->id],
+            ],
+        );
+        $matchAttacking = $this->makeMatch(
+            userTactics: ['mentality' => Mentality::ATTACKING->value],
+            events: [
+                ['minute' => 20, 'type' => MatchEvent::TYPE_GOAL, 'team_id' => $this->userTeam->id],
+            ],
+        );
+
+        $balancedIds = $this->indexById($this->service->buildTips($matchBalanced, $this->game));
+        $attackingIds = $this->indexById($this->service->buildTips($matchAttacking, $this->game));
+
+        $this->assertArrayNotHasKey('result_one_goal_lead_attacking', $balancedIds);
+        $this->assertArrayHasKey('result_one_goal_lead_attacking', $attackingIds);
+    }
+
+    public function test_own_goals_credit_the_correct_team(): void
+    {
+        // Opponent scores an own goal → counts as user's goal.
+        $match = $this->makeMatch(
+            events: [
+                ['minute' => 15, 'type' => MatchEvent::TYPE_OWN_GOAL, 'team_id' => $this->opponent->id],
+                ['minute' => 25, 'type' => MatchEvent::TYPE_OWN_GOAL, 'team_id' => $this->opponent->id],
+            ],
+        );
+
+        $tipById = $this->indexById($this->service->buildTips($match, $this->game));
+
+        $this->assertArrayHasKey('result_two_goal_lead', $tipById);
+    }
+
+    public function test_returns_release_press_tip_when_opponent_high_presses_our_high_line(): void
+    {
+        $match = $this->makeMatch(
+            userTactics: ['defensive_line' => DefensiveLineHeight::HIGH_LINE->value],
+            opponentTactics: ['pressing' => PressingIntensity::HIGH_PRESS->value],
+        );
+
+        $tipById = $this->indexById($this->service->buildTips($match, $this->game));
+
+        $this->assertArrayHasKey('matchup_release_press', $tipById);
+        $change = $tipById['matchup_release_press']->tacticalChange;
+        $this->assertEquals(DefensiveLineHeight::NORMAL->value, $change['defensive_line']);
+        $this->assertEquals(PlayingStyle::DIRECT->value, $change['playing_style']);
+    }
+
+    public function test_returns_break_low_block_tip_when_opponent_sits_deep(): void
+    {
+        $match = $this->makeMatch(
+            opponentTactics: ['pressing' => PressingIntensity::LOW_BLOCK->value],
+        );
+
+        $tipById = $this->indexById($this->service->buildTips($match, $this->game));
+
+        $this->assertArrayHasKey('matchup_break_low_block', $tipById);
+        $this->assertEquals(
+            PlayingStyle::POSSESSION->value,
+            $tipById['matchup_break_low_block']->tacticalChange['playing_style'],
+        );
+    }
+
+    public function test_returns_card_risk_tip_advisory_only(): void
+    {
+        $userPlayerId = (string) Str::uuid();
+
+        $match = $this->makeMatch(
+            events: [
+                ['minute' => 18, 'type' => MatchEvent::TYPE_YELLOW_CARD, 'team_id' => $this->userTeam->id, 'player_id' => $userPlayerId],
+                ['minute' => 31, 'type' => MatchEvent::TYPE_YELLOW_CARD, 'team_id' => $this->userTeam->id, 'player_id' => $userPlayerId],
+            ],
+        );
+
+        $tipById = $this->indexById($this->service->buildTips($match, $this->game));
+
+        $this->assertArrayHasKey('discipline_card_risk', $tipById);
+        $this->assertNull(
+            $tipById['discipline_card_risk']->tacticalChange,
+            'Discipline tip should be advisory-only (no apply payload).'
+        );
+    }
+
+    public function test_falls_back_to_balanced_tip_when_nothing_notable(): void
+    {
+        $match = $this->makeMatch();
+
+        $tips = $this->service->buildTips($match, $this->game);
+
+        $this->assertNotEmpty($tips);
+        $this->assertEquals('balanced_general', $tips[0]->id);
+    }
+
+    public function test_caps_tips_at_three(): void
+    {
+        $userPlayerId = (string) Str::uuid();
+
+        $match = $this->makeMatch(
+            userTactics: ['defensive_line' => DefensiveLineHeight::HIGH_LINE->value],
+            opponentTactics: ['pressing' => PressingIntensity::HIGH_PRESS->value],
+            events: [
+                ['minute' => 10, 'type' => MatchEvent::TYPE_GOAL, 'team_id' => $this->opponent->id],
+                ['minute' => 20, 'type' => MatchEvent::TYPE_GOAL, 'team_id' => $this->opponent->id],
+                ['minute' => 30, 'type' => MatchEvent::TYPE_YELLOW_CARD, 'team_id' => $this->userTeam->id, 'player_id' => $userPlayerId],
+                ['minute' => 38, 'type' => MatchEvent::TYPE_YELLOW_CARD, 'team_id' => $this->userTeam->id, 'player_id' => $userPlayerId],
+            ],
+        );
+
+        $this->assertLessThanOrEqual(3, count($this->service->buildTips($match, $this->game)));
+    }
+
+    public function test_ignores_events_after_half_time(): void
+    {
+        // Two opponent goals after 45' should not trigger the chasing tip.
+        $match = $this->makeMatch(
+            events: [
+                ['minute' => 60, 'type' => MatchEvent::TYPE_GOAL, 'team_id' => $this->opponent->id],
+                ['minute' => 70, 'type' => MatchEvent::TYPE_GOAL, 'team_id' => $this->opponent->id],
+            ],
+        );
+
+        $tipById = $this->indexById($this->service->buildTips($match, $this->game));
+        $this->assertArrayNotHasKey('result_chasing', $tipById);
+    }
+
+    public function test_tips_serialise_to_array(): void
+    {
+        $match = $this->makeMatch(
+            events: [
+                ['minute' => 10, 'type' => MatchEvent::TYPE_GOAL, 'team_id' => $this->opponent->id],
+                ['minute' => 30, 'type' => MatchEvent::TYPE_GOAL, 'team_id' => $this->opponent->id],
+            ],
+        );
+
+        $tip = $this->service->buildTips($match, $this->game)[0];
+        $array = $tip->toArray();
+
+        $this->assertArrayHasKey('id', $array);
+        $this->assertArrayHasKey('headline', $array);
+        $this->assertArrayHasKey('rationale', $array);
+        $this->assertArrayHasKey('tacticalChange', $array);
+        $this->assertArrayHasKey('tone', $array);
+        $this->assertArrayHasKey('confidence', $array);
+    }
+
+    /**
+     * Build an in-memory GameMatch with attached events. We don't persist the
+     * match — tests only need the relation to be loaded and tactical fields
+     * present, so an in-memory model with `setRelation('events', ...)` is
+     * cheaper and side-effect-free.
+     *
+     * @param  array<string, string>  $userTactics
+     * @param  array<string, string>  $opponentTactics
+     * @param  array<int, array{minute: int, type: string, team_id: string, player_id?: string}>  $events
+     */
+    private function makeMatch(
+        array $userTactics = [],
+        array $opponentTactics = [],
+        array $events = [],
+    ): GameMatch {
+        $userTactics = array_merge([
+            'mentality' => Mentality::BALANCED->value,
+            'playing_style' => PlayingStyle::BALANCED->value,
+            'pressing' => PressingIntensity::STANDARD->value,
+            'defensive_line' => DefensiveLineHeight::NORMAL->value,
+        ], $userTactics);
+
+        $opponentTactics = array_merge([
+            'mentality' => Mentality::BALANCED->value,
+            'playing_style' => PlayingStyle::BALANCED->value,
+            'pressing' => PressingIntensity::STANDARD->value,
+            'defensive_line' => DefensiveLineHeight::NORMAL->value,
+        ], $opponentTactics);
+
+        // User team is home in these fixtures (irrelevant to the logic, kept
+        // consistent so isHomeTeam() returns true and tactical-prefix lookup
+        // routes home_* fields to the user side).
+        $match = new GameMatch([
+            'game_id' => $this->game->id,
+            'competition_id' => $this->game->competition_id,
+            'round_number' => 1,
+            'home_team_id' => $this->userTeam->id,
+            'away_team_id' => $this->opponent->id,
+            'scheduled_date' => $this->game->current_date,
+            'home_mentality' => $userTactics['mentality'],
+            'home_playing_style' => $userTactics['playing_style'],
+            'home_pressing' => $userTactics['pressing'],
+            'home_defensive_line' => $userTactics['defensive_line'],
+            'away_mentality' => $opponentTactics['mentality'],
+            'away_playing_style' => $opponentTactics['playing_style'],
+            'away_pressing' => $opponentTactics['pressing'],
+            'away_defensive_line' => $opponentTactics['defensive_line'],
+        ]);
+
+        $eventCollection = new Collection();
+        foreach ($events as $eventSpec) {
+            $eventCollection->push(new MatchEvent([
+                'game_id' => $this->game->id,
+                'team_id' => $eventSpec['team_id'],
+                'game_player_id' => $eventSpec['player_id'] ?? (string) Str::uuid(),
+                'minute' => $eventSpec['minute'],
+                'event_type' => $eventSpec['type'],
+            ]));
+        }
+
+        $match->setRelation('events', $eventCollection);
+
+        return $match;
+    }
+
+    /**
+     * @param  array<int, CoachingTip>  $tips
+     * @return array<string, CoachingTip>
+     */
+    private function indexById(array $tips): array
+    {
+        $indexed = [];
+        foreach ($tips as $tip) {
+            $indexed[$tip->id] = $tip;
+        }
+
+        return $indexed;
+    }
+}


### PR DESCRIPTION
Introduces an `app/Modules/Coaching/` module that turns the existing
`predictOpponentTactics` payload into a confidence-gated scouting report
shown on the lineup screen's coach assistant panel. Items cover the
opponent's likely formation, tactical setup (style + pressing + defensive
line), mentality, top-scorer threat, and weaknesses (suspensions/injuries,
fatigue, or quality shortfall). Each item carries HIGH / MEDIUM / LOW
confidence so users see a probabilistic read rather than a deterministic
oracle, dodging both the agency-vs-cracking trap and any change to the
match simulation engine.

Phase 1 ships a single in-house assistant; Phase 2 will scale report
depth and confidence by an assistant's profile when the staff hiring
layer lands.