### PR TITLE
Lock each non-user league to a single standings source

### DIFF
--- a/app/Modules/Competition/Playoffs/PrimeraRFEFPlayoffGenerator.php
+++ b/app/Modules/Competition/Playoffs/PrimeraRFEFPlayoffGenerator.php
@@ -264,6 +264,14 @@ class PrimeraRFEFPlayoffGenerator implements PlayoffGenerator
      * Reserve teams whose parent club plays in ESP2 are skipped; the next
      * eligible team slides into their playoff slot.
      *
+     * Lane invariant: the "GameStanding first, SimulatedSeason fallback"
+     * order is load-bearing. Per (game, league, season) only one source ever
+     * gets populated — SyntheticLeagueResolver refuses to write standings
+     * once a SimulatedSeason exists, and SeasonSimulationProcessor refuses
+     * to write SimulatedSeason once real standings exist. PrimeraRFEFPromotionRule
+     * uses the same preference order, so the bracket draw and the direct-
+     * promotion read always agree on positions.
+     *
      * @return array<string> Team UUIDs in seed order [2nd, 3rd, 4th, 5th].
      */
     private function eligibleTopTeams(

--- a/app/Modules/Competition/Promotions/PrimeraRFEFPromotionRule.php
+++ b/app/Modules/Competition/Promotions/PrimeraRFEFPromotionRule.php
@@ -238,6 +238,12 @@ class PrimeraRFEFPromotionRule implements SelfSwappingPromotionRule
     }
 
     /**
+     * Lane invariant: GameStanding first, SimulatedSeason fallback. The
+     * playoff bracket draw (PrimeraRFEFPlayoffGenerator::eligibleTopTeams)
+     * uses the same preference order, and only one of the two sources is
+     * ever populated for a given (game, league, season) — so position 1
+     * here can never collide with positions 2..5 used to seed the bracket.
+     *
      * @return array{teamId: string, position: int|string, teamName: string, origin: string}|null
      */
     private function directPromotion(Game $game, string $groupId): ?array
@@ -346,6 +352,9 @@ class PrimeraRFEFPromotionRule implements SelfSwappingPromotionRule
 
             if ($standIn) {
                 $results[] = $standIn;
+                // Accumulate so Group B's resolution can't pick the same team
+                // again if the data sources happen to overlap.
+                $already[] = $standIn['teamId'];
             }
         }
 

--- a/app/Modules/Match/Services/SyntheticLeagueResolver.php
+++ b/app/Modules/Match/Services/SyntheticLeagueResolver.php
@@ -6,6 +6,7 @@ use App\Models\Competition;
 use App\Models\CompetitionEntry;
 use App\Models\Game;
 use App\Models\GameMatch;
+use App\Models\SimulatedSeason;
 use App\Modules\Competition\Services\LeagueFixtureGenerator;
 use App\Modules\Competition\Services\StandingsCalculator;
 use Carbon\CarbonInterface;
@@ -82,6 +83,10 @@ class SyntheticLeagueResolver
             return;
         }
 
