### PR TITLE
Fix transfer budget sync and investment row materialization

### DIFF
--- a/app/Models/Game.php
+++ b/app/Models/Game.php
@@ -409,7 +409,10 @@ class Game extends Model
      */
     public function currentFinances(): HasOne
     {
-        return $this->hasOne(GameFinances::class)->where('season', $this->season);
+        // games.season is string(10), game_finances.season is integer — cast
+        // explicitly so PostgreSQL doesn't have to coerce a varchar parameter
+        // against an integer column on every lookup.
+        return $this->hasOne(GameFinances::class)->where('season', (int) $this->season);
     }
 
     public function investments(): HasMany
@@ -423,7 +426,9 @@ class Game extends Model
      */
     public function currentInvestment(): HasOne
     {
-        return $this->hasOne(GameInvestment::class)->where('season', $this->season);
+        // games.season is string(10), game_investments.season is integer —
+        // cast explicitly so the relation lookup matches the column type.
+        return $this->hasOne(GameInvestment::class)->where('season', (int) $this->season);
     }
 
     /**

--- a/app/Modules/Transfer/Services/TransferCompletionService.php
+++ b/app/Modules/Transfer/Services/TransferCompletionService.php
@@ -4,6 +4,7 @@ namespace App\Modules\Transfer\Services;
 
 use App\Models\FinancialTransaction;
 use App\Models\Game;
+use App\Models\GameInvestment;
 use App\Models\GamePlayer;
 use App\Models\GameTransfer;
 use App\Models\Loan;
@@ -70,15 +71,18 @@ class TransferCompletionService
             window: TransferWindowType::currentValue($game->current_date),
         );
 
-        // Update transfer budget and record the transaction
-        $investment = $game->currentInvestment;
+        // Update transfer budget and record the transaction.
+        // firstOrCreate guarantees the (game, season) investment row exists so
+        // the increment cannot be silently skipped — the visible budget and
+        // the FinancialTransaction ledger must always move together.
         if ($offer->transfer_fee > 0) {
-            // Add transfer fee back to transfer budget
-            if ($investment) {
-                $investment->increment('transfer_budget', $offer->transfer_fee);
-            }
+            $investment = GameInvestment::firstOrCreate([
+                'game_id' => $game->id,
+                'season' => (int) $game->season,
+            ]);
 
-            // Record the transaction
+            $investment->increment('transfer_budget', $offer->transfer_fee);
+
             FinancialTransaction::recordIncome(
                 gameId: $game->id,
                 category: FinancialTransaction::CATEGORY_TRANSFER_IN,
@@ -161,9 +165,19 @@ class TransferCompletionService
      */
     public function completeIncomingTransfer(TransferOffer $offer, Game $game): bool
     {
+        // Resolve the (game, season) investment up-front via firstOrCreate so
+        // the budget check and the later decrement both operate on the same
+        // guaranteed row — no silent skip if the relation cache is stale or
+        // the season's row hasn't been allocated yet.
+        $investment = $offer->transfer_fee > 0
+            ? GameInvestment::firstOrCreate([
+                'game_id' => $game->id,
+                'season' => (int) $game->season,
+            ])
+            : null;
+
         // Safety net: reject if budget would go negative
-        $investment = $game->currentInvestment;
-        if ($offer->transfer_fee > 0 && $investment && $offer->transfer_fee > $investment->transfer_budget) {
+        if ($investment && $offer->transfer_fee > $investment->transfer_budget) {
             $offer->update(['status' => TransferOffer::STATUS_REJECTED, 'resolved_at' => $game->current_date]);
             return false;
         }
@@ -206,13 +220,11 @@ class TransferCompletionService
             window: TransferWindowType::currentValue($game->current_date),
         );
 
-        // Deduct from transfer budget and record the transaction
-        $investment = $game->currentInvestment;
+        // Deduct from transfer budget and record the transaction. $investment
+        // was resolved at the top of the method via firstOrCreate, so the
+        // decrement and the FinancialTransaction always move together.
         if ($offer->transfer_fee > 0) {
-            // Deduct from transfer budget
-            if ($investment) {
-                $investment->decrement('transfer_budget', $offer->transfer_fee);
-            }
+            $investment->decrement('transfer_budget', $offer->transfer_fee);
 
             FinancialTransaction::recordExpense(
                 gameId: $game->id,

--- a/tests/Unit/CompleteAgreedTransfersOnWindowOpenTest.php
+++ b/tests/Unit/CompleteAgreedTransfersOnWindowOpenTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit;
 
+use App\Models\FinancialTransaction;
 use App\Models\Game;
 use App\Models\GameFinances;
 use App\Models\GameInvestment;
@@ -219,6 +220,112 @@ class CompleteAgreedTransfersOnWindowOpenTest extends TestCase
         $offer->refresh();
         $this->assertSame(TransferOffer::STATUS_AGREED, $offer->status,
             'Listener should only act on a closed→open transition, not on intra-window advances');
+    }
+
+    /**
+     * Regression: agreed sales accepted outside the window must credit the
+     * seller's transfer_budget AND record a TRANSFER_IN FinancialTransaction
+     * when the window opens. Both must move together — the previous code
+     * silently skipped the budget increment when the in-memory investment
+     * relation was null, leaving the ledger and the visible budget desynced.
+     */
+    public function test_outgoing_agreed_transfer_credits_budget_and_records_ledger_when_window_opens(): void
+    {
+        $game = $this->setupGameWithFinances('2024-12-28', '2024');
+        $userTeam = $game->team;
+        $buyerTeam = Team::factory()->create();
+
+        $player = GamePlayer::factory()->forGame($game)->forTeam($userTeam)->create([
+            'contract_until' => '2027-06-30',
+        ]);
+
+        $fee = 7_500_000_00;
+        $offer = TransferOffer::create([
+            'game_id' => $game->id,
+            'game_player_id' => $player->id,
+            'offering_team_id' => $buyerTeam->id,
+            'offer_type' => TransferOffer::TYPE_LISTED,
+            'transfer_fee' => $fee,
+            'status' => TransferOffer::STATUS_AGREED,
+            'direction' => TransferOffer::DIRECTION_OUTGOING,
+            'expires_at' => '2025-02-01',
+            'game_date' => '2024-12-28',
+            'resolved_at' => '2024-12-28',
+        ]);
+
+        $game->update(['current_date' => '2025-01-04']);
+        GameDateAdvanced::dispatch(
+            $game->refresh(),
+            Carbon::parse('2024-12-28'),
+            Carbon::parse('2025-01-04'),
+        );
+
+        $offer->refresh();
+        $this->assertSame(TransferOffer::STATUS_COMPLETED, $offer->status);
+
+        $investment = GameInvestment::where('game_id', $game->id)
+            ->where('season', 2024)
+            ->firstOrFail();
+        $this->assertSame(50_000_000_00 + $fee, (int) $investment->transfer_budget,
+            'Sale fee must be added to transfer_budget the moment the window opens');
+
+        $this->assertDatabaseHas('financial_transactions', [
+            'game_id' => $game->id,
+            'category' => FinancialTransaction::CATEGORY_TRANSFER_IN,
+            'type' => FinancialTransaction::TYPE_INCOME,
+            'amount' => $fee,
+            'related_player_id' => $player->id,
+        ]);
+    }
+
+    /**
+     * Regression: even if the GameInvestment row for the current season is
+     * missing when the window opens (e.g. on saves where allocation hasn't
+     * run yet for the season), the listener must still materialise it via
+     * firstOrCreate and credit the sale fee. Previously the `if ($investment)`
+     * guard silently skipped the increment, leaving the seller without funds.
+     */
+    public function test_outgoing_agreed_transfer_credits_budget_when_investment_row_is_missing(): void
+    {
+        $game = $this->setupGameWithFinances('2024-12-28', '2024');
+        $userTeam = $game->team;
+        $buyerTeam = Team::factory()->create();
+
+        // Delete the investment row to simulate a save state where it hasn't
+        // been created yet for the current season.
+        GameInvestment::where('game_id', $game->id)->delete();
+
+        $player = GamePlayer::factory()->forGame($game)->forTeam($userTeam)->create([
+            'contract_until' => '2027-06-30',
+        ]);
+
+        $fee = 3_000_000_00;
+        TransferOffer::create([
+            'game_id' => $game->id,
+            'game_player_id' => $player->id,
+            'offering_team_id' => $buyerTeam->id,
+            'offer_type' => TransferOffer::TYPE_LISTED,
+            'transfer_fee' => $fee,
+            'status' => TransferOffer::STATUS_AGREED,
+            'direction' => TransferOffer::DIRECTION_OUTGOING,
+            'expires_at' => '2025-02-01',
+            'game_date' => '2024-12-28',
+            'resolved_at' => '2024-12-28',
+        ]);
+
+        $game->update(['current_date' => '2025-01-04']);
+        GameDateAdvanced::dispatch(
+            $game->refresh(),
+            Carbon::parse('2024-12-28'),
+            Carbon::parse('2025-01-04'),
+        );
+
+        $investment = GameInvestment::where('game_id', $game->id)
+            ->where('season', 2024)
+            ->first();
+        $this->assertNotNull($investment, 'firstOrCreate must materialise the missing investment row');
+        $this->assertSame($fee, (int) $investment->transfer_budget,
+            'transfer_budget must equal the sale fee when the row was created on the fly');
     }
 
     /**


### PR DESCRIPTION
## Summary
This PR fixes a critical bug where outgoing agreed transfers accepted outside the transfer window would fail to credit the seller's transfer budget when the window opened. The issue occurred because the code silently skipped the budget increment when the in-memory `GameInvestment` relation was null, causing the visible budget and financial ledger to become desynced.

## Key Changes

- **TransferCompletionService**: Changed from conditional `$game->currentInvestment` lookups to explicit `GameInvestment::firstOrCreate()` calls in both `completeOutgoingTransfer()` and `completeIncomingTransfer()` methods. This guarantees the investment row exists before attempting budget operations, preventing silent failures.

- **Budget and Ledger Synchronization**: Ensured that whenever a transfer fee is processed, both the `transfer_budget` increment/decrement AND the corresponding `FinancialTransaction` record are created together. Previously, a missing investment row would skip the budget update while still creating the transaction, leaving them desynced.

- **Incoming Transfer Safety**: Refactored `completeIncomingTransfer()` to resolve the investment row upfront via `firstOrCreate()`, ensuring the budget check and later decrement operate on the same guaranteed row rather than potentially different cached states.

- **Type Casting in Relations**: Added explicit `(int)` casts in `Game::currentFinances()` and `Game::currentInvestment()` relations to ensure PostgreSQL correctly matches string season values against integer columns without implicit coercion.

## Notable Implementation Details

- The fix handles edge cases where the `GameInvestment` row for the current season hasn't been created yet (e.g., on saves where allocation hasn't run), by materializing it on-demand via `firstOrCreate()`.
- Two new regression tests verify that outgoing agreed transfers properly credit both the budget and the financial ledger when the window opens, even when the investment row is initially missing.
- The changes maintain backward compatibility while eliminating the silent failure mode that previously left budgets and ledgers desynced.

https://claude.ai/code/session_013MTRbgFcoSy4CmQj3edasY