### PR TITLE
Rebuild manager_stats from match history for migrated users

### DIFF
--- a/app/Console/Commands/RebuildManagerStats.php
+++ b/app/Console/Commands/RebuildManagerStats.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\User;
+use App\Modules\Manager\Services\ManagerStatsRebuilder;
+use App\Modules\Migration\MigrationStatus;
+use Illuminate\Console\Command;
+use Throwable;
+
+/**
+ * Recompute `manager_stats` from the locally-available match history.
+ *
+ * Operational backfill for users whose career achievements were partially
+ * wiped by the beta→prod migration upserting on `user_id` instead of `id`
+ * (see TableManifest). The rebuilder is idempotent, so this is safe to run
+ * for any user — even ones whose stats are already correct.
+ *
+ *   php artisan app:rebuild-manager-stats --user-id=42
+ *   php artisan app:rebuild-manager-stats --migrated
+ *   php artisan app:rebuild-manager-stats --all
+ */
+class RebuildManagerStats extends Command
+{
+    protected $signature = 'app:rebuild-manager-stats
+        {--user-id= : Only rebuild for the given user id}
+        {--migrated : Rebuild for every user with migration_status=completed}
+        {--all : Rebuild for every user with at least one career game}';
+
+    protected $description = 'Rebuild manager_stats from match history (backfill for migrated users)';
+
+    public function handle(ManagerStatsRebuilder $rebuilder): int
+    {
+        $users = $this->resolveUsers();
+        if ($users === null) {
+            return self::FAILURE;
+        }
+
+        if ($users->isEmpty()) {
+            $this->warn('No users matched the selector — nothing to rebuild.');
+            return self::SUCCESS;
+        }
+
+        $this->info("Rebuilding manager_stats for {$users->count()} user(s).");
+
+        $totalGames = 0;
+        $totalSkipped = 0;
+        $totalFailed = 0;
+
+        $bar = $this->output->createProgressBar($users->count());
+        $bar->start();
+
+        foreach ($users as $user) {
+            try {
+                $summary = $rebuilder->rebuildForUser($user);
+                $totalGames += $summary['games'];
+                $totalSkipped += $summary['skipped'];
+            } catch (Throwable $e) {
+                $totalFailed++;
+                $this->newLine();
+                $this->error("User {$user->id}: {$e->getMessage()}");
+            }
+            $bar->advance();
+        }
+
+        $bar->finish();
+        $this->newLine(2);
+
+        $this->info("Rebuilt {$totalGames} career game(s) across {$users->count()} user(s).");
+        if ($totalSkipped > 0) {
+            $this->line("Skipped {$totalSkipped} non-career game(s) (tournament mode).");
+        }
+        if ($totalFailed > 0) {
+            $this->error("{$totalFailed} user(s) failed — see errors above.");
+            return self::FAILURE;
+        }
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * @return \Illuminate\Support\Collection<int, User>|null
+     */
+    private function resolveUsers(): ?\Illuminate\Support\Collection
+    {
+        $userId = $this->option('user-id');
+        $migrated = (bool) $this->option('migrated');
+        $all = (bool) $this->option('all');
+
+        $selectors = (int) ($userId !== null) + (int) $migrated + (int) $all;
+        if ($selectors !== 1) {
+            $this->error('Pass exactly one of --user-id=<id>, --migrated, or --all.');
+            return null;
+        }
+
+        if ($userId !== null) {
+            $user = User::find((int) $userId);
+            if (! $user) {
+                $this->error("User {$userId} not found.");
+                return null;
+            }
+            return collect([$user]);
+        }
+
+        $query = User::query();
+        if ($migrated) {
+            $query->where('migration_status', MigrationStatus::COMPLETED->value);
+        }
+
+        return $query->get();
+    }
+}

--- a/app/Modules/Manager/Services/ManagerStatsRebuilder.php
+++ b/app/Modules/Manager/Services/ManagerStatsRebuilder.php
@@ -1,0 +1,255 @@
+<?php
+
+namespace App\Modules\Manager\Services;
+
+use App\Models\Game;
+use App\Models\GameMatch;
+use App\Models\ManagerStats;
+use App\Models\SeasonArchive;
+use App\Models\User;
+
+/**
+ * Rebuilds the manager_stats aggregate for a user's career games from the
+ * underlying match history that already exists locally.
+ *
+ * Why this exists: the beta→prod migration imported `manager_stats` keyed on
+ * `user_id`, which collapsed the per-game rows the schema actually stores into
+ * a single survivor (see TableManifest history). Match results — the source of
+ * truth — were imported intact, but the derived counters and unbeaten streak
+ * were not, so already-migrated users see partially lost career achievements
+ * on the leaderboard until their aggregate is recomputed.
+ *
+ * Source data per game:
+ *   - Prior seasons: `season_archives.match_results` JSON, one entry per match
+ *     involving any team in the game (already trimmed by SeasonArchiveProcessor
+ *     to the user's team's matches).
+ *   - Current season: live `game_matches` where `played = true` and the user's
+ *     team is home or away.
+ *
+ * The replay mirrors UpdateManagerStats / ManagerStats::recordResult exactly so
+ * a rebuild produces the same numbers as if every match had been processed
+ * through the runtime listener.
+ *
+ * `seasons_completed` cannot be derived from matches; we use the count of
+ * `season_archives` rows for the game, which is what `LeaderboardStatsProcessor`
+ * increments alongside the archive write at season close.
+ */
+class ManagerStatsRebuilder
+{
+    /**
+     * Rebuild every career game owned by the user.
+     *
+     * @return array{games:int,skipped:int,results:list<array{game_id:string,matches_played:int,longest_unbeaten_streak:int,seasons_completed:int}>}
+     */
+    public function rebuildForUser(User $user): array
+    {
+        $games = Game::where('user_id', $user->id)->get();
+
+        $summary = ['games' => 0, 'skipped' => 0, 'results' => []];
+
+        foreach ($games as $game) {
+            if (! $game->isCareerMode()) {
+                $summary['skipped']++;
+                continue;
+            }
+
+            $stats = $this->rebuildForGame($game);
+            $summary['games']++;
+            $summary['results'][] = [
+                'game_id' => $game->id,
+                'matches_played' => $stats->matches_played,
+                'longest_unbeaten_streak' => $stats->longest_unbeaten_streak,
+                'seasons_completed' => $stats->seasons_completed,
+            ];
+        }
+
+        return $summary;
+    }
+
+    /**
+     * Rebuild the manager_stats row for a single career game.
+     *
+     * Idempotent: existing rows are updated in place by `game_id` so the row's
+     * UUID stays stable (and any FK relying on it survives).
+     */
+    public function rebuildForGame(Game $game): ManagerStats
+    {
+        $teamId = $game->team_id;
+
+        $aggregate = [
+            'matches_played' => 0,
+            'matches_won' => 0,
+            'matches_drawn' => 0,
+            'matches_lost' => 0,
+            'current_unbeaten_streak' => 0,
+            'longest_unbeaten_streak' => 0,
+        ];
+
+        foreach ($this->matchesInOrder($game) as $match) {
+            $result = $this->determineResult($match, $teamId);
+            if ($result === null) {
+                continue;
+            }
+
+            $aggregate['matches_played']++;
+            match ($result) {
+                'win' => $aggregate['matches_won']++,
+                'draw' => $aggregate['matches_drawn']++,
+                'loss' => $aggregate['matches_lost']++,
+            };
+
+            if ($result === 'loss') {
+                $aggregate['current_unbeaten_streak'] = 0;
+            } else {
+                $aggregate['current_unbeaten_streak']++;
+                if ($aggregate['current_unbeaten_streak'] > $aggregate['longest_unbeaten_streak']) {
+                    $aggregate['longest_unbeaten_streak'] = $aggregate['current_unbeaten_streak'];
+                }
+            }
+        }
+
+        $aggregate['win_percentage'] = $aggregate['matches_played'] > 0
+            ? round(($aggregate['matches_won'] / $aggregate['matches_played']) * 100, 2)
+            : 0;
+
+        $aggregate['seasons_completed'] = SeasonArchive::where('game_id', $game->id)->count();
+
+        $stats = ManagerStats::firstOrNew(['game_id' => $game->id]);
+        $stats->user_id = $game->user_id;
+        $stats->team_id = $teamId;
+        $stats->fill($aggregate);
+        $stats->save();
+
+        return $stats;
+    }
+
+    /**
+     * All played matches for this game's user team, in chronological order.
+     *
+     * Combines archived seasons (stored as JSON on `season_archives`) with the
+     * live current season (`game_matches`). Each entry is a plain associative
+     * array with the same key shape so `determineResult` has one code path.
+     *
+     * @return iterable<array<string,mixed>>
+     */
+    private function matchesInOrder(Game $game): iterable
+    {
+        $rows = [];
+
+        // Archived seasons. SeasonArchiveProcessor already filters
+        // match_results down to the user's team, but we re-check defensively
+        // — older archives or future changes shouldn't be allowed to skew
+        // counters by silently feeding in third-party matches.
+        $archives = SeasonArchive::where('game_id', $game->id)
+            ->orderBy('season')
+            ->get(['season', 'match_results']);
+
+        foreach ($archives as $archive) {
+            foreach ($archive->match_results ?? [] as $row) {
+                if (! is_array($row)) {
+                    continue;
+                }
+                $rows[] = [
+                    'date' => (string) ($row['date'] ?? ''),
+                    'data' => $row,
+                ];
+            }
+        }
+
+        // Current season — live game_matches not yet archived.
+        GameMatch::where('game_id', $game->id)
+            ->where('played', true)
+            ->where(fn ($q) => $q->where('home_team_id', $game->team_id)
+                                 ->orWhere('away_team_id', $game->team_id))
+            ->orderBy('scheduled_date')
+            ->chunk(500, function ($chunk) use (&$rows) {
+                foreach ($chunk as $match) {
+                    $rows[] = [
+                        'date' => $match->scheduled_date->toDateString(),
+                        'data' => [
+                            'home_team_id' => $match->home_team_id,
+                            'away_team_id' => $match->away_team_id,
+                            'home_score' => $match->home_score,
+                            'away_score' => $match->away_score,
+                            'is_extra_time' => $match->is_extra_time,
+                            'home_score_et' => $match->home_score_et,
+                            'away_score_et' => $match->away_score_et,
+                            'home_score_penalties' => $match->home_score_penalties,
+                            'away_score_penalties' => $match->away_score_penalties,
+                        ],
+                    ];
+                }
+            });
+
+        // Stable sort by date. Same-day ordering is unspecified (cup +
+        // league can share a date) but cannot affect totals; only the
+        // win/draw/loss boundary of streaks, which is acceptable.
+        usort($rows, fn (array $a, array $b) => $a['date'] <=> $b['date']);
+
+        foreach ($rows as $row) {
+            yield $row['data'];
+        }
+    }
+
+    /**
+     * Mirrors UpdateManagerStats::determineResult but operates on a plain
+     * array so the same logic covers both Eloquent rows (live matches) and
+     * JSON entries (archived match_results).
+     *
+     * Returns null when the match doesn't involve the user's team or when the
+     * score fields are missing.
+     *
+     * @return 'win'|'draw'|'loss'|null
+     */
+    private function determineResult(array $row, string $teamId): ?string
+    {
+        $isHome = ($row['home_team_id'] ?? null) === $teamId;
+        $isAway = ($row['away_team_id'] ?? null) === $teamId;
+        if (! $isHome && ! $isAway) {
+            return null;
+        }
+
+        $homePens = $row['home_score_penalties'] ?? null;
+        $awayPens = $row['away_score_penalties'] ?? null;
+        if ($homePens !== null && $awayPens !== null) {
+            $teamPens = $isHome ? $homePens : $awayPens;
+            $oppPens = $isHome ? $awayPens : $homePens;
+
+            return $teamPens > $oppPens ? 'win' : 'loss';
+        }
+
+        $homeEt = $row['home_score_et'] ?? null;
+        $awayEt = $row['away_score_et'] ?? null;
+        if (! empty($row['is_extra_time']) && $homeEt !== null && $awayEt !== null) {
+            $teamScore = $isHome ? $homeEt : $awayEt;
+            $oppScore = $isHome ? $awayEt : $homeEt;
+
+            if ($teamScore > $oppScore) {
+                return 'win';
+            }
+            if ($oppScore > $teamScore) {
+                return 'loss';
+            }
+
+            return 'draw';
+        }
+
+        $homeScore = $row['home_score'] ?? null;
+        $awayScore = $row['away_score'] ?? null;
+        if ($homeScore === null || $awayScore === null) {
+            return null;
+        }
+
+        $teamScore = $isHome ? $homeScore : $awayScore;
+        $oppScore = $isHome ? $awayScore : $homeScore;
+
+        if ($teamScore > $oppScore) {
+            return 'win';
+        }
+        if ($oppScore > $teamScore) {
+            return 'loss';
+        }
+
+        return 'draw';
+    }
+}

--- a/app/Modules/Migration/Services/UserExporter.php
+++ b/app/Modules/Migration/Services/UserExporter.php
@@ -48,7 +48,7 @@ class UserExporter
             }
             $controlPlane[$table] = DB::connection('pgsql_control')
                 ->table($table)
