### PR TITLE
Show live player rating from half-time onwards in tactical center

### DIFF
--- a/resources/js/modules/ratings-glue.js
+++ b/resources/js/modules/ratings-glue.js
@@ -67,18 +67,21 @@ export function createRatingsGlue(ctx) {
          * Live (pre-full-time) rating for a player, derived solely from the
          * cached performance modifier — no event, score, or card bonuses.
          *
-         * Only exposed during the half-time (and ET half-time) substitution
-         * window. Outside those windows the rating has no actionable value —
-         * showing it during live play would just be noise, and showing it at
-         * full time would compete with the proper event-weighted rating.
+         * Exposed from half-time onwards (second half, ET, penalties) so the
+         * manager can keep monitoring how players are performing while making
+         * tactical decisions. Hidden during the first half (not enough data
+         * yet) and at full time (where the proper event-weighted rating
+         * supersedes this base value).
          *
-         * Returns null when not in a half-time window or when no performance
+         * Returns null before half-time, at full time, or when no performance
          * data is available for the player.
          */
         getBaseRating(playerId) {
             if (!playerId) return null;
             const c = ctx();
-            if (c.phase !== PHASE.HALF_TIME && c.phase !== PHASE.EXTRA_TIME_HALF_TIME) {
+            if (c.phase === PHASE.PRE_MATCH
+                || c.phase === PHASE.FIRST_HALF
+                || c.phase === PHASE.FULL_TIME) {
                 return null;
             }
             const player = c.homeLineupRoster.find(p => p.id === playerId)


### PR DESCRIPTION
Previously the performance-based rating in the tactical center sub picker
was only visible during the half-time and ET half-time windows. Now it
stays visible through the second half, extra time, and penalties so the
manager can keep gauging player form while planning substitutions.
First-half and full-time remain hidden (no data yet / event-weighted
rating takes over).