### PR TITLE
Queue ProcessTransferWindowClose listener

### DIFF
--- a/app/Modules/Transfer/Listeners/ProcessTransferWindowClose.php
+++ b/app/Modules/Transfer/Listeners/ProcessTransferWindowClose.php
@@ -6,9 +6,17 @@ use App\Models\GameNotification;
 use App\Modules\Match\Events\GameDateAdvanced;
 use App\Modules\Transfer\Enums\TransferWindowType;
 use App\Modules\Transfer\Services\AITransferMarketService;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Queue\InteractsWithQueue;
 
-class ProcessTransferWindowClose
+class ProcessTransferWindowClose implements ShouldQueue
 {
+    use InteractsWithQueue;
+
+    public int $tries = 1;
+
+    public string $queue = 'gameplay';
+
     public function __construct(
         private readonly AITransferMarketService $aiTransferMarketService,
     ) {}


### PR DESCRIPTION
The listener triggers AITransferMarketService::processWindowClose, which loads full team rosters and runs free-agent signings plus AI-to-AI transfers. Running it inline on the Continue request adds latency to a user-facing path even though the work itself is AI-to-AI bookkeeping the next page does not read.

Implement ShouldQueue and route the job to the gameplay queue with tries=1, mirroring ProcessCareerActions. The handler's existing GameNotification dedupe keeps it safe against duplicate dispatch.