### PR TITLE
Fix stale competition_id in pro-manager team switches

### DIFF
--- a/app/Console/Commands/RepairProManagerTeamSwitch.php
+++ b/app/Console/Commands/RepairProManagerTeamSwitch.php
@@ -1,0 +1,197 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Competition;
+use App\Models\CompetitionEntry;
+use App\Models\CupTie;
+use App\Models\Game;
+use App\Models\GameMatch;
+use App\Models\GameStanding;
+use App\Modules\Season\DTOs\SeasonTransitionData;
+use App\Modules\Season\Processors\ContinentalAndCupInitProcessor;
+use App\Modules\Season\Processors\LeagueFixtureProcessor;
+use App\Modules\Season\Processors\PreSeasonFixtureProcessor;
+use App\Modules\Season\Processors\StandingsResetProcessor;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Recovery command for pro-manager games stranded by the stale-offer
+ * competition_id race in ApplyPendingTeamSwitchProcessor (fixed in this same
+ * branch). End-of-season job offers were stamped with the destination team's
+ * current league BEFORE the closing pipeline ran. If
+ * PromotionRelegationProcessor then moved the destination team between leagues
+ * during closing, the setup pipeline wrote that stale offer.competition_id
+ * onto Game.competition_id — so the user "managed" a league their new club
+ * wasn't entered in, and SyntheticLeagueResolver silently resolved the team's
+ * real league as a "non-user" league at season-close. Only Copa del Rey ties
+ * (where ESPCUP competition_entries survive) remained playable.
+ *
+ * Per-game cleanup:
+ *   1. Read competition_entries to find the team's actual league for this
+ *      game. Bail if it already matches Game.competition_id.
+ *   2. Wipe game_matches / match_attendances / cup_ties / game_standings —
+ *      the previous setup wrote them against the wrong league.
+ *   3. Update Game.competition_id to the team's real league.
+ *   4. Re-run the affected setup processors:
+ *      LeagueFixtureProcessor → fixtures for the real league
+ *      StandingsResetProcessor → standings for the real league
+ *      ContinentalAndCupInitProcessor → cup draws + current_date
+ *      PreSeasonFixtureProcessor → friendlies for the user's actual team
+ *
+ * Budget re-projection is intentionally skipped — the user may already have
+ * taken financial actions (transfers, contracts) based on the wrong tier, and
+ * a re-projection would either invalidate those or silently absorb the gap.
+ * Operator can run BudgetProjectionProcessor manually if needed.
+ *
+ * Safe to re-run: every step is idempotent given a correct Game.competition_id.
+ */
+class RepairProManagerTeamSwitch extends Command
+{
+    protected $signature = 'app:repair-pro-manager-team-switch
+        {gameId? : Game UUID. Omit with --all to scan every pro-manager game.}
+        {--all : Repair every detectably-affected game.}
+        {--dry-run : Print what would be done without writing changes.}';
+
+    protected $description = 'Repair a pro-manager game whose competition_id does not match the team\'s actual league.';
+
+    public function handle(
+        LeagueFixtureProcessor $fixtureProcessor,
+        StandingsResetProcessor $standingsProcessor,
+        ContinentalAndCupInitProcessor $cupInitProcessor,
+        PreSeasonFixtureProcessor $preSeasonProcessor,
+    ): int {
+        $gameId = $this->argument('gameId');
+        $all = $this->option('all');
+
+        if (!$gameId && !$all) {
+            $this->error('Provide a gameId or pass --all.');
+            return self::FAILURE;
+        }
+
+        $gameIds = $all ? $this->findAffectedGameIds() : [$gameId];
+
+        if (empty($gameIds)) {
+            $this->info('No affected games detected.');
+            return self::SUCCESS;
+        }
+
+        $failures = 0;
+        foreach ($gameIds as $id) {
+            if (!$this->repairOne((string) $id, $fixtureProcessor, $standingsProcessor, $cupInitProcessor, $preSeasonProcessor)) {
+                $failures++;
+            }
+        }
+
+        return $failures === 0 ? self::SUCCESS : self::FAILURE;
+    }
+
+    /**
+     * @return string[]
+     */
+    private function findAffectedGameIds(): array
+    {
+        // Cache the league competition_ids on the control plane so the per-game
+        // scan stays on the tenant connection.
+        $leagueIds = Competition::where('role', Competition::ROLE_LEAGUE)->pluck('id')->all();
+
+        $games = Game::query()
+            ->where('game_mode', Game::MODE_CAREER_PRO)
+            ->whereNotNull('setup_completed_at')
+            ->whereNull('season_transitioning_at')
+            ->get(['id', 'team_id', 'competition_id']);
+
+        $affected = [];
+        foreach ($games as $game) {
+            $actual = CompetitionEntry::where('game_id', $game->id)
+                ->where('team_id', $game->team_id)
+                ->whereIn('competition_id', $leagueIds)
+                ->value('competition_id');
+
+            if ($actual && $actual !== $game->competition_id) {
+                $affected[] = $game->id;
+            }
+        }
+
+        $this->info('Detected ' . count($affected) . ' affected game(s).');
+        return $affected;
+    }
+
+    private function repairOne(
+        string $gameId,
+        LeagueFixtureProcessor $fixtureProcessor,
+        StandingsResetProcessor $standingsProcessor,
+        ContinentalAndCupInitProcessor $cupInitProcessor,
+        PreSeasonFixtureProcessor $preSeasonProcessor,
+    ): bool {
+        $game = Game::find($gameId);
+        if (!$game) {
+            $this->error("Game {$gameId} not found.");
+            return false;
+        }
+
+        if (!$game->isProManagerMode()) {
+            $this->warn("Game {$gameId} is not pro-manager mode — skipping.");
+            return false;
+        }
+
+        $leagueIds = Competition::where('role', Competition::ROLE_LEAGUE)->pluck('id')->all();
+        $actualLeagueId = CompetitionEntry::where('game_id', $gameId)
+            ->where('team_id', $game->team_id)
+            ->whereIn('competition_id', $leagueIds)
+            ->value('competition_id');
+
+        if (!$actualLeagueId) {
+            $this->error("Game {$gameId}: team {$game->team_id} is not entered in any league. Cannot recover.");
+            return false;
+        }
+
+        if ($actualLeagueId === $game->competition_id) {
+            $this->info("Game {$gameId}: already healthy (team in {$actualLeagueId}). Skipping.");
+            return true;
+        }
+
+        $this->line(sprintf(
+            'Game %s: team %s currently recorded in %s but entered in %s — will repair.',
+            $gameId,
+            $game->team_id,
+            $game->competition_id,
+            $actualLeagueId,
+        ));
+
+        if ($this->option('dry-run')) {
+            return true;
+        }
+
+        try {
+            DB::transaction(function () use ($game, $actualLeagueId, $fixtureProcessor, $standingsProcessor, $cupInitProcessor, $preSeasonProcessor) {
+                DB::table('match_attendances')->where('game_id', $game->id)->delete();
+                GameMatch::where('game_id', $game->id)->delete();
+                CupTie::where('game_id', $game->id)->delete();
+                GameStanding::where('game_id', $game->id)->delete();
+
+                $game->update(['competition_id' => $actualLeagueId]);
+                $game->refresh();
+
+                $data = new SeasonTransitionData(
+                    oldSeason: (string) ((int) $game->season - 1),
+                    newSeason: $game->season,
+                    competitionId: $actualLeagueId,
+                    isInitialSeason: false,
+                );
+
+                $fixtureProcessor->process($game, $data);
+                $standingsProcessor->process($game->refresh(), $data);
+                $cupInitProcessor->process($game->refresh(), $data);
+                $preSeasonProcessor->process($game->refresh(), $data);
+            });
+        } catch (\Throwable $e) {
+            $this->error("Game {$gameId}: repair failed — {$e->getMessage()}");
+            return false;
+        }
+
+        $this->info("Game {$gameId}: repaired to {$actualLeagueId}.");
+        return true;
+    }
+}

