### PR TITLE
Fix game:simulate and app:stress-test by running advances as fast mode

### DIFF
--- a/app/Console/Commands/SimulateSeason.php
+++ b/app/Console/Commands/SimulateSeason.php
@@ -4,6 +4,7 @@ namespace App\Console\Commands;
 
 use App\Models\Game;
 use App\Models\GameMatch;
+use App\Modules\Match\Services\FastModeService;
 use App\Modules\Match\Services\MatchdayAdvanceCoordinator;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\DB;
@@ -41,42 +42,57 @@ class SimulateSeason extends Command
         DB::disableQueryLog();
         DB::flushQueryLog();
 
+        // Run as fast mode so the orchestrator finalizes the user's match
+        // inline. Without fastForward the HTTP flow takes over: the user's
+        // match is left as pending_finalization_match_id waiting for a
+        // FinalizeMatch handoff that never comes in console context.
+        $fastModeWasEntered = $game->isFastMode();
+        if (! $fastModeWasEntered) {
+            app(FastModeService::class)->enter($game);
+        }
+
         $advances = 0;
 
-        while ($advances < 500) {
-            $game->refresh();
+        try {
+            while ($advances < 500) {
+                $game->refresh();
 
-            if ($this->lastPlayedMatchday($game) >= $targetMatchday) {
-                break;
+                if ($this->lastPlayedMatchday($game) >= $targetMatchday) {
+                    break;
+                }
+
+                $hasMatches = GameMatch::where('game_id', $game->id)
+                    ->where('played', false)
+                    ->exists();
+
+                if (! $hasMatches) {
+                    $this->warn('No more matches to play. Season complete.');
+                    break;
+                }
+
+                // Advance synchronously. The HTTP AdvanceMatchday action dispatches
+                // to the queue so the UI can show a loading screen; console commands
+                // need inline completion, so runSync it.
+                if (! app(MatchdayAdvanceCoordinator::class)->runSync($game->id, fastForward: true)) {
+                    $this->warn('Could not claim advancing flag — another process may be running.');
+                    break;
+                }
+                $advances++;
+
+                // Force PHP to collect circular references (Eloquent models
+                // create model<->relation cycles that only gc_collect_cycles
+                // can reclaim).
+                gc_collect_cycles();
+
+                $game->refresh();
+                $lastPlayed = $this->lastPlayedMatchday($game);
+                $mem = round(memory_get_usage() / 1024 / 1024, 1);
+                $this->line("  Batch #{$advances} — matchday {$lastPlayed} — {$game->current_date->toDateString()} — {$mem}MB");
             }
-
-            $hasMatches = GameMatch::where('game_id', $game->id)
-                ->where('played', false)
-                ->exists();
-
-            if (! $hasMatches) {
-                $this->warn('No more matches to play. Season complete.');
-                break;
+        } finally {
+            if (! $fastModeWasEntered) {
+                app(FastModeService::class)->exit($game->refresh());
             }
-
-            // Advance synchronously. The HTTP AdvanceMatchday action dispatches
-            // to the queue so the UI can show a loading screen; console commands
-            // need inline completion, so runSync it.
-            if (! app(MatchdayAdvanceCoordinator::class)->runSync($game->id)) {
-                $this->warn('Could not claim advancing flag — another process may be running.');
-                break;
-            }
-            $advances++;
-
-            // Force PHP to collect circular references (Eloquent models
-            // create model<->relation cycles that only gc_collect_cycles
-            // can reclaim).
-            gc_collect_cycles();
-
-            $game->refresh();
-            $lastPlayed = $this->lastPlayedMatchday($game);
-            $mem = round(memory_get_usage() / 1024 / 1024, 1);
-            $this->line("  Batch #{$advances} — matchday {$lastPlayed} — {$game->current_date->toDateString()} — {$mem}MB");
         }
 
         $peak = round(memory_get_peak_usage() / 1024 / 1024, 1);

--- a/app/Console/Commands/SimulateSeason.php
+++ b/app/Console/Commands/SimulateSeason.php
@@ -79,6 +79,15 @@ class SimulateSeason extends Command
                 }
                 $advances++;
 
+                // The orchestrator queues a ProcessCareerActions job on the
+                // gameplay queue at the end of advance(); its handler clears
+                // career_actions_processing_at. The next claim() refuses to
+                // run while that flag is set, so we have to wait for it. Drain
+                // anything queue:work can grab itself (so we don't depend on
+                // Horizon being up), then wait briefly in case Horizon already
+                // picked it up and is still running it.
+                $this->drainCareerActions($game->id);
+
                 // Force PHP to collect circular references (Eloquent models
                 // create model<->relation cycles that only gc_collect_cycles
                 // can reclaim).
@@ -108,5 +117,29 @@ class SimulateSeason extends Command
             ->where('played', true)
             ->whereNull('cup_tie_id')
             ->max('round_number');
+    }
+
+    private function drainCareerActions(string $gameId): void
+    {
+        $this->callSilently('queue:work', [
+            '--queue' => 'gameplay',
+            '--stop-when-empty' => true,
+            '--tries' => 1,
+        ]);
+
+        // If Horizon grabbed the job before queue:work above, the flag may
+        // still be set while Horizon finishes. Poll for up to ~30s.
+        $deadline = microtime(true) + 30;
+        while (microtime(true) < $deadline) {
+            $stillProcessing = (bool) Game::where('id', $gameId)
+                ->whereNotNull('career_actions_processing_at')
+                ->exists();
+
+            if (! $stillProcessing) {
+                return;
+            }
+
+            usleep(100_000); // 100ms
+        }
     }
 }

