### PR TITLE
Apply UEFA category multiplier to commercial revenue

### DIFF
--- a/app/Models/GameFinances.php
+++ b/app/Models/GameFinances.php
@@ -136,6 +136,7 @@ class GameFinances extends Model
         'carried_surplus',
         'previous_loan_repayment',
         'projected_stadium_debt_service',
+        'commercial_uefa_multiplier_bps',
     ];
 
     protected $casts = [
@@ -173,6 +174,7 @@ class GameFinances extends Model
         'carried_surplus' => 'integer',
         'previous_loan_repayment' => 'integer',
         'projected_stadium_debt_service' => 'integer',
+        'commercial_uefa_multiplier_bps' => 'integer',
     ];
 
     public function game(): BelongsTo

--- a/app/Modules/Finance/Services/BudgetProjectionService.php
+++ b/app/Modules/Finance/Services/BudgetProjectionService.php
@@ -11,12 +11,14 @@ use App\Models\GameFinances;
 use App\Models\GameInvestment;
 use App\Models\GameMatch;
 use App\Models\GamePlayer;
+use App\Models\GameStadium;
 use App\Models\Team;
 use App\Models\TeamReputation;
 use App\Modules\Squad\Services\SquadService;
 use App\Modules\Stadium\Services\MatchAttendanceService;
 use App\Modules\Stadium\Services\SeasonTicketPricingService;
 use App\Modules\Finance\Services\StadiumLoanService;
+use App\Modules\Stadium\UefaCategory;
 use Carbon\Carbon;
 
 class BudgetProjectionService
@@ -95,7 +97,9 @@ class BudgetProjectionService
         $projectedTvRevenue = $this->calculateTvRevenue($projectedPosition, $league);
         $projectedMatchdayRevenue = $this->calculateMatchdayRevenue($team, $game);
         $projectedSolidarityFundsRevenue = self::SOLIDARITY_FUNDS_BY_TIER[$game->competition->tier] ?? 0;
-        $projectedCommercialRevenue = $this->getBaseCommercialRevenue($game, $team, $league);
+        $commercialUefaMultiplier = $this->currentCommercialUefaMultiplier($game, $team);
+        $projectedCommercialRevenue = $this->getBaseCommercialRevenue($game, $team, $league, $commercialUefaMultiplier);
+        $commercialUefaMultiplierBps = (int) round($commercialUefaMultiplier * 10_000);
         $projectedSeasonTicketRevenue = $this->seasonTicketPricingService->getCurrent($game)?->total_revenue ?? 0;
 
         $projectedTotalRevenue = $projectedTvRevenue
@@ -157,6 +161,7 @@ class BudgetProjectionService
                 'carried_surplus' => $carriedSurplus,
                 'previous_loan_repayment' => $previousLoanRepayment,
                 'projected_stadium_debt_service' => $projectedStadiumDebtService,
+                'commercial_uefa_multiplier_bps' => $commercialUefaMultiplierBps,
             ]
         );
 
@@ -362,10 +367,17 @@ class BudgetProjectionService
 
     /**
      * Get base commercial revenue for budget projections.
-     * Season 2+: uses previous season's actual commercial revenue.
+     * Season 2+: inherits previous season's actual commercial revenue,
+     * stripping the prior UEFA multiplier so the current season's
+     * multiplier can be re-applied (this is what lets a mid-save
+     * UEFA-category upgrade flow into commercial without compounding).
      * Season 1: calculates from stadium_seats × config rate.
+     *
+     * The UEFA multiplier is applied to the returned value — callers
+     * pass the current value in so the same factor can be persisted on
+     * the GameFinances row.
      */