--- a/app/Modules/Manager/Processors/ApplyPendingTeamSwitchProcessor.php
+++ b/app/Modules/Manager/Processors/ApplyPendingTeamSwitchProcessor.php
@@ -2,6 +2,8 @@
 
 namespace App\Modules\Manager\Processors;
 
+use App\Models\Competition;
+use App\Models\CompetitionEntry;
 use App\Models\Game;
 use App\Models\ManagerJobHistory;
 use App\Models\ManagerJobOffer;
@@ -12,6 +14,7 @@ use App\Modules\Season\Contracts\SeasonProcessor;
 use App\Modules\Season\DTOs\SeasonTransitionData;
 use App\Modules\Season\Services\TeamReputationSeeder;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
 
 /**
  * Apply a pro-manager team switch the user accepted at the previous
@@ -42,23 +45,45 @@ class ApplyPendingTeamSwitchProcessor implements SeasonProcessor
 
         $offer = ManagerJobOffer::find($game->pending_team_switch);
         if (!$offer || $offer->status !== ManagerJobOffer::STATUS_ACCEPTED) {
-            // Stale or invalid pointer — clear it so the user isn't stuck.
+            Log::warning('[ApplyPendingTeamSwitch] aborting: offer missing or not accepted', [
+                'game_id' => $game->id,
+                'pending_team_switch' => $game->pending_team_switch,
+                'offer_status' => $offer?->status,
+            ]);
             $game->update(['pending_team_switch' => null]);
             return $data;
         }
 
         $newTeam = Team::find($offer->team_id);
         if (!$newTeam) {
+            Log::warning('[ApplyPendingTeamSwitch] aborting: offer team not found', [
+                'game_id' => $game->id,
+                'offer_id' => $offer->id,
+                'team_id' => $offer->team_id,
+            ]);
             $game->update(['pending_team_switch' => null]);
             return $data;
         }
 
-        $newCompetitionId = $offer->competition_id
+        // Resolve from per-game competition_entries first. The offer was
+        // stamped before the closing pipeline ran, so its competition_id is
+        // stale whenever PromotionRelegationProcessor moved the destination
+        // team between leagues during closing — picking the offer's value
+        // strands the user in a league their new club isn't entered in,
+        // and SyntheticLeagueResolver silently resolves the team's real
+        // league as a "non-user" league at season-close (Copa del Rey is
+        // the only thing left to play).
+        $newCompetitionId = $this->resolveCurrentLeagueForTeam($game->id, $offer->team_id)
+            ?? $offer->competition_id
             ?? $this->jobOfferService->resolveAcceptedCompetitionId($offer->team_id);
 
         if (!$newCompetitionId) {
-            // Should never happen for reference-seeded clubs, but bail
-            // rather than land the user in an unconfigured league.
+            Log::warning('[ApplyPendingTeamSwitch] aborting: could not resolve destination competition', [
+                'game_id' => $game->id,
+                'offer_id' => $offer->id,
+                'team_id' => $offer->team_id,
+                'offer_competition_id' => $offer->competition_id,
+            ]);
             $game->update(['pending_team_switch' => null]);
             return $data;
         }
@@ -152,5 +177,23 @@ class ApplyPendingTeamSwitchProcessor implements SeasonProcessor
             'season_end' => null,
             'end_reason' => ManagerJobHistory::REASON_STILL_ACTIVE,
         ]);
+    }
+
+    /**
+     * Return the league competition the team is currently entered in for this
+     * game. Reads competition_entries (tenant) and the cached set of league
+     * competition_ids (control) separately to avoid a planes-seam JOIN.
+     */
+    private function resolveCurrentLeagueForTeam(string $gameId, string $teamId): ?string
+    {
+        $leagueIds = Competition::where('role', Competition::ROLE_LEAGUE)->pluck('id')->all();
+        if ($leagueIds === []) {
+            return null;
+        }
+
+        return CompetitionEntry::where('game_id', $gameId)
+            ->where('team_id', $teamId)
+            ->whereIn('competition_id', $leagueIds)
+            ->value('competition_id');
     }
 }

