### PR TITLE
Add called-up flag for World Cup players

### DIFF
--- a/app/Http/Views/ShowSquadSelection.php
+++ b/app/Http/Views/ShowSquadSelection.php
@@ -110,6 +110,7 @@ class ShowSquadSelection
                 'club_name' => $tournamentInfo?->club_name,
                 'club_crest_url' => $tournamentInfo?->club_crest_url,
                 'is_injured' => (bool) $tournamentInfo?->is_injured,
+                'is_called_up' => (bool) $tournamentInfo?->is_called_up,
             ];
 
             $groupKey = match ($positionGroup) {

--- a/app/Models/GamePlayerTemplateTournamentInfo.php
+++ b/app/Models/GamePlayerTemplateTournamentInfo.php
@@ -19,12 +19,14 @@ class GamePlayerTemplateTournamentInfo extends Model
     protected $fillable = [
         'game_player_template_id',
         'is_injured',
+        'is_called_up',
         'club_name',
         'club_crest_url',
     ];
 
     protected $casts = [
         'is_injured' => 'boolean',
+        'is_called_up' => 'boolean',
     ];
 
     public function template(): BelongsTo

--- a/app/Modules/Season/Jobs/SetupTournamentGame.php
+++ b/app/Modules/Season/Jobs/SetupTournamentGame.php
@@ -236,6 +236,31 @@ class SetupTournamentGame implements ShouldQueue
 
         $placeholders = implode(',', array_fill(0, count($eligibleNationalTeamIds), '?'));
 
+        // National teams that have an explicit "called up" roster published in
+        // their JSON (via game_player_template_tournament_info.is_called_up).
+        // For those, AI opponents start the tournament with only that 26-man
+        // squad. Teams without any called-up flag fall through to the legacy
+        // behavior of copying every templated player, so the JSON files can be
+        // updated incrementally without breaking unseeded nations.
+        $teamsWithCalledUp = DB::connection('pgsql_control')
+            ->table('game_player_template_tournament_info as ti')
+            ->join('game_player_templates as t', 't.id', '=', 'ti.game_player_template_id')
+            ->where('t.season', '2025')
+            ->where('ti.is_called_up', true)
+            ->whereIn('t.team_id', $eligibleNationalTeamIds)
+            ->distinct()
+            ->pluck('t.team_id')
+            ->all();
+
+        if ($teamsWithCalledUp !== []) {
+            $calledUpPlaceholders = implode(',', array_fill(0, count($teamsWithCalledUp), '?'));
+            $calledUpFilter = "AND (ti.is_called_up = true OR t.team_id NOT IN ($calledUpPlaceholders))";
+            $calledUpBindings = $teamsWithCalledUp;
+        } else {
+            $calledUpFilter = '';
+            $calledUpBindings = [];
+        }
+
         DB::insert(<<<SQL
             INSERT INTO game_players (
                 id, game_id, player_id,
@@ -253,11 +278,13 @@ class SetupTournamentGame implements ShouldQueue
                 t.overall_score,
                 t.potential, t.potential_low, t.potential_high, t.tier
             FROM game_player_templates t
+            LEFT JOIN game_player_template_tournament_info ti ON ti.game_player_template_id = t.id
             WHERE t.season = '2025'
               AND t.team_id IN ($placeholders)
               AND t.team_id <> ?
+              $calledUpFilter
             ON CONFLICT (game_id, player_id) DO NOTHING
-        SQL, [$this->gameId, ...$eligibleNationalTeamIds, $this->teamId]);
+        SQL, [$this->gameId, ...$eligibleNationalTeamIds, $this->teamId, ...$calledUpBindings]);
 
         DB::insert(<<<'SQL'
             INSERT INTO game_player_match_state (game_player_id, game_id, fitness, morale)

--- a/app/Modules/Season/Services/GamePlayerTemplateService.php
+++ b/app/Modules/Season/Services/GamePlayerTemplateService.php
@@ -117,6 +117,7 @@ class GamePlayerTemplateService
                         'club_name' => $playerData['club']['name'] ?? null,
                         'club_crest_url' => $playerData['club']['image'] ?? null,
                         'is_injured' => (bool) ($playerData['injured'] ?? false),
+                        'is_called_up' => (bool) ($playerData['calledUp'] ?? false),
                     ];
                 }
             }
@@ -161,13 +162,14 @@ class GamePlayerTemplateService
             }
 
             // Skip rows with no useful data so the satellite stays small.
-            if (!$info['is_injured'] && !$info['club_name'] && !$info['club_crest_url']) {
+            if (!$info['is_injured'] && !$info['is_called_up'] && !$info['club_name'] && !$info['club_crest_url']) {
                 continue;
             }
 
             $satelliteRows[] = [
                 'game_player_template_id' => $templateId,
                 'is_injured' => $info['is_injured'],
+                'is_called_up' => $info['is_called_up'],
                 'club_name' => $info['club_name'],
                 'club_crest_url' => $info['club_crest_url'],
             ];
@@ -179,7 +181,7 @@ class GamePlayerTemplateService
                 ->upsert(
                     $chunk,
                     ['game_player_template_id'],
-                    ['is_injured', 'club_name', 'club_crest_url'],
+                    ['is_injured', 'is_called_up', 'club_name', 'club_crest_url'],
                 );
         }
     }

--- a/data/2025/WC2026/teams/3384.json
+++ b/data/2025/WC2026/teams/3384.json
@@ -1,352 +1,368 @@
 {
-  "image": "https://tmssl.akamaized.net/images/wappen/big/3384.png",
+  "image": "https://assets.virtuafc.com/crests/3384.png",
   "name": "Switzerland",
   "players": [
     {
-      "contract": "Sep 1, 2021",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/16.png",
+        "name": "Borussia Dortmund"
+      },
       "dateOfBirth": "Dec 6, 1997",
       "foot": "right",
       "height": "1,96m",
       "id": "257814",
+      "injured": false,
       "marketValue": "€40.00m",
       "name": "Gregor Kobel",
       "position": "Goalkeeper"
     },
     {
-      "dateOfBirth": "Jun 1, 2003",
-      "foot": "right",
-      "height": "1,91m",
-      "id": "583038",
-      "marketValue": "€4.00m",
-      "name": "Pascal Loretz",
-      "position": "Goalkeeper"
-    },
-    {
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/452.png",
+        "name": "BSC Young Boys"
+      },
       "dateOfBirth": "Jul 3, 2002",
       "foot": "right",
       "height": "1,89m",
       "id": "500763",
-      "marketValue": "€3.50m",
+      "injured": false,
+      "marketValue": "€7.00m",
       "name": "Marvin Keller",
       "position": "Goalkeeper"
     },
     {
-      "contract": "Oct 15, 2018",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/1158.png",
+        "name": "FC Lorient"
+      },
       "dateOfBirth": "Jun 6, 1994",
       "foot": "right",
       "height": "1,90m",
       "id": "147051",
+      "injured": false,
       "marketValue": "€3.00m",
       "name": "Yvon Mvogo",
       "position": "Goalkeeper"
     },
     {
-      "contract": "Jun 9, 2017",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/46.png",
+        "name": "Inter Milan"
+      },
       "dateOfBirth": "Jul 19, 1995",
       "foot": "right",
       "height": "1,88m",
       "id": "284730",
-      "marketValue": "€40.00m",
+      "injured": false,
+      "marketValue": "€18.00m",
       "name": "Manuel Akanji",
       "position": "Centre-Back"
     },
     {
-      "contract": "Nov 15, 2024",
-      "dateOfBirth": "Jul 31, 2003",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/79.png",
+        "name": "VfB Stuttgart"
+      },
+      "dateOfBirth": "Jun 2, 2003",
       "foot": "right",
-      "height": "1,94m",
-      "id": "635645",
-      "marketValue": "€9.50m",
-      "name": "Aurèle Amenda",
+      "height": "1,87m",
+      "id": "539798",
+      "injured": false,
+      "marketValue": "€10.00m",
+      "name": "Luca Jaquez",
       "position": "Centre-Back"
     },
     {
-      "contract": "May 28, 2016",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/18.png",
+        "name": "Borussia Mönchengladbach"
+      },
       "dateOfBirth": "Sep 30, 1996",
       "foot": "right",
       "height": "1,89m",
       "id": "192635",
+      "injured": false,
       "marketValue": "€8.00m",
       "name": "Nico Elvedi",
       "position": "Centre-Back"
     },
     {
-      "contract": "Mar 25, 2025",
-      "dateOfBirth": "May 18, 2003",
-      "foot": "left",
-      "height": "1,89m",
-      "id": "579459",
-      "marketValue": "€7.00m",
-      "name": "Albian Hajdari",
-      "position": "Centre-Back"
-    },
-    {
-      "contract": "Oct 7, 2020",
-      "dateOfBirth": "Jan 20, 2002",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/24.png",
+        "name": "Eintracht Frankfurt"
+      },
+      "dateOfBirth": "Jul 31, 2003",
       "foot": "right",
-      "height": "1,87m",
-      "id": "507344",
-      "marketValue": "€5.00m",
-      "name": "Becir Omeragic",
-      "number": "2",
-      "position": "Centre-Back"
-    },
-    {
-      "contract": "Oct 10, 2025",
-      "dateOfBirth": "Jun 2, 2003",
-      "foot": "right",
-      "height": "1,87m",
-      "id": "539798",
-      "marketValue": "€4.50m",
-      "name": "Luca Jaquez",
-      "position": "Centre-Back"
-    },
-    {
-      "contract": "Sep 1, 2021",
-      "dateOfBirth": "Jun 24, 1998",
-      "foot": "left",
       "height": "1,94m",
-      "id": "382478",
-      "marketValue": "€4.00m",
-      "name": "Cédric Zesiger",
+      "id": "635645",
+      "injured": false,
+      "marketValue": "€8.00m",
+      "name": "Aurèle Amenda",
       "position": "Centre-Back"
     },
     {
-      "contract": "Nov 18, 2019",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/1049.png",
+        "name": "Valencia CF"
+      },
       "dateOfBirth": "Feb 4, 1998",
       "foot": "right",
       "height": "1,83m",
       "id": "298583",
-      "marketValue": "€3.00m",
+      "injured": false,
+      "marketValue": "€2.50m",
       "name": "Eray Cömert",
       "position": "Centre-Back"
     },
     {
-      "contract": "Sep 1, 2021",
-      "dateOfBirth": "Jan 11, 1996",
-      "foot": "left",
-      "height": "1,82m",
-      "id": "192616",
-      "marketValue": "€4.00m",
-      "name": "Ulisses Garcia",
-      "position": "Left-Back"
-    },
-    {
-      "contract": "Nov 18, 2024",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/41.png",
+        "name": "Hamburger SV"
+      },
       "dateOfBirth": "Mar 24, 1998",
       "foot": "left",
       "height": "1,82m",
       "id": "298603",
-      "marketValue": "€2.70m",
+      "injured": false,
+      "marketValue": "€5.00m",
       "name": "Miro Muheim",
       "position": "Left-Back"
     },
     {
-      "contract": "Oct 7, 2011",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/150.png",
+        "name": "Real Betis Balompié"
+      },
       "dateOfBirth": "Aug 25, 1992",
       "foot": "left",
       "height": "1,82m",
       "id": "86784",
-      "marketValue": "€2.50m",
+      "injured": false,
+      "marketValue": "€1.50m",
       "name": "Ricardo Rodríguez",
       "position": "Left-Back"
     },
     {
-      "contract": "Mar 21, 2025",
-      "dateOfBirth": "Dec 7, 1999",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/39.png",
+        "name": "1.FSV Mainz 05"
+      },
+      "dateOfBirth": "Mar 5, 1993",
       "foot": "right",
-      "height": "1,72m",
-      "id": "449597",
-      "marketValue": "€2.20m",
-      "name": "Isaac Schmidt",
-      "position": "Left-Back"
-    },
-    {
-      "dateOfBirth": "Dec 13, 2004",
-      "foot": "right",
-      "height": "1,81m",
-      "id": "990637",
-      "marketValue": "€3.00m",
-      "name": "Zachary Athekame",
+      "height": "1,83m",
+      "id": "168989",
+      "injured": false,
+      "marketValue": "€800k",
+      "name": "Silvan Widmer",
       "position": "Right-Back"
     },
     {
-      "contract": "Mar 21, 2025",
-      "dateOfBirth": "Sep 14, 1996",
-      "foot": "right",
-      "height": "1,78m",
-      "id": "503348",
-      "marketValue": "€2.20m",
-      "name": "Lucas Blondel",
-      "position": "Right-Back"
-    },
-    {
-      "contract": "May 28, 2016",
-      "dateOfBirth": "Nov 20, 1996",
-      "foot": "right",
-      "height": "1,90m",
-      "id": "334526",
-      "marketValue": "€30.00m",
-      "name": "Denis Zakaria",
-      "position": "Defensive Midfield"
-    },
-    {
-      "contract": "Jun 4, 2011",
-      "dateOfBirth": "Sep 27, 1992",
-      "foot": "left",
-      "height": "1,86m",
-      "id": "111455",
-      "marketValue": "€17.00m",
-      "name": "Granit Xhaka",
-      "position": "Defensive Midfield"
-    },
-    {
-      "contract": "Sep 27, 2022",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/5.png",
+        "name": "AC Milan"
+      },
       "dateOfBirth": "Jul 30, 2002",
       "foot": "left",
       "height": "1,81m",
       "id": "608172",
