### PR TITLE
Replace hardcoded match minute bounds with MatchSimulator constant

### DIFF
--- a/tests/Unit/RedCardSimulationTest.php
+++ b/tests/Unit/RedCardSimulationTest.php
@@ -115,7 +115,8 @@ class RedCardSimulationTest extends TestCase
         // All goal events should have valid minutes
         foreach ($goalEvents as $event) {
             $this->assertGreaterThanOrEqual(1, $event->minute, 'Goal event minute should be >= 1');
-            $this->assertLessThanOrEqual(93, $event->minute, 'Goal event minute should be <= 93');
+            $this->assertLessThanOrEqual(MatchSimulator::REGULATION_UPPER_BOUND, $event->minute,
+                'Goal event minute should be <= REGULATION_UPPER_BOUND');
         }
 
         // Goal events for home team after minute 30 should NOT involve the red-carded player
@@ -223,7 +224,7 @@ class RedCardSimulationTest extends TestCase
                 foreach ($output->result->redCards() as $event) {
                     $this->assertEquals('red_card', $event->type);
                     $this->assertGreaterThanOrEqual(1, $event->minute);
-                    $this->assertLessThanOrEqual(93, $event->minute);
+                    $this->assertLessThanOrEqual(MatchSimulator::REGULATION_UPPER_BOUND, $event->minute);
                     $this->assertNotEmpty($event->gamePlayerId);
                     $this->assertNotEmpty($event->teamId);
                 }


### PR DESCRIPTION
## Summary
Replaces hardcoded magic number `93` (regulation match upper bound) with the `MatchSimulator::REGULATION_UPPER_BOUND` constant in unit tests for consistency and maintainability.

## Changes
- Updated `test_red_card_split_produces_valid_results()` to use `MatchSimulator::REGULATION_UPPER_BOUND` instead of hardcoded `93` for goal event minute validation
- Updated `test_simulation_produces_red_card_events()` to use `MatchSimulator::REGULATION_UPPER_BOUND` instead of hardcoded `93` for red card event minute validation
- Improved assertion message clarity by referencing the constant name

## Details
This change eliminates magic numbers in tests by centralizing the regulation match upper bound definition. If the constant value changes in `MatchSimulator`, tests will automatically use the updated value without requiring manual updates to multiple test locations.

https://claude.ai/code/session_01Xq8dV6m4YUBMQgXeqdvc7i