### PR TITLE
Mark remaining unmigrated users completed on beta cutover

### DIFF
--- a/database/migrations/2026_05_10_000001_mark_remaining_unmigrated_users_completed.php
+++ b/database/migrations/2026_05_10_000001_mark_remaining_unmigrated_users_completed.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Beta cutover cleanup. After beta.virtuafc.com is disconnected and the DNS
+ * is redirected to play.virtuafc.com, no user can complete a real import —
+ * the export endpoints are gone. Flip every remaining unmigrated user to
+ * `completed` so RequireMigrationOnImport stops redirecting them to the
+ * import page; they land on a normal (empty) dashboard instead, the same
+ * experience a brand-new signup gets.
+ *
+ * Merge this migration only AFTER the export deployment is offline. Running
+ * it earlier would short-circuit legitimate in-flight migrations.
+ *
+ * Once this has run on production, MIGRATION_MODE can safely be set to
+ * `off` — the middleware no-ops for `completed` users regardless of mode.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        DB::connection('pgsql_control')
+            ->table('users')
+            ->whereIn('migration_status', ['pending', 'in_progress', 'failed'])
+            ->update([
+                'migration_status' => 'completed',
+                'migration_completed_at' => now(),
+            ]);
+    }
+
+    public function down(): void
+    {
+        // Irreversible: we don't record which users were originally in which
+        // pre-cutover state, so there's no honest way to restore it.
+    }
+};


### PR DESCRIPTION
After beta.virtuafc.com is disconnected, no user can finish an import
(the export endpoints are gone). This data migration flips every
pending/in_progress/failed user to completed so they bypass the import
page entirely and land on a normal empty dashboard. Once deployed,
MIGRATION_MODE can be set to off.

Merge only after the export deployment is offline.