### PR TITLE
Preserve secondary positions when creating tournament game players

### DIFF
--- a/app/Http/Actions/SaveSquadSelection.php
+++ b/app/Http/Actions/SaveSquadSelection.php
@@ -88,6 +88,7 @@ class SaveSquadSelection
                 'team_id' => $teamId,
                 'number' => null,
                 'position' => $positionByTmId[$tmId] ?? 'Central Midfield',
+                'secondary_positions' => $template->getRawOriginal('secondary_positions'),
                 'market_value' => null,
                 'market_value_cents' => 0,
                 'contract_until' => null,


### PR DESCRIPTION
## Summary
When creating tournament game players from a squad template, the `secondary_positions` field is now preserved from the template data instead of being omitted.

## Changes
- Added `secondary_positions` to the player data array in `SaveSquadSelection::createTournamentGamePlayers()`, retrieving it from the template's raw original data via `getRawOriginal('secondary_positions')`

## Details
This ensures that player secondary positions (tactical flexibility information) are properly carried over when tournament squads are initialized from templates, maintaining data consistency across the squad selection workflow.

https://claude.ai/code/session_014MENyeA36D5Lr9KXQuBixh