-      "marketValue": "€11.00m",
+      "injured": false,
+      "marketValue": "€30.00m",
       "name": "Ardon Jashari",
       "position": "Defensive Midfield"
     },
     {
-      "contract": "Nov 18, 2019",
-      "dateOfBirth": "Jan 6, 1997",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/162.png",
+        "name": "AS Monaco"
+      },
+      "dateOfBirth": "Nov 20, 1996",
       "foot": "right",
-      "height": "1,83m",
-      "id": "237658",
+      "height": "1,90m",
+      "id": "334526",
+      "injured": false,
+      "marketValue": "€25.00m",
+      "name": "Denis Zakaria",
+      "position": "Defensive Midfield"
+    },
+    {
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/289.png",
+        "name": "Sunderland AFC"
+      },
+      "dateOfBirth": "Sep 27, 1992",
+      "foot": "left",
+      "height": "1,86m",
+      "id": "111455",
+      "injured": false,
       "marketValue": "€10.00m",
-      "name": "Michel Aebischer",
+      "name": "Granit Xhaka",
+      "position": "Defensive Midfield"
+    },
+    {
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/60.png",
+        "name": "SC Freiburg"
+      },
+      "dateOfBirth": "Oct 14, 2005",
+      "foot": "right",
+      "height": "1,82m",
+      "id": "927353",
+      "injured": false,
+      "marketValue": "€35.00m",
+      "name": "Johan Manzambi",
       "position": "Central Midfield"
     },
     {
-      "contract": "Sep 8, 2018",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/368.png",
+        "name": "Sevilla FC"
+      },
       "dateOfBirth": "Feb 6, 1997",
       "foot": "right",
       "height": "1,84m",
       "id": "212723",
+      "injured": false,
       "marketValue": "€7.50m",
       "name": "Djibril Sow",
       "position": "Central Midfield"
     },
     {
-      "contract": "Mar 25, 2017",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/4172.png",
+        "name": "Pisa Sporting Club"
+      },
+      "dateOfBirth": "Jan 6, 1997",
+      "foot": "right",
+      "height": "1,83m",
+      "id": "237658",
+      "injured": false,
+      "marketValue": "€4.50m",
+      "name": "Michel Aebischer",
+      "position": "Central Midfield"
+    },
+    {
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/1025.png",
+        "name": "Bologna FC 1909"
+      },
       "dateOfBirth": "Apr 15, 1992",
       "foot": "right",
       "height": "1,80m",
       "id": "148252",
-      "marketValue": "€6.50m",
+      "injured": false,
+      "marketValue": "€4.00m",
       "name": "Remo Freuler",
       "position": "Central Midfield"
     },
     {
-      "contract": "Mar 26, 2024",
-      "dateOfBirth": "Oct 8, 1995",
-      "foot": "right",
-      "height": "1,85m",
-      "id": "280387",
-      "marketValue": "€4.00m",
-      "name": "Vincent Sierro",
-      "position": "Central Midfield"
-    },
-    {
-      "contract": "Oct 7, 2020",
-      "dateOfBirth": "Apr 11, 2001",
-      "foot": "right",
-      "height": "1,88m",
-      "id": "507486",
-      "marketValue": "€4.00m",
-      "name": "Simon Sohm",
-      "position": "Central Midfield"
-    },
-    {
-      "contract": "Sep 8, 2024",
-      "dateOfBirth": "Aug 5, 1999",
-      "foot": "right",
-      "height": "1,91m",
-      "id": "410787",
-      "marketValue": "€7.00m",
-      "name": "Joël Monteiro",
-      "position": "Left Midfield"
-    },
-    {
-      "contract": "Nov 24, 2022",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/167.png",
+        "name": "FC Augsburg"
+      },
       "dateOfBirth": "Feb 16, 2002",
       "foot": "left",
       "height": "1,79m",
       "id": "507341",
-      "marketValue": "€10.00m",
+      "injured": false,
+      "marketValue": "€8.00m",
       "name": "Fabian Rieder",
       "position": "Attacking Midfield"
     },
     {
-      "contract": "Mar 21, 2025",
-      "dateOfBirth": "Feb 12, 2003",
-      "foot": "left",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/452.png",
+        "name": "BSC Young Boys"
+      },
+      "dateOfBirth": "Nov 11, 1993",
+      "foot": "right",
       "height": "1,83m",
-      "id": "583058",
-      "marketValue": "€9.00m",
-      "name": "Alvyn Sanches",
+      "id": "250490",
+      "injured": false,
+      "marketValue": "€2.00m",
+      "name": "Christian Fassnacht",
       "position": "Attacking Midfield"
     },
     {
-      "contract": "Sep 8, 2019",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/399.png",
+        "name": "Leeds United"
+      },
+      "dateOfBirth": "May 24, 2000",
+      "foot": "right",
+      "height": "1,85m",
+      "id": "346890",
+      "injured": false,
+      "marketValue": "€18.00m",
+      "name": "Noah Okafor",
+      "position": "Left Winger"
+    },
+    {
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/368.png",
+        "name": "Sevilla FC"
+      },
       "dateOfBirth": "Aug 5, 1998",
       "foot": "right",
       "height": "1,79m",
       "id": "345886",
-      "marketValue": "€7.00m",
+      "injured": false,
+      "marketValue": "€12.00m",
       "name": "Rubén Vargas",
       "position": "Left Winger"
     },
     {
-      "contract": "Sep 24, 2022",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/703.png",
+        "name": "Nottingham Forest"
+      },
       "dateOfBirth": "Oct 25, 2000",
       "foot": "right",
       "height": "1,84m",
       "id": "365108",
-      "marketValue": "€25.00m",
+      "injured": false,
+      "marketValue": "€35.00m",
       "name": "Dan Ndoye",
       "position": "Right Winger"
     },
     {
-      "contract": "Sep 27, 2022",
-      "dateOfBirth": "Dec 4, 2000",
-      "foot": "both",
-      "height": "1,85m",
-      "id": "548729",
-      "marketValue": "€15.00m",
-      "name": "Zeki Amdouni",
-      "position": "Centre-Forward"
-    },
-    {
-      "contract": "Mar 31, 2015",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/273.png",
+        "name": "Stade Rennais FC"
+      },
       "dateOfBirth": "Feb 14, 1997",
       "foot": "right",
       "height": "1,87m",
       "id": "237662",
+      "injured": false,
       "marketValue": "€12.00m",
       "name": "Breel Embolo",
       "position": "Centre-Forward"
     },
     {
-      "contract": "Sep 1, 2021",
-      "dateOfBirth": "Jun 22, 1999",
-      "foot": "left",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/1132.png",
+        "name": "Burnley FC"
+      },
+      "dateOfBirth": "Dec 4, 2000",
+      "foot": "both",
       "height": "1,85m",
-      "id": "345468",
-      "marketValue": "€4.00m",
-      "name": "Andi Zeqiri",
+      "id": "548729",
+      "injured": false,
+      "marketValue": "€9.00m",
+      "name": "Zeki Amdouni",
       "position": "Centre-Forward"
     },
     {
-      "contract": "Nov 15, 2019",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/38.png",
+        "name": "Fortuna Düsseldorf"
+      },
       "dateOfBirth": "Dec 27, 1996",
       "foot": "right",
       "height": "1,90m",
       "id": "243856",
-      "marketValue": "€2.00m",
+      "injured": false,
+      "marketValue": "€1.80m",
       "name": "Cedric Itten",
       "position": "Centre-Forward"
     }

--- a/data/2025/WC2026/teams/3439.json
+++ b/data/2025/WC2026/teams/3439.json
@@ -1,540 +1,759 @@
 {
-  "image": "https://tmssl.akamaized.net/images/wappen/big/3439.png",
+  "image": "https://assets.virtuafc.com/crests/3439.png",
   "name": "Brazil",
   "players": [
     {
-      "contract": "Oct 11, 2017",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/36.png",
+        "name": "Fenerbahce"
+      },
       "dateOfBirth": "Aug 17, 1993",
       "foot": "left",
       "height": "1,88m",
       "id": "238223",
+      "injured": false,
       "marketValue": "€30.00m",
       "name": "Ederson",
       "position": "Goalkeeper"
     },
     {
-      "contract": "Oct 14, 2015",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/31.png",
+        "name": "Liverpool FC"
+      },
       "dateOfBirth": "Oct 2, 1992",
       "foot": "right",
       "height": "1,93m",
       "id": "105470",
+      "injured": true,
       "marketValue": "€25.00m",
       "name": "Alisson",
       "position": "Goalkeeper"
     },
     {
-      "contract": "Mar 23, 2024",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/18544.png",
+        "name": "Al-Nassr FC"
+      },
       "dateOfBirth": "Jun 10, 1999",
       "foot": "right",
       "height": "1,90m",
       "id": "691906",
+      "injured": false,
       "marketValue": "€12.00m",
       "name": "Bento",
       "position": "Goalkeeper"
     },
     {
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/399.png",
+        "name": "Leeds United"
+      },
       "dateOfBirth": "Dec 10, 1997",
       "foot": "right",
       "height": "1,97m",
       "id": "352041",
+      "injured": false,
       "marketValue": "€8.00m",
       "name": "Lucas Perri",
       "position": "Goalkeeper"
     },
     {
-      "contract": "Oct 14, 2025",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/199.png",
+        "name": "Sport Club Corinthians Paulista"
+      },
       "dateOfBirth": "Jan 31, 1999",
       "foot": "right",
       "height": "1,99m",
       "id": "574901",
+      "injured": false,
       "marketValue": "€8.00m",
       "name": "Hugo Souza",
-      "number": "1",
       "position": "Goalkeeper"
     },
     {
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/703.png",
+        "name": "Nottingham Forest"
+      },
       "dateOfBirth": "Feb 13, 1996",
       "foot": "right",
       "height": "1,97m",
       "id": "432914",
+      "injured": false,
       "marketValue": "€7.00m",
       "name": "John Victor",
       "position": "Goalkeeper"
     },
     {
-      "contract": "Jan 26, 2017",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/210.png",
+        "name": "Grêmio Foot-Ball Porto Alegrense"
+      },
       "dateOfBirth": "Dec 13, 1987",
       "foot": "right",
       "height": "1,89m",
       "id": "69400",
+      "injured": false,
       "marketValue": "€1.80m",
       "name": "Weverton",
       "position": "Goalkeeper"
     },
     {
-      "contract": "Sep 9, 2023",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/11.png",
+        "name": "Arsenal FC"
+      },
       "dateOfBirth": "Dec 19, 1997",
       "foot": "left",
       "height": "1,90m",
       "id": "435338",
+      "injured": false,
       "marketValue": "€75.00m",
       "name": "Gabriel",
       "position": "Centre-Back"
     },
     {
-      "contract": "Mar 26, 2025",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/703.png",
+        "name": "Nottingham Forest"
+      },
       "dateOfBirth": "Jul 4, 2002",
       "foot": "left",
       "height": "1,80m",
       "id": "1005649",
+      "injured": true,
       "marketValue": "€50.00m",
       "name": "Murillo",
       "position": "Centre-Back"
     },
     {
-      "contract": "Nov 17, 2013",
-      "dateOfBirth": "May 14, 1994",
-      "foot": "right",
-      "height": "1,83m",
-      "id": "181767",
-      "marketValue": "€40.00m",
-      "name": "Marquinhos",
-      "position": "Centre-Back"
-    },
-    {
-      "contract": "Sep 12, 2018",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/418.png",
+        "name": "Real Madrid"
+      },
       "dateOfBirth": "Jan 18, 1998",
       "foot": "right",
       "height": "1,86m",
       "id": "401530",
+      "injured": true,
       "marketValue": "€40.00m",
       "name": "Éder Militão",
       "position": "Centre-Back"
     },
     {
-      "contract": "Mar 23, 2024",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/583.png",
+        "name": "Paris Saint-Germain"
+      },
+      "dateOfBirth": "May 14, 1994",
+      "foot": "right",
+      "height": "1,83m",
+      "id": "181767",
+      "injured": false,
+      "marketValue": "€40.00m",
+      "name": "Marquinhos",
+      "position": "Centre-Back"
+    },
+    {
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/583.png",
+        "name": "Paris Saint-Germain"
+      },
       "dateOfBirth": "Nov 24, 2003",
       "foot": "left",
       "height": "1,86m",
       "id": "872171",
+      "injured": false,
       "marketValue": "€30.00m",
       "name": "Lucas Beraldo",
       "position": "Centre-Back"
     },
     {
-      "contract": "Jun 6, 2025",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/1082.png",
+        "name": "LOSC Lille"
+      },
       "dateOfBirth": "Aug 9, 1999",
       "foot": "both",
       "height": "1,91m",
       "id": "648020",
+      "injured": false,
       "marketValue": "€12.00m",
       "name": "Alexsandro",
       "position": "Centre-Back"
     },
     {
-      "contract": "Mar 21, 2025",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/614.png",
+        "name": "CR Flamengo"
+      },
       "dateOfBirth": "Jan 3, 1996",
       "foot": "right",
       "height": "1,85m",
       "id": "374136",