--- a/app/Console/Commands/StressTest.php
+++ b/app/Console/Commands/StressTest.php
@@ -2,6 +2,7 @@
 
 namespace App\Console\Commands;
 
+use App\Modules\Match\Services\FastModeService;
 use App\Modules\Match\Services\MatchdayAdvanceCoordinator;
 use App\Modules\Season\Services\GameCreationService;
 use App\Models\Game;
@@ -170,49 +171,64 @@ class StressTest extends Command
 
         $matchCountBefore = GameMatch::where('game_id', $game->id)->where('played', true)->count();
 
-        while ($advances < 600) {
-            $game->refresh();
+        // Run as fast mode so the orchestrator finalizes the user's match
+        // inline. Without fastForward the HTTP flow takes over: the user's
+        // match is left as pending_finalization_match_id waiting for a
+        // FinalizeMatch handoff that never comes in console context.
+        $fastModeWasEntered = $game->isFastMode();
+        if (! $fastModeWasEntered) {
+            app(FastModeService::class)->enter($game);
+        }
 
-            $hasMatches = GameMatch::where('game_id', $game->id)
-                ->where('played', false)
-                ->exists();
+        try {
+            while ($advances < 600) {
+                $game->refresh();
 
-            if (! $hasMatches) {
-                break;
-            }
+                $hasMatches = GameMatch::where('game_id', $game->id)
+                    ->where('played', false)
+                    ->exists();
 
-            $t0 = microtime(true);
-            $mem0 = memory_get_usage(true);
+                if (! $hasMatches) {
+                    break;
+                }
 
-            DB::enableQueryLog();
-            $result = app(MatchdayAdvanceCoordinator::class)->runSync($game->id);
-            $queryCount = count(DB::getQueryLog());
+                $t0 = microtime(true);
+                $mem0 = memory_get_usage(true);
 
-            if (! $result) {
-                $this->warn("  Could not claim advancing flag for game {$game->id} — skipping.");
+                DB::enableQueryLog();
+                $result = app(MatchdayAdvanceCoordinator::class)->runSync($game->id, fastForward: true);
+                $queryCount = count(DB::getQueryLog());
+
+                if (! $result) {
+                    $this->warn("  Could not claim advancing flag for game {$game->id} — skipping.");
+                    DB::disableQueryLog();
+                    DB::flushQueryLog();
+                    break;
+                }
                 DB::disableQueryLog();
                 DB::flushQueryLog();
-                break;
+
+                $elapsed = (microtime(true) - $t0) * 1000;
+
+                $batchTimings[] = [
+                    'advance' => $advances + 1,
+                    'elapsed_ms' => round($elapsed, 1),
+                    'queries' => $queryCount,
+                    'memory_mb' => round(memory_get_usage(true) / 1024 / 1024, 2),
+                ];
+
+                $advances++;
+
+                // Show progress every 20 advances
+                if ($advances % 20 === 0) {
+                    $avgMs = round(collect($batchTimings)->avg('elapsed_ms'));
+                    $avgQ = round(collect($batchTimings)->avg('queries'));
+                    $this->line("    Game {$gameNumber}/{$totalGames}: {$advances} advances (avg {$avgMs}ms, {$avgQ} queries/advance)");
+                }
             }
-            DB::disableQueryLog();
-            DB::flushQueryLog();
-
-            $elapsed = (microtime(true) - $t0) * 1000;
-
-            $batchTimings[] = [
-                'advance' => $advances + 1,
-                'elapsed_ms' => round($elapsed, 1),
-                'queries' => $queryCount,
-                'memory_mb' => round(memory_get_usage(true) / 1024 / 1024, 2),
-            ];
-
-            $advances++;
-
-            // Show progress every 20 advances
-            if ($advances % 20 === 0) {
-                $avgMs = round(collect($batchTimings)->avg('elapsed_ms'));
-                $avgQ = round(collect($batchTimings)->avg('queries'));
-                $this->line("    Game {$gameNumber}/{$totalGames}: {$advances} advances (avg {$avgMs}ms, {$avgQ} queries/advance)");
+        } finally {
+            if (! $fastModeWasEntered) {
+                app(FastModeService::class)->exit($game->refresh());
             }
         }
 

--- a/app/Console/Commands/StressTest.php
+++ b/app/Console/Commands/StressTest.php
@@ -208,6 +208,13 @@ class StressTest extends Command
                 DB::disableQueryLog();
                 DB::flushQueryLog();
 
+                // The orchestrator queued ProcessCareerActions on the gameplay
+                // queue; its handler clears career_actions_processing_at. The
+                // next claim() bails while that flag is set, so drain the
+                // queue inline (works without Horizon) then wait briefly in
+                // case Horizon already grabbed the job.
+                $this->drainCareerActions($game->id);
+
                 $elapsed = (microtime(true) - $t0) * 1000;
 
                 $batchTimings[] = [
@@ -395,5 +402,27 @@ class StressTest extends Command
             '--once' => true,
             '--queue' => 'default',
         ]);
+    }
+
+    private function drainCareerActions(string $gameId): void
+    {
+        $this->callSilently('queue:work', [
+            '--queue' => 'gameplay',
+            '--stop-when-empty' => true,
+            '--tries' => 1,
+        ]);
+
+        $deadline = microtime(true) + 30;
+        while (microtime(true) < $deadline) {
+            $stillProcessing = (bool) Game::where('id', $gameId)
+                ->whereNotNull('career_actions_processing_at')
+                ->exists();
+
+            if (! $stillProcessing) {
+                return;
+            }
+
+            usleep(100_000);
+        }
     }
 }


### PR DESCRIPTION
Both console commands called MatchdayAdvanceCoordinator::runSync without fastForward: true, so the orchestrator returned live_match and stamped pending_finalization_match_id expecting a FinalizeMatch HTTP handoff that never came — the user's match stayed unfinalized and subsequent runs tripped on the stuck pending-finalization state.

Enter fast mode before the loop (and exit it in a finally) so the fast-mode guard in the coordinator's claim() passes, then thread fastForward: true through runSync so the orchestrator finalizes the user's match inline.