### PR TITLE
Let AI clubs buy from reserve teams via existing market machinery

### DIFF
--- a/app/Modules/Transfer/Services/AITransferMarketService.php
+++ b/app/Modules/Transfer/Services/AITransferMarketService.php
@@ -225,6 +225,9 @@ class AITransferMarketService
         $teamAverages = $teamRosters->map(fn ($players) => $this->calculateTeamAverage($players));
         $takenNumbers = $this->preloadSquadNumbers($game->id);
         $reputationLevels = TeamReputation::resolveLevels($game->id, $teamRosters->keys()->all());
+        // Needed to filter reserves out of the buy side — reserves are now
+        // in $teamRosters as sellers but must not sign free agents.
+        $teams = Team::whereIn('id', $teamRosters->keys())->get()->keyBy('id');
 
         $freeAgents = $this->loadGamePlayersWithPlayerDob(function ($query) use ($game): void {
             $query->where('game_players.game_id', $game->id)
@@ -259,6 +262,12 @@ class AITransferMarketService
         $teamNeeds = [];
         foreach ($teamRosters as $teamId => $players) {
             if ($players->count() >= self::MAX_SQUAD_SIZE) {
+                continue;
+            }
+
+            // Reserves only appear in $teamRosters as sellers (see
+            // loadAIRosters) — they never sign free agents.
+            if ($teams->get($teamId)?->parent_team_id !== null) {
                 continue;
             }
 
@@ -329,7 +338,7 @@ class AITransferMarketService
                 break;
             }
 
-            $bestTeamId = $this->findBestTeamForSeasonSigning($fa, $teamRosters, $teamAverages, $reputationLevels);
+            $bestTeamId = $this->findBestTeamForSeasonSigning($fa, $teamRosters, $teamAverages, $reputationLevels, $teams);
             if (! $bestTeamId) {
                 continue;
             }
@@ -897,6 +906,12 @@ class AITransferMarketService
                 continue;
             }
 
+            // Reserves only appear in $teamRosters as sellers (see
+            // loadAIRosters) — they never sign senior players.
+            if ($teams->get($teamId)?->parent_team_id !== null) {
+                continue;
+            }
+
             // Skip AI teams configured to rely exclusively on their youth academy
             if ($this->exclusionList->contains($teamId)) {
                 continue;
@@ -976,6 +991,12 @@ class AITransferMarketService
 
         foreach ($teamRosters as $teamId => $players) {
             if ($teamId === $sellerTeamId || $teamId === $game->team_id) {
+                continue;
+            }
+
+            // Reserves only appear in $teamRosters as sellers (see
+            // loadAIRosters) — they never sign senior players.
+            if ($teams->get($teamId)?->parent_team_id !== null) {
                 continue;
             }
 
@@ -1142,6 +1163,12 @@ class AITransferMarketService
 
         foreach ($teamRosters as $teamId => $players) {
             if ($players->count() >= self::MAX_SQUAD_SIZE) {
+                continue;
+            }
+
+            // Reserves only appear in $teamRosters as sellers (see
+            // loadAIRosters) — they never sign free agents.
+            if ($teams->get($teamId)?->parent_team_id !== null) {
                 continue;
             }
 
@@ -1325,7 +1352,7 @@ class AITransferMarketService
      * strongly preferred. Unlike findBestTeamForFreeAgent (used at window close),
      * this method doesn't require specific position group needs.
      */
-    private function findBestTeamForSeasonSigning(GamePlayer $freeAgent, Collection $teamRosters, Collection $teamAverages, Collection $reputationLevels): ?string
+    private function findBestTeamForSeasonSigning(GamePlayer $freeAgent, Collection $teamRosters, Collection $teamAverages, Collection $reputationLevels, Collection $teams): ?string
     {
         $playerAbility = $this->getPlayerAbility($freeAgent);
         $playerTier = $freeAgent->tier ?? 1;
@@ -1335,6 +1362,12 @@ class AITransferMarketService
         foreach ($teamRosters as $teamId => $players) {
             $squadSize = $players->count();
             if ($squadSize >= self::MAX_SQUAD_SIZE) {
+                continue;
+            }
+
+            // Reserves only appear in $teamRosters as sellers (see
+            // loadAIRosters) — they never sign free agents.
+            if ($teams->get($teamId)?->parent_team_id !== null) {
                 continue;
             }
 
@@ -1406,25 +1439,25 @@ class AITransferMarketService
     }
 
     /**
-     * Load all AI team rosters (excludes human player's team and reserve teams).
+     * Load all AI team rosters (excludes every team the user controls —
+     * first team and, in filial mode, their reserve).
      *
-     * Reserve teams (parent_team_id IS NOT NULL) are development pipelines
-     * for their parent club, not transfer-market participants. Excluding
-     * them here keeps them out of both the seller and buyer sides of
-     * AI-to-AI transfers.
+     * Other reserve teams (parent_team_id IS NOT NULL) ARE included so
+     * they appear on the SELL side of AI-to-AI activity — the regen
+     * pipeline (SquadReplenishmentProcessor) keeps refilling them, so
+     * high turnover is the intended development-squad behaviour. The
+     * BUY side is gated separately inside each buyer-matching method
+     * via a `parent_team_id` check against $teams, so reserves never
+     * end up signing senior players or free agents.
      */
     private function loadAIRosters(Game $game): Collection
     {
-        // PLANES-SEAM: teams lookup is cross-plane (control), but we issue
-        // it as a separate query so loadGamePlayersWithPlayerDob keeps
-        // querying game_players directly without ambiguous column joins.
-        $reserveTeamIds = Team::whereNotNull('parent_team_id')->pluck('id')->all();
+        $userTeamIds = $game->userTeamIds();
 
-        return $this->loadGamePlayersWithPlayerDob(function ($query) use ($game, $reserveTeamIds): void {
+        return $this->loadGamePlayersWithPlayerDob(function ($query) use ($game, $userTeamIds): void {
             $query->where('game_players.game_id', $game->id)
                 ->whereNotNull('game_players.team_id')
-                ->where('game_players.team_id', '!=', $game->team_id)
-                ->when(! empty($reserveTeamIds), fn ($q) => $q->whereNotIn('game_players.team_id', $reserveTeamIds));
+                ->whereNotIn('game_players.team_id', $userTeamIds);
         })->groupBy('team_id');
     }
 


### PR DESCRIPTION
## Summary
- `AITransferMarketService::loadAIRosters()` excluded reserves from both sides of AI-to-AI activity, leaving top prospects to stockpile in their parent's reserve indefinitely.
- Drop the exclusion: reserves now appear as sellers and the existing scoring / reputation gating / budget envelope logic handles them naturally. No per-reserve caps, no eligibility filters, no separate code path. `SquadReplenishmentProcessor` refills reserves with fresh youth every season, so high turnover IS the intended development-squad behaviour.
- The BUY side stays closed via a single `parent_team_id` guard against the existing `$teams` collection at the five buyer-iteration points (`findClearingBuyer`, `findUpgradeBuyer`, `findBestTeamForFreeAgent`, `findBestTeamForSeasonSigning`, and the priority-queue loop in `processSeasonFreeAgentSignings`).
- The foreign-departure fallback already excludes reserves as destinations (`Team::transferMarketEligible` scope), so unsold reserve players can flow abroad without polluting the destination side.

This is PR #4 of 4 in the reserve-team-rebalance series — deployed last so prior PRs can be observed in isolation first.

## What "let the market self-direct" means in practice
- Reserves get AI-team budgets and sell capacity automatically via the existing `AITeamBudgetCalculator`.
- Reserves with reputation X can be poached by any AI team with reputation ≥ X (in `findUpgradeBuyer`'s `buyerRep ≤ sellerRep` rule, lower index = better). Since reserves usually carry a low reputation tier, this naturally opens them up to most of the league as buyers.
- `MIN_SQUAD_SIZE = 20` and per-position `MIN_GROUP_COUNTS` are the natural ceilings on how many a reserve can sell in a single window — once it would drop below those, no more offers.
- Buyer budget envelopes (max fee by reputation index) keep the matchups realistic: only elite clubs can pay €120M+ for a Yamal-class reserve prospect; modest clubs only match modest prospects.

## Test plan
- [ ] Simulate one season (`php artisan app:simulate-season`); inspect `game_transfers` for `type = transfer` rows whose `from_team_id` is a reserve. Expect a healthy stream (estimated 1–4 per reserve per window, capped by `MIN_SQUAD_SIZE`).
- [ ] Confirm reserves never appear as `to_team_id` of an AI-driven transfer: `SELECT COUNT(*) FROM game_transfers gt JOIN teams t ON t.id = gt.to_team_id WHERE t.parent_team_id IS NOT NULL AND gt.type IN ('transfer', 'free_transfer')` — expect zero.
- [ ] Confirm the user's filial isn't raided: start a game managing a parent club with a reserve, simulate a season. The user's reserve players should not appear in any AI-driven `TYPE_TRANSFER` rows (the user team is excluded from `$teamRosters` upstream).
- [ ] Long horizon: simulate 3–5 seasons combined with PRs #1108, #1109, #1110. Reserves should drain their best young players each window, get refilled by `SquadReplenishmentProcessor`, and end up clustered mid-to-lower-table in ESP2 / ESP3 standings.
- [ ] Sanity check the foreign-fallback path still works for reserve players — unsold reserve prospects flowing abroad with `FOREIGN_FALLBACK_CHANCE = 50` is desirable and unaffected by this change.

## What changed vs. the original draft
The first version of this PR added a separate `processReservePoaching` phase (~180 lines) with explicit per-reserve caps, potential-gap filters, and parent-reputation gating. The minimal version drops all of that: reserves go through the same machinery as every other AI club. The result is fewer lines, fewer rules to maintain, and emergent market dynamics that mirror real Spanish football's reserve-team economy.

https://claude.ai/code/session_01RMZYzkNtmJxj53wuqHFChN