### PR TITLE
Iterate planner reserve protection until coexistence stabilises

### DIFF
--- a/app/Modules/Competition/Promotions/CountryPromotionRelegationPlanner.php
+++ b/app/Modules/Competition/Promotions/CountryPromotionRelegationPlanner.php
@@ -73,29 +73,61 @@ class CountryPromotionRelegationPlanner
             );
         }
 
-        // Step 4: Reserve protection — cascade reserves whose parent is about to
-        // land in their tier, or cancel the parent's relegation if there's no
-        // deeper tier to cascade to.
-        [$cascadeMoves, $compensationMoves, $cancellations] = $this->resolveReserveProtection(
-            $snapshot,
-            $tierStructure,
-            $promotionRules,
-            $relegatorsByRule,
-            $promotersByRule,
-        );
+        // Steps 4-5: Iterate reserve protection + cancellation until stable.
+        //
+        // A single pass isn't enough on split rules (ESP2 ↔ ESP3A/ESP3B): the
+        // first cancellation pass also drops promotions, which shrinks the
+        // capacity of one of the sibling destinations. Recomputing the split
+        // assignment with the reduced capacity can push a previously
+        // non-colliding parent into the colliding sibling — but the original
+        // resolveReserveProtection only saw the pre-cancellation assignment,
+        // so that residual collision is never escape-hatched and trips
+        // validatePlan's coexistence check.
+        //
+        // Re-running resolveReserveProtection against the post-cancellation
+        // state surfaces those residual collisions. The loop terminates
+        // because each iteration either applies new cancellations (strictly
+        // reducing relegators + promoters) or stabilises.
+        $skippedRelegations = [];
+        $cascadeMoves = [];
+        $compensationMoves = [];
+        $iterationLimit = $this->reserveProtectionIterationLimit($relegatorsByRule);
 
-        // Step 5: Apply cancellations from the escape hatch.
-        foreach ($cancellations['relegations'] as $ruleIdx => $cancelledTeamIds) {
-            $relegatorsByRule[$ruleIdx] = array_values(
-                array_diff($relegatorsByRule[$ruleIdx], $cancelledTeamIds),
+        for ($iter = 0; $iter <= $iterationLimit; $iter++) {
+            [$cascadeMoves, $compensationMoves, $cancellations] = $this->resolveReserveProtection(
+                $snapshot,
+                $tierStructure,
+                $promotionRules,
+                $relegatorsByRule,
+                $promotersByRule,
             );
-        }
-        foreach ($cancellations['promotionsCount'] as $ruleIdx => $count) {
-            // Drop the lowest-priority promoters (end of list = playoff winners
-            // / lowest-seeded direct slot, depending on rule order).
-            $current = $promotersByRule[$ruleIdx];
-            $keep = max(0, count($current) - $count);
-            $promotersByRule[$ruleIdx] = array_slice($current, 0, $keep);
+
+            $hadCancellation = false;
+            foreach ($cancellations['relegations'] as $ruleIdx => $cancelledTeamIds) {
+                if (empty($cancelledTeamIds)) {
+                    continue;
+                }
+                $relegatorsByRule[$ruleIdx] = array_values(
+                    array_diff($relegatorsByRule[$ruleIdx], $cancelledTeamIds),
+                );
+                $hadCancellation = true;
+            }
+            foreach ($cancellations['promotionsCount'] as $ruleIdx => $count) {
+                if ($count <= 0) {
+                    continue;
+                }
+                // Drop the lowest-priority promoters (end of list = playoff
+                // winners / lowest-seeded direct slot, depending on rule order).
+                $current = $promotersByRule[$ruleIdx];
+                $keep = max(0, count($current) - $count);
+                $promotersByRule[$ruleIdx] = array_slice($current, 0, $keep);
+                $hadCancellation = true;
+            }
+            $skippedRelegations = array_merge($skippedRelegations, $cancellations['skipped']);
+
+            if (!$hadCancellation) {
+                break;
+            }
         }
 
         // Step 6: Build the rule-driven moves (relegations + promotions).
@@ -115,13 +147,30 @@ class CountryPromotionRelegationPlanner
         $plan = new PromotionRelegationPlan(
             countryCode: $snapshot->countryCode,
             moves: array_values($moves),
-            skippedRelegations: $cancellations['skipped'],
+            skippedRelegations: $skippedRelegations,
             touchedCompetitionIds: $touched,
         );
 
         $this->validatePlan($plan, $snapshot, $tierStructure);
 
         return $plan;
+    }
+
+    /**
+     * Upper bound on reserve-protection iterations. Each iteration that
+     * makes progress strictly reduces relegators (and matching promoters),
+     * so the loop terminates in at most one iteration per relegator plus
+     * one stabilisation pass.
+     *
+     * @param  array<int, list<string>>  $relegatorsByRule
+     */
+    private function reserveProtectionIterationLimit(array $relegatorsByRule): int
+    {
+        $total = 0;
+        foreach ($relegatorsByRule as $ids) {
+            $total += count($ids);
+        }
+        return $total + 1;
     }
 
     // ──────────────────────────────────────────────────

--- a/tests/Unit/CountryPromotionRelegationPlannerTest.php
+++ b/tests/Unit/CountryPromotionRelegationPlannerTest.php
@@ -364,6 +364,75 @@ class CountryPromotionRelegationPlannerTest extends TestCase
         $this->assertTierCountsPreserved($plan, $snapshot, $config);
     }
 
