### PR TITLE
Convert reassigned yellow into a red when the player is already booked

### DIFF
--- a/app/Modules/Match/Services/MatchSimulator.php
+++ b/app/Modules/Match/Services/MatchSimulator.php
@@ -463,7 +463,7 @@ class MatchSimulator
         $allHomePlayers = $this->buildAllPlayersSeen($initialHomePlayers, $initialHomeBench, $allEvents, $homeTeam->id);
         $allAwayPlayers = $this->buildAllPlayersSeen($initialAwayPlayers, $initialAwayBench, $allEvents, $awayTeam->id);
         $allEvents = $this->reassignEventsFromUnavailablePlayers(
-            $allEvents, $allHomePlayers, $allAwayPlayers, $homeTeam->id, $awayTeam->id
+            $allEvents, $allHomePlayers, $allAwayPlayers, $homeTeam->id, $awayTeam->id, $existingYellowPlayerIds
         );
 
         // Apply xG adjustment using accumulated totals from all periods
@@ -971,7 +971,7 @@ class MatchSimulator
         $allHomePlayers = $this->buildAllPlayersSeen($initialHomePlayers, $initialHomeBench, $allEvents, $homeTeam->id);
         $allAwayPlayers = $this->buildAllPlayersSeen($initialAwayPlayers, $initialAwayBench, $allEvents, $awayTeam->id);
         $allEvents = $this->reassignEventsFromUnavailablePlayers(
-            $allEvents, $allHomePlayers, $allAwayPlayers, $homeTeam->id, $awayTeam->id
+            $allEvents, $allHomePlayers, $allAwayPlayers, $homeTeam->id, $awayTeam->id, $existingYellowPlayerIds
         );
 
         // Apply xG adjustment using accumulated totals from all periods
@@ -1020,6 +1020,7 @@ class MatchSimulator
         Collection $awayPlayers,
         string $homeTeamId,
         string $awayTeamId,
