### PR TITLE
Reconcile saved lineups against current squad on every read

### DIFF
--- a/app/Http/Views/ShowLineup.php
+++ b/app/Http/Views/ShowLineup.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Views;
 
+use App\Models\GamePlayer;
 use App\Modules\Lineup\Enums\DefensiveLineHeight;
 use App\Modules\Lineup\Enums\Formation;
 use App\Modules\Lineup\Enums\Mentality;
@@ -95,27 +96,77 @@ class ShowLineup
             ];
         })->keyBy('id')->toArray();
 
-        // Filter stale player IDs from lineups (e.g. players sold after lineup was saved)
         $validPlayerIds = array_keys($playersData);
-        if (! empty($currentLineup)) {
-            $currentLineup = array_values(array_intersect($currentLineup, $validPlayerIds));
-        }
 
         // Resolve the authoritative slot map for this match. If the match row
         // already has a persisted map, use it; otherwise lazily compute from
         // the stored lineup + formation (no persistence on the read path).
         // Falls back to the team's default_slot_assignments for brand-new
         // games where the match has no lineup yet.
-        $currentSlotMap = $this->lineupService->resolveSlotAssignments($match, $game->team_id);
-        if (empty($currentSlotMap) && ! empty($game->tactics?->default_slot_assignments)) {
-            $currentSlotMap = $game->tactics->default_slot_assignments;
+        $rawSlotMap = $this->lineupService->resolveSlotAssignments($match, $game->team_id);
+        if (empty($rawSlotMap) && ! empty($game->tactics?->default_slot_assignments)) {
+            $rawSlotMap = $game->tactics->default_slot_assignments;
         }
-        if (! empty($currentSlotMap)) {
-            $currentSlotMap = array_filter(
-                $currentSlotMap,
-                fn ($playerId) => in_array($playerId, $validPlayerIds),
+
+        // Reconcile the saved lineup state against the current squad. If the
+        // user's `default_lineup` or saved slot map references players who
+        // have since been transferred / retired / long-term injured, the
+        // reconciler drops them and tops the lineup back up to 11 via the
+        // same FormationRecommender path used at match-time. This stops the
+        // lineup page from rendering a broken state (gaps in the formation,
+        // orphan goalkeepers) — the bug the user reported when the displayed
+        // pitch diverged from what the simulator would actually run with.
+        $rawPitchPositions = $game->tactics?->default_pitch_positions;
+        $reconciliation = [
+            'lineup' => $currentLineup,
+            'slot_assignments' => $rawSlotMap,
+            'pitch_positions' => $rawPitchPositions,
+            'replaced' => [],
+            'changed' => false,
+        ];
+        $hadSavedState = ! empty($currentLineup) || ! empty($rawSlotMap);
+        if ($hadSavedState) {
+            $availablePlayers = $this->lineupService->getAvailablePlayers(
+                $game->id,
+                $game->team_id,
+                $matchDate,
+                $competitionId,
+                $requireEnrollment,
+            );
+            $reconciliation = $this->lineupService->reconcileLineupState(
+                $currentLineup,
+                $rawSlotMap,
+                $rawPitchPositions,
+                $availablePlayers,
+                $allPlayers,
+                $formationEnum,
             );
         }
+
+        $currentLineup = $reconciliation['lineup'];
+        $currentSlotMap = $reconciliation['slot_assignments'];
+        $currentPitchPositions = $reconciliation['pitch_positions'];
+        $replaced = $reconciliation['replaced'];
+
+        // Persist the reconciled state back to `game.tactics` so the next
+        // page load doesn't re-show the broken state and so match-time
+        // `ensureTeamLineup` reads a consistent preferred lineup. Only
+        // touches tactics rows that already had a saved lineup — brand-new
+        // games (no default_lineup yet) should keep falling back to the
+        // auto-selector on each visit rather than being silently locked in.
+        if ($reconciliation['changed'] && ! empty($game->tactics?->default_lineup)) {
+            $game->tactics->update([
+                'default_lineup' => $currentLineup,
+                'default_slot_assignments' => $currentSlotMap,
+                'default_pitch_positions' => $currentPitchPositions,
+            ]);
+        }
+
+        // Resolve names for the reconciliation banner. The "out" players may
+        // no longer belong to the user's team (transferred to AI) or may
+        // have been deleted (retirement) — look them up by id across the
+        // game without the team filter, falling back to a generic label.
+        $reconciliationBanner = $this->buildReconciliationBanner($replaced, $game->id, $playersData);
 
         // Prepare pitch slots for each formation, adding Spanish display labels
         $formationSlots = [];
@@ -213,7 +264,7 @@ class ShowLineup
 
         // Pitch grid config for advanced positioning
         $gridConfig = PitchGrid::getGridConfig();
-        $currentPitchPositions = $game->tactics?->default_pitch_positions;
+        // $currentPitchPositions is set above by the reconciliation block.
 
         return view('lineup', [
             'game' => $game,
@@ -253,6 +304,7 @@ class ShowLineup
             'xgConfig' => $xgConfig,
             'gridConfig' => $gridConfig,
             'currentPitchPositions' => $currentPitchPositions,
+            'reconciliationBanner' => $reconciliationBanner,
 
             'tacticalPresets' => $game->tacticalPresets,
             'presetsConfig' => $game->tacticalPresets->map(fn ($p) => [
@@ -272,4 +324,47 @@ class ShowLineup
         ]);
     }
 
+    /**
+     * Build the per-replacement banner payload for the lineup page. Resolves
+     * the OUT player's name across the whole game (without team filter,
+     * since transferred players sit on the AI team they were sold to) and
+     * the IN player's name from the current squad's `$playersData` map.
+     *
+     * Returns null when nothing was reconciled — the view hides the banner
+     * in that case.
+     *
+     * @param  list<array{out_id: string, in_id: string|null}>  $replaced
+     * @param  array<string, array{name: string}>  $playersData
+     */
+    private function buildReconciliationBanner(array $replaced, string $gameId, array $playersData): ?array
+    {
+        if (empty($replaced)) {
+            return null;
+        }
+
+        $outIds = array_values(array_unique(array_column($replaced, 'out_id')));
+        $outNames = GamePlayer::query()
+            ->where('game_id', $gameId)
+            ->whereIn('id', $outIds)
+            ->pluck('name', 'id')
+            ->all();
+
+        $items = [];
+        foreach ($replaced as $entry) {
+            $outName = $outNames[$entry['out_id']] ?? __('squad.unavailable_player');
+            $inName = null;
+            if ($entry['in_id'] !== null && isset($playersData[$entry['in_id']])) {
+                $inName = $playersData[$entry['in_id']]['name'];
+            }
+            $items[] = [
+                'out_name' => $outName,
+                'in_name' => $inName,
+            ];
+        }
+
+        return [
+            'items' => $items,
+            'count' => count($items),
+        ];
+    }
 }

--- a/app/Http/Views/ShowLiveMatch.php
+++ b/app/Http/Views/ShowLiveMatch.php
@@ -12,6 +12,7 @@ use Illuminate\Support\Facades\Cache;
 use App\Models\CupTie;
 use App\Models\Game;
 use App\Models\GameMatch;
+use App\Models\GamePlayer;
 use App\Models\GameStanding;
 use App\Models\MatchAttendance;
 use App\Models\PlayerSuspension;
@@ -224,6 +225,8 @@ class ShowLiveMatch
 
         $narrativeTemplates = LiveMatchNarrativeTemplates::build();
 
+        $userPitchData = $this->resolveUserPitchData($playerMatch, $game, $userLineupIds, $userFormation, $prefix);
+
         // MatchdayOrchestrator::processBatch persists the attendance row before
         // simulating the match, so it's always present when this view loads.
         $attendanceRow = MatchAttendance::where('game_match_id', $playerMatch->id)->first();
@@ -285,13 +288,15 @@ class ShowLiveMatch
             'teamColors' => $teamColorsHex,
             'slotCompatibility' => $slotCompatibility,
             'gridConfig' => $gridConfig,
-            'pitchPositions' => $playerMatch->{"{$prefix}_pitch_positions"}
-                ?? $game->tactics?->default_pitch_positions ?? [],
-            // Authoritative slot map: persisted value on the match if present,
-            // otherwise lazy-computed via LineupService, with a final fallback
-            // to the team's default_slot_assignments for brand-new installs.
-            'slotAssignments' => $this->lineupService->resolveSlotAssignments($playerMatch, $game->team_id)
-                ?: ($game->tactics?->default_slot_assignments ?? []),
+            // Reconciled against the user's actual `{prefix}_lineup` (the XI
+            // the simulator used / is about to use) so the tactical-panel
+            // pitch can never disagree with the simulator. Defensive: if the
+            // persisted slot map references players not in `home_lineup` or
+            // slot ids that don't exist in the current formation, drop them
+            // and recompute via FormationRecommender. `pitch_positions` are
+            // also filtered to slot ids that still exist in the formation.
+            'slotAssignments' => $userPitchData['slotAssignments'],
+            'pitchPositions' => $userPitchData['pitchPositions'],
             // Endpoint for formation-preview fetches from the tactical panel.
             // Same endpoint the lineup page uses — single source of truth for
             // the placement algorithm.
@@ -307,4 +312,66 @@ class ShowLiveMatch
         ]);
     }
 