+      "injured": false,
       "marketValue": "€11.00m",
       "name": "Léo Ortiz",
       "position": "Centre-Back"
     },
     {
-      "contract": "Mar 23, 2024",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/609.png",
+        "name": "Cruzeiro Esporte Clube"
+      },
       "dateOfBirth": "Feb 12, 1996",
       "foot": "right",
       "height": "1,90m",
       "id": "432773",
+      "injured": false,
       "marketValue": "€7.00m",
       "name": "Fabrício Bruno",
       "position": "Centre-Back"
     },
     {
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/614.png",
+        "name": "CR Flamengo"
+      },
       "dateOfBirth": "Jul 15, 1991",
       "foot": "right",
       "height": "1,84m",
       "id": "145707",
+      "injured": false,
       "marketValue": "€4.00m",
       "name": "Danilo",
       "position": "Centre-Back"
     },
     {
-      "contract": "Oct 18, 2023",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/46.png",
+        "name": "Inter Milan"
+      },
       "dateOfBirth": "Jan 7, 1999",
       "foot": "left",
       "height": "1,84m",
       "id": "585982",
+      "injured": false,
       "marketValue": "€22.00m",
       "name": "Carlos Augusto",
       "position": "Left-Back"
     },
     {
-      "contract": "Sep 9, 2023",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/162.png",
+        "name": "AS Monaco"
+      },
       "dateOfBirth": "Jul 31, 1997",
       "foot": "left",
       "height": "1,78m",
       "id": "420064",
+      "injured": true,
       "marketValue": "€18.00m",
       "name": "Caio Henrique",
       "position": "Left-Back"
     },
     {
-      "contract": "Oct 8, 2021",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/2462.png",
+        "name": "Fluminense Football Club"
+      },
       "dateOfBirth": "Apr 14, 1997",
       "foot": "left",
       "height": "1,76m",
       "id": "346766",
+      "injured": false,
       "marketValue": "€13.00m",
       "name": "Guilherme Arana",
       "position": "Left-Back"
     },
     {
-      "contract": "May 30, 2016",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/964.png",
+        "name": "Zenit St. Petersburg"
+      },
       "dateOfBirth": "Mar 22, 1994",
       "foot": "left",
       "height": "1,76m",
       "id": "220793",
+      "injured": false,
       "marketValue": "€10.00m",
       "name": "Douglas Santos",
       "position": "Left-Back"
     },
     {
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/10010.png",
+        "name": "Esporte Clube Bahia"
+      },
       "dateOfBirth": "Aug 29, 1999",
       "foot": "left",
       "height": "1,76m",
       "id": "676035",
+      "injured": false,
       "marketValue": "€3.00m",
       "name": "Luciano Juba",
       "position": "Left-Back"
     },
     {
-      "contract": "Nov 10, 2011",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/614.png",
+        "name": "CR Flamengo"
+      },
       "dateOfBirth": "Jan 26, 1991",
       "foot": "left",
       "height": "1,81m",
       "id": "79960",
+      "injured": false,
       "marketValue": "€1.80m",
       "name": "Alex Sandro",
       "position": "Left-Back"
     },
     {
-      "contract": "Jun 17, 2023",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/162.png",
+        "name": "AS Monaco"
+      },
       "dateOfBirth": "Jun 21, 2001",
       "foot": "right",
       "height": "1,73m",
       "id": "789082",
+      "injured": false,
       "marketValue": "€20.00m",
       "name": "Vanderson",
       "position": "Right-Back"
     },
     {
-      "contract": "Mar 21, 2025",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/12.png",
+        "name": "AS Roma"
+      },
       "dateOfBirth": "Sep 6, 2003",
       "foot": "right",
       "height": "1,78m",
       "id": "964580",
+      "injured": false,
       "marketValue": "€9.00m",
       "name": "Wesley",
       "position": "Right-Back"
     },
     {
-      "contract": "Sep 10, 2025",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/537.png",
+        "name": "Botafogo de Futebol e Regatas"
+      },
       "dateOfBirth": "Jul 23, 1999",
       "foot": "right",
       "height": "1,74m",
       "id": "468249",
+      "injured": false,
       "marketValue": "€6.00m",
       "name": "Vitinho",
       "position": "Right-Back"
     },
     {
-      "contract": "Oct 10, 2025",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/978.png",
+        "name": "Clube de Regatas Vasco da Gama"
+      },
       "dateOfBirth": "Jul 25, 1996",
       "foot": "right",
       "height": "1,75m",
       "id": "412594",
+      "injured": true,
       "marketValue": "€1.70m",
       "name": "Paulo Henrique",
       "position": "Right-Back"
     },
     {
-      "contract": "Jun 20, 2023",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/543.png",
+        "name": "Wolverhampton Wanderers"
+      },
       "dateOfBirth": "Jul 16, 2001",
       "foot": "right",
       "height": "1,76m",
       "id": "800176",
+      "injured": false,
       "marketValue": "€25.00m",
       "name": "André",
       "position": "Defensive Midfield"
     },
     {
-      "contract": "Jun 7, 2015",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/8023.png",
+        "name": "Al-Ittihad Club"
+      },
       "dateOfBirth": "Oct 23, 1993",
       "foot": "right",
       "height": "1,88m",
       "id": "225693",
+      "injured": false,
       "marketValue": "€18.00m",
       "name": "Fabinho",
       "position": "Defensive Midfield"
     },
     {
-      "contract": "Sep 15, 2011",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/985.png",
+        "name": "Manchester United"
+      },
       "dateOfBirth": "Feb 23, 1992",
       "foot": "right",
       "height": "1,85m",
       "id": "16306",
+      "injured": false,
       "marketValue": "€12.00m",
       "name": "Casemiro",
       "position": "Defensive Midfield"
     },
     {
-      "contract": "Nov 18, 2020",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/762.png",
+        "name": "Newcastle United"
+      },
       "dateOfBirth": "Nov 16, 1997",
       "foot": "right",
       "height": "1,82m",
       "id": "520624",
+      "injured": false,
       "marketValue": "€80.00m",
       "name": "Bruno Guimarães",
       "position": "Central Midfield"
     },
     {
-      "contract": "Jun 9, 2024",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/800.png",
+        "name": "Atalanta BC"
+      },
       "dateOfBirth": "Jul 7, 1999",
       "foot": "right",
       "height": "1,83m",
       "id": "607854",
+      "injured": false,
       "marketValue": "€50.00m",
       "name": "Éderson",
       "position": "Central Midfield"
     },
     {
-      "contract": "Jun 17, 2023",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/762.png",
+        "name": "Newcastle United"
+      },
       "dateOfBirth": "Aug 14, 1996",
       "foot": "right",
       "height": "1,86m",
       "id": "333241",
+      "injured": true,
       "marketValue": "€40.00m",
       "name": "Joelinton",
       "position": "Central Midfield"
     },
     {
-      "contract": "Mar 23, 2024",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/543.png",
+        "name": "Wolverhampton Wanderers"
+      },
       "dateOfBirth": "Feb 12, 2001",
       "foot": "right",
       "height": "1,76m",
       "id": "735570",
+      "injured": false,
       "marketValue": "€40.00m",
       "name": "João Gomes",
       "position": "Central Midfield"
     },
     {
-      "contract": "Mar 25, 2023",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/631.png",
+        "name": "Chelsea FC"
+      },
       "dateOfBirth": "May 3, 2004",
       "foot": "right",
       "height": "1,80m",
       "id": "743600",
+      "injured": false,
       "marketValue": "€25.00m",
       "name": "Andrey Santos",
       "position": "Central Midfield"
     },
     {
-      "contract": "Sep 12, 2018",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/1023.png",
+        "name": "Sociedade Esportiva Palmeiras"
+      },
       "dateOfBirth": "Jan 1, 1996",
       "foot": "right",
       "height": "1,78m",
       "id": "203394",
+      "injured": false,
       "marketValue": "€20.00m",
       "name": "Andreas Pereira",
       "position": "Central Midfield"
     },
     {
-      "contract": "Sep 3, 2021",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/609.png",
+        "name": "Cruzeiro Esporte Clube"
+      },
       "dateOfBirth": "May 20, 1997",
       "foot": "left",
       "height": "1,84m",
       "id": "341705",
+      "injured": false,
       "marketValue": "€20.00m",
       "name": "Gerson",
       "position": "Central Midfield"
     },
     {
-      "contract": "Sep 10, 2025",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/10010.png",
+        "name": "Esporte Clube Bahia"
+      },
       "dateOfBirth": "Jun 22, 1998",
       "foot": "right",
       "height": "1,81m",
       "id": "578872",
+      "injured": false,
       "marketValue": "€8.00m",
       "name": "Jean Lucas",
       "position": "Central Midfield"
     },
     {
-      "contract": "Sep 8, 2018",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/614.png",
+        "name": "CR Flamengo"
+      },
       "dateOfBirth": "Aug 27, 1997",
       "foot": "left",
       "height": "1,80m",
       "id": "444523",
+      "injured": false,
       "marketValue": "€40.00m",
       "name": "Lucas Paquetá",
       "position": "Attacking Midfield"
     },
     {
-      "contract": "Sep 11, 2019",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/418.png",
+        "name": "Real Madrid"
+      },
       "dateOfBirth": "Jul 12, 2000",
       "foot": "right",
       "height": "1,76m",
       "id": "371998",
+      "injured": false,
       "marketValue": "€200.00m",
       "name": "Vinicius Junior",
       "position": "Left Winger"
     },
     {
-      "contract": "Oct 8, 2021",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/131.png",
+        "name": "FC Barcelona"
+      },
       "dateOfBirth": "Dec 14, 1996",
       "foot": "left",
       "height": "1,76m",
       "id": "411295",
+      "injured": false,
       "marketValue": "€80.00m",
       "name": "Raphinha",
       "position": "Left Winger"
     },
     {
-      "contract": "Mar 25, 2022",
-      "dateOfBirth": "Jun 18, 2001",
-      "foot": "right",
-      "height": "1,78m",
-      "id": "655488",
-      "marketValue": "€55.00m",
-      "name": "Gabriel Martinelli",
-      "position": "Left Winger"
-    },
-    {
-      "contract": "Mar 23, 2024",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/281.png",
+        "name": "Manchester City"
+      },
       "dateOfBirth": "Apr 10, 2004",
       "foot": "left",
       "height": "1,76m",
       "id": "743591",
+      "injured": false,
       "marketValue": "€55.00m",
       "name": "Savinho",
       "position": "Left Winger"
     },
     {
-      "contract": "Sep 10, 2025",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/11.png",
+        "name": "Arsenal FC"
+      },
+      "dateOfBirth": "Jun 18, 2001",
+      "foot": "right",
+      "height": "1,78m",
+      "id": "655488",
+      "injured": false,
+      "marketValue": "€55.00m",
+      "name": "Gabriel Martinelli",
+      "position": "Left Winger"
+    },
+    {
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/614.png",
+        "name": "CR Flamengo"
+      },
       "dateOfBirth": "Dec 23, 1999",
       "foot": "right",
       "height": "1,77m",
       "id": "694928",
+      "injured": false,
       "marketValue": "€25.00m",
       "name": "Samuel Lino",
       "position": "Left Winger"
     },
     {
-      "contract": "Nov 15, 2019",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/418.png",
+        "name": "Real Madrid"
+      },
       "dateOfBirth": "Jan 9, 2001",
       "foot": "right",
       "height": "1,74m",
       "id": "412363",
+      "injured": true,
       "marketValue": "€100.00m",
       "name": "Rodrygo",
       "position": "Right Winger"
     },
     {
-      "contract": "Sep 7, 2024",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/631.png",
+        "name": "Chelsea FC"
+      },
       "dateOfBirth": "Apr 24, 2007",
       "foot": "left",
-      "height": "1,76m",
+      "height": "1,78m",
       "id": "1056993",
+      "injured": true,
       "marketValue": "€50.00m",
       "name": "Estêvão",
       "position": "Right Winger"
     },
     {
-      "contract": "Sep 7, 2024",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/964.png",
+        "name": "Zenit St. Petersburg"
+      },
       "dateOfBirth": "Jan 2, 2001",
       "foot": "left",
       "height": "1,82m",
       "id": "800175",
+      "injured": false,
       "marketValue": "€22.00m",
       "name": "Luiz Henrique",
       "position": "Right Winger"
     },
     {
-      "contract": "Oct 8, 2021",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/150.png",
+        "name": "Real Betis Balompié"
+      },
       "dateOfBirth": "Feb 24, 2000",
       "foot": "left",
       "height": "1,72m",
       "id": "602105",
+      "injured": false,
       "marketValue": "€20.00m",
       "name": "Antony",
       "position": "Right Winger"
     },
     {
-      "contract": "Sep 3, 2021",
-      "dateOfBirth": "May 27, 1999",
-      "foot": "right",
-      "height": "1,83m",
-      "id": "517894",
-      "marketValue": "€50.00m",
-      "name": "Matheus Cunha",
-      "position": "Centre-Forward"
-    },
-    {
-      "contract": "Nov 17, 2023",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/631.png",
+        "name": "Chelsea FC"
+      },
       "dateOfBirth": "Sep 26, 2001",
       "foot": "right",
-      "height": "1,82m",
+      "height": "1,86m",
       "id": "626724",