--- a/tests/Unit/ApplyPendingTeamSwitchProcessorTest.php
+++ b/tests/Unit/ApplyPendingTeamSwitchProcessorTest.php
@@ -1,0 +1,157 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\Competition;
+use App\Models\CompetitionEntry;
+use App\Models\Game;
+use App\Models\ManagerJobHistory;
+use App\Models\ManagerJobOffer;
+use App\Models\Team;
+use App\Models\User;
+use App\Modules\Manager\Processors\ApplyPendingTeamSwitchProcessor;
+use App\Modules\Manager\Services\JobOfferService;
+use App\Modules\Season\DTOs\SeasonTransitionData;
+use App\Modules\Season\Services\TeamReputationSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Mockery;
+use Tests\TestCase;
+
+class ApplyPendingTeamSwitchProcessorTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * Regression: the offer's competition_id was stamped before the closing
+     * pipeline ran. If PromotionRelegationProcessor moved the destination
+     * team between leagues during closing, the offer's competition_id is
+     * stale by the time this processor runs. The processor must read
+     * competition_entries (post-closing state) instead of trusting the offer.
+     */
+    public function test_uses_competition_entries_when_offer_competition_is_stale(): void
+    {
+        [$processor, $game, $newTeam, $offer, $espTwo, $espThreeB] = $this->buildScenario(
+            offerCompetitionId: 'ESP2',
+            actualEntryCompetitionId: 'ESP3B',
+        );
+
+        $data = new SeasonTransitionData(
+            oldSeason: '2027',
+            newSeason: '2028',
+            competitionId: $game->competition_id,
+        );
+
+        $processor->process($game->refresh(), $data);
+
+        $this->assertSame('ESP3B', $game->refresh()->competition_id,
+            'Game.competition_id should resolve to the team\'s actual league, not the stale offer value.');
+        $this->assertSame($newTeam->id, $game->team_id);
+        $this->assertSame('ESP3B', $data->competitionId,
+            'Setup-pipeline DTO must be updated so LeagueFixtureProcessor regenerates against the real league.');
+        $this->assertNull($game->pending_team_switch);
+
+        $tenure = ManagerJobHistory::where('game_id', $game->id)
+            ->whereNull('season_end')
+            ->first();
+        $this->assertNotNull($tenure);
+        $this->assertSame($newTeam->id, $tenure->team_id);
+        $this->assertSame('ESP3B', $tenure->competition_id);
+    }
+
+    /**
+     * When the offer's competition_id still matches the destination team's
+     * actual entry (no mid-transition promotion/relegation), the processor
+     * should land on the same value either way.
+     */
+    public function test_preserves_offer_competition_when_entries_agree(): void
+    {
+        [$processor, $game, $newTeam] = $this->buildScenario(
+            offerCompetitionId: 'ESP2',
+            actualEntryCompetitionId: 'ESP2',
+        );
+
+        $data = new SeasonTransitionData(
+            oldSeason: '2027',
+            newSeason: '2028',
+            competitionId: $game->competition_id,
+        );
+
+        $processor->process($game->refresh(), $data);
+
+        $this->assertSame('ESP2', $game->refresh()->competition_id);
+        $this->assertSame($newTeam->id, $game->team_id);
+    }
+
+    /**
+     * @return array{0: ApplyPendingTeamSwitchProcessor, 1: Game, 2: Team, 3: ManagerJobOffer, 4: Competition, 5: Competition}
+     */
+    private function buildScenario(string $offerCompetitionId, string $actualEntryCompetitionId): array
+    {
+        $espTwo = Competition::factory()->create([
+            'id' => 'ESP2',
+            'name' => 'LaLiga2',
+            'country' => 'ES',
+            'tier' => 2,
+            'role' => Competition::ROLE_LEAGUE,
+            'handler_type' => 'league_with_playoff',
+            'scope' => Competition::SCOPE_DOMESTIC,
+        ]);
+
+        $espThreeB = Competition::factory()->create([
+            'id' => 'ESP3B',
+            'name' => 'Primera Federación - Grupo II',
+            'country' => 'ES',
+            'tier' => 3,
+            'role' => Competition::ROLE_LEAGUE,
+            'handler_type' => 'league_with_playoff',
+            'scope' => Competition::SCOPE_DOMESTIC,
+        ]);
+
+        $user = User::factory()->create();
+        $oldTeam = Team::factory()->create(['country' => 'ES']);
+        $newTeam = Team::factory()->create(['country' => 'ES']);
+
+        $game = Game::factory()->create([
+            'user_id' => $user->id,
+            'game_mode' => Game::MODE_CAREER_PRO,
+            'country' => 'ES',
+            'team_id' => $oldTeam->id,
+            'competition_id' => 'ESP3A',
+            'season' => '2028',
+        ]);
+
+        CompetitionEntry::create([
+            'game_id' => $game->id,
+            'competition_id' => $actualEntryCompetitionId,
+            'team_id' => $newTeam->id,
+            'entry_round' => 1,
+        ]);
+
+        $offer = ManagerJobOffer::create([
+            'user_id' => $user->id,
+            'game_id' => $game->id,
+            'team_id' => $newTeam->id,
+            'competition_id' => $offerCompetitionId,
+            'season' => '2027',
+            'offer_type' => ManagerJobOffer::TYPE_END_OF_SEASON,
+            'status' => ManagerJobOffer::STATUS_ACCEPTED,
+            'source_reputation_level' => 'local',
+            'target_reputation_level' => 'modest',
+        ]);
+
+        $game->update(['pending_team_switch' => $offer->id]);
+
+        $processor = new ApplyPendingTeamSwitchProcessor(
+            Mockery::mock(JobOfferService::class),
+            Mockery::mock(TeamReputationSeeder::class)->shouldIgnoreMissing(),
+        );
+
+        return [$processor, $game, $newTeam, $offer, $espTwo, $espThreeB];
+    }
+
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+}