+    /**
+     * Resolve the slot map + pitch_positions for the user's side, reconciled
+     * against `{prefix}_lineup` (the XI the simulator is actually using).
+     * Defensive layer for any edge case where the persisted slot map could
+     * drift from the lineup — e.g. the tactics-default fallback firing on
+     * a match that never had its slot map written, or a stale entry that
+     * survived a between-save squad change. Returns a string-keyed
+     * `slotAssignments` map and `pitchPositions` array safe to feed
+     * directly into the live-match tactical panel.
+     *
+     * @param  array<int, string>  $userLineupIds
+     * @return array{slotAssignments: array<string, string>, pitchPositions: array<string, array{0:int,1:int}>}
+     */
+    private function resolveUserPitchData(
+        GameMatch $playerMatch,
+        Game $game,
+        array $userLineupIds,
+        string $userFormationValue,
+        string $prefix,
+    ): array {
+        $rawSlotMap = $this->lineupService->resolveSlotAssignments($playerMatch, $game->team_id)
+            ?: ($game->tactics?->default_slot_assignments ?? []);
+        $rawPitchPositions = $playerMatch->{"{$prefix}_pitch_positions"}
+            ?? $game->tactics?->default_pitch_positions;
+
+        $formation = Formation::tryFrom($userFormationValue) ?? Formation::F_4_3_3;
+
+        // Nothing to reconcile against — keep the current behaviour of
+        // passing the raw fallback through. Brand-new installs / matches
+        // that never had a lineup written hit this branch.
+        if (empty($userLineupIds)) {
+            return [
+                'slotAssignments' => is_array($rawSlotMap) ? $rawSlotMap : [],
+                'pitchPositions' => is_array($rawPitchPositions) ? $rawPitchPositions : [],
+            ];
+        }
+
+        // Constrain the "available" pool to the players actually on the
+        // pitch. The reconciler will drop any slot entries pointing to
+        // players outside this set and re-run FormationRecommender to fill
+        // the gaps. We deliberately don't open up the wider squad here —
+        // the simulator already decided who plays.
+        $lineupPlayers = GamePlayer::with(['matchState'])
+            ->where('game_id', $game->id)
+            ->where('team_id', $game->team_id)
+            ->whereIn('id', $userLineupIds)
+            ->get();
+
+        $reconciled = $this->lineupService->reconcileLineupState(
+            $userLineupIds,
+            is_array($rawSlotMap) ? $rawSlotMap : [],
+            is_array($rawPitchPositions) ? $rawPitchPositions : null,
+            $lineupPlayers,
+            $lineupPlayers,
+            $formation,
+        );
+
+        return [
+            'slotAssignments' => $reconciled['slot_assignments'],
+            'pitchPositions' => $reconciled['pitch_positions'] ?? [],
+        ];
+    }
 }

