### PR TITLE
Show current club and injury status on tournament squad selection

### DIFF
--- a/app/Http/Views/ShowSquadSelection.php
+++ b/app/Http/Views/ShowSquadSelection.php
@@ -66,7 +66,8 @@ class ShowSquadSelection
         // canonical roster source post-Phase-3, so abilities and date_of_birth
         // are read off them instead of the deprecated Player table.
         $tmIds = array_column($jsonPlayers, 'id');
-        $templates = GamePlayerTemplate::whereIn('transfermarkt_id', $tmIds)
+        $templates = GamePlayerTemplate::with('tournamentInfo')
+            ->whereIn('transfermarkt_id', $tmIds)
             ->get()
             ->keyBy('transfermarkt_id');
 
@@ -88,6 +89,8 @@ class ShowSquadSelection
             $positionDisplay = PositionMapper::getPositionDisplay($position);
             $overall = (int) $template->overall_score;
 
+            $tournamentInfo = $template->tournamentInfo;
+
             $candidate = [
                 'transfermarkt_id' => (string) $tmId,
                 'player_id' => $template->player_id,
@@ -100,6 +103,9 @@ class ShowSquadSelection
                 'age' => $template->date_of_birth->age,
                 'height' => $jp['height'] ?? null,
                 'overall' => $overall,
+                'club_name' => $tournamentInfo?->club_name,
+                'club_crest_url' => $tournamentInfo?->club_crest_url,
+                'is_injured' => (bool) $tournamentInfo?->is_injured,
             ];
 
             $groupKey = match ($positionGroup) {

--- a/app/Http/Views/ShowSquadSelection.php
+++ b/app/Http/Views/ShowSquadSelection.php
@@ -64,9 +64,13 @@ class ShowSquadSelection
 
         // Look up the matching templates for biography. Templates are the
         // canonical roster source post-Phase-3, so abilities and date_of_birth
-        // are read off them instead of the deprecated Player table.
+        // are read off them instead of the deprecated Player table. Filter
+        // by the game's national team id so we never resolve to a club
+        // template that shares the same transfermarkt_id (the same player
+        // can exist as both a club and a national-team template).
         $tmIds = array_column($jsonPlayers, 'id');
         $templates = GamePlayerTemplate::with('tournamentInfo')
+            ->where('team_id', $game->team_id)
             ->whereIn('transfermarkt_id', $tmIds)
             ->get()
             ->keyBy('transfermarkt_id');

--- a/app/Models/GamePlayerTemplate.php
+++ b/app/Models/GamePlayerTemplate.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasOne;
 
 class GamePlayerTemplate extends Model
 {
@@ -68,5 +69,10 @@ class GamePlayerTemplate extends Model
     public function audits(): HasMany
     {
         return $this->hasMany(GamePlayerTemplateAudit::class)->orderByDesc('created_at');
+    }
+
+    public function tournamentInfo(): HasOne
+    {
+        return $this->hasOne(GamePlayerTemplateTournamentInfo::class, 'game_player_template_id');
     }
 }

--- a/app/Models/GamePlayerTemplateTournamentInfo.php
+++ b/app/Models/GamePlayerTemplateTournamentInfo.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class GamePlayerTemplateTournamentInfo extends Model
+{
+    use HasUuids;
+
+    protected $table = 'game_player_template_tournament_info';
+
+    protected $connection = 'pgsql_control';
+
+    public $timestamps = false;
+
+    protected $fillable = [
+        'game_player_template_id',
+        'is_injured',
+        'club_name',
+        'club_crest_url',
+    ];
+
+    protected $casts = [
+        'is_injured' => 'boolean',
+    ];
+
+    public function template(): BelongsTo
+    {
+        return $this->belongsTo(GamePlayerTemplate::class, 'game_player_template_id');
+    }
+}

--- a/app/Modules/Season/Services/GamePlayerTemplateService.php
+++ b/app/Modules/Season/Services/GamePlayerTemplateService.php
@@ -72,6 +72,11 @@ class GamePlayerTemplateService
     public function generateForWorldCup(string $season = '2025'): int
     {
         $this->clearTemplatesForNationalTeams($season);
+        // Wipe any satellite rows that the buggy initial implementation may
+        // have attached to non-national templates. Those rows survived
+        // `clearTemplatesForNationalTeams` and tripped the unique constraint
+        // on re-runs.
+        $this->clearOrphanTournamentInfo();
 
         $basePath = base_path('data/2025/WC2026/teams');
 
@@ -121,25 +126,30 @@ class GamePlayerTemplateService
             DB::connection('pgsql_control')->table('game_player_templates')->insert($chunk);
         }
 
-        $this->insertTournamentInfo($season, $tournamentInfoByPlayerId);
+        $this->upsertTournamentInfo($season, $tournamentInfoByPlayerId, $nationalTeams->pluck('id')->all());
 
         return count($rows);
     }
 
     /**
-     * Insert satellite tournament-info rows keyed by the templates we just
-     * inserted. `generateForWorldCup` calls clearTemplatesForNationalTeams
-     * first, so the FK cascade already wiped any stale satellite rows.
+     * Upsert satellite tournament-info rows keyed by the templates we just
+     * inserted. Filters by national-team team_ids because the same real-world
+     * player can also have a club-team template in the same season — without
+     * the filter, the lookup may resolve to the club template, attach the
+     * satellite there, and that orphan row then survives subsequent
+     * `clearTemplatesForNationalTeams` calls and trips the unique constraint
+     * on re-run.
      */
