### PR TITLE
Fix AI squad bloat that strangles the AI-to-AI transfer market

### DIFF
--- a/app/Modules/Season/Processors/SquadReplenishmentProcessor.php
+++ b/app/Modules/Season/Processors/SquadReplenishmentProcessor.php
@@ -152,11 +152,14 @@ class SquadReplenishmentProcessor implements SeasonProcessor
             $currentSquadSize = $players->count() + count($positionsToFill);
             $youthCount = mt_rand(self::YOUTH_INTAKE_MIN, self::YOUTH_INTAKE_MAX);
 
-            // Collect release candidates if squad would exceed cap
-            $slotsAvailable = self::YOUTH_INTAKE_SQUAD_CAP - $currentSquadSize;
-            if ($slotsAvailable < $youthCount) {
-                $toRelease = $youthCount - max(0, $slotsAvailable);
-                $candidates = $this->getOldestWeakestIds($players, $game->current_date, $toRelease);
+            // Trim back to YOUTH_INTAKE_SQUAD_CAP after this season's intake.
+            // Target-based, not delta-based: a squad that has drifted past the
+            // cap (via loan returns, reserve promotions, etc.) gets pulled back
+            // down, not merely held flat.
+            $projectedSize = $currentSquadSize + $youthCount;
+            $toRelease = max(0, $projectedSize - self::YOUTH_INTAKE_SQUAD_CAP);
+            if ($toRelease > 0) {
+                $candidates = $this->getReleaseCandidates($players, $game->current_date, $toRelease);
                 $releaseIds = array_merge($releaseIds, $candidates);
             }
 
@@ -337,20 +340,58 @@ class SquadReplenishmentProcessor implements SeasonProcessor
     }
 
     /**
-     * Get IDs of the oldest, weakest players from a team to release.
-     * Only targets players aged 30+ sorted by ability ascending.
+     * Pick players to release down to a target squad size.
+     *
+     * Retirement-age players are preferred (lowest-rated first), then any other
+     * player by ability ascending. GROUP_MINIMUMS are respected so a release
+     * never leaves a position group below its viable floor (e.g. < 3 GK).
+     *
+     * Returning fewer than $count is acceptable — if the squad is at the
+     * minimums in every group there's nothing safe to release.
      *
      * @return string[]
      */
-    private function getOldestWeakestIds(Collection $players, Carbon $currentDate, int $count): array
+    private function getReleaseCandidates(Collection $players, Carbon $currentDate, int $count): array
     {
+        if ($count <= 0) {
+            return [];
+        }
+
         $cutoff = PlayerAge::dateOfBirthCutoff(PlayerAge::MIN_RETIREMENT_OUTFIELD, $currentDate);
 
-        return $players
-            ->filter(fn ($gp) => $gp->date_of_birth && Carbon::parse($gp->date_of_birth)->lte($cutoff))
-            ->sortBy(fn ($gp) => $gp->overall_score ?? 0)
-            ->take($count)
-            ->pluck('id')
-            ->toArray();
+        $sorted = $players->sort(function ($a, $b) use ($cutoff) {
+            $aOlder = $a->date_of_birth && Carbon::parse($a->date_of_birth)->lte($cutoff);
+            $bOlder = $b->date_of_birth && Carbon::parse($b->date_of_birth)->lte($cutoff);
+
+            if ($aOlder !== $bOlder) {
+                return $aOlder ? -1 : 1;
+            }
+
+            return ($a->overall_score ?? 0) <=> ($b->overall_score ?? 0);
+        })->values();
+
+        $groupCounts = [];
+        foreach ($players as $player) {
+            $group = PositionMapper::getPositionGroup($player->position);
+            $groupCounts[$group] = ($groupCounts[$group] ?? 0) + 1;
+        }
+
+        $selected = [];
+        foreach ($sorted as $player) {
+            if (count($selected) >= $count) {
+                break;
+            }
+
+            $group = PositionMapper::getPositionGroup($player->position);
+            $groupMin = self::GROUP_MINIMUMS[$group] ?? 0;
+            if (($groupCounts[$group] ?? 0) <= $groupMin) {
+                continue;
+            }
+
+            $selected[] = $player->id;
+            $groupCounts[$group]--;
+        }
+
+        return $selected;
     }
 }


