### PR TITLE
Increment appearances for auto-subs during live-match resimulation

### DIFF
--- a/app/Modules/Match/Services/MatchResimulationService.php
+++ b/app/Modules/Match/Services/MatchResimulationService.php
@@ -736,6 +736,7 @@ class MatchResimulationService
         // Update player stats
         $statIncrements = [];
         $specialEvents = [];
+        $subbedInPlayerIds = [];
 
         foreach ($events as $event) {
             $playerId = $event->gamePlayerId;
@@ -767,6 +768,16 @@ class MatchResimulationService
                 case 'injury':
                     $specialEvents[] = $event;
                     break;
+                case 'substitution':
+                    // Mirrors MatchResultProcessor::bulkUpdateAppearances and
+                    // TacticalChangeService: subbed-in players get an appearance.
+                    // revertEventsAfterMinute() decrements on revert, so without
+                    // this the count drifts negative across resimulations.
+                    $playerInId = $event->metadata['player_in_id'] ?? null;
+                    if ($playerInId !== null) {
+                        $subbedInPlayerIds[] = $playerInId;
+                    }
+                    break;
             }
         }
 
@@ -782,6 +793,10 @@ class MatchResimulationService
         $validIncrements = array_intersect_key($statIncrements, $players->all());
         $validIncrements = array_filter($validIncrements, fn ($inc) => ! empty($inc));
         GamePlayerMatchState::bulkIncrementStats($validIncrements);
+
+        if (! empty($subbedInPlayerIds)) {
+            GamePlayerMatchState::bulkIncrementAppearances(array_values(array_unique($subbedInPlayerIds)));
+        }
 
         // Process special events
         // Skip card suspensions for pre-season matches (cards are recorded but don't carry over)

--- a/tests/Feature/SkipMatchToEndTest.php
+++ b/tests/Feature/SkipMatchToEndTest.php
@@ -154,6 +154,25 @@ class SkipMatchToEndTest extends TestCase
             $userSubsInJson,
             'Rebuilt substitutions JSON must reflect the newly-generated user auto-subs',
         );
+
+        // Each subbed-in player must accumulate an appearance — the same
+        // bookkeeping that manual subs (TacticalChangeService) and batch
+        // matchday advance (MatchResultProcessor::bulkUpdateAppearances) do.
+        $playerInIds = $userTeamSubsAfter
+            ->pluck('metadata.player_in_id')
+            ->filter()
+            ->all();
+        $this->assertNotEmpty($playerInIds, 'Auto-subs must record a player_in_id');
+
+        $appearancesByPlayer = \App\Models\GamePlayerMatchState::whereIn('game_player_id', $playerInIds)
+            ->pluck('appearances', 'game_player_id');
+        foreach ($playerInIds as $inId) {
+            $this->assertSame(
+                1,
+                $appearancesByPlayer[$inId] ?? 0,
+                "Subbed-in player {$inId} must have appearances incremented to 1",
+            );
+        }
     }
 
     public function test_skip_to_end_is_noop_when_user_has_used_all_subs(): void


### PR DESCRIPTION
MatchResimulationService::applyNewEvents handled goals, cards, and
injuries but never incremented appearances for substitution events.
revertEventsAfterMinute already decrements on revert, so the count
would drift negative across resimulations. The bug was most visible in
preseason where Skip-to-end auto-subs the user's bench, but it equally
affected opponent auto-subs in any live match advance.