### PR TITLE
Enforce U-23 cap on AI reserve squads at season close

### DIFF
--- a/app/Modules/ReserveTeam/Services/ReserveTeamService.php
+++ b/app/Modules/ReserveTeam/Services/ReserveTeamService.php
@@ -162,22 +162,37 @@ class ReserveTeamService
      * recorded as a GameTransfer of type INTERNAL_PROMOTION. Any active
      * call-up loan for the player is closed first.
      *
+     * Defaults to the user's filial pair ($game->reserve_team_id /
+     * $game->team_id). Pass explicit ids to operate on an AI club's reserve
+     * — in that case the user-only side effects (squad-number assignment via
+     * SquadNumberService, UserSquadCareerRecord, and the user notification)
+     * are skipped, since SquadNumberService is hard-wired to $game->team_id
+     * and the career/notification streams are user-scoped.
+     *
      * Returns the list of promoted players for downstream processors.
      *
      * @return Collection<int, GamePlayer>
      */
-    public function autoPromoteOverageReservePlayers(Game $game): Collection
-    {
-        if ($game->reserve_team_id === null) {
+    public function autoPromoteOverageReservePlayers(
+        Game $game,
+        ?string $reserveTeamId = null,
+        ?string $parentTeamId = null,
+    ): Collection {
+        $reserveTeamId ??= $game->reserve_team_id;
+        $parentTeamId ??= $game->team_id;
+
+        if ($reserveTeamId === null || $parentTeamId === null) {
             return collect();
         }
+
+        $isUserFilial = ($reserveTeamId === $game->reserve_team_id);
 
         // Season close runs before $game->season is incremented, so we evaluate
         // against next season's U-23 cutoff: players who'd be overage (NOT
         // U-23) under next season's rule must move up to the first team now.
         $nextSeasonU23Cutoff = $game->getU23BirthCutoff((int) $game->season + 1);
 
-        $candidates = GamePlayer::ownedByTeam($game->reserve_team_id)
+        $candidates = GamePlayer::ownedByTeam($reserveTeamId)
             ->where('game_id', $game->id)
             ->where('date_of_birth', '<', $nextSeasonU23Cutoff)
             ->with(['activeLoan'])
@@ -188,50 +203,57 @@ class ReserveTeamService
         foreach ($candidates as $player) {
             // Close any active call-up loan first so returnLoan() doesn't
             // later try to flip the player back to the reserve team.
-            if ($player->activeLoan && $player->activeLoan->parent_team_id === $game->reserve_team_id) {
+            if ($player->activeLoan && $player->activeLoan->parent_team_id === $reserveTeamId) {
                 $player->activeLoan->update(['status' => Loan::STATUS_COMPLETED]);
             }
 
             // Permanent move to first team. Null the reserve number first so
             // the (game_id, team_id, number) unique constraint can't fire on
-            // the team_id flip.
-            $reserveTeamName = $game->reserveTeam?->name;
-            $player->update(['number' => null, 'team_id' => $game->team_id]);
-            $number = $this->squadNumberService->assignNumberForNewPlayer($game, $player);
-            if ($number !== null) {
-                $player->update(['number' => $number]);
-            }
+            // the team_id flip. AI promotions leave the number null — AI
+            // squads don't depend on shirt numbers and SquadNumberService is
+            // user-scoped.
+            $player->update(['number' => null, 'team_id' => $parentTeamId]);
 
-            \App\Models\UserSquadCareerRecord::updateOrCreate(
-                ['game_player_id' => $player->id],
-                [
-                    'game_id' => $game->id,
-                    'team_id' => $game->team_id,
-                    'joined_season' => (int) $game->season,
-                    'joined_from' => $reserveTeamName ?? \App\Models\UserSquadCareerRecord::ORIGIN_ACADEMY,
-                ],
-            );
+            if ($isUserFilial) {
+                $reserveTeamName = $game->reserveTeam?->name;
+                $number = $this->squadNumberService->assignNumberForNewPlayer($game, $player);
+                if ($number !== null) {
+                    $player->update(['number' => $number]);
+                }
+
+                \App\Models\UserSquadCareerRecord::updateOrCreate(
+                    ['game_player_id' => $player->id],
+                    [
+                        'game_id' => $game->id,
+                        'team_id' => $parentTeamId,
+                        'joined_season' => (int) $game->season,
+                        'joined_from' => $reserveTeamName ?? \App\Models\UserSquadCareerRecord::ORIGIN_ACADEMY,
+                    ],
+                );
+            }
 
             GameTransfer::record(
                 gameId: $game->id,
                 gamePlayerId: $player->id,
-                fromTeamId: $game->reserve_team_id,
-                toTeamId: $game->team_id,
+                fromTeamId: $reserveTeamId,
+                toTeamId: $parentTeamId,
                 transferFee: 0,
                 type: GameTransfer::TYPE_INTERNAL_PROMOTION,
                 season: $game->season,
                 window: TransferWindowType::currentValue($game->current_date),
             );
 
-            $this->notificationService->create(
-                game: $game,
-                type: \App\Models\GameNotification::TYPE_ACADEMY_PROSPECT,
-                title: __('notifications.reserve_overage_promoted_title'),
-                message: __('notifications.reserve_overage_promoted_message', [
-                    'player' => $player->name ?? '',
-                ]),
-                priority: \App\Models\GameNotification::PRIORITY_INFO,
-            );
+            if ($isUserFilial) {
+                $this->notificationService->create(
+                    game: $game,
+                    type: \App\Models\GameNotification::TYPE_ACADEMY_PROSPECT,
+                    title: __('notifications.reserve_overage_promoted_title'),
+                    message: __('notifications.reserve_overage_promoted_message', [
+                        'player' => $player->name ?? '',
+                    ]),
+                    priority: \App\Models\GameNotification::PRIORITY_INFO,
+                );
+            }
 
             $promoted->push($player);
         }

--- a/app/Modules/Season/Processors/ReserveOveragePromotionProcessor.php
+++ b/app/Modules/Season/Processors/ReserveOveragePromotionProcessor.php
@@ -3,18 +3,19 @@
 namespace App\Modules\Season\Processors;
 
 use App\Models\Game;
+use App\Models\Team;
 use App\Modules\ReserveTeam\Services\ReserveTeamService;
 use App\Modules\Season\Contracts\SeasonProcessor;
 use App\Modules\Season\DTOs\SeasonTransitionData;
 
 /**
- * For filial games, permanently promotes any reserve player who has aged
- * past the reserve cutoff (over 23) to the first team.
+ * Permanently promotes any reserve player who has aged past the reserve
+ * cutoff (over 23) to the first team. Applies to both the user's filial
+ * (if any) and every AI parent club that has a reserve team — without this
+ * the AI side accumulates over-age players on reserve rosters indefinitely.
  *
  * Runs before LoanReturnProcessor (priority 5) so age-23 players are settled
  * permanently in the first team before remaining call-up loans snap back.
- *
- * No-op for non-filial games.
  *
  * Priority: 4
  */
@@ -31,11 +32,33 @@ class ReserveOveragePromotionProcessor implements SeasonProcessor
 
     public function process(Game $game, SeasonTransitionData $data): SeasonTransitionData
     {
-        if ($game->reserve_team_id === null) {
-            return $data;
+        $promoted = collect();
+
+        if ($game->reserve_team_id !== null) {
+            $promoted = $promoted->concat(
+                $this->reserveTeamService->autoPromoteOverageReservePlayers($game)
+            );
         }
 
-        $promoted = $this->reserveTeamService->autoPromoteOverageReservePlayers($game);
+        // Reserves Team lookup is single-plane (control); the per-reserve
+        // promotion runs only tenant-plane queries internally. No cross-plane
+        // JOIN.
+        $userTeamIds = $game->userTeamIds();
+        $aiReserves = Team::whereNotNull('parent_team_id')
+            ->when(! empty($userTeamIds), fn ($q) => $q
+                ->whereNotIn('id', $userTeamIds)
+                ->whereNotIn('parent_team_id', $userTeamIds))
+            ->get(['id', 'parent_team_id']);
+
+        foreach ($aiReserves as $reserve) {
+            $promoted = $promoted->concat(
+                $this->reserveTeamService->autoPromoteOverageReservePlayers(
+                    $game,
+                    $reserve->id,
+                    $reserve->parent_team_id,
+                )
+            );
+        }
 
         if ($promoted->isNotEmpty()) {
             $data->setMetadata('reserve_overage_promoted', $promoted->count());


### PR DESCRIPTION
## Summary
- Reserve overage promotion previously ran only for the user's filial. AI parent clubs accumulated over-age players on their reserve rosters indefinitely, inflating reserve quality and contributing to filiales reaching promotion positions in ESP2/ESP3.
- `ReserveOveragePromotionProcessor` now iterates every AI reserve team (control-plane lookup) and promotes outfielders who would no longer be U-23 next season. Single-plane queries on both sides — no cross-plane JOIN.
- `ReserveTeamService::autoPromoteOverageReservePlayers()` takes optional `$reserveTeamId` / `$parentTeamId`. For AI promotions it skips the user-only side effects (`SquadNumberService` is hard-wired to `$game->team_id`, `UserSquadCareerRecord` and the user notification stream are user-scoped) and leaves the promoted player's number `null`.

This is PR #1 of 4 in a series that reshapes reserves into actual development squads (see plan: weaker initial ratings, AI call-ups, AI poaching, age-cap enforcement). It is the smallest change with the highest leverage and ships first so the downstream PRs can be observed in isolation.

## Test plan
- [ ] Existing user-managed filial: starting a game where the user manages a parent club (e.g. Real Madrid + Castilla), simulating a season, and confirming the same overage promotions land on the first team with squad numbers + `UserSquadCareerRecord` + notification as before.
- [ ] AI reserves: simulate one full season (`php artisan app:simulate-season`); query reserves for outfielders born before next season's U-23 cutoff — expect zero on every AI reserve.
- [ ] Inspect `game_transfers` for `type = internal_promotion` rows whose `from_team_id` is an AI reserve — expect a non-zero count.
- [ ] Long horizon: simulate 3–5 seasons; check that ESP2 standings for reserves cluster mid-to-lower-table rather than top-6 (the cumulative effect — full impact also depends on PRs #2–#4).
- [ ] No new tests broken: `php artisan test --filter=ReserveTeam` and `php artisan test --filter=Promotion`.

https://claude.ai/code/session_01RMZYzkNtmJxj53wuqHFChN

---
_Generated by [Claude Code](https://claude.ai/code/session_01RMZYzkNtmJxj53wuqHFChN)_