+      "injured": false,
       "marketValue": "€50.00m",
       "name": "João Pedro",
       "position": "Centre-Forward"
     },
     {
-      "contract": "Nov 17, 2023",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/985.png",
+        "name": "Manchester United"
+      },
+      "dateOfBirth": "May 27, 1999",
+      "foot": "right",
+      "height": "1,83m",
+      "id": "517894",
+      "injured": false,
+      "marketValue": "€50.00m",
+      "name": "Matheus Cunha",
+      "position": "Centre-Forward"
+    },
+    {
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/1041.png",
+        "name": "Olympique Lyon"
+      },
       "dateOfBirth": "Jul 21, 2006",
       "foot": "left",
       "height": "1,73m",
       "id": "971570",
+      "injured": false,
       "marketValue": "€40.00m",
       "name": "Endrick",
       "position": "Centre-Forward"
     },
     {
-      "contract": "Sep 8, 2018",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/148.png",
+        "name": "Tottenham Hotspur"
+      },
       "dateOfBirth": "May 10, 1997",
       "foot": "right",
       "height": "1,84m",
       "id": "378710",
+      "injured": false,
       "marketValue": "€30.00m",
       "name": "Richarlison",
       "position": "Centre-Forward"
     },
     {
-      "contract": "Mar 25, 2023",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/1023.png",
+        "name": "Sociedade Esportiva Palmeiras"
+      },
       "dateOfBirth": "Feb 28, 2005",
       "foot": "right",
       "height": "1,74m",
       "id": "943837",
+      "injured": true,
       "marketValue": "€20.00m",
       "name": "Vitor Roque",
       "position": "Centre-Forward"
     },
     {
-      "contract": "Oct 11, 2024",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/703.png",
+        "name": "Nottingham Forest"
+      },
       "dateOfBirth": "Feb 25, 2001",
       "foot": "right",
       "height": "1,79m",
       "id": "432164",
+      "injured": false,
       "marketValue": "€15.00m",
       "name": "Igor Jesus",
       "position": "Centre-Forward"
     },
     {
-      "contract": "Sep 5, 2025",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/609.png",
+        "name": "Cruzeiro Esporte Clube"
+      },
       "dateOfBirth": "Jan 24, 2002",
       "foot": "right",
       "height": "1,82m",
       "id": "620477",
+      "injured": false,
       "marketValue": "€4.50m",
       "name": "Kaio Jorge",
       "position": "Centre-Forward"

--- a/data/2025/WC2026/teams/3445.json
+++ b/data/2025/WC2026/teams/3445.json
@@ -1,275 +1,409 @@
 {
-  "image": "https://tmssl.akamaized.net/images/wappen/big/3445.png",
+  "image": "https://assets.virtuafc.com/crests/3445.png",
   "name": "Czechia",
   "players": [
     {
-      "contract": "Mar 31, 2026",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/1075.png",
+        "name": "SC Braga"
+      },
       "dateOfBirth": "Jul 13, 2002",
       "foot": "right",
       "height": "1,98m",
       "id": "629773",
+      "injured": false,
       "marketValue": "€15.00m",
       "name": "Lukas Hornicek",
-      "number": "16",
       "position": "Goalkeeper"
     },
     {
-      "contract": "Mar 26, 2024",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/383.png",
+        "name": "PSV Eindhoven"
+      },
       "dateOfBirth": "May 17, 2000",
       "foot": "right",
       "height": "1,96m",
       "id": "550829",
+      "injured": false,
       "marketValue": "€7.00m",
       "name": "Matej Kovar",
-      "number": "1",
       "position": "Goalkeeper"
     },
     {
-      "contract": "Nov 13, 2025",
-      "dateOfBirth": "Jan 24, 1998",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/62.png",
+        "name": "SK Slavia Prague"
+      },
+      "dateOfBirth": "Apr 27, 1996",
       "foot": "right",
-      "height": "1,87m",
-      "id": "293357",
-      "marketValue": "€2.50m",
-      "name": "Martin Jedlicka",
-      "number": "23",
+      "height": "1,92m",
+      "id": "242089",
+      "injured": false,
+      "marketValue": "€2.00m",
+      "name": "Jindrich Stanek",
       "position": "Goalkeeper"
     },
     {
-      "contract": "Mar 24, 2022",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/543.png",
+        "name": "Wolverhampton Wanderers"
+      },
       "dateOfBirth": "Apr 20, 1999",
       "foot": "left",
       "height": "1,91m",
       "id": "345911",
+      "injured": false,
       "marketValue": "€22.00m",
       "name": "Ladislav Krejčí",
-      "number": "7",
       "position": "Centre-Back"
     },
     {
-      "contract": "Mar 26, 2024",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/533.png",
+        "name": "TSG 1899 Hoffenheim"
+      },
       "dateOfBirth": "Jan 29, 2000",
       "foot": "right",
       "height": "1,90m",
       "id": "620217",
+      "injured": false,
       "marketValue": "€10.00m",
       "name": "Robin Hranac",
-      "number": "4",
       "position": "Centre-Back"
     },
     {
-      "contract": "Nov 20, 2023",
-      "dateOfBirth": "Jan 21, 2003",
-      "foot": "right",
-      "height": "1,93m",
-      "id": "652054",
-      "marketValue": "€10.00m",
-      "name": "Martin Vitík",
-      "number": "6",
-      "position": "Centre-Back"
-    },
-    {
-      "contract": "Nov 17, 2025",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/62.png",
+        "name": "SK Slavia Prague"
+      },
       "dateOfBirth": "Mar 8, 2003",
       "foot": "right",
       "height": "1,88m",
       "id": "944827",
-      "marketValue": "€8.00m",
+      "injured": false,
+      "marketValue": "€10.00m",
       "name": "Stepan Chaloupek",
-      "number": "2",
       "position": "Centre-Back"
     },
     {
-      "contract": "Sep 7, 2020",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/62.png",
+        "name": "SK Slavia Prague"
+      },
+      "dateOfBirth": "Nov 8, 2000",
+      "foot": "right",
+      "height": "1,90m",
+      "id": "544149",
+      "injured": false,
+      "marketValue": "€7.00m",
+      "name": "David Zima",
+      "position": "Centre-Back"
+    },
+    {
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/62.png",
+        "name": "SK Slavia Prague"
+      },
       "dateOfBirth": "Mar 31, 1993",
       "foot": "right",
       "height": "1,80m",
       "id": "216278",
-      "marketValue": "€1.20m",
+      "injured": false,
+      "marketValue": "€1.00m",
       "name": "Tomas Holes",
-      "number": "3",
       "position": "Centre-Back"
     },
     {
-      "contract": "Sep 7, 2020",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/197.png",
+        "name": "AC Sparta Prague"
+      },
       "dateOfBirth": "Aug 20, 1992",
       "foot": "left",
       "height": "1,90m",
       "id": "142219",
-      "marketValue": "€700k",
+      "injured": false,
+      "marketValue": "€600k",
       "name": "Jaroslav Zelený",
-      "number": "20",
       "position": "Centre-Back"
     },
     {
-      "contract": "Mar 24, 2023",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/62.png",
+        "name": "SK Slavia Prague"
+      },
       "dateOfBirth": "Aug 7, 2000",
       "foot": "left",
       "height": "1,83m",
       "id": "500054",
+      "injured": false,
       "marketValue": "€5.00m",
       "name": "David Jurásek",
-      "number": "17",
       "position": "Left-Back"
     },
     {
-      "contract": "Nov 11, 2017",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/533.png",
+        "name": "TSG 1899 Hoffenheim"
+      },
       "dateOfBirth": "Aug 22, 1992",
       "foot": "right",
       "height": "1,74m",
       "id": "157672",
+      "injured": false,
       "marketValue": "€2.70m",
       "name": "Vladimír Coufal",
-      "number": "5",
       "position": "Right-Back"
     },
     {
-      "contract": "Nov 15, 2016",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/379.png",
+        "name": "West Ham United"
+      },
       "dateOfBirth": "Feb 27, 1995",
       "foot": "right",
       "height": "1,92m",
       "id": "283628",
+      "injured": false,
       "marketValue": "€12.00m",
       "name": "Tomáš Souček",
-      "number": "22",
       "position": "Defensive Midfield"
     },
     {
-      "contract": "Jun 4, 2021",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/62.png",
+        "name": "SK Slavia Prague"
+      },
       "dateOfBirth": "May 31, 1999",
       "foot": "left",
       "height": "1,69m",
       "id": "321204",
+      "injured": false,
       "marketValue": "€8.00m",
       "name": "Michal Sadílek",
-      "number": "18",
       "position": "Central Midfield"
     },
     {
-      "contract": "Jun 7, 2024",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/941.png",
+        "name": "FC Viktoria Plzen"
+      },
       "dateOfBirth": "Apr 10, 2001",
       "height": "1,82m",
       "id": "611049",
+      "injured": false,
       "marketValue": "€6.00m",
       "name": "Lukas Cerv",
-      "number": "12",
       "position": "Central Midfield"
     },
     {
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/51772.png",
+        "name": "FC Cincinnati"
+      },
       "dateOfBirth": "Mar 11, 1998",
       "foot": "right",
       "height": "1,77m",
       "id": "563033",
+      "injured": false,
       "marketValue": "€4.00m",
       "name": "Pavel Bucha",
       "position": "Central Midfield"
     },
     {
-      "contract": "May 26, 2012",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/197.png",
+        "name": "AC Sparta Prague"
+      },
+      "dateOfBirth": "Jun 7, 2008",
+      "foot": "right",
+      "height": "1,83m",
+      "id": "1206877",
+      "injured": false,
+      "marketValue": "€3.50m",
+      "name": "Hugo Sochurek",
+      "position": "Central Midfield"
+    },
+    {
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/941.png",
+        "name": "FC Viktoria Plzen"
+      },
+      "dateOfBirth": "Apr 2, 2003",
+      "height": "1,88m",
+      "id": "826103",
+      "injured": false,
+      "marketValue": "€2.30m",
+      "name": "Alexandr Sojka",
+      "position": "Central Midfield"
+    },
+    {
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/1897.png",
+        "name": "FC Hradec Kralove"
+      },
       "dateOfBirth": "Aug 8, 1990",
       "foot": "right",
       "height": "1,72m",
       "id": "179643",
-      "marketValue": "€400k",
+      "injured": false,
+      "marketValue": "€375k",
       "name": "Vladimír Darida",
-      "number": "8",
       "position": "Central Midfield"
     },
     {
-      "contract": "Mar 22, 2024",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/62.png",
+        "name": "SK Slavia Prague"
+      },
+      "dateOfBirth": "May 31, 1998",
+      "foot": "right",
+      "height": "1,75m",
+      "id": "493758",
+      "injured": false,
+      "marketValue": "€3.50m",
+      "name": "David Doudera",
+      "position": "Right Midfield"
+    },
+    {
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/1041.png",
+        "name": "Olympique Lyon"
+      },
       "dateOfBirth": "Dec 29, 2000",
       "foot": "right",
       "height": "1,77m",
       "id": "500053",
+      "injured": false,
       "marketValue": "€20.00m",
       "name": "Pavel Sulc",
-      "number": "15",
       "position": "Attacking Midfield"
     },
     {
-      "contract": "Sep 8, 2025",
-      "dateOfBirth": "Jul 2, 2003",
-      "foot": "left",
-      "height": "1,87m",
-      "id": "652061",
-      "marketValue": "€8.00m",
-      "name": "Adam Karabec",
-      "number": "9",
-      "position": "Attacking Midfield"
-    },
-    {
-      "contract": "Sep 4, 2020",
-      "dateOfBirth": "Oct 23, 1996",
-      "foot": "left",
-      "height": "1,89m",
-      "id": "292779",
-      "marketValue": "€8.00m",
-      "name": "Lukas Provod",
-      "number": "14",
-      "position": "Attacking Midfield"
-    },
-    {
-      "contract": "Mar 31, 2026",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/941.png",
+        "name": "FC Viktoria Plzen"
+      },
       "dateOfBirth": "Mar 21, 2003",
       "foot": "right",
       "height": "1,78m",
       "id": "652060",
-      "marketValue": "€1.80m",
+      "injured": false,
+      "marketValue": "€3.00m",
       "name": "Denis Visinsky",
-      "number": "21",
       "position": "Attacking Midfield"
     },
     {
-      "contract": "Nov 13, 2025",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/941.png",
+        "name": "FC Viktoria Plzen"
+      },
       "dateOfBirth": "Apr 24, 1997",
       "foot": "right",
       "height": "1,78m",
       "id": "334803",
-      "marketValue": "€1.00m",
+      "injured": false,
+      "marketValue": "€1.30m",
       "name": "Tomas Ladra",
       "position": "Attacking Midfield"
     },
     {
-      "contract": "May 27, 2016",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/62.png",
+        "name": "SK Slavia Prague"
+      },
+      "dateOfBirth": "Oct 23, 1996",
+      "foot": "left",
+      "height": "1,91m",
+      "id": "292779",
+      "injured": false,
+      "marketValue": "€8.00m",
+      "name": "Lukas Provod",
+      "position": "Left Winger"
+    },
+    {
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/15.png",
+        "name": "Bayer 04 Leverkusen"
+      },
       "dateOfBirth": "Jan 24, 1996",
       "foot": "left",
       "height": "1,91m",
       "id": "242086",
