### PR TITLE
Clear pitch positions when formation changes in live match

### DIFF
--- a/app/Modules/Lineup/Services/TacticalChangeService.php
+++ b/app/Modules/Lineup/Services/TacticalChangeService.php
@@ -52,6 +52,12 @@ class TacticalChangeService
 
         if ($formation !== null) {
             $matchUpdates["{$prefix}_formation"] = $formation;
+            // Custom pitch positions are keyed by slot IDs whose grid-cell
+            // meaning is formation-specific, so the saved map doesn't survive
+            // a shape change. Clear it alongside the formation update so a
+            // page reload after the change doesn't re-seed the live pitch
+            // with positions tied to the old formation.
+            $matchUpdates["{$prefix}_pitch_positions"] = null;
         }
         if ($mentality !== null) {
             $matchUpdates["{$prefix}_mentality"] = $mentality;

--- a/resources/js/modules/tactical-submission.js
+++ b/resources/js/modules/tactical-submission.js
@@ -129,6 +129,16 @@ export function createTacticalSubmission(ctx) {
 
                 // Update active tactics
                 if (result.formation) {
+                    // Custom pitch positions are keyed by slot IDs whose
+                    // grid-cell meaning is formation-specific, so a formation
+                    // change makes the saved positions meaningless against the
+                    // new shape. Drop them in lockstep with the formation
+                    // bump — mirrors what the lineup page does in
+                    // updateAutoLineup() — and keep _pitchPositionsFormation
+                    // pointing at the formation the (now-empty) map belongs to.
+                    if (result.formation !== c.activeFormation) {
+                        c.livePitchPositions = {};
+                    }
                     c.activeFormation = result.formation;
                     c._pitchPositionsFormation = result.formation;
                 }


### PR DESCRIPTION
## Summary

When a formation changes during a live match, custom pitch positions are now cleared to prevent stale position data from being applied to the new formation shape. This ensures consistency between the frontend and backend, mirroring the behavior already implemented on the lineup page.

## Changes

- **Frontend (`tactical-submission.js`):** Clear `livePitchPositions` when formation changes, with detailed comments explaining why custom positions are formation-specific and must be dropped when the shape changes.
- **Backend (`TacticalChangeService.php`):** Set `pitch_positions` to `null` in match updates when formation changes, preventing stale position data from persisting after a page reload.

## Implementation Details

Custom pitch positions are keyed by slot IDs whose grid-cell meaning is formation-specific. When a formation changes, the saved position map becomes meaningless against the new shape. Both changes work in lockstep:

1. The backend clears the stored positions so a page reload doesn't re-seed the live pitch with old formation data
2. The frontend clears the in-memory positions to maintain consistency with the new formation

This mirrors the existing behavior in the lineup page's `updateAutoLineup()` method and ensures the position map always corresponds to the current active formation.

https://claude.ai/code/session_013YRHcc1A5MM66NZ3mojDuQ