+        if ($this->isLockedToSimulatedLane($game, $competition)) {
+            return;
+        }
+
         $this->withLock($game->id, $competition->id, function () use ($game, $competition, $upToDate): void {
             $this->ensureInitializedLocked($game, $competition);
             $this->resolveDueMatchesLocked($game, $competition, $upToDate ?? $game->current_date);
@@ -98,6 +103,10 @@ class SyntheticLeagueResolver
             return;
         }
 
+        if ($this->isLockedToSimulatedLane($game, $competition)) {
+            return;
+        }
+
         $this->withLock($game->id, $competition->id, function () use ($game, $competition): void {
             $this->ensureInitializedLocked($game, $competition);
         });
@@ -110,6 +119,10 @@ class SyntheticLeagueResolver
     public function resolveDueMatches(Game $game, Competition $competition, ?CarbonInterface $upToDate = null): void
     {
         if (! $this->isSupported($competition) || $this->isUsersPrimaryLeague($game, $competition)) {
+            return;
+        }
+
+        if ($this->isLockedToSimulatedLane($game, $competition)) {
             return;
         }
 
@@ -130,6 +143,25 @@ class SyntheticLeagueResolver
     private function isUsersPrimaryLeague(Game $game, Competition $competition): bool
     {
         return $competition->id === $game->competition_id;
+    }
+
+    /**
+     * Each (game, league, season) is locked to exactly one source of truth.
+     * If a SimulatedSeason row already exists for this league, some prior
+     * caller (the Primera RFEF playoff generator, SeasonSimulationProcessor,
+     * etc.) has committed to the "simulated lane" — the ordering in
+     * `simulated_seasons.results` is authoritative. Writing `game_standings`
+     * here would produce a competing ordering that disagrees on positions,
+     * which is how a team can end up listed both as a direct promotion and
+     * as a playoff bracket winner (see PrimeraRFEFPromotionRule). Bail out
+     * so the simulated lane stays the only source.
+     */
+    private function isLockedToSimulatedLane(Game $game, Competition $competition): bool
+    {
+        return SimulatedSeason::where('game_id', $game->id)
+            ->where('competition_id', $competition->id)
+            ->where('season', $game->season)
+            ->exists();
     }
 
     /**

--- a/app/Modules/Season/Processors/SeasonSimulationProcessor.php
+++ b/app/Modules/Season/Processors/SeasonSimulationProcessor.php
@@ -47,6 +47,15 @@ class SeasonSimulationProcessor implements SeasonProcessor
      * (e.g. on the season-end screen). When true, existing simulated data
      * is overwritten — used after promotion/relegation swaps change rosters.
      *
+     * Lane invariant: the `hasRealStandings` skip below is what keeps a
+     * league from carrying both a SimulatedSeason row and real game_standings
+     * for the same (game, season). The matching guard on the other side lives
+     * in SyntheticLeagueResolver::isLockedToSimulatedLane, which refuses to
+     * write standings once a SimulatedSeason already exists. Together they
+     * guarantee exactly one source of truth per (game, league, season), which
+     * PrimeraRFEFPromotionRule relies on to avoid the same team appearing as
+     * both a direct promotion and a playoff bracket winner.
+     *
      * @param  string[]|null  $competitionIds  If provided, only simulate these competition IDs
      * @param  bool  $forceResimulate  If true, overwrite existing simulated data
      */

--- a/tests/Feature/PrimeraRFEFPromotionTest.php
+++ b/tests/Feature/PrimeraRFEFPromotionTest.php
@@ -604,4 +604,76 @@ class PrimeraRFEFPromotionTest extends TestCase
         $this->expectException(PlayoffInProgressException::class);
         $rule->getPromotedTeams($this->game);
     }
+
+    // ──────────────────────────────────────────────────
+    // Lane invariant: simulated and standings cannot coexist
+    // ──────────────────────────────────────────────────
+
+    /**
+     * Regression for the dual-truth bug: the playoff was drawn from
+     * SimulatedSeason (so a bracket winner is the position-2 simulated team),
+     * but the season-close path later wrote real game_standings with a
+     * different ordering that puts that same team at position 1. The promotion
+     * rule then listed the team as both a direct promotion AND a playoff
+     * winner. With the lane lock in SyntheticLeagueResolver, the standings
+     * write must be refused — so the promoted list reads consistently from
+     * the simulated lane and contains 4 distinct teams.
+     */
+    public function test_resolver_refuses_to_write_standings_after_simulated_lane_committed(): void
+    {
+        $this->game->update(['competition_id' => 'ESP2']);
+
+        $simulatedA = $this->createSimulatedTeams(20);
+        $simulatedB = $this->createSimulatedTeams(20);
+        $this->createSimulatedSeason('ESP3A', $simulatedA);
+        $this->createSimulatedSeason('ESP3B', $simulatedB);
+
+        $resolver = app(\App\Modules\Match\Services\SyntheticLeagueResolver::class);
+        $esp3a = Competition::find('ESP3A');
+
+        $resolver->catchUp($this->game, $esp3a, $this->game->current_date?->copy()->addYear());
+
+        $this->assertSame(0, GameStanding::where('game_id', $this->game->id)
+            ->where('competition_id', 'ESP3A')
+            ->count(), 'catchUp must not write game_standings when SimulatedSeason already exists.');
+        $this->assertSame(0, GameMatch::where('game_id', $this->game->id)
+            ->where('competition_id', 'ESP3A')
+            ->count(), 'catchUp must not write game_matches when SimulatedSeason already exists.');
+    }
+
+    /**
+     * Counterpart of the lock test: with no SimulatedSeason row in place,
+     * catchUp is free to materialize fixtures and standings as before.
+     */
+    public function test_resolver_initializes_when_no_simulated_season_exists(): void
+    {
+        $this->game->update(['competition_id' => 'ESP2']);
+
+        // Seed CompetitionEntry for ESP3A only (20 teams), no SimulatedSeason.
+        $teams = $this->createSimulatedTeams(20);
+        foreach ($teams as $team) {
+            CompetitionEntry::create([
+                'game_id' => $this->game->id,
+                'competition_id' => 'ESP3A',
+                'team_id' => $team->id,
+                'entry_round' => 1,
+            ]);
+        }
+
+        $resolver = app(\App\Modules\Match\Services\SyntheticLeagueResolver::class);
+        $esp3a = Competition::find('ESP3A');
+
+        $resolver->ensureInitialized($this->game, $esp3a);
+
+        $this->assertGreaterThan(0, GameMatch::where('game_id', $this->game->id)
+            ->where('competition_id', 'ESP3A')
+            ->count(), 'ensureInitialized should create fixtures when no lane is locked yet.');
+        $this->assertGreaterThan(0, GameStanding::where('game_id', $this->game->id)
+            ->where('competition_id', 'ESP3A')
+            ->count(), 'ensureInitialized should seed standings when no lane is locked yet.');
+        $this->assertSame(0, SimulatedSeason::where('game_id', $this->game->id)
+            ->where('competition_id', 'ESP3A')
+            ->where('season', $this->game->season)
+            ->count(), 'No SimulatedSeason should be written by the resolver itself.');
+    }
 }


