### PR TITLE
AI parent clubs promote top reserve prospects at season close

### DIFF
--- a/app/Modules/ReserveTeam/Services/ReserveTeamService.php
+++ b/app/Modules/ReserveTeam/Services/ReserveTeamService.php
@@ -368,6 +368,110 @@ class ReserveTeamService
         );
     }
 
+    /**
+     * AI-side: at season close, permanently promote the top young prospects
+     * from an AI club's reserve to its parent first team. Ranked per
+     * position group by a blend of current ability and potential; only the
+     * clearest "this kid is going somewhere" profiles are picked (blend
+     * score ≥ MIN_PROSPECT_BLEND), so the typical reserve loses one or two
+     * stars per season rather than its whole squad.
+     *
+     * Permanent move (TYPE_INTERNAL_PROMOTION), so the call-up doesn't
+     * oscillate back to the reserve via LoanReturnProcessor next season.
+     * User-only side effects (UserSquadCareerRecord, notifications,
+     * SquadNumberService) are skipped — this method is invoked only for AI
+     * parent clubs by AIReserveCallUpProcessor.
+     *
+     * @return Collection<int, GamePlayer>
+     */
+    public function autoPromoteAIReserveProspects(
+        Game $game,
+        string $reserveTeamId,
+        string $parentTeamId,
+    ): Collection {
+        // Still-U23 next season: complements the overage promotion that
+        // already moved age-24+ players up at priority 4.
+        $nextSeasonU23Cutoff = $game->getU23BirthCutoff((int) $game->season + 1);
+
+        $candidates = GamePlayer::ownedByTeam($reserveTeamId)
+            ->where('game_id', $game->id)
+            ->where('date_of_birth', '>=', $nextSeasonU23Cutoff)
+            ->whereNotNull('overall_score')
+            ->with(['activeLoan'])
+            ->get();
+
+        if ($candidates->isEmpty()) {
+            return collect();
+        }
+
+        // Blend current ability and potential: catches both ready-now
+        // prospects (high overall) and high-upside ones (modest overall,
+        // huge potential).
+        $scored = $candidates->map(function (GamePlayer $p) {
+            $potential = $p->potential ?? $p->overall_score;
+            $blend = ($p->overall_score + $potential) / 2;
+
+            return ['player' => $p, 'blend' => $blend];
+        });
+
+        $byPosition = $scored->groupBy(fn ($row) => $row['player']->position);
+
+        $picks = collect();
+        foreach ($byPosition as $rows) {
+            $top = collect($rows)->sortByDesc('blend')->first();
+            if ($top !== null && $top['blend'] >= self::MIN_PROSPECT_BLEND) {
+                $picks->push($top);
+            }
+        }
+
+        $picks = $picks->sortByDesc('blend')->take(self::MAX_PROSPECTS_PER_SEASON);
+
+        $promoted = collect();
+        foreach ($picks as $entry) {
+            /** @var GamePlayer $player */
+            $player = $entry['player'];
+
+            // Close any active call-up loan from this reserve first so a
+            // later LoanReturnProcessor sweep (next season) doesn't try to
+            // flip the player back.
+            if ($player->activeLoan && $player->activeLoan->parent_team_id === $reserveTeamId) {
+                $player->activeLoan->update(['status' => Loan::STATUS_COMPLETED]);
+            }
+
+            $player->update(['number' => null, 'team_id' => $parentTeamId]);
+
+            GameTransfer::record(
+                gameId: $game->id,
+                gamePlayerId: $player->id,
+                fromTeamId: $reserveTeamId,
+                toTeamId: $parentTeamId,
+                transferFee: 0,
+                type: GameTransfer::TYPE_INTERNAL_PROMOTION,
+                season: $game->season,
+                window: TransferWindowType::currentValue($game->current_date),
+            );
+
+            $promoted->push($player);
+        }
+
+        return $promoted;
+    }
+
+    /**
+     * Blended score (overall + potential) / 2 floor for promoting a reserve
+     * prospect to the AI parent first team. 76 corresponds to clearly
+     * above-development-squad profiles (e.g. 72 + 80, 70 + 82, 68 + 84);
+     * average reserve players (65/75 blend = 70) stay put.
+     */
+    private const MIN_PROSPECT_BLEND = 76;
+
+    /**
+     * Per-AI-parent cap on prospects promoted in a single season. Prevents
+     * a wholesale gutting of the reserve when several players cross the
+     * blend threshold in the same year.
+     */
+    private const MAX_PROSPECTS_PER_SEASON = 3;
+
     private function assertFilial(Game $game): void
     {
         if ($game->reserve_team_id === null) {

--- a/app/Modules/Season/Processors/AIReserveCallUpProcessor.php
+++ b/app/Modules/Season/Processors/AIReserveCallUpProcessor.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Modules\Season\Processors;
+
+use App\Models\Game;
+use App\Models\Team;
+use App\Modules\ReserveTeam\Services\ReserveTeamService;
+use App\Modules\Season\Contracts\SeasonProcessor;
+use App\Modules\Season\DTOs\SeasonTransitionData;
+
+/**
+ * After loans return at season close, AI parent clubs promote their own
+ * top young reserve prospects to the first team. Permanent moves recorded
+ * as TYPE_INTERNAL_PROMOTION. Without this, AI reserves stockpile their
+ * best young talent indefinitely instead of feeding the senior squad.
+ *
+ * Priority: 6 — runs after ReserveOveragePromotionProcessor (4) has
+ * already moved age-24+ players up, and after LoanReturnProcessor (5)
+ * has returned any active call-up loans so the reserve roster is clean
+ * before prospect ranking.
+ */
+class AIReserveCallUpProcessor implements SeasonProcessor
+{
+    public function __construct(
+        private readonly ReserveTeamService $reserveTeamService,
+    ) {}
+
+    public function priority(): int
+    {
+        return 6;
+    }
+
+    public function process(Game $game, SeasonTransitionData $data): SeasonTransitionData
+    {
+        $promoted = collect();
+        $userTeamIds = $game->userTeamIds();
+
+        // Reserves Team lookup is single-plane (control); per-reserve
+        // promotion runs only tenant-plane queries internally. No
+        // cross-plane JOIN.
+        $aiReserves = Team::whereNotNull('parent_team_id')
+            ->when(! empty($userTeamIds), fn ($q) => $q
+                ->whereNotIn('id', $userTeamIds)
+                ->whereNotIn('parent_team_id', $userTeamIds))
+            ->get(['id', 'parent_team_id']);
+
+        foreach ($aiReserves as $reserve) {
+            $promoted = $promoted->concat(
+                $this->reserveTeamService->autoPromoteAIReserveProspects(
+                    $game,
+                    $reserve->id,
+                    $reserve->parent_team_id,
+                )
+            );
+        }
+
+        if ($promoted->isNotEmpty()) {
+            $data->setMetadata('reserve_prospects_promoted', $promoted->count());
+        }
+
+        return $data;
+    }
+}

--- a/app/Modules/Season/Services/SeasonClosingPipeline.php
+++ b/app/Modules/Season/Services/SeasonClosingPipeline.php
@@ -8,6 +8,7 @@ use App\Modules\Season\Contracts\SeasonProcessor;
 use App\Modules\Season\DTOs\SeasonTransitionData;
 use App\Modules\Season\Processors\AgreedTransferCompletionProcessor;
 use App\Modules\Season\Processors\AIFreeAgentSigningProcessor;
+use App\Modules\Season\Processors\AIReserveCallUpProcessor;
 use App\Modules\Season\Processors\ContractExpirationProcessor;
 use App\Modules\Season\Processors\ContractRenewalProcessor;
 use App\Modules\Season\Processors\CopaQualificationProcessor;
@@ -49,6 +50,7 @@ class SeasonClosingPipeline
     public function __construct(
         ReserveOveragePromotionProcessor $reserveOveragePromotion,
         LoanReturnProcessor $loanReturn,
+        AIReserveCallUpProcessor $aiReserveCallUp,
         TrophyRecordingProcessor $trophyRecording,
         LeaderboardStatsProcessor $leaderboardStats,
         SnapshotManagerSeasonRecordProcessor $snapshotManagerSeasonRecord,
@@ -79,6 +81,7 @@ class SeasonClosingPipeline
         $this->processors = [
             $reserveOveragePromotion,
             $loanReturn,
+            $aiReserveCallUp,
             $trophyRecording,
             $leaderboardStats,
             $snapshotManagerSeasonRecord,


### PR DESCRIPTION
## Summary
- AI reserves stockpile their best young talent indefinitely: the call-up flow exists but only fires for the user's filial. Combined with no AI poaching (PR #4) and no age-cap enforcement (PR #1), this leaves AI reserves overflowing with 70+ rated prospects.
- New `AIReserveCallUpProcessor` (priority 6) runs across every AI reserve at season close and permanently promotes the clearest prospects to the parent first team. Sits between `LoanReturnProcessor` (5) and `TrophyRecordingProcessor` (10) so it operates on rosters with no active loans.
- Selection: per position group, take the top U-23 player ranked by `(overall + potential) / 2`; promote only those whose blend ≥ **76** — clear "this kid is going somewhere" profiles (e.g. 72/80, 70/82, 68/84). Average reserve players (65/75 blend = 70) stay put.
- Cap: **3 promotions per AI parent per season** to avoid wholesale gutting of a single reserve.
- Permanent move (`TYPE_INTERNAL_PROMOTION`) rather than a call-up loan so the player doesn't oscillate back to the reserve via the next season's `LoanReturnProcessor` sweep. User-only side effects (`UserSquadCareerRecord`, notifications, `SquadNumberService`) are skipped — this is invoked only for AI parents.

This is PR #3 of 4 in the reserve-team-rebalance series.

## Pipeline order (priority)
| # | Processor | Effect |
|---|---|---|
| 4 | `ReserveOveragePromotionProcessor` | Promote age-24+ reserve players permanently (PR #1). |
| 5 | `LoanReturnProcessor` | Return active loans, including call-up loans. |
| **6** | **`AIReserveCallUpProcessor`** (new) | **Promote top U-23 prospects from AI reserves.** |
| 10+ | `TrophyRecordingProcessor`, …, `SquadReplenishmentProcessor` (42) | Downstream replenishment fills the now-thinner reserve with youth intake. |

## Test plan
- [ ] Simulate one season (`php artisan app:simulate-season`); query `game_transfers` for `type = internal_promotion` rows whose `from_team_id` is an AI reserve and `to_team_id` is its parent — expect a non-zero count per AI parent that had ≥1 prospect over the blend floor.
- [ ] Confirm the cap holds: no AI parent has >3 such promotions in a single season.
- [ ] Confirm only U-23 players are picked (`age <= 23` at season close).
- [ ] Confirm user-side filial behaviour unchanged: the user manages Real Madrid + Castilla, simulates a season — the user's own reserve promotions still flow only through `ReserveOveragePromotionProcessor` (age-24+) and the existing user call-up UI, not through this new processor.
- [ ] Confirm no notification spam: the new processor doesn't trigger user notifications.
- [ ] Multi-season smoke test: simulate 3–5 seasons, then check that AI reserve squads cluster around lower current overall (top prospects drained) while parent clubs occasionally bench an internally-promoted player.

https://claude.ai/code/session_01RMZYzkNtmJxj53wuqHFChN

---
_Generated by [Claude Code](https://claude.ai/code/session_01RMZYzkNtmJxj53wuqHFChN)_