--- a/app/Modules/Lineup/Services/LineupService.php
+++ b/app/Modules/Lineup/Services/LineupService.php
@@ -141,19 +141,70 @@ class LineupService
         }
 
         // When slot assignments are provided, skip position group validation
-        // (the user has explicitly chosen where each player plays)
+        // (the user has explicitly chosen where each player plays). The slot
+        // map must still be structurally complete: every formation slot
+        // filled, no duplicates, exactly one player at the GK slot. Without
+        // this guard, a malformed POST could persist a lineup with no
+        // goalkeeper or with two players assigned to the same slot, which
+        // then renders as a broken pitch even after reconciliation.
         if (!empty($slotAssignments)) {
-            // Validate slot assignments reference valid players and slots
             $slots = $formation->pitchSlots();
             $slotIds = array_column($slots, 'id');
+            $slotIdSet = array_flip(array_map(fn ($id) => (string) $id, $slotIds));
+
+            $normalisedSlotMap = [];
+            $invalidSlotFound = false;
             foreach ($slotAssignments as $slotId => $playerId) {
-                if (!in_array((int) $slotId, $slotIds, true)) {
+                if (!isset($slotIdSet[(string) $slotId])) {
                     $errors[] = 'Invalid slot assignment.';
+                    $invalidSlotFound = true;
                     break;
                 }
                 if (!in_array($playerId, $playerIds, true)) {
                     $errors[] = 'Slot assigned to player not in lineup.';
+                    $invalidSlotFound = true;
                     break;
+                }
+                $normalisedSlotMap[(string) $slotId] = $playerId;
+            }
+
+            if ($invalidSlotFound) {
+                return $errors;
+            }
+
+            // Every formation slot must be filled exactly once.
+            if (count($normalisedSlotMap) !== count($slotIds)) {
+                $errors[] = __('squad.formation_slot_map_incomplete');
+                return $errors;
+            }
+
+            // No two slots may share a player.
+            if (count($normalisedSlotMap) !== count(array_unique($normalisedSlotMap))) {
+                $errors[] = __('squad.formation_slot_map_duplicates');
+                return $errors;
+            }
+
+            // The GK slot (label === 'GK') must be filled by a Goalkeeper.
+            // Allows the user to drag-swap any outfield player anywhere they
+            // like, but blocks the malformed states the lineup page can fall
+            // into when the saved GK leaves the squad and nothing refills
+            // slot 0 (the bug this fix addresses).
+            $gkSlotId = null;
+            foreach ($slots as $slot) {
+                if ($slot['label'] === 'GK') {
+                    $gkSlotId = (string) $slot['id'];
+                    break;
+                }
+            }
+            if ($gkSlotId !== null) {
+                if (!isset($normalisedSlotMap[$gkSlotId])) {
+                    $errors[] = __('squad.formation_missing_goalkeeper');
+                    return $errors;
+                }
+                $gkPlayer = $availablePlayers->firstWhere('id', $normalisedSlotMap[$gkSlotId]);
+                if ($gkPlayer === null || $gkPlayer->position_group !== 'Goalkeeper') {
+                    $errors[] = __('squad.formation_gk_slot_must_be_goalkeeper');
+                    return $errors;
                 }
             }
 
@@ -578,6 +629,206 @@ class LineupService
         }
 
         return $map;
+    }
+
+    /**
+     * Reconcile a stored lineup / slot map / pitch positions against the
+     * current pool of available players, returning a fully-valid triple plus
+     * a list of replacements that happened.
+     *
+     * Read paths (`ShowLineup`, `ShowLiveMatch`) call this so the user never
+     * sees a lineup that references sold / retired / long-term injured
+     * players. The previous behaviour was a subtractive filter that left
+     * gaps in the formation (e.g. 10 players in 11 slots); this method tops
+     * up via `selectLineupWithPreferencesFromCollection` and re-runs
+     * `computeSlotAssignments` with the surviving slot entries pinned, so
+     * user-intentional placements stick wherever the player is still around.
+     *
+     * Idempotent: a valid input (11 available players, complete slot map for
+     * the formation) returns equivalent output with `changed = false` and
+     * `replaced = []`.
+     *
+     * `pitch_positions` are slot-keyed, so they survive a player swap on
+     * the same slot. We only drop entries for slot ids that don't exist in
+     * `$formation`.
+     *
+     * @param  array<int, string>|null            $lineup
+     * @param  array<int|string, string>|null     $slotMap
+     * @param  array<int|string, array{0:int,1:int}>|null $pitchPositions
+     * @return array{
+     *     lineup: array<int, string>,
+     *     slot_assignments: array<string, string>,
+     *     pitch_positions: array<string, array{0:int,1:int}>|null,
+     *     replaced: list<array{out_id: string, in_id: string|null}>,
+     *     changed: bool,
+     * }
+     */
+    public function reconcileLineupState(
+        ?array $lineup,
+        ?array $slotMap,
+        ?array $pitchPositions,
+        Collection $availablePlayers,
+        Collection $allTeamPlayers,
+        Formation $formation,
+        bool $applyFitnessRotation = false,
+    ): array {
+        $lineup = array_values(array_filter((array) ($lineup ?? []), fn ($id) => is_string($id) && $id !== ''));
+        $slotMap = (array) ($slotMap ?? []);
+
+        $availableIds = $availablePlayers->pluck('id')->all();
+        $availableIdSet = array_flip($availableIds);
+
+        $formationSlots = $formation->pitchSlots();
+        $formationSlotIds = array_map(fn ($s) => (string) $s['id'], $formationSlots);
+        $formationSlotIdSet = array_flip($formationSlotIds);
+
+        // Pass 1: split the saved slot map into "still valid" pins and
+        // "stale" entries we'll need to backfill. Slot ids not in the
+        // current formation are dropped silently.
+        $survivingPins = [];
+        $staleSlotEntries = []; // [slotId => oldPlayerId]
+        foreach ($slotMap as $slotId => $playerId) {
+            $slotKey = (string) $slotId;
+            if (! isset($formationSlotIdSet[$slotKey])) {
+                continue;
+            }
+            if (! is_string($playerId) || $playerId === '') {
+                continue;
+            }
+            if (! isset($availableIdSet[$playerId])) {
+                $staleSlotEntries[$slotKey] = $playerId;
+                continue;
+            }
+            $survivingPins[$slotKey] = $playerId;
+        }
+
+        // Pass 2: filter the lineup list. Track the players we removed so
+        // we can report them in the banner even if they had no slot entry.
+        $filteredLineup = [];
+        $removedFromLineup = [];
+        foreach ($lineup as $playerId) {
+            if (isset($availableIdSet[$playerId])) {
+                $filteredLineup[] = $playerId;
+            } else {
+                $removedFromLineup[] = $playerId;
+            }
+        }
+        // Dedupe in case the saved lineup had duplicates.
+        $filteredLineup = array_values(array_unique($filteredLineup));
+
+        $pitchPositionsOut = $this->filterPitchPositions($pitchPositions, $formationSlotIdSet);
+
+        // Short-circuit: nothing stale, lineup already complete, slot map
+        // already complete. Return as-is — idempotency contract.
+        $slotMapAlreadyComplete = count($survivingPins) === count($formationSlotIds);
+        $nothingChanged = empty($staleSlotEntries)
+            && empty($removedFromLineup)
+            && count($filteredLineup) === 11
+            && $slotMapAlreadyComplete;
+
+        if ($nothingChanged) {
+            // Normalise key types: callers may have int keys after a JSON
+            // round-trip; we always return string-keyed maps.
+            $normalisedSlotMap = [];
+            foreach ($survivingPins as $slotKey => $playerId) {
+                $normalisedSlotMap[(string) $slotKey] = $playerId;
+            }
+
+            return [
+                'lineup' => $filteredLineup,
+                'slot_assignments' => $normalisedSlotMap,
+                'pitch_positions' => $pitchPositionsOut,
+                'replaced' => [],
+                'changed' => false,
+            ];
+        }
+
+        // Top up the lineup to 11 using the same preference-aware selector
+        // that runs at match-time, so the rebuild respects position groups
+        // (a sold CB is replaced by another CB first, not by whoever's
+        // highest-rated on the bench).
+        $rebuiltLineup = $this->selectLineupWithPreferencesFromCollection(
+            $availablePlayers,
+            $allTeamPlayers,
+            $formation,
+            $filteredLineup,
+            $availableIds,
+            applyFitnessRotation: $applyFitnessRotation,
+        );
+
+        // The selector can return < 11 if the squad is genuinely short.
+        // Keep what it returned — the caller can render whatever fits;
+        // `computeSlotAssignments` will simply leave the rest unfilled.
+        $rebuiltLineup = array_values(array_unique($rebuiltLineup));
+
+        // Re-run FormationRecommender, pinning surviving slot entries so
+        // a user's intentional drag-swap placements stick.
+        $rebuiltSet = array_flip($rebuiltLineup);
+        $manualPins = array_filter(
+            $survivingPins,
+            fn ($pid) => isset($rebuiltSet[$pid]),
+        );
+
+        $lineupPlayers = $availablePlayers
+            ->filter(fn ($p) => isset($rebuiltSet[$p->id]))
+            ->values();
+
+        $newSlotMap = $this->computeSlotAssignments($formation, $lineupPlayers, $manualPins);
+
+        // Build replacement report for the banner.
+        $replaced = [];
+        $reportedOutIds = [];
+        foreach ($staleSlotEntries as $slotKey => $oldPlayerId) {
+            $replaced[] = [
+                'out_id' => $oldPlayerId,
+                'in_id' => $newSlotMap[$slotKey] ?? null,
+            ];
+            $reportedOutIds[$oldPlayerId] = true;
+        }
+        // Lineup-only stale ids (no slot entry) — still surface them so the
+        // user knows somebody got dropped, even if we can't name the slot.
+        foreach ($removedFromLineup as $oldPlayerId) {
+            if (isset($reportedOutIds[$oldPlayerId])) {
+                continue;
+            }
+            $replaced[] = ['out_id' => $oldPlayerId, 'in_id' => null];
+            $reportedOutIds[$oldPlayerId] = true;
+        }
+
+        return [
+            'lineup' => $rebuiltLineup,
+            'slot_assignments' => $newSlotMap,
+            'pitch_positions' => $pitchPositionsOut,
+            'replaced' => $replaced,
+            'changed' => true,
+        ];
+    }
+
+    /**
+     * Strip pitch-position overrides that point at slot ids not present in
+     * the current formation. Kept as a helper because `reconcileLineupState`
+     * uses it both on the short-circuit and rebuild paths.
+     *
+     * @param  array<int|string, array{0:int,1:int}>|null  $pitchPositions
+     * @param  array<string, int>  $formationSlotIdSet
+     * @return array<string, array{0:int,1:int}>|null
+     */
+    private function filterPitchPositions(?array $pitchPositions, array $formationSlotIdSet): ?array
+    {
+        if ($pitchPositions === null) {
+            return null;
+        }
+
+        $filtered = [];
+        foreach ($pitchPositions as $slotId => $pos) {
+            $slotKey = (string) $slotId;
+            if (! isset($formationSlotIdSet[$slotKey])) {
+                continue;
+            }
+            $filtered[$slotKey] = $pos;
+        }
+
+        return $filtered;
     }
 
     /**

--- a/lang/en/squad.php
+++ b/lang/en/squad.php
@@ -67,6 +67,17 @@ return [
     // Lineup validation
     'formation_position_mismatch' => 'Formation :formation requires :required :position, but you selected :actual.',
     'player_not_available' => 'One or more selected players are not available.',
+    'formation_slot_map_incomplete' => 'Every position in the formation must be filled.',
+    'formation_slot_map_duplicates' => 'The same player cannot be assigned to two positions.',
+    'formation_missing_goalkeeper' => 'You must assign a goalkeeper to the GK position.',
+    'formation_gk_slot_must_be_goalkeeper' => 'Only a goalkeeper can play in the GK position.',
+
+    // Lineup reconciliation banner
+    'lineup_reconciled_title' => 'Your lineup was updated automatically',
+    'lineup_reconciled_subtitle' => '{1}A player from your saved lineup is no longer available and has been replaced. Review and save your changes.|[2,*]:count players from your saved lineup are no longer available and have been replaced. Review and save your changes.',
+    'lineup_reconciled_replacement' => ':out → :in',
+    'lineup_reconciled_removed' => ':out (removed)',
+    'unavailable_player' => 'An unavailable player',
 
     // Lineup
     'formation' => 'Formation',

--- a/lang/es/squad.php
+++ b/lang/es/squad.php
@@ -67,6 +67,17 @@ return [
     // Lineup validation
     'formation_position_mismatch' => 'La formación :formation requiere :required :position, pero seleccionaste :actual.',
     'player_not_available' => 'Uno o más jugadores seleccionados no están disponibles.',
+    'formation_slot_map_incomplete' => 'Todas las posiciones de la formación deben estar cubiertas.',
+    'formation_slot_map_duplicates' => 'Un mismo jugador no puede ocupar dos posiciones.',
+    'formation_missing_goalkeeper' => 'Debes asignar un portero a la posición de PT.',
+    'formation_gk_slot_must_be_goalkeeper' => 'Solo un portero puede jugar en la posición de PT.',
+
+    // Banner de reconciliación de alineación
+    'lineup_reconciled_title' => 'Tu alineación se actualizó automáticamente',
+    'lineup_reconciled_subtitle' => '{1}Un jugador de tu alineación guardada ya no está disponible y ha sido reemplazado. Revisa y guarda tus cambios.|[2,*]:count jugadores de tu alineación guardada ya no están disponibles y han sido reemplazados. Revisa y guarda tus cambios.',
+    'lineup_reconciled_replacement' => ':out → :in',
+    'lineup_reconciled_removed' => ':out (sin reemplazo)',
+    'unavailable_player' => 'Un jugador no disponible',
 
     // Lineup
     'formation' => 'Formación',

--- a/resources/views/lineup.blade.php
+++ b/resources/views/lineup.blade.php
@@ -69,6 +69,35 @@
     })">
         <div class="max-w-7xl mx-auto px-4 pb-8">
 
+            {{-- Lineup reconciliation banner: appears when the saved lineup
+                 referenced players who are no longer available (sold,
+                 transferred, retired, long-term injured) and the system
+                 auto-replaced them on load. Lets the user see which slots
+                 were affected so they can review before playing. --}}
+            @if(!empty($reconciliationBanner))
+                <x-status-banner color="gold"
+                    :title="__('squad.lineup_reconciled_title')"
+                    :description="trans_choice('squad.lineup_reconciled_subtitle', $reconciliationBanner['count'], ['count' => $reconciliationBanner['count']])"
+                    class="mt-4">
+                    <x-slot name="icon">
+                        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4.5c-.77-.833-2.694-.833-3.464 0L3.34 16.5c-.77.833.192 2.5 1.732 2.5z" />
+                        </svg>
+                    </x-slot>
+                </x-status-banner>
+                <ul class="mt-2 mb-2 text-xs md:text-sm text-text-secondary space-y-1 pl-3">
+                    @foreach($reconciliationBanner['items'] as $item)
+                        <li>
+                            @if($item['in_name'])
+                                {{ __('squad.lineup_reconciled_replacement', ['out' => $item['out_name'], 'in' => $item['in_name']]) }}
+                            @else
+                                {{ __('squad.lineup_reconciled_removed', ['out' => $item['out_name']]) }}
+                            @endif
+                        </li>
+                    @endforeach
+                </ul>
+            @endif
+
             {{-- Errors --}}
             @if ($errors->any())
                 <div class="mt-4 p-4 bg-accent-red/10 border border-accent-red/20 rounded-lg">

--- a/tests/Feature/LineupReconciliationTest.php
+++ b/tests/Feature/LineupReconciliationTest.php
@@ -1,0 +1,399 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Competition;
+use App\Models\Game;
+use App\Models\GameMatch;
+use App\Models\GamePlayer;
+use App\Models\GameTactics;
+use App\Models\Team;
+use App\Models\User;
+use App\Modules\Lineup\Enums\Formation;
+use App\Modules\Lineup\Services\LineupService;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Coverage for the "lineup state is reconciled against the current squad on
+ * every read" behaviour. The bug this guards against: a user saves a
+ * lineup, one of those players later leaves the squad (transfer / retire /
+ * long-term injury), and the lineup page renders the broken state (10
+ * players in 11 slots, sometimes with the wrong outfielder in slot 0).
+ *
+ * `LineupService::reconcileLineupState` is the pure helper; `ShowLineup`
+ * is the integration test that the helper is wired up correctly and that
+ * `game.tactics` is updated so the broken state doesn't recur.
+ */
+class LineupReconciliationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+    private Team $playerTeam;
+    private Team $opponentTeam;
+    private Competition $competition;
+    private Game $game;
+    private GameMatch $match;
+    private LineupService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = User::factory()->create();
+        $this->playerTeam = Team::factory()->create(['name' => 'Player Team']);
+        $this->opponentTeam = Team::factory()->create(['name' => 'Opponent Team']);
+
+        $this->competition = Competition::factory()->league()->create([
+            'id' => 'ESP1',
+            'name' => 'LaLiga',
+        ]);
+
+        $this->game = Game::factory()->create([
+            'user_id' => $this->user->id,
+            'team_id' => $this->playerTeam->id,
+            'competition_id' => $this->competition->id,
+            'season' => '2024',
+            'current_date' => '2024-09-01',
+        ]);
+
+        GameTactics::create([
+            'game_id' => $this->game->id,
+            'default_formation' => '4-3-3',
+            'default_mentality' => 'balanced',
+            'default_playing_style' => 'balanced',
+            'default_pressing' => 'standard',
+            'default_defensive_line' => 'normal',
+        ]);
+
+        $this->match = GameMatch::factory()->create([
+            'game_id' => $this->game->id,
+            'competition_id' => $this->competition->id,
+            'round_number' => 1,
+            'home_team_id' => $this->playerTeam->id,
+            'away_team_id' => $this->opponentTeam->id,
+            'scheduled_date' => Carbon::parse('2024-09-01'),
+            'played' => false,
+        ]);
+
+        $this->game->update(['pending_finalization_match_id' => $this->match->id]);
+
+        $this->service = app(LineupService::class);
+    }
+
+    /**
+     * Build a full 4-3-3 squad with every primary position filled. Returns
+     * the starting XI as a Collection in slot order: GK, LB, CBs, RB,
+     * CMs, LW, CF, RW.
+     */
+    private function buildSquad(): \Illuminate\Support\Collection
+    {
+        $spec = [
+            'Goalkeeper',
+            'Left-Back', 'Centre-Back', 'Centre-Back', 'Right-Back',
+            'Central Midfield', 'Central Midfield', 'Central Midfield',
+            'Left Winger', 'Centre-Forward', 'Right Winger',
+        ];
+
+        return collect($spec)->map(fn (string $pos) => GamePlayer::factory()
+            ->forGame($this->game)
+            ->forTeam($this->playerTeam)
+            ->create(['position' => $pos, 'overall_score' => 75]));
+    }
+
+    private function addBenchPlayer(string $position, int $rating = 70): GamePlayer
+    {
+        return GamePlayer::factory()
+            ->forGame($this->game)
+            ->forTeam($this->playerTeam)
+            ->create(['position' => $position, 'overall_score' => $rating]);
+    }
+
+    public function test_reconciler_is_idempotent_on_a_complete_valid_input(): void
+    {
+        $players = $this->buildSquad();
+        $playerIds = $players->pluck('id')->all();
+        $slotMap = $this->service->computeSlotAssignments(Formation::F_4_3_3, $players);
+
+        $result = $this->service->reconcileLineupState(
+            $playerIds,
+            $slotMap,
+            null,
+            $players,
+            $players,
+            Formation::F_4_3_3,
+        );
+
+        $this->assertFalse($result['changed']);
+        $this->assertSame([], $result['replaced']);
+        $this->assertSame($playerIds, $result['lineup']);
+        $this->assertCount(11, $result['slot_assignments']);
+        foreach ($slotMap as $slotId => $playerId) {
+            $this->assertSame($playerId, $result['slot_assignments'][(string) $slotId]);
+        }
+    }
+
+    public function test_reconciler_replaces_stale_outfield_player_with_same_position_bench(): void
+    {
+        $players = $this->buildSquad();
+        $playerIds = $players->pluck('id')->all();
+        $slotMap = $this->service->computeSlotAssignments(Formation::F_4_3_3, $players);
+
+        // Add a same-position backup to the bench.
+        $backupLb = $this->addBenchPlayer('Left-Back', rating: 68);
+
+        // Sell off the starting LB — simulate by detaching from team.
+        $players[1]->update(['team_id' => $this->opponentTeam->id]);
+        // Refresh team players: starting LB is now gone, backup LB is in the pool.
+        $available = collect($players->slice(2))
+            ->concat([$backupLb])
+            ->push($players[0]); // re-add GK
+        $allTeam = GamePlayer::where('game_id', $this->game->id)
+            ->where('team_id', $this->playerTeam->id)
+            ->get();
+        $available = $allTeam; // all are available (no injuries set)
+
+        $result = $this->service->reconcileLineupState(
+            $playerIds,
+            $slotMap,
+            null,
+            $available,
+            $allTeam,
+            Formation::F_4_3_3,
+        );
+
+        $this->assertTrue($result['changed']);
+        $this->assertCount(1, $result['replaced']);
+        $this->assertSame($players[1]->id, $result['replaced'][0]['out_id']);
+        $this->assertSame($backupLb->id, $result['replaced'][0]['in_id']);
+        $this->assertCount(11, $result['lineup']);
+        $this->assertContains($backupLb->id, $result['lineup']);
+        $this->assertNotContains($players[1]->id, $result['lineup']);
+        // The replacement must land at the LB slot the recommender picks.
+        $this->assertContains($backupLb->id, $result['slot_assignments']);
+    }
+
+    public function test_reconciler_replaces_stale_goalkeeper_with_backup_goalkeeper(): void
+    {
+        $players = $this->buildSquad();
+        $playerIds = $players->pluck('id')->all();
+        $slotMap = $this->service->computeSlotAssignments(Formation::F_4_3_3, $players);
+
+        // Add a backup goalkeeper.
+        $backupGk = $this->addBenchPlayer('Goalkeeper', rating: 65);
+
+        // Starting GK gets transferred out.
+        $players[0]->update(['team_id' => $this->opponentTeam->id]);
+
+        $allTeam = GamePlayer::where('game_id', $this->game->id)
+            ->where('team_id', $this->playerTeam->id)
+            ->get();
+
+        $result = $this->service->reconcileLineupState(
+            $playerIds,
+            $slotMap,
+            null,
+            $allTeam,
+            $allTeam,
+            Formation::F_4_3_3,
+        );
+
+        $this->assertTrue($result['changed']);
+        $this->assertSame($backupGk->id, $result['slot_assignments']['0']);
+        $this->assertCount(11, $result['slot_assignments']);
+        // The "out" entry must reference the sold GK; the "in" entry the backup.
+        $replacementForGk = collect($result['replaced'])
+            ->firstWhere('out_id', $players[0]->id);
+        $this->assertNotNull($replacementForGk);
+        $this->assertSame($backupGk->id, $replacementForGk['in_id']);
+    }
+
+    public function test_reconciler_preserves_user_pinned_outfield_slot(): void
+    {
+        $players = $this->buildSquad();
+
+        // Build a custom slot map: put the Right Winger at the Left Winger
+        // slot (an explicit user drag-swap, allowed in the UI).
+        $rw = $players[10];
+        $lw = $players[8];
+        $rw->update(['secondary_positions' => ['Left Winger']]);
+        $slotMap = $this->service->computeSlotAssignments(
+            Formation::F_4_3_3,
+            $players,
+            ['8' => $rw->id, '10' => $lw->id],
+        );
+
+        $playerIds = $players->pluck('id')->all();
+
+        // Now sell the LB; reconcile.
+        $players[1]->update(['team_id' => $this->opponentTeam->id]);
+        $allTeam = GamePlayer::where('game_id', $this->game->id)
+            ->where('team_id', $this->playerTeam->id)
+            ->get();
+
+        $result = $this->service->reconcileLineupState(
+            $playerIds,
+            $slotMap,
+            null,
+            $allTeam,
+            $allTeam,
+            Formation::F_4_3_3,
+        );
+
+        $this->assertTrue($result['changed']);
+        $this->assertSame($rw->id, $result['slot_assignments']['8'], 'Pinned RW-at-LW must survive');
+        $this->assertSame($lw->id, $result['slot_assignments']['10'], 'Pinned LW-at-RW must survive');
+    }
+
+    public function test_reconciler_filters_pitch_positions_to_formation_slot_ids(): void
+    {
+        $players = $this->buildSquad();
+        $playerIds = $players->pluck('id')->all();
+        $slotMap = $this->service->computeSlotAssignments(Formation::F_4_3_3, $players);
+
+        // Saved pitch positions include an entry for slot 11, which doesn't
+        // exist in any 11-slot formation. The reconciler must drop it.
+        $pitchPositions = [
+            '0' => [4, 1],
+            '5' => [3, 7],
+            '11' => [9, 9],
+        ];
+
+        // Force a reconciliation by removing one player so `changed` flips.
+        $players[1]->update(['team_id' => $this->opponentTeam->id]);
+        $allTeam = GamePlayer::where('game_id', $this->game->id)
+            ->where('team_id', $this->playerTeam->id)
+            ->get();
+        $backupLb = $this->addBenchPlayer('Left-Back');
+        $allTeam = $allTeam->push($backupLb);
+
+        $result = $this->service->reconcileLineupState(
+            $playerIds,
+            $slotMap,
+            $pitchPositions,
+            $allTeam,
+            $allTeam,
+            Formation::F_4_3_3,
+        );
+
+        $this->assertArrayHasKey('0', $result['pitch_positions']);
+        $this->assertArrayHasKey('5', $result['pitch_positions']);
+        $this->assertArrayNotHasKey('11', $result['pitch_positions']);
+    }
+
+    public function test_show_lineup_persists_reconciled_state_back_to_tactics(): void
+    {
+        $players = $this->buildSquad();
+        $playerIds = $players->pluck('id')->all();
+        $slotMap = $this->service->computeSlotAssignments(Formation::F_4_3_3, $players);
+        $backupLb = $this->addBenchPlayer('Left-Back');
+
+        // Persist a saved lineup into game.tactics, then transfer the LB
+        // out — exactly the broken-state scenario from the bug report.
+        $this->game->tactics->update([
+            'default_lineup' => $playerIds,
+            'default_slot_assignments' => $slotMap,
+            'default_formation' => '4-3-3',
+        ]);
+
+        $players[1]->update(['team_id' => $this->opponentTeam->id]);
+
+        $response = $this->actingAs($this->user)->get(route('game.lineup', $this->game->id));
+        $response->assertOk();
+
+        $this->game->tactics->refresh();
+
+        $newDefaults = $this->game->tactics->default_lineup;
+        $newSlotMap = $this->game->tactics->default_slot_assignments;
+
+        $this->assertCount(11, $newDefaults);
+        $this->assertNotContains($players[1]->id, $newDefaults, 'Sold LB must be out of the saved defaults');
+        $this->assertContains($backupLb->id, $newDefaults, 'Backup LB must be in the saved defaults');
+        $this->assertCount(11, $newSlotMap);
+    }
+
+    public function test_show_lineup_does_not_touch_tactics_for_brand_new_games(): void
+    {
+        // No saved lineup yet — tactics.default_lineup is null.
+        $this->assertNull($this->game->tactics->default_lineup);
+
+        $this->buildSquad();
+
+        $response = $this->actingAs($this->user)->get(route('game.lineup', $this->game->id));
+        $response->assertOk();
+
+        $this->game->tactics->refresh();
+        $this->assertNull($this->game->tactics->default_lineup, 'Brand-new games must keep falling back to autoSelect');
+    }
+
+    public function test_validate_lineup_rejects_slot_map_with_non_goalkeeper_at_gk_slot(): void
+    {
+        $players = $this->buildSquad();
+        $playerIds = $players->pluck('id')->all();
+
+        // Put an outfield player at slot 0, push the actual GK to a CB slot.
+        $badSlotMap = $this->service->computeSlotAssignments(Formation::F_4_3_3, $players);
+        $gkId = $players[0]->id;
+        $cbId = $players[2]->id;
+        $badSlotMap['0'] = $cbId;
+        $badSlotMap['2'] = $gkId;
+
+        $errors = $this->service->validateLineup(
+            $playerIds,
+            $this->game->id,
+            $this->playerTeam->id,
+            $this->match->scheduled_date,
+            $this->competition->id,
+            Formation::F_4_3_3,
+            $badSlotMap,
+        );
+
+        $this->assertNotEmpty($errors);
+        $this->assertContains(__('squad.formation_gk_slot_must_be_goalkeeper'), $errors);
+    }
+
+    public function test_validate_lineup_rejects_incomplete_slot_map(): void
+    {
+        $players = $this->buildSquad();
+        $playerIds = $players->pluck('id')->all();
+
+        $partialSlotMap = $this->service->computeSlotAssignments(Formation::F_4_3_3, $players);
+        unset($partialSlotMap['6']); // drop a CM slot
+
+        $errors = $this->service->validateLineup(
+            $playerIds,
+            $this->game->id,
+            $this->playerTeam->id,
+            $this->match->scheduled_date,
+            $this->competition->id,
+            Formation::F_4_3_3,
+            $partialSlotMap,
+        );
+
+        $this->assertContains(__('squad.formation_slot_map_incomplete'), $errors);
+    }
+
+    public function test_validate_lineup_rejects_slot_map_with_duplicate_player(): void
+    {
+        $players = $this->buildSquad();
+        $playerIds = $players->pluck('id')->all();
+
+        $slotMap = $this->service->computeSlotAssignments(Formation::F_4_3_3, $players);
+        // Force a duplicate: pretend slot 5 and slot 6 are the same player.
+        $slotMap['6'] = $slotMap['5'];
+
+        $errors = $this->service->validateLineup(
+            $playerIds,
+            $this->game->id,
+            $this->playerTeam->id,
+            $this->match->scheduled_date,
+            $this->competition->id,
+            Formation::F_4_3_3,
+            $slotMap,
+        );
+
+        $this->assertContains(__('squad.formation_slot_map_duplicates'), $errors);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes a bug where users could see broken lineup states (gaps in formation, missing goalkeepers) when saved players were transferred, retired, or long-term injured after the lineup was saved. The system now reconciles stored lineups against the current squad on every read, automatically replacing unavailable players while preserving user-intentional placements.

## Key Changes

- **New `LineupService::reconcileLineupState()` method**: Validates saved lineup/slot map/pitch positions against available players. Removes stale entries, tops up the lineup to 11 via the same FormationRecommender used at match-time, and re-pins surviving user-intentional placements. Returns a reconciliation report including which players were replaced.

- **Enhanced `LineupService::validateLineup()` validation**: Added structural checks for slot maps:
  - Every formation slot must be filled exactly once (no gaps, no duplicates)
  - The GK slot must contain a Goalkeeper (prevents the core bug where a sold GK left slot 0 empty)
  - Invalid slot IDs are rejected early

- **Updated `ShowLineup` view**: Calls `reconcileLineupState()` when a saved lineup exists, persists the reconciled state back to `game.tactics` (only for games that already had a saved lineup, not brand-new games), and displays a reconciliation banner showing which players were replaced.

- **Updated `ShowLiveMatch` view**: New `resolveUserPitchData()` helper reconciles the tactical panel's slot map against the actual lineup the simulator is using, preventing disagreement between the UI and match engine.

- **New `filterPitchPositions()` helper**: Strips pitch-position overrides for slot IDs that don't exist in the current formation, keeping positional data consistent across formation changes.

- **Localization**: Added English and Spanish strings for validation errors and the reconciliation banner.

## Implementation Details

- **Idempotent design**: A valid input (11 available players, complete slot map) returns equivalent output with `changed = false` and `replaced = []`, enabling safe repeated calls.

- **User intent preservation**: When reconciling, the method pins surviving slot entries from the original map so user-intentional drag-swaps (e.g., RW at LW) stick wherever the player is still available.

- **Defensive persistence**: Only updates `game.tactics` if the reconciliation actually changed something AND the game already had a saved lineup. Brand-new games keep falling back to auto-selection on each visit.

- **Replacement reporting**: Tracks both slot-specific replacements and lineup-only removals (players with no slot entry), surfacing all changes in a banner so users can review before playing.

https://claude.ai/code/session_01WhYccsdtfQJw7xLPfh6ycr