+      "injured": false,
       "marketValue": "€20.00m",
       "name": "Patrik Schick",
-      "number": "10",
       "position": "Centre-Forward"
     },
     {
-      "contract": "Nov 16, 2022",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/533.png",
+        "name": "TSG 1899 Hoffenheim"
+      },
+      "dateOfBirth": "Jul 25, 2002",
+      "foot": "right",
+      "height": "1,88m",
+      "id": "552057",
+      "injured": false,
+      "marketValue": "€12.00m",
+      "name": "Adam Hlozek",
+      "position": "Centre-Forward"
+    },
+    {
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/62.png",
+        "name": "SK Slavia Prague"
+      },
       "dateOfBirth": "Apr 29, 1999",
+      "foot": "right",
       "height": "1,87m",
       "id": "405855",
+      "injured": false,
       "marketValue": "€4.00m",
       "name": "Mojmír Chytil",
-      "number": "13",
       "position": "Centre-Forward"
     },
     {
-      "contract": "Nov 20, 2023",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/62.png",
+        "name": "SK Slavia Prague"
+      },
       "dateOfBirth": "Jan 26, 1995",
       "foot": "right",
       "height": "1,99m",
       "id": "198614",
-      "marketValue": "€3.00m",
+      "injured": false,
+      "marketValue": "€2.70m",
       "name": "Tomas Chory",
-      "number": "19",
       "position": "Centre-Forward"
     },
     {
-      "contract": "Sep 1, 2017",
-      "dateOfBirth": "Sep 1, 1993",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/197.png",
+        "name": "AC Sparta Prague"
+      },
+      "dateOfBirth": "Jan 8, 1997",
       "foot": "right",
       "height": "1,85m",
-      "id": "218299",
-      "marketValue": "€500k",
-      "name": "Jan Kliment",
-      "number": "11",
+      "id": "334802",
+      "injured": false,
+      "marketValue": "€2.70m",
+      "name": "Jan Kuchta",
+      "position": "Centre-Forward"
+    },
+    {
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/5546.png",
+        "name": "FK Mlada Boleslav"
+      },
+      "dateOfBirth": "Aug 27, 2003",
+      "foot": "right",
+      "height": "1,88m",
+      "id": "707347",
+      "injured": false,
+      "marketValue": "€750k",
+      "name": "Christophe Kabongo",
       "position": "Centre-Forward"
     }
   ],

--- a/data/2025/WC2026/teams/3446.json
+++ b/data/2025/WC2026/teams/3446.json
@@ -1,268 +1,369 @@
 {
-  "image": "https://tmssl.akamaized.net/images/wappen/big/3446.png",
+  "image": "https://assets.virtuafc.com/crests/3446.png",
   "name": "Bosnia-Herzegovina",
   "players": [
     {
-      "contract": "Mar 27, 2021",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/35.png",
+        "name": "FC St. Pauli"
+      },
       "dateOfBirth": "Dec 2, 1995",
       "foot": "right",
       "height": "1,93m",
       "id": "248454",
+      "injured": false,
       "marketValue": "€4.50m",
       "name": "Nikola Vasilj",
-      "number": "1",
       "position": "Goalkeeper"
     },
     {
-      "contract": "Nov 19, 2024",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/144.png",
+        "name": "HNK Rijeka"
+      },
       "dateOfBirth": "Aug 16, 1998",
       "foot": "right",
       "height": "1,90m",
       "id": "495320",
+      "injured": false,
       "marketValue": "€2.00m",
       "name": "Martin Zlomislic",
-      "number": "22",
       "position": "Goalkeeper"
     },
     {
-      "contract": "Mar 31, 2026",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/2362.png",
+        "name": "Slaven Belupo Koprivnica"
+      },
       "dateOfBirth": "Mar 12, 1996",
       "foot": "right",
       "height": "1,89m",
       "id": "188881",
+      "injured": false,
       "marketValue": "€400k",
       "name": "Osman Hadzikic",
-      "number": "12",
       "position": "Goalkeeper"
     },
     {
-      "contract": "Jun 3, 2024",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/6574.png",
+        "name": "US Sassuolo"
+      },
       "dateOfBirth": "Feb 28, 2003",
       "foot": "left",
       "height": "1,92m",
       "id": "679423",
+      "injured": false,
       "marketValue": "€20.00m",
       "name": "Tarik Muharemović",
-      "number": "4",
       "position": "Centre-Back"
     },
     {
-      "contract": "Nov 19, 2013",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/800.png",
+        "name": "Atalanta BC"
+      },
       "dateOfBirth": "Jun 20, 1993",
       "foot": "left",
       "height": "1,83m",
       "id": "94005",
+      "injured": false,
       "marketValue": "€6.00m",
       "name": "Sead Kolasinac",
-      "number": "5",
       "position": "Centre-Back"
     },
     {
-      "contract": "Mar 31, 2026",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/826.png",
+        "name": "RC Lens"
+      },
       "dateOfBirth": "Jul 17, 2006",
       "foot": "right",
       "height": "1,92m",
       "id": "819566",
+      "injured": false,
       "marketValue": "€4.00m",
       "name": "Nidal Celik",
-      "number": "3",
       "position": "Centre-Back"
     },
     {
-      "contract": "Jun 3, 2024",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/144.png",
+        "name": "HNK Rijeka"
+      },
       "dateOfBirth": "Sep 5, 1997",
       "foot": "left",
       "height": "2,01m",
       "id": "384568",
+      "injured": false,
       "marketValue": "€2.80m",
       "name": "Stjepan Radeljic",
-      "number": "21",
       "position": "Centre-Back"
     },
     {
-      "contract": "Jun 3, 2024",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/33.png",
+        "name": "FC Schalke 04"
+      },
       "dateOfBirth": "Oct 10, 1996",
       "foot": "right",
       "height": "1,94m",
       "id": "422051",
+      "injured": false,
       "marketValue": "€1.80m",
       "name": "Nikola Katic",
-      "number": "18",
       "position": "Centre-Back"
     },
     {
-      "contract": "Nov 16, 2023",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/1038.png",
+        "name": "UC Sampdoria"
+      },
+      "dateOfBirth": "Jul 9, 1998",
+      "foot": "right",
+      "height": "1,91m",
+      "id": "322065",
+      "injured": false,
+      "marketValue": "€1.30m",
+      "name": "Dennis Hadzikadunic",
+      "position": "Centre-Back"
+    },
+    {
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/2832.png",
+        "name": "Gaziantep FK"
+      },
       "dateOfBirth": "Apr 15, 1998",
       "foot": "left",
       "height": "1,89m",
       "id": "380919",
+      "injured": false,
       "marketValue": "€1.20m",
       "name": "Nihad Mujakic",
-      "number": "2",
       "position": "Centre-Back"
     },
     {
-      "contract": "Mar 29, 2022",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/294.png",
+        "name": "SL Benfica"
+      },
       "dateOfBirth": "Aug 18, 2002",
       "foot": "right",
       "height": "1,80m",
       "id": "519184",
+      "injured": false,
       "marketValue": "€15.00m",
       "name": "Amar Dedić",
-      "number": "7",
       "position": "Right-Back"
     },
     {
-      "contract": "Sep 4, 2020",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/3008.png",
+        "name": "Hull City"
+      },
       "dateOfBirth": "Mar 8, 1997",
       "foot": "right",
       "height": "1,81m",
       "id": "293213",
+      "injured": false,
       "marketValue": "€4.20m",
       "name": "Amir Hadziahmetovic",
-      "number": "16",
       "position": "Defensive Midfield"
     },
     {
-      "contract": "Nov 16, 2024",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/45457.png",
+        "name": "Pafos FC"
+      },
       "dateOfBirth": "Oct 9, 1996",
       "foot": "right",
       "height": "1,85m",
       "id": "226097",
+      "injured": false,
       "marketValue": "€1.80m",
       "name": "Ivan Sunjic",
-      "number": "14",
       "position": "Defensive Midfield"
     },
     {
-      "contract": "Jun 3, 2024",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/48.png",
+        "name": "Karlsruher SC"
+      },
       "dateOfBirth": "May 22, 1998",
       "foot": "left",
       "height": "1,81m",
       "id": "251295",
+      "injured": false,
       "marketValue": "€1.20m",
       "name": "Dzenis Burnic",
-      "number": "17",
       "position": "Defensive Midfield"
     },
     {
-      "contract": "Mar 23, 2023",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/206.png",
+        "name": "Bröndby IF"
+      },
       "dateOfBirth": "Mar 3, 2003",
       "foot": "right",
       "height": "1,91m",
       "id": "787907",
+      "injured": false,
       "marketValue": "€4.50m",
       "name": "Benjamin Tahirović",
-      "number": "6",
       "position": "Central Midfield"
     },
     {
-      "contract": "Jun 3, 2024",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/452.png",
+        "name": "BSC Young Boys"
+      },
       "dateOfBirth": "Apr 6, 2002",
       "foot": "right",
       "height": "1,87m",
       "id": "651269",
+      "injured": false,
       "marketValue": "€2.50m",
       "name": "Armin Gigovic",
-      "number": "8",
       "position": "Central Midfield"
     },
     {
-      "contract": "Nov 19, 2023",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/22220.png",
+        "name": "FC Astana"
+      },
       "dateOfBirth": "Apr 30, 2002",
       "foot": "left",
       "height": "1,78m",
       "id": "620560",
+      "injured": false,
       "marketValue": "€1.20m",
       "name": "Ivan Basic",
-      "number": "13",
       "position": "Central Midfield"
     },
     {
-      "contract": "Mar 21, 2025",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/941.png",
+        "name": "FC Viktoria Plzen"
+      },
       "dateOfBirth": "Jan 20, 2001",
       "foot": "right",
       "height": "1,76m",
       "id": "638990",
+      "injured": false,
       "marketValue": "€4.50m",
       "name": "Amar Memić",
-      "number": "15",
       "position": "Right Midfield"
     },
     {
-      "contract": "Sep 6, 2025",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/697.png",
+        "name": "FC Slovan Liberec"
+      },
+      "dateOfBirth": "Mar 14, 2005",
+      "foot": "right",
+      "height": "1,82m",
+      "id": "803049",
+      "injured": false,
+      "marketValue": "€5.00m",
+      "name": "Ermin Mahmic",
+      "position": "Attacking Midfield"
+    },
+    {
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/409.png",
+        "name": "Red Bull Salzburg"
+      },
       "dateOfBirth": "Sep 21, 2007",
       "foot": "both",
       "height": "1,86m",
       "id": "929994",
+      "injured": false,
       "marketValue": "€15.00m",
       "name": "Kerim Alajbegovic",
-      "number": "19",
       "position": "Left Winger"
     },
     {
-      "contract": "Sep 7, 2024",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/383.png",
+        "name": "PSV Eindhoven"
+      },
       "dateOfBirth": "Mar 10, 2005",
       "foot": "left",
       "height": "1,75m",
       "id": "925862",
+      "injured": false,
       "marketValue": "€5.00m",
       "name": "Esmir Bajraktarevic",
-      "number": "20",
       "position": "Right Winger"
     },
     {
-      "contract": "Mar 24, 2021",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/79.png",
+        "name": "VfB Stuttgart"
+      },
       "dateOfBirth": "Mar 25, 1998",
       "foot": "right",
       "height": "1,85m",
       "id": "335457",
+      "injured": false,
       "marketValue": "€22.00m",
       "name": "Ermedin Demirovic",
-      "number": "10",
       "position": "Centre-Forward"
     },
     {
-      "contract": "Nov 16, 2023",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/18.png",
+        "name": "Borussia Mönchengladbach"
+      },
       "dateOfBirth": "Jun 20, 1994",
       "foot": "right",
       "height": "1,96m",
       "id": "203123",
+      "injured": false,
       "marketValue": "€3.00m",
       "name": "Haris Tabakovic",
-      "number": "23",
       "position": "Centre-Forward"
     },
     {
-      "contract": "Dec 19, 2021",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/6429.png",
+        "name": "FC Universitatea Cluj"
+      },
       "dateOfBirth": "Nov 28, 1998",
       "foot": "left",
       "height": "1,90m",
       "id": "457738",
+      "injured": false,
       "marketValue": "€1.50m",
       "name": "Jovo Lukić",
       "position": "Centre-Forward"
     },
     {
-      "contract": "Nov 16, 2024",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/2300.png",
+        "name": "Jagiellonia Bialystok"
+      },
       "dateOfBirth": "Jan 31, 2004",
       "foot": "right",
       "height": "1,89m",
       "id": "710969",
+      "injured": false,
       "marketValue": "€1.50m",
       "name": "Samed Bazdar",
-      "number": "9",
       "position": "Centre-Forward"
     },
     {
-      "contract": "Jun 2, 2007",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/33.png",
+        "name": "FC Schalke 04"
+      },
       "dateOfBirth": "Mar 17, 1986",
       "foot": "right",
       "height": "1,93m",
       "id": "28396",
+      "injured": false,
       "marketValue": "€1.50m",
       "name": "Edin Dzeko",
-      "number": "11",
       "position": "Centre-Forward"
     }
   ],

