### PR TITLE
Expand narrative variants to 5 versions for match commentary

### DIFF
--- a/app/Modules/Match/Services/MatchNarrativeService.php
+++ b/app/Modules/Match/Services/MatchNarrativeService.php
@@ -599,7 +599,7 @@ class MatchNarrativeService
     private function pickVariant(string $baseKey, int $matchday): string
     {
         $variantCount = 0;
-        for ($i = 1; $i <= 3; $i++) {
+        for ($i = 1; $i <= 5; $i++) {
             if (__("narrative.{$baseKey}_v{$i}") !== "narrative.{$baseKey}_v{$i}") {
                 $variantCount = $i;
             } else {

--- a/lang/en/narrative.php
+++ b/lang/en/narrative.php
@@ -35,18 +35,23 @@ return [
 
     'streak_win_long_v1' => ':count consecutive victories. The squad is brimming with confidence.',
     'streak_win_long_v2' => 'A remarkable run of :count straight wins. Can the streak continue?',
+    'streak_win_long_v3' => 'RED-HOT. :count wins on the spin and nobody is stopping them.',
 
     'streak_win_v1' => ':count wins in a row heading into this one.',
     'streak_win_v2' => 'Riding a :count-game winning streak. Momentum is building.',
+    'streak_win_v3' => 'ROLLING. :count straight victories and counting.',
 
     'streak_lose_v1' => ':count defeats on the bounce. The pressure is mounting.',
     'streak_lose_v2' => 'A tough spell — :count losses in a row. Time to turn it around.',
+    'streak_lose_v3' => 'FREE-FALL. :count defeats in a row and the questions are stacking up.',
 
     'unbeaten_v1' => 'Unbeaten in the last :count matches. Momentum is on your side.',
     'unbeaten_v2' => ':count games without defeat. The squad knows how to grind out results.',
+    'unbeaten_v3' => 'UNTOUCHED. :count matches without tasting defeat.',
 
     'winless_v1' => ':count matches without a win. Frustration is building.',
     'winless_v2' => 'A winless run of :count games weighs on the squad.',
+    'winless_v3' => 'STUCK. :count matches and still searching for a win.',
 
     // ── League Position & Stakes ────────────────────────────────────
 
@@ -75,18 +80,23 @@ return [
 
     'injury_crisis_v1' => ':count players ruled out through injury. A depleted squad faces a test.',
     'injury_crisis_v2' => 'The treatment room is busy — :count players unavailable through injury.',
+    'injury_crisis_v3' => 'WALKING WOUNDED. :count players out and the bench is paper-thin.',
 
     'morale_low_v1' => 'Squad morale is fragile. A good result here could lift spirits.',
     'morale_low_v2' => 'Heads are down in the dressing room. The squad needs a spark.',
+    'morale_low_v3' => 'HEADS DOWN. The dressing room mood is fragile.',
 
     'morale_high_v1' => 'Confidence is sky-high in the dressing room.',
     'morale_high_v2' => 'The squad is buzzing. High spirits across the board.',
+    'morale_high_v3' => 'FLYING HIGH. The dressing room is buzzing.',
 
     'fitness_low_v1' => 'Energy levels are concerning — rotation might be wise.',
     'fitness_low_v2' => 'The squad looks leggy. Fatigue could be a factor today.',
+    'fitness_low_v3' => 'RUNNING ON FUMES. Legs look heavy across the side.',
 
     'fitness_high_v1' => 'The squad is fresh and ready to go.',
     'fitness_high_v2' => 'High energy levels across the board. No excuses today.',
+    'fitness_high_v3' => 'FULL TANKS. Fresh legs across the eleven.',
 
     // ── Opponent Scouting ───────────────────────────────────────────
 
@@ -161,7 +171,7 @@ return [
     // ── Tournament: Opponent Context ────────────────────────────────
 
     'wc_opponent_group_leader_v1' => ':opponent lead the group. A tough test on paper.',
-    'wc_opponent_group_leader_v2' => ':opponent are top of the group. A good benchmark.',
+    'wc_opponent_group_leader_v2' => ':opponent top the group — the gold standard to topple.',
     'wc_opponent_group_leader_v3' => 'TOP DOG. :opponent sit first in the group.',
 
     'wc_opponent_group_bottom_v1' => ':opponent are bottom of the group. Still, no game at this level is straightforward.',
@@ -181,21 +191,35 @@ return [
     'wc_weather_v1' => 'High temperatures expected. The heat could be a factor.',
     'wc_weather_v2' => 'Warm conditions in North America. Fitness and hydration will matter.',
     'wc_weather_v3' => 'Humid conditions forecast. Managing energy will be important.',
+    'wc_weather_v4' => 'Air thick with heat. Tactics may need adjusting in the second half.',
+    'wc_weather_v5' => 'PRESSURE COOKER. The conditions will test legs and lungs.',
 
     'wc_fans_v1' => 'A full stadium expected. Good atmosphere anticipated.',
     'wc_fans_v2' => 'Millions watching worldwide. A big occasion for both sides.',
     'wc_fans_v3' => 'Colourful scenes expected in the stands. The World Cup draws a unique crowd.',
+    'wc_fans_v4' => 'Travelling support out in force — a wall of colour behind the goal.',
+    'wc_fans_v5' => 'The roar at kick-off will rattle the rafters.',
 
-    'wc_media_v1' => 'Plenty of media attention on this one. A high-profile fixture.',
-    'wc_media_v2' => 'International press covering the match. The spotlight is on.',
+    'wc_media_v1' => 'Cameras and microphones everywhere. A high-stakes fixture.',
+    'wc_media_v2' => 'Headlines worldwide tomorrow. The spotlight is sharp.',
+    'wc_media_v3' => 'STAGE IS SET. The world\'s media is locked in on this one.',
+    'wc_media_v4' => 'The pundits are split down the middle on this one.',
+    'wc_media_v5' => 'Front pages are reserved for the result. No hiding place.',
 
     'wc_group_color_v1' => 'Group stage is underway. Results here shape the path ahead.',
     'wc_group_color_v2' => 'Every group match counts. The knockout bracket depends on it.',
+    'wc_group_color_v3' => 'GROUP STAGE GRIND. Every point shapes what comes next.',
+    'wc_group_color_v4' => 'Permutations on every desk. A win here changes the maths.',
+    'wc_group_color_v5' => 'Group football rewards patience as much as quality.',
 
     'wc_knockout_color_v1' => 'Single-elimination format. There is no room for an off day.',
     'wc_knockout_color_v2' => 'Knockout football. The margins between advancing and going home are slim.',
+    'wc_knockout_color_v3' => 'ONE LIFE LEFT. Win or pack the bags.',
+    'wc_knockout_color_v4' => 'One bad half can end a tournament. Concentration above all.',
+    'wc_knockout_color_v5' => 'Sudden-death football. The rules are unforgiving.',
 
-    'wc_late_tournament_v1' => 'The latter stages of the tournament. The remaining teams have earned their place.',
-    'wc_late_tournament_v2' => 'Deep into the World Cup. Only a handful of teams are left.',
+    'wc_late_tournament_v1' => 'Few teams remain. Each one has earned its place at this stage.',
+    'wc_late_tournament_v2' => 'The pretenders are gone. Only contenders remain.',
+    'wc_late_tournament_v3' => 'FINAL FEW. Only the heavyweights are still standing.',
 
 ];

--- a/lang/es/narrative.php
+++ b/lang/es/narrative.php
@@ -35,18 +35,23 @@ return [
 
     'streak_win_long_v1' => ':count victorias consecutivas. El vestuario rebosa confianza.',
     'streak_win_long_v2' => 'Una racha impresionante de :count triunfos seguidos. ¿Podrá continuar?',
+    'streak_win_long_v3' => 'FUEGO PURO. :count victorias seguidas y nadie las frena.',
 
     'streak_win_v1' => ':count victorias seguidas. A seguir la racha.',
     'streak_win_v2' => 'En racha con :count triunfos consecutivos. El impulso crece.',
+    'streak_win_v3' => 'EN VOLANDAS. :count victorias seguidas y subiendo.',
 
     'streak_lose_v1' => ':count derrotas seguidas. La presión aumenta.',
     'streak_lose_v2' => 'Un bache difícil — :count derrotas consecutivas. Hora de reaccionar.',
+    'streak_lose_v3' => 'EN CAÍDA LIBRE. :count derrotas seguidas y las dudas se acumulan.',
 
     'unbeaten_v1' => ':count partidos sin perder. El impulso está de vuestro lado.',
     'unbeaten_v2' => ':count encuentros invictos. El equipo sabe competir.',
+    'unbeaten_v3' => 'INTOCABLES. :count partidos sin morder el polvo.',
 
     'winless_v1' => ':count partidos sin ganar. La frustración se acumula.',
     'winless_v2' => 'Una racha de :count encuentros sin victoria pesa en el equipo.',
+    'winless_v3' => 'ATASCADOS. :count partidos buscando la primera victoria.',
 
     // ── Posición y Contexto ─────────────────────────────────────────
 
@@ -75,18 +80,23 @@ return [
 
     'injury_crisis_v1' => ':count jugadores fuera por lesión. Una plantilla mermada afronta el reto.',
     'injury_crisis_v2' => 'La enfermería está llena — :count jugadores no disponibles por lesión.',
+    'injury_crisis_v3' => 'PARTE MÉDICO LARGO. :count jugadores fuera y el banquillo justo.',
 
     'morale_low_v1' => 'La moral del equipo es frágil. Un buen resultado podría levantar el ánimo.',
     'morale_low_v2' => 'El vestuario está tocado. El equipo necesita una chispa.',
+    'morale_low_v3' => 'CABEZAS BAJAS. El ánimo del vestuario está tocado.',
 
     'morale_high_v1' => 'La confianza está por las nubes en el vestuario.',
     'morale_high_v2' => 'El equipo está enchufado. Moral alta en toda la plantilla.',
+    'morale_high_v3' => 'POR LAS NUBES. El vestuario vive un momento dulce.',
 
     'fitness_low_v1' => 'Los niveles de energía preocupan — rotaciones podrían ser necesarias.',
     'fitness_low_v2' => 'El equipo se nota cansado. La fatiga podría ser un factor hoy.',
+    'fitness_low_v3' => 'CON LA LENGUA FUERA. Las piernas pesan en toda la plantilla.',
 
     'fitness_high_v1' => 'La plantilla está fresca y preparada.',
     'fitness_high_v2' => 'Niveles de energía óptimos. Sin excusas hoy.',
+    'fitness_high_v3' => 'A TOPE. Piernas frescas en todos los puestos.',
 
     // ── Análisis del Rival ──────────────────────────────────────────
 
@@ -161,7 +171,7 @@ return [
     // ── Torneo: Contexto del Rival ──────────────────────────────────
 
     'wc_opponent_group_leader_v1' => ':opponent lidera el grupo. Un partido exigente sobre el papel.',
-    'wc_opponent_group_leader_v2' => ':opponent es el primer clasificado del grupo. Un buen termómetro.',
+    'wc_opponent_group_leader_v2' => ':opponent lidera el grupo — el listón a derribar.',
     'wc_opponent_group_leader_v3' => 'EL COCO DEL GRUPO. :opponent manda en la clasificación.',
 
     'wc_opponent_group_bottom_v1' => ':opponent es último del grupo. Aun así, a este nivel nada es sencillo.',
@@ -181,21 +191,35 @@ return [
     'wc_weather_v1' => 'Se esperan altas temperaturas. El calor podría ser un factor.',
     'wc_weather_v2' => 'Condiciones cálidas en Norteamérica. La forma física y la hidratación importarán.',
     'wc_weather_v3' => 'ALERTA POR CALOR. Previsión de humedad y temperaturas altas.',
+    'wc_weather_v4' => 'Aire denso por el calor. La táctica podría ajustarse en la segunda parte.',
+    'wc_weather_v5' => 'OLLA A PRESIÓN. Las condiciones exigirán piernas y pulmones.',
 
     'wc_fans_v1' => 'Se espera un estadio lleno. Buen ambiente previsto.',
     'wc_fans_v2' => 'Millones de espectadores en todo el mundo. Una gran cita para ambos equipos.',
     'wc_fans_v3' => 'FIESTA EN LAS GRADAS. El Mundial atrae a un público único.',
+    'wc_fans_v4' => 'Afición visitante en masa — un muro de color tras la portería.',
+    'wc_fans_v5' => 'El rugido del pitido inicial hará temblar las gradas.',
 
-    'wc_media_v1' => 'Mucha atención mediática sobre este partido. Un encuentro de alto perfil.',
-    'wc_media_v2' => 'Prensa internacional cubriendo el partido. El foco está puesto.',
+    'wc_media_v1' => 'Cámaras y micrófonos por todas partes. Un partido de máxima exigencia.',
+    'wc_media_v2' => 'Mañana, titulares en todo el mundo. El foco aprieta.',
+    'wc_media_v3' => 'ESCENARIO PREPARADO. La prensa mundial está pendiente de este partido.',
+    'wc_media_v4' => 'La opinión de los expertos está partida en dos sobre este encuentro.',
+    'wc_media_v5' => 'Las portadas esperan al resultado. No hay donde esconderse.',
 
     'wc_group_color_v1' => 'La fase de grupos está en marcha. Los resultados aquí marcan el camino.',
     'wc_group_color_v2' => 'Cada partido de grupo cuenta. El cuadro eliminatorio depende de ello.',
+    'wc_group_color_v3' => 'OFICIO DE FASE DE GRUPOS. Cada punto define el camino.',
+    'wc_group_color_v4' => 'Las cuentas en cada despacho. Una victoria aquí cambia las matemáticas.',
+    'wc_group_color_v5' => 'La fase de grupos premia tanto la paciencia como la calidad.',
 
     'wc_knockout_color_v1' => 'Formato de eliminación directa. No hay margen para un mal día.',
     'wc_knockout_color_v2' => 'Fútbol de eliminatorias. Los márgenes entre avanzar y volver a casa son mínimos.',
+    'wc_knockout_color_v3' => 'UNA SOLA VIDA. Ganar o hacer las maletas.',
+    'wc_knockout_color_v4' => 'Una mala parte puede acabar con un torneo. Concentración por encima de todo.',
+    'wc_knockout_color_v5' => 'Fútbol de muerte súbita. Las reglas no perdonan.',
 
-    'wc_late_tournament_v1' => 'Fase avanzada del torneo. Las selecciones que quedan se lo han ganado.',
-    'wc_late_tournament_v2' => 'Recta final del Mundial. Solo queda un puñado de equipos.',
+    'wc_late_tournament_v1' => 'Pocas selecciones quedan. Cada una se ha ganado estar aquí.',
+    'wc_late_tournament_v2' => 'Los pretendientes han caído. Solo quedan candidatos.',
+    'wc_late_tournament_v3' => 'LOS POCOS QUE QUEDAN. Solo los pesos pesados siguen en pie.',
 
 ];


### PR DESCRIPTION
## Summary
Extends the match narrative system to support up to 5 variants per narrative key (previously capped at 3), enabling richer and more varied match commentary. Updates both English and Spanish narrative strings, and modifies the `MatchNarrativeService` to pick from the expanded variant pool.

## Changes

### Narrative Strings (English & Spanish)
- **Form narratives** (`streak_win_long`, `streak_win`, `streak_lose`, `unbeaten`, `winless`): Added v3 variants with more emphatic language (e.g., "RED-HOT", "FREE-FALL", "UNTOUCHED")
- **Squad condition narratives** (`injury_crisis`, `morale_low`, `morale_high`, `fitness_low`, `fitness_high`): Added v3 variants with punchy, all-caps descriptors
- **World Cup context narratives**:
  - `wc_weather`: Added v4 and v5 variants (heat management, pressure cooker conditions)
  - `wc_fans`: Added v4 and v5 variants (travelling support, stadium roar)
  - `wc_media`: Rewrote v1–v2 for sharper tone, added v3–v5 variants (stage is set, pundit splits, front pages)
  - `wc_group_color`: Added v3–v5 variants (group stage grind, permutations, patience vs quality)
  - `wc_knockout_color`: Added v3–v5 variants (one life left, concentration, sudden-death)
  - `wc_late_tournament`: Rewrote v1–v2 for clarity, added v3 variant (final few, heavyweights)
  - `wc_opponent_group_leader`: Rewrote v2 for consistency with v3 tone

### Service Logic
- **MatchNarrativeService.pickVariant()**: Updated loop from `i <= 3` to `i <= 5` to detect and randomly select from all available variants (v1 through v5)

## Implementation Details
- Variant selection remains random via the existing `pickVariant()` logic; no changes to selection algorithm
- All new variants follow the established tone and style conventions (emphatic all-caps descriptors for v3+)
- Backwards compatible: existing v1–v3 variants continue to work; new v4–v5 variants are optional per key
- Both language files updated in parallel to maintain parity

https://claude.ai/code/session_01JdMowPQEiyaJr628o9UJSU