+        array $existingYellowPlayerIds = [],
     ): Collection {
         // Track sub-outs and red cards separately so that a red_card event doesn't
         // treat itself as the reason to reassign itself. Red cards still exclude
@@ -1029,6 +1030,14 @@ class MatchSimulator
         $redRemovedAt = [];
         // Build map of player_id => minute they entered (substituted in)
         $enteredAt = [];
+        // Track which players already have a yellow card. Seeded from
+        // prior-period yellows so a reassignment that lands on an already-booked
+        // player can be converted into a second-yellow red instead of silently
+        // producing two yellow cards on the same player.
+        $yellowedAt = [];
+        foreach ($existingYellowPlayerIds as $priorYellowPlayerId) {
+            $yellowedAt[$priorYellowPlayerId] = 0;
+        }
 
         foreach ($events as $event) {
             if ($event->type === 'substitution') {
@@ -1044,6 +1053,11 @@ class MatchSimulator
                 $playerId = $event->gamePlayerId;
                 if (! isset($redRemovedAt[$playerId]) || $event->minute < $redRemovedAt[$playerId]) {
                     $redRemovedAt[$playerId] = $event->minute;
+                }
+            } elseif ($event->type === 'yellow_card') {
+                $playerId = $event->gamePlayerId;
+                if (! isset($yellowedAt[$playerId]) || $event->minute < $yellowedAt[$playerId]) {
+                    $yellowedAt[$playerId] = $event->minute;
                 }
             }
         }
@@ -1064,7 +1078,7 @@ class MatchSimulator
 
         $reassignableTypes = ['goal', 'assist', 'yellow_card', 'red_card', 'own_goal', 'penalty_missed'];
 
-        return $events->map(function (MatchEventData $event) use ($subRemovedAt, $redRemovedAt, $removedAt, $enteredAt, $homePlayers, $awayPlayers, $homeTeamId, $awayTeamId, $reassignableTypes) {
+        return $events->map(function (MatchEventData $event) use ($subRemovedAt, &$redRemovedAt, &$removedAt, $enteredAt, &$yellowedAt, $homePlayers, $awayPlayers, $homeTeamId, $awayTeamId, $reassignableTypes) {
             if (! in_array($event->type, $reassignableTypes)) {
                 return $event;
             }
@@ -1135,6 +1149,30 @@ class MatchSimulator
                 // attributed to a player who wasn't on the pitch. Returning null
                 // is filtered out after the map.
                 return null;
+            }
+
+            // A reassigned yellow that lands on a player who already has a
+            // yellow earlier in this match must be logged as a second-yellow
+            // red — otherwise the player would silently accumulate two yellows
+            // and stay on the pitch.
+            if ($event->type === 'yellow_card'
+                && isset($yellowedAt[$replacement->id])
+                && $yellowedAt[$replacement->id] < $event->minute
+            ) {
+                if (! isset($redRemovedAt[$replacement->id]) || $event->minute < $redRemovedAt[$replacement->id]) {
+                    $redRemovedAt[$replacement->id] = $event->minute;
+                }
+                if (! isset($removedAt[$replacement->id]) || $event->minute < $removedAt[$replacement->id]) {
+                    $removedAt[$replacement->id] = $event->minute;
+                }
+
+                return MatchEventData::redCard($event->teamId, $replacement->id, $event->minute, true);
+            }
+
+            if ($event->type === 'yellow_card') {
+                if (! isset($yellowedAt[$replacement->id]) || $event->minute < $yellowedAt[$replacement->id]) {
+                    $yellowedAt[$replacement->id] = $event->minute;
+                }
             }
 
             return match ($event->type) {
@@ -2149,7 +2187,7 @@ class MatchSimulator
             );
 
             $events = $this->reassignEventsFromUnavailablePlayers(
-                $events, $homePlayers, $awayPlayers, $homeTeam->id, $awayTeam->id
+                $events, $homePlayers, $awayPlayers, $homeTeam->id, $awayTeam->id, $existingYellowPlayerIds
             );
         } elseif ($homePlayers->isNotEmpty() || $awayPlayers->isNotEmpty()) {
             // One team has no players (e.g. lower-division cup opponent).

--- a/tests/Unit/OffPitchEventReassignmentTest.php
+++ b/tests/Unit/OffPitchEventReassignmentTest.php
@@ -125,6 +125,69 @@ class OffPitchEventReassignmentTest extends TestCase
         }
     }
 
+    public function test_a_player_never_receives_two_yellows_without_being_sent_off(): void
+    {
+        // Crank yellows and injuries to maximise the chance of the reassignment
+        // pass landing a "redirected" yellow on a teammate who was already
+        // booked earlier in the match. Without the second-yellow check inside
+        // reassignEventsFromUnavailablePlayers, this would produce two yellow
+        // events on the same player with no accompanying red.
+        config([
+            'match_simulation.injury_chance' => 100,
+            'match_simulation.yellow_cards_per_team' => 6,
+        ]);
+
+        $game = Game::factory()->create(['current_date' => '2025-10-01']);
+        $homeTeam = Team::factory()->create();
+        $awayTeam = Team::factory()->create();
+
+        $homePlayers = $this->createLineup($game, $homeTeam, 11, 75);
+        $awayPlayers = $this->createLineup($game, $awayTeam, 11, 75);
+        $homeBench = $this->createBenchPlayers($game, $homeTeam, 7, 72);
+        $awayBench = $this->createBenchPlayers($game, $awayTeam, 7, 72);
+
+        for ($i = 0; $i < 30; $i++) {
+            $output = $this->simulator->simulate(
+                $homeTeam, $awayTeam,
+                $homePlayers, $awayPlayers,
+                Formation::F_4_4_2, Formation::F_4_4_2,
+                Mentality::BALANCED, Mentality::BALANCED,
+                $game,
+                homeBenchPlayers: $homeBench,
+                awayBenchPlayers: $awayBench,
+            );
+
+            $yellowsByPlayer = [];
+            $redsByPlayer = [];
+            foreach ($output->result->events as $event) {
+                if ($event->type === 'yellow_card') {
+                    $yellowsByPlayer[$event->gamePlayerId] = ($yellowsByPlayer[$event->gamePlayerId] ?? 0) + 1;
+                } elseif ($event->type === 'red_card') {
+                    $redsByPlayer[$event->gamePlayerId] = true;
+                }
+            }
+
+            foreach ($yellowsByPlayer as $playerId => $count) {
+                $this->assertLessThanOrEqual(
+                    1,
+                    $count,
+                    "Player $playerId received $count yellow cards in a single match without being expelled (iteration $i). A second yellow must convert into a red_card with second_yellow=true.",
+                );
+
+                if ($count >= 2) {
+                    // Belt-and-braces: even if the count assertion above were to
+                    // be relaxed in the future, two yellows must still be
+                    // accompanied by a red card for the same player.
+                    $this->assertArrayHasKey(
+                        $playerId,
+                        $redsByPlayer,
+                        "Player $playerId has $count yellow cards but no red_card event (iteration $i).",
+                    );
+                }
+            }
+        }
+    }
+
     /**
      * Assert that no gameplay event occurs after the player was subbed off.
      *


### PR DESCRIPTION
## Summary
- Fix bug where a player could accumulate two `yellow_card` events in the same match without being sent off
- Cause: `MatchSimulator::reassignEventsFromUnavailablePlayers()` picks a teammate when a card targets someone who has been subbed off, but never checked whether the picked teammate already had a yellow earlier in the match
- The reassignment now tracks yellow-card history (seeded from prior-period yellows) and converts a reassigned yellow into a `red_card` with `second_yellow=true` when the replacement is already booked. The newly red-carded player is also added to the in-pass removal map so subsequent events exclude them
- Added regression test `test_a_player_never_receives_two_yellows_without_being_sent_off` that cranks injury and yellow rates and asserts no player ever ends a match with ≥2 yellows and no red

## Test plan
- [ ] CI runs `tests/Unit/OffPitchEventReassignmentTest.php` and the new case passes
- [ ] Spot-check a live match in dev with a high-yellow seed and confirm a 2nd-yellow recipient is removed from the pitch and shown with the "second yellow" red-card label

🤖 Generated with [Claude Code](https://claude.com/claude-code)