### PR TITLE
Show ghost slots and connectors for predetermined cup brackets

### DIFF
--- a/app/Http/Views/ShowCompetition.php
+++ b/app/Http/Views/ShowCompetition.php
@@ -6,6 +6,7 @@ use App\Models\Competition;
 use App\Models\CompetitionEntry;
 use App\Models\Game;
 use App\Modules\Competition\Services\CompetitionViewService;
+use App\Modules\Competition\Services\WorldCupKnockoutGenerator;
 use App\Modules\Match\Services\SyntheticLeagueResolver;
 
 class ShowCompetition
@@ -13,6 +14,7 @@ class ShowCompetition
     public function __construct(
         private readonly CompetitionViewService $competitionViewService,
         private readonly SyntheticLeagueResolver $syntheticLeagueResolver,
+        private readonly WorldCupKnockoutGenerator $worldCupKnockoutGenerator,
     ) {}
 
     public function __invoke(string $gameId, string $competitionId)
@@ -187,6 +189,8 @@ class ShowCompetition
             'groupStageComplete' => $groupStageComplete,
             'knockoutRounds' => $knockoutRounds,
             'knockoutTies' => $knockoutTies,
+            'knockoutSlotsByRound' => $this->worldCupKnockoutGenerator->getSlotsPerRound(),
+            'knockoutDisplayOrderByRound' => $this->worldCupKnockoutGenerator->getDisplayOrderPerRound(),
             'playerTie' => $playerTie,
             'knockoutStatus' => $knockoutStatus,
             'otherLeagues' => $otherLeagues,

