### PR TITLE
Reject promotion/relegation snapshots with partial-standings tiers

### DIFF
--- a/app/Modules/Competition/Exceptions/TierStandingsMissingException.php
+++ b/app/Modules/Competition/Exceptions/TierStandingsMissingException.php
@@ -26,4 +26,18 @@ class TierStandingsMissingException extends RuntimeException
             . 'for this game and season.'
         );
     }
+
+    public static function sizeMismatch(string $competitionId, int $actual, int $expected): self
+    {
+        return new self(
+            "Cannot build promotion/relegation snapshot: tier competition '{$competitionId}' "
+            . "has {$actual} teams with played > 0 in standings, expected {$expected} per country "
+            . 'config. The missing teams are most likely phantom rows from a prior incomplete '
+            . 'season transition (registered in competition_entries / game_standings but with '
+            . 'played = 0). The planner cannot produce a balanced plan against partial standings '
+            . '— the relegation positions would resolve to slots that no team actually competed '
+            . 'in. Resolve the standings (either by completing the missing matches or by removing '
+            . 'the phantom rows) before retrying the season transition.'
+        );
+    }
 }

--- a/app/Modules/Competition/Promotions/CountrySeasonSnapshotBuilder.php
+++ b/app/Modules/Competition/Promotions/CountrySeasonSnapshotBuilder.php
@@ -42,6 +42,8 @@ class CountrySeasonSnapshotBuilder
             }
         }
 
+        $this->assertTierStandingsMatchConfig($config, $standingsByCompetition);
+
         $reserveToParent = $this->buildReserveMap($country, $standingsByCompetition);
 
         [$playoffStates, $playoffWinners] = $this->buildPlayoffData($game, $config);
@@ -71,6 +73,51 @@ class CountrySeasonSnapshotBuilder
             }
         }
         return $ids;
+    }
+
+    /**
+     * Belt-and-braces check that every tier's standings match the team count
+     * the country config declares. If they don't, the planner is being handed
+     * partial data and will silently produce an unbalanced plan — the failure
+     * eventually surfaces as a confusing mid-validation "ends with N teams"
+     * error well after the snapshot was built. Throwing at the boundary keeps
+     * the operator-facing message pointed at the real precondition violation.
+     *
+     * @param  array<string, list<string>>  $standingsByCompetition
+     */
+    private function assertTierStandingsMatchConfig(array $config, array $standingsByCompetition): void
+    {
+        foreach ($config['tiers'] ?? [] as $tier) {
+            $this->assertCompetitionMatchesTierSize(
+                $tier['competition'],
+                $tier['teams'] ?? null,
+                $standingsByCompetition,
+            );
+            foreach ($tier['siblings'] ?? [] as $sibling) {
+                $this->assertCompetitionMatchesTierSize(
+                    $sibling['competition'],
+                    $sibling['teams'] ?? null,
+                    $standingsByCompetition,
+                );
+            }
+        }
+    }
+
+    /**
+     * @param  array<string, list<string>>  $standingsByCompetition
+     */
+    private function assertCompetitionMatchesTierSize(
+        string $competitionId,
+        ?int $expectedSize,
+        array $standingsByCompetition,
+    ): void {
+        if ($expectedSize === null) {
+            return;
+        }
+        $actual = count($standingsByCompetition[$competitionId] ?? []);
+        if ($actual !== $expectedSize) {
+            throw TierStandingsMissingException::sizeMismatch($competitionId, $actual, $expectedSize);
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary

Tighten `CountrySeasonSnapshotBuilder` to fail at the snapshot boundary when a playable tier has fewer `played > 0` standings than the country config declares.

## Background

After #1092 (playoff-winner dedupe) the cryptic mid-validation error `Planner produced an unbalanced plan: ESP3A ends with 14 teams, expected 20` showed up on a real game. Per-game investigation traced it to **phantom GameStanding rows**:

- ESP2 had 4 teams at positions 19-22 with `played = 0` (Athletic Club, CD Arenteiro, Real Avilés, Marbella FC). Real play covered positions 1-18.
- ESP3A had 3 teams at positions 18-20 with `played = 0`, all reserves of top-flight clubs (Castilla, Bilbao Athletic, Fortuna). Real play covered positions 1-17.

The `played > 0` filter in `StandingsReader` silently dropped those rows, handing the planner an 18-team ESP2 / 17-team ESP3A snapshot. The planner happily produced an unbalanced plan against partial data; the failure surfaced much later in validation with a message that pointed at the symptom rather than the precondition.

The clustering at the bottom positions and the population (a La Liga team + three reserves) is consistent with a previous season transition that committed partial state across processor transactions and left placeholder rows behind. That's an upstream bug to chase separately — not in scope here.

## Change

`CountrySeasonSnapshotBuilder::build()` now compares each tier's standings count against `tiers[].teams` (and `siblings[].teams`) in the country config. Mismatch → `TierStandingsMissingException::sizeMismatch(...)` with an operator-actionable message naming the competition, the actual count, the expected count, and the likely cause.

### Considered and rejected

Silently filling missing slots from `played = 0` rows in `StandingsReader`. Those rows have no meaningful league ordering — relegating whichever team happens to be loaded as a phantom would be arbitrary punishment, and would paper over the upstream data issue.

## Test plan

- [ ] Existing planner unit tests pass (12 / 12, 113 assertions).
- [ ] Deploy and confirm the failing game now surfaces `TierStandingsMissingException: tier competition 'ESP2' has 18 teams with played > 0 in standings, expected 22 ...` at snapshot build time — *before* the planner runs.
- [ ] Operator cleans up the phantom rows on the affected game and reruns the season transition successfully.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hqf5bB6XuH7MxCnsocmJTB)_