--- a/data/2025/WC2026/teams/3589.json
+++ b/data/2025/WC2026/teams/3589.json
@@ -1,374 +1,369 @@
 {
-  "image": "https://tmssl.akamaized.net/images/wappen/big/3589.png",
+  "image": "https://assets.virtuafc.com/crests/3589.png",
   "name": "South Korea",
   "players": [
     {
-      "contract": "Jul 24, 2022",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/6502.png",
+        "name": "Jeonbuk Hyundai Motors"
+      },
       "dateOfBirth": "Oct 15, 1997",
       "foot": "right",
       "height": "1,94m",
       "id": "508237",
-      "marketValue": "€850k",
+      "injured": false,
+      "marketValue": "€1.00m",
       "name": "Bum-keun Song",
-      "number": "12",
       "position": "Goalkeeper"
     },
     {
-      "contract": "Nov 14, 2017",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/3535.png",
+        "name": "Ulsan HD FC"
+      },
       "dateOfBirth": "Sep 25, 1991",
       "foot": "right",
       "height": "1,89m",
       "id": "260171",
-      "marketValue": "€850k",
+      "injured": false,
+      "marketValue": "€650k",
       "name": "Hyeon-woo Jo",
-      "number": "21",
       "position": "Goalkeeper"
     },
     {
-      "contract": "Aug 14, 2013",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/6631.png",
+        "name": "FC Tokyo"
+      },
       "dateOfBirth": "Sep 30, 1990",
       "foot": "right",
       "height": "1,89m",
       "id": "92076",
-      "marketValue": "€700k",
+      "injured": false,
+      "marketValue": "€600k",
       "name": "Seung-gyu Kim",
-      "number": "1",
       "position": "Goalkeeper"
     },
     {
-      "contract": "Aug 31, 2017",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/27.png",
+        "name": "Bayern Munich"
+      },
       "dateOfBirth": "Nov 15, 1996",
       "foot": "right",
       "height": "1,90m",
       "id": "503482",
-      "marketValue": "€45.00m",
+      "injured": false,
+      "marketValue": "€25.00m",
       "name": "Min-jae Kim",
-      "number": "4",
       "position": "Centre-Back"
     },
     {
-      "contract": "Jul 20, 2022",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/13613.png",
+        "name": "Sharjah FC"
+      },
       "dateOfBirth": "Nov 17, 1996",
       "foot": "right",
-      "height": "1,85m",
+      "height": "1,86m",
       "id": "561212",
-      "marketValue": "€2.00m",
+      "injured": false,
+      "marketValue": "€1.80m",
       "name": "Yu-min Cho",
       "position": "Centre-Back"
     },
     {
-      "contract": "Jun 6, 2024",
-      "dateOfBirth": "May 7, 1997",
-      "foot": "right",
-      "height": "1,84m",
-      "id": "658776",
-      "marketValue": "€1.00m",
-      "name": "Seung-wook Park",
-      "position": "Centre-Back"
-    },
-    {
-      "contract": "Jun 10, 2025",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/865.png",
+        "name": "FC Midtjylland"
+      },
       "dateOfBirth": "Jun 17, 2002",
       "foot": "right",
       "height": "1,90m",
       "id": "706963",
-      "marketValue": "€1.00m",
+      "injured": false,
+      "marketValue": "€1.80m",
       "name": "Han-beom Lee",
-      "number": "3",
       "position": "Centre-Back"
     },
     {
-      "contract": "Jul 24, 2022",
-      "dateOfBirth": "Dec 12, 2000",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/21459.png",
+        "name": "Gangwon FC"
+      },
+      "dateOfBirth": "Jul 7, 2000",
       "foot": "left",
-      "height": "1,89m",
-      "id": "568633",
-      "marketValue": "€850k",
-      "name": "Ju-sung Kim",
-      "number": "14",
+      "height": "1,85m",
+      "id": "763349",
+      "injured": false,
+      "marketValue": "€800k",
+      "name": "Gi-hyuk Lee",
       "position": "Centre-Back"
     },
     {
-      "contract": "Jun 20, 2023",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/2241.png",
+        "name": "Kashima Antlers"
+      },
+      "dateOfBirth": "Sep 17, 2000",
+      "foot": "left",
+      "height": "1,87m",
+      "id": "645847",
+      "injured": false,
+      "marketValue": "€700k",
+      "name": "Tae-hyeon Kim",
+      "position": "Centre-Back"
+    },
+    {
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/14.png",
+        "name": "Austria Vienna"
+      },
+      "dateOfBirth": "Jul 28, 2002",
+      "foot": "left",
+      "height": "1,74m",
+      "id": "639027",
+      "injured": false,
+      "marketValue": "€1.50m",
+      "name": "Tae-seok Lee",
+      "position": "Left-Back"
+    },
+    {
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/159.png",
+        "name": "Red Star Belgrade"
+      },
       "dateOfBirth": "Dec 5, 1998",
       "foot": "right",
       "height": "1,83m",
       "id": "639414",
-      "marketValue": "€2.00m",
+      "injured": false,
+      "marketValue": "€5.00m",
       "name": "Young-woo Seol",
-      "number": "22",
       "position": "Right-Back"
     },
     {
-      "contract": "Sep 7, 2018",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/6499.png",
+        "name": "Daejeon Hana Citizen"
+      },
       "dateOfBirth": "Aug 1, 1995",
       "foot": "right",
       "height": "1,73m",
       "id": "524592",
-      "marketValue": "€850k",
+      "injured": false,
+      "marketValue": "€750k",
       "name": "Moon-hwan Kim",
-      "number": "15",
       "position": "Right-Back"
     },
     {
-      "contract": "Jun 5, 2025",
-      "dateOfBirth": "Apr 17, 1999",
-      "foot": "right",
-      "height": "1,77m",
-      "id": "630167",
-      "marketValue": "€700k",
-      "name": "Jun Choi",
-      "position": "Right-Back"
-    },
-    {
-      "contract": "Sep 7, 2018",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/234.png",
+        "name": "Feyenoord Rotterdam"
+      },
       "dateOfBirth": "Sep 20, 1996",
       "foot": "both",
       "height": "1,77m",
       "id": "365394",
-      "marketValue": "€12.00m",
+      "injured": false,
+      "marketValue": "€8.00m",
       "name": "In-beom Hwang",
       "position": "Defensive Midfield"
     },
     {
-      "contract": "Jun 16, 2023",
-      "dateOfBirth": "Sep 10, 1993",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/17276.png",
+        "name": "Zhejiang FC"
+      },
+      "dateOfBirth": "Oct 23, 1995",
       "foot": "right",
       "height": "1,86m",
-      "id": "374076",
-      "marketValue": "€1.30m",
-      "name": "Yong-woo Park",
+      "id": "557469",
+      "injured": false,
+      "marketValue": "€1.00m",
+      "name": "Jin-seob Park",
       "position": "Defensive Midfield"
     },
     {
-      "contract": "Nov 14, 2020",
-      "dateOfBirth": "Nov 18, 1997",
-      "foot": "right",
-      "height": "1,87m",
-      "id": "429696",
-      "marketValue": "€900k",
-      "name": "Du-jae Won",
-      "number": "5",
-      "position": "Defensive Midfield"
-    },
-    {
-      "dateOfBirth": "Mar 13, 2001",
-      "foot": "right",
-      "height": "1,92m",
-      "id": "550957",
-      "marketValue": "€750k",
-      "name": "Hyeok-kyu Kwon",
-      "position": "Defensive Midfield"
-    },
-    {
-      "contract": "Sep 6, 2025",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/18.png",
+        "name": "Borussia Mönchengladbach"
+      },
       "dateOfBirth": "Jul 29, 2003",
       "foot": "right",
       "height": "1,78m",
       "id": "613192",
-      "marketValue": "€3.00m",
+      "injured": false,
+      "marketValue": "€6.00m",
       "name": "Jens Castrop",
-      "number": "23",
       "position": "Central Midfield"
     },
     {
-      "contract": "Jun 11, 2019",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/337.png",
+        "name": "Birmingham City"
+      },
       "dateOfBirth": "Mar 17, 1997",
       "foot": "right",
       "height": "1,82m",
       "id": "282689",
-      "marketValue": "€1.20m",
+      "injured": false,
+      "marketValue": "€2.50m",
       "name": "Seung-ho Paik",
-      "number": "8",
       "position": "Central Midfield"
     },
     {
-      "contract": "Jul 7, 2025",
-      "dateOfBirth": "Dec 26, 1999",
-      "foot": "right",
-      "height": "1,81m",
-      "id": "782763",
-      "marketValue": "€900k",
-      "name": "Bong-soo Kim",
-      "position": "Central Midfield"
-    },
-    {
-      "contract": "Jan 15, 2022",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/6502.png",
+        "name": "Jeonbuk Hyundai Motors"
+      },
       "dateOfBirth": "Feb 24, 1997",
       "foot": "right",
       "height": "1,77m",
       "id": "365377",
-      "marketValue": "€800k",
+      "injured": false,
+      "marketValue": "€1.20m",
       "name": "Jin-gyu Kim",
-      "number": "24",
       "position": "Central Midfield"
     },
     {
-      "contract": "Sep 5, 2019",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/583.png",
+        "name": "Paris Saint-Germain"
+      },
       "dateOfBirth": "Feb 19, 2001",
       "foot": "left",
       "height": "1,73m",
       "id": "557149",
-      "marketValue": "€30.00m",
+      "injured": false,
+      "marketValue": "€28.00m",
       "name": "Kang-in Lee",
-      "number": "18",
       "position": "Attacking Midfield"
     },
     {
-      "contract": "Mar 27, 2015",
-      "dateOfBirth": "Aug 10, 1992",
-      "foot": "left",
-      "height": "1,80m",
-      "id": "314398",
-      "marketValue": "€2.50m",
-      "name": "Jae-sung Lee",
-      "number": "10",
-      "position": "Attacking Midfield"
-    },
-    {
-      "contract": "Jun 6, 2024",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/512.png",
+        "name": "Stoke City"
+      },
       "dateOfBirth": "Aug 21, 2003",
       "foot": "right",
       "height": "1,80m",
       "id": "912081",
-      "marketValue": "€1.50m",
+      "injured": false,
+      "marketValue": "€3.00m",
       "name": "Jun-ho Bae",
-      "number": "17",
       "position": "Attacking Midfield"
     },
     {
-      "contract": "Sep 5, 2019",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/39.png",
+        "name": "1.FSV Mainz 05"
+      },
+      "dateOfBirth": "Aug 10, 1992",
+      "foot": "left",
+      "height": "1,80m",
+      "id": "314398",
+      "injured": false,
+      "marketValue": "€2.00m",
+      "name": "Jae-sung Lee",
+      "position": "Attacking Midfield"
+    },
+    {
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/3535.png",
+        "name": "Ulsan HD FC"
+      },
       "dateOfBirth": "Sep 20, 1997",
       "foot": "left",
       "height": "1,76m",
       "id": "558086",
-      "marketValue": "€1.20m",
+      "injured": false,
+      "marketValue": "€1.60m",
       "name": "Dong-gyeong Lee",
       "position": "Attacking Midfield"
     },
     {
-      "contract": "Dec 30, 2010",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/51828.png",
+        "name": "Los Angeles FC"
+      },
       "dateOfBirth": "Jul 8, 1992",
       "foot": "both",
       "height": "1,84m",
       "id": "91845",
-      "marketValue": "€38.00m",
+      "injured": false,
+      "marketValue": "€17.00m",
       "name": "Heung-min Son",
-      "number": "7",
       "position": "Left Winger"
     },
     {
-      "contract": "Jan 15, 2022",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/2288.png",
+        "name": "Swansea City"
+      },
       "dateOfBirth": "May 9, 2002",
       "foot": "right",
       "height": "1,76m",
       "id": "706968",
-      "marketValue": "€1.20m",
+      "injured": false,
+      "marketValue": "€1.40m",
       "name": "Ji-sung Eom",
-      "number": "20",
       "position": "Left Winger"
     },
     {
-      "contract": "Nov 17, 2018",
-      "dateOfBirth": "Aug 12, 1996",
-      "foot": "right",
-      "height": "1,73m",
-      "id": "508381",
-      "marketValue": "€900k",
-      "name": "Sang-ho Na",
-      "position": "Left Winger"
-    },
-    {
-      "contract": "Mar 25, 2025",
-      "dateOfBirth": "Apr 16, 2006",
-      "foot": "right",
-      "height": "1,76m",
-      "id": "1004327",
-      "marketValue": "€3.50m",
-      "name": "Min-hyeok Yang",
-      "position": "Right Winger"
-    },
-    {
-      "contract": "Sep 7, 2023",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/371.png",
+        "name": "Celtic FC"
+      },
       "dateOfBirth": "May 25, 2002",
       "foot": "right",
       "height": "1,76m",
       "id": "853110",
