### PR TITLE
Skip reserve cascade when reserve is already relegating

### DIFF
--- a/app/Modules/Competition/Exceptions/TierStandingsMissingException.php
+++ b/app/Modules/Competition/Exceptions/TierStandingsMissingException.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Modules\Competition\Exceptions;
+
+use RuntimeException;
+
+/**
+ * Thrown when the promotion/relegation snapshot builder finds a playable
+ * tier with no standings to read. Without standings the planner would
+ * relegate teams INTO an empty tier without any compensating promoters out
+ * of it, producing an unbalanced plan that fails much later in validation
+ * with a confusing "ends with N teams" error.
+ *
+ * Failing fast at snapshot build surfaces the real precondition violation:
+ * GameStanding (played > 0) is empty and SimulatedSeason has no fallback
+ * results for this competition/season. Operator action is needed (seed the
+ * tier, run the unstick command, etc.) before retrying the season transition.
+ */
+class TierStandingsMissingException extends RuntimeException
+{
+    public static function forCompetition(string $competitionId): self
+    {
+        return new self(
+            "Cannot build promotion/relegation snapshot: tier competition '{$competitionId}' "
+            . 'has no standings. Both GameStanding (played > 0) and SimulatedSeason are empty '
+            . 'for this game and season.'
+        );
+    }
+}