--- a/app/Modules/Competition/Services/WorldCupKnockoutGenerator.php
+++ b/app/Modules/Competition/Services/WorldCupKnockoutGenerator.php
@@ -347,6 +347,97 @@ class WorldCupKnockoutGenerator
     }
 
     /**
+     * Match numbers for each round in **bracket display order** — i.e. the order in which
+     * slots should appear top-to-bottom so that paired ties (whose winners meet in the next
+     * round) sit adjacent. Derived by walking bracket.json from the final back to R32.
+     *
+     * Without this, sorting purely by `bracket_position` produces visually misaligned pairs
+     * (e.g. match 73 pairs with match 75 in R16, not match 74).
+     *
+     * @return array<int, array<int>>  round_number => [match_number, ...] in display order
+     */
+    public function getDisplayOrderPerRound(): array
+    {
+        $bracket = $this->loadBracket();
+
+        $finalMatches = array_map(fn ($m) => $m['match_number'], $bracket['final'] ?? []);
+
+        $orderByRound = [self::ROUND_FINAL => $finalMatches];
+
+        $rounds = [
+            self::ROUND_SEMI_FINALS => 'semi_finals',
+            self::ROUND_QUARTER_FINALS => 'quarter_finals',
+            self::ROUND_OF_16 => 'round_of_16',
+            self::ROUND_OF_32 => 'round_of_32',
+        ];
+
+        $currentRound = self::ROUND_FINAL;
+        foreach ($rounds as $roundNumber => $roundKey) {
+            $parentOrder = $orderByRound[$currentRound];
+            $parentLookup = [];
+            foreach ($bracket[$this->roundKey($currentRound)] ?? [] as $match) {
+                $parentLookup[$match['match_number']] = $match;
+            }
+
+            $childOrder = [];
+            foreach ($parentOrder as $parentMatchNumber) {
+                $parent = $parentLookup[$parentMatchNumber] ?? null;
+                if (! $parent) {
+                    continue;
+                }
+                foreach ([$parent['home'], $parent['away']] as $ref) {
+                    if (preg_match('/^W(\d+)$/', $ref, $m)) {
+                        $childOrder[] = (int) $m[1];
+                    }
+                }
+            }
+
+            $orderByRound[$roundNumber] = $childOrder;
+            $currentRound = $roundNumber;
+        }
+
+        // Third-place is rendered out-of-band, but expose its match number(s) for completeness.
+        $orderByRound[self::ROUND_THIRD_PLACE] = array_map(
+            fn ($m) => $m['match_number'],
+            $bracket['third_place'] ?? []
+        );
+
+        return $orderByRound;
+    }
+
+    private function roundKey(int $round): string
+    {
+        return match ($round) {
+            self::ROUND_OF_32 => 'round_of_32',
+            self::ROUND_OF_16 => 'round_of_16',
+            self::ROUND_QUARTER_FINALS => 'quarter_finals',
+            self::ROUND_SEMI_FINALS => 'semi_finals',
+            self::ROUND_THIRD_PLACE => 'third_place',
+            self::ROUND_FINAL => 'final',
+        };
+    }
+
+    /**
+     * Slot count per round, derived from bracket.json. Used by the bracket UI to render
+     * empty placeholders for rounds whose CupTie rows haven't been generated yet.
+     *
+     * @return array<int, int>  round_number => slot count
+     */
+    public function getSlotsPerRound(): array
+    {
+        $bracket = $this->loadBracket();
+
+        return [
+            self::ROUND_OF_32 => count($bracket['round_of_32'] ?? []),
+            self::ROUND_OF_16 => count($bracket['round_of_16'] ?? []),
+            self::ROUND_QUARTER_FINALS => count($bracket['quarter_finals'] ?? []),
+            self::ROUND_SEMI_FINALS => count($bracket['semi_finals'] ?? []),
+            self::ROUND_THIRD_PLACE => count($bracket['third_place'] ?? []),
+            self::ROUND_FINAL => count($bracket['final'] ?? []),
+        ];
+    }
+
+    /**
      * Get teams that qualified from the group stage (top 2 per group + best 8 third-place).
      *
      * @return array<string> Team IDs

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -678,6 +678,38 @@ input[type="radio"]:checked {
     scrollbar-width: none;
 }
 
+/* Cup bracket: connector lines for predetermined-bracket cups (World Cup) */
+.cup-bracket__pair--has-out {
+    position: relative;
+}
+.cup-bracket__pair--has-out::after {
+    content: "";
+    position: absolute;
+    top: 25%;
+    bottom: 25%;
+    right: calc(var(--connector-w) * -0.5);
+    border-right: 1px solid var(--border-strong);
+}
+.cup-bracket__cell--has-in {
+    position: relative;
+}
+.cup-bracket__cell--has-in::before {
+    content: "";
+    position: absolute;
+    top: 50%;
+    left: calc(var(--connector-w) * -1);
+    width: var(--connector-w);
+    border-top: 1px solid var(--border-strong);
+}
+.cup-bracket__pair--has-out.cup-bracket__pair--ghost-out::after {
+    border-right-style: dashed;
+    border-right-color: var(--border-default);
+}
+.cup-bracket__cell--has-in.cup-bracket__cell--ghost::before {
+    border-top-style: dashed;
+    border-top-color: var(--border-default);
+}
+
 /* Mobile: larger touch targets for range slider thumbs */
 @media (max-width: 767px) {
     .dual-range input[type="range"]::-webkit-slider-thumb {

--- a/resources/views/components/cup-bracket.blade.php
+++ b/resources/views/components/cup-bracket.blade.php
@@ -1,36 +1,167 @@
-@props(['rounds', 'tiesByRound', 'playerTeamId'])
+@props([
+    'rounds',
+    'tiesByRound',
+    'playerTeamId',
+    'mode' => 'draw',                  // 'draw' = round-by-round (Copa del Rey) | 'fixed' = predetermined bracket (World Cup)
+    'slotsByRound' => null,            // array<int, int>  round_number => slot count, required when mode='fixed'
+    'displayOrderByRound' => null,     // array<int, array<int>>  round_number => [match_number,...] in bracket-tree order
+])
+
+@php
+    $isFixed = $mode === 'fixed' && is_array($slotsByRound) && is_array($displayOrderByRound);
+
+    if ($isFixed) {
+        // 3rd-place ties branch off the SF losers, sharing the SF parent with the Final.
+        // Render them out-of-band below the main bracket so connectors flow cleanly SF → Final.
+        $thirdPlaceRound = $rounds->first(fn ($r) => $r->name === 'cup.third_place');
+        $bracketRounds = $rounds->reject(fn ($r) => $r->name === 'cup.third_place')->values();
+
+        // Build a per-round lookup of match_number → CupTie for fast slot resolution.
+        $tiesByMatchNumber = [];
+        foreach ($tiesByRound as $roundNumber => $roundTies) {
+            $tiesByMatchNumber[$roundNumber] = $roundTies->keyBy('bracket_position');
+        }
+
+        // WC2026 generates rounds atomically — either all ties for a round exist or none.
+        // We treat the connector style as a per-round flag: solid when both endpoints exist.
+        $roundHasTies = [];
+        foreach ($rounds as $r) {
+            $roundHasTies[$r->round] = $tiesByRound->get($r->round, collect())->isNotEmpty();
+        }
+
+        // Column height drives every round's `justify-around` distribution. Allocate 5rem per
+        // first-round slot — card height is ~4.5rem, leaving ~0.5rem between adjacent R32 cards.
+        $maxSlots = max($slotsByRound ?: [1]);
+        $columnHeightRem = max(16, $maxSlots * 5);
+    }
+@endphp
 
 <x-section-card :title="__('cup.bracket')">
-    <div class="overflow-x-auto p-4 md:p-5">
-        <div class="flex gap-4" style="min-width: fit-content;">
-            @foreach($rounds as $round)
-                @php $ties = $tiesByRound->get($round->round, collect()); @endphp
-                <div class="shrink-0 w-64">
-                    <div class="text-center mb-4">
-                        <h4 class="font-heading text-sm font-semibold uppercase tracking-wide text-text-body">{{ __($round->name) }}</h4>
-                        <div class="text-[10px] text-text-muted mt-0.5">
-                            {{ $round->firstLegDate->format('d M') }}
-                            @if($round->twoLegged)
-                                / {{ $round->secondLegDate->format('d M') }}
-                            @endif
+    @if($isFixed)
+        <div class="overflow-x-auto p-4 md:p-5">
+            <div
+                class="cup-bracket flex"
+                style="min-width: fit-content; --col-h: {{ $columnHeightRem }}rem; --connector-w: 1rem;"
+            >
+                @foreach($bracketRounds as $idx => $round)
+                    @php
+                        $slots = $slotsByRound[$round->round] ?? 0;
+                        $displayOrder = $displayOrderByRound[$round->round] ?? [];
+                        $tieLookup = $tiesByMatchNumber[$round->round] ?? collect();
+                        $isLastRound = $idx === $bracketRounds->count() - 1;
+                        $cardsPerPair = $isLastRound ? 1 : 2;
+                        $pairCount = max(1, (int) ceil($slots / $cardsPerPair));
+                        $hasIncomingConnector = $idx > 0;
+                        $hasOutgoingConnector = ! $isLastRound;
+
+                        $prevRound = $idx > 0 ? $bracketRounds[$idx - 1] : null;
+                        $nextRound = ! $isLastRound ? $bracketRounds[$idx + 1] : null;
+                        $incomingGhost = $hasIncomingConnector
+                            && ! ($roundHasTies[$round->round] && $roundHasTies[$prevRound->round]);
+                        $outgoingGhost = $hasOutgoingConnector
+                            && ! ($roundHasTies[$round->round] && $roundHasTies[$nextRound->round]);
+                    @endphp
+                    <div class="cup-bracket__col shrink-0 w-64 flex flex-col" @if($hasIncomingConnector) style="margin-left: var(--connector-w);" @endif>
+                        <div class="text-center mb-3">
+                            <h4 class="font-heading text-sm font-semibold uppercase tracking-wide text-text-body">{{ __($round->name) }}</h4>
+                            <div class="text-[10px] text-text-muted mt-0.5">
+                                {{ $round->firstLegDate->format('d M') }}
+                                @if($round->twoLegged)
+                                    / {{ $round->secondLegDate->format('d M') }}
+                                @endif
+                            </div>
+                        </div>
+
+                        <div class="cup-bracket__column-body flex flex-col" style="height: var(--col-h);">
+                            @for($pairIdx = 0; $pairIdx < $pairCount; $pairIdx++)
+                                <div
+                                    @class([
+                                        'cup-bracket__pair flex flex-col justify-around flex-1 min-h-0',
+                                        'cup-bracket__pair--has-out' => $hasOutgoingConnector,
+                                        'cup-bracket__pair--ghost-out' => $outgoingGhost,
+                                    ])
+                                >
+                                    @for($cardIdx = 0; $cardIdx < $cardsPerPair; $cardIdx++)
+                                        @php
+                                            $slotIndex = $pairIdx * $cardsPerPair + $cardIdx;
+                                            $matchNumber = $displayOrder[$slotIndex] ?? null;
+                                            $tie = $matchNumber !== null ? $tieLookup->get($matchNumber) : null;
+                                        @endphp
+                                        <div @class([
+                                            'cup-bracket__cell',
+                                            'cup-bracket__cell--has-in' => $hasIncomingConnector,
+                                            'cup-bracket__cell--ghost' => $incomingGhost,
+                                        ])>
+                                            @if($tie)
+                                                <x-cup-tie-card :tie="$tie" :player-team-id="$playerTeamId" />
+                                            @else
+                                                <x-cup-tie-card-ghost />
+                                            @endif
+                                        </div>
+                                    @endfor
+                                </div>
+                            @endfor
                         </div>
                     </div>
+                @endforeach
+            </div>
+        </div>
 
-                    @if($ties->isEmpty())
-                        <div class="p-4 text-center border border-dashed border-border-strong rounded-lg">
-                            <div class="text-text-muted text-xs">{{ __('cup.draw_pending') }}</div>
-                        </div>
+        @if($thirdPlaceRound)
+            @php
+                $thirdTies = $tiesByRound->get($thirdPlaceRound->round, collect())->values();
+            @endphp
+            <div class="px-4 md:px-5 pb-4">
+                <div class="flex items-center gap-3">
+                    <div class="flex-1 border-t border-dashed border-border-default"></div>
+                    <div class="text-[10px] uppercase tracking-wide text-text-muted font-heading">
+                        {{ __($thirdPlaceRound->name) }}
+                        <span class="ml-1 normal-case tracking-normal">{{ $thirdPlaceRound->firstLegDate->format('d M') }}</span>
+                    </div>
+                    <div class="flex-1 border-t border-dashed border-border-default"></div>
+                </div>
+                <div class="mt-3 max-w-xs mx-auto">
+                    @if($thirdTies->isEmpty())
+                        <x-cup-tie-card-ghost />
                     @else
-                        <div class="space-y-2">
-                            @foreach($ties as $tie)
-                                <x-cup-tie-card :tie="$tie" :player-team-id="$playerTeamId" />
-                            @endforeach
-                        </div>
+                        <x-cup-tie-card :tie="$thirdTies->first()" :player-team-id="$playerTeamId" />
                     @endif
                 </div>
-            @endforeach
+            </div>
+        @endif
+    @else
+        {{-- Draw mode: round-by-round draws (e.g. Copa del Rey). Empty rounds show "draw pending". --}}
+        <div class="overflow-x-auto p-4 md:p-5">
+            <div class="flex gap-4" style="min-width: fit-content;">
+                @foreach($rounds as $round)
+                    @php $ties = $tiesByRound->get($round->round, collect()); @endphp
+                    <div class="shrink-0 w-64">
+                        <div class="text-center mb-4">
+                            <h4 class="font-heading text-sm font-semibold uppercase tracking-wide text-text-body">{{ __($round->name) }}</h4>
+                            <div class="text-[10px] text-text-muted mt-0.5">
+                                {{ $round->firstLegDate->format('d M') }}
+                                @if($round->twoLegged)
+                                    / {{ $round->secondLegDate->format('d M') }}
+                                @endif
+                            </div>
+                        </div>
+
+                        @if($ties->isEmpty())
+                            <div class="p-4 text-center border border-dashed border-border-strong rounded-lg">
+                                <div class="text-text-muted text-xs">{{ __('cup.draw_pending') }}</div>
+                            </div>
+                        @else
+                            <div class="space-y-2">
+                                @foreach($ties as $tie)
+                                    <x-cup-tie-card :tie="$tie" :player-team-id="$playerTeamId" />
+                                @endforeach
+                            </div>
+                        @endif
+                    </div>
+                @endforeach
+            </div>
         </div>
-    </div>
+    @endif
 
     {{-- Legend --}}
     <div class="px-4 md:px-5 py-3 border-t border-border-default">

--- a/resources/views/components/cup-tie-card-ghost.blade.php
+++ b/resources/views/components/cup-tie-card-ghost.blade.php
@@ -1,0 +1,10 @@
+{{--
+    Empty placeholder slot for a future tie in a predetermined bracket.
+    Matches the outer geometry of <x-cup-tie-card> (two stacked rows of py-2 + 1.25rem
+    crest height = ~2.25rem each) so bracket connectors align with real and ghost
+    slots interchangeably.
+--}}
+<div {{ $attributes->merge(['class' => 'rounded-lg overflow-hidden border border-dashed border-border-strong']) }}>
+    <div class="px-2.5 py-2 h-[2.25rem]"></div>
+    <div class="px-2.5 py-2 h-[2.25rem] border-t border-dashed border-border-default"></div>
+</div>

--- a/resources/views/group-stage-cup.blade.php
+++ b/resources/views/group-stage-cup.blade.php
@@ -105,7 +105,10 @@
                 <x-cup-bracket
                     :rounds="$knockoutRounds"
                     :ties-by-round="$knockoutTies"
+                    :slots-by-round="$knockoutSlotsByRound"
+                    :display-order-by-round="$knockoutDisplayOrderByRound"
                     :player-team-id="$game->team_id"
+                    mode="fixed"
                 />
             @endif
         </div>


### PR DESCRIPTION
The cup bracket component now has a 'fixed' mode for cups whose entire knockout tree is known up-front (currently the World Cup). Empty rounds render dashed empty slots with connector lines back to their parents instead of "Sorteo pendiente", which was misleading — there is no draw to wait for.

Round-by-round draw cups (Copa del Rey) keep the previous behavior.