-      "marketValue": "€2.00m",
+      "injured": false,
+      "marketValue": "€5.00m",
       "name": "Hyun-jun Yang",
       "position": "Right Winger"
     },
     {
-      "contract": "Jul 11, 2025",
-      "dateOfBirth": "Feb 27, 1997",
-      "foot": "right",
-      "height": "1,73m",
-      "id": "497440",
-      "marketValue": "€650k",
-      "name": "Seung-won Jeong",
-      "position": "Right Winger"
-    },
-    {
-      "contract": "Sep 1, 2016",
-      "dateOfBirth": "Jan 26, 1996",
-      "foot": "right",
-      "height": "1,77m",
-      "id": "292246",
-      "marketValue": "€22.00m",
-      "name": "Hee-chan Hwang",
-      "number": "11",
-      "position": "Centre-Forward"
-    },
-    {
-      "contract": "Sep 7, 2021",
-      "dateOfBirth": "Jan 25, 1998",
-      "foot": "right",
-      "height": "1,88m",
-      "id": "652537",
-      "marketValue": "€4.50m",
-      "name": "Gue-sung Cho",
-      "position": "Centre-Forward"
-    },
-    {
-      "contract": "Nov 11, 2022",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/114.png",
+        "name": "Besiktas JK"
+      },
       "dateOfBirth": "Apr 12, 2001",
       "foot": "right",
       "height": "1,87m",
       "id": "639246",
-      "marketValue": "€3.00m",
+      "injured": false,
+      "marketValue": "€15.00m",
       "name": "Hyeon-gyu Oh",
-      "number": "19",
       "position": "Centre-Forward"
     },
     {
-      "contract": "Jun 9, 2021",
-      "dateOfBirth": "Apr 1, 2002",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/543.png",
+        "name": "Wolverhampton Wanderers"
+      },
+      "dateOfBirth": "Jan 26, 1996",
       "foot": "right",
-      "height": "1,75m",
-      "id": "638571",
+      "height": "1,77m",
+      "id": "292246",
+      "injured": false,
+      "marketValue": "€8.00m",
+      "name": "Hee-chan Hwang",
+      "position": "Centre-Forward"
+    },
+    {
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/865.png",
+        "name": "FC Midtjylland"
+      },
+      "dateOfBirth": "Jan 25, 1998",
+      "foot": "right",
+      "height": "1,88m",
+      "id": "652537",
+      "injured": false,
       "marketValue": "€3.00m",
-      "name": "Sang-bin Jeong",
-      "number": "25",
-      "position": "Centre-Forward"
-    },
-    {
-      "contract": "Mar 21, 2024",
-      "dateOfBirth": "Apr 13, 1990",
-      "foot": "right",
-      "height": "1,83m",
-      "id": "264082",
-      "marketValue": "€800k",
-      "name": "Min-kyu Joo",
-      "position": "Centre-Forward"
-    },
-    {
-      "contract": "Jun 6, 2024",
-      "dateOfBirth": "Jan 15, 1999",
-      "foot": "left",
-      "height": "1,93m",
-      "id": "402167",
-      "marketValue": "€800k",
-      "name": "Se-hun Oh",
+      "name": "Gue-sung Cho",
       "position": "Centre-Forward"
     }
   ],

--- a/data/2025/WC2026/teams/3806.json
+++ b/data/2025/WC2026/teams/3806.json
@@ -1,367 +1,460 @@
 {
-  "image": "https://tmssl.akamaized.net/images/wappen/big/3806.png",
+  "image": "https://assets.virtuafc.com/crests/3806.png",
   "name": "South Africa",
   "players": [
     {
-      "contract": "Mar 5, 2014",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/2557.png",
+        "name": "Orlando Pirates"
+      },
+      "dateOfBirth": "Dec 14, 1996",
+      "height": "1,81m",
+      "id": "453370",
+      "injured": false,
+      "marketValue": "€1.40m",
+      "name": "Sipho Chaine",
+      "position": "Goalkeeper"
+    },
+    {
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/6356.png",
+        "name": "Mamelodi Sundowns FC"
+      },
       "dateOfBirth": "Jan 21, 1992",
       "foot": "right",
       "height": "1,84m",
       "id": "175577",
-      "marketValue": "€1.00m",
+      "injured": false,
+      "marketValue": "€900k",
       "name": "Ronwen Williams",
-      "number": "1",
       "position": "Goalkeeper"
     },
     {
-      "contract": "Sep 10, 2024",
-      "dateOfBirth": "Dec 14, 1996",
-      "height": "1,81m",
-      "id": "453370",
-      "marketValue": "€700k",
-      "name": "Sipho Chaine",
-      "number": "16",
-      "position": "Goalkeeper"
-    },
-    {
-      "contract": "Oct 8, 2020",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/132785.png",
+        "name": "Siwelele Football Club"
+      },
       "dateOfBirth": "Apr 2, 1994",
       "foot": "right",
       "height": "1,81m",
       "id": "258304",
-      "marketValue": "€700k",
+      "injured": false,
+      "marketValue": "€350k",
       "name": "Ricardo Goss",
-      "number": "22",
       "position": "Goalkeeper"
     },
     {
-      "contract": "Jun 7, 2024",
-      "dateOfBirth": "Jul 15, 1997",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/568.png",
+        "name": "Kaizer Chiefs"
+      },
+      "dateOfBirth": "Sep 22, 1994",
       "foot": "right",
-      "height": "1,88m",
-      "id": "445610",
-      "marketValue": "€2.20m",
-      "name": "Siyabonga Ngezana",
-      "number": "21",
+      "height": "1,85m",
+      "id": "268567",
+      "injured": false,
+      "marketValue": "€50k",
+      "name": "Brandon Petersen",
+      "position": "Goalkeeper"
+    },
+    {
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/432.png",
+        "name": "Chicago Fire FC"
+      },
+      "dateOfBirth": "Sep 19, 2005",
+      "foot": "left",
+      "height": "1,77m",
+      "id": "1378320",
+      "injured": false,
+      "marketValue": "€2.50m",
+      "name": "Mbekezeli Mbokazi",
       "position": "Centre-Back"
     },
     {
-      "contract": "Jun 10, 2021",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/25467.png",
+        "name": "Philadelphia Union"
+      },
+      "dateOfBirth": "Apr 30, 2004",
+      "foot": "right",
+      "height": "1,88m",
+      "id": "1069801",
+      "injured": false,
+      "marketValue": "€2.00m",
+      "name": "Olwethu Makhanya",
+      "position": "Centre-Back"
+    },
+    {
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/42.png",
+        "name": "Hannover 96"
+      },
+      "dateOfBirth": "Feb 20, 2004",
+      "foot": "right",
+      "height": "1,87m",
+      "id": "1107265",
+      "injured": false,
+      "marketValue": "€2.00m",
+      "name": "Ime Okon",
+      "position": "Centre-Back"
+    },
+    {
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/2557.png",
+        "name": "Orlando Pirates"
+      },
       "dateOfBirth": "Sep 22, 1995",
       "foot": "right",
       "height": "1,77m",
       "id": "399068",
-      "marketValue": "€1.40m",
+      "injured": false,
+      "marketValue": "€1.60m",
       "name": "Nkosinathi Sibisi",
-      "number": "19",
       "position": "Centre-Back"
     },
     {
-      "contract": "Jun 6, 2025",
-      "dateOfBirth": "Feb 24, 1999",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/6356.png",
+        "name": "Mamelodi Sundowns FC"
+      },
+      "dateOfBirth": "Feb 5, 2004",
       "foot": "right",
-      "height": "1,78m",
-      "id": "579124",
-      "marketValue": "€650k",
-      "name": "Thabo Moloisane",
-      "number": "28",
+      "id": "1283140",
+      "injured": false,
+      "marketValue": "€800k",
+      "name": "Khulumani Ndamane",
       "position": "Centre-Back"
     },
     {
-      "contract": "Jun 9, 2022",
-      "dateOfBirth": "Oct 31, 1992",
-      "foot": "right",
-      "height": "1,79m",
-      "id": "43030",
-      "marketValue": "€600k",
-      "name": "Grant Kekana",
-      "position": "Centre-Back"
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/687.png",
+        "name": "Molde FK"
+      },
+      "dateOfBirth": "Mar 15, 2004",
+      "foot": "left",
+      "height": "1,81m",
+      "id": "1175086",
+      "injured": false,
+      "marketValue": "€2.00m",
+      "name": "Samukele Kabini",
+      "position": "Left-Back"
     },
     {
-      "contract": "Jun 18, 2016",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/6356.png",
+        "name": "Mamelodi Sundowns FC"
+      },
       "dateOfBirth": "Jul 22, 1995",
       "foot": "left",
       "height": "1,67m",
       "id": "353432",
-      "marketValue": "€1.60m",
+      "injured": false,
+      "marketValue": "€1.80m",
       "name": "Aubrey Modiba",
-      "number": "6",
       "position": "Left-Back"
     },
     {
-      "contract": "Nov 15, 2024",
-      "dateOfBirth": "Dec 23, 1996",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/568.png",
+        "name": "Kaizer Chiefs"
+      },
+      "dateOfBirth": "Jan 30, 2001",
       "foot": "left",
-      "id": "478520",
-      "marketValue": "€1.20m",
-      "name": "Fawaaz Basadien",
+      "height": "1,83m",
+      "id": "555209",
+      "injured": false,
+      "marketValue": "€650k",
+      "name": "Bradley Cross",
       "position": "Left-Back"
     },
     {
-      "contract": "Mar 25, 2022",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/6356.png",
+        "name": "Mamelodi Sundowns FC"
+      },
       "dateOfBirth": "Apr 26, 1995",
       "foot": "right",
       "height": "1,81m",
       "id": "450806",
-      "marketValue": "€1.40m",
+      "injured": false,
+      "marketValue": "€1.20m",
       "name": "Khuliso Mudau",
-      "number": "20",
       "position": "Right-Back"
     },
     {
-      "contract": "Mar 25, 2015",
-      "dateOfBirth": "Aug 6, 1993",
-      "foot": "right",
-      "height": "1,70m",
-      "id": "297509",
-      "marketValue": "€1.20m",
-      "name": "Thapelo Morena",
-      "position": "Right-Back"
-    },
-    {
-      "contract": "Aug 4, 2019",
-      "dateOfBirth": "Sep 11, 1994",
-      "foot": "right",
-      "height": "1,80m",
-      "id": "435086",
-      "marketValue": "€1.20m",
-      "name": "Nyiko Mobbie",
-      "position": "Right-Back"
-    },
-    {
-      "contract": "Jun 6, 2025",
-      "dateOfBirth": "Nov 24, 1996",
-      "foot": "right",
-      "height": "1,77m",
-      "id": "514175",
-      "marketValue": "€1.20m",
-      "name": "Deano Van Rooyen",
-      "position": "Right-Back"
-    },
-    {
-      "contract": "Jul 13, 2022",
-      "dateOfBirth": "Mar 31, 2001",
-      "foot": "right",
-      "height": "1,80m",
-      "id": "659775",
-      "marketValue": "€850k",
-      "name": "Kegan Johannes",
-      "position": "Right-Back"
-    },
-    {
-      "contract": "Sep 9, 2023",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/568.png",
+        "name": "Kaizer Chiefs"
+      },
       "dateOfBirth": "Apr 30, 2000",
       "foot": "right",
       "height": "1,67m",
       "id": "579037",
-      "marketValue": "€750k",
+      "injured": false,
+      "marketValue": "€900k",
       "name": "Thabiso Monyane",
       "position": "Right-Back"
     },
     {
-      "contract": "Sep 5, 2025",
-      "dateOfBirth": "Jun 6, 1999",
-      "height": "1,74m",
-      "id": "801354",
-      "marketValue": "€700k",
-      "name": "Zuko Mdunyelwa",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/21202.png",
+        "name": "Polokwane City FC"
+      },
+      "dateOfBirth": "Jan 14, 1999",
+      "foot": "right",
+      "id": "1109254",
+      "injured": false,
+      "marketValue": "€900k",
+      "name": "Thabang Matuludi",
       "position": "Right-Back"
     },
     {
-      "contract": "Mar 24, 2018",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/6356.png",
+        "name": "Mamelodi Sundowns FC"
+      },
+      "dateOfBirth": "Aug 6, 1993",
+      "foot": "right",
+      "height": "1,70m",
+      "id": "297509",
+      "injured": false,
+      "marketValue": "€900k",
+      "name": "Thapelo Morena",
+      "position": "Right-Back"
+    },
+    {
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/2557.png",
+        "name": "Orlando Pirates"
+      },
+      "dateOfBirth": "Jul 21, 2002",
+      "foot": "right",
+      "id": "994370",
+      "injured": false,
+      "marketValue": "€850k",
+      "name": "Kamogelo Sebelebele",
+      "position": "Right-Back"
+    },
+    {
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/6356.png",
+        "name": "Mamelodi Sundowns FC"
+      },
       "dateOfBirth": "Jan 24, 1997",
       "foot": "right",
       "height": "1,76m",
       "id": "436372",
-      "marketValue": "€2.40m",
+      "injured": false,
+      "marketValue": "€2.50m",
       "name": "Teboho Mokoena",
-      "number": "4",
       "position": "Defensive Midfield"
     },
     {
-      "contract": "Jul 22, 2017",
-      "dateOfBirth": "Mar 22, 1998",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/14187.png",
+        "name": "Durban City Football Club"
+      },
+      "dateOfBirth": "Oct 3, 1999",
       "foot": "right",
