### PR TITLE
Display club of origin in tournament mode squad view

### DIFF
--- a/app/Modules/Squad/Services/SquadService.php
+++ b/app/Modules/Squad/Services/SquadService.php
@@ -8,6 +8,7 @@ use App\Models\CompetitionEntry;
 use App\Models\Game;
 use App\Models\GameMatch;
 use App\Models\GamePlayer;
+use App\Models\GamePlayerTemplate;
 use App\Models\Team;
 use App\Modules\Player\PlayerAge;
 use App\Modules\Player\Services\PlayerDevelopmentService;
@@ -34,6 +35,13 @@ class SquadService
             ->where('game_id', $gameId)
             ->where('team_id', $game->team_id)
             ->get();
+
+        // Tournament mode: enrich each player with their real-world club of
+        // origin (name + crest) from the control-plane template. Issued as a
+        // separate query so we never JOIN across planes.
+        if ($game->isTournamentMode()) {
+            $this->attachClubOfOrigin($allPlayers, $game);
+        }
 
         $seasonEndDate = $game->getSeasonEndDate();
         $nextMatch = $game->next_match;
@@ -222,6 +230,34 @@ class SquadService
             'mvpCounts' => $mvpCounts,
             'playerFlags' => $playerFlags,
         ];
+    }
+
+    /**
+     * Attach `club_name` and `club_crest_url` attributes on each player by
+     * looking up the matching control-plane template (filtered by national
+     * team id, since the same transfermarkt id can exist as both a club and
+     * a national-team template). Runs as one query on the control plane to
+     * avoid cross-plane JOINs.
+     */
+    private function attachClubOfOrigin($players, Game $game): void
+    {
+        $tmIds = $players->pluck('transfermarkt_id')->filter()->unique()->values();
+        if ($tmIds->isEmpty()) {
+            return;
+        }
+
+        $infosByTmId = GamePlayerTemplate::with('tournamentInfo')
+            ->where('team_id', $game->team_id)
+            ->whereIn('transfermarkt_id', $tmIds)
+            ->get()
+            ->keyBy('transfermarkt_id');
+
+        foreach ($players as $player) {
+            $template = $infosByTmId->get($player->transfermarkt_id);
+            $info = $template?->tournamentInfo;
+            $player->setAttribute('club_name', $info?->club_name);
+            $player->setAttribute('club_crest_url', $info?->club_crest_url);
+        }
     }
 
     private function buildDepthChart($players): array

--- a/resources/views/squad.blade.php
+++ b/resources/views/squad.blade.php
@@ -336,6 +336,10 @@
                                                 </div>
                                             </div>
 
+                                            @if($gp->club_crest_url ?? null)
+                                                <img src="{{ $gp->club_crest_url }}" alt="" title="{{ $gp->club_name }}" class="w-4 h-4 shrink-0 object-contain">
+                                            @endif
+
                                             {{-- Rating badge --}}
                                             <x-rating-badge :value="$gp->effective_rating" size="sm" class="shrink-0" />
                                         </div>
@@ -370,6 +374,16 @@
                                                 </div>
                                                 @endif
                                             </div>
+                                            @if(!empty($gp->club_name) || !empty($gp->club_crest_url))
+                                                <div class="ml-auto flex items-center gap-1.5 min-w-0 text-xs text-text-muted" title="{{ $gp->club_name }}">
+                                                    @if($gp->club_crest_url)
+                                                        <img src="{{ $gp->club_crest_url }}" alt="" class="w-4 h-4 shrink-0 object-contain">
+                                                    @endif
+                                                    @if($gp->club_name)
+                                                        <span class="truncate max-w-[140px]">{{ $gp->club_name }}</span>
+                                                    @endif
+                                                </div>
+                                            @endif
                                         </div>
 
                                         {{-- Position badges --}}


### PR DESCRIPTION
## Summary

Enriches the squad overview in tournament mode by displaying each player's real-world club of origin (name and crest) alongside their profile information. This provides context about where players come from in the tournament.

## Changes

- **SquadService**: Added `attachClubOfOrigin()` method that queries `GamePlayerTemplate` records from the control plane to fetch club information (name and crest URL) for each player, keyed by transfermarkt ID. This is called conditionally when the game is in tournament mode.
- **squad.blade.php**: 
  - Added club crest display in the player row header (small 4×4 icon with club name tooltip)
  - Added club information section in the player details area showing both crest and club name with truncation for long names

## Implementation Details

- The club enrichment uses a separate query on the control plane (`GamePlayerTemplate`) to avoid cross-plane JOINs, following the architectural constraint that tenant and control plane queries should remain separate.
- Club information is attached as dynamic attributes (`club_name`, `club_crest_url`) on each player model after fetching, rather than modifying the initial query.
- The feature is gated to tournament mode only via `$game->isTournamentMode()` check.
- Template display is defensive: both crest and name are optional and only rendered if present.

https://claude.ai/code/session_014yWHekZPT92jQVjEs7ayZT