-    private function getBaseCommercialRevenue(Game $game, Team $team, Competition $league): int|float
+    private function getBaseCommercialRevenue(Game $game, Team $team, Competition $league, float $currentUefaMultiplier): int|float
     {
         // Check for prior season actual commercial revenue
         $previousSeason = (int) $game->season - 1;
@@ -374,7 +386,12 @@ class BudgetProjectionService
             ->first();
 
         if ($previousFinances && $previousFinances->actual_commercial_revenue > 0) {
-            return $previousFinances->actual_commercial_revenue;
+            $previousMultiplier = $previousFinances->commercial_uefa_multiplier_bps
+                ? $previousFinances->commercial_uefa_multiplier_bps / 10_000
+                : 1.0;
+            $unscaledBase = $previousFinances->actual_commercial_revenue / $previousMultiplier;
+
+            return $unscaledBase * $currentUefaMultiplier;
         }
 
         // First season: calculate from stadium seats × config rate (capped)
@@ -385,7 +402,25 @@ class BudgetProjectionService
 
         $tierMultiplier = config("finances.commercial_tier_multiplier.{$league->tier}", 1.0);
 
-        return $base * $tierMultiplier;
+        return $base * $tierMultiplier * $currentUefaMultiplier;
+    }
+
+    /**
+     * Reads the current UEFA category for the team's stadium and maps it
+     * to a commercial-revenue multiplier. Prefers the per-game overlay
+     * (game_stadiums) so mid-save upgrades take effect; falls back to the
+     * team's seed category for saves that predate the backfill.
+     */
+    private function currentCommercialUefaMultiplier(Game $game, Team $team): float
+    {
+        $stadium = GameStadium::query()
+            ->where('game_id', $game->id)
+            ->where('team_id', $team->id)
+            ->first();
+
+        $category = $stadium?->effective_uefa_level ?? $team->uefa_stadium_category;
+
+        return UefaCategory::commercialMultiplier($category);
     }
 
     /**

--- a/app/Modules/Stadium/UefaCategory.php
+++ b/app/Modules/Stadium/UefaCategory.php
@@ -22,6 +22,28 @@ final class UefaCategory
     public const MAX = 4;
 
     /**
+     * Commercial revenue multiplier by UEFA category. A modern, fully
+     * fitted-out ground attracts richer sponsorship, hospitality and brand
+     * deals — the same effect Bernabéu / Tottenham renovations produced in
+     * the real world. Band is intentionally tight so upgrades pay back
+     * over several seasons rather than flipping the economy.
+     *
+     * Applied at projection time on top of the seat-based base. Uncategorised
+     * grounds (null) and Cat 1 see no uplift.
+     */
+    public const COMMERCIAL_MULTIPLIERS = [
+        1 => 1.00,
+        2 => 1.05,
+        3 => 1.12,
+        4 => 1.20,
+    ];
+
+    public static function commercialMultiplier(?int $category): float
+    {
+        return self::COMMERCIAL_MULTIPLIERS[$category] ?? 1.00;
+    }
+
+    /**
      * Real UEFA minimum-capacity floors a stadium must clear to qualify for
      * a given category. Used to gate upgrades server-side and surface
      * "expand the stadium first" hints in the UI.

--- a/database/migrations/2026_05_15_000001_add_commercial_uefa_multiplier_to_game_finances.php
+++ b/database/migrations/2026_05_15_000001_add_commercial_uefa_multiplier_to_game_finances.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('game_finances', function (Blueprint $table) {
+            // UEFA-category commercial revenue multiplier applied at
+            // projection time, stored in basis points (10000 = 1.0×).
+            // Persisted so next season's projection can strip this factor
+            // from the inherited actual before applying the current
+            // category's multiplier — that way mid-save stadium upgrades
+            // flow into commercial revenue without the bump compounding
+            // season after season.
+            $table->integer('commercial_uefa_multiplier_bps')->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('game_finances', function (Blueprint $table) {
+            $table->dropColumn('commercial_uefa_multiplier_bps');
+        });
+    }
+};


### PR DESCRIPTION
## Summary
- Closes the loop on UEFA-category investment: a modernised ground now lifts commercial revenue (sponsorship, hospitality, brand) at projection time. Cat 1 → 1.00×, Cat 2 → 1.05×, Cat 3 → 1.12×, Cat 4 → 1.20×.
- Reads the current category from `game_stadiums` (with a fallback to `teams.uefa_stadium_category`) so mid-save upgrades take effect.
- Persists the applied multiplier on `game_finances` (basis points) so next season's projection can strip the prior multiplier from the inherited actual before re-applying the current one — bump never compounds and downgrades behave symmetrically.
- `SeasonSettlementProcessor` is untouched: it still does `projected × position_mult`, and `projected` now carries the UEFA bump.

## Why matchday revenue is not changed in this PR
Matchday revenue already scales with the per-game `game_stadiums` capacity via `StadiumCapacityResolver` + `MatchAttendance`, so adding seats is already rewarded. Modernisation (UEFA category) without seat changes had **no** financial payoff — that's what this PR addresses, on the commercial side. A small UEFA bump on the matchday per-seat rate is a possible follow-up.

## Notes for existing saves
Pre-existing `game_finances` rows have `commercial_uefa_multiplier_bps = NULL`, which the inheritance branch treats as `1.0×`. The first season transition after this ships will apply the current category's multiplier cleanly — established saves with a Cat 2+ stadium will see a one-time commercial bump.

## Test plan
- [ ] CI: migration runs cleanly on a fresh DB
- [ ] CI: existing finance/season-settlement tests pass
- [ ] Manual: start a new save with a Cat 4 club (e.g. Real Madrid) — confirm season 1 `projected_commercial_revenue` ≈ 20% above the pre-PR baseline
- [ ] Manual: start a new save with a Cat 1 / uncategorised club — projection unchanged from before
- [ ] Manual: upgrade UEFA category mid-save, advance one season, confirm the next projection picks up the new multiplier without compounding the old one
- [ ] Manual: with no upgrades, advance two seasons and confirm commercial revenue evolves only via the position multiplier (no drift from the UEFA factor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)