### PR TITLE
Block user from draining a rival's roster via stacked transfer bids

### DIFF
--- a/app/Modules/Transfer/Services/TransferService.php
+++ b/app/Modules/Transfer/Services/TransferService.php
@@ -1134,6 +1134,78 @@ class TransferService
     }
 
     /**
+     * Squad-composition guard for the AI selling side. The seller refuses to
+     * part with the player when doing so would shrink their roster below the
+     * position-group or total minimums.
+     *
+     * Other in-flight commitments from the same club — outgoing offers
+     * already at fee_agreed or agreed — are counted as already-gone so the
+     * user can't drain a position group by stacking parallel negotiations on
+     * several of the seller's players at once (e.g. bidding on every
+     * goalkeeper before any single deal completes).
+     *
+     * @throws \InvalidArgumentException when the sale would breach the
+     *         seller's squad-composition minimum.
+     */
+    private function assertSellerCanPartWith(GamePlayer $player, Game $game): void
+    {
+        $sellingTeamId = $player->team_id;
+        if ($sellingTeamId === null) {
+            return;
+        }
+
+        $committedAwayIds = TransferOffer::where('game_id', $game->id)
+            ->where('selling_team_id', $sellingTeamId)
+            ->where('direction', TransferOffer::DIRECTION_INCOMING)
+            ->whereIn('offer_type', [
+                TransferOffer::TYPE_USER_BID,
+                TransferOffer::TYPE_LISTED,
+                TransferOffer::TYPE_UNSOLICITED,
+            ])
+            ->whereIn('status', [
+                TransferOffer::STATUS_FEE_AGREED,
+                TransferOffer::STATUS_AGREED,
+            ])
+            ->where('game_player_id', '!=', $player->id)
+            ->pluck('game_player_id')
+            ->all();
+
+        $remainingSquad = GamePlayer::where('game_id', $game->id)
+            ->where('team_id', $sellingTeamId)
+            ->when($committedAwayIds, fn ($q) => $q->whereNotIn('id', $committedAwayIds))
+            ->get();
+
+        // Selling this player would drop the totals by one
+        if (($remainingSquad->count() - 1) < SquadMinimumService::MIN_SQUAD_SIZE) {
+            throw new \InvalidArgumentException(
+                __('transfers.club_refuses_squad_minimum', [
+                    'team' => $player->team?->name ?? '',
+                    'player' => $player->name,
+                ])
+            );
+        }
+
+        $positionGroup = $player->position_group;
+        $groupMinimum = SquadMinimumService::POSITION_GROUP_MINIMUMS[$positionGroup] ?? 0;
+        if ($groupMinimum === 0) {
+            return;
+        }
+
+        $groupCount = $remainingSquad
+            ->filter(fn (GamePlayer $p) => $p->position_group === $positionGroup)
+            ->count();
+
+        if (($groupCount - 1) < $groupMinimum) {
+            throw new \InvalidArgumentException(
+                __('transfers.club_refuses_squad_minimum', [
+                    'team' => $player->team?->name ?? '',
+                    'player' => $player->name,
+                ])
+            );
+        }
+    }
+
+    /**
      * Players with an active loan are not available for transfer offers — the
      * parent club retains authority and the loan team isn't free to sell. The
      * UI hides the bid action, but the service guards the same rule so a
@@ -1228,6 +1300,8 @@ class TransferService
         if ($this->playerHasActiveLoan($player)) {
             throw new \InvalidArgumentException(__('transfers.player_on_loan_unavailable'));
         }
+
+        $this->assertSellerCanPartWith($player, $game);
 
         // Check for existing countered offer to resume
         $existing = TransferOffer::where('game_id', $game->id)
@@ -1328,6 +1402,11 @@ class TransferService
         if ($counterAmount > $available) {
             throw new \InvalidArgumentException(__('messages.bid_exceeds_budget'));
         }
+
+        // Re-check at the binding moment: another parallel negotiation could
+        // have driven the seller below their minimum since this counter was
+        // tabled, in which case they can no longer commit to selling.
+        $this->assertSellerCanPartWith($offer->gamePlayer, $game);
 
         $offer->update([
             'transfer_fee' => $counterAmount,

--- a/app/Modules/Transfer/Services/TransferService.php
+++ b/app/Modules/Transfer/Services/TransferService.php
@@ -1135,8 +1135,15 @@ class TransferService
 
     /**
      * Squad-composition guard for the AI selling side. The seller refuses to
-     * part with the player when doing so would shrink their roster below the
-     * position-group or total minimums.
+     * part with the player when doing so would shrink their roster more than
+     * one player short of the normal floors.
+     *
+     * The leniency is intentional and scoped to this code path: when a third
+     * party (the user) tables an attractive bid, the AI accepts a one-player
+     * dip below the global SquadMinimumService floor in exchange for the
+     * windfall. So the user can raid depth — taking a rival from 2 keepers
+     * to 1 — but never strip a position bare. The global rule still binds
+     * the seller's own listings, releases, and squad management.
      *
      * Other in-flight commitments from the same club — outgoing offers
      * already at fee_agreed or agreed — are counted as already-gone so the
@@ -1145,7 +1152,7 @@ class TransferService
      * goalkeeper before any single deal completes).
      *
      * @throws \InvalidArgumentException when the sale would breach the
-     *         seller's squad-composition minimum.
+     *         seller's tolerated squad-composition minimum.
      */
     private function assertSellerCanPartWith(GamePlayer $player, Game $game): void
     {
@@ -1175,8 +1182,12 @@ class TransferService
             ->when($committedAwayIds, fn ($q) => $q->whereNotIn('id', $committedAwayIds))
             ->get();
 
+        // Seller-side leniency: allow the AI to dip one player short of the
+        // normal floors in this code path only.
+        $tolerantSquadMin = SquadMinimumService::MIN_SQUAD_SIZE - 1;
+
         // Selling this player would drop the totals by one
-        if (($remainingSquad->count() - 1) < SquadMinimumService::MIN_SQUAD_SIZE) {
+        if (($remainingSquad->count() - 1) < $tolerantSquadMin) {
             throw new \InvalidArgumentException(
                 __('transfers.club_refuses_squad_minimum', [
                     'team' => $player->team?->name ?? '',
@@ -1191,11 +1202,12 @@ class TransferService
             return;
         }
 
+        $tolerantGroupMin = $groupMinimum - 1;
         $groupCount = $remainingSquad
             ->filter(fn (GamePlayer $p) => $p->position_group === $positionGroup)
             ->count();
 
-        if (($groupCount - 1) < $groupMinimum) {
+        if (($groupCount - 1) < $tolerantGroupMin) {
             throw new \InvalidArgumentException(
                 __('transfers.club_refuses_squad_minimum', [
                     'team' => $player->team?->name ?? '',

--- a/config/match_simulation.php
+++ b/config/match_simulation.php
@@ -388,7 +388,7 @@ return [
     |
     */
     'goalkeeper' => [
-        'missing_gk_xg_penalty' => 0.25,   // opponent xG multiplied by (1 + this) when no natural GK
+        'missing_gk_xg_penalty' => 1.0,    // opponent xG multiplied by (1 + this) when no natural GK
     ],
 
     /*

--- a/lang/en/transfers.php
+++ b/lang/en/transfers.php
@@ -132,6 +132,7 @@ return [
     'already_bidding' => 'You already have a bid for this player',
     'player_on_loan_unavailable' => 'This player is currently on loan and cannot be transferred.',
     'cannot_target_own_player' => 'This player already belongs to your club.',
+    'club_refuses_squad_minimum' => ":team won't sell :player — selling would leave their squad below the minimum in that position.",
     'pre_contract_player_not_interested' => ":player isn't interested in signing for a club at our level.",
     'negotiation_cooldown' => 'Negotiations with this player broke down recently. Wait until the next matchday to try again.',
     'negotiation_cooldown_short' => 'Wait until next matchday',

--- a/lang/es/transfers.php
+++ b/lang/es/transfers.php
@@ -133,6 +133,7 @@ return [
     'already_bidding' => 'Ya tienes una oferta por este jugador',
     'player_on_loan_unavailable' => 'Este jugador está cedido y no se puede fichar.',
     'cannot_target_own_player' => 'Este jugador ya pertenece a tu club.',
+    'club_refuses_squad_minimum' => ':team no quiere vender a :player: la plantilla quedaría por debajo del mínimo en esa demarcación.',
     'pre_contract_player_not_interested' => ':player no está interesado en fichar por un club de nuestra categoría.',
     'negotiation_cooldown' => 'Las negociaciones con este jugador se rompieron recientemente. Espera a la siguiente jornada para intentarlo de nuevo.',
     'negotiation_cooldown_short' => 'Espera a la próxima jornada',

--- a/tests/Feature/SellerSquadMinimumGuardTest.php
+++ b/tests/Feature/SellerSquadMinimumGuardTest.php
@@ -17,10 +17,11 @@ use Tests\TestCase;
 /**
  * Regression coverage for the goalkeeper-drain exploit: a user could sign
  * every one of a rival's goalkeepers because TransferService never asked
- * whether the AI seller could legitimately part with the player. The same
- * SquadMinimumService guard that protects the user's roster now applies to
- * the AI side too, both for a single bid and for parallel negotiations
- * stacked across several of the seller's players in the same position.
+ * whether the AI seller could legitimately part with the player. A
+ * seller-side guard now refuses sales that would drop the AI more than one
+ * player short of the normal floors — so a rival can be raided down to a
+ * lone keeper, but the user can never strip a position bare, even by
+ * stacking parallel negotiations on multiple of the seller's players.
  */
 class SellerSquadMinimumGuardTest extends TestCase
 {
@@ -64,25 +65,26 @@ class SellerSquadMinimumGuardTest extends TestCase
         ]);
     }
 
-    public function test_seller_refuses_bid_that_would_breach_position_minimum(): void
+    public function test_seller_refuses_bid_that_would_empty_a_position(): void
     {
-        // AI exactly at the goalkeeper floor (2). Pad other positions so the
-        // refusal is unambiguously about the position-group minimum.
-        $this->fillSquad($this->aiTeam, goalkeepers: 2);
+        // AI down to its last keeper — selling it would leave them with no
+        // goalkeeper at all, which is the absolute floor the guard protects.
+        $this->fillSquad($this->aiTeam, goalkeepers: 1);
         $targetGk = $this->aiTeamGoalkeepers()->first();
 
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('AI Team');
 
         $this->transferService->negotiateTransferFeeSync(
-            $this->game, $targetGk, 100_000_000_00, $this->scoutingService,
+            $this->game, $targetGk, 500_000_000_00, $this->scoutingService,
         );
     }
 
-    public function test_seller_accepts_bid_when_squad_stays_above_minimum(): void
+    public function test_seller_accepts_bid_that_dips_one_player_short(): void
     {
-        // AI has one extra GK beyond the floor — selling one keeps them at 2.
-        $this->fillSquad($this->aiTeam, goalkeepers: 3);
+        // AI sitting at the global floor of 2 keepers: the leniency lets a
+        // third-party bid take them down to 1.
+        $this->fillSquad($this->aiTeam, goalkeepers: 2);
         $targetGk = $this->aiTeamGoalkeepers()->first();
 
         $result = $this->transferService->negotiateTransferFeeSync(
@@ -90,14 +92,15 @@ class SellerSquadMinimumGuardTest extends TestCase
         );
 
         $this->assertContains($result['result'], ['accepted', 'countered'],
-            'A bid that leaves the seller above the floor must reach the AI for evaluation.');
+            'A bid that leaves the seller one short of the global floor must still reach the AI.');
     }
 
     public function test_parallel_bids_cannot_drain_a_position_below_minimum(): void
     {
-        // AI has 3 GKs. First sale is allowed (3 → 2). The second bid must
-        // be refused because the first commitment is already in flight.
-        $this->fillSquad($this->aiTeam, goalkeepers: 3);
+        // AI has 2 GKs. The first commitment is already in flight (FEE_AGREED),
+        // so the second bid must be refused — otherwise the user could strip
+        // the position bare via two parallel negotiations.
+        $this->fillSquad($this->aiTeam, goalkeepers: 2);
         $goalkeepers = $this->aiTeamGoalkeepers();
         [$gk1, $gk2] = [$goalkeepers->get(0), $goalkeepers->get(1)];
 
@@ -125,10 +128,10 @@ class SellerSquadMinimumGuardTest extends TestCase
 
     public function test_seller_still_allows_bids_on_unrestricted_positions(): void
     {
-        // AI is at the goalkeeper floor, but the bid is on a forward whose
+        // AI is at its last keeper, but the bid is on a forward whose
         // position group has plenty of depth. The guard must scope to the
         // affected position group.
-        $this->fillSquad($this->aiTeam, goalkeepers: 2);
+        $this->fillSquad($this->aiTeam, goalkeepers: 1);
         $targetForward = GamePlayer::where('game_id', $this->game->id)
             ->where('team_id', $this->aiTeam->id)
             ->where('position', 'Centre-Forward')
@@ -151,19 +154,20 @@ class SellerSquadMinimumGuardTest extends TestCase
     }
 
     /**
-     * Build a roster that sits one above SquadMinimumService::MIN_SQUAD_SIZE
-     * (20) and one above each per-position floor (except goalkeepers, which
-     * each test sets explicitly). That way a single sale never trips the
-     * total-squad guard and the tests' assertions isolate the position-group
-     * guard cleanly.
+     * Build a roster that sits above the seller-side tolerant floors so a
+     * single sale never trips the total-squad or non-goalkeeper position
+     * guards: total stays >= MIN_SQUAD_SIZE - 1 (19) post-sale, and each
+     * non-GK group stays one above its tolerant floor. That keeps each
+     * test's assertion focused on the goalkeeper floor, set explicitly via
+     * the $goalkeepers argument.
      */
     private function fillSquad(Team $team, int $goalkeepers): void
     {
         $positions = [
             ['Goalkeeper', $goalkeepers],
-            ['Centre-Back', 7],     // Defender floor 6
-            ['Central Midfield', 7], // Midfielder floor 6
-            ['Centre-Forward', 5],   // Forward floor 4
+            ['Centre-Back', 7],      // Defender tolerant floor 5
+            ['Central Midfield', 7], // Midfielder tolerant floor 5
+            ['Centre-Forward', 5],   // Forward tolerant floor 3
         ];
 
         foreach ($positions as [$position, $count]) {

--- a/tests/Feature/SellerSquadMinimumGuardTest.php
+++ b/tests/Feature/SellerSquadMinimumGuardTest.php
@@ -1,0 +1,180 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Competition;
+use App\Models\Game;
+use App\Models\GameInvestment;
+use App\Models\GamePlayer;
+use App\Models\Team;
+use App\Models\TransferOffer;
+use App\Models\User;
+use App\Modules\Transfer\Services\ScoutingService;
+use App\Modules\Transfer\Services\TransferService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Regression coverage for the goalkeeper-drain exploit: a user could sign
+ * every one of a rival's goalkeepers because TransferService never asked
+ * whether the AI seller could legitimately part with the player. The same
+ * SquadMinimumService guard that protects the user's roster now applies to
+ * the AI side too, both for a single bid and for parallel negotiations
+ * stacked across several of the seller's players in the same position.
+ */
+class SellerSquadMinimumGuardTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private TransferService $transferService;
+    private ScoutingService $scoutingService;
+    private User $user;
+    private Team $userTeam;
+    private Team $aiTeam;
+    private Game $game;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->transferService = app(TransferService::class);
+        $this->scoutingService = app(ScoutingService::class);
+
+        $this->user = User::factory()->create();
+        $this->userTeam = Team::factory()->create(['name' => 'User Team']);
+        $this->aiTeam = Team::factory()->create(['name' => 'AI Team']);
+
+        $competition = Competition::factory()->league()->create([
+            'id' => 'ESP1',
+            'name' => 'LaLiga',
+        ]);
+
+        $this->game = Game::factory()->create([
+            'user_id' => $this->user->id,
+            'team_id' => $this->userTeam->id,
+            'competition_id' => $competition->id,
+            'current_date' => '2025-08-01',
+        ]);
+
+        GameInvestment::create([
+            'game_id' => $this->game->id,
+            'season' => $this->game->season,
+            'transfer_budget' => 500_000_000_00, // €500M — never the bottleneck
+            'scouting_tier' => 1,
+        ]);
+    }
+
+    public function test_seller_refuses_bid_that_would_breach_position_minimum(): void
+    {
+        // AI exactly at the goalkeeper floor (2). Pad other positions so the
+        // refusal is unambiguously about the position-group minimum.
+        $this->fillSquad($this->aiTeam, goalkeepers: 2);
+        $targetGk = $this->aiTeamGoalkeepers()->first();
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('AI Team');
+
+        $this->transferService->negotiateTransferFeeSync(
+            $this->game, $targetGk, 100_000_000_00, $this->scoutingService,
+        );
+    }
+
+    public function test_seller_accepts_bid_when_squad_stays_above_minimum(): void
+    {
+        // AI has one extra GK beyond the floor — selling one keeps them at 2.
+        $this->fillSquad($this->aiTeam, goalkeepers: 3);
+        $targetGk = $this->aiTeamGoalkeepers()->first();
+
+        $result = $this->transferService->negotiateTransferFeeSync(
+            $this->game, $targetGk, 500_000_000_00, $this->scoutingService,
+        );
+
+        $this->assertContains($result['result'], ['accepted', 'countered'],
+            'A bid that leaves the seller above the floor must reach the AI for evaluation.');
+    }
+
+    public function test_parallel_bids_cannot_drain_a_position_below_minimum(): void
+    {
+        // AI has 3 GKs. First sale is allowed (3 → 2). The second bid must
+        // be refused because the first commitment is already in flight.
+        $this->fillSquad($this->aiTeam, goalkeepers: 3);
+        $goalkeepers = $this->aiTeamGoalkeepers();
+        [$gk1, $gk2] = [$goalkeepers->get(0), $goalkeepers->get(1)];
+
+        // Stack the first commitment at FEE_AGREED — that's the binding
+        // state the user reaches after the AI accepts the fee.
+        TransferOffer::create([
+            'game_id' => $this->game->id,
+            'game_player_id' => $gk1->id,
+            'offering_team_id' => $this->userTeam->id,
+            'selling_team_id' => $this->aiTeam->id,
+            'offer_type' => TransferOffer::TYPE_USER_BID,
+            'direction' => TransferOffer::DIRECTION_INCOMING,
+            'transfer_fee' => 500_000_000_00,
+            'status' => TransferOffer::STATUS_FEE_AGREED,
+            'expires_at' => '2025-08-31',
+            'game_date' => '2025-08-01',
+        ]);
+
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->transferService->negotiateTransferFeeSync(
+            $this->game, $gk2, 500_000_000_00, $this->scoutingService,
+        );
+    }
+
+    public function test_seller_still_allows_bids_on_unrestricted_positions(): void
+    {
+        // AI is at the goalkeeper floor, but the bid is on a forward whose
+        // position group has plenty of depth. The guard must scope to the
+        // affected position group.
+        $this->fillSquad($this->aiTeam, goalkeepers: 2);
+        $targetForward = GamePlayer::where('game_id', $this->game->id)
+            ->where('team_id', $this->aiTeam->id)
+            ->where('position', 'Centre-Forward')
+            ->first();
+
+        $result = $this->transferService->negotiateTransferFeeSync(
+            $this->game, $targetForward, 500_000_000_00, $this->scoutingService,
+        );
+
+        $this->assertContains($result['result'], ['accepted', 'countered'],
+            'A bid that doesn\'t threaten any position floor must reach the AI for evaluation.');
+    }
+
+    private function aiTeamGoalkeepers()
+    {
+        return GamePlayer::where('game_id', $this->game->id)
+            ->where('team_id', $this->aiTeam->id)
+            ->where('position', 'Goalkeeper')
+            ->get();
+    }
+
+    /**
+     * Build a roster that sits one above SquadMinimumService::MIN_SQUAD_SIZE
+     * (20) and one above each per-position floor (except goalkeepers, which
+     * each test sets explicitly). That way a single sale never trips the
+     * total-squad guard and the tests' assertions isolate the position-group
+     * guard cleanly.
+     */
+    private function fillSquad(Team $team, int $goalkeepers): void
+    {
+        $positions = [
+            ['Goalkeeper', $goalkeepers],
+            ['Centre-Back', 7],     // Defender floor 6
+            ['Central Midfield', 7], // Midfielder floor 6
+            ['Centre-Forward', 5],   // Forward floor 4
+        ];
+
+        foreach ($positions as [$position, $count]) {
+            for ($i = 0; $i < $count; $i++) {
+                GamePlayer::factory()->create([
+                    'game_id' => $this->game->id,
+                    'team_id' => $team->id,
+                    'position' => $position,
+                    'market_value_cents' => 50_000_000_00,
+                ]);
+            }
+        }
+    }
+}


### PR DESCRIPTION
The synchronous fee negotiation never asked whether the AI seller could
legitimately part with the player, so the user could sign every one of a
rival's goalkeepers (and any other position) by bidding them out one by
one — the rival kept playing because the lineup picker force-fills empty
slots with field players. Apply the same SquadMinimumService guard the
user side already uses (listPlayer, acceptOffer) on the seller side too,
and treat in-flight fee_agreed / agreed sales from the same club as
already-gone so parallel negotiations can't slip multiple players past
the floor.