### PR TITLE
Generalize reserve/parent coexistence repair to any country

### DIFF
--- a/app/Console/Commands/RepairReserveParentCoexistence.php
+++ b/app/Console/Commands/RepairReserveParentCoexistence.php
@@ -6,235 +6,276 @@ use App\Models\CompetitionEntry;
 use App\Models\Game;
 use App\Models\GameStanding;
 use App\Models\SimulatedSeason;
+use App\Models\Team;
+use App\Modules\Competition\Services\CountryConfig;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\DB;
 
 /**
- * One-off repair for game 101770e2-bc57-497b-a0ee-2621b7a0f2fa, stuck mid
- * season-transition with two structural problems carried over from prior
- * seasons (surfaced by app:diagnose-stuck-game):
+ * Repair reserve/parent league assignments for a game stuck mid season-transition
+ * because CountryPromotionRelegationPlanner::validatePlan detected one of:
  *
- *   COEXISTENCE: CA Osasuna (parent) and CA Osasuna Promesas (reserve) both
- *                in ESP3A. CountryPromotionRelegationPlanner::validatePlan
- *                seeds finalComp from snapshot standings before applying any
- *                plan moves, so the planner throws on the inherited
- *                coexistence even when it would otherwise emit no relevant
- *                moves.
+ *   INVERTED:    reserve in a higher tier than its parent (e.g. Promesas ESP1,
+ *                Osasuna ESP2). validatePlan seeds finalComp from snapshot
+ *                standings before applying any plan moves, so the inversion
+ *                gets carried into finalComp; once the planner emits any
+ *                relegation that lands the reserve in the parent's tier, the
+ *                pair collides.
  *
- *   INVERTED:    RC Celta Fortuna (reserve) in ESP2 with parent RC Celta in
- *                ESP3B. Would trip the planner the moment either team got
- *                touched.
+ *   COEXISTENCE: reserve and parent already share a competition in the
+ *                snapshot. validatePlan throws immediately, even when no
+ *                relevant moves were emitted.
  *
- * Repair: two 1:1 league swaps in a single transaction.
+ * For each detected issue, plans a 1:1 league swap:
  *
- *   Celta swap   — Fortuna (ESP2) <-> Celta (ESP3B)
- *   Osasuna swap — Osasuna (ESP3A) <-> bottom-of-ESP2 team (ESP2)
+ *   - INVERTED:    swap reserve <-> parent. Reserve drops to parent's tier,
+ *                  parent rises to reserve's tier — restores correct hierarchy
+ *                  with no displacement of unrelated teams.
+ *   - COEXISTENCE: swap parent with the bottom team of the next-higher tier.
+ *                  Parent moves up; the displaced team drops into the shared
+ *                  tier. Requires a single competition at the next-higher tier
+ *                  (aborts when that tier has siblings — manual choice needed).
  *
- * ESP2 is non-played for this game, so its ordering lives in
- * simulated_seasons.results (JSON array). ESP3A/ESP3B are played; their
- * ordering lives in game_standings. The command touches both tables and
- * preserves table order — each swap keeps the existing index/position and
- * just exchanges team_ids.
+ * For each swap, mutates whichever store backs each affected league:
+ *   - played league:     game_standings row (team_id swap, position preserved)
+ *   - non-played league: simulated_seasons.results array slot (team_id swap)
  *
- * After the swap:
- *   - Osasuna in ESP2, Promesas in ESP3A         (no coexistence)
- *   - Celta in ESP2, Fortuna in ESP3B            (proper tier order)
+ * Plus competition_entries rows in both directions.
  *
- * Operator then runs app:diagnose-stuck-game to confirm the flags are gone
- * and app:resume-season-transition to re-run the closing pipeline from
+ * Defaults to dry-run; pass --apply to write. Safe to leave in the tree —
+ * preconditions guarantee it only acts on a game checkpointed at the
+ * pre-PromotionRelegation step, and the issue detector only emits swaps for
+ * pairs that would currently trip validatePlan.
+ *
+ * After applying, run app:diagnose-stuck-game to confirm flags are gone,
+ * then app:resume-season-transition to re-run the closing pipeline from
  * step 23 (PromotionRelegationProcessor builds a fresh snapshot, replans,
  * and validatePlan passes).
- *
- * Deliberately specific to this game's known state — hardcoded UUIDs and
- * preconditions, not a general team-swap tool. Safe to delete from the tree
- * once the production run succeeds.
  */
 class RepairReserveParentCoexistence extends Command
 {
     protected $signature = 'app:repair-reserve-parent-coexistence
-        {gameId : Game UUID. Must be the known stuck game.}
-        {--dry-run : Print planned mutations without writing.}';
+        {game : Game UUID stuck mid season-transition.}
+        {--apply : Actually write changes (default is dry-run).}';
 
-    protected $description = 'One-off repair for the known reserve/parent coexistence + inversion in game 101770e2.';
+    protected $description = 'Repair reserve/parent inversion or coexistence for a stuck game (dry-run by default).';
 
-    private const EXPECTED_GAME_ID = '101770e2-bc57-497b-a0ee-2621b7a0f2fa';
-    private const EXPECTED_COUNTRY = 'ES';
+    /**
+     * The season_transition_step at which PromotionRelegationProcessor is
+     * the next processor to run. The planner explodes during that processor,
+     * which leaves the game checkpointed at the prior step.
+     */
     private const EXPECTED_STEP = 22;
-    private const EXPECTED_SEASON = '2045';
 
-    private const OSASUNA_PARENT_ID = '956bf812-5dbe-48f8-a812-82d00400b8dc';
-    private const OSASUNA_RESERVE_ID = '8a519d48-3c8b-4121-b6ae-49cc89ff1fcf';
-    private const CELTA_PARENT_ID = 'd21458e1-6063-4022-af08-f98aa675ffbf';
-    private const CELTA_RESERVE_ID = '853060a1-9253-4662-82b5-b413d3045c81';
-    private const ESP2_BOTTOM_ID = 'c18f6e69-8926-4074-955e-efc2b9564a2c';
+    public function __construct(private readonly CountryConfig $countryConfig)
+    {
+        parent::__construct();
+    }
 
     public function handle(): int
     {
-        $gameId = (string) $this->argument('gameId');
-        $dryRun = (bool) $this->option('dry-run');
-
-        if ($gameId !== self::EXPECTED_GAME_ID) {
-            $this->error("This command only repairs game " . self::EXPECTED_GAME_ID . ". Got: {$gameId}.");
-            return self::FAILURE;
-        }
+        $gameId = (string) $this->argument('game');
+        $apply = (bool) $this->option('apply');
 
         $game = Game::find($gameId);
         if (!$game) {
             $this->error("Game {$gameId} not found.");
             return self::FAILURE;
         }
-
-        // Precondition checks. Bail loudly rather than half-repair if the
-        // game's state has drifted from what we observed during diagnosis.
-        if ($game->country !== self::EXPECTED_COUNTRY) {
-            $this->error("Game {$gameId} country is {$game->country}, expected " . self::EXPECTED_COUNTRY . ".");
-            return self::FAILURE;
-        }
-        if ((string) $game->season !== self::EXPECTED_SEASON) {
-            $this->error("Game {$gameId} season is {$game->season}, expected " . self::EXPECTED_SEASON . ".");
+        if (!$game->isTransitioningSeason()) {
+            $this->error("Game {$gameId} is not in a transitioning state (season_transitioning_at is null). Aborting.");
             return self::FAILURE;
         }
         if ((int) $game->season_transition_step !== self::EXPECTED_STEP) {
-            $this->error("Game {$gameId} season_transition_step is {$game->season_transition_step}, expected " . self::EXPECTED_STEP . ".");
+            $this->error(sprintf(
+                "Game %s season_transition_step is %s, expected %d. Aborting — the planner runs at the next step.",
+                $gameId,
+                $game->season_transition_step ?? 'NULL',
+                self::EXPECTED_STEP,
+            ));
             return self::FAILURE;
         }
 
-        // Confirm each team currently sits in its expected league. Cup
-        // entries (ESPCUP) are ignored — we only check league placements.
-        $leagueIds = ['ESP1', 'ESP2', 'ESP3A', 'ESP3B'];
+        // Build tier maps from country config. Only league tier competitions
+        // count; cups, promotion playoffs, and continentals are excluded.
+        $tierToComps = [];
+        $compToTier = [];
+        foreach (array_keys($this->countryConfig->tiers($game->country)) as $tier) {
+            $ids = $this->countryConfig->tierCompetitionIds($game->country, (int) $tier);
+            $tierToComps[(int) $tier] = $ids;
+            foreach ($ids as $compId) {
+                $compToTier[$compId] = (int) $tier;
+            }
+        }
+        if (empty($compToTier)) {
+            $this->error("Country {$game->country} has no playable tiers configured. Aborting.");
+            return self::FAILURE;
+        }
+        $leagueIds = array_keys($compToTier);
 
-        $currentLeague = function (string $teamId) use ($gameId, $leagueIds): ?string {
-            return CompetitionEntry::where('game_id', $gameId)
-                ->where('team_id', $teamId)
+        // Detect issues.
+        $issues = [];
+        $reserves = Team::where('country', $game->country)
+            ->whereNotNull('parent_team_id')
+            ->get(['id', 'name', 'parent_team_id']);
+
+        foreach ($reserves as $reserve) {
+            $rLeagues = CompetitionEntry::where('game_id', $gameId)
+                ->where('team_id', $reserve->id)
                 ->whereIn('competition_id', $leagueIds)
-                ->value('competition_id');
-        };
+                ->pluck('competition_id')->all();
+            $pLeagues = CompetitionEntry::where('game_id', $gameId)
+                ->where('team_id', $reserve->parent_team_id)
+                ->whereIn('competition_id', $leagueIds)
+                ->pluck('competition_id')->all();
 
-        $expectations = [
-            self::OSASUNA_PARENT_ID  => ['name' => 'CA Osasuna',         'league' => 'ESP3A'],
-            self::OSASUNA_RESERVE_ID => ['name' => 'CA Osasuna Promesas','league' => 'ESP3A'],
-            self::CELTA_PARENT_ID    => ['name' => 'RC Celta',           'league' => 'ESP3B'],
-            self::CELTA_RESERVE_ID   => ['name' => 'RC Celta Fortuna',   'league' => 'ESP2'],
-            self::ESP2_BOTTOM_ID     => ['name' => 'ESP2 bottom team',   'league' => 'ESP2'],
-        ];
-
-        foreach ($expectations as $teamId => $exp) {
-            $actual = $currentLeague($teamId);
-            if ($actual !== $exp['league']) {
+            // Multi-league membership for a single team is a separate corruption.
+            // Bail rather than guess which league to swap.
+            if (count($rLeagues) > 1 || count($pLeagues) > 1) {
                 $this->error(sprintf(
-                    "Precondition failed: %s (%s) is in %s, expected %s.",
-                    $exp['name'], $teamId, $actual ?? 'NONE', $exp['league'],
+                    "Reserve %s or parent (%s) has multiple league entries — refusing to swap. Investigate competition_entries first.",
+                    $reserve->name,
+                    $reserve->parent_team_id,
                 ));
                 return self::FAILURE;
             }
+
+            $rLeague = $rLeagues[0] ?? null;
+            $pLeague = $pLeagues[0] ?? null;
+            if ($rLeague === null || $pLeague === null) {
+                continue;
+            }
+
+            $rTier = $compToTier[$rLeague];
+            $pTier = $compToTier[$pLeague];
+            $parentName = Team::where('id', $reserve->parent_team_id)->value('name');
+
+            if ($rLeague === $pLeague) {
+                $issues[] = [
+                    'kind' => 'COEXISTENCE',
+                    'reserve' => ['id' => $reserve->id, 'name' => $reserve->name, 'league' => $rLeague, 'tier' => $rTier],
+                    'parent'  => ['id' => (string) $reserve->parent_team_id, 'name' => $parentName, 'league' => $pLeague, 'tier' => $pTier],
+                ];
+            } elseif ($rTier < $pTier) {
+                // Lower tier *number* = higher division. Reserve above parent is inverted.
+                $issues[] = [
+                    'kind' => 'INVERTED',
+                    'reserve' => ['id' => $reserve->id, 'name' => $reserve->name, 'league' => $rLeague, 'tier' => $rTier],
+                    'parent'  => ['id' => (string) $reserve->parent_team_id, 'name' => $parentName, 'league' => $pLeague, 'tier' => $pTier],
+                ];
+            }
         }
 
-        // ESP2 simulated_seasons row must exist (non-played league for this game).
-        $esp2Sim = SimulatedSeason::where('game_id', $gameId)
-            ->where('season', self::EXPECTED_SEASON)
-            ->where('competition_id', 'ESP2')
-            ->first();
-        if (!$esp2Sim) {
-            $this->error("Precondition failed: no simulated_seasons row for ESP2 season " . self::EXPECTED_SEASON . ".");
-            return self::FAILURE;
-        }
-        $results = $esp2Sim->results;
-        if (!is_array($results) || count($results) !== 22) {
-            $this->error("Precondition failed: ESP2 simulated_seasons.results is not a 22-element array (got " . (is_array($results) ? count($results) : gettype($results)) . ").");
-            return self::FAILURE;
-        }
-        $fortunaIdx = array_search(self::CELTA_RESERVE_ID, $results, true);
-        $bottomIdx = array_search(self::ESP2_BOTTOM_ID, $results, true);
-        if ($fortunaIdx === false || $bottomIdx === false) {
-            $this->error("Precondition failed: Fortuna or ESP2 bottom team not found in simulated_seasons.results.");
-            return self::FAILURE;
-        }
-        if ($bottomIdx !== count($results) - 1) {
-            $this->warn("Note: ESP2 bottom team is at index {$bottomIdx}, not " . (count($results) - 1) . " — proceeding anyway (swap is still safe).");
+        if (empty($issues)) {
+            $this->info('No reserve/parent inversions or coexistences detected. Nothing to repair.');
+            return self::SUCCESS;
         }
 
-        // GameStanding rows for the played-league reassignments.
-        $celtaStanding = GameStanding::where('game_id', $gameId)
-            ->where('competition_id', 'ESP3B')
-            ->where('team_id', self::CELTA_PARENT_ID)
-            ->first();
-        $osasunaStanding = GameStanding::where('game_id', $gameId)
-            ->where('competition_id', 'ESP3A')
-            ->where('team_id', self::OSASUNA_PARENT_ID)
-            ->first();
-        if (!$celtaStanding) {
-            $this->error("Precondition failed: no game_standings row for RC Celta in ESP3B.");
-            return self::FAILURE;
+        $this->info('--- Detected issues ---');
+        foreach ($issues as $i) {
+            $this->line("  {$i['kind']}: reserve {$i['reserve']['name']} ({$i['reserve']['league']}) <- parent {$i['parent']['name']} ({$i['parent']['league']})");
         }
-        if (!$osasunaStanding) {
-            $this->error("Precondition failed: no game_standings row for CA Osasuna in ESP3A.");
-            return self::FAILURE;
-        }
-
-        // Print plan.
-        $this->info('--- Planned mutations ---');
-        $this->line("Celta swap (fixes INVERTED):");
-        $this->line("  competition_entries: Fortuna (" . self::CELTA_RESERVE_ID . ") ESP2 -> ESP3B");
-        $this->line("  competition_entries: Celta   (" . self::CELTA_PARENT_ID  . ") ESP3B -> ESP2");
-        $this->line("  game_standings:      ESP3B row pos {$celtaStanding->position} team_id Celta -> Fortuna");
-        $this->line("  simulated_seasons:   ESP2 results[{$fortunaIdx}] Fortuna -> Celta");
-        $this->line('');
-        $this->line("Osasuna swap (fixes COEXISTENCE):");
-        $this->line("  competition_entries: Osasuna (" . self::OSASUNA_PARENT_ID . ") ESP3A -> ESP2");
-        $this->line("  competition_entries: bottom  (" . self::ESP2_BOTTOM_ID     . ") ESP2 -> ESP3A");
-        $this->line("  game_standings:      ESP3A row pos {$osasunaStanding->position} team_id Osasuna -> bottom");
-        $this->line("  simulated_seasons:   ESP2 results[{$bottomIdx}] bottom -> Osasuna");
         $this->line('');
 
-        if ($dryRun) {
-            $this->info('Dry run — no changes written.');
+        // Plan a swap for each issue.
+        $swaps = [];
+        foreach ($issues as $issue) {
+            if ($issue['kind'] === 'INVERTED') {
+                $swaps[] = [
+                    'reason'     => "INVERTED: {$issue['reserve']['name']} ({$issue['reserve']['league']}) <-> {$issue['parent']['name']} ({$issue['parent']['league']})",
+                    'teamA'      => $issue['reserve']['id'],
+                    'teamA_name' => $issue['reserve']['name'],
+                    'leagueA'    => $issue['reserve']['league'],
+                    'teamB'      => $issue['parent']['id'],
+                    'teamB_name' => $issue['parent']['name'],
+                    'leagueB'    => $issue['parent']['league'],
+                ];
+                continue;
+            }
+
+            // COEXISTENCE: swap parent with the bottom team of the next-higher tier.
+            $parentTier = $issue['parent']['tier'];
+            $targetTier = $parentTier - 1;
+            $targetComps = $tierToComps[$targetTier] ?? [];
+            if (empty($targetComps)) {
+                $this->error("Cannot resolve COEXISTENCE for {$issue['parent']['name']} in tier {$parentTier}: no higher tier exists. Aborting.");
+                return self::FAILURE;
+            }
+            if (count($targetComps) > 1) {
+                $this->error("Cannot resolve COEXISTENCE for {$issue['parent']['name']}: tier {$targetTier} has siblings (" . implode(',', $targetComps) . "). Manual swap target required. Aborting.");
+                return self::FAILURE;
+            }
+            $targetComp = $targetComps[0];
+            $bottomTeamId = $this->bottomTeamOf($gameId, (string) $game->season, $targetComp);
+            if ($bottomTeamId === null) {
+                $this->error("Cannot resolve COEXISTENCE for {$issue['parent']['name']}: no bottom team found in {$targetComp}. Aborting.");
+                return self::FAILURE;
+            }
+            $bottomName = Team::where('id', $bottomTeamId)->value('name');
+            $swaps[] = [
+                'reason'     => "COEXISTENCE: {$issue['parent']['name']} ({$issue['parent']['league']}) <-> {$bottomName} ({$targetComp}) [parent moves up]",
+                'teamA'      => $issue['parent']['id'],
+                'teamA_name' => $issue['parent']['name'],
+                'leagueA'    => $issue['parent']['league'],
+                'teamB'      => $bottomTeamId,
+                'teamB_name' => $bottomName,
+                'leagueB'    => $targetComp,
+            ];
+        }
+
+        // Resolve slots for every swap so we can print the full mutation list
+        // up front and fail before any writes if a slot is unlocatable.
+        $mutations = [];
+        $this->info('--- Planned swaps ---');
+        foreach ($swaps as $swap) {
+            $this->line("  {$swap['reason']}");
+            $slotA = $this->locateSlot($gameId, (string) $game->season, $swap['leagueA'], $swap['teamA']);
+            $slotB = $this->locateSlot($gameId, (string) $game->season, $swap['leagueB'], $swap['teamB']);
+            if ($slotA === null) {
+                $this->error("    Cannot locate slot for {$swap['teamA_name']} in {$swap['leagueA']} (no game_standings or simulated_seasons entry). Aborting.");
+                return self::FAILURE;
+            }
+            if ($slotB === null) {
+                $this->error("    Cannot locate slot for {$swap['teamB_name']} in {$swap['leagueB']} (no game_standings or simulated_seasons entry). Aborting.");
+                return self::FAILURE;
+            }
+            $this->line("    competition_entries: {$swap['teamA_name']} {$swap['leagueA']} -> {$swap['leagueB']}");
+            $this->line("    competition_entries: {$swap['teamB_name']} {$swap['leagueB']} -> {$swap['leagueA']}");
+            $this->line("    {$swap['leagueA']} ({$slotA['kind']}): {$swap['teamA_name']} -> {$swap['teamB_name']}");
+            $this->line("    {$swap['leagueB']} ({$slotB['kind']}): {$swap['teamB_name']} -> {$swap['teamA_name']}");
+            $mutations[] = ['swap' => $swap, 'slotA' => $slotA, 'slotB' => $slotB];
+        }
+        $this->line('');
+
+        if (!$apply) {
+            $this->info('Dry run — no changes written. Pass --apply to execute.');
             return self::SUCCESS;
         }
 
         try {
-            DB::transaction(function () use ($gameId, $esp2Sim, $celtaStanding, $osasunaStanding, $fortunaIdx, $bottomIdx) {
-                // --- Celta swap ---
-                CompetitionEntry::where('game_id', $gameId)
-                    ->where('team_id', self::CELTA_RESERVE_ID)
-                    ->where('competition_id', 'ESP2')
-                    ->update(['competition_id' => 'ESP3B']);
-                CompetitionEntry::where('game_id', $gameId)
-                    ->where('team_id', self::CELTA_PARENT_ID)
-                    ->where('competition_id', 'ESP3B')
-                    ->update(['competition_id' => 'ESP2']);
+            DB::transaction(function () use ($gameId, $mutations) {
+                foreach ($mutations as $m) {
+                    $swap = $m['swap'];
 
-                $celtaStanding->team_id = self::CELTA_RESERVE_ID;
-                $celtaStanding->save();
+                    $a = CompetitionEntry::where('game_id', $gameId)
+                        ->where('team_id', $swap['teamA'])
+                        ->where('competition_id', $swap['leagueA'])
+                        ->update(['competition_id' => $swap['leagueB']]);
+                    if ($a !== 1) {
+                        throw new \RuntimeException("Expected 1 competition_entries update for {$swap['teamA_name']} {$swap['leagueA']}->{$swap['leagueB']}, got {$a}.");
+                    }
+                    $b = CompetitionEntry::where('game_id', $gameId)
+                        ->where('team_id', $swap['teamB'])
+                        ->where('competition_id', $swap['leagueB'])
+                        ->update(['competition_id' => $swap['leagueA']]);
+                    if ($b !== 1) {
+                        throw new \RuntimeException("Expected 1 competition_entries update for {$swap['teamB_name']} {$swap['leagueB']}->{$swap['leagueA']}, got {$b}.");
+                    }
 
-                $results = $esp2Sim->results;
-                $results[$fortunaIdx] = self::CELTA_PARENT_ID;
-
-                // --- Osasuna swap ---
-                CompetitionEntry::where('game_id', $gameId)
-                    ->where('team_id', self::OSASUNA_PARENT_ID)
-                    ->where('competition_id', 'ESP3A')
-                    ->update(['competition_id' => 'ESP2']);
-                CompetitionEntry::where('game_id', $gameId)
-                    ->where('team_id', self::ESP2_BOTTOM_ID)
-                    ->where('competition_id', 'ESP2')
-                    ->update(['competition_id' => 'ESP3A']);
-
-                $osasunaStanding->team_id = self::ESP2_BOTTOM_ID;
-                $osasunaStanding->save();
-
-                // Find the bottom team's current index in the (already
-                // mutated) results array — array_search rather than the
-                // pre-computed index, in case the Celta swap shifted things
-                // (it doesn't, but the cost is negligible and the safety
-                // margin is real).
-                $bottomIdxNow = array_search(self::ESP2_BOTTOM_ID, $results, true);
-                if ($bottomIdxNow === false) {
-                    throw new \RuntimeException('ESP2 bottom team disappeared from results mid-transaction.');
+                    // Slot A (was teamA) becomes teamB; slot B (was teamB) becomes teamA.
+                    $this->applySlotSwap($m['slotA'], $swap['teamB']);
+                    $this->applySlotSwap($m['slotB'], $swap['teamA']);
                 }
-                $results[$bottomIdxNow] = self::OSASUNA_PARENT_ID;
-
-                $esp2Sim->results = $results;
-                $esp2Sim->save();
             });
         } catch (\Throwable $e) {
             $this->error("Repair failed: {$e->getMessage()}");
@@ -246,5 +287,81 @@ class RepairReserveParentCoexistence extends Command
         $this->line("  php artisan app:resume-season-transition {$gameId}");
 
         return self::SUCCESS;
+    }
+
+    /**
+     * Locate a team's slot inside a league for the given game/season. Returns
+     * a descriptor for a game_standings row (played league) or a
+     * simulated_seasons.results index (non-played league), or null if the
+     * team isn't present in either store.
+     *
+     * @return array{kind: string, standing?: GameStanding, sim?: SimulatedSeason, index?: int}|null
+     */
+    private function locateSlot(string $gameId, string $season, string $competitionId, string $teamId): ?array
+    {
+        $standing = GameStanding::where('game_id', $gameId)
+            ->where('competition_id', $competitionId)
+            ->where('team_id', $teamId)
+            ->first();
+        if ($standing) {
+            return ['kind' => 'standing', 'standing' => $standing];
+        }
+
+        $sim = SimulatedSeason::where('game_id', $gameId)
+            ->where('season', $season)
+            ->where('competition_id', $competitionId)
+            ->first();
+        if ($sim && is_array($sim->results)) {
+            $idx = array_search($teamId, $sim->results, true);
+            if ($idx !== false) {
+                return ['kind' => 'sim', 'sim' => $sim, 'index' => $idx];
+            }
+        }
+
+        return null;
+    }
+
+    private function applySlotSwap(array $slot, string $newTeamId): void
+    {
+        if ($slot['kind'] === 'standing') {
+            $standing = $slot['standing'];
+            $standing->team_id = $newTeamId;
+            $standing->save();
+            return;
+        }
+        if ($slot['kind'] === 'sim') {
+            $sim = $slot['sim'];
+            $results = $sim->results;
+            $results[$slot['index']] = $newTeamId;
+            $sim->results = $results;
+            $sim->save();
+            return;
+        }
+        throw new \RuntimeException("Unknown slot kind: {$slot['kind']}.");
+    }
+
+    /**
+     * Bottom team of a league: last position by game_standings if played,
+     * otherwise last element of simulated_seasons.results.
+     */
+    private function bottomTeamOf(string $gameId, string $season, string $competitionId): ?string
+    {
+        $standing = GameStanding::where('game_id', $gameId)
+            ->where('competition_id', $competitionId)
+            ->orderByDesc('position')
+            ->first();
+        if ($standing) {
+            return (string) $standing->team_id;
+        }
+
+        $sim = SimulatedSeason::where('game_id', $gameId)
+            ->where('season', $season)
+            ->where('competition_id', $competitionId)
+            ->first();
+        if ($sim && is_array($sim->results) && !empty($sim->results)) {
+            return (string) $sim->results[array_key_last($sim->results)];
+        }
+
+        return null;
     }
 }


### PR DESCRIPTION
## Summary

Converts the hardcoded, game-specific `RepairReserveParentCoexistence` command into a general-purpose repair tool that detects and fixes reserve/parent league assignment issues for any game and country.

## Key Changes

- **Removed hardcoded preconditions**: Deleted checks for specific game ID, country (ES), season (2045), and step (22). Now accepts any game UUID and validates only the essential precondition: `season_transition_step === 22` (the step before PromotionRelegationProcessor runs).

- **Dynamic tier/competition mapping**: Replaced hardcoded league IDs (`ESP1`, `ESP2`, `ESP3A`, `ESP3B`) with dynamic lookup via `CountryConfig::tiers()` and `CountryConfig::tierCompetitionIds()`. Works for any country's tier structure.

- **Automatic issue detection**: Scans all reserve teams in the game's country and detects two issue types:
  - **INVERTED**: reserve in a higher tier than its parent (e.g., Promesas ESP1, Osasuna ESP2)
  - **COEXISTENCE**: reserve and parent already share a competition

- **Generalized swap planning**:
  - **INVERTED**: swaps reserve ↔ parent directly (restores hierarchy, no unrelated displacement)
  - **COEXISTENCE**: swaps parent with the bottom team of the next-higher tier (requires single competition at that tier; aborts if tier has siblings)

- **Unified slot resolution**: Introduced `locateSlot()` to find a team's position in either `game_standings` (played league) or `simulated_seasons.results` (non-played league), eliminating duplicate logic.

- **Refactored mutations**: Consolidated swap logic into a loop that applies both `competition_entries` updates and slot swaps (standing or sim) in a single transaction.

- **Improved UX**:
  - Changed `--dry-run` flag to `--apply` (dry-run is now the default, safer)
  - Prints full mutation plan before any writes
  - Validates all slots exist before attempting transaction
  - Better error messages with context (tier numbers, competition names, etc.)

- **Added dependency injection**: Constructor now accepts `CountryConfig` for cleaner tier lookups.

## Implementation Details

- Preconditions are minimal: game exists, is transitioning, and is at step 22. No hardcoded UUIDs or season checks.
- Multi-league membership (a team in multiple leagues) is detected and rejected with a clear error — a separate corruption that requires manual investigation.
- For COEXISTENCE repairs, aborts if the target tier has multiple competitions (siblings), since the choice of which to swap into requires manual judgment.
- All mutations are wrapped in a single transaction; any failure rolls back cleanly.
- Safe to leave in the tree indefinitely — preconditions guarantee it only acts on games in the exact state where the planner would fail.

https://claude.ai/code/session_01RBmvJ4graeQWM44QCRfgVn