### PR DESCRIPTION
## Summary

Users have been reporting that AI-to-AI transfers dry up as a save ages. Production data confirms it (1,578 games at age 0, 175 at age 6):

| save-year | median AI squad | summer AI-to-AI transfers / game |
|---|---|---|
| 0 | 28 | 74.2 |
| 1 | **30** | 25.2 |
| 2 | 30 | 12.8 |
| 4 | 32 | 3.2 |
| 6 | 34 | 3.4 |
| 10 | 36 | 0.8 |

`AITransferMarketService` requires `buyer.squad_count < MAX_SQUAD_SIZE (30)` to qualify a buyer. AI squads grow ~1 player per season past that cap, so the buyer pool empties and the AI market collapses — in lockstep, season by season.

Other candidates were ruled out by data and code:
- Wage-pressure clamp: wage-to-revenue ratios are flat or *declining* across save age; `pct_at_max_clamp` for elite teams drops from 25% (age 0) to ~1% (age 10).
- Cumulative `spent`/`earned` eroding budget: `AITransferMarketService.php:1389-1394` filters per-window, not cumulative.
- Player value inflation vs. static budgets: plausible but slow; not the dominant lever once squad bloat was confirmed.

## What changed

`SquadReplenishmentProcessor` already releases surplus AI players to free-agency, but had three bugs:

1. **Delta-based release math.** A team at 31 about to add 3 youths would release 3 and add 3 — net zero. Prevented growth but never reduced existing bloat.
2. **No catch-up trim.** Squads that drifted past 28 via loan returns, reserve promotions, or Phase-1 position fills were never pulled back.
3. **Release pool limited to age 33+.** Young bloated squads found zero candidates and added youth anyway, so growth was fastest exactly where it was worst.

Fix:
- `toRelease = max(0, projectedSize - YOUTH_INTAKE_SQUAD_CAP)` — the cap is now a target ceiling, not a delta.
- New `getReleaseCandidates`: retirement-age first (lowest-rated among them), then anyone by ability ascending, gated by `GROUP_MINIMUMS` (3 GK / 6 DEF / 6 MID / 4 FWD) so a release never breaks the squad floor.

Released players land at `team_id = NULL` and feed the existing free-agent pool — `AIFreeAgentSigningProcessor` (priority 45, right after this one at priority 42) consumes from it, so the supply recycles naturally between clubs.

Existing inflated saves converge in one season (a team at 36 releases 8 on the next season-close run, lands at 28). New saves never drift.

## What we deliberately are NOT doing

- Not raising `MAX_SQUAD_SIZE` or `YOUTH_INTAKE_SQUAD_CAP` — the values are correct; the enforcement was wrong.
- Not touching budgets / wage clamp / market values — Q2 ruled out the financial-side mechanisms.
- Not patching `LoanService::returnAllLoans` or `ReserveTeamService::permanentlyPromoteCalledUpPlayers` — those still bypass `MAX_SQUAD_SIZE` mid-season, but the season-close trim absorbs the overflow. Leaving as a follow-up if mid-season bloat surfaces as a separate complaint.

## Test plan

- [ ] On an existing save at age ≥ 3, run `php artisan app:simulate-season` and verify AI rosters drop from 32+ toward 28
- [ ] On a fresh `app:seed-reference-data --fresh` save, simulate 5 consecutive seasons and verify AI squad sizes hold around 26–28
- [ ] Spot-check that no AI team ends a season with fewer than 3 GK / 6 DEF / 6 MID / 4 FWD
- [ ] Re-run the production Q1 query on a re-simulated save: AI-to-AI per game in summer at age 3 should rise from ~6 toward ~20+
- [ ] CI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)