### PR TITLE
Stop forcing a reactive substitution on the user team after a red card

### DIFF
--- a/app/Modules/Match/Services/MatchSimulator.php
+++ b/app/Modules/Match/Services/MatchSimulator.php
@@ -429,6 +429,7 @@ class MatchSimulator
                 $homeEntryMinutes, $awayEntryMinutes,
                 $homeSubsUsed, $awaySubsUsed, $homeWindowsUsed, $awayWindowsUsed,
                 $allEvents,
+                $userTeamId,
             );
 
             // Apply AI substitutions at this split minute
@@ -635,6 +636,13 @@ class MatchSimulator
      *
      * The team that received the red card reshapes by bringing on a goalkeeper
      * or defender, sacrificing a random attacker or midfielder.
+     *
+     * The user's team is excluded: the sent-off player is still removed from
+     * the on-pitch collection so the remainder is simulated 10-vs-11, but no
+     * substitution event is emitted — the human picks the reaction (or not)
+     * via the tactical panel. Without this gate, the user silently loses one
+     * of their 5 subs and one of their 3 windows to a server-side choice they
+     * never made and can't cancel.
      */
     private function applyRedCardReactiveSubs(
         Collection $periodEvents,
@@ -651,6 +659,7 @@ class MatchSimulator
         int &$homeWindowsUsed,
         int &$awayWindowsUsed,
         Collection $allEvents,
+        ?string $userTeamId = null,
     ): void {
         $redCards = $periodEvents->filter(fn (MatchEventData $e) => $e->type === 'red_card');
         if ($redCards->isEmpty()) {
@@ -662,14 +671,23 @@ class MatchSimulator
 
         foreach ($redCards as $redCard) {
             $subMinute = $redCard->minute + 2;
+            $isUserTeam = $userTeamId !== null && $redCard->teamId === $userTeamId;
 
             if ($redCard->teamId === $homeTeamId) {
+                if ($isUserTeam) {
+                    $homePlayers = $homePlayers->reject(fn ($p) => $p->id === $redCard->gamePlayerId)->values();
+                    continue;
+                }
                 $this->applyRedCardTeamReactiveSub(
                     $redCard, $subMinute, $maxSubs, $maxWindows,
                     $homeTeamId, $homePlayers, $homeBench, $homeEntryMinutes,
                     $homeSubsUsed, $homeWindowsUsed, $allEvents,
                 );
             } else {
+                if ($isUserTeam) {
+                    $awayPlayers = $awayPlayers->reject(fn ($p) => $p->id === $redCard->gamePlayerId)->values();
+                    continue;
+                }
                 $this->applyRedCardTeamReactiveSub(
                     $redCard, $subMinute, $maxSubs, $maxWindows,
                     $awayTeamId, $awayPlayers, $awayBench, $awayEntryMinutes,
@@ -939,6 +957,7 @@ class MatchSimulator
                 $homeEntryMinutes, $awayEntryMinutes,
                 $homeSubsUsed, $awaySubsUsed, $homeWindowsUsed, $awayWindowsUsed,
                 $allEvents,
+                $userTeamId,
             );
 
             // Apply AI substitutions at this window

--- a/tests/Unit/RedCardSimulationTest.php
+++ b/tests/Unit/RedCardSimulationTest.php
@@ -455,6 +455,78 @@ class RedCardSimulationTest extends TestCase
             'Player subbed in should be a defender');
     }
 
+    public function test_user_team_red_card_does_not_force_reactive_sub(): void
+    {
+        // direct_red_chance=50 makes red cards near-certain within a handful
+        // of sims. We need a defender red card on the user (home) team to
+        // exercise the gate, since forward red cards don't trigger a reshape.
+        config(['match_simulation.direct_red_chance' => 50]);
+
+        $game = Game::factory()->create(['current_date' => '2025-10-01']);
+        $homeTeam = Team::factory()->create();
+        $awayTeam = Team::factory()->create();
+
+        $homePlayers = $this->createLineup($game, $homeTeam, 11, 75);
+        $awayPlayers = $this->createLineup($game, $awayTeam, 11, 75);
+        $homeBench = $this->createBenchPlayers($game, $homeTeam, 7, 70);
+        $awayBench = $this->createBenchPlayers($game, $awayTeam, 7, 70);
+
+        $defenderPositions = ['Goalkeeper', 'Centre-Back', 'Left-Back', 'Right-Back'];
+        $verifiedUserGate = false;
+        $verifiedAIPath = false;
+
+        for ($i = 0; $i < 200; $i++) {
+            $output = $this->simulator->simulate(
+                $homeTeam, $awayTeam,
+                $homePlayers->values(), $awayPlayers->values(),
+                Formation::F_4_3_3, Formation::F_4_3_3,
+                Mentality::BALANCED, Mentality::BALANCED,
+                $game,
+                PlayingStyle::BALANCED, PlayingStyle::BALANCED,
+                PressingIntensity::STANDARD, PressingIntensity::STANDARD,
+                DefensiveLineHeight::NORMAL, DefensiveLineHeight::NORMAL,
+                $homeBench->values(), $awayBench->values(),
+                userTeamId: $homeTeam->id,
+            );
+
+            $events = $output->result->events;
+            $redCards = $events->filter(fn ($e) => $e->type === 'red_card');
+
+            foreach ($redCards as $rc) {
+                $sentOffPlayer = $homePlayers->merge($awayPlayers)->firstWhere('id', $rc->gamePlayerId);
+                if (! $sentOffPlayer || ! in_array($sentOffPlayer->position, $defenderPositions)) {
+                    // Forward red cards never trigger a reshape sub regardless
+                    // of the gate, so they can't distinguish the fix.
+                    continue;
+                }
+
+                $reactiveSub = $events->first(fn ($e) => $e->type === 'substitution'
+                    && $e->teamId === $rc->teamId
+                    && $e->minute >= $rc->minute
+                    && $e->minute <= $rc->minute + 3);
+
+                if ($rc->teamId === $homeTeam->id) {
+                    $this->assertNull($reactiveSub,
+                        'User-team red card must not trigger a forced reactive substitution');
+                    $verifiedUserGate = true;
+                } else {
+                    $this->assertNotNull($reactiveSub,
+                        'AI-team red card should still trigger a reactive substitution');
+                    $verifiedAIPath = true;
+                }
+            }
+
+            if ($verifiedUserGate && $verifiedAIPath) {
+                break;
+            }
+        }
+
+        $this->assertTrue($verifiedUserGate,
+            'Expected at least one defender red card on the user team across 200 sims');
+        $this->assertTrue($verifiedAIPath,
+            'Expected at least one defender red card on the AI team across 200 sims');
+    }
+
     public function test_forward_red_card_does_not_trigger_reshape_sub(): void
     {
         $aiSubService = new AISubstitutionService;


### PR DESCRIPTION
When the user's own team got a red card during a live match, the
simulator silently emitted a substitution event ~2 minutes later,
consuming one of the user's 5 subs and one of their 3 windows with a
server-picked replacement the user couldn't cancel or override.

applyRedCardReactiveSubs was the one auto-sub path missing a userTeamId
guard. Add it: the red-carded user-team player is still removed from
the on-pitch collection so the remainder simulates 10-vs-11, but the
substitution event itself is suppressed. The human picks the reaction
(or not) via the tactical panel. AI opponents are unaffected.