### PR TITLE
Skip cascade moves for reserves already being relegated

### DIFF
--- a/app/Modules/Competition/Promotions/CountryPromotionRelegationPlanner.php
+++ b/app/Modules/Competition/Promotions/CountryPromotionRelegationPlanner.php
@@ -784,10 +784,17 @@ class CountryPromotionRelegationPlanner
             // Skip pairs the per-rule loop will resolve naturally:
             //   - parent being relegated: leaves the coexistence tier.
             //   - parent being promoted: leaves the coexistence tier.
+            //   - reserve being relegated: leaves the coexistence tier.
             //   - reserve being promoted: leaves the coexistence tier.
-            // In all three cases the post-plan finalComp puts the two
-            // teams in different competitions without any repair move.
+            // In all four cases the post-plan finalComp puts the two
+            // teams in different competitions without any repair move —
+            // emitting a cascade move for a team that already has a
+            // relegation/promotion move trips validatePlan's
+            // no-double-move check.
             if (isset($beingRelegated[$parent])) {
+                continue;
+            }
+            if (isset($beingRelegated[$reserve])) {
                 continue;
             }
             if (isset($alreadyPromoted[$parent])) {
@@ -942,6 +949,16 @@ class CountryPromotionRelegationPlanner
                 if ($reserveCurrentComp !== $parentDest) {
                     // Parent landing in a different competition than the reserve.
                     // For sibling tiers (ESP3A/ESP3B), that means no collision at all.
+                    continue;
+                }
+
+                if (isset($beingRelegated[$reserve])) {
+                    // The reserve is itself being relegated out of this tier by
+                    // a deeper rule (e.g. parent relegating ESP1→ESP2 while the
+                    // reserve relegates ESP2→ESP3 on its own merits). The reserve
+                    // leaves the collision tier under its own rule's move, so
+                    // adding a cascade here would emit a second move for the
+                    // same team and trip validatePlan's no-double-move check.
                     continue;
                 }
 

--- a/tests/Unit/CountryPromotionRelegationPlannerTest.php
+++ b/tests/Unit/CountryPromotionRelegationPlannerTest.php
@@ -809,6 +809,113 @@ class CountryPromotionRelegationPlannerTest extends TestCase
         $this->assertTierCountsPreserved($plan, $snapshot, $this->spainConfig);
     }
 