--- a/tests/Unit/ApplyPendingTeamSwitchProcessorTest.php
+++ b/tests/Unit/ApplyPendingTeamSwitchProcessorTest.php
@@ -87,6 +87,16 @@ class ApplyPendingTeamSwitchProcessorTest extends TestCase
      */
     private function buildScenario(string $offerCompetitionId, string $actualEntryCompetitionId): array
     {
+        $espThreeA = Competition::factory()->create([
+            'id' => 'ESP3A',
+            'name' => 'Primera Federación - Grupo I',
+            'country' => 'ES',
+            'tier' => 3,
+            'role' => Competition::ROLE_LEAGUE,
+            'handler_type' => 'league_with_playoff',
+            'scope' => Competition::SCOPE_DOMESTIC,
+        ]);
+
         $espTwo = Competition::factory()->create([
             'id' => 'ESP2',
             'name' => 'LaLiga2',


### PR DESCRIPTION
## Summary

Fixes a race condition in `ApplyPendingTeamSwitchProcessor` where job offers stamped with a destination team's league *before* the closing pipeline ran could become stale if `PromotionRelegationProcessor` moved that team between leagues during closing. This stranded users in a league their new club wasn't entered in, leaving only Copa del Rey playable.

The fix prioritizes reading the team's actual league from `competition_entries` (post-closing state) over trusting the offer's stale `competition_id`.

## Key Changes

- **ApplyPendingTeamSwitchProcessor**: Added `resolveCurrentLeagueForTeam()` method that queries `competition_entries` to find the team's actual league for the game, falling back to the offer's `competition_id` only if no entry exists. This ensures the processor uses post-closing league assignments, not pre-closing offer data.

- **RepairProManagerTeamSwitch command**: New recovery command for games already stranded by this bug. Scans all pro-manager games to detect mismatches between `Game.competition_id` and the team's actual league entry, then:
  - Wipes stale game data (matches, standings, cup ties)
  - Updates `Game.competition_id` to the correct league
  - Re-runs setup processors (fixtures, standings, cups, friendlies) against the real league
  - Supports `--all` to repair all affected games or a single `gameId`
  - Includes `--dry-run` for safe preview

- **ApplyPendingTeamSwitchProcessorTest**: Regression test verifying the processor reads `competition_entries` when the offer's `competition_id` is stale, and preserves the offer value when entries agree.

- **Logging**: Added warning logs to `ApplyPendingTeamSwitchProcessor` for all abort paths (missing offer, missing team, unresolvable competition) to aid future debugging.

## Implementation Details

- The fix avoids a cross-plane JOIN by caching league competition IDs on the control plane, then querying `competition_entries` on the tenant connection separately.
- The repair command is idempotent: re-running it on an already-healthy game is safe and will skip.
- Budget re-projection is intentionally skipped during repair to avoid invalidating user financial actions taken under the wrong tier; operators can run `BudgetProjectionProcessor` manually if needed.

https://claude.ai/code/session_01DVMsy863WeBEHEqXuGquVj