+    public function test_split_rule_escape_hatch_iterates_until_no_residual_coexistence(): void
+    {
+        // Production regression (planner produced a coexistence violation in
+        // ESP3A): every ESP2 relegator has a reserve in ESP3A, so all four
+        // need to land in ESP3B. ESP3B has only one promotion slot (1 direct
+        // + both playoff winners coming from ESP3A), so three relegators
+        // collide in the first assignment pass.
+        //
+        // The escape hatch cancels those three relegations and drops three
+        // promotions. The drop removes ESP3B's only direct promoter, leaving
+        // cap_B = 0 in the second assignment pass. The fourth relegator —
+        // which sat safely in ESP3B in the first pass — now has nowhere to
+        // go but the colliding sibling. Without iteration the planner emits
+        // a plan with that residual collision and validatePlan trips.
+        $esp1 = $this->ids(20, 'a1');
+        $esp2 = $this->ids(18, 'a2');
+        $parents = ['parent-A', 'parent-B', 'parent-C', 'parent-D'];
+        // ESP2 positions 19-22 (indexes 18-21) all relegate.
+        $esp2 = array_merge($esp2, $parents);
+
+        // All four reserves sit in ESP3A. Place them past the direct-promotion
+        // slot so they don't muddy the eligibility check; cap_A still adds up
+        // to 3 (direct + 2 playoff winners) for the standard four-team flow.
+        $reserves = ['reserve-A', 'reserve-B', 'reserve-C', 'reserve-D'];
+        $esp3a = array_merge(
+            [$this->ids(1, 'a3-top')[0]], // pos 1 (direct promoter)
+            $reserves,                     // pos 2-5 (reserves of ESP2 relegators)
+            $this->ids(15, 'a3-rest'),
+        );
+        $esp3b = $this->ids(20, 'b3');
+
+        $snapshot = new CountrySeasonSnapshot(
+            countryCode: 'ES',
+            standingsByCompetition: [
+                'ESP1' => $esp1,
+                'ESP2' => $esp2,
+                'ESP3A' => $esp3a,
+                'ESP3B' => $esp3b,
+            ],
+            reserveToParent: [
+                'reserve-A' => 'parent-A',
+                'reserve-B' => 'parent-B',
+                'reserve-C' => 'parent-C',
+                'reserve-D' => 'parent-D',
+            ],
+            playoffStates: ['ESP2' => PlayoffState::NotStarted, 'ESP3PO' => PlayoffState::Completed],
+            // Both bracket winners from ESP3A → cap_A = 3, cap_B = 1.
+            playoffWinners: ['ESP3PO' => [$esp3a[6], $esp3a[7]]],
+        );
+
+        $plan = $this->planner->planFromSnapshot($snapshot, $this->spainConfig);
+
+        // All four parents stay in ESP2 (every ESP3 slot would coexist with
+        // their reserve once capacities collapse).
+        foreach ($parents as $parent) {
+            $this->assertNull(
+                $this->findMove($plan, $parent),
+                "Parent {$parent} should not relegate when capacity is exhausted",
+            );
+        }
+        $this->assertCount(4, $plan->skippedRelegations);
+        foreach ($plan->skippedRelegations as $skipped) {
+            $this->assertSame(SkippedRelegation::REASON_RESERVE_AT_FLOOR, $skipped->reason);
+        }
+
+        $this->assertNoReserveParentCoexistenceAfterPlan($plan, $snapshot);
+        $this->assertTierCountsPreserved($plan, $snapshot, $this->spainConfig);
+    }
+
     // ──────────────────────────────────────────────────
     // Reserve promotion + parent relegation (the user's stated case)
     // ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Production crash: `LogicException: Planner produced a coexistence violation: reserve=8a519d48 parent=956bf812 competition=ESP3A.`

The split rule (ESP2 ↔ ESP3A/ESP3B) was running reserve protection in a single pass. When the escape hatch cancelled colliding relegations AND dropped matching promotions, the second assignment pass in `buildRuleMoves` saw a different sibling capacity than the first pass in `resolveReserveProtection`. A parent that had been safely placed in ESP3B before cancellations could now have nowhere to go but its reserve's sibling — that residual collision was never escape-hatched and tripped `validatePlan`.

**Repro scenario** (added as `test_split_rule_escape_hatch_iterates_until_no_residual_coexistence`): all four ESP2 relegators have reserves in ESP3A, both ESP3PO winners come from ESP3A. `cap_A = 3, cap_B = 1`. Three relegators collide on the first pass and are cancelled, dropping the lowest three promoters — which include ESP3B's only direct slot. `cap_B` falls to 0; the fourth relegator, previously placed in ESP3B, gets pushed into ESP3A and coexists with its reserve.

**Fix:** loop reserve protection + cancellation application until no new cancellations are produced. Each iteration with progress strictly reduces relegators (and matching promoters), so the loop terminates in at most one iteration per relegator plus one stabilisation pass. `cascade`/`compensation` moves from the final stable iteration are the ones we emit; the skipped-relegations list accumulates across all iterations.

Existing escape-hatch and cascade tests still pass — they stabilise in a single iteration so the loop just breaks immediately on the second pass.

## Test plan

- [ ] CI passes (`tests/Unit/CountryPromotionRelegationPlannerTest.php` + existing planner suite)
- [ ] New test `test_split_rule_escape_hatch_iterates_until_no_residual_coexistence` reproduces the production scenario and asserts all four parents are escape-hatched cleanly
- [ ] Existing `test_escape_hatch_cancels_parent_relegation_when_reserve_at_deepest_tier` and `test_parent_relegated_into_reserve_tier_cascades_reserve_down` still pass


---
_Generated by [Claude Code](https://claude.ai/code/session_014frfaxXTygS6sMkNKRYRdq)_