-    private function insertTournamentInfo(string $season, array $tournamentInfoByPlayerId): void
+    private function upsertTournamentInfo(string $season, array $tournamentInfoByPlayerId, array $nationalTeamIds): void
     {
-        if (empty($tournamentInfoByPlayerId)) {
+        if (empty($tournamentInfoByPlayerId) || empty($nationalTeamIds)) {
             return;
         }
 
         $templateIdsByPlayerId = DB::connection('pgsql_control')
             ->table('game_player_templates')
             ->where('season', $season)
+            ->whereIn('team_id', $nationalTeamIds)
             ->whereIn('player_id', array_keys($tournamentInfoByPlayerId))
             ->pluck('id', 'player_id');
 
@@ -166,8 +176,32 @@ class GamePlayerTemplateService
         foreach (array_chunk($satelliteRows, 500) as $chunk) {
             DB::connection('pgsql_control')
                 ->table('game_player_template_tournament_info')
-                ->insert($chunk);
+                ->upsert(
+                    $chunk,
+                    ['game_player_template_id'],
+                    ['is_injured', 'club_name', 'club_crest_url'],
+                );
         }
+    }
+
+    /**
+     * Delete satellite rows that point to templates which aren't national
+     * teams. Tournament info is only meaningful on national-team templates,
+     * so any other row is an orphan from the buggy initial implementation
+     * that resolved player_id to an ambiguous template id.
+     */
+    private function clearOrphanTournamentInfo(): void
+    {
+        DB::connection('pgsql_control')
+            ->table('game_player_template_tournament_info')
+            ->whereIn('game_player_template_id', function ($query) {
+                $query->select('id')
+                    ->from('game_player_templates')
+                    ->whereNotIn('team_id', function ($inner) {
+                        $inner->select('id')->from('teams')->where('type', 'national');
+                    });
+            })
+            ->delete();
     }
 
     /**

--- a/app/Modules/Season/Services/GamePlayerTemplateService.php
+++ b/app/Modules/Season/Services/GamePlayerTemplateService.php
@@ -99,6 +99,7 @@ class GamePlayerTemplateService
 
         $processedPlayerIds = [];
         $rows = [];
+        $tournamentInfoByPlayerId = [];
 
         foreach ($teamRosters as $roster) {
             foreach ($roster['players'] as $playerData) {
@@ -107,6 +108,11 @@ class GamePlayerTemplateService
                     $row['number'] = null; // WC templates must not store squad numbers
                     $rows[] = $row;
                     $processedPlayerIds[$row['player_id']] = true;
+                    $tournamentInfoByPlayerId[$row['player_id']] = [
+                        'club_name' => $playerData['club']['name'] ?? null,
+                        'club_crest_url' => $playerData['club']['image'] ?? null,
+                        'is_injured' => (bool) ($playerData['injured'] ?? false),
+                    ];
                 }
             }
         }
@@ -115,7 +121,53 @@ class GamePlayerTemplateService
             DB::connection('pgsql_control')->table('game_player_templates')->insert($chunk);
         }
 
+        $this->insertTournamentInfo($season, $tournamentInfoByPlayerId);
+
         return count($rows);
+    }
+
+    /**
+     * Insert satellite tournament-info rows keyed by the templates we just
+     * inserted. `generateForWorldCup` calls clearTemplatesForNationalTeams
+     * first, so the FK cascade already wiped any stale satellite rows.
+     */
+    private function insertTournamentInfo(string $season, array $tournamentInfoByPlayerId): void
+    {
+        if (empty($tournamentInfoByPlayerId)) {
+            return;
+        }
+
+        $templateIdsByPlayerId = DB::connection('pgsql_control')
+            ->table('game_player_templates')
+            ->where('season', $season)
+            ->whereIn('player_id', array_keys($tournamentInfoByPlayerId))
+            ->pluck('id', 'player_id');
+
+        $satelliteRows = [];
+        foreach ($tournamentInfoByPlayerId as $playerId => $info) {
+            $templateId = $templateIdsByPlayerId[$playerId] ?? null;
+            if (!$templateId) {
+                continue;
+            }
+
+            // Skip rows with no useful data so the satellite stays small.
+            if (!$info['is_injured'] && !$info['club_name'] && !$info['club_crest_url']) {
+                continue;
+            }
+
+            $satelliteRows[] = [
+                'game_player_template_id' => $templateId,
+                'is_injured' => $info['is_injured'],
+                'club_name' => $info['club_name'],
+                'club_crest_url' => $info['club_crest_url'],
+            ];
+        }
+
+        foreach (array_chunk($satelliteRows, 500) as $chunk) {
+            DB::connection('pgsql_control')
+                ->table('game_player_template_tournament_info')
+                ->insert($chunk);
+        }
     }
 
     /**

--- a/data/2025/WC2026/teams/3375.json
+++ b/data/2025/WC2026/teams/3375.json
@@ -3,6 +3,7 @@
   "name": "Spain",
   "players": [
     {
+      "club": { "name": "Arsenal FC", "image": "https://tmssl.akamaized.net/images/wappen/head/11.png" },
       "contract": "Mar 26, 2022",
       "dateOfBirth": "Sep 15, 1995",
       "foot": "right",
@@ -14,6 +15,7 @@
       "position": "Goalkeeper"
     },
     {
+      "club": { "name": "RCD Espanyol", "image": "https://tmssl.akamaized.net/images/wappen/head/714.png" },
       "dateOfBirth": "May 4, 2001",
       "foot": "right",
       "height": "1,94m",
@@ -23,6 +25,7 @@
       "position": "Goalkeeper"
     },
     {
+      "club": { "name": "Athletic Club", "image": "https://tmssl.akamaized.net/images/wappen/head/621.png" },
       "contract": "Nov 11, 2020",
       "dateOfBirth": "Jun 11, 1997",
       "foot": "right",
@@ -34,6 +37,7 @@
       "position": "Goalkeeper"
     },
     {
+      "club": { "name": "Real Sociedad", "image": "https://tmssl.akamaized.net/images/wappen/head/681.png" },
       "contract": "Mar 22, 2024",
       "dateOfBirth": "Mar 24, 1995",
       "foot": "right",
@@ -45,6 +49,7 @@
       "position": "Goalkeeper"
     },
     {
+      "club": { "name": "Athletic Club", "image": "https://tmssl.akamaized.net/images/wappen/head/621.png" },
       "contract": "Jun 4, 2021",
       "dateOfBirth": "May 27, 1994",
       "foot": "left",
@@ -56,6 +61,7 @@
       "position": "Centre-Back"
     },
     {
+      "club": { "name": "Valencia CF", "image": "https://tmssl.akamaized.net/images/wappen/head/1049.png" },
       "dateOfBirth": "Jun 27, 2004",
       "foot": "right",
       "height": "1,91m",
@@ -65,6 +71,7 @@
       "position": "Centre-Back"
     },
     {
+      "club": { "name": "Athletic Club", "image": "https://tmssl.akamaized.net/images/wappen/head/621.png" },
       "contract": "Mar 22, 2024",
       "dateOfBirth": "Jul 5, 1999",
       "foot": "right",
@@ -76,6 +83,7 @@
       "position": "Centre-Back"
     },
     {
+      "club": { "name": "Real Madrid", "image": "https://tmssl.akamaized.net/images/wappen/head/418.png" },
       "contract": "Mar 20, 2025",
       "dateOfBirth": "Apr 14, 2005",
       "foot": "both",
@@ -86,6 +94,7 @@
       "position": "Centre-Back"
     },
     {
+      "club": { "name": "FC Barcelona", "image": "https://tmssl.akamaized.net/images/wappen/head/131.png" },
       "contract": "Mar 22, 2024",
       "dateOfBirth": "Jan 22, 2007",
       "foot": "right",
@@ -97,6 +106,7 @@
       "position": "Centre-Back"
     },
     {
+      "club": { "name": "Real Madrid", "image": "https://tmssl.akamaized.net/images/wappen/head/418.png" },
       "dateOfBirth": "Feb 13, 2003",
       "foot": "right",
       "height": "1,84m",
@@ -106,6 +116,7 @@
       "position": "Centre-Back"
     },
     {
+      "club": { "name": "FC Barcelona", "image": "https://tmssl.akamaized.net/images/wappen/head/131.png" },
       "dateOfBirth": "Jan 9, 2001",
       "foot": "right",
       "height": "1,82m",
@@ -115,6 +126,7 @@
       "position": "Centre-Back"
     },
     {
+      "club": { "name": "Atlético de Madrid", "image": "https://tmssl.akamaized.net/images/wappen/head/13.png" },
       "contract": "Jun 15, 2023",
       "dateOfBirth": "Nov 11, 1996",
       "foot": "right",
@@ -126,6 +138,7 @@
       "position": "Centre-Back"
     },
     {
+      "club": { "name": "Atlético de Madrid", "image": "https://tmssl.akamaized.net/images/wappen/head/13.png" },
       "contract": "Jun 30, 2030",
       "dateOfBirth": "Jun 20, 2003",
       "foot": "right",
@@ -136,6 +149,7 @@
       "position": "Centre-Back"
     },
     {
+      "club": { "name": "Bayer 04 Leverkusen", "image": "https://tmssl.akamaized.net/images/wappen/head/15.png" },
       "contract": "Nov 16, 2023",
       "dateOfBirth": "Sep 20, 1995",
       "foot": "left",
@@ -147,6 +161,7 @@
       "position": "Left-Back"
     },
     {
+      "club": { "name": "Chelsea FC", "image": "https://tmssl.akamaized.net/images/wappen/head/631.png" },
       "dateOfBirth": "Jul 22, 1998",
       "foot": "left",
       "height": "1,73m",
@@ -156,6 +171,7 @@
       "position": "Left-Back"
     },
     {
+      "club": { "name": "FC Barcelona", "image": "https://tmssl.akamaized.net/images/wappen/head/131.png" },
       "contract": "Jun 30, 2028",
       "dateOfBirth": "Oct 18, 2003",
       "foot": "left",
@@ -166,6 +182,7 @@
       "position": "Left-Back"
     },
     {
+      "club": { "name": "Real Madrid", "image": "https://tmssl.akamaized.net/images/wappen/head/418.png" },
       "contract": "Jun 30, 2031",
       "dateOfBirth": "Mar 23, 2003",
       "foot": "left",
@@ -177,16 +194,19 @@
       "position": "Left-Back"
     },
     {
+      "club": { "name": "Real Madrid", "image": "https://tmssl.akamaized.net/images/wappen/head/418.png" },
       "contract": "Sep 4, 2014",
       "dateOfBirth": "Jan 11, 1992",
       "foot": "right",
       "height": "1,73m",
       "id": "138927",
+      "injured": true,
       "marketValue": "€10.00m",
       "name": "Daniel Carvajal",
       "position": "Right-Back"
     },
     {
+      "club": { "name": "Atlético de Madrid", "image": "https://tmssl.akamaized.net/images/wappen/head/13.png" },
       "contract": "Nov 11, 2020",
       "dateOfBirth": "Jan 30, 1995",
       "foot": "right",
@@ -198,6 +218,7 @@
       "position": "Right-Back"
     },
     {
+      "club": { "name": "Tottenham Hotspur", "image": "https://tmssl.akamaized.net/images/wappen/head/148.png" },
       "contract": "Mar 28, 2021",
       "dateOfBirth": "Sep 13, 1999",
       "foot": "right",
@@ -209,6 +230,7 @@
       "position": "Right-Back"
     },
     {
+      "club": { "name": "Celta de Vigo", "image": "https://tmssl.akamaized.net/images/wappen/head/940.png" },
       "contract": "Jun 8, 2021",
       "dateOfBirth": "May 13, 1999",
       "foot": "right",
@@ -219,6 +241,7 @@
       "position": "Right-Back"
     },
     {
+      "club": { "name": "Arsenal FC", "image": "https://tmssl.akamaized.net/images/wappen/head/11.png" },
       "contract": "Jun 8, 2021",
       "dateOfBirth": "Feb 2, 1999",
       "foot": "right",
@@ -230,6 +253,7 @@
       "position": "Defensive Midfield"
     },
     {
+      "club": { "name": "RCD Espanyol", "image": "https://tmssl.akamaized.net/images/wappen/head/714.png" },
       "dateOfBirth": "Oct 29, 2001",
       "foot": "left",
       "height": "1,74m",
@@ -239,16 +263,19 @@
       "position": "Left-Back"
     },
     {
+      "club": { "name": "Manchester City", "image": "https://tmssl.akamaized.net/images/wappen/head/281.png" },
       "contract": "Mar 23, 2018",
       "dateOfBirth": "Jun 22, 1996",
       "foot": "right",
       "height": "1,91m",
       "id": "357565",
+      "injured": true,
       "marketValue": "€65.00m",
       "name": "Rodri",
       "position": "Defensive Midfield"
     },
     {
+      "club": { "name": "FC Barcelona", "image": "https://tmssl.akamaized.net/images/wappen/head/131.png" },
       "contract": "Jun 30, 2029",
       "dateOfBirth": "May 26, 2007",
       "foot": "left",
@@ -259,6 +286,7 @@
       "position": "Defensive Midfield"
     },
     {
+      "club": { "name": "Bayer 04 Leverkusen", "image": "https://tmssl.akamaized.net/images/wappen/head/15.png" },
       "contract": "Nov 16, 2023",
       "dateOfBirth": "Jun 28, 1997",
       "foot": "right",
@@ -270,6 +298,7 @@
       "position": "Central Midfield"
     },
     {
+      "club": { "name": "Real Sociedad", "image": "https://tmssl.akamaized.net/images/wappen/head/681.png" },
       "contract": "Sep 2, 2021",
       "dateOfBirth": "Jan 2, 1997",
       "foot": "right",
@@ -280,6 +309,7 @@
       "position": "Central Midfield"
     },
     {
+      "club": { "name": "Paris Saint-Germain", "image": "https://tmssl.akamaized.net/images/wappen/head/583.png" },
       "contract": "Jun 7, 2019",
       "dateOfBirth": "Apr 3, 1996",
       "foot": "left",
@@ -291,16 +321,19 @@
       "position": "Central Midfield"
     },
     {
+      "club": { "name": "FC Barcelona", "image": "https://tmssl.akamaized.net/images/wappen/head/131.png" },
       "contract": "Oct 6, 2021",
       "dateOfBirth": "Aug 5, 2004",
       "foot": "right",
       "height": "1,73m",
       "id": "646740",
+      "injured": true,
       "marketValue": "€80.00m",
       "name": "Gavi",
       "position": "Central Midfield"
     },
     {
+      "club": { "name": "Arsenal FC", "image": "https://tmssl.akamaized.net/images/wappen/head/11.png" },
       "contract": "Sep 3, 2020",
       "dateOfBirth": "Jun 22, 1996",
       "foot": "left",
@@ -312,6 +345,7 @@
       "position": "Central Midfield"
     },
     {
+      "club": { "name": "Atlético de Madrid", "image": "https://tmssl.akamaized.net/images/wappen/head/13.png" },
       "contract": "Nov 18, 2024",
       "dateOfBirth": "Jun 15, 2003",
       "foot": "right",
@@ -322,6 +356,7 @@
       "position": "Central Midfield"
     },
     {
+      "club": { "name": "Real Betis Balompié", "image": "https://tmssl.akamaized.net/images/wappen/head/150.png" },
       "contract": "May 29, 2016",
       "dateOfBirth": "Feb 22, 1996",
       "foot": "right",
@@ -332,6 +367,7 @@
       "position": "Central Midfield"
     },
     {
+      "club": { "name": "FC Barcelona", "image": "https://tmssl.akamaized.net/images/wappen/head/131.png" },
       "contract": "Mar 25, 2021",
       "dateOfBirth": "Nov 25, 2002",
       "foot": "right",
@@ -342,6 +378,7 @@
       "position": "Central Midfield"
     },
     {
+      "club": { "name": "FC Barcelona", "image": "https://tmssl.akamaized.net/images/wappen/head/131.png" },
       "contract": "Nov 15, 2019",
       "dateOfBirth": "May 7, 1998",
       "foot": "right",
@@ -353,6 +390,7 @@
       "position": "Attacking Midfield"
     },
     {
+      "club": { "name": "FC Barcelona", "image": "https://tmssl.akamaized.net/images/wappen/head/131.png" },
       "contract": "Jun 5, 2024",
       "dateOfBirth": "May 11, 2003",
       "foot": "right",
@@ -363,6 +401,7 @@
       "position": "Attacking Midfield"
     },
     {
+      "club": { "name": "Real Betis Balompié", "image": "https://tmssl.akamaized.net/images/wappen/head/150.png" },
       "contract": "Feb 6, 2013",
       "dateOfBirth": "Apr 21, 1992",
       "foot": "right",
@@ -373,6 +412,7 @@
       "position": "Attacking Midfield"
     },
     {
+      "club": { "name": "Aston Villa", "image": "https://tmssl.akamaized.net/images/wappen/head/405.png" },
       "contract": "May 30, 2028",
       "dateOfBirth": "Jan 21, 1996",
       "foot": "left",
@@ -383,6 +423,7 @@
       "position": "Attacking Midfield"
     },
     {
+      "club": { "name": "Real Sociedad", "image": "https://tmssl.akamaized.net/images/wappen/head/681.png" },
       "dateOfBirth": "Dec 27, 2001",
       "foot": "right",
       "height": "1,75m",
@@ -392,6 +433,7 @@
       "position": "Left Winger"
     },
     {
+      "club": { "name": "RC Deportivo", "image": "https://tmssl.akamaized.net/images/wappen/head/897.png" },
       "contract": "Jun 30, 2030",
       "dateOfBirth": "Dec 10, 2002",
       "foot": "right",
@@ -403,6 +445,7 @@
       "position": "Left Winger"
     },
     {
+      "club": { "name": "FC Barcelona", "image": "https://tmssl.akamaized.net/images/wappen/head/131.png" },
       "contract": "Jun 30, 2030",
       "dateOfBirth": "Jul 26, 2006",
       "foot": "right",
@@ -414,6 +457,7 @@
       "position": "Left Winger"
     },
     {
+      "club": { "name": "Athletic Club", "image": "https://tmssl.akamaized.net/images/wappen/head/621.png" },
       "contract": "Sep 24, 2022",
       "dateOfBirth": "Jul 12, 2002",
       "foot": "right",
@@ -424,6 +468,7 @@
       "position": "Left Winger"
     },
     {
+      "club": { "name": "Girona FC", "image": "https://tmssl.akamaized.net/images/wappen/head/12321.png" },
       "dateOfBirth": "Jul 13, 2003",
       "foot": "right",
       "height": "1,73m",
@@ -433,6 +478,7 @@
       "position": "Left Winger"
     },
     {
+      "club": { "name": "Atlético de Madrid", "image": "https://tmssl.akamaized.net/images/wappen/head/13.png" },
       "contract": "Sep 12, 2023",
       "dateOfBirth": "Jul 20, 2001",
       "foot": "right",
@@ -443,6 +489,7 @@
       "position": "Left Winger"
     },
     {
+      "club": { "name": "Rayo Vallecano", "image": "https://tmssl.akamaized.net/images/wappen/head/367.png" },
       "contract": "Sep 7, 2025",
       "dateOfBirth": "Feb 20, 1997",
       "foot": "right",
@@ -454,6 +501,7 @@
       "position": "Right Winger"
     },
     {
+      "club": { "name": "FC Barcelona", "image": "https://tmssl.akamaized.net/images/wappen/head/131.png" },
       "contract": "Sep 8, 2023",
       "dateOfBirth": "Jul 13, 2007",
       "foot": "left",
@@ -465,6 +513,7 @@
       "position": "Right Winger"
     },
     {
+      "club": { "name": "Crystal Palace", "image": "https://tmssl.akamaized.net/images/wappen/head/873.png" },
       "contract": "Oct 6, 2021",
       "dateOfBirth": "Oct 20, 2002",
       "foot": "right",
@@ -476,6 +525,7 @@
       "position": "Right Winger"
     },
     {
+      "club": { "name": "Villarreal CF", "image": "https://tmssl.akamaized.net/images/wappen/head/1050.png" },
       "contract": "Jun 5, 2024",
       "dateOfBirth": "Jul 29, 1993",
       "foot": "right",
@@ -486,6 +536,7 @@
       "position": "Centre-Forward"
     },
     {
+      "club": { "name": "Celta de Vigo", "image": "https://tmssl.akamaized.net/images/wappen/head/940.png" },
       "contract": "Sep 24, 2022",
       "dateOfBirth": "Jan 17, 1993",
       "foot": "right",
@@ -497,6 +548,7 @@
       "position": "Centre-Forward"
     },
     {
+      "club": { "name": "FC Barcelona", "image": "https://tmssl.akamaized.net/images/wappen/head/131.png" },
       "contract": "Sep 3, 2020",
       "dateOfBirth": "Feb 29, 2000",
       "foot": "right",
@@ -508,6 +560,7 @@
       "position": "Centre-Forward"
     },
     {
+      "club": { "name": "Real Sociedad", "image": "https://tmssl.akamaized.net/images/wappen/head/681.png" },
       "contract": "May 29, 2016",
       "dateOfBirth": "Apr 21, 1997",
       "foot": "left",
@@ -519,6 +572,7 @@
       "position": "Centre-Forward"
     },
     {
+      "club": { "name": "FC Porto", "image": "https://tmssl.akamaized.net/images/wappen/head/720.png" },
       "contract": "Nov 18, 2024",
       "dateOfBirth": "May 5, 2004",
       "foot": "right",
@@ -529,6 +583,7 @@
       "position": "Centre-Forward"
     },
     {
+      "club": { "name": "Como 1907", "image": "https://tmssl.akamaized.net/images/wappen/head/1047.png" },
       "contract": "Nov 15, 2014",
       "dateOfBirth": "Oct 23, 1992",
       "foot": "right",
@@ -539,6 +594,7 @@
       "position": "Centre-Forward"
     },
     {
+      "club": { "name": "Real Madrid", "image": "https://tmssl.akamaized.net/images/wappen/head/418.png" },
       "contract": "Jun 30, 2030",
       "dateOfBirth": "Mar 24, 2004",
       "foot": "both",

--- a/data/2025/WC2026/teams/3375.json
+++ b/data/2025/WC2026/teams/3375.json
@@ -3,19 +3,10 @@
   "name": "Spain",
   "players": [
     {
-      "club": { "name": "Arsenal FC", "image": "https://tmssl.akamaized.net/images/wappen/head/11.png" },
-      "contract": "Mar 26, 2022",
-      "dateOfBirth": "Sep 15, 1995",
-      "foot": "right",
-      "height": "1,83m",
-      "id": "262749",
-      "marketValue": "€35.00m",
-      "name": "David Raya",
-      "number": "1",
-      "position": "Goalkeeper"
-    },
-    {
-      "club": { "name": "RCD Espanyol", "image": "https://tmssl.akamaized.net/images/wappen/head/714.png" },
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/131.png",
+        "name": "FC Barcelona"
+      },
       "dateOfBirth": "May 4, 2001",
       "foot": "right",
       "height": "1,94m",
@@ -25,66 +16,88 @@
       "position": "Goalkeeper"
     },
     {
-      "club": { "name": "Athletic Club", "image": "https://tmssl.akamaized.net/images/wappen/head/621.png" },
-      "contract": "Nov 11, 2020",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/11.png",
+        "name": "Arsenal FC"
+      },
+      "dateOfBirth": "Sep 15, 1995",
+      "foot": "right",
+      "height": "1,83m",
+      "id": "262749",
+      "marketValue": "€35.00m",
+      "name": "David Raya",
+      "position": "Goalkeeper"
+    },
+    {
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/621.png",
+        "name": "Athletic Club"
+      },
       "dateOfBirth": "Jun 11, 1997",
       "foot": "right",
       "height": "1,90m",
       "id": "262396",
       "marketValue": "€25.00m",
       "name": "Unai Simón",
-      "number": "23",
       "position": "Goalkeeper"
     },
     {
-      "club": { "name": "Real Sociedad", "image": "https://tmssl.akamaized.net/images/wappen/head/681.png" },
-      "contract": "Mar 22, 2024",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/681.png",
+        "name": "Real Sociedad"
+      },
       "dateOfBirth": "Mar 24, 1995",
       "foot": "right",
       "height": "1,91m",
       "id": "212862",
       "marketValue": "€14.00m",
       "name": "Álex Remiro",
-      "number": "13",
       "position": "Goalkeeper"
     },
     {
-      "club": { "name": "Athletic Club", "image": "https://tmssl.akamaized.net/images/wappen/head/621.png" },
-      "contract": "Jun 4, 2021",
-      "dateOfBirth": "May 27, 1994",
-      "foot": "left",
-      "height": "1,91m",
-      "id": "176553",
-      "marketValue": "€9.00m",
-      "name": "Aymeric Laporte",
-      "number": "14",
-      "position": "Centre-Back"
-    },
-    {
-      "club": { "name": "Valencia CF", "image": "https://tmssl.akamaized.net/images/wappen/head/1049.png" },
-      "dateOfBirth": "Jun 27, 2004",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/631.png",
+        "name": "Chelsea FC"
+      },
+      "dateOfBirth": "Nov 18, 1997",
       "foot": "right",
-      "height": "1,91m",
-      "id": "646750",
-      "marketValue": "€35.00m",
-      "name": "Cristhian Mosquera",
-      "position": "Centre-Back"
+      "height": "1,97m",
+      "id": "403151",
+      "marketValue": "€22.00m",
+      "name": "Robert Sánchez",
+      "position": "Goalkeeper"
     },
     {
-      "club": { "name": "Athletic Club", "image": "https://tmssl.akamaized.net/images/wappen/head/621.png" },
-      "contract": "Mar 22, 2024",
-      "dateOfBirth": "Jul 5, 1999",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/237.png",
+        "name": "RCD Mallorca"
+      },
+      "dateOfBirth": "Jul 6, 2000",
+      "foot": "right",
+      "height": "1,89m",
+      "id": "562742",
+      "marketValue": "€6.00m",
+      "name": "Leo Román",
+      "position": "Goalkeeper"
+    },
+    {
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/131.png",
+        "name": "FC Barcelona"
+      },
+      "dateOfBirth": "Jan 22, 2007",
       "foot": "right",
       "height": "1,84m",
-      "id": "524000",
-      "marketValue": "€40.00m",
-      "name": "Dani Vivian",
-      "number": "4",
+      "id": "962110",
+      "marketValue": "€80.00m",
+      "name": "Pau Cubarsí",
       "position": "Centre-Back"
     },
     {
-      "club": { "name": "Real Madrid", "image": "https://tmssl.akamaized.net/images/wappen/head/418.png" },
-      "contract": "Mar 20, 2025",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/418.png",
+        "name": "Real Madrid"
+      },
       "dateOfBirth": "Apr 14, 2005",
       "foot": "both",
       "height": "1,97m",
@@ -94,29 +107,75 @@
       "position": "Centre-Back"
     },
     {
-      "club": { "name": "FC Barcelona", "image": "https://tmssl.akamaized.net/images/wappen/head/131.png" },
-      "contract": "Mar 22, 2024",
-      "dateOfBirth": "Jan 22, 2007",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/11.png",
+        "name": "Arsenal FC"
+      },
+      "dateOfBirth": "Jun 27, 2004",
       "foot": "right",
-      "height": "1,84m",
-      "id": "962110",
-      "marketValue": "€80.00m",
-      "name": "Pau Cubarsí",
-      "number": "15",
+      "height": "1,91m",
+      "id": "646750",
+      "marketValue": "€35.00m",
+      "name": "Cristhian Mosquera",
       "position": "Centre-Back"
     },
     {
-      "club": { "name": "Real Madrid", "image": "https://tmssl.akamaized.net/images/wappen/head/418.png" },
-      "dateOfBirth": "Feb 13, 2003",
-      "foot": "right",
-      "height": "1,84m",
-      "id": "935245",
-      "marketValue": "€7.50m",
-      "name": "Raúl Asencio",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/131.png",
+        "name": "FC Barcelona"
+      },
+      "dateOfBirth": "Jan 16, 1997",
+      "foot": "left",
+      "height": "1,92m",
+      "id": "399776",
+      "marketValue": "€25.00m",
+      "name": "Pau Torres",
       "position": "Centre-Back"
     },
     {
-      "club": { "name": "FC Barcelona", "image": "https://tmssl.akamaized.net/images/wappen/head/131.png" },
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/621.png",
+        "name": "Athletic Club"
+      },
+      "dateOfBirth": "May 27, 1994",
+      "foot": "left",
+      "height": "1,91m",
+      "id": "176553",
+      "marketValue": "€9.00m",
+      "name": "Aymeric Laporte",
+      "position": "Centre-Back"
+    },
+    {
+      "club": {
+        "name": "Atlético de Madrid",
+        "image": "https://assets.virtuafc.com/crests/13.png"
+      },
+      "dateOfBirth": "Nov 11, 1996",
+      "foot": "right",
+      "height": "1,87m",
+      "id": "351809",
+      "marketValue": "€40.00m",
+      "name": "Robin Le Normand",
+      "position": "Centre-Back"
+    },
+    {
+      "club": {
+        "name": "Athletic Club",
+        "image": "https://assets.virtuafc.com/crests/621.png"
+      },
+      "dateOfBirth": "Jul 5, 1999",
+      "foot": "right",
+      "height": "1,84m",
+      "id": "524000",
+      "marketValue": "€25.00m",
+      "name": "Dani Vivian",
+      "position": "Centre-Back"
+    },
+    {
+      "club": {
+        "name": "FC Barcelona",
+        "image": "https://assets.virtuafc.com/crests/131.png"
+      },
       "dateOfBirth": "Jan 9, 2001",
       "foot": "right",
       "height": "1,82m",
@@ -126,42 +185,10 @@
       "position": "Centre-Back"
     },
     {
-      "club": { "name": "Atlético de Madrid", "image": "https://tmssl.akamaized.net/images/wappen/head/13.png" },
-      "contract": "Jun 15, 2023",
-      "dateOfBirth": "Nov 11, 1996",
-      "foot": "right",
-      "height": "1,87m",
-      "id": "351809",
-      "marketValue": "€40.00m",
-      "name": "Robin Le Normand",
-      "number": "3",
-      "position": "Centre-Back"
-    },
-    {
-      "club": { "name": "Atlético de Madrid", "image": "https://tmssl.akamaized.net/images/wappen/head/13.png" },
-      "contract": "Jun 30, 2030",
-      "dateOfBirth": "Jun 20, 2003",
-      "foot": "right",
-      "height": "1,90m",
-      "id": "844637",
-      "marketValue": "€15.00m",
-      "name": "Marc Pubill",
-      "position": "Centre-Back"
-    },
-    {
-      "club": { "name": "Bayer 04 Leverkusen", "image": "https://tmssl.akamaized.net/images/wappen/head/15.png" },
-      "contract": "Nov 16, 2023",
-      "dateOfBirth": "Sep 20, 1995",
-      "foot": "left",
-      "height": "1,71m",
-      "id": "193082",
-      "marketValue": "€24.00m",
-      "name": "Alejandro Grimaldo",
-      "number": "17",
-      "position": "Left-Back"
-    },
-    {
-      "club": { "name": "Chelsea FC", "image": "https://tmssl.akamaized.net/images/wappen/head/631.png" },
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/631.png",
+        "name": "Chelsea FC"
+      },
       "dateOfBirth": "Jul 22, 1998",
       "foot": "left",
       "height": "1,73m",
@@ -171,204 +198,114 @@
       "position": "Left-Back"
     },
     {
-      "club": { "name": "FC Barcelona", "image": "https://tmssl.akamaized.net/images/wappen/head/131.png" },
-      "contract": "Jun 30, 2028",
-      "dateOfBirth": "Oct 18, 2003",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/15.png",
+        "name": "Bayer 04 Leverkusen"
+      },
+      "dateOfBirth": "Sep 20, 1995",
       "foot": "left",
-      "height": "1,77m",
-      "id": "636688",
-      "marketValue": "€55.00m",
-      "name": "Alejandro Balde",
+      "height": "1,71m",
+      "id": "193082",
+      "marketValue": "€24.00m",
+      "name": "Alejandro Grimaldo",
       "position": "Left-Back"
     },
     {
-      "club": { "name": "Real Madrid", "image": "https://tmssl.akamaized.net/images/wappen/head/418.png" },
-      "contract": "Jun 30, 2031",
-      "dateOfBirth": "Mar 23, 2003",
-      "foot": "left",
-      "height": "1,86m",
-      "id": "811778",
-      "marketValue": "€60.00m",
-      "name": "Álvaro Carreras",
-      "number": "18",
-      "position": "Left-Back"
-    },
-    {
-      "club": { "name": "Real Madrid", "image": "https://tmssl.akamaized.net/images/wappen/head/418.png" },
-      "contract": "Sep 4, 2014",
-      "dateOfBirth": "Jan 11, 1992",
-      "foot": "right",
-      "height": "1,73m",
-      "id": "138927",
-      "injured": true,
-      "marketValue": "€10.00m",
-      "name": "Daniel Carvajal",
-      "position": "Right-Back"
-    },
-    {
-      "club": { "name": "Atlético de Madrid", "image": "https://tmssl.akamaized.net/images/wappen/head/13.png" },
-      "contract": "Nov 11, 2020",
-      "dateOfBirth": "Jan 30, 1995",
-      "foot": "right",
-      "height": "1,84m",
-      "id": "282411",
-      "marketValue": "€22.00m",
-      "name": "Marcos Llorente",
-      "number": "5",
-      "position": "Right-Back"
-    },
-    {
-      "club": { "name": "Tottenham Hotspur", "image": "https://tmssl.akamaized.net/images/wappen/head/148.png" },
-      "contract": "Mar 28, 2021",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/148.png",
+        "name": "Tottenham Hotspur"
+      },
       "dateOfBirth": "Sep 13, 1999",
       "foot": "right",
       "height": "1,73m",
       "id": "553875",
       "marketValue": "€40.00m",
       "name": "Pedro Porro",
-      "number": "12",
       "position": "Right-Back"
     },
     {
-      "club": { "name": "Celta de Vigo", "image": "https://tmssl.akamaized.net/images/wappen/head/940.png" },
-      "contract": "Jun 8, 2021",
-      "dateOfBirth": "May 13, 1999",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/13.png",
+        "name": "Atlético de Madrid"
+      },
+      "dateOfBirth": "Jan 30, 1995",
       "foot": "right",
       "height": "1,84m",
-      "id": "331505",
-      "marketValue": "€20.00m",
-      "name": "Óscar Mingueza",
+      "id": "282411",
+      "marketValue": "€22.00m",
+      "name": "Marcos Llorente",
       "position": "Right-Back"
     },
     {
-      "club": { "name": "Arsenal FC", "image": "https://tmssl.akamaized.net/images/wappen/head/11.png" },
-      "contract": "Jun 8, 2021",
+      "club": {
+        "name": "Atlético de Madrid",
+        "image": "https://assets.virtuafc.com/crests/13.png"
+      },
+      "dateOfBirth": "Jun 20, 2003",
+      "foot": "right",
+      "height": "1,90m",
+      "id": "844637",
+      "marketValue": "€15.00m",
+      "name": "Marc Pubill",
+      "position": "Centre-Back"
+    },
+    {
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/681.png",
+        "name": "Real Sociedad"
+      },
+      "dateOfBirth": "Sep 4, 2000",
+      "foot": "left",
+      "height": "1,71m",
+      "id": "366930",
+      "marketValue": "€15.00m",
+      "name": "Sergio Gómez",
+      "position": "Left-Back"
+    },
+    {
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/1075.png",
+        "name": "SC Braga"
+      },
+      "dateOfBirth": "Apr 1, 2000",
+      "foot": "right",
+      "height": "1,69m",
+      "id": "495601",
+      "marketValue": "€7.00m",
+      "name": "Víctor Gómez",
+      "position": "Right-Back"
+    },
+    {
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/11.png",
+        "name": "Arsenal FC"
+      },
       "dateOfBirth": "Feb 2, 1999",
       "foot": "right",
       "height": "1,81m",
       "id": "423440",
       "marketValue": "€80.00m",
       "name": "Martín Zubimendi",
-      "number": "18",
       "position": "Defensive Midfield"
     },
     {
-      "club": { "name": "RCD Espanyol", "image": "https://tmssl.akamaized.net/images/wappen/head/714.png" },
-      "dateOfBirth": "Oct 29, 2001",
-      "foot": "left",
-      "height": "1,74m",
-      "id": "709372",
-      "marketValue": "€25.00m",
-      "name": "Carlos Romero",
-      "position": "Left-Back"
-    },
-    {
-      "club": { "name": "Manchester City", "image": "https://tmssl.akamaized.net/images/wappen/head/281.png" },
-      "contract": "Mar 23, 2018",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/281.png",
+        "name": "Manchester City"
+      },
       "dateOfBirth": "Jun 22, 1996",
       "foot": "right",
       "height": "1,91m",
       "id": "357565",
-      "injured": true,
       "marketValue": "€65.00m",
       "name": "Rodri",
       "position": "Defensive Midfield"
     },
     {
-      "club": { "name": "FC Barcelona", "image": "https://tmssl.akamaized.net/images/wappen/head/131.png" },
-      "contract": "Jun 30, 2029",
-      "dateOfBirth": "May 26, 2007",
-      "foot": "left",
-      "height": "1,93m",
-      "id": "1018920",
-      "marketValue": "€30.00m",
-      "name": "Marc Bernal",
-      "position": "Defensive Midfield"
-    },
-    {
-      "club": { "name": "Bayer 04 Leverkusen", "image": "https://tmssl.akamaized.net/images/wappen/head/15.png" },
-      "contract": "Nov 16, 2023",
-      "dateOfBirth": "Jun 28, 1997",
-      "foot": "right",
-      "height": "1,73m",
-      "id": "261504",
-      "marketValue": "€20.00m",
-      "name": "Aleix García",
-      "number": "8",
-      "position": "Central Midfield"
-    },
-    {
-      "club": { "name": "Real Sociedad", "image": "https://tmssl.akamaized.net/images/wappen/head/681.png" },
-      "contract": "Sep 2, 2021",
-      "dateOfBirth": "Jan 2, 1997",
-      "foot": "right",
-      "height": "1,80m",
-      "id": "372246",
-      "marketValue": "€8.00m",
-      "name": "Carlos Soler",
-      "position": "Central Midfield"
-    },
-    {
-      "club": { "name": "Paris Saint-Germain", "image": "https://tmssl.akamaized.net/images/wappen/head/583.png" },
-      "contract": "Jun 7, 2019",
-      "dateOfBirth": "Apr 3, 1996",
-      "foot": "left",
-      "height": "1,89m",
-      "id": "350219",
-      "marketValue": "€35.00m",
-      "name": "Fabián Ruiz",
-      "number": "8",
-      "position": "Central Midfield"
-    },
-    {
-      "club": { "name": "FC Barcelona", "image": "https://tmssl.akamaized.net/images/wappen/head/131.png" },
-      "contract": "Oct 6, 2021",
-      "dateOfBirth": "Aug 5, 2004",
-      "foot": "right",
-      "height": "1,73m",
-      "id": "646740",
-      "injured": true,
-      "marketValue": "€80.00m",
-      "name": "Gavi",
-      "position": "Central Midfield"
-    },
-    {
-      "club": { "name": "Arsenal FC", "image": "https://tmssl.akamaized.net/images/wappen/head/11.png" },
-      "contract": "Sep 3, 2020",
-      "dateOfBirth": "Jun 22, 1996",
-      "foot": "left",
-      "height": "1,89m",
-      "id": "338424",
-      "marketValue": "€45.00m",
-      "name": "Mikel Merino",
-      "number": "6",
-      "position": "Central Midfield"
-    },
-    {
-      "club": { "name": "Atlético de Madrid", "image": "https://tmssl.akamaized.net/images/wappen/head/13.png" },
-      "contract": "Nov 18, 2024",
-      "dateOfBirth": "Jun 15, 2003",
-      "foot": "right",
-      "height": "1,81m",
-      "id": "775605",
-      "marketValue": "€50.00m",
-      "name": "Pablo Barrios",
-      "position": "Central Midfield"
-    },
-    {
-      "club": { "name": "Real Betis Balompié", "image": "https://tmssl.akamaized.net/images/wappen/head/150.png" },
-      "contract": "May 29, 2016",
-      "dateOfBirth": "Feb 22, 1996",
-      "foot": "right",
-      "height": "1,78m",
-      "id": "357885",
-      "marketValue": "€8.00m",
-      "name": "Pablo Fornals",
-      "position": "Central Midfield"
-    },
-    {
-      "club": { "name": "FC Barcelona", "image": "https://tmssl.akamaized.net/images/wappen/head/131.png" },
-      "contract": "Mar 25, 2021",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/131.png",
+        "name": "FC Barcelona"
+      },
       "dateOfBirth": "Nov 25, 2002",
       "foot": "right",
       "height": "1,74m",
@@ -378,20 +315,62 @@
       "position": "Central Midfield"
     },
     {
-      "club": { "name": "FC Barcelona", "image": "https://tmssl.akamaized.net/images/wappen/head/131.png" },
-      "contract": "Nov 15, 2019",
-      "dateOfBirth": "May 7, 1998",
+      "club": {
+        "name": "Atlético de Madrid",
+        "image": "https://assets.virtuafc.com/crests/13.png"
+      },
+      "dateOfBirth": "Jun 15, 2003",
       "foot": "right",
-      "height": "1,79m",
-      "id": "293385",
-      "marketValue": "€60.00m",
-      "name": "Dani Olmo",
-      "number": "10",
-      "position": "Attacking Midfield"
+      "height": "1,81m",
+      "id": "775605",
+      "marketValue": "€50.00m",
+      "name": "Pablo Barrios",
+      "position": "Central Midfield"
     },
     {
-      "club": { "name": "FC Barcelona", "image": "https://tmssl.akamaized.net/images/wappen/head/131.png" },
-      "contract": "Jun 5, 2024",
+      "club": {
+        "name": "Bayer 04 Leverkusen",
+        "image": "https://assets.virtuafc.com/crests/15.png"
+      },
+      "dateOfBirth": "Jun 28, 1997",
+      "foot": "right",
+      "height": "1,73m",
+      "id": "261504",
+      "marketValue": "€20.00m",
+      "name": "Aleix García",
+      "position": "Central Midfield"
+    },
+    {
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/681.png",
+        "name": "Real Sociedad"
+      },
+      "dateOfBirth": "Jan 2, 1997",
+      "foot": "right",
+      "height": "1,80m",
+      "id": "372246",
+      "marketValue": "€8.00m",
+      "name": "Carlos Soler",
+      "position": "Central Midfield"
+    },
+    {
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/150.png",
+        "name": "Real Betis Balompié"
+      },
+      "dateOfBirth": "Feb 22, 1996",
+      "foot": "right",
+      "height": "1,78m",
+      "id": "357885",
+      "marketValue": "€8.00m",
+      "name": "Pablo Fornals",
+      "position": "Central Midfield"
+    },
+    {
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/131.png",
+        "name": "FC Barcelona"
+      },
       "dateOfBirth": "May 11, 2003",
       "foot": "right",
       "height": "1,74m",
@@ -401,85 +380,36 @@
       "position": "Attacking Midfield"
     },
     {
-      "club": { "name": "Real Betis Balompié", "image": "https://tmssl.akamaized.net/images/wappen/head/150.png" },
-      "contract": "Feb 6, 2013",
-      "dateOfBirth": "Apr 21, 1992",
-      "foot": "right",
-      "height": "1,76m",
-      "id": "85288",
-      "marketValue": "€6.00m",
-      "name": "Isco",
-      "position": "Attacking Midfield"
-    },
-    {
-      "club": { "name": "Aston Villa", "image": "https://tmssl.akamaized.net/images/wappen/head/405.png" },
-      "contract": "May 30, 2028",
-      "dateOfBirth": "Jan 21, 1996",
-      "foot": "left",
-      "height": "1,82m",
-      "id": "296622",
-      "marketValue": "€15.00m",
-      "name": "Marco Asensio",
-      "position": "Attacking Midfield"
-    },
-    {
-      "club": { "name": "Real Sociedad", "image": "https://tmssl.akamaized.net/images/wappen/head/681.png" },
-      "dateOfBirth": "Dec 27, 2001",
-      "foot": "right",
-      "height": "1,75m",
-      "id": "616369",
-      "marketValue": "€18.00m",
-      "name": "Ander Barrenetxea",
-      "position": "Left Winger"
-    },
-    {
-      "club": { "name": "RC Deportivo", "image": "https://tmssl.akamaized.net/images/wappen/head/897.png" },
-      "contract": "Jun 30, 2030",
-      "dateOfBirth": "Dec 10, 2002",
-      "foot": "right",
-      "height": "1,70m",
-      "id": "636385",
-      "marketValue": "€25.00m",
-      "name": "Yeremay Hernández",
-      "number": "10",
-      "position": "Left Winger"
-    },
-    {
-      "club": { "name": "FC Barcelona", "image": "https://tmssl.akamaized.net/images/wappen/head/131.png" },
-      "contract": "Jun 30, 2030",
-      "dateOfBirth": "Jul 26, 2006",
-      "foot": "right",
-      "height": "1,77m",
-      "id": "1301775",
-      "marketValue": "€15.00m",
-      "name": "Jan Virgili",
-      "number": "17",
-      "position": "Left Winger"
-    },
-    {
-      "club": { "name": "Athletic Club", "image": "https://tmssl.akamaized.net/images/wappen/head/621.png" },
-      "contract": "Sep 24, 2022",
-      "dateOfBirth": "Jul 12, 2002",
-      "foot": "right",
-      "height": "1,81m",
-      "id": "709187",
-      "marketValue": "€70.00m",
-      "name": "Nico Williams",
-      "position": "Left Winger"
-    },
-    {
-      "club": { "name": "Girona FC", "image": "https://tmssl.akamaized.net/images/wappen/head/12321.png" },
-      "dateOfBirth": "Jul 13, 2003",
+      "club": {
+        "name": "FC Barcelona",
+        "image": "https://assets.virtuafc.com/crests/131.png"
+      },
+      "dateOfBirth": "Aug 5, 2004",
       "foot": "right",
       "height": "1,73m",
-      "id": "935231",
-      "marketValue": "€20.00m",
-      "name": "Víctor Muñoz",
-      "position": "Left Winger"
+      "id": "646740",
+      "marketValue": "€80.00m",
+      "name": "Gavi",
+      "position": "Central Midfield"
     },
     {
-      "club": { "name": "Atlético de Madrid", "image": "https://tmssl.akamaized.net/images/wappen/head/13.png" },
-      "contract": "Sep 12, 2023",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/131.png",
+        "name": "FC Barcelona"
+      },
+      "dateOfBirth": "May 7, 1998",
+      "foot": "right",
+      "height": "1,79m",
+      "id": "293385",
+      "marketValue": "€60.00m",
+      "name": "Dani Olmo",
+      "position": "Attacking Midfield"
+    },
+    {
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/13.png",
+        "name": "Atlético de Madrid"
+      },
       "dateOfBirth": "Jul 20, 2001",
       "foot": "right",
       "height": "1,74m",
@@ -489,119 +419,147 @@
       "position": "Left Winger"
     },
     {
-      "club": { "name": "Rayo Vallecano", "image": "https://tmssl.akamaized.net/images/wappen/head/367.png" },
-      "contract": "Sep 7, 2025",
-      "dateOfBirth": "Feb 20, 1997",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/331.png",
+        "name": "CA Osasuna"
+      },
+      "dateOfBirth": "Jul 13, 2003",
       "foot": "right",
       "height": "1,73m",
-      "id": "455181",
-      "marketValue": "€4.00m",
-      "name": "Jorge de Frutos",
-      "number": "2",
-      "position": "Right Winger"
+      "id": "935231",
+      "marketValue": "€20.00m",
+      "name": "Víctor Muñoz",
+      "position": "Left Winger"
     },
     {
-      "club": { "name": "FC Barcelona", "image": "https://tmssl.akamaized.net/images/wappen/head/131.png" },
-      "contract": "Sep 8, 2023",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/681.png",
+        "name": "Real Sociedad"
+      },
+      "dateOfBirth": "Dec 27, 2001",
+      "foot": "right",
+      "height": "1,75m",
+      "id": "616369",
+      "marketValue": "€18.00m",
+      "name": "Ander Barrenetxea",
+      "position": "Left Winger"
+    },
+    {
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/131.png",
+        "name": "FC Barcelona"
+      },
       "dateOfBirth": "Jul 13, 2007",
       "foot": "left",
       "height": "1,80m",
       "id": "937958",
       "marketValue": "€200.00m",
       "name": "Lamine Yamal",
-      "number": "19",
       "position": "Right Winger"
     },
     {
-      "club": { "name": "Crystal Palace", "image": "https://tmssl.akamaized.net/images/wappen/head/873.png" },
-      "contract": "Oct 6, 2021",
+      "club": {
+        "name": "Rayo Vallecano",
+        "image": "https://assets.virtuafc.com/crests/367.png"
+      },
+      "dateOfBirth": "Feb 20, 1997",
+      "foot": "right",
+      "height": "1,73m",
+      "id": "455181",
+      "marketValue": "€4.00m",
+      "name": "Jorge de Frutos",
+      "position": "Right Winger"
+    },
+    {
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/873.png",
+        "name": "Crystal Palace"
+      },
       "dateOfBirth": "Oct 20, 2002",
       "foot": "right",
       "height": "1,72m",
       "id": "568157",
       "marketValue": "€35.00m",
       "name": "Yéremy Pino",
-      "number": "11",
       "position": "Right Winger"
     },
     {
-      "club": { "name": "Villarreal CF", "image": "https://tmssl.akamaized.net/images/wappen/head/1050.png" },
-      "contract": "Jun 5, 2024",
-      "dateOfBirth": "Jul 29, 1993",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/1047.png",
+        "name": "Como 1907"
+      },
+      "dateOfBirth": "Nov 21, 2005",
       "foot": "right",
-      "height": "1,78m",
-      "id": "246968",
-      "marketValue": "€10.00m",
-      "name": "Ayoze Pérez",
-      "position": "Centre-Forward"
+      "height": "1,85m",
+      "id": "1190411",
+      "marketValue": "€30.00m",
+      "name": "Jesús Rodríguez",
+      "position": "Left Winger"
     },
     {
-      "club": { "name": "Celta de Vigo", "image": "https://tmssl.akamaized.net/images/wappen/head/940.png" },
-      "contract": "Sep 24, 2022",
-      "dateOfBirth": "Jan 17, 1993",
-      "foot": "right",
-      "height": "1,87m",
-      "id": "278359",
-      "marketValue": "€3.00m",
-      "name": "Borja Iglesias",
-      "number": "9",
-      "position": "Centre-Forward"
-    },
-    {
-      "club": { "name": "FC Barcelona", "image": "https://tmssl.akamaized.net/images/wappen/head/131.png" },
-      "contract": "Sep 3, 2020",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/131.png",
+        "name": "FC Barcelona"
+      },
       "dateOfBirth": "Feb 29, 2000",
       "foot": "right",
       "height": "1,82m",
       "id": "398184",
       "marketValue": "€50.00m",
       "name": "Ferran Torres",
-      "number": "7",
       "position": "Centre-Forward"
     },
     {
-      "club": { "name": "Real Sociedad", "image": "https://tmssl.akamaized.net/images/wappen/head/681.png" },
-      "contract": "May 29, 2016",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/681.png",
+        "name": "Real Sociedad"
+      },
       "dateOfBirth": "Apr 21, 1997",
       "foot": "left",
       "height": "1,81m",
       "id": "351478",
       "marketValue": "€25.00m",
       "name": "Mikel Oyarzabal",
-      "number": "21",
       "position": "Centre-Forward"
     },
     {
-      "club": { "name": "FC Porto", "image": "https://tmssl.akamaized.net/images/wappen/head/720.png" },
-      "contract": "Nov 18, 2024",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/940.png",
+        "name": "RC Celta"
+      },
+      "dateOfBirth": "Jan 17, 1993",
+      "foot": "right",
+      "height": "1,87m",
+      "id": "278359",
+      "marketValue": "€3.00m",
+      "name": "Borja Iglesias",
+      "position": "Centre-Forward"
+    },
+    {
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/1050.png",
+        "name": "Villarreal CF"
+      },
+      "dateOfBirth": "Sep 30, 2003",
+      "foot": "right",
+      "height": "1,71m",
+      "id": "733576",
+      "marketValue": "€40.00m",
+      "name": "Alberto Moleiro",
+      "position": "Left Winger"
+    },
+    {
+      "club": {
+        "name": "FC Porto",
+        "image": "https://assets.virtuafc.com/crests/720.png"
+      },
       "dateOfBirth": "May 5, 2004",
       "foot": "right",
       "height": "1,93m",
       "id": "991268",
+      "injured": true,
       "marketValue": "€50.00m",
       "name": "Samu Aghehowa",
-      "position": "Centre-Forward"
-    },
-    {
-      "club": { "name": "Como 1907", "image": "https://tmssl.akamaized.net/images/wappen/head/1047.png" },
-      "contract": "Nov 15, 2014",
-      "dateOfBirth": "Oct 23, 1992",
-      "foot": "right",
-      "height": "1,89m",
-      "id": "128223",
-      "marketValue": "€13.00m",
-      "name": "Álvaro Morata",
-      "position": "Centre-Forward"
-    },
-    {
-      "club": { "name": "Real Madrid", "image": "https://tmssl.akamaized.net/images/wappen/head/418.png" },
-      "contract": "Jun 30, 2030",
-      "dateOfBirth": "Mar 24, 2004",
-      "foot": "both",
-      "height": "1,82m",
-      "id": "935230",
-      "marketValue": "€30.00m",
-      "name": "Gonzalo García",
       "position": "Centre-Forward"
     }
   ],

--- a/database/migrations/2026_05_12_165019_create_game_player_template_tournament_info_table.php
+++ b/database/migrations/2026_05_12_165019_create_game_player_template_tournament_info_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('game_player_template_tournament_info', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->unsignedBigInteger('game_player_template_id');
+            $table->boolean('is_injured')->default(false);
+            $table->string('club_name')->nullable();
+            $table->string('club_crest_url')->nullable();
+
+            $table->foreign('game_player_template_id')
+                ->references('id')
+                ->on('game_player_templates')
+                ->onDelete('cascade');
+
+            $table->unique('game_player_template_id');
+        });
+
+        DB::statement('ALTER TABLE game_player_template_tournament_info ALTER COLUMN id SET DEFAULT gen_random_uuid()');
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('game_player_template_tournament_info');
+    }
+};

--- a/resources/views/squad-selection.blade.php
+++ b/resources/views/squad-selection.blade.php
@@ -99,12 +99,26 @@ $tabs = [
 
                         {{-- Name + Meta --}}
                         <div class="flex-1 min-w-0">
-                            <div class="font-semibold text-sm md:text-base text-text-primary truncate">{{ $candidate['name'] }}</div>
-                            <div class="flex items-center gap-2 text-xs text-text-secondary mt-0.5">
-                                <span>{{ $candidate['age'] }} {{ __('squad.years_abbr') }}</span>
+                            <div class="flex items-center gap-1.5 min-w-0">
+                                <div class="font-semibold text-sm md:text-base text-text-primary truncate">{{ $candidate['name'] }}</div>
+                                @if($candidate['is_injured'])
+                                    <svg title="{{ __('squad.injured_generic') }}" aria-label="{{ __('squad.injured_generic') }}" class="w-3.5 h-3.5 text-accent-red shrink-0" viewBox="0 0 20 20" fill="currentColor">
+                                        <path fill-rule="evenodd" d="M8 2a1 1 0 0 0-1 1v4H3a1 1 0 0 0-1 1v4a1 1 0 0 0 1 1h4v4a1 1 0 0 0 1 1h4a1 1 0 0 0 1-1v-4h4a1 1 0 0 0 1-1V8a1 1 0 0 0-1-1h-4V3a1 1 0 0 0-1-1H8z" clip-rule="evenodd"/>
+                                    </svg>
+                                @endif
+                            </div>
+                            <div class="flex items-center gap-1.5 text-xs text-text-secondary mt-0.5 min-w-0">
+                                @if($candidate['club_crest_url'])
+                                    <img src="{{ $candidate['club_crest_url'] }}" alt="" class="w-3.5 h-3.5 shrink-0 object-contain">
+                                @endif
+                                @if($candidate['club_name'])
+                                    <span class="truncate">{{ $candidate['club_name'] }}</span>
+                                    <span class="shrink-0">&middot;</span>
+                                @endif
+                                <span class="shrink-0">{{ $candidate['age'] }} {{ __('squad.years_abbr') }}</span>
                                 @if($candidate['height'])
-                                <span>&middot;</span>
-                                <span>{{ $candidate['height'] }}</span>
+                                    <span class="shrink-0">&middot;</span>
+                                    <span class="shrink-0">{{ $candidate['height'] }}</span>
                                 @endif
                             </div>
                         </div>


### PR DESCRIPTION
Adds a `game_player_template_tournament_info` satellite table holding the
real-world club (name + crest URL) and an injury flag, populated from new
optional `club` and `injured` fields in the WC2026 team JSON files. The
tournament squad-selection screen displays a club crest + name beneath each
player and a red medical-cross icon on injured players (still selectable).
Seeds Spain's roster (3375.json) with example data; other nations render
unchanged.

https://claude.ai/code/session_01K97aKnMFNE8CXyaEgg3orb