+    public function test_parent_relegating_into_already_relegating_reserve_tier_does_not_double_move_reserve(): void
+    {
+        // Production regression (game 03449aaa, season 2039): parent (e.g.
+        // Real Sociedad) at ESP1 pos 18 is relegating to ESP2. Reserve (Real
+        // Sociedad B) at ESP2 pos 22 is itself relegating to ESP3. The
+        // per-rule cascade for rule #1 would naively emit a cascade move
+        // pushing the reserve from ESP2 to ESP3 (parent's destination ==
+        // reserve's current comp), but buildRuleMoves ALREADY emits a
+        // relegation move for the reserve from rule #2's relegators. Two
+        // moves for the same team trip validatePlan's no-double-move check.
+        //
+        // The reserve's own relegation leaves the collision tier naturally,
+        // so the cascade is redundant — it must be skipped.
+        $esp1 = $this->ids(20, 'a1');
+        $parent = $esp1[17]; // pos 18, relegating to ESP2
+        $reserve = 'reserve-of-' . $parent;
+        // Reserve at the bottom of ESP2 (pos 22) — also relegating.
+        $esp2 = array_merge($this->ids(21, 'a2'), [$reserve]);
+
+        $snapshot = new CountrySeasonSnapshot(
+            countryCode: 'ES',
+            standingsByCompetition: [
+                'ESP1' => $esp1,
+                'ESP2' => $esp2,
+                'ESP3A' => $this->ids(20, 'a3'),
+                'ESP3B' => $this->ids(20, 'b3'),
+            ],
+            reserveToParent: [$reserve => $parent],
+            playoffStates: [
+                'ESP2' => PlayoffState::NotStarted,
+                'ESP3PO' => PlayoffState::NotStarted,
+            ],
+        );
+
+        $plan = $this->planner->planFromSnapshot($snapshot, $this->spainConfig);
+
+        // Reserve has exactly one move: its own relegation ESP2 → ESP3*.
+        $reserveMoves = array_values(array_filter(
+            $plan->moves,
+            fn (PromotionMove $m) => $m->teamId === $reserve,
+        ));
+        $this->assertCount(1, $reserveMoves, 'Reserve should only appear in one move');
+        $this->assertSame(PromotionMove::REASON_RELEGATION, $reserveMoves[0]->reason);
+        $this->assertSame('ESP2', $reserveMoves[0]->fromCompetitionId);
+        $this->assertContains($reserveMoves[0]->toCompetitionId, ['ESP3A', 'ESP3B']);
+
+        // Parent still relegates to ESP2.
+        $parentMove = $this->findMove($plan, $parent);
+        $this->assertNotNull($parentMove);
+        $this->assertSame('ESP2', $parentMove->toCompetitionId);
+
+        $this->assertNoTeamMovedTwice($plan);
+        $this->assertNoReserveParentCoexistenceAfterPlan($plan, $snapshot);
+        $this->assertTierCountsPreserved($plan, $snapshot, $this->spainConfig);
+    }
+
+    public function test_inherited_coexistence_skipped_when_reserve_is_relegating(): void
+    {
+        // Pre-pass companion to the above: reserve and parent already
+        // coexist in ESP2 (data drift), parent is mid-table, but reserve
+        // is at ESP2 pos 22 — relegating to ESP3 under its own rule. The
+        // pre-pass must not cascade the reserve, because rule #2's
+        // relegation move already moves it out of the coexistence tier.
+        $esp1 = $this->ids(20, 'a1');
+        $parent = 'midtable-parent';
+        $reserve = 'relegating-reserve';
+        // Parent mid-table, reserve at bottom (pos 22) — both in ESP2.
+        $esp2 = array_merge(
+            $this->ids(10, 'a2-top'),
+            [$parent],
+            $this->ids(10, 'a2-mid'),
+            [$reserve],
+        );
+
+        $snapshot = new CountrySeasonSnapshot(
+            countryCode: 'ES',
+            standingsByCompetition: [
+                'ESP1' => $esp1,
+                'ESP2' => $esp2,
+                'ESP3A' => $this->ids(20, 'a3'),
+                'ESP3B' => $this->ids(20, 'b3'),
+            ],
+            reserveToParent: [$reserve => $parent],
+            playoffStates: [
+                'ESP2' => PlayoffState::NotStarted,
+                'ESP3PO' => PlayoffState::NotStarted,
+            ],
+        );
+
+        $plan = $this->planner->planFromSnapshot($snapshot, $this->spainConfig);
+
+        // Reserve has exactly one move (its own relegation).
+        $reserveMoves = array_values(array_filter(
+            $plan->moves,
+            fn (PromotionMove $m) => $m->teamId === $reserve,
+        ));
+        $this->assertCount(1, $reserveMoves);
+        $this->assertSame(PromotionMove::REASON_RELEGATION, $reserveMoves[0]->reason);
+
+        // Parent untouched.
+        $this->assertNull($this->findMove($plan, $parent));
+
+        $this->assertNoTeamMovedTwice($plan);
+        $this->assertNoReserveParentCoexistenceAfterPlan($plan, $snapshot);
+        $this->assertTierCountsPreserved($plan, $snapshot, $this->spainConfig);
+    }
+
     public function test_reserve_promotion_blocked_when_parent_in_destination_no_relegation(): void
     {
         // Standard case: parent stays in ESP1, reserve at ESP2 pos 1 — blocked.


### PR DESCRIPTION
## Summary

Fixes a regression where reserve teams being relegated on their own merits would receive duplicate moves when their parent club was also being relegated into the same tier. The planner now correctly skips redundant cascade moves for reserves that are already leaving the coexistence tier via their own relegation rule.

## Changes

- **CountryPromotionRelegationPlanner.php:**
  - Added check in `resolveReserveProtection()` pre-pass to skip coexistence pairs where the reserve is already being relegated (lines 797–799)
  - Added check in the cascade move builder to skip emitting cascade moves for reserves with existing relegation moves (lines 955–964)
  - Updated comments to document the four cases where cascade moves should be skipped (lines 787–791)

- **CountryPromotionRelegationPlannerTest.php:**
  - Added `test_parent_relegating_into_already_relegating_reserve_tier_does_not_double_move_reserve()` — regression test for the production case where parent (e.g. Real Sociedad at ESP1 pos 18) relegates to ESP2 while reserve (Real Sociedad B at ESP2 pos 22) is also relegating to ESP3
  - Added `test_inherited_coexistence_skipped_when_reserve_is_relegating()` — companion test for pre-existing coexistence where parent is mid-table and reserve is at the bottom, both in ESP2, with reserve relegating

## Implementation Details

The fix prevents `validatePlan`'s no-double-move check from failing by recognizing that when a reserve is being relegated under rule #2 (its own relegation), any cascade move from rule #1 (parent's relegation) is redundant—the reserve naturally leaves the collision tier via its own move. The reserve's final competition is determined by its own relegation rule, not by a cascade, so the cascade must be skipped to avoid emitting two moves for the same team.

https://claude.ai/code/session_014GCKjyL9BHERtmSc9AX3ED