### PR TITLE
Fix reserve-team coexistence + pro-manager supercup draw crash

### DIFF
--- a/app/Console/Commands/FixReserveCoexistence.php
+++ b/app/Console/Commands/FixReserveCoexistence.php
@@ -1,0 +1,339 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\CompetitionEntry;
+use App\Models\Game;
+use App\Models\GameStanding;
+use App\Models\Team;
+use App\Modules\Competition\Services\CountryConfig;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Recovery command for games whose reserve-team invariant has drifted:
+ * a reserve club (Team::parent_team_id NOT NULL) sharing a competition
+ * with its parent. The upstream root cause — the cross-rule parent-
+ * relegation/reserve-promotion collision in PromotionRelegationProcessor —
+ * is fixed going forward, but games that accumulated the violation over
+ * many seasons need a one-off correction.
+ *
+ * Per affected game: for each (reserve, parent, competition) triplet,
+ * find the next-most-eligible non-reserve team in a lower tier that
+ * doesn't include the reserve's parent, and swap places. The vacated
+ * top-tier slot is filled with that lower-tier team; the reserve drops
+ * down into the slot the swapped team left behind. This preserves
+ * division sizes — every league keeps its team count.
+ *
+ * Side-effects per affected game:
+ *   - Clear ESPSUP entries so SupercupQualificationProcessor will re-derive
+ *     the field with the corrected ESP1 roster on the next pipeline run.
+ *   - Reset `season_transition_step` to NULL if the game is mid-transition
+ *     so the pipeline restarts cleanly from the beginning of the closing
+ *     phase (idempotent processors will short-circuit the already-done work).
+ *
+ * Safe to re-run: each step is idempotent. Default mode is dry-run; pass
+ * --fix to apply.
+ */
+class FixReserveCoexistence extends Command
+{
+    protected $signature = 'app:fix-reserve-coexistence {--game=} {--fix}';
+
+    protected $description = 'Detect and (optionally) repair reserve teams sharing a competition with their parent club.';
+
+    public function handle(CountryConfig $countryConfig): int
+    {
+        $apply = (bool) $this->option('fix');
+        $specificGame = $this->option('game');
+
+        $games = Game::query()
+            ->when($specificGame, fn ($q) => $q->where('id', $specificGame))
+            ->get(['id', 'country', 'season', 'season_transition_step']);
+
+        if ($games->isEmpty()) {
+            $this->info('No games found.');
+
+            return self::SUCCESS;
+        }
+
+        $totalViolations = 0;
+        $totalRepairs = 0;
+
+        foreach ($games as $game) {
+            $country = $game->country ?? 'ES';
+            $reserveTeams = Team::where('country', $country)
+                ->whereNotNull('parent_team_id')
+                ->get(['id', 'name', 'parent_team_id']);
+
+            if ($reserveTeams->isEmpty()) {
+                continue;
+            }
+
+            $violations = $this->findViolations($game->id, $reserveTeams);
+
+            if ($violations->isEmpty()) {
+                continue;
+            }
+
+            $this->line("Game {$game->id} (season {$game->season}, country {$country}): " . $violations->count() . ' violation(s)');
+            $totalViolations += $violations->count();
+
+            if (!$apply) {
+                foreach ($violations as $v) {
+                    $this->line("  - reserve {$v['reserve_name']} ({$v['reserve_id']}) and parent {$v['parent_id']} share {$v['competition_id']}");
+                }
+                continue;
+            }
+
+            $repaired = $this->repairGame($game, $country, $violations, $countryConfig);
+            $totalRepairs += $repaired;
+
+            $this->info("  → repaired {$repaired} violation(s) and reset pipeline state");
+        }
+
+        $this->line('');
+        $this->info("Scanned {$games->count()} game(s) — {$totalViolations} violation(s) detected" . ($apply ? ", {$totalRepairs} repaired." : '. Re-run with --fix to apply.'));
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * @return \Illuminate\Support\Collection<int, array{
+     *     reserve_id: string,
+     *     reserve_name: string,
+     *     parent_id: string,
+     *     competition_id: string,
+     * }>
+     */
+    private function findViolations(string $gameId, \Illuminate\Support\Collection $reserveTeams)
+    {
+        $reservesById = $reserveTeams->keyBy('id');
+
+        $reserveEntries = CompetitionEntry::where('game_id', $gameId)
+            ->whereIn('team_id', $reservesById->keys())
+            ->get(['competition_id', 'team_id']);
+
+        if ($reserveEntries->isEmpty()) {
+            return collect();
+        }
+
+        $parentIds = $reservesById->pluck('parent_team_id')->unique()->all();
+        $parentEntries = CompetitionEntry::where('game_id', $gameId)
+            ->whereIn('team_id', $parentIds)
+            ->get(['competition_id', 'team_id'])
+            ->groupBy('team_id')
+            ->map(fn ($e) => $e->pluck('competition_id')->all());
+
+        return $reserveEntries->map(function ($entry) use ($reservesById, $parentEntries) {
+            $reserve = $reservesById->get($entry->team_id);
+            $parentDivisions = $parentEntries->get($reserve->parent_team_id, []);
+
+            if (!in_array($entry->competition_id, $parentDivisions, true)) {
+                return null;
+            }
+
+            return [
+                'reserve_id' => $entry->team_id,
+                'reserve_name' => $reserve->name,
+                'parent_id' => $reserve->parent_team_id,
+                'competition_id' => $entry->competition_id,
+            ];
+        })->filter()->values();
+    }
+
+    /**
+     * Apply repairs inside a transaction so a partial failure rolls back
+     * cleanly. Returns the number of successful swaps.
+     *
+     * @param  \Illuminate\Support\Collection<int, array{reserve_id: string, reserve_name: string, parent_id: string, competition_id: string}>  $violations
+     */
+    private function repairGame(Game $game, string $country, $violations, CountryConfig $countryConfig): int
+    {
+        return DB::transaction(function () use ($game, $country, $violations, $countryConfig) {
+            $repaired = 0;
+
+            foreach ($violations as $v) {
+                $replacement = $this->findReplacement($game->id, $country, $v, $countryConfig);
+
+                if ($replacement === null) {
+                    Log::warning('[ReserveCoexistenceFix] No replacement found — skipping', [
+                        'game_id' => $game->id,
+                        'violation' => $v,
+                    ]);
+                    $this->warn("    no replacement found for {$v['reserve_name']} — skipped");
+                    continue;
+                }
+
+                $this->swapTeams(
+                    $game->id,
+                    reserveId: $v['reserve_id'],
+                    replacementId: $replacement['team_id'],
+                    reserveCompetition: $v['competition_id'],
+                    replacementCompetition: $replacement['competition_id'],
+                );
+
+                Log::info('[ReserveCoexistenceFix] Swapped', [
+                    'game_id' => $game->id,
+                    'reserve' => $v,
+                    'replacement' => $replacement,
+                ]);
+
+                $repaired++;
+            }
+
+            if ($repaired > 0) {
+                // Clear ESPSUP-style supercup entries so the next pipeline run
+                // re-derives them against the corrected league rosters. Use
+                // the country's supercup config rather than hard-coding ESPSUP.
+                $supercupConfig = $countryConfig->supercup($country);
+                if ($supercupConfig !== null && !empty($supercupConfig['competition'])) {
+                    CompetitionEntry::where('game_id', $game->id)
+                        ->where('competition_id', $supercupConfig['competition'])
+                        ->delete();
+                }
+
+                // If the game is mid-transition, clear the checkpoint so the
+                // pipeline restarts from the beginning of the closing phase.
+                // Most processors are idempotent — they short-circuit already-
+                // completed work. Leaving a stale step pointer would skip
+                // SupercupQualificationProcessor, which is exactly the step we
+                // want to re-run.
+                if ($game->season_transition_step !== null) {
+                    Game::where('id', $game->id)->update([
+                        'season_transition_step' => null,
+                        'season_transition_data' => null,
+                    ]);
+                }
+            }
+
+            return $repaired;
+        });
+    }
+
+    /**
+     * Find a non-reserve team to swap into the violating competition. Looks
+     * for the worst-ranked non-reserve in a lower tier than the violation's
+     * competition where the reserve's parent is NOT present. Preferring the
+     * worst-ranked team minimises competitive disruption — a struggling
+     * lower-tier team gets a bump up; the reserve drops into the slot it
+     * vacates.
+     *
+     * @param  array{reserve_id: string, parent_id: string, competition_id: string}  $violation
+     * @return array{team_id: string, competition_id: string}|null
+     */
+    private function findReplacement(string $gameId, string $country, array $violation, CountryConfig $countryConfig): ?array
+    {
+        $tierMap = $countryConfig->tiers($country);
+
+        $violationTier = $this->resolveTier($violation['competition_id'], $tierMap, $countryConfig, $country);
+        if ($violationTier === null) {
+            return null;
+        }
+
+        $parentCompetitions = CompetitionEntry::where('game_id', $gameId)
+            ->where('team_id', $violation['parent_id'])
+            ->pluck('competition_id')
+            ->all();
+
+        // Walk tiers strictly below the violation downward. Prefer the
+        // worst-ranked eligible team in the lowest tier that doesn't host
+        // the parent. Reserve teams in those tiers are skipped — replacing
+        // a reserve with another reserve solves nothing.
+        for ($tier = $violationTier + 1; $tier <= max(array_keys($tierMap)); $tier++) {
+            foreach ($countryConfig->tierCompetitionIds($country, $tier) as $candidateCompetition) {
+                if (in_array($candidateCompetition, $parentCompetitions, true)) {
+                    continue;
+                }
+
+                $candidate = $this->worstNonReserveIn($gameId, $candidateCompetition);
+                if ($candidate !== null) {
+                    return [
+                        'team_id' => $candidate,
+                        'competition_id' => $candidateCompetition,
+                    ];
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private function resolveTier(string $competitionId, array $tierMap, CountryConfig $countryConfig, string $country): ?int
+    {
+        foreach (array_keys($tierMap) as $tier) {
+            foreach ($countryConfig->tierCompetitionIds($country, $tier) as $id) {
+                if ($id === $competitionId) {
+                    return $tier;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Worst-ranked non-reserve team in a competition (last position in
+     * standings, or last entry if standings are empty / placeholder).
+     */
+    private function worstNonReserveIn(string $gameId, string $competitionId): ?string
+    {
+        $candidates = CompetitionEntry::where('game_id', $gameId)
+            ->where('competition_id', $competitionId)
+            ->join('teams', 'teams.id', '=', 'competition_entries.team_id')
+            ->whereNull('teams.parent_team_id')
+            ->pluck('competition_entries.team_id')
+            ->all();
+
+        if (empty($candidates)) {
+            return null;
+        }
+
+        $worst = GameStanding::where('game_id', $gameId)
+            ->where('competition_id', $competitionId)
+            ->whereIn('team_id', $candidates)
+            ->where('played', '>', 0)
+            ->orderByDesc('position')
+            ->value('team_id');
+
+        return $worst ?? end($candidates) ?: null;
+    }
+
+    /**
+     * Swap a reserve with its non-reserve replacement: each moves into the
+     * other's competition. Mirrors the move semantics in
+     * PromotionRelegationProcessor::moveTeam but as a direct swap.
+     */
+    private function swapTeams(
+        string $gameId,
+        string $reserveId,
+        string $replacementId,
+        string $reserveCompetition,
+        string $replacementCompetition,
+    ): void {
+        $this->moveTeam($gameId, $reserveId, $reserveCompetition, $replacementCompetition);
+        $this->moveTeam($gameId, $replacementId, $replacementCompetition, $reserveCompetition);
+    }
+
+    private function moveTeam(string $gameId, string $teamId, string $fromDivision, string $toDivision): void
+    {
+        CompetitionEntry::where('game_id', $gameId)
+            ->where('competition_id', $fromDivision)
+            ->where('team_id', $teamId)
+            ->delete();
+
+        CompetitionEntry::updateOrCreate(
+            [
+                'game_id' => $gameId,
+                'competition_id' => $toDivision,
+                'team_id' => $teamId,
+            ],
+            ['entry_round' => 1],
+        );
+
+        GameStanding::where('game_id', $gameId)
+            ->where('competition_id', $fromDivision)
+            ->where('team_id', $teamId)
+            ->delete();
+    }
+}

--- a/app/Modules/Competition/Contracts/PromotionRelegationRule.php
+++ b/app/Modules/Competition/Contracts/PromotionRelegationRule.php
@@ -32,11 +32,20 @@ interface PromotionRelegationRule
     public function getPlayoffGenerator(): ?PlayoffGenerator;
 
     /**
-     * Get all teams to be promoted (direct + playoff winner if applicable)
+     * Get all teams to be promoted (direct + playoff winner if applicable).
      *
+     * $incomingByDivision describes teams scheduled to land in each division
+     * via other rules' relegations in the same season. The reserve-team filter
+     * consults this to block a reserve from being promoted into a division
+     * that its parent club is about to be relegated INTO — a parent/reserve
+     * collision the per-rule filter can't otherwise see because the parent
+     * is still in its old division at read time. Keyed by destination
+     * competition_id; value is a list of team UUIDs.
+     *
+     * @param  array<string, array<int, string>>  $incomingByDivision
      * @return array<array{teamId: string, position: int|string, teamName: string}>
      */
-    public function getPromotedTeams(Game $game): array;
+    public function getPromotedTeams(Game $game, array $incomingByDivision = []): array;
 
     /**
      * Get all teams to be relegated
@@ -44,4 +53,16 @@ interface PromotionRelegationRule
      * @return array<array{teamId: string, position: int, teamName: string}>
      */
     public function getRelegatedTeams(Game $game): array;
+
+    /**
+     * Competition IDs that this rule's relegated teams will land in. Used by
+     * PromotionRelegationProcessor to build the $incomingByDivision context
+     * shared across rules. Standard rules return a single destination
+     * (bottom_division). Rules whose relegated teams fan out across multiple
+     * sibling competitions (e.g. PrimeraRFEFPromotionRule splitting between
+     * ESP3A and ESP3B) return all candidate destinations.
+     *
+     * @return string[]
+     */
+    public function getRelegationDestinations(): array;
 }

--- a/app/Modules/Competition/Promotions/ConfigDrivenPromotionRule.php
+++ b/app/Modules/Competition/Promotions/ConfigDrivenPromotionRule.php
@@ -78,7 +78,7 @@ class ConfigDrivenPromotionRule implements PromotionRelegationRule
         return $this->playoffGenerator;
     }
 
-    public function getPromotedTeams(Game $game): array
+    public function getPromotedTeams(Game $game, array $incomingByDivision = []): array
     {
         if (!$this->hasDataSource($game, $this->bottomDivision)) {
             return [];
@@ -96,6 +96,7 @@ class ConfigDrivenPromotionRule implements PromotionRelegationRule
             $this->bottomDivision,
             $this->directCount,
             $this->playoffCount,
+            $incomingByDivision[$this->topDivision] ?? [],
         );
 
         $promoted = $allocation->directPromotions;
@@ -115,6 +116,11 @@ class ConfigDrivenPromotionRule implements PromotionRelegationRule
         $this->validateTeamCount($promoted, $expectedCount, 'promoted', $this->bottomDivision, $game);
 
         return $promoted;
+    }
+
+    public function getRelegationDestinations(): array
+    {
+        return [$this->bottomDivision];
     }
 
     public function getRelegatedTeams(Game $game): array

--- a/app/Modules/Competition/Promotions/PrimeraRFEFPromotionRule.php
+++ b/app/Modules/Competition/Promotions/PrimeraRFEFPromotionRule.php
@@ -79,9 +79,10 @@ class PrimeraRFEFPromotionRule implements SelfSwappingPromotionRule
     }
 
     /**
+     * @param  array<string, array<int, string>>  $incomingByDivision
      * @return array<array{teamId: string, position: int|string, teamName: string, origin: string}>
      */
-    public function getPromotedTeams(Game $game): array
+    public function getPromotedTeams(Game $game, array $incomingByDivision = []): array
     {
         if (!$this->isActiveForGame($game)) {
             return [];
@@ -111,12 +112,23 @@ class PrimeraRFEFPromotionRule implements SelfSwappingPromotionRule
         // case and promoted a losing team. Explicit state handling prevents
         // that class of bug.
         $state = $this->resolvePlayoffState($game);
+        $incomingToEsp2 = $incomingByDivision[self::TOP_DIVISION] ?? [];
 
         return match ($state) {
             PlayoffState::Completed => array_merge($promoted, $this->requirePlayoffWinners($game)),
             PlayoffState::InProgress => throw PlayoffInProgressException::forCompetition(self::PLAYOFF_ID),
-            PlayoffState::NotStarted => array_merge($promoted, $this->simulatedPlayoffStandIns($game, $promoted)),
+            PlayoffState::NotStarted => array_merge($promoted, $this->simulatedPlayoffStandIns($game, $promoted, $incomingToEsp2)),
         };
+    }
+
+    public function getRelegationDestinations(): array
+    {
+        // Relegated ESP2 teams are redistributed between the two ESP3 groups
+        // by performSwap(); the exact per-group split isn't known until
+        // promotion counts settle. Return both groups so any consumer of
+        // cross-rule incoming context treats either as a possible landing
+        // place for a parent club.
+        return [self::GROUP_A_ID, self::GROUP_B_ID];
     }
 
     /**
@@ -334,9 +346,13 @@ class PrimeraRFEFPromotionRule implements SelfSwappingPromotionRule
      * is the player's, the other is simulated.
      *
      * @param array<array{teamId: string, position: int|string, teamName: string, origin: string}> $alreadyPromoted
+     * @param  array<int, string>  $incomingToEsp2  Teams about to land in ESP2
+     *     via sibling rules' relegations; merged into the reserve-filter
+     *     reference set so a parent being relegated to ESP2 this season
+     *     blocks its reserve from being a stand-in here.
      * @return array<array{teamId: string, position: int|string, teamName: string, origin: string}>
      */
-    private function simulatedPlayoffStandIns(Game $game, array $alreadyPromoted): array
+    private function simulatedPlayoffStandIns(Game $game, array $alreadyPromoted, array $incomingToEsp2 = []): array
     {
         $already = array_column($alreadyPromoted, 'teamId');
         $filter = $this->reserveTeamFilter ?? app(ReserveTeamFilter::class);
@@ -344,6 +360,10 @@ class PrimeraRFEFPromotionRule implements SelfSwappingPromotionRule
         $topDivisionTeamIds = CompetitionEntry::where('game_id', $game->id)
             ->where('competition_id', self::TOP_DIVISION)
             ->pluck('team_id');
+
+        if (!empty($incomingToEsp2)) {
+            $topDivisionTeamIds = $topDivisionTeamIds->concat($incomingToEsp2)->unique()->values();
+        }
 
         $results = [];
         foreach ([self::GROUP_A_ID, self::GROUP_B_ID] as $groupId) {

--- a/app/Modules/Competition/Promotions/PromotionSlotAllocator.php
+++ b/app/Modules/Competition/Promotions/PromotionSlotAllocator.php
@@ -46,12 +46,19 @@ class PromotionSlotAllocator
      * @param  string  $bottomDivision  Competition ID being walked (e.g., 'ESP2').
      * @param  int  $directCount  Number of direct-promotion slots to fill.
      * @param  int  $playoffCount  Number of bracket slots to fill.
+     * @param  array<int, string>  $incomingToTopDivision  Team UUIDs scheduled
+     *     to land in the destination of this allocation via sibling rules'
+     *     relegations. Merged into the reserve-filter reference set so a
+     *     parent being relegated into the destination this season blocks its
+     *     reserve from being promoted there in the same swap. Empty array =
+     *     standalone allocation with no cross-rule context.
      */
     public function allocate(
         Game $game,
         string $bottomDivision,
         int $directCount,
         int $playoffCount,
+        array $incomingToTopDivision = [],
     ): PromotionSlotAllocation {
         $orderedTeams = $this->loadOrderedTeams($game, $bottomDivision, $directCount + $playoffCount);
 
@@ -60,6 +67,11 @@ class PromotionSlotAllocator
         }
 
         $topDivisionTeamIds = $this->reserveFilter->getTopDivisionTeamIds($game, $bottomDivision);
+
+        if (!empty($incomingToTopDivision)) {
+            $topDivisionTeamIds = $topDivisionTeamIds->concat($incomingToTopDivision)->unique()->values();
+        }
+
         $parentMap = $this->reserveFilter->loadParentTeamIds(
             array_column($orderedTeams, 'teamId')
         );

--- a/app/Modules/Season/Processors/PromotionRelegationProcessor.php
+++ b/app/Modules/Season/Processors/PromotionRelegationProcessor.php
@@ -59,11 +59,39 @@ class PromotionRelegationProcessor implements SeasonProcessor
             // reads — e.g. the ESP1↔ESP2 swap inserting teams at the bottom
             // of ESP2 before the ESP2↔ESP3 rule reads positions 19–22.
 
-            // Pass 1: Read — collect promoted/relegated teams from every rule.
-            $ruleData = [];
+            // Pass 1a: Read relegations first, build a cross-rule
+            // "incoming to division" map. A reserve team in ESP3 about to be
+            // promoted to ESP2 must be blocked if its parent is being
+            // relegated FROM ESP1 to ESP2 this same season — the per-rule
+            // reserve filter reads a stale snapshot (parent still in ESP1)
+            // and misses the collision. The map lets each rule's promotion
+            // computation see what its destination division will look like
+            // after every other rule's relegations land.
+            $relegatedByRule = [];
+            $incomingByDivision = [];
             foreach ($this->ruleFactory->all() as $rule) {
-                $promoted = $rule->getPromotedTeams($game);
                 $relegated = $rule->getRelegatedTeams($game);
+                $relegatedByRule[] = ['rule' => $rule, 'relegated' => $relegated];
+
+                if (empty($relegated)) {
+                    continue;
+                }
+
+                $relegatedIds = array_column($relegated, 'teamId');
+                foreach ($rule->getRelegationDestinations() as $destinationId) {
+                    foreach ($relegatedIds as $teamId) {
+                        $incomingByDivision[$destinationId][] = $teamId;
+                    }
+                }
+            }
+            foreach ($incomingByDivision as $division => $ids) {
+                $incomingByDivision[$division] = array_values(array_unique($ids));
+            }
+
+            // Pass 1b: Read promotions with the cross-rule context attached.
+            $ruleData = [];
+            foreach ($relegatedByRule as ['rule' => $rule, 'relegated' => $relegated]) {
+                $promoted = $rule->getPromotedTeams($game, $incomingByDivision);
 
                 if (empty($promoted) && empty($relegated)) {
                     continue;
@@ -131,12 +159,83 @@ class PromotionRelegationProcessor implements SeasonProcessor
                 $this->resimulateAffectedLeagues($game, array_unique($affectedCompetitionIds));
             }
 
+            // Belt-and-suspenders invariant check: no reserve team should
+            // share a competition with its parent club after all swaps. The
+            // cross-rule incoming context above prevents the known collision
+            // path; this guard catches any future regression (a new rule
+            // shape that bypasses the filter, a data drift in CompetitionTeam
+            // seeding) before it accumulates into a multi-season corruption
+            // like the game that produced this fix.
+            $this->assertNoReserveCoexistence($game, array_unique($affectedCompetitionIds));
+
             // Store only the user's division promotions/relegations for the transition log
             $data->setMetadata('promotedTeams', $userPromoted);
             $data->setMetadata('relegatedTeams', $userRelegated);
 
             return $data;
         });
+    }
+
+    /**
+     * Scan competitions touched by this run for any reserve team whose
+     * parent club shares the division. Throws with a list of offending
+     * (reserve, parent, competition) tuples so the rollback message names
+     * exactly what went wrong.
+     *
+     * @param  string[]  $competitionIds
+     */
+    private function assertNoReserveCoexistence(Game $game, array $competitionIds): void
+    {
+        if (empty($competitionIds)) {
+            return;
+        }
+
+        $rows = CompetitionEntry::where('game_id', $game->id)
+            ->whereIn('competition_id', $competitionIds)
+            ->join('teams', 'teams.id', '=', 'competition_entries.team_id')
+            ->whereNotNull('teams.parent_team_id')
+            ->select([
+                'competition_entries.competition_id as competition_id',
+                'competition_entries.team_id as reserve_id',
+                'teams.parent_team_id as parent_id',
+            ])
+            ->get();
+
+        if ($rows->isEmpty()) {
+            return;
+        }
+
+        $parentIds = $rows->pluck('parent_id')->unique()->all();
+        $parentCompetitions = CompetitionEntry::where('game_id', $game->id)
+            ->whereIn('team_id', $parentIds)
+            ->whereIn('competition_id', $competitionIds)
+            ->get(['competition_id', 'team_id'])
+            ->groupBy('team_id')
+            ->map(fn ($entries) => $entries->pluck('competition_id')->all());
+
+        $violations = [];
+        foreach ($rows as $row) {
+            $parentDivisions = $parentCompetitions->get($row->parent_id, []);
+            if (in_array($row->competition_id, $parentDivisions, true)) {
+                $violations[] = sprintf(
+                    'reserve=%s parent=%s competition=%s',
+                    $row->reserve_id,
+                    $row->parent_id,
+                    $row->competition_id,
+                );
+            }
+        }
+
+        if (empty($violations)) {
+            return;
+        }
+
+        throw new \RuntimeException(
+            'Reserve/parent coexistence invariant violated after promotion/relegation: '
+            . implode('; ', $violations)
+            . '. This shouldn\'t reach here — the per-rule reserve filter plus the '
+            . 'incomingByDivision cross-rule context should block it upstream.'
+        );
     }
 
     /**

--- a/app/Modules/Season/Processors/SupercupQualificationProcessor.php
+++ b/app/Modules/Season/Processors/SupercupQualificationProcessor.php
@@ -10,6 +10,7 @@ use App\Models\Game;
 use App\Models\CompetitionEntry;
 use App\Models\GameStanding;
 use App\Models\SimulatedSeason;
+use App\Models\Team;
 use RuntimeException;
 
 /**
@@ -78,12 +79,23 @@ class SupercupQualificationProcessor implements SeasonProcessor
             return;
         }
 
-        // Get cup finalists
-        $cupFinalists = $this->getCupFinalists($game->id, $cupId, $cupFinalRound);
+        // Reserve teams must never appear as supercup qualifiers — they're
+        // ineligible for the cup, so the downstream entry_round bump can't
+        // place them at the supercup-skip round and round 1 ends up odd
+        // (OddCupDrawPoolException). Filter once here against the country's
+        // full reserve roster rather than per-source; it covers both the
+        // GameStanding/SimulatedSeason path and a reserve cup-finalist
+        // (shouldn't happen in practice but cheap to guard against).
+        $reserveTeamIds = Team::where('country', $game->country ?? 'ES')
+            ->whereNotNull('parent_team_id')
+            ->pluck('id')
+            ->all();
+
+        $cupFinalists = $this->getCupFinalists($game->id, $cupId, $cupFinalRound, $reserveTeamIds);
 
         // Fetch league top 4 — enough to backfill 3rd/4th slots when both
         // cup finalists overlap with the league champion/runner-up.
-        $leagueTopTeams = $this->getLeagueTopTeams($game->id, $leagueId, 4);
+        $leagueTopTeams = $this->getLeagueTopTeams($game->id, $leagueId, 4, $reserveTeamIds);
 
         // Determine the 4 supercup qualifiers
         $qualifiers = $this->determineQualifiers($cupFinalists, $leagueTopTeams);
@@ -116,9 +128,10 @@ class SupercupQualificationProcessor implements SeasonProcessor
     /**
      * Get the two cup finalists.
      *
+     * @param  string[]  $reserveTeamIds  Reserve team IDs to scrub from the result.
      * @return array{winner: string|null, runnerUp: string|null}
      */
-    private function getCupFinalists(string $gameId, string $cupId, int $finalRound): array
+    private function getCupFinalists(string $gameId, string $cupId, int $finalRound, array $reserveTeamIds = []): array
     {
         $finalTie = CupTie::where('game_id', $gameId)
             ->where('competition_id', $cupId)
@@ -130,23 +143,44 @@ class SupercupQualificationProcessor implements SeasonProcessor
             return ['winner' => null, 'runnerUp' => null];
         }
 
+        $reserveLookup = array_flip($reserveTeamIds);
+        $winner = $finalTie->winner_id;
+        $runnerUp = $finalTie->getLoserId();
+
         return [
-            'winner' => $finalTie->winner_id,
-            'runnerUp' => $finalTie->getLoserId(),
+            'winner' => isset($reserveLookup[$winner]) ? null : $winner,
+            'runnerUp' => isset($reserveLookup[$runnerUp]) ? null : $runnerUp,
         ];
     }
 
     /**
      * Get the top N teams from league standings.
      *
+     * GameStanding rows are skipped when `played = 0` — those are placeholder
+     * rows written by StandingsResetProcessor at season setup and never
+     * touched again for leagues the user doesn't play (in pro-manager mode
+     * the user can be coaching a tier-3 club, so ESP1 standings stay at
+     * played=0 all season). Without this filter, the supercup qualifier
+     * path picks team IDs ordered by placeholder position rather than the
+     * real season's simulated outcome, which has put a Primera RFEF reserve
+     * into the supercup in production (cup_entry_round bump then misses the
+     * reserve, since it's not in the cup, and round 1 ends up odd).
+     *
+     * @param  string[]  $reserveTeamIds  Reserve team IDs to skip in both sources.
      * @return array<int, string> Team IDs in order of position
      */
-    private function getLeagueTopTeams(string $gameId, string $leagueId, int $count): array
+    private function getLeagueTopTeams(string $gameId, string $leagueId, int $count, array $reserveTeamIds = []): array
     {
-        // Try real standings first (player's league)
-        $teams = GameStanding::where('game_id', $gameId)
+        $standingsQuery = GameStanding::where('game_id', $gameId)
             ->where('competition_id', $leagueId)
-            ->orderBy('position')
+            ->where('played', '>', 0)
+            ->orderBy('position');
+
+        if (!empty($reserveTeamIds)) {
+            $standingsQuery->whereNotIn('team_id', $reserveTeamIds);
+        }
+
+        $teams = $standingsQuery
             ->limit($count)
             ->pluck('team_id')
             ->toArray();
@@ -163,7 +197,13 @@ class SupercupQualificationProcessor implements SeasonProcessor
             ->first();
 
         if ($simulated && !empty($simulated->results)) {
-            return array_slice($simulated->results, 0, $count);
+            $reserveLookup = array_flip($reserveTeamIds);
+            $filtered = array_values(array_filter(
+                $simulated->results,
+                fn (string $teamId) => !isset($reserveLookup[$teamId]),
+            ));
+
+            return array_slice($filtered, 0, $count);
         }
 
         return [];

--- a/app/Modules/Season/Services/SeasonInitializationService.php
+++ b/app/Modules/Season/Services/SeasonInitializationService.php
@@ -212,6 +212,13 @@ class SeasonInitializationService
     /**
      * Update ESPCUP entry_rounds for teams qualifying for the supercup.
      * Supercup-qualifying teams enter the cup at a later round.
+     *
+     * Upserts (rather than a plain UPDATE) so a supercup team that isn't
+     * already a cup entry is inserted at the configured entry_round. The
+     * supercup qualifier path now scrubs reserves up front, so any team
+     * landing here is eligible for the cup — the upsert is a tiny safety
+     * belt for the silent-UPDATE-miss case that produced the 113-team
+     * round-1 OddCupDrawPoolException in production.
      */
     private function updateCupEntryRoundsForSupercupTeams(string $gameId, string $countryCode): void
     {
@@ -228,7 +235,6 @@ class SeasonInitializationService
         $domesticCupId = $supercupConfig['cup'];
         $supercupId = $supercupConfig['competition'];
 
-        // Get teams qualifying for the supercup
         $supercupTeamIds = CompetitionEntry::where('game_id', $gameId)
             ->where('competition_id', $supercupId)
             ->pluck('team_id')
@@ -238,16 +244,50 @@ class SeasonInitializationService
             return;
         }
 
+        // Scrub reserves from the supercup list before the upsert below.
+        // The upstream SupercupQualificationProcessor scrubs reserves at
+        // qualification time now, but games whose supercup field was
+        // written by the previous code can still carry one. Without this
+        // filter, the upsert would insert the reserve into the cup,
+        // breaking the reserve-never-in-cup invariant. Note: this does
+        // not by itself recover an in-flight transition that already
+        // contains a reserve supercup pick (round 1 parity is fixed
+        // upstream by SupercupQualificationProcessor re-deriving the
+        // field with the corrected query).
+        $reserveTeamIds = Team::where('country', $countryCode)
+            ->whereNotNull('parent_team_id')
+            ->pluck('id')
+            ->all();
+
+        if (!empty($reserveTeamIds)) {
+            $reserveLookup = array_flip($reserveTeamIds);
+            $supercupTeamIds = array_values(array_filter(
+                $supercupTeamIds,
+                fn (string $teamId) => !isset($reserveLookup[$teamId]),
+            ));
+        }
+
         // Reset ALL domestic cup entries to round 1
         CompetitionEntry::where('game_id', $gameId)
             ->where('competition_id', $domesticCupId)
             ->update(['entry_round' => 1]);
 
-        // Set supercup-qualifying teams to enter at the later round
-        CompetitionEntry::where('game_id', $gameId)
-            ->where('competition_id', $domesticCupId)
-            ->whereIn('team_id', $supercupTeamIds)
-            ->update(['entry_round' => $cupEntryRound]);
+        if (empty($supercupTeamIds)) {
+            return;
+        }
+
+        $supercupRows = array_map(fn (string $teamId) => [
+            'game_id' => $gameId,
+            'competition_id' => $domesticCupId,
+            'team_id' => $teamId,
+            'entry_round' => $cupEntryRound,
+        ], $supercupTeamIds);
+
+        CompetitionEntry::upsert(
+            $supercupRows,
+            ['game_id', 'competition_id', 'team_id'],
+            ['entry_round']
+        );
     }
 
     /**

--- a/tests/Feature/SupercupQualificationTest.php
+++ b/tests/Feature/SupercupQualificationTest.php
@@ -7,6 +7,7 @@ use App\Models\CompetitionEntry;
 use App\Models\CupTie;
 use App\Models\Game;
 use App\Models\GameStanding;
+use App\Models\SimulatedSeason;
 use App\Models\Team;
 use App\Models\User;
 use App\Modules\Season\DTOs\SeasonTransitionData;
@@ -249,6 +250,87 @@ class SupercupQualificationTest extends TestCase
 
         $this->assertNotContains($stranger->id, $entries);
         $this->assertCount(4, $entries);
+    }
+
+    public function test_pro_manager_simulated_league_uses_simulated_season_not_placeholder_standings(): void
+    {
+        // Pro-manager regression: the user plays a tier-3 league, so ESP1
+        // is fully simulated. StandingsResetProcessor wrote placeholder
+        // GameStanding rows (played=0) for ESP1 at season setup that
+        // never get touched; the real ranking lives in SimulatedSeason.
+        //
+        // The pre-fix getLeagueTopTeams read those placeholder rows by
+        // position and returned them, which in production (season 2037 of
+        // game a6f6db6e-…) put a Primera RFEF reserve (RC Celta Fortuna,
+        // somehow promoted up to ESP1's CompetitionEntry over time) into
+        // the supercup. The downstream entry_round bump then failed
+        // because reserves aren't in the cup, leaving round 1 odd and
+        // crashing the season transition with OddCupDrawPoolException.
+        //
+        // Two protections against that path:
+        //   1. played=0 placeholder rows are skipped, forcing fallback
+        //      to SimulatedSeason.
+        //   2. Reserve teams are filtered from both sources, so even if
+        //      a reserve sneaks into the simulated ranking it can't
+        //      become a supercup pick.
+        GameStanding::where('game_id', $this->game->id)
+            ->where('competition_id', 'ESP1')
+            ->update(['played' => 0]);
+
+        $reserve = Team::factory()->create([
+            'country' => 'ES',
+            'name' => 'Reserve B',
+            'parent_team_id' => $this->league[1]->id,
+        ]);
+
+        // Simulated ranking: a reserve at the top (must be filtered),
+        // then the legitimate teams in a known order.
+        SimulatedSeason::create([
+            'game_id' => $this->game->id,
+            'season' => '2025',
+            'competition_id' => 'ESP1',
+            'results' => [
+                $reserve->id,           // must be filtered — reserves never qualify
+                $this->league[2]->id,
+                $this->league[3]->id,
+                $this->league[4]->id,
+                $this->league[5]->id,
+            ],
+        ]);
+
+        $this->runProcessor();
+
+        $this->assertSupercupTeams([
+            $this->league[2]->id,
+            $this->league[3]->id,
+            $this->league[4]->id,
+            $this->league[5]->id,
+        ]);
+    }
+
+    public function test_reserve_cup_finalist_is_scrubbed_from_qualifiers(): void
+    {
+        // A reserve should never be a cup finalist in practice (reserves
+        // aren't in the cup), but if data drift lets one through, the
+        // supercup must not include it — the entry_round bump can't
+        // place a reserve in the cup, which is what produced the
+        // OddCupDrawPoolException in production.
+        $reserve = Team::factory()->create([
+            'country' => 'ES',
+            'name' => 'Reserve B',
+            'parent_team_id' => $this->league[1]->id,
+        ]);
+
+        $this->setCupFinalists($reserve, $this->league[6]);
+
+        $this->runProcessor();
+
+        $this->assertSupercupTeams([
+            $this->league[6]->id, // runner-up survives
+            $this->league[1]->id,
+            $this->league[2]->id,
+            $this->league[3]->id, // backfills the displaced reserve slot
+        ]);
     }
 
     public function test_metadata_records_qualifiers_in_priority_order(): void

--- a/tests/Unit/PromotionSlotAllocatorTest.php
+++ b/tests/Unit/PromotionSlotAllocatorTest.php
@@ -489,4 +489,77 @@ class PromotionSlotAllocatorTest extends TestCase
         $this->assertSame(4, $allocation->playoffQualifiers[0]['position']);
         $this->assertSame(7, $allocation->playoffQualifiers[3]['position']);
     }
+
+    // ──────────────────────────────────────────────────
+    // Cross-rule incoming context — parent relegation collision
+    // ──────────────────────────────────────────────────
+
+    /**
+     * The pro-manager game (a6f6db6e-…) regression. Same-season collision:
+     * a reserve at the top of the bottom division gets promoted while its
+     * parent is being relegated from above into the destination division.
+     *
+     * The reserve filter's snapshot reads the top division's current state —
+     * the parent is still in its old division, not the destination — so it
+     * doesn't block. PromotionRelegationProcessor now threads each rule's
+     * incoming-relegation list into the allocator so the filter sees the
+     * post-relegation roster of the destination and treats the reserve as
+     * blocked.
+     */
+    public function test_reserve_is_blocked_when_parent_is_about_to_be_relegated_into_destination(): void
+    {
+        $teams = $this->seedFullStandings();
+
+        // Pick a parent club. Crucially, the parent is NOT currently in the
+        // top division — it's about to be relegated INTO it via a sibling
+        // rule. Without the incoming context, the filter sees no parent in
+        // ESP1 and clears the reserve.
+        $parent = Team::factory()->create();
+        $reserve = Team::factory()->create(['parent_team_id' => $parent->id]);
+
+        GameStanding::where('game_id', $this->game->id)
+            ->where('competition_id', self::BOTTOM_DIVISION)
+            ->where('position', 1)
+            ->delete();
+        $this->placeAtPosition(1, $reserve);
+        $teams[1] = $reserve;
+
+        // No-context call: filter is blind to the pending relegation, so the
+        // reserve at position 1 is promoted. This pins the pre-fix behaviour
+        // as the explicit baseline the new arg corrects.
+        $allocationWithoutContext = $this->allocator()->allocate(
+            $this->game,
+            self::BOTTOM_DIVISION,
+            2,
+            4,
+        );
+        $this->assertSame(
+            $reserve->id,
+            $allocationWithoutContext->directPromotions[0]['teamId'],
+            'Without incoming context, the allocator allows the reserve through (legacy behaviour).',
+        );
+
+        // With-context call: the parent is in the list of teams about to
+        // land in ESP1 this season. Filter now blocks the reserve and the
+        // direct-promotion slot slides to the next eligible team.
+        $allocationWithContext = $this->allocator()->allocate(
+            $this->game,
+            self::BOTTOM_DIVISION,
+            2,
+            4,
+            [$parent->id],
+        );
+
+        $direct = $this->teamIds($allocationWithContext->directPromotions);
+        $this->assertNotContains(
+            $reserve->id,
+            $direct,
+            'Reserve must be blocked when its parent is incoming to the destination.',
+        );
+        $this->assertSame(
+            [$teams[2]->id, $teams[3]->id],
+            $direct,
+            'Direct slots slide down to the next eligible teams.',
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Fixes the `OddCupDrawPoolException` (pool has 113 teams, round 1 odd) that crashed season transition for pro-manager games, and the underlying invariant violation (a reserve team — RC Celta Fortuna — sharing ESP1 with its parent RC Celta) that produced it.

- **Root cause**: same-season cross-rule collision in `PromotionRelegationProcessor`. Pass 1 reads each rule's promoted/relegated lists against the pre-swap snapshot, so when parent (RC Celta) is relegated ESP1→ESP2 and reserve (Celta Fortuna) is promoted ESP3→ESP2 in the same season, the reserve filter sees the parent still in ESP1 and doesn't block. Both land in ESP2; subsequent seasons cascade the reserve up to ESP1.
- **Symptom**: `SupercupQualificationProcessor.getLeagueTopTeams` read `GameStanding` for ESP1 without filtering `played > 0`. In pro-manager mode ESP1 carries placeholder standings (the user plays tier-3, ESP1's real ranking is in `SimulatedSeason`), so the query returned whatever sat at position 1 — a reserve in this game. The downstream `entry_round` bump couldn't place the reserve in the cup and round 1 ended up odd.

### Going-forward fix
- `PromotionRelegationRule::getPromotedTeams` now accepts `$incomingByDivision`; `PromotionRelegationProcessor` builds it in a new Pass 1a and threads it through Pass 1b. The allocator + `PrimeraRFEFPromotionRule`'s playoff-standin helpers union the destination's incoming list into the reserve-filter reference set.
- `assertNoReserveCoexistence` runs at the end of `process()` and fails loudly with the offending (reserve, parent, competition) tuple if anything still slips through.

### Symptom defenses
- `SupercupQualificationProcessor` filters `played = 0` placeholder rows and scrubs reserves from both `GameStanding` and `SimulatedSeason` results, plus cup finalists.
- `SeasonInitializationService` uses `upsert` for the `entry_round` bump and scrubs stale reserves from the supercup list.

### Recovery
- `app:fix-reserve-coexistence` artisan command scans games, swaps any reserve sharing a competition with its parent for the worst-ranked non-reserve in a lower tier, clears stale supercup entries, and resets `season_transition_step`. Default dry-run; `--fix` to apply; `--game=<id>` to scope.

## Test plan

- [ ] `php artisan test --filter=PromotionSlotAllocatorTest` — new test pins the pre-fix (no-context) vs post-fix (with-context) allocator behaviour.
- [ ] `php artisan test --filter=SupercupQualificationTest` — two new tests pin the `played = 0` fallthrough to `SimulatedSeason` and the reserve cup-finalist scrub.
- [ ] `php artisan test --filter=PromotionRelegationValidationTest` — existing tests still pass with the new optional `$incomingByDivision` arg.
- [ ] `php artisan test --filter=PrimeraRFEFPromotionTest` — existing tests still pass.
- [ ] Manual: `php artisan app:fix-reserve-coexistence --game=a6f6db6e-9cd6-4aff-99f1-e271b73a7621` (dry-run), confirm the violation is reported. Re-run with `--fix` and confirm Celta Fortuna is moved out of ESP1.
- [ ] Resume the affected game's season transition; the supercup draw should succeed with an even round-1 pool.
- [ ] `SELECT t.name FROM competition_entries ce JOIN teams t ON t.id = ce.team_id WHERE t.parent_team_id IS NOT NULL AND ce.competition_id IN ('ESP1','ESP2');` returns 0 rows after the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)