-      "height": "1,77m",
-      "id": "436374",
-      "marketValue": "€800k",
-      "name": "Sipho Mbule",
-      "number": "17",
+      "id": "533547",
+      "injured": false,
+      "marketValue": "€450k",
+      "name": "Brooklyn Poggenpoel",
+      "position": "Defensive Midfield"
+    },
+    {
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/2557.png",
+        "name": "Orlando Pirates"
+      },
+      "dateOfBirth": "Mar 6, 2000",
+      "foot": "right",
+      "height": "1,80m",
+      "id": "735697",
+      "injured": false,
+      "marketValue": "€1.60m",
+      "name": "Thalente Mbatha",
       "position": "Central Midfield"
     },
     {
-      "contract": "Sep 24, 2022",
-      "dateOfBirth": "Mar 10, 2000",
-      "foot": "right",
-      "height": "1,84m",
-      "id": "467616",
-      "marketValue": "€700k",
-      "name": "Luke Le Roux",
-      "position": "Central Midfield"
-    },
-    {
-      "contract": "Mar 2, 2025",
-      "dateOfBirth": "Dec 1, 1995",
-      "foot": "left",
-      "height": "1,67m",
-      "id": "560463",
-      "marketValue": "€1.50m",
-      "name": "Neo Maema",
-      "position": "Attacking Midfield"
-    },
-    {
-      "contract": "Mar 21, 2024",
-      "dateOfBirth": "Apr 4, 1998",
-      "foot": "left",
-      "height": "1,78m",
-      "id": "555606",
-      "marketValue": "€1.40m",
-      "name": "Patrick Maswanganyi",
-      "position": "Attacking Midfield"
-    },
-    {
-      "contract": "Jan 21, 2024",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/6356.png",
+        "name": "Mamelodi Sundowns FC"
+      },
       "dateOfBirth": "May 5, 2001",
       "foot": "right",
       "height": "1,75m",
       "id": "804472",
-      "marketValue": "€1.00m",
+      "injured": false,
+      "marketValue": "€1.40m",
       "name": "Jayden Adams",
-      "position": "Attacking Midfield"
+      "position": "Central Midfield"
     },
     {
-      "contract": "Aug 8, 2025",
-      "dateOfBirth": "May 28, 1995",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/7179.png",
+        "name": "CD Tondela"
+      },
+      "dateOfBirth": "Mar 3, 1999",
       "foot": "right",
-      "height": "1,61m",
-      "id": "636981",
-      "marketValue": "€850k",
-      "name": "Ndabayithethwa Ndlondlo",
-      "position": "Attacking Midfield"
+      "height": "1,86m",
+      "id": "401736",
+      "injured": false,
+      "marketValue": "€600k",
+      "name": "Yaya Sithole",
+      "position": "Central Midfield"
     },
     {
-      "contract": "Nov 20, 2018",
-      "dateOfBirth": "May 13, 1993",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/568.png",
+        "name": "Kaizer Chiefs"
+      },
+      "dateOfBirth": "Sep 17, 1994",
       "foot": "right",
-      "height": "1,81m",
-      "id": "370663",
-      "marketValue": "€750k",
-      "name": "Fortune Makaringe",
-      "position": "Attacking Midfield"
+      "height": "1,72m",
+      "id": "420543",
+      "injured": false,
+      "marketValue": "€400k",
+      "name": "Lebohang Maboe",
+      "position": "Central Midfield"
     },
     {
-      "contract": "Jun 11, 2024",
-      "dateOfBirth": "Oct 23, 2004",
-      "foot": "right",
-      "height": "1,66m",
-      "id": "1125037",
-      "marketValue": "€800k",
-      "name": "Relebohile Mofokeng",
-      "number": "10",
-      "position": "Left Winger"
-    },
-    {
-      "contract": "Dec 26, 2025",
-      "dateOfBirth": "Jul 15, 2005",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/2557.png",
+        "name": "Orlando Pirates"
+      },
+      "dateOfBirth": "Apr 4, 1998",
       "foot": "left",
       "height": "1,78m",
-      "id": "1159786",
-      "marketValue": "€800k",
-      "name": "Shandre Campbell",
-      "number": "24",
-      "position": "Left Winger"
+      "id": "555606",
+      "injured": false,
+      "marketValue": "€1.20m",
+      "name": "Patrick Maswanganyi",
+      "position": "Attacking Midfield"
     },
     {
-      "contract": "Sep 5, 2014",
-      "dateOfBirth": "Jan 22, 1993",
-      "foot": "left",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/6356.png",
+        "name": "Mamelodi Sundowns FC"
+      },
+      "dateOfBirth": "Aug 3, 1989",
+      "foot": "right",
       "height": "1,70m",
-      "id": "234006",
-      "marketValue": "€600k",
-      "name": "Keagan Dolly",
-      "position": "Left Winger"
+      "id": "176578",
+      "injured": false,
+      "marketValue": "€300k",
+      "name": "Themba Zwane",
+      "position": "Attacking Midfield"
     },
     {
-      "contract": "Nov 21, 2023",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/2557.png",
+        "name": "Orlando Pirates"
+      },
       "dateOfBirth": "Aug 25, 2001",
       "foot": "right",
       "height": "1,71m",
       "id": "673381",
-      "marketValue": "€600k",
+      "injured": false,
+      "marketValue": "€2.00m",
       "name": "Oswin Appollis",
-      "number": "7",
       "position": "Left Winger"
     },
     {
-      "contract": "Mar 25, 2017",
-      "dateOfBirth": "May 13, 1994",
-      "foot": "left",
-      "height": "1,75m",
-      "id": "312239",
-      "marketValue": "€1.50m",
-      "name": "Percy Tau",
-      "position": "Right Winger"
-    },
-    {
-      "contract": "Mar 21, 2024",
-      "dateOfBirth": "Sep 8, 1999",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/2557.png",
+        "name": "Orlando Pirates"
+      },
+      "dateOfBirth": "Oct 23, 2004",
       "foot": "right",
-      "height": "1,75m",
-      "id": "968496",
-      "marketValue": "€900k",
-      "name": "Elias Mokwana",
-      "number": "12",
+      "height": "1,66m",
+      "id": "1125037",
+      "injured": false,
+      "marketValue": "€2.00m",
+      "name": "Relebohile Mofokeng",
+      "position": "Left Winger"
+    },
+    {
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/2557.png",
+        "name": "Orlando Pirates"
+      },
+      "dateOfBirth": "Oct 2, 2000",
+      "id": "844485",
+      "injured": false,
+      "marketValue": "€1.00m",
+      "name": "Tshepang Moremi",
+      "position": "Left Winger"
+    },
+    {
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/786.png",
+        "name": "AEL Limassol"
+      },
+      "dateOfBirth": "Nov 11, 2003",
+      "foot": "left",
+      "height": "1,78m",
+      "id": "983330",
+      "injured": false,
+      "marketValue": "€750k",
+      "name": "Thapelo Maseko",
+      "position": "Left Winger"
+    },
+    {
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/56089.png",
+        "name": "Minnesota United FC"
+      },
+      "dateOfBirth": "Jun 20, 2000",
+      "foot": "right",
+      "height": "1,82m",
+      "id": "669202",
+      "injured": false,
+      "marketValue": "€3.50m",
+      "name": "Bongokuhle Hlongwane",
       "position": "Right Winger"
     },
     {
-      "contract": "Sep 5, 2025",
-      "dateOfBirth": "Jul 21, 2002",
-      "id": "994370",
-      "marketValue": "€550k",
-      "name": "Kamogelo Sebelebele",
-      "position": "Right Winger"
-    },
-    {
-      "contract": "Oct 8, 2020",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/1132.png",
+        "name": "Burnley FC"
+      },
       "dateOfBirth": "Sep 3, 2000",
       "foot": "right",
       "height": "1,85m",
       "id": "467623",
-      "marketValue": "€9.00m",
+      "injured": false,
+      "marketValue": "€10.00m",
       "name": "Lyle Foster",
-      "number": "9",
       "position": "Centre-Forward"
     },
     {
-      "contract": "Mar 21, 2024",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/6356.png",
+        "name": "Mamelodi Sundowns FC"
+      },
       "dateOfBirth": "Dec 19, 1995",
       "foot": "right",
       "height": "1,76m",
       "id": "337884",
-      "marketValue": "€1.80m",
+      "injured": false,
+      "marketValue": "€3.00m",
       "name": "Iqraam Rayners",
-      "number": "27",
       "position": "Centre-Forward"
     },
     {
-      "contract": "Sep 24, 2022",
-      "dateOfBirth": "Mar 19, 1997",
-      "foot": "right",
-      "height": "1,79m",
-      "id": "596913",
-      "marketValue": "€650k",
-      "name": "Zakhele Lepasa",
-      "position": "Centre-Forward"
-    },
-    {
-      "contract": "Jun 10, 2021",
+      "club": {
+        "image": "https://assets.virtuafc.com/crests/2557.png",
+        "name": "Orlando Pirates"
+      },
       "dateOfBirth": "Jun 5, 2000",
       "foot": "right",
       "height": "1,88m",
       "id": "746781",
-      "marketValue": "€650k",
+      "injured": false,
+      "marketValue": "€1.20m",
       "name": "Evidence Makgopa",
-      "number": "23",
       "position": "Centre-Forward"
     }
   ],

--- a/database/migrations/2026_05_21_000001_add_is_called_up_to_game_player_template_tournament_info_table.php
+++ b/database/migrations/2026_05_21_000001_add_is_called_up_to_game_player_template_tournament_info_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('game_player_template_tournament_info', function (Blueprint $table) {
+            $table->boolean('is_called_up')->default(false)->after('is_injured');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('game_player_template_tournament_info', function (Blueprint $table) {
+            $table->dropColumn('is_called_up');
+        });
+    }
+};

--- a/lang/en/squad.php
+++ b/lang/en/squad.php
@@ -268,6 +268,7 @@ return [
     'invalid_selection' => 'Invalid selection. Please check the selected players.',
     'download_squad' => 'Download squad',
     'squad_list' => 'Squad List',
+    'called_up_badge' => 'Called up',
 
     // Radar chart
     'radar_gk' => 'Goalkeeping',

--- a/lang/es/squad.php
+++ b/lang/es/squad.php
@@ -268,6 +268,7 @@ return [
     'invalid_selection' => 'Selección inválida. Verifica los jugadores seleccionados.',
     'download_squad' => 'Descargar convocatoria',
     'squad_list' => 'Lista de convocados',
+    'called_up_badge' => 'Convocado',
 
     // Radar chart
     'radar_gk' => 'Portería',

--- a/resources/js/squad-selection.js
+++ b/resources/js/squad-selection.js
@@ -20,6 +20,21 @@ export default function squadSelection(config) {
         fifaCode: config.fifaCode,
         gameId: config.gameId,
 
+        init() {
+            // Pre-select the officially called-up players (up to maxPlayers).
+            // Teams whose JSON hasn't been flagged yet start empty, matching
+            // the legacy manual-selection flow.
+            const calledUp = [];
+            for (const group of Object.keys(this.players)) {
+                for (const p of this.players[group]) {
+                    if (p.is_called_up && calledUp.length < this.maxPlayers) {
+                        calledUp.push(p.transfermarkt_id);
+                    }
+                }
+            }
+            this.selectedIds = calledUp;
+        },
+
         togglePlayer(id) {
             const idx = this.selectedIds.indexOf(id);
             if (idx > -1) {

--- a/resources/views/components/called-up-badge.blade.php
+++ b/resources/views/components/called-up-badge.blade.php
@@ -1,0 +1,3 @@
+<span {{ $attributes->merge(['class' => 'inline-flex items-center px-1.5 py-0.5 rounded text-[9px] font-semibold uppercase tracking-wide bg-accent-blue/10 text-accent-blue shrink-0']) }}>
+    {{ __('squad.called_up_badge') }}
+</span>

--- a/resources/views/squad-selection.blade.php
+++ b/resources/views/squad-selection.blade.php
@@ -106,6 +106,9 @@ $tabs = [
                                         <path fill-rule="evenodd" d="M8 2a1 1 0 0 0-1 1v4H3a1 1 0 0 0-1 1v4a1 1 0 0 0 1 1h4v4a1 1 0 0 0 1 1h4a1 1 0 0 0 1-1v-4h4a1 1 0 0 0 1-1V8a1 1 0 0 0-1-1h-4V3a1 1 0 0 0-1-1H8z" clip-rule="evenodd"/>
                                     </svg>
                                 @endif
+                                @if($candidate['is_called_up'])
+                                    <x-called-up-badge />
+                                @endif
                             </div>
                             <div class="flex items-center gap-1.5 text-xs text-text-secondary mt-0.5 min-w-0">
                                 @if($candidate['club_crest_url'])


### PR DESCRIPTION
National team JSON files at data/2025/WC2026/teams/*.json can now mark
players with calledUp: true. The flag is stored on
game_player_template_tournament_info.is_called_up and drives two
behaviors:

- Squad-selection form: called-up players are pre-checked on mount and
  carry a "Convocado" / "Called up" badge so the user starts with the
  official 26 and can swap from there.
- AI opponents: SetupTournamentGame copies only called-up players into
  game_players for each AI nation. Teams whose JSON doesn't carry any
  called-up flag fall through to the legacy behavior of taking every
  templated player, so JSONs can be updated incrementally without
  breaking unseeded nations.

https://claude.ai/code/session_01QvPgN1i5YKjBxji4FKZUTM