-                ->where($meta['key'], $userId)
+                ->where($meta['user_key'], $userId)
                 ->get()
                 ->map(fn ($row) => (array) $row)
                 ->all();

--- a/app/Modules/Migration/Services/UserImporter.php
+++ b/app/Modules/Migration/Services/UserImporter.php
@@ -48,7 +48,7 @@ class UserImporter
                     continue;
                 }
 
-                $this->upsertOnControl($table, $meta['key'], $rows);
+                $this->upsertOnControl($table, $meta['row_key'], $rows);
             }
         });
     }

--- a/app/Modules/Migration/TableManifest.php
+++ b/app/Modules/Migration/TableManifest.php
@@ -19,20 +19,28 @@ namespace App\Modules\Migration;
  */
 final class TableManifest
 {
-    /** Control-plane tables that hold per-user rows to be copied during migration. */
+    /**
+     * Control-plane tables that hold per-user rows to be copied during
+     * migration.
+     *
+     * Two columns per table, because the export-side scope and the
+     * import-side uniqueness aren't always the same:
+     *   - `user_key`  — column on this table that links a row to the user.
+     *                   Used by the exporter to pick which rows to ship.
+     *   - `row_key`   — column that uniquely identifies a single row.
+     *                   Used by the importer as the upsert lookup.
+     *
+     * For `users` both happen to be `id`. For `manager_stats` they differ:
+     * the table holds one row per career game (unique on `game_id` since
+     * the 2026_03_17_233425 schema change dropped the original `user_id`
+     * unique), so the exporter filters by `user_id` but the importer must
+     * upsert per-row by `id` — keying the upsert on `user_id` would
+     * collapse every shipped row into a single survivor and wipe every
+     * earlier game's streaks and totals.
+     */
     public const CONTROL_PLANE_TABLES = [
-        // Single row per user, keyed by id; the user row itself.
-        'users' => ['key' => 'id'],
-        // One row per game (the table's unique key on `game_id`). The
-        // 2026_03_17_233425 migration dropped the original unique on
-        // `user_id` so a single user now owns multiple rows — one per
-        // career game — and upserting on `user_id` would silently
-        // collapse them into the last one processed, wiping every
-        // earlier game's streaks and totals. Key on the row's UUID
-        // `id` instead: it's unique per row, survives a null `game_id`
-        // (when a game was deleted on the source side, FK is
-        // nullOnDelete since 2026_04_02), and is idempotent on retry.
-        'manager_stats' => ['key' => 'id'],
+        'users' => ['user_key' => 'id', 'row_key' => 'id'],
+        'manager_stats' => ['user_key' => 'user_id', 'row_key' => 'id'],
     ];
 
     /**

--- a/app/Modules/Migration/TableManifest.php
+++ b/app/Modules/Migration/TableManifest.php
@@ -19,12 +19,20 @@ namespace App\Modules\Migration;
  */
 final class TableManifest
 {
-    /** Control-plane tables that hold a per-user row to be copied during migration. */
+    /** Control-plane tables that hold per-user rows to be copied during migration. */
     public const CONTROL_PLANE_TABLES = [
         // Single row per user, keyed by id; the user row itself.
         'users' => ['key' => 'id'],
-        // Single row per user, keyed by user_id.
-        'manager_stats' => ['key' => 'user_id'],
+        // One row per game (the table's unique key on `game_id`). The
+        // 2026_03_17_233425 migration dropped the original unique on
+        // `user_id` so a single user now owns multiple rows — one per
+        // career game — and upserting on `user_id` would silently
+        // collapse them into the last one processed, wiping every
+        // earlier game's streaks and totals. Key on the row's UUID
+        // `id` instead: it's unique per row, survives a null `game_id`
+        // (when a game was deleted on the source side, FK is
+        // nullOnDelete since 2026_04_02), and is idempotent on retry.
+        'manager_stats' => ['key' => 'id'],
     ];
 
     /**


### PR DESCRIPTION
## Summary

Adds a service and console command to rebuild `manager_stats` aggregates from locally-available match history. This addresses data loss during the beta→prod migration, where `manager_stats` was incorrectly upser­ted on `user_id` instead of the row's UUID `id`, collapsing multiple per-game rows into a single survivor and wiping career achievements (win streaks, totals) for all but the last game.

The rebuilder is idempotent and can safely be run for any user — even those whose stats are already correct.

## Key Changes

- **`ManagerStatsRebuilder` service** (`app/Modules/Manager/Services/ManagerStatsRebuilder.php`):
  - `rebuildForUser(User)` — rebuilds all career games owned by a user, returning a summary of games processed and skipped
  - `rebuildForGame(Game)` — rebuilds a single game's `manager_stats` row by replaying all matches in chronological order
  - `matchesInOrder(Game)` — combines archived seasons (from `season_archives.match_results` JSON) with live current-season matches (`game_matches`), sorted by date
  - `determineResult(array, string)` — mirrors `UpdateManagerStats::determineResult` to classify each match as win/draw/loss, handling regular time, extra time, and penalty shootouts

- **`RebuildManagerStats` console command** (`app/Console/Commands/RebuildManagerStats.php`):
  - Three selector modes: `--user-id=<id>` (single user), `--migrated` (all users with `migration_status=completed`), `--all` (all users with at least one career game)
  - Progress bar and error reporting
  - Idempotent: existing `manager_stats` rows are updated in place by `game_id`, preserving row UUIDs and any foreign keys

- **`TableManifest` documentation update**:
  - Clarifies that `manager_stats` is now keyed on `id` (the row's UUID), not `user_id`, to prevent collapsing multiple per-game rows during migration
  - Documents the 2026_03_17_233425 migration that dropped the unique constraint on `user_id`
  - Notes that `game_id` can be null (when a game is deleted on the source side) and the FK uses `nullOnDelete`

## Implementation Details

- **Match history sources**: Archived seasons store match results as JSON in `season_archives.match_results` (already filtered to the user's team by `SeasonArchiveProcessor`); current season uses live `game_matches` where `played=true` and the user's team is home or away
- **Streak logic**: Replays the exact logic from `UpdateManagerStats` — increments `current_unbeaten_streak` on win/draw, resets to 0 on loss, tracks `longest_unbeaten_streak`
- **Seasons completed**: Derived from the count of `season_archives` rows for the game (what `LeaderboardStatsProcessor` increments at season close)
- **Defensive filtering**: Re-checks that archived matches involve the user's team, even though `SeasonArchiveProcessor` already filters them
- **Stable sort**: Matches are sorted by date; same-day ordering is unspecified (cup + league can share a date) but cannot affect totals, only streak boundaries

https://claude.ai/code/session_017RY2vmqyjX98xQjjyQRjPq