### PR TITLE
Persist squad filters and view mode in URL query parameters

### DIFF
--- a/app/Http/Actions/ReleasePlayer.php
+++ b/app/Http/Actions/ReleasePlayer.php
@@ -22,19 +22,16 @@ class ReleasePlayer
             ->whereIn('team_id', $game->userTeamIds())
             ->firstOrFail();
 
-        $wasOnReserve = $game->reserve_team_id !== null && $player->team_id === $game->reserve_team_id;
-        $redirectRoute = $wasOnReserve ? 'game.squad.reserve' : 'game.squad';
-
         $result = $this->contractService->releasePlayer($game, $player);
 
         if ($result['error'] ?? false) {
             return redirect()
-                ->route($redirectRoute, $gameId)
+                ->back()
                 ->with('error', $result['error']);
         }
 
         return redirect()
-            ->route($redirectRoute, $gameId)
+            ->back()
             ->with('success', __('messages.player_released', [
                 'player' => $result['playerName'],
                 'severance' => $result['formattedSeverance'],

--- a/app/Http/Actions/UnlistPlayerFromTransfer.php
+++ b/app/Http/Actions/UnlistPlayerFromTransfer.php
@@ -25,7 +25,7 @@ class UnlistPlayerFromTransfer
         $this->transferService->unlistPlayer($player);
 
         return redirect()
-            ->route('game.transfers.outgoing', $gameId)
+            ->back()
             ->with('success', __('messages.player_unlisted', ['player' => $player->name]));
     }
 }

--- a/resources/views/squad.blade.php
+++ b/resources/views/squad.blade.php
@@ -23,13 +23,33 @@
 
     <div x-data="{
         viewMode: new URLSearchParams(window.location.search).get('mode') || 'tactical',
-        posFilter: 'all',
-        availFilter: 'all',
+        posFilter: new URLSearchParams(window.location.search).get('pos') || 'all',
+        availFilter: new URLSearchParams(window.location.search).get('avail') || 'all',
         statusFilter: 'all',
         sortCol: null,
         sortDir: 'desc',
         sidebarOpen: true,
 
+        init() {
+            const sync = () => {
+                const url = new URL(window.location.href);
+                const set = (key, value, defaultValue) => {
+                    if (value && value !== defaultValue) {
+                        url.searchParams.set(key, value);
+                    } else {
+                        url.searchParams.delete(key);
+                    }
+                };
+                set('mode', this.viewMode, 'tactical');
+                set('pos', this.posFilter, 'all');
+                set('avail', this.availFilter, 'all');
+                history.replaceState({}, '', url);
+            };
+            this.$watch('viewMode', sync);
+            this.$watch('posFilter', sync);
+            this.$watch('availFilter', sync);
+            sync();
+        },
         isVisible(group, available, status) {
             if (this.posFilter !== 'all' && group !== this.posFilter) return false;
             if (this.availFilter === 'available' && !available) return false;


### PR DESCRIPTION
## Summary
Adds URL query parameter persistence for squad view filters and mode, allowing users to bookmark or share filtered squad views. Filter state is now synchronized with the URL in real-time via Alpine.js watchers.

## Key Changes

- **Squad view state persistence:** Position filter (`pos`), availability filter (`avail`), and view mode (`mode`) are now read from and written to URL query parameters
  - Filters default to `'all'` if not present in the URL
  - View mode defaults to `'tactical'` if not present
  - State syncs automatically when any filter changes via `init()` method with watchers

- **Simplified redirect logic in player actions:**
  - `ReleasePlayer` action: replaced conditional route logic with `redirect()->back()`, removing the need to track whether player was on reserve team
  - `UnlistPlayerFromTransfer` action: replaced hardcoded route redirect with `redirect()->back()`
  - These changes work seamlessly with the new URL persistence—users are redirected back to their filtered view

## Implementation Details

The Alpine.js `init()` method uses a `sync()` function that:
- Builds the current URL with updated query parameters
- Only includes parameters that differ from defaults (cleaner URLs)
- Uses `history.replaceState()` to update the browser URL without navigation
- Is called on component initialization and whenever any watched filter changes

This approach maintains browser history cleanly while preserving filter state across page reloads and shareable links.

https://claude.ai/code/session_012R8MLwwLF4nLGouDVbgqrw