### PR TITLE
SupercupQualification: skip cleanly when no league data exists

### DIFF
--- a/app/Console/Commands/FixReserveCoexistence.php
+++ b/app/Console/Commands/FixReserveCoexistence.php
@@ -216,9 +216,13 @@ class FixReserveCoexistence extends Command
             }
 
             if ($repaired > 0) {
-                // Clear ESPSUP-style supercup entries so the next pipeline run
-                // re-derives them against the corrected league rosters. Use
-                // the country's supercup config rather than hard-coding ESPSUP.
+                // Clear ESPSUP-style supercup entries so the bump step in
+                // SeasonInitializationService::updateCupEntryRoundsForSupercupTeams
+                // becomes a no-op (no supercup teams to bump = no odd
+                // round-1 pool). The supercup for THIS season simply doesn't
+                // get played; next season's closing pipeline re-derives it
+                // cleanly. Use the country's supercup config rather than
+                // hard-coding ESPSUP.
                 $supercupConfig = $countryConfig->supercup($country);
                 if ($supercupConfig !== null && !empty($supercupConfig['competition'])) {
                     CompetitionEntry::where('game_id', $game->id)
@@ -226,18 +230,14 @@ class FixReserveCoexistence extends Command
                         ->delete();
                 }
 
-                // If the game is mid-transition, clear the checkpoint so the
-                // pipeline restarts from the beginning of the closing phase.
-                // Most processors are idempotent — they short-circuit already-
-                // completed work. Leaving a stale step pointer would skip
-                // SupercupQualificationProcessor, which is exactly the step we
-                // want to re-run.
-                if ($game->season_transition_step !== null) {
-                    Game::where('id', $game->id)->update([
-                        'season_transition_step' => null,
-                        'season_transition_data' => null,
-                    ]);
-                }
+                // DON'T clear season_transition_step. A first version did,
+                // which caused the closing pipeline to re-run for the
+                // already-advanced new season — which has no played data,
+                // and SupercupQualificationProcessor then crashed with
+                // "expected 4 qualifiers, got 0". Leaving the checkpoint
+                // in place lets the pipeline resume from where it crashed
+                // in the setup phase, where the cup draw can now succeed
+                // with the empty supercup field.
             }
 
             return $repaired;

--- a/app/Modules/Season/Processors/SupercupQualificationProcessor.php
+++ b/app/Modules/Season/Processors/SupercupQualificationProcessor.php
@@ -11,6 +11,7 @@ use App\Models\CompetitionEntry;
 use App\Models\GameStanding;
 use App\Models\SimulatedSeason;
 use App\Models\Team;
+use Illuminate\Support\Facades\Log;
 use RuntimeException;
 
 /**
@@ -99,6 +100,31 @@ class SupercupQualificationProcessor implements SeasonProcessor
 
         // Determine the 4 supercup qualifiers
         $qualifiers = $this->determineQualifiers($cupFinalists, $leagueTopTeams);
+
+        if (count($qualifiers) === 0
+            && $cupFinalists['winner'] === null
+            && $cupFinalists['runnerUp'] === null
+            && empty($leagueTopTeams)) {
+            // No data at all to derive a supercup field — neither real
+            // standings, simulated results, nor a completed cup final.
+            // Happens on recovery paths where the closing pipeline is
+            // re-run for a season that hasn't actually played yet (the
+            // setup pipeline already advanced the season but crashed
+            // mid-way, and a recovery rewound the checkpoint). Skip
+            // cleanly rather than crash — the supercup for this season
+            // simply doesn't get derived; next season it picks up again.
+            // The < 4 partial-data path below still throws, which is the
+            // Population A signal we want to keep.
+            Log::warning('[SupercupQualification] No data to derive qualifiers — skipping', [
+                'game_id' => $game->id,
+                'supercup_id' => $supercupId,
+                'cup_id' => $cupId,
+                'league_id' => $leagueId,
+                'season' => $game->season,
+            ]);
+
+            return;
+        }
 
         if (count($qualifiers) !== 4) {
             // Source of Population A in the cup-draw incident: cup didn't


### PR DESCRIPTION
## Summary

Follow-up to #1084. Second-pass recovery on the affected game surfaced a follow-on crash:

\`\`\`
RuntimeException: [SupercupQualification] expected 4 qualifiers for ESPSUP in game a6f6db6e-…, got 0.
cup_winner=null cup_runnerup=null league_top_teams=0
\`\`\`

The first recovery (in #1083) cleared \`season_transition_step\`, which made \`ProcessSeasonTransition\` re-run the **closing pipeline** against a season the **setup pipeline** had already advanced to (\`season=2037\`, ESP1 standings reset to \`played=0\`). With no real or simulated data for ESP1 and no completed cup final, the supercup qualifier path produced 0 teams and tripped the partial-data guard meant for the Population A bug.

Two corrections:

- **\`SupercupQualificationProcessor\`** distinguishes "no data" from "partial data". 0 qualifiers + null cup finalists + 0 league top teams = no data → log a warning and return. \`< 4\` qualifiers with *any* data present still throws — the Population A guard is preserved.
- **\`FixReserveCoexistence\`** no longer clears \`season_transition_step\`. Side-effect of the original "let the pipeline re-derive cleanly" intent was running closing against a freshly-set-up season. Clearing only ESPSUP is sufficient — the bump step becomes a no-op when there are no supercup teams, so the cup draw succeeds with an even round-1 pool.

For games already in the cleared-step state (the affected production game), the SQL recovery is:

\`\`\`sql
UPDATE games SET season_transition_step = 27 WHERE id = '<id>';
\`\`\`

This skips closing (28 processors total → \`idx 27\` = last) and resumes setup from the beginning. Setup processors are idempotent.

## Test plan

- [ ] Affected game: apply the SQL above, trigger the season transition, confirm setup pipeline completes and the cup draws successfully.
- [ ] Fresh game: \`php artisan app:fix-reserve-coexistence --game=<id> --fix\` no longer clears \`season_transition_step\`; pipeline resumes from setup checkpoint.
- [ ] Defensive: any future re-trigger of the closing pipeline against a freshly-setup season logs \`[SupercupQualification] No data to derive qualifiers — skipping\` instead of crashing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)