### PR TITLE
Spawn AI academy graduates younger so they can reach their potential

### DIFF
--- a/app/Modules/Squad/Services/PlayerGeneratorService.php
+++ b/app/Modules/Squad/Services/PlayerGeneratorService.php
@@ -343,13 +343,18 @@ class PlayerGeneratorService
 
     /**
      * Average potential upside (points above current ability) per reputation tier.
+     *
+     * Aligned with YouthAcademyService::POTENTIAL_UPSIDE_MEAN — the two pools
+     * should produce comparable distributions. Earlier values were too
+     * conservative for the AI side, leaving aggregate synthetic p90_potential
+     * ~8 points below originals and starving the league of replacement stars.
      */
     private const POTENTIAL_UPSIDE_MEAN = [
         0 => 12,
-        1 => 12,
-        2 => 10,
-        3 => 12,
-        4 => 14,
+        1 => 15,
+        2 => 15,
+        3 => 14,
+        4 => 16,
     ];
 
     private const POTENTIAL_UPSIDE_STD_DEV = 5;
@@ -360,9 +365,9 @@ class PlayerGeneratorService
     private const POTENTIAL_FLOOR = [
         0 => 42,
         1 => 45,
-        2 => 50,
-        3 => 55,
-        4 => 60,
+        2 => 52,
+        3 => 58,
+        4 => 62,
     ];
 
     /**
@@ -395,7 +400,28 @@ class PlayerGeneratorService
         $reputationIndex = ClubProfile::getReputationTierIndex($reputationLevel);
         $abilityMean = self::REPUTATION_BASE_QUALITY[$reputationIndex];
 
-        $overallScore = $this->sampler->sampleAbility($abilityMean, self::ABILITY_STD_DEV, 30, 80);
+        // Spawn academy graduates inside the dev-curve growth window (17-20)
+        // rather than past it (20-23), so the existing DevelopmentCurve has
+        // enough runway to deliver players to their potential. A 17-year-old
+        // gets ~6 development years before plateau; a 23-year-old gets zero.
+        $ageRoll = mt_rand(1, 100);
+        $age = match (true) {
+            $ageRoll <= 20 => 17,
+            $ageRoll <= 55 => 18,
+            $ageRoll <= 85 => 19,
+            default        => 20,
+        };
+
+        // Per-age cap on rolled ability so a 17-year-old elite prospect
+        // doesn't spawn at overall 78. Mirrors YouthAcademyService's
+        // age-cap shape. Headroom lives in `potential`, not in spawn ability.
+        $ageCap = match ($age) {
+            17 => 72,
+            18 => 74,
+            19 => 76,
+            default => 80,
+        };
+        $overallScore = $this->sampler->sampleAbility($abilityMean, self::ABILITY_STD_DEV, 30, $ageCap);
 
         $potentialData = $this->sampler->generatePotentialFromAbility(
             $overallScore,
@@ -407,14 +433,6 @@ class PlayerGeneratorService
         $potential = $potentialData['potential'];
         $potentialLow = $potentialData['potentialLow'];
         $potentialHigh = $potentialData['potentialHigh'];
-
-        $ageRoll = mt_rand(1, 100);
-        $age = match (true) {
-            $ageRoll <= 20 => 20,
-            $ageRoll <= 55 => 21,
-            $ageRoll <= 85 => 22,
-            default => 23,
-        };
 
         $dateOfBirth = $game->current_date->copy()->subYears($age)->subDays(mt_rand(0, 364));
 

--- a/tests/Feature/SquadReplenishmentTest.php
+++ b/tests/Feature/SquadReplenishmentTest.php
@@ -373,8 +373,8 @@ class SquadReplenishmentTest extends TestCase
         foreach ($youthEntries as $entry) {
             $gamePlayer = GamePlayer::find($entry['playerId']);
             $age = $gamePlayer->age($this->game->current_date);
-            $this->assertGreaterThanOrEqual(20, $age, "Youth player should be at least 20");
-            $this->assertLessThanOrEqual(23, $age, "Youth player should be at most 23");
+            $this->assertGreaterThanOrEqual(17, $age, "Youth player should be at least 17");
+            $this->assertLessThanOrEqual(20, $age, "Youth player should be at most 20");
         }
     }
 


### PR DESCRIPTION
## Summary

Follow-up to #1039 (squad-bloat fix). Same production-data investigation surfaced a second, deeper problem: AI squads not only bloat over time, they also progressively **decay in quality**. Production data over 14 game-seasons:

| save-year | squad avg_overall | squad p90_overall |
|---|---|---|
| 0 | 60.0 | 76 |
| 5 | 57.6 | 74 |
| 10 | 53.3 | 69 |
| 14 | 51.5 | 68 |

Both the mean and the top end slide ~0.6 points per save-year. Splitting by player origin (`transfermarkt_id LIKE 'gen-%'` = synthetic, else original real-world template) reveals why:

- **Originals** decline with age as expected — football careers peak and fall.
- **Synthetics** stay flat at avg_overall 53-55 across every save-year, never realizing their potential. `avg_unrealized` (potential − overall) sits at 12-16 points for their entire careers.

Tracing the mechanics:

1. `PlayerGeneratorService::buildYouthPlayerData` spawns AI academy graduates at ages 20-23. `DevelopmentCurve::AGE_CURVES` delivers only +1/season at those ages and plateaus at 23 — leaving at most ~+5 lifetime growth headroom. A typical spawn gap to potential is 15-25 points. **The growth window doesn't exist by the time they spawn.**
2. `POTENTIAL_UPSIDE_MEAN` for AI tiers is *lower* than the corresponding `YouthAcademyService::POTENTIAL_UPSIDE_MEAN` for user-side prospects. AI established-tier upside is 10; user established-tier upside is 15. Synthetic `p90_potential` is 83-84; originals at age 21 reach 91. **Synthetics can't become stars even if they did develop.**

As originals retire, synthetics replace them at permanently lower ceilings, and the league's quality nowhere to go but down.

## What changed

One file: `app/Modules/Squad/Services/PlayerGeneratorService.php`.

**Lever A — younger spawn + age-based ability cap**
- `buildYouthPlayerData` age roll: 20-23 → **17-20**. Aligns AI with `YouthAcademyService` prospect ages and gives the existing dev curve 5-6 years of runway.
- New `$ageCap` (72/74/76/80 for ages 17/18/19/20) applied to `sampleAbility` so a 17-year-old elite prospect spawns at overall ≤72, not 78. Mirrors the age-cap shape in `YouthAcademyService::rollProspectTraits`. Headroom lives in `potential`, not in spawn ability.

**Lever B — align AI potential rolls with user academy**
- `POTENTIAL_UPSIDE_MEAN`: tier 1: 12→15, tier 2: 10→15, tier 4: 14→16. Numbers come straight from `YouthAcademyService::POTENTIAL_UPSIDE_MEAN`.
- `POTENTIAL_FLOOR`: tier 2: 50→52, tier 3: 55→58, tier 4: 60→62.
- `POTENTIAL_MAX` unchanged (already at 95 elite — the issue was how often we approached the ceiling, not the ceiling itself).

## What we deliberately are NOT doing

- **Not** touching `DevelopmentCurve` — Lever A gives it enough runway as-is.
- **Not** touching `buildReplenishmentPlayerData` — different use case (mid-career emergency fill, not academy intake).
- **Not** touching `YouthAcademyService` — user side is already in the desired state; we're bringing AI into alignment with it.
- **Not** raising spawn `overall_score` directly — the lever is potential + runway, not raw spawn ability.

## What this fixes (and what it doesn't)

- Fixes the **long-term quality decay** (Q-AQ from the investigation shows squad avg_overall sliding 0.6 points/save-year).
- Does **not** fix the lurking issue of the ~12k weak 17-19 synthetic cohort — those are user-side academy prospects (`YouthAcademyService::generateSeasonBatch`), separate path. To be revisited after this lands.

## Test plan

- [ ] Fresh `app:seed-reference-data --fresh` save, simulate 10 consecutive seasons via `app:simulate-season`. Re-run the Q-AQ query (squad-quality by save-year). Expect `avg_overall` and `p90_overall` to remain stable across save-years rather than declining.
- [ ] Spawn-distribution query (synthetics only): expect ages now 17-20, p90_potential at age 21+ around 88-91 (not 83).
- [ ] Spot-check a top-tier AI team's youngest first-team players in the dev server: should see 17-19-year-olds with realistic ratings (mid-60s overall, 80-90 potential), not the old 20-23-year-olds clamped at overall ~55.
- [ ] Existing inflated saves: verify gradual recovery (~3-5 seasons) as new corrected synthetics replace older under-rolled stock.
- [ ] CI tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)