### PR TITLE
Use effective stadium capacity in season ticket pricing

### DIFF
--- a/app/Modules/Stadium/Services/SeasonTicketPricingService.php
+++ b/app/Modules/Stadium/Services/SeasonTicketPricingService.php
@@ -121,6 +121,10 @@ class SeasonTicketPricingService
     private array $currentCache = [];
     private array $defaultPricingCache = [];
 
+    public function __construct(
+        private readonly StadiumCapacityResolver $capacityResolver,
+    ) {}
+
     /**
      * Build the seating layout for a stadium of the given capacity.
      * Returns a list of areas with absolute capacity (proportions of the
@@ -177,7 +181,11 @@ class SeasonTicketPricingService
     {
         $reputation = TeamReputation::resolveLevel($game->id, $team->id);
         $homeRep = $this->resolveReputation($game->id, $team->id, $reputation);
-        $capacity = (int) ($team->stadium_seats ?? 0);
+        $capacity = $this->capacityResolver->effectiveCapacity(
+            $game->id,
+            $team->id,
+            (int) ($team->stadium_seats ?? 0),
+        );
 
         $areas = $this->buildAreas($capacity, $reputation);
 
@@ -198,7 +206,11 @@ class SeasonTicketPricingService
     {
         $reputation = TeamReputation::resolveLevel($game->id, $team->id);
         $homeRep = $this->resolveReputation($game->id, $team->id, $reputation);
-        $capacity = (int) ($team->stadium_seats ?? 0);
+        $capacity = $this->capacityResolver->effectiveCapacity(
+            $game->id,
+            $team->id,
+            (int) ($team->stadium_seats ?? 0),
+        );
 
         $areas = $this->buildAreas($capacity, $reputation);
 

--- a/app/Modules/Stadium/Services/StadiumSummaryService.php
+++ b/app/Modules/Stadium/Services/StadiumSummaryService.php
@@ -48,7 +48,6 @@ class StadiumSummaryService
         $direction = $loyaltyDelta > 5 ? 'rising' : ($loyaltyDelta < -5 ? 'declining' : 'stable');
 
         $lastHomeMatch = $this->resolveLastHomeMatch($game);
-        $seasonTickets = $this->resolveSeasonTickets($game);
 
         // Per-game stadium row captures upgrades (rebuild + supletorias).
         // Falls back to the control-plane baseline for saves that predate
@@ -59,6 +58,8 @@ class StadiumSummaryService
             ->first();
         $capacity = $stadium?->effective_capacity ?? (int) ($team->stadium_seats ?? 0);
         $uefaLevel = $stadium?->effective_uefa_level ?? $team->uefa_stadium_category;
+
+        $seasonTickets = $this->resolveSeasonTickets($game, $capacity);
 
         $finances = $game->currentFinances;
         $projectedMatchday = (int) ($finances?->projected_matchday_revenue ?? 0);
@@ -170,11 +171,10 @@ class StadiumSummaryService
      * layout (so the schematic always has something to render) and the
      * editable flag.
      */
-    private function resolveSeasonTickets(Game $game): array
+    private function resolveSeasonTickets(Game $game, int $capacity): array
     {
         $pricing = $this->seasonTicketPricingService->getCurrent($game);
         $reputation = TeamReputation::resolveLevel($game->id, $game->team_id);
-        $capacity = (int) ($game->team->stadium_seats ?? 0);
         $baselineAreas = $this->seasonTicketPricingService->buildAreas($capacity, $reputation);
 
         // Areas with persisted sold/fill, or computed defaults so the


### PR DESCRIPTION
## Summary

Refactors season ticket pricing to use effective stadium capacity (accounting for upgrades and supletorias) instead of the base `stadium_seats` value. This ensures pricing calculations reflect the actual available capacity.

## Key Changes

- **SeasonTicketPricingService**: Added constructor dependency injection for `StadiumCapacityResolver` and updated both `buildDefaultPricing()` and `buildFromUserPrices()` methods to call `capacityResolver->effectiveCapacity()` instead of directly reading `team->stadium_seats`
- **StadiumSummaryService**: Refactored `resolveSeasonTickets()` to accept `$capacity` as a parameter, allowing it to use the pre-calculated effective capacity from the stadium record rather than computing it independently

## Implementation Details

- The effective capacity is now resolved once in `StadiumSummaryService.build()` from the stadium record (with fallback to base `stadium_seats`), then passed to `resolveSeasonTickets()` to ensure consistency
- `SeasonTicketPricingService` delegates capacity resolution to the injected `StadiumCapacityResolver`, maintaining separation of concerns
- This change ensures that season ticket pricing reflects actual stadium capacity after any upgrades or modifications, providing more accurate revenue projections

https://claude.ai/code/session_015H8Edjhhkzv3UJHpGeHpFs