### PR TITLE
Lock free-agent signings from same-season sale

### DIFF
--- a/app/Http/Actions/AcceptTransferOffer.php
+++ b/app/Http/Actions/AcceptTransferOffer.php
@@ -34,7 +34,7 @@ class AcceptTransferOffer
             abort(403, 'Cannot accept offers for loaned players.');
         }
 
-        if ($offer->gamePlayer->joinedInCurrentWindow($game)) {
+        if ($offer->gamePlayer->isInSaleCooldown($game)) {
             return redirect()->back()->with('error', __('messages.cannot_sell_same_window', [
                 'player' => $offer->gamePlayer->name,
             ]));

--- a/app/Http/Actions/ListPlayerForTransfer.php
+++ b/app/Http/Actions/ListPlayerForTransfer.php
@@ -27,7 +27,7 @@ class ListPlayerForTransfer
             abort(403, 'Cannot list a loaned player for transfer.');
         }
 
-        if ($player->joinedInCurrentWindow($game)) {
+        if ($player->isInSaleCooldown($game)) {
             return redirect()->back()->with('error', __('messages.cannot_sell_same_window', [
                 'player' => $player->name,
             ]));

--- a/app/Models/GamePlayer.php
+++ b/app/Models/GamePlayer.php
@@ -358,14 +358,33 @@ class GamePlayer extends Model
 
     /**
      * True if the player joined their current team during the currently-open
-     * transfer window. Used to prevent flipping a player in the same window
-     * they were acquired.
+     * transfer window, or was signed as a free agent during the current
+     * season. Used to prevent flipping a player shortly after acquisition.
+     *
+     * Free agent signings are always covered, even outside an open transfer
+     * window: free agents can be signed at any time and come in at zero cost,
+     * so without a season-long lock a user could sign a free player and
+     * immediately flip them for full market value.
      */
     public function joinedInCurrentWindow(?Game $game = null): bool
     {
         $game = $game ?? $this->game;
 
-        if (! $game?->current_date || ! $game->isTransferWindowOpen()) {
+        if (! $game?->current_date) {
+            return false;
+        }
+
+        $signedAsFreeAgentThisSeason = GameTransfer::where('game_player_id', $this->id)
+            ->where('to_team_id', $this->team_id)
+            ->where('type', GameTransfer::TYPE_FREE_AGENT)
+            ->where('season', $game->season)
+            ->exists();
+
+        if ($signedAsFreeAgentThisSeason) {
+            return true;
+        }
+
+        if (! $game->isTransferWindowOpen()) {
             return false;
         }
 

--- a/app/Models/GamePlayer.php
+++ b/app/Models/GamePlayer.php
@@ -357,16 +357,16 @@ class GamePlayer extends Model
     }
 
     /**
-     * True if the player joined their current team during the currently-open
-     * transfer window, or was signed as a free agent during the current
-     * season. Used to prevent flipping a player shortly after acquisition.
+     * True if the player is currently locked from being sold. Triggered when
+     * they joined during the currently-open transfer window, or were signed
+     * as a free agent at any point in the current season.
      *
      * Free agent signings are always covered, even outside an open transfer
      * window: free agents can be signed at any time and come in at zero cost,
      * so without a season-long lock a user could sign a free player and
      * immediately flip them for full market value.
      */
-    public function joinedInCurrentWindow(?Game $game = null): bool
+    public function isInSaleCooldown(?Game $game = null): bool
     {
         $game = $game ?? $this->game;
 

--- a/lang/en/messages.php
+++ b/lang/en/messages.php
@@ -7,7 +7,7 @@ return [
     'bid_exceeds_budget' => 'The bid exceeds your transfer budget.',
     'player_listed' => ':player listed for sale. Offers may arrive after the next matchday.',
     'player_unlisted' => ':player removed from the transfer list.',
-    'cannot_sell_same_window' => 'Cannot sell :player — they joined your team in the current transfer window.',
+    'cannot_sell_same_window' => 'Cannot sell :player — they were signed recently and can\'t be transferred yet.',
     'offer_rejected' => ':team_de offer rejected.',
     'offer_accepted_sale' => ':player sold :team_a for :fee.',
     'offer_accepted_pre_contract' => 'Deal agreed! :player will sign for :team for :fee when the :window window opens.',

--- a/lang/es/messages.php
+++ b/lang/es/messages.php
@@ -7,7 +7,7 @@ return [
     'bid_exceeds_budget' => 'La oferta supera tu presupuesto de fichajes.',
     'player_listed' => ':player puesto a la venta. Las ofertas pueden llegar tras la próxima jornada.',
     'player_unlisted' => ':player retirado de la lista de fichajes.',
-    'cannot_sell_same_window' => 'No se puede vender a :player — se unió a tu equipo en la ventana de fichajes actual.',
+    'cannot_sell_same_window' => 'No se puede vender a :player — fue fichado recientemente y aún no puede ser traspasado.',
     'offer_rejected' => 'Oferta :team_de rechazada.',
     'offer_accepted_sale' => ':player vendido :team_a por :fee.',
     'offer_accepted_pre_contract' => '¡Acuerdo cerrado! :player fichará por :team por :fee cuando abra la ventana de :window.',

--- a/resources/views/partials/player-detail.blade.php
+++ b/resources/views/partials/player-detail.blade.php
@@ -17,7 +17,7 @@
         && !$gamePlayer->hasPreContractAgreement()
         && !$gamePlayer->hasAgreedTransfer()
         && !$gamePlayer->hasActiveLoanSearch();
-    $canSell = $canManage && !$gamePlayer->joinedInCurrentWindow($game);
+    $canSell = $canManage && !$gamePlayer->isInSaleCooldown($game);
     $isTransferWindow = $isCareerMode && $game->isTransferWindowOpen();
     $showActions = $isCareerMode && ($isListed || $canManage);
 


### PR DESCRIPTION
Free agents could be signed and immediately listed/sold because
joinedInCurrentWindow short-circuited to false whenever the transfer
window was closed — and free agents are typically signed outside any
window. Treat any free-agent signing in the current season as a recent
acquisition, regardless of window state, so a €0 signing can't be
flipped for full market value.