### PR TITLE
Rebalance AI contract renewal rates for healthier January market

### DIFF
--- a/app/Modules/Transfer/Listeners/RollAIContractRenewals.php
+++ b/app/Modules/Transfer/Listeners/RollAIContractRenewals.php
@@ -18,11 +18,12 @@ use Illuminate\Support\Facades\DB;
  * the user can shop the entire top flight on a free.
  *
  * Distributes the renewal work across the season instead of doing it in one
- * batch at setup. By Jan 1 (~20 ticks in) the high-importance bucket is
- * roughly 75% renewed; by season end it's near-complete. Mid-window the user
- * still encounters some pre-contractable players from each tier, but the
- * pool drains as the window progresses — which matches how clubs really
- * keep extending stars throughout the year to avoid the Bosman.
+ * batch at setup. By Jan 1 (~20 ticks in) roughly half the high-importance
+ * bucket is renewed; the rest of each tier remains shoppable. Mid-window the
+ * user still encounters a healthy supply of pre-contractable players from
+ * each tier, and the pool gradually drains as the window progresses — which
+ * matches how clubs really keep extending stars throughout the year to avoid
+ * the Bosman, without making the January free market dry up entirely.
  *
  * Skips veterans (they keep the existing 50/50 retire-vs-renew coin flip at
  * season end), loaned-out players (renewal authority sits with the parent
@@ -35,13 +36,15 @@ class RollAIContractRenewals
      * Per-tick renewal probability in permille (parts per 1000).
      *
      * Calibrated against ~20 ticks Aug→Dec so cumulative chance by the Jan 1
-     * pre-contract window lands roughly where the old once-per-season batch
-     * put it: ~75% / ~45% / ~10% renewed for top / mid / low importance.
-     * Over the full ~38-tick season the rates converge to ~94% / ~70% / ~17%.
+     * pre-contract window lands at roughly ~50% / ~22% / ~4% renewed for
+     * top / mid / low importance — leaving a healthy free-agent pool to shop
+     * in January. Over the full ~38-tick season the rates converge to
+     * ~74% / ~37% / ~7%, with the remainder handled by the existing
+     * season-end ContractExpirationProcessor coin flip.
      */
-    private const ROLL_TOP_PERMILLE = 70;
-    private const ROLL_MID_PERMILLE = 30;
-    private const ROLL_LOW_PERMILLE = 5;
+    private const ROLL_TOP_PERMILLE = 35;
+    private const ROLL_MID_PERMILLE = 12;
+    private const ROLL_LOW_PERMILLE = 2;
 
     private const TOP_IMPORTANCE_THRESHOLD = 0.70;
     private const MID_IMPORTANCE_THRESHOLD = 0.40;

--- a/tests/Unit/RollAIContractRenewalsTest.php
+++ b/tests/Unit/RollAIContractRenewalsTest.php
@@ -45,8 +45,8 @@ class RollAIContractRenewalsTest extends TestCase
     public function test_top_importance_player_is_renewed_after_enough_ticks(): void
     {
         // Cumulative test: ~20 ticks (Aug→Dec) is enough for a top-importance
-        // player to cross the renewal line in the strong majority of runs.
-        // Per-tick rate 70‰ → 1 - 0.93^20 ≈ 76% chance the top player is
+        // player to cross the renewal line in a meaningful share of runs.
+        // Per-tick rate 35‰ → 1 - 0.965^20 ≈ 51% chance the top player is
         // renewed by tick 20; loose bound to absorb noise.
         $renewedRuns = 0;
         $iterations = 50;
@@ -67,15 +67,15 @@ class RollAIContractRenewalsTest extends TestCase
         }
 
         $this->assertGreaterThanOrEqual(
-            (int) ($iterations * 0.55),
+            (int) ($iterations * 0.30),
             $renewedRuns,
-            "Top-importance player should be renewed in the majority of runs by tick 20 (got {$renewedRuns}/{$iterations})",
+            "Top-importance player should be renewed in a meaningful share of runs by tick 20 (got {$renewedRuns}/{$iterations})",
         );
     }
 
     public function test_low_importance_player_is_rarely_renewed_after_few_ticks(): void
     {
-        // Low bucket rate is 5‰; even at tick 20 cumulative ≈ 10%. Loose
+        // Low bucket rate is 2‰; even at tick 20 cumulative ≈ 4%. Loose
         // upper bound asserts the floor doesn't accidentally drift up.
         $renewedRuns = 0;
         $iterations = 50;


### PR DESCRIPTION
## Summary

Adjusts the per-tick renewal probabilities for AI contract renewals to create a healthier free-agent pool during the January transfer window, while still ensuring meaningful renewal activity throughout the season.

## Changes

- **Reduced renewal rates** across all importance tiers:
  - Top importance: 70‰ → 35‰ per tick
  - Mid importance: 30‰ → 12‰ per tick
  - Low importance: 5‰ → 2‰ per tick

- **Updated renewal expectations** by Jan 1 (~20 ticks):
  - Top tier: ~76% → ~51% renewed
  - Mid tier: ~45% → ~22% renewed
  - Low tier: ~10% → ~4% renewed

- **Extended full-season convergence rates** (accounting for season-end ContractExpirationProcessor):
  - Top tier: ~94% → ~74% renewed
  - Mid tier: ~70% → ~37% renewed
  - Low tier: ~17% → ~7% renewed

- **Updated documentation** in class docblock and test comments to reflect the new behavior: players encounter a "healthy supply" of pre-contractable players mid-window rather than a "strong majority" being renewed early.

## Rationale

The previous rates front-loaded too many renewals before January, leaving the free-agent pool depleted during the critical pre-contract window. The new rates distribute renewals more evenly across the season, ensuring users can still shop for talent in January while maintaining realistic renewal activity throughout the year. The remainder of unrenewed contracts are handled by the existing season-end coin flip, preventing artificial contract expirations.

https://claude.ai/code/session_01J1BgkppaAZhAVaNDzfCJLr