--- a/app/Modules/Competition/Promotions/CountryPromotionRelegationPlanner.php
+++ b/app/Modules/Competition/Promotions/CountryPromotionRelegationPlanner.php
@@ -315,7 +315,15 @@ class CountryPromotionRelegationPlanner
         $playoffPickCount = 2; // Two bracket finals → two promotion spots.
 
         $playoffPicks = match ($state) {
-            PlayoffState::Completed => $this->primeraRfefCompletedWinners($snapshot, $playoffComp, $playoffPickCount),
+            PlayoffState::Completed => $this->primeraRfefCompletedWinners(
+                $snapshot,
+                $playoffComp,
+                $playoffPickCount,
+                array_column($out, 'teamId'),
+                $sources,
+                $directCount,
+                $effectiveTopRoster,
+            ),
             PlayoffState::NotStarted => $this->primeraRfefStandIns(
                 $snapshot,
                 $sources,
@@ -412,7 +420,13 @@ class CountryPromotionRelegationPlanner
         $state = $snapshot->playoffState($playoffComp);
 
         return match ($state) {
-            PlayoffState::Completed => array_slice($snapshot->playoffWinners($playoffComp), 0, 1),
+            PlayoffState::Completed => $this->completedPlayoffSlots(
+                $snapshot,
+                $playoffComp,
+                $eligible,
+                $directAlreadyTaken,
+                1,
+            ),
             PlayoffState::InProgress => throw PlayoffInProgressException::forCompetition($playoffComp),
             PlayoffState::NotStarted => array_slice(
                 array_values(array_diff($eligible, $directAlreadyTaken)),
@@ -423,16 +437,111 @@ class CountryPromotionRelegationPlanner
     }
 
     /**
+     * Build the playoff-promoted team list for the Completed branch, skipping
+     * any winner that's already a direct promoter and falling back to the next
+     * eligible team in standings order to keep the promotion count consistent.
+     *
+     * The bracket is seeded mid-season (at the trigger matchday). A team
+     * seeded into the playoff range can climb into direct-promotion territory
+     * by season-end and then win the bracket — without this dedupe the planner
+     * would emit two promotion moves for the same team and trip the
+     * no-double-move invariant. The direct promotion (earned by final
+     * standings) is treated as the stronger claim; the playoff slot falls
+     * through to the next eligible team.
+     *
+     * @param  list<string>  $eligible
+     * @param  list<string>  $directAlreadyTaken
+     * @return list<string>
+     */
+    private function completedPlayoffSlots(
+        CountrySeasonSnapshot $snapshot,
+        string $playoffComp,
+        array $eligible,
+        array $directAlreadyTaken,
+        int $slots,
+    ): array {
+        $taken = array_flip($directAlreadyTaken);
+        $out = [];
+
+        foreach ($snapshot->playoffWinners($playoffComp) as $teamId) {
+            if (isset($taken[$teamId])) {
+                continue;
+            }
+            $out[] = $teamId;
+            $taken[$teamId] = true;
+            if (count($out) >= $slots) {
+                return $out;
+            }
+        }
+
+        // Fallback: at least one winner was also a direct promoter, leaving
+        // the playoff slot short. Pull the next eligible team(s) past the
+        // direct range to fill the gap.
+        foreach (array_slice($eligible, count($directAlreadyTaken)) as $teamId) {
+            if (isset($taken[$teamId])) {
+                continue;
+            }
+            $out[] = $teamId;
+            $taken[$teamId] = true;
+            if (count($out) >= $slots) {
+                break;
+            }
+        }
+
+        return $out;
+    }
+
+    /**
+     * Build playoff-promoted picks for the split (PrimeraRFEF) rule, skipping
+     * any bracket winner that's already a direct promoter from one of the
+     * feeder groups. Same rationale as {@see completedPlayoffSlots}: bracket
+     * seeding is a mid-season snapshot and the standings can shift before
+     * season-end. Stand-in logic fills any gaps left by the dedupe so the
+     * total promotion count stays consistent.
+     *
+     * @param  list<string>  $directAlreadyTaken
+     * @param  list<string>  $sources
+     * @param  list<string>  $effectiveTopRoster
      * @return list<array{teamId: string, source: string}>
      */
-    private function primeraRfefCompletedWinners(CountrySeasonSnapshot $snapshot, string $playoffComp, int $count): array
-    {
-        $winners = array_slice($snapshot->playoffWinners($playoffComp), 0, $count);
+    private function primeraRfefCompletedWinners(
+        CountrySeasonSnapshot $snapshot,
+        string $playoffComp,
+        int $count,
+        array $directAlreadyTaken,
+        array $sources,
+        int $directCount,
+        array $effectiveTopRoster,
+    ): array {
+        $taken = array_flip($directAlreadyTaken);
         $out = [];
-        foreach ($winners as $teamId) {
+
+        foreach ($snapshot->playoffWinners($playoffComp) as $teamId) {
+            if (isset($taken[$teamId])) {
+                continue;
+            }
             $source = $snapshot->competitionOf($teamId) ?? '';
             $out[] = ['teamId' => $teamId, 'source' => $source];
+            $taken[$teamId] = true;
+            if (count($out) >= $count) {
+                return $out;
+            }
         }
+
+        if (count($out) < $count) {
+            $standIns = $this->primeraRfefStandIns(
+                $snapshot,
+                $sources,
+                $directCount,
+                $effectiveTopRoster,
+                array_keys($taken),
+                $count - count($out),
+            );
+            foreach ($standIns as $pick) {
+                $out[] = $pick;
+            }
+        }
+
         return $out;
     }
 

--- a/app/Modules/Competition/Promotions/CountrySeasonSnapshotBuilder.php
+++ b/app/Modules/Competition/Promotions/CountrySeasonSnapshotBuilder.php
@@ -6,6 +6,7 @@ use App\Models\CupTie;
 use App\Models\Game;
 use App\Models\Team;
 use App\Modules\Competition\Enums\PlayoffState;
+use App\Modules\Competition\Exceptions\TierStandingsMissingException;
 use App\Modules\Competition\Playoffs\PlayoffGeneratorFactory;
 use App\Modules\Competition\Services\CountryConfig;
 
@@ -36,6 +37,9 @@ class CountrySeasonSnapshotBuilder
         foreach ($this->tierCompetitionIds($config) as $competitionId) {
             $entries = $this->standingsReader->read($game, $competitionId);
             $standingsByCompetition[$competitionId] = array_column($entries, 'teamId');
+            if (empty($standingsByCompetition[$competitionId])) {
+                throw TierStandingsMissingException::forCompetition($competitionId);
+            }
         }
 
         $reserveToParent = $this->buildReserveMap($country, $standingsByCompetition);

--- a/tests/Unit/CountryPromotionRelegationPlannerTest.php
+++ b/tests/Unit/CountryPromotionRelegationPlannerTest.php
@@ -192,6 +192,95 @@ class CountryPromotionRelegationPlannerTest extends TestCase
         $this->assertTierCountsPreserved($plan, $snapshot, $this->spainConfig);
     }
 
+    // ──────────────────────────────────────────────────
+     // Playoff winner ↔ direct promoter dedupe
+     // (production bug: bracket seeded mid-season, winner climbs to direct
+     // slot by season-end → planner emits two moves for the same team)
+     // ──────────────────────────────────────────────────
+
+    public function test_simple_rule_playoff_winner_also_direct_promoter_dedupes(): void
+    {
+        // Reproduces the Racing Santander scenario: ESP2 finalist climbs to
+        // pos 2 (a direct-promotion slot) by season-end and also wins the
+        // bracket. Without dedupe the planner emits two ESP2→ESP1 moves for
+        // the same team and trips the no-double-move invariant.
+        $esp1 = $this->ids(20, 'a1');
+        $esp2 = $this->ids(22, 'a2');
+        $playoffWinner = $esp2[1]; // pos 2 = direct promoter
+
+        $snapshot = new CountrySeasonSnapshot(
+            countryCode: 'ES',
+            standingsByCompetition: [
+                'ESP1' => $esp1,
+                'ESP2' => $esp2,
+                'ESP3A' => $this->ids(20, 'a3'),
+                'ESP3B' => $this->ids(20, 'b3'),
+            ],
+            reserveToParent: [],
+            playoffStates: ['ESP2' => PlayoffState::Completed, 'ESP3PO' => PlayoffState::NotStarted],
+            playoffWinners: ['ESP2' => [$playoffWinner]],
+        );
+
+        $plan = $this->planner->planFromSnapshot($snapshot, $this->spainConfig);
+
+        $promotedToEsp1 = array_map(fn ($m) => $m->teamId, $plan->promotionsInto('ESP1'));
+
+        // Three unique promoters: the two direct slots + a fallback playoff
+        // pick (the next eligible team in standings after the direct range).
+        $this->assertCount(3, $promotedToEsp1);
+        $this->assertSame(
+            [$esp2[0], $esp2[1], $esp2[2]],
+            $promotedToEsp1,
+            'Direct slots take pos 1-2; playoff slot falls through to pos 3 because pos 2 is already direct',
+        );
+
+        $this->assertNoTeamMovedTwice($plan);
+        $this->assertTierCountsPreserved($plan, $snapshot, $this->spainConfig);
+    }
+
+    public function test_split_rule_playoff_winner_also_direct_promoter_dedupes(): void
+    {
+        // Same dedupe applied to the PrimeraRFEF split rule: a bracket winner
+        // that's also taking a direct slot from its feeder group falls back
+        // to the next eligible team in the same group.
+        $esp1 = $this->ids(20, 'a1');
+        $esp2 = $this->ids(22, 'a2');
+        $esp3a = $this->ids(20, 'a3');
+        $esp3b = $this->ids(20, 'b3');
+
+        // ESP3PO completed with two winners; the first is also ESP3A's
+        // direct promoter (pos 1) — that's the dedupe target.
+        $snapshot = new CountrySeasonSnapshot(
+            countryCode: 'ES',
+            standingsByCompetition: [
+                'ESP1' => $esp1,
+                'ESP2' => $esp2,
+                'ESP3A' => $esp3a,
+                'ESP3B' => $esp3b,
+            ],
+            reserveToParent: [],
+            playoffStates: ['ESP2' => PlayoffState::NotStarted, 'ESP3PO' => PlayoffState::Completed],
+            playoffWinners: ['ESP3PO' => [$esp3a[0], $esp3a[2]]], // pos 1 (also direct) + pos 3 (clean)
+        );
+
+        $plan = $this->planner->planFromSnapshot($snapshot, $this->spainConfig);
+
+        $promotedToEsp2 = array_map(fn ($m) => $m->teamId, $plan->promotionsInto('ESP2'));
+
+        // 4 unique promoters expected (1 direct from each of A and B, plus 2 playoff slots).
+        $this->assertCount(4, $promotedToEsp2);
+        // The duplicate (esp3a[0]) appears only once; the missing playoff slot
+        // falls back to a stand-in past the direct range.
+        $this->assertSame(
+            1,
+            count(array_keys($promotedToEsp2, $esp3a[0], true)),
+            'Duplicate winner appears only once in promotion moves',
+        );
+
+        $this->assertNoTeamMovedTwice($plan);
+        $this->assertTierCountsPreserved($plan, $snapshot, $this->spainConfig);
+    }
+
     public function test_escape_hatch_cancels_parent_relegation_when_reserve_at_deepest_tier(): void
     {
         // Spain's tier 3 (ESP3A/B) has siblings, so the split rule can always


### PR DESCRIPTION
The cascade pass only checked the reserve's CURRENT competition against
the parent's destination. When a parent relegated ESP1→ESP2 and its
reserve sat at one of ESP2's relegation positions (going to ESP3 via
the split rule), the planner emitted a REASON_RESERVE_CASCADE move on
top of the natural REASON_RELEGATION move, producing two moves for the
same team and tripping the planner's no-double-move invariant.

Compare the reserve's POST-rule destination instead: if another rule is
already moving the reserve out of parentDest, the cascade is redundant
and would unbalance the destination tier.