### PR TITLE
Pay UEFA league-phase qualification bonus + polish transaction history

### DIFF
--- a/app/Modules/Competition/Configs/BundesligaConfig.php
+++ b/app/Modules/Competition/Configs/BundesligaConfig.php
@@ -111,6 +111,11 @@ class BundesligaConfig implements CompetitionConfig, HasSeasonGoals
         return 0;
     }
 
+    public function getLeaguePhaseQualificationBonus(int $position): int
+    {
+        return 0;
+    }
+
     public function getStandingsZones(): array
     {
         $slots = config('countries.DE.continental_slots.DEU1', []);

--- a/app/Modules/Competition/Configs/ChampionsLeagueConfig.php
+++ b/app/Modules/Competition/Configs/ChampionsLeagueConfig.php
@@ -92,6 +92,18 @@ class ChampionsLeagueConfig implements CompetitionConfig
         return self::KNOCKOUT_PRIZE_MONEY[$roundNumber] ?? 0;
     }
 
+    public function getLeaguePhaseQualificationBonus(int $position): int
+    {
+        if ($position <= 8) {
+            return 400_000_000; // €4M — direct R16
+        }
+        if ($position <= 24) {
+            return 100_000_000; // €1M — qualified to knockout playoff
+        }
+
+        return 0; // Eliminated
+    }
+
     public function getStandingsZones(): array
     {
         return [

--- a/app/Modules/Competition/Configs/ConferenceLeagueConfig.php
+++ b/app/Modules/Competition/Configs/ConferenceLeagueConfig.php
@@ -53,6 +53,18 @@ class ConferenceLeagueConfig implements CompetitionConfig
         return self::KNOCKOUT_PRIZE_MONEY[$roundNumber] ?? 0;
     }
 
+    public function getLeaguePhaseQualificationBonus(int $position): int
+    {
+        if ($position <= 8) {
+            return 100_000_000; // €1M — direct R16
+        }
+        if ($position <= 24) {
+            return 30_000_000;  // €300K — qualified to knockout playoff
+        }
+
+        return 0; // Eliminated
+    }
+
     public function getStandingsZones(): array
     {
         return [

--- a/app/Modules/Competition/Configs/DefaultLeagueConfig.php
+++ b/app/Modules/Competition/Configs/DefaultLeagueConfig.php
@@ -108,6 +108,11 @@ class DefaultLeagueConfig implements CompetitionConfig, HasSeasonGoals
         return 0;
     }
 
+    public function getLeaguePhaseQualificationBonus(int $position): int
+    {
+        return 0;
+    }
+
     public function getStandingsZones(): array
     {
         // Calculate zones dynamically based on league size

--- a/app/Modules/Competition/Configs/EuropaLeagueConfig.php
+++ b/app/Modules/Competition/Configs/EuropaLeagueConfig.php
@@ -53,6 +53,18 @@ class EuropaLeagueConfig implements CompetitionConfig
         return self::KNOCKOUT_PRIZE_MONEY[$roundNumber] ?? 0;
     }
 
+    public function getLeaguePhaseQualificationBonus(int $position): int
+    {
+        if ($position <= 8) {
+            return 200_000_000; // €2M — direct R16
+        }
+        if ($position <= 24) {
+            return 50_000_000;  // €500K — qualified to knockout playoff
+        }
+
+        return 0; // Eliminated
+    }
+
     public function getStandingsZones(): array
     {
         return [

--- a/app/Modules/Competition/Configs/KnockoutCupConfig.php
+++ b/app/Modules/Competition/Configs/KnockoutCupConfig.php
@@ -43,6 +43,11 @@ class KnockoutCupConfig implements CompetitionConfig
         return self::KNOCKOUT_PRIZE_MONEY[$roundNumber] ?? self::KNOCKOUT_PRIZE_MONEY[1];
     }
 
+    public function getLeaguePhaseQualificationBonus(int $position): int
+    {
+        return 0;
+    }
+
     public function getStandingsZones(): array
     {
         return [];

--- a/app/Modules/Competition/Configs/LaLiga2Config.php
+++ b/app/Modules/Competition/Configs/LaLiga2Config.php
@@ -114,6 +114,11 @@ class LaLiga2Config implements CompetitionConfig, HasSeasonGoals
         return 0;
     }
 
+    public function getLeaguePhaseQualificationBonus(int $position): int
+    {
+        return 0;
+    }
+
     public function getStandingsZones(): array
     {
         $promotions = config('countries.ES.promotions', []);

--- a/app/Modules/Competition/Configs/LaLigaConfig.php
+++ b/app/Modules/Competition/Configs/LaLigaConfig.php
@@ -112,6 +112,11 @@ class LaLigaConfig implements CompetitionConfig, HasSeasonGoals
         return 0;
     }
 
+    public function getLeaguePhaseQualificationBonus(int $position): int
+    {
+        return 0;
+    }
+
     public function getStandingsZones(): array
     {
         $slots = config('countries.ES.continental_slots.ESP1', []);

--- a/app/Modules/Competition/Configs/Ligue1Config.php
+++ b/app/Modules/Competition/Configs/Ligue1Config.php
@@ -111,6 +111,11 @@ class Ligue1Config implements CompetitionConfig, HasSeasonGoals
         return 0;
     }
 
+    public function getLeaguePhaseQualificationBonus(int $position): int
+    {
+        return 0;
+    }
+
     public function getStandingsZones(): array
     {
         $slots = config('countries.FR.continental_slots.FRA1', []);

--- a/app/Modules/Competition/Configs/PremierLeagueConfig.php
+++ b/app/Modules/Competition/Configs/PremierLeagueConfig.php
@@ -113,6 +113,11 @@ class PremierLeagueConfig implements CompetitionConfig, HasSeasonGoals
         return 0;
     }
 
+    public function getLeaguePhaseQualificationBonus(int $position): int
+    {
+        return 0;
+    }
+
     public function getStandingsZones(): array
     {
         $slots = config('countries.EN.continental_slots.ENG1', []);

--- a/app/Modules/Competition/Configs/PrimeraRFEFConfig.php
+++ b/app/Modules/Competition/Configs/PrimeraRFEFConfig.php
@@ -99,6 +99,11 @@ class PrimeraRFEFConfig implements CompetitionConfig, HasSeasonGoals
         return 0;
     }
 
+    public function getLeaguePhaseQualificationBonus(int $position): int
+    {
+        return 0;
+    }
+
     public function getStandingsZones(): array
     {
         return [

--- a/app/Modules/Competition/Configs/PrimeraRFEFPlayoffConfig.php
+++ b/app/Modules/Competition/Configs/PrimeraRFEFPlayoffConfig.php
@@ -48,6 +48,11 @@ class PrimeraRFEFPlayoffConfig implements CompetitionConfig
         return self::KNOCKOUT_PRIZE_MONEY[$roundNumber] ?? 0;
     }
 
+    public function getLeaguePhaseQualificationBonus(int $position): int
+    {
+        return 0;
+    }
+
     public function getStandingsZones(): array
     {
         return [];

--- a/app/Modules/Competition/Configs/SerieAConfig.php
+++ b/app/Modules/Competition/Configs/SerieAConfig.php
@@ -112,6 +112,11 @@ class SerieAConfig implements CompetitionConfig, HasSeasonGoals
         return 0;
     }
 
+    public function getLeaguePhaseQualificationBonus(int $position): int
+    {
+        return 0;
+    }
+
     public function getStandingsZones(): array
     {
         $slots = config('countries.IT.continental_slots.ITA1', []);

--- a/app/Modules/Competition/Configs/UefaSuperCupConfig.php
+++ b/app/Modules/Competition/Configs/UefaSuperCupConfig.php
@@ -39,6 +39,11 @@ class UefaSuperCupConfig implements CompetitionConfig
         return self::KNOCKOUT_PRIZE_MONEY[$roundNumber] ?? 0;
     }
 
+    public function getLeaguePhaseQualificationBonus(int $position): int
+    {
+        return 0;
+    }
+
     public function getStandingsZones(): array
     {
         return [];

--- a/app/Modules/Competition/Contracts/CompetitionConfig.php
+++ b/app/Modules/Competition/Contracts/CompetitionConfig.php
@@ -51,4 +51,15 @@ interface CompetitionConfig
      * Returns 0 for competitions without knockout prize money.
      */
     public function getKnockoutPrizeMoney(int $roundNumber): int;
+
+    /**
+     * Get the bonus paid to a team for qualifying out of the league phase,
+     * based on its final league-phase position (in cents).
+     *
+     * Applies to Swiss-format competitions (UCL/UEL/UECL) where finishing
+     * the league phase is itself an achievement worth rewarding mid-season,
+     * independent of the end-of-season position-based TV revenue. Returns 0
+     * for competitions without a league phase.
+     */
+    public function getLeaguePhaseQualificationBonus(int $position): int;
 }

--- a/app/Modules/Match/Events/LeaguePhaseCompleted.php
+++ b/app/Modules/Match/Events/LeaguePhaseCompleted.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Modules\Match\Events;
+
+use App\Models\Competition;
+use App\Models\Game;
+use Illuminate\Foundation\Events\Dispatchable;
+
+/**
+ * Fired once per (game, competition) when the league phase of a Swiss-format
+ * UEFA competition finishes — i.e. all 8 matchdays have been played and final
+ * standings are known. Used to award the qualification bonus before the
+ * knockout phase begins.
+ */
+class LeaguePhaseCompleted
+{
+    use Dispatchable;
+
+    public function __construct(
+        public readonly Game $game,
+        public readonly Competition $competition,
+    ) {}
+}

--- a/app/Modules/Match/Handlers/SwissFormatHandler.php
+++ b/app/Modules/Match/Handlers/SwissFormatHandler.php
@@ -5,6 +5,7 @@ namespace App\Modules\Match\Handlers;
 use App\Models\Competition;
 use App\Modules\Competition\Services\FinalVenueResolver;
 use App\Modules\Competition\Services\SwissKnockoutGenerator;
+use App\Modules\Match\Events\LeaguePhaseCompleted;
 use App\Modules\Match\Services\CupTieResolver;
 use App\Modules\Squad\Services\EligibilityService;
 use App\Models\CupTie;
@@ -118,10 +119,18 @@ class SwissFormatHandler extends CupCompetitionHandler
             return;
         }
 
-        // For round 1 (knockout playoff), generate if it doesn't exist
+        // For round 1 (knockout playoff), generate if it doesn't exist.
+        // Generating round 1 is also the moment the league phase definitively
+        // ends — final standings are known, so fire LeaguePhaseCompleted so
+        // qualification bonuses can be paid before the knockout begins.
         if ($nextRound === SwissKnockoutGenerator::ROUND_KNOCKOUT_PLAYOFF) {
             if (!$this->roundExists($game->id, $competitionId, $nextRound)) {
                 $this->generateKnockoutRound($game, $competitionId, $nextRound);
+
+                $competition = Competition::find($competitionId);
+                if ($competition) {
+                    LeaguePhaseCompleted::dispatch($game, $competition);
+                }
             }
             return;
         }

--- a/app/Modules/Match/Listeners/AwardCupPrizeMoney.php
+++ b/app/Modules/Match/Listeners/AwardCupPrizeMoney.php
@@ -24,11 +24,16 @@ class AwardCupPrizeMoney
             return;
         }
 
+        $roundKey = $event->cupTie->firstLegMatch?->round_name;
+        $roundLabel = $roundKey
+            ? __($roundKey)
+            : __('cup.round_n', ['round' => $event->cupTie->round_number]);
+
         FinancialTransaction::recordIncome(
             gameId: $event->game->id,
             category: FinancialTransaction::CATEGORY_CUP_BONUS,
             amount: $amount,
-            description: __('finances.tx_cup_advancement', ['competition' => $competition->name, 'round' => $event->cupTie->round_number]),
+            description: __('finances.tx_cup_advancement', ['competition' => $competition->name, 'round' => $roundLabel]),
             transactionDate: $event->game->current_date->toDateString(),
         );
     }

--- a/app/Modules/Match/Listeners/AwardLeaguePhaseBonus.php
+++ b/app/Modules/Match/Listeners/AwardLeaguePhaseBonus.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Modules\Match\Listeners;
+
+use App\Models\FinancialTransaction;
+use App\Models\GameStanding;
+use App\Modules\Match\Events\LeaguePhaseCompleted;
+
+class AwardLeaguePhaseBonus
+{
+    public function handle(LeaguePhaseCompleted $event): void
+    {
+        $standing = GameStanding::where('game_id', $event->game->id)
+            ->where('competition_id', $event->competition->id)
+            ->where('team_id', $event->game->team_id)
+            ->first();
+
+        if (! $standing) {
+            return;
+        }
+
+        $amount = $event->competition->getConfig()->getLeaguePhaseQualificationBonus($standing->position);
+
+        if ($amount <= 0) {
+            return;
+        }
+
+        FinancialTransaction::recordIncome(
+            gameId: $event->game->id,
+            category: FinancialTransaction::CATEGORY_CUP_BONUS,
+            amount: $amount,
+            description: __('finances.tx_league_phase_qualification', [
+                'competition' => $event->competition->name,
+                'position' => $standing->position,
+            ]),
+            transactionDate: $event->game->current_date->toDateString(),
+        );
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -11,6 +11,7 @@ use App\Events\TournamentEnded;
 use App\Modules\Academy\Listeners\GenerateInitialAcademyBatch;
 use App\Modules\Match\Events\CupTieResolved;
 use App\Modules\Match\Events\GameDateAdvanced;
+use App\Modules\Match\Events\LeaguePhaseCompleted;
 use App\Modules\Match\Events\MatchFinalized;
 use App\Modules\Match\Handlers\PreSeasonHandler;
 use App\Modules\Match\Handlers\GroupStageCupHandler;
@@ -19,6 +20,7 @@ use App\Modules\Match\Handlers\LeagueHandler;
 use App\Modules\Match\Handlers\LeagueWithPlayoffHandler;
 use App\Modules\Match\Handlers\SwissFormatHandler;
 use App\Modules\Match\Listeners\AwardCupPrizeMoney;
+use App\Modules\Match\Listeners\AwardLeaguePhaseBonus;
 use App\Modules\Match\Listeners\ConductNextCupRoundDraw;
 use App\Modules\Match\Listeners\EnsureMatchAttendance;
 use App\Modules\Notification\Listeners\NotifyTransferWindowClosed;
@@ -157,6 +159,8 @@ class AppServiceProvider extends ServiceProvider
         Event::listen(CupTieResolved::class, AwardCupPrizeMoney::class);
         Event::listen(CupTieResolved::class, ConductNextCupRoundDraw::class);
         Event::listen(CupTieResolved::class, SendCupTieNotifications::class);
+
+        Event::listen(LeaguePhaseCompleted::class, AwardLeaguePhaseBonus::class);
 
         Event::listen(SeasonStarted::class, GenerateInitialAcademyBatch::class);
 

--- a/lang/en/finances.php
+++ b/lang/en/finances.php
@@ -196,7 +196,8 @@ return [
     'tx_player_signed' => ':player signed from :team',
     'tx_loan_in' => ':player loaned from :team (salary)',
     'tx_player_released' => ':player released (severance)',
-    'tx_cup_advancement' => ':competition - Round :round advancement',
+    'tx_cup_advancement' => ':competition - :round',
+    'tx_league_phase_qualification' => ':competition - League phase qualification (:position)',
     'tx_infrastructure_upgrade' => ':area upgraded from Tier :from to Tier :to',
     'tx_budget_loan_received' => 'Budget loan received: :amount',
 

--- a/lang/es/finances.php
+++ b/lang/es/finances.php
@@ -196,7 +196,8 @@ return [
     'tx_player_signed' => ':player fichado de :team',
     'tx_loan_in' => ':player cedido de :team (salario)',
     'tx_player_released' => ':player liberado (indemnización)',
-    'tx_cup_advancement' => ':competition - Ronda :round superada',
+    'tx_cup_advancement' => ':competition - :round',
+    'tx_league_phase_qualification' => ':competition - Fase de liga superada (:positionº)',
     'tx_infrastructure_upgrade' => ':area mejorada de Nivel :from a Nivel :to',
     'tx_budget_loan_received' => 'Préstamo presupuestario recibido: :amount',
 

--- a/resources/views/club/finances.blade.php
+++ b/resources/views/club/finances.blade.php
@@ -278,7 +278,7 @@
                                 <tr class="border-b border-border-default"
                                     x-show="filter === 'all' || filter === '{{ $transaction->type }}'"
                                     x-transition>
-                                    <td class="px-5 py-2.5 text-text-muted whitespace-nowrap">{{ $transaction->transaction_date->format('d M') }}</td>
+                                    <td class="px-5 py-2.5 text-text-muted whitespace-nowrap">{{ $transaction->transaction_date->locale(app()->getLocale())->translatedFormat('d M') }}</td>
                                     <td class="py-2.5">
                                         <span class="px-2 py-0.5 text-[10px] font-semibold rounded-full {{ $transaction->isIncome() ? 'bg-accent-green/10 text-accent-green' : 'bg-accent-red/10 text-accent-red' }}">
                                             {{ $transaction->category_label }}


### PR DESCRIPTION
## Summary
- UCL/UEL/UECL teams now receive a `cup_bonus` transaction when their league phase ends, sized by final position. Closes the gap where a team qualifying directly to R16 saw no mid-season prize while a 9th–24th finisher got the playoff bonus.
- New `LeaguePhaseCompleted` event dispatched once per (game, competition) from `SwissFormatHandler` when round 1 (knockout playoff) is first generated — same idempotency guard as round creation, no separate marker needed.
- Transaction history polish: cup advancement descriptions now use the localized round name (e.g. "Cuartos de final") instead of the raw `Ronda N superada`. Dates render in the active app locale.

### Bonus tiers
| Competition | Top 8 (direct R16) | 9–24 (to playoff) | 25–36 (eliminated) |
|---|---|---|---|
| UCL | €4M | €1M | €0 |
| UEL | €2M | €500K | €0 |
| UECL | €1M | €300K | €0 |

End-of-season TV revenue (€9M–€80M position-based) is unchanged.

## Test plan
- [ ] Play the last UCL league-phase matchday with the user team finishing top 8 → verify one `Bonificación Copa` transaction `Champions League · Fase de liga superada (Nº)` for the right amount, dated around the playoff first leg.
- [ ] Repeat with user team finishing 9–24 → smaller league-phase bonus appears, then the existing €1M playoff bonus shows up after winning the playoff tie.
- [ ] User team finishing 25–36 → no league-phase bonus (existing TV revenue path still applies at season end).
- [ ] User team not in any UEFA competition → nothing fires.
- [ ] Win a Copa del Rey tie → description now reads `Copa del Rey · Cuartos de final` rather than `Ronda 3 superada`.
- [ ] Transaction history dates render in Spanish ("04 feb") when locale is `es`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)