### PR DESCRIPTION
## Summary
- Adds `isLockedToSimulatedLane()` guard in `SyntheticLeagueResolver` so `catchUp`, `ensureInitialized`, and `resolveDueMatches` refuse to write `game_standings` for a league that already has a `SimulatedSeason` row for the current season.
- Fixes a latent overlap in `PrimeraRFEFPromotionRule::simulatedPlayoffStandIns()`: accumulate each resolved stand-in into `$already` before resolving the next group's stand-in.
- Documents the "first-lane-wins" invariant on `PrimeraRFEFPlayoffGenerator::eligibleTopTeams`, `PrimeraRFEFPromotionRule::directPromotion`, and `SeasonSimulationProcessor::simulateNonPlayedLeagues`.
- Adds two regression tests covering the lane lock.

## Why
The `PromotionRelegationProcessor::validatePlan` validation introduced in fdb23835 caught a real corruption: a team appearing twice in the ESP3A→ESP2 promotion list, once as a direct promotion and once as an ESP3PO bracket winner.

Root cause: after #993 (`FinalizeOtherLeaguesProcessor` + `SyntheticLeagueResolver`), two independent sources of truth could coexist for the same `(game, league, season)`:

1. `SimulatedSeason.results` — written mid-season by `PrimeraRFEFPlayoffGenerator::orderedTeamsFromSimulation()` while seeding the ESP3PO bracket against the sister group the user isn't in.
2. `game_standings` — written later by `FinalizeOtherLeaguesProcessor` at season close via `SyntheticLeagueResolver::catchUp()`, using a completely independent squad-strength Poisson simulation.

`PrimeraRFEFPromotionRule::directPromotion()` reads `GameStanding` first → returns position 1 from the season-close ordering. `requirePlayoffWinners()` reads `CupTie` rows, which were seeded from the mid-season `SimulatedSeason` ordering. The two orderings disagree about who finished 1st vs 2nd, so the same team can appear as both a direct promotion and a bracket winner.

## How it works now
Per `(game, league, season)` exactly one source is ever populated:

- **Standings lane** (`game_standings` exists): `SyntheticLeagueResolver` may top up unplayed fixtures. `SeasonSimulationProcessor` already skips via its `hasRealStandings` guard. No `SimulatedSeason` row is ever written.
- **Simulated lane** (`SimulatedSeason` exists): `SyntheticLeagueResolver::isLockedToSimulatedLane()` short-circuits, so `game_standings` is never written. All readers fall through to the simulated ordering.
- **Unset**: whichever code path needs an ordering first picks the lane and materialises.

`PrimeraRFEFPlayoffGenerator::eligibleTopTeams()` and `PrimeraRFEFPromotionRule::directPromotion()` already preferred `GameStanding` then `SimulatedSeason`, so they automatically read consistently from whichever lane is populated.

## Test plan
- [ ] CI runs `tests/Feature/PrimeraRFEFPromotionTest.php` including the two new cases:
  - `test_resolver_refuses_to_write_standings_after_simulated_lane_committed` — given a `SimulatedSeason` row for ESP3A, `SyntheticLeagueResolver::catchUp` writes no `game_standings` and no `game_matches`.
  - `test_resolver_initializes_when_no_simulated_season_exists` — with no lane locked, `ensureInitialized` materialises fixtures and standings as before, and does not create a `SimulatedSeason` itself.
- [ ] Manually verify the previously failing game (the one whose log surfaced the `[error] Duplicate team in ESP3A→ESP2 promotions: 137b4e41-…`) progresses past `PromotionRelegationProcessor` after the fix is deployed.

## Out of scope
- UI rendering for "Other Leagues" when a league is on the simulated lane (currently shows empty standings instead of falling back to the `SimulatedSeason` ordering). Worth a follow-up.
- ESP1↔ESP2 and UEFA paths were always one feature away from the same failure mode but not affected today; the lock generalises the protection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)