### PR TITLE
Refine wage negotiation: finer steps and round-aware counters

### DIFF
--- a/app/Http/Actions/NegotiateRenewal.php
+++ b/app/Http/Actions/NegotiateRenewal.php
@@ -139,7 +139,7 @@ class NegotiateRenewal
                     'years' => $demand['contractYears'],
                     'mood' => $mood,
                 ], [
-                    'canAccept' => false,
+                    'canAccept' => true,
                     'suggestedWage' => (int) ($demand['wage'] / 100),
                     'preferredYears' => $demand['contractYears'],
                 ]),

--- a/app/Modules/Transfer/Services/WageNegotiationEvaluator.php
+++ b/app/Modules/Transfer/Services/WageNegotiationEvaluator.php
@@ -10,9 +10,6 @@ namespace App\Modules\Transfer\Services;
  */
 class WageNegotiationEvaluator
 {
-    /** Counter threshold: offer must be >= 85% of minimum acceptable to get a counter */
-    private const COUNTER_THRESHOLD = 0.85;
-
     /** Default disposition-to-flexibility scaling factor */
     private const DEFAULT_FLEXIBILITY_RATIO = 0.30;
 
@@ -58,10 +55,9 @@ class WageNegotiationEvaluator
             return ['result' => 'accepted', 'counterWage' => null];
         }
 
-        // Check if close enough for a counter
-        $counterThreshold = (int) ($minimumAcceptable * self::COUNTER_THRESHOLD);
-
-        if ($effectiveOffer >= $counterThreshold && $round < $maxRounds) {
+        // While rounds remain, the player holds firm rather than walking out:
+        // counter near the minimum acceptable so the user can keep negotiating.
+        if ($round < $maxRounds) {
             $counterWage = (int) (($minimumAcceptable + $playerDemand) / 2);
             $counterWage = $this->roundCounterOffer($counterWage, $minimumAcceptable);
 

--- a/resources/js/negotiation-chat.js
+++ b/resources/js/negotiation-chat.js
@@ -286,11 +286,27 @@ export default function negotiationChat() {
                     }
                 }
             } else {
-                // Renewal mode
-                const data = await this.sendAction('accept_counter');
-                if (data) {
-                    this.negotiationStatus = data.negotiation_status;
-                    this.appendMessages(data.messages);
+                // Renewal mode. On round 0 the user is accepting the player's
+                // opening demand — no negotiation row exists yet, so submit a
+                // normal offer at the demand wage/years rather than calling
+                // accept_counter (which only resolves an existing counter).
+                if (this.round === 0) {
+                    const data = await this.sendAction('offer', {
+                        wage: this.offerWage,
+                        years: this.offerYears,
+                    });
+                    if (data) {
+                        this.negotiationStatus = data.negotiation_status;
+                        this.round = data.round || this.round;
+                        this.appendMessages(data.messages);
+                        this.prefillFromOptions();
+                    }
+                } else {
+                    const data = await this.sendAction('accept_counter');
+                    if (data) {
+                        this.negotiationStatus = data.negotiation_status;
+                        this.appendMessages(data.messages);
+                    }
                 }
             }
             this.loading = false;

--- a/resources/js/negotiation-chat.js
+++ b/resources/js/negotiation-chat.js
@@ -64,7 +64,8 @@ export default function negotiationChat() {
             if (this.mode === 'transfer_fee' || this.phase === 'counter_offer') {
                 if (this.offerWage >= 10000000) return 1000000;  // >= €10M: €1M steps
                 if (this.offerWage >= 1000000) return 100000;    // >= €1M: €100K steps
-                return 50000;                                     // < €1M: €50K steps
+                if (this.offerWage >= 100000) return 10000;      // >= €100K: €10K steps
+                return 5000;                                      // < €100K: €5K steps
             }
             if (this.offerWage >= 1000000) return 100000;
             if (this.offerWage >= 100000) return 10000;

--- a/tests/Unit/WageNegotiationEvaluatorTest.php
+++ b/tests/Unit/WageNegotiationEvaluatorTest.php
@@ -31,8 +31,10 @@ class WageNegotiationEvaluatorTest extends TestCase
         $this->assertNull($result['counterWage']);
     }
 
-    public function test_very_low_offer_is_rejected(): void
+    public function test_very_low_offer_within_rounds_is_countered(): void
     {
+        // Lowballs no longer hard-reject while negotiation rounds remain — the
+        // player holds firm with a counter near their minimum acceptable wage.
         $result = $this->evaluator->evaluate(
             offerWage: 10_000_000,
             offeredYears: 3,
@@ -40,6 +42,23 @@ class WageNegotiationEvaluatorTest extends TestCase
             preferredYears: 3,
             disposition: 0.50,
             round: 1,
+            maxRounds: 3,
+        );
+
+        $this->assertEquals('countered', $result['result']);
+        $this->assertNotNull($result['counterWage']);
+        $this->assertLessThanOrEqual(50_000_000, $result['counterWage']);
+    }
+
+    public function test_very_low_offer_at_final_round_is_rejected(): void
+    {
+        $result = $this->evaluator->evaluate(
+            offerWage: 10_000_000,
+            offeredYears: 3,
+            playerDemand: 50_000_000,
+            preferredYears: 3,
+            disposition: 0.50,
+            round: 3,
             maxRounds: 3,
         );
 


### PR DESCRIPTION
## Summary

Improves wage negotiation mechanics by introducing finer wage increment steps for lower salary ranges and making counter-offer behavior round-aware. The player now holds firm with counters throughout negotiation rounds rather than hard-rejecting lowball offers, and only rejects at the final round.

## Key Changes

- **Finer wage steps for lower salaries:** Split the sub-€1M range into two tiers:
  - €100K–€1M: €10K steps (previously €50K)
  - Below €100K: €5K steps (new)
  - This allows more granular negotiation in lower wage brackets

- **Round-aware counter logic:** Removed the hard 85% counter threshold. The player now:
  - Counters with a mid-point offer (between minimum acceptable and demand) on all rounds except the final one
  - Only rejects lowball offers when `round === maxRounds`
  - This gives users more negotiation opportunities before a deal breaks down

- **Renewal mode round-0 handling:** Fixed renewal negotiations to properly handle the opening demand acceptance:
  - On round 0, submit a normal `offer` action (not `accept_counter`, which requires an existing negotiation row)
  - Correctly updates round number and prefills form after acceptance
  - Subsequent rounds use the existing `accept_counter` flow

- **Test updates:** Renamed and split lowball rejection test to clarify behavior:
  - `test_very_low_offer_within_rounds_is_countered` — lowballs get countered while rounds remain
  - `test_very_low_offer_at_final_round_is_rejected` — lowballs are rejected only at final round

- **UI fix:** Set `canAccept: true` on renewal opening demand so users can immediately accept the player's initial wage/years request

## Implementation Details

The evaluator now uses round count as the sole determinant for counter vs. reject, removing the threshold check entirely. This simplifies logic and makes negotiation feel more fair—players always get a chance to counter until the final round, regardless of how low the offer is.

https://claude.ai/code/session_01Wm4qJD9AK6RN8bPtRnJVco