### PR TITLE
Decouple young-player overall from market-value inflation

### DIFF
--- a/app/Modules/Player/Services/PlayerDevelopmentService.php
+++ b/app/Modules/Player/Services/PlayerDevelopmentService.php
@@ -170,7 +170,7 @@ class PlayerDevelopmentService
     /**
      * Calculate potential bonus based on market value relative to age.
      *
-     * @return int Bonus points to add to potential range (0-10)
+     * @return int Bonus points to add to potential range (0-12)
      */
     private function getValuePotentialBonus(int $age, int $marketValueCents): int
     {
@@ -192,6 +192,24 @@ class PlayerDevelopmentService
         };
 
         $valueRatio = $marketValueCents / max(1, $typicalValueForAge);
+
+        // Young players: PlayerValuationService::adjustAbilityForAge() no
+        // longer raises the age cap on current ability for high-market-value
+        // youngsters — that headroom now lives in potential instead. Bonus
+        // kicks in at lower value ratios so a 19yo who's merely "expensive
+        // for his age" still gains potential, not just the megastars.
+        if ($age <= PlayerAge::YOUNG_END) {
+            return match (true) {
+                $valueRatio >= 100 => 12, // e.g. €120M 17yo (240x typical)
+                $valueRatio >= 50 => 10,
+                $valueRatio >= 20 => 8,
+                $valueRatio >= 10 => 6,
+                $valueRatio >= 5 => 4,
+                $valueRatio >= 2 => 2,
+                $valueRatio >= 1 => 1,
+                default => 0,
+            };
+        }
 
         // Higher ratio = more proven potential
         return match (true) {

--- a/app/Modules/Player/Services/PlayerValuationService.php
+++ b/app/Modules/Player/Services/PlayerValuationService.php
@@ -177,27 +177,26 @@ class PlayerValuationService
     }
 
     /**
-     * Adjust raw ability for age (young players capped, veterans boosted).
+     * Adjust raw ability for age.
      *
-     * Young players with exceptional market value get higher caps (proven talent).
-     * Veterans with high market value get ability boosts (proven quality).
+     * Young players (< YOUNG_END) are capped by age: market value at this
+     * stage signals POTENTIAL, not current ability — a 17yo worth €120M is
+     * priced for his ceiling, not for being world-class today. The extra
+     * headroom is channelled into potential by
+     * PlayerDevelopmentService::generatePotential(), not into current
+     * overall.
+     *
+     * Veterans (PRIME_END - 2 onwards) get an ability boost when their
+     * market value proves they're still elite. Different signal: a 33yo
+     * worth €40M is staying expensive because he's still delivering at top
+     * level, so the market value does map to current ability.
      */
     private function adjustAbilityForAge(int $rawAbility, int $marketValueCents, int $age): int
     {
         if ($age < PlayerAge::YOUNG_END) {
-            // Base cap increases with age: 17yo = 75, 22yo = 85
+            // Base cap increases with age: 17yo = 75, 22yo = 85. No market-
+            // value boost: the headroom flows into potential, not overall.
             $ageCap = 75 + ($age - 17) * 2;
-
-            // Exceptional market value raises the cap significantly
-            if ($marketValueCents >= 15_000_000_000) {      // €150M+
-                $ageCap += 14;
-            } elseif ($marketValueCents >= 10_000_000_000) { // €100M+
-                $ageCap += 10;
-            } elseif ($marketValueCents >= 5_000_000_000) {  // €50M+
-                $ageCap += 6;
-            } elseif ($marketValueCents >= 2_000_000_000) {  // €20M+
-                $ageCap += 3;
-            }
 
             return min($rawAbility, $ageCap);
         }


### PR DESCRIPTION
## Summary
- A young player's market value reflects POTENTIAL, not current ability — a 17yo priced at €120M is priced for his ceiling, not for being world-class today. The seed formula routed both signals into current overall, so high-market-value 17yo spawned at overall 85+ with potential 99 (only a 14-point growth gap).
- `PlayerValuationService::adjustAbilityForAge()` no longer raises the age cap on current ability for young players. The cap stays at `75 + (age - 17) * 2` regardless of market value: a 19yo €50M prospect now spawns at 79 (was 83), a 17yo €120M prodigy at 75 (was 85).
- `PlayerDevelopmentService::getValuePotentialBonus()` adds a young branch with a lower-threshold ladder (kicks in at valueRatio ≥ 1 instead of ≥ 5) and a higher ceiling (max +12 vs +10). The headroom that used to inflate current ability now lives in the potential window, so growth runway through the development curve expresses what the price tag implied.
- Veteran ability boost (PRIME_END − 2 onwards) is unchanged: at that age market value tracks current delivery, not ceiling.

This is PR #2 of 4 in the reserve-team-rebalance series. Only affects new games seeded after deploy.

## Canonical sanity checks (formula trace)
| Profile | Old overall | New overall | Old potential | New potential |
|---|---|---|---|---|
| 19yo / €5M (typical reserve star) | 68 | 68 | ~83 | ~84 |
| 19yo / €50M (Yamal-class) | 83 | 79 | ~99 | ~99 |
| 17yo / €120M (prodigy) | 85 | 75 | 99 | 99 |
| 22yo / €5M (older reserve) | 68 | 68 | ~70 | ~70 |
| 28yo / €5M (veteran starter) | 68 | 68 | ~69 | ~69 |

## Test plan
- [ ] `php artisan app:seed-reference-data --fresh`, start a new game, then query reserve squads:
  - Expect avg `overall_score` for ages ≤ 21 to drop slightly relative to a pre-PR seed (mainly from high-market-value stars dropping toward the cap, not from typical €5M reserve players).
  - Expect avg `potential` for the same group to be stable or slightly higher.
- [ ] Check a known prodigy template (e.g. Lamine Yamal at age 17 — high market value): confirm overall lands around the new age cap with potential at/near 99. Verify the development curve can grow them toward that potential over 4–5 seasons.
- [ ] Verify veteran ratings unchanged (spot-check a 33yo €40M Modric-class — current branch still applies veteran boost).
- [ ] `php artisan test --filter=PlayerDevelopmentProcessorTest`: existing test exercises `overallScoreToMarketValue` (inverse mapping) which is not touched — should still pass.

https://claude.ai/code/session_01RMZYzkNtmJxj53wuqHFChN

---
_Generated by [Claude Code](https://claude.ai/code/session_01RMZYzkNtmJxj53wuqHFChN)_