### PR TITLE
Delay new signings until the matchday after the agreement

### DIFF
--- a/app/Http/Actions/AcceptLoanOffer.php
+++ b/app/Http/Actions/AcceptLoanOffer.php
@@ -38,7 +38,6 @@ class AcceptLoanOffer
 
         $playerName = $offer->gamePlayer->name;
         $team = $offer->offeringTeam;
-        $windowOpen = $game->isTransferWindowOpen();
 
         try {
             $this->loanService->acceptLoanOffer($offer, $game);
@@ -46,10 +45,10 @@ class AcceptLoanOffer
             return redirect()->back()->with('error', $this->formatBreachMessage($e));
         }
 
-        if ($windowOpen) {
-            $message = __('messages.loan_offer_accepted', [
+        if ($game->isTransferWindowOpen()) {
+            $message = __('messages.loan_offer_agreed_intra_window', [
                 'player' => $playerName,
-                'team_a' => $team->nameWithA(),
+                'team' => $team->name,
             ]);
         } else {
             $message = __('messages.loan_offer_accepted_pre_window', [

--- a/app/Http/Actions/AcceptLoanOffer.php
+++ b/app/Http/Actions/AcceptLoanOffer.php
@@ -49,11 +49,13 @@ class AcceptLoanOffer
             $message = __('messages.loan_offer_agreed_intra_window', [
                 'player' => $playerName,
                 'team' => $team->name,
+                'team_a' => $team->nameWithA(),
             ]);
         } else {
             $message = __('messages.loan_offer_accepted_pre_window', [
                 'player' => $playerName,
                 'team' => $team->name,
+                'team_a' => $team->nameWithA(),
                 'window' => $game->getNextWindowName(),
             ]);
         }

--- a/app/Http/Actions/AcceptTransferOffer.php
+++ b/app/Http/Actions/AcceptTransferOffer.php
@@ -54,6 +54,7 @@ class AcceptTransferOffer
             $message = __('messages.offer_accepted_intra_window', [
                 'player' => $playerName,
                 'team' => $team->name,
+                'team_a' => $team->nameWithA(),
                 'fee' => $fee,
             ]);
         } else {

--- a/app/Http/Actions/AcceptTransferOffer.php
+++ b/app/Http/Actions/AcceptTransferOffer.php
@@ -45,15 +45,15 @@ class AcceptTransferOffer
         $fee = $offer->formatted_transfer_fee;
 
         try {
-            $completedImmediately = $this->transferService->acceptOffer($offer);
+            $this->transferService->acceptOffer($offer);
         } catch (SquadMinimumException $e) {
             return redirect()->back()->with('error', $this->formatBreachMessage($e));
         }
 
-        if ($completedImmediately) {
-            $message = __('messages.offer_accepted_sale', [
+        if ($game->isTransferWindowOpen()) {
+            $message = __('messages.offer_accepted_intra_window', [
                 'player' => $playerName,
-                'team_a' => $team->nameWithA(),
+                'team' => $team->name,
                 'fee' => $fee,
             ]);
         } else {

--- a/app/Http/Actions/NegotiateCounterOffer.php
+++ b/app/Http/Actions/NegotiateCounterOffer.php
@@ -175,7 +175,7 @@ class NegotiateCounterOffer
     private function handleAcceptCounter(Game $game, TransferOffer $offer): JsonResponse
     {
         $player = $offer->gamePlayer;
-        $buyerName = $offer->offeringTeam->name;
+        $buyer = $offer->offeringTeam;
 
         try {
             $completedImmediately = $this->transferService->acceptCounterOfferBid($offer);
@@ -199,7 +199,8 @@ class NegotiateCounterOffer
                 $this->agentMessage('accepted', [
                     'text' => __('transfers.chat_buyer_deal_complete', [
                         'player' => $player->name,
-                        'team' => $buyerName,
+                        'team' => $buyer->name,
+                        'team_a' => $buyer->nameWithA(),
                         'fee' => Money::format($offer->transfer_fee),
                     ]),
                     'fee' => (int) ($offer->transfer_fee / 100),

--- a/app/Http/Actions/NegotiateFreeAgent.php
+++ b/app/Http/Actions/NegotiateFreeAgent.php
@@ -247,8 +247,13 @@ class NegotiateFreeAgent
 
     private function completeFreeAgentSigning(TransferOffer $offer, Game $game, GamePlayer $player): JsonResponse
     {
-        $this->transferService->completeFreeAgentSigning($game, $player, $offer);
-        $this->notificationService->notifyTransferComplete($game, $offer->refresh());
+        // Park the agreement; the player joins after the next match
+        // (CompleteAgreedTransfersOnMatchPlayed) or when the window opens
+        // (CompleteAgreedTransfersOnWindowOpen).
+        $offer->update([
+            'status' => TransferOffer::STATUS_AGREED,
+            'resolved_at' => $game->current_date,
+        ]);
 
         return response()->json([
             'status' => 'ok',

--- a/app/Http/Actions/NegotiateTransfer.php
+++ b/app/Http/Actions/NegotiateTransfer.php
@@ -516,10 +516,13 @@ class NegotiateTransfer
 
     private function completeTransferNegotiation(TransferOffer $offer, Game $game, GamePlayer $player): JsonResponse
     {
-        $completedImmediately = $this->transferService->acceptIncomingOffer($offer);
+        $this->transferService->acceptIncomingOffer($offer);
 
-        // Transfer was rejected by a safety check (budget exceeded)
-        if ($completedImmediately === false && $offer->refresh()->status === TransferOffer::STATUS_REJECTED) {
+        // Defensive: re-check status in case acceptIncomingOffer flipped it
+        // (e.g. a sibling guard rejected the deal). Today acceptIncomingOffer
+        // only parks as agreed, but keep the check so a future safety net
+        // surfaces in the UI immediately.
+        if ($offer->refresh()->status === TransferOffer::STATUS_REJECTED) {
             $reason = __('messages.transfer_failed');
 
             return response()->json([
@@ -535,12 +538,8 @@ class NegotiateTransfer
             ]);
         }
 
-        if ($completedImmediately) {
-            $this->notificationService->notifyTransferComplete($game, $offer->refresh());
-        }
-
-        $messageKey = $completedImmediately
-            ? 'transfers.chat_transfer_complete'
+        $messageKey = $game->isTransferWindowOpen()
+            ? 'transfers.chat_transfer_complete_intra_window'
             : 'transfers.chat_transfer_complete_pending';
 
         return response()->json([

--- a/app/Http/Actions/SignFreeAgent.php
+++ b/app/Http/Actions/SignFreeAgent.php
@@ -4,7 +4,6 @@ namespace App\Http\Actions;
 
 use App\Models\Game;
 use App\Models\GamePlayer;
-use App\Modules\Notification\Services\NotificationService;
 use App\Modules\Transfer\Enums\NegotiationScenario;
 use App\Modules\Transfer\Services\ContractService;
 use App\Modules\Transfer\Services\DispositionService;
@@ -17,7 +16,6 @@ class SignFreeAgent
         private readonly ContractService $contractService,
         private readonly DispositionService $dispositionService,
         private readonly TransferService $transferService,
-        private readonly NotificationService $notificationService,
     ) {}
 
     public function __invoke(Request $request, string $gameId, string $playerId)
@@ -44,10 +42,9 @@ class SignFreeAgent
 
         $demand = $this->contractService->calculateWageDemand($player, NegotiationScenario::FREE_AGENT, $game->team);
 
-        $offer = $this->transferService->signFreeAgent($game, $player, $demand['wage']);
-        $this->notificationService->notifyTransferComplete($game, $offer);
+        $this->transferService->signFreeAgent($game, $player, $demand['wage']);
 
         return redirect()->route('game.transfers', $gameId)
-            ->with('success', __('messages.free_agent_signed', ['player' => $player->name]));
+            ->with('success', __('messages.free_agent_agreed', ['player' => $player->name]));
     }
 }

--- a/app/Http/Actions/SkipPreSeason.php
+++ b/app/Http/Actions/SkipPreSeason.php
@@ -4,6 +4,7 @@ namespace App\Http\Actions;
 
 use App\Models\Game;
 use App\Models\GameMatch;
+use App\Modules\Match\Events\GameDateAdvanced;
 use App\Modules\Match\Jobs\ProcessCareerActions;
 use Illuminate\Support\Facades\Log;
 
@@ -29,12 +30,21 @@ class SkipPreSeason
             ->orderBy('scheduled_date')
             ->first();
 
+        $previousDate = $game->current_date;
         $updates = ['pre_season' => false];
         if ($earliestMatch) {
             $updates['current_date'] = $earliestMatch->scheduled_date->toDateString();
         }
 
         $game->update($updates);
+
+        // Notify listeners that the date jumped from pre-season to matchday 1.
+        // This lets the transfer subsystem flush summer signings (parked as
+        // STATUS_AGREED) and lets the AI window-close handler run before the
+        // first competitive match.
+        if ($earliestMatch && $earliestMatch->scheduled_date->gt($previousDate)) {
+            GameDateAdvanced::dispatch($game->refresh(), $previousDate, $earliestMatch->scheduled_date);
+        }
 
         // Run career action ticks in the background to simulate pre-season transfer activity
         $updated = Game::where('id', $game->id)

--- a/app/Modules/Transfer/Enums/NegotiationScenario.php
+++ b/app/Modules/Transfer/Enums/NegotiationScenario.php
@@ -91,7 +91,9 @@ enum NegotiationScenario: string
         return match ($this) {
             self::TRANSFER => [],
             self::PRE_CONTRACT => ['status' => TransferOffer::STATUS_AGREED, 'resolved_at' => $currentDate],
-            self::FREE_AGENT => ['status' => TransferOffer::STATUS_COMPLETED, 'resolved_at' => $currentDate],
+            // Free-agent signings are parked as agreed; they join the squad
+            // after the next match via CompleteAgreedTransfersOnMatchPlayed.
+            self::FREE_AGENT => ['status' => TransferOffer::STATUS_AGREED, 'resolved_at' => $currentDate],
             self::RENEWAL => [],
         };
     }

--- a/app/Modules/Transfer/Listeners/CompleteAgreedTransfersOnMatchPlayed.php
+++ b/app/Modules/Transfer/Listeners/CompleteAgreedTransfersOnMatchPlayed.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Modules\Transfer\Listeners;
+
+use App\Modules\Match\Events\GameDateAdvanced;
+use App\Modules\Notification\Services\NotificationService;
+use App\Modules\Transfer\Enums\TransferWindowType;
+use App\Modules\Transfer\Services\TransferService;
+
+/**
+ * Completes agreed transfers once the team has played a match in the window.
+ *
+ * Transfers accepted while a window is OPEN are no longer completed
+ * immediately — they sit as STATUS_AGREED with resolved_at = current_date
+ * (i.e. the upcoming match the player would otherwise have plugged) and wait
+ * for that match to be played. After the match finalises, current_date moves
+ * forward and this listener flushes the agreements so the player joins from
+ * the *following* matchday onwards.
+ *
+ * The guard "previousDate was inside a transfer window" deliberately covers
+ * both the intra-window match case and the window-close boundary (where a
+ * summer signing made during pre-season needs to join before the league
+ * starts). The closed→open boundary stays the responsibility of
+ * CompleteAgreedTransfersOnWindowOpen.
+ */
+class CompleteAgreedTransfersOnMatchPlayed
+{
+    public function __construct(
+        private readonly TransferService $transferService,
+        private readonly NotificationService $notificationService,
+    ) {}
+
+    public function handle(GameDateAdvanced $event): void
+    {
+        if (TransferWindowType::fromDate($event->previousDate) === null) {
+            return;
+        }
+
+        $game = $event->game;
+
+        $completedOutgoing = $this->transferService->completeAgreedTransfers($game);
+        $completedIncoming = $this->transferService->completeIncomingTransfers($game);
+
+        foreach ($completedOutgoing->merge($completedIncoming) as $offer) {
+            $this->notificationService->notifyTransferComplete($game, $offer);
+        }
+    }
+}

--- a/app/Modules/Transfer/Services/LoanService.php
+++ b/app/Modules/Transfer/Services/LoanService.php
@@ -484,24 +484,18 @@ class LoanService
             $evaluation = $scoutingService->evaluateLoanRequest($offer->gamePlayer, $game);
 
             if ($evaluation['result'] === 'accepted') {
-                if ($game->isTransferWindowOpen()) {
-                    $this->completeLoanIn($offer, $game);
-                    $resolvedOffers->push([
-                        'offer' => $offer->fresh(),
-                        'result' => 'accepted',
-                        'completed' => true,
-                    ]);
-                } else {
-                    $offer->update([
-                        'status' => TransferOffer::STATUS_AGREED,
-                        'resolved_at' => $game->current_date,
-                    ]);
-                    $resolvedOffers->push([
-                        'offer' => $offer->fresh(),
-                        'result' => 'accepted',
-                        'completed' => false,
-                    ]);
-                }
+                // Park as agreed; the loan completes via
+                // CompleteAgreedTransfersOnMatchPlayed (next match) or
+                // CompleteAgreedTransfersOnWindowOpen (next window).
+                $offer->update([
+                    'status' => TransferOffer::STATUS_AGREED,
+                    'resolved_at' => $game->current_date,
+                ]);
+                $resolvedOffers->push([
+                    'offer' => $offer->fresh(),
+                    'result' => 'accepted',
+                    'completed' => false,
+                ]);
             } else {
                 $offer->update([
                     'status' => TransferOffer::STATUS_REJECTED,
@@ -622,18 +616,14 @@ class LoanService
     }
 
     /**
-     * Complete a sync-negotiated loan. Calls completeLoanIn if window open,
-     * otherwise marks as agreed.
+     * Complete a sync-negotiated loan. Always parks as agreed so the player
+     * joins from the next matchday (see CompleteAgreedTransfersOnMatchPlayed)
+     * rather than being immediately available for the current matchday.
      *
      * @return array{result: string, offer: TransferOffer}
      */
     public function completeSyncLoan(TransferOffer $offer, Game $game): array
     {
-        if ($game->isTransferWindowOpen()) {
-            $this->completeLoanIn($offer, $game);
-            return ['result' => 'accepted', 'offer' => $offer->fresh()];
-        }
-
         $offer->update([
             'status' => TransferOffer::STATUS_AGREED,
             'resolved_at' => $game->current_date,
@@ -652,10 +642,10 @@ class LoanService
     }
 
     /**
-     * Accept a pending loan-out offer: completes the loan if the window is
-     * open (moves player, creates Loan), or marks it as agreed so it completes
-     * when the window opens. Any sibling pending offers for the same player
-     * are auto-rejected.
+     * Accept a pending loan-out offer: parks it as agreed so the player
+     * leaves only after the next match has been played (open window) or
+     * when the next window opens (closed window). Sibling pending offers
+     * for the same player are auto-rejected.
      */
     public function acceptLoanOffer(TransferOffer $offer, Game $game): void
     {
@@ -683,15 +673,8 @@ class LoanService
                 'resolved_at' => $game->current_date,
             ]);
 
-        if ($game->isTransferWindowOpen()) {
-            // completeLoanOut already removes the TransferListing
-            $this->completeLoanOut($offer, $game);
-            return;
-        }
-
-        // Window closed: mark as agreed, remove listing (no more offers).
-        // TransferService::completeIncomingTransfers() will finalise the move
-        // when the window opens.
+        // TransferService::completeIncomingTransfers() (invoked via the
+        // match-played or window-open listener) finalises the move.
         $offer->update([
             'status' => TransferOffer::STATUS_AGREED,
             'resolved_at' => $game->current_date,

--- a/app/Modules/Transfer/Services/LoanService.php
+++ b/app/Modules/Transfer/Services/LoanService.php
@@ -566,6 +566,7 @@ class LoanService
             description: __('finances.tx_loan_in', [
                 'player' => $player->name ?? $player->id,
                 'team' => $parentTeam->name ?? '',
+                'team_de' => $parentTeam?->nameWithDe() ?? '',
             ]),
             transactionDate: $game->current_date,
             relatedPlayerId: $player->id,

--- a/app/Modules/Transfer/Services/TransferCompletionService.php
+++ b/app/Modules/Transfer/Services/TransferCompletionService.php
@@ -36,7 +36,9 @@ class TransferCompletionService
     {
         $player = $offer->gamePlayer;
         $playerName = $player->name;
-        $buyerName = $offer->offeringTeam->name;
+        $buyer = $offer->offeringTeam;
+        $buyerName = $buyer->name;
+        $buyerNameWithA = $buyer->nameWithA();
         $isLoan = $offer->offer_type === TransferOffer::TYPE_LOAN_OUT;
 
         // Transfer player to the buying team
@@ -87,7 +89,7 @@ class TransferCompletionService
                 gameId: $game->id,
                 category: FinancialTransaction::CATEGORY_TRANSFER_IN,
                 amount: $offer->transfer_fee,
-                description: __('finances.tx_player_sold', ['player' => $playerName, 'team' => $buyerName]),
+                description: __('finances.tx_player_sold', ['player' => $playerName, 'team' => $buyerName, 'team_a' => $buyerNameWithA]),
                 transactionDate: $game->current_date,
                 relatedPlayerId: $player->id,
             );
@@ -113,7 +115,9 @@ class TransferCompletionService
     {
         $player = $offer->gamePlayer;
         $playerName = $player->name;
-        $buyerName = $offer->offeringTeam->name;
+        $buyer = $offer->offeringTeam;
+        $buyerName = $buyer->name;
+        $buyerNameWithA = $buyer->nameWithA();
         $game = $player->game;
         $fromTeamId = $player->team_id;
         $fromTeamName = $player->team->name ?? null;
@@ -150,7 +154,7 @@ class TransferCompletionService
             gameId: $game->id,
             category: FinancialTransaction::CATEGORY_TRANSFER_IN,
             amount: 0,
-            description: __('finances.tx_free_transfer_out', ['player' => $playerName, 'team' => $buyerName]),
+            description: __('finances.tx_free_transfer_out', ['player' => $playerName, 'team' => $buyerName, 'team_a' => $buyerNameWithA]),
             transactionDate: $game->current_date,
             relatedPlayerId: $player->id,
         );
@@ -184,7 +188,9 @@ class TransferCompletionService
 
         $player = $offer->gamePlayer;
         $playerName = $player->name;
-        $sellerName = $offer->sellingTeam->name ?? $player->team->name ?? 'Unknown';
+        $sellerTeam = $offer->sellingTeam ?? $player->team;
+        $sellerName = $sellerTeam->name ?? 'Unknown';
+        $sellerNameWithDe = $sellerTeam?->nameWithDe() ?? 'de Unknown';
         $fromTeamId = $offer->selling_team_id ?? $player->team_id;
 
         // Transfer player to user's team
@@ -230,7 +236,7 @@ class TransferCompletionService
                 gameId: $game->id,
                 category: FinancialTransaction::CATEGORY_TRANSFER_OUT,
                 amount: $offer->transfer_fee,
-                description: __('finances.tx_player_signed', ['player' => $playerName, 'team' => $sellerName]),
+                description: __('finances.tx_player_signed', ['player' => $playerName, 'team' => $sellerName, 'team_de' => $sellerNameWithDe]),
                 transactionDate: $game->current_date,
                 relatedPlayerId: $player->id,
             );

--- a/app/Modules/Transfer/Services/TransferService.php
+++ b/app/Modules/Transfer/Services/TransferService.php
@@ -585,11 +585,12 @@ class TransferService
     }
 
     /**
-     * Accept a transfer offer.
-     * If transfer window is open, completes immediately.
-     * If outside window, marks as agreed and completes when next window opens.
+     * Accept a transfer offer. Parks the deal as STATUS_AGREED; the player
+     * does not change teams until either the next match finalises (open
+     * window) or the next window opens (closed window). The intra-window
+     * delay solves the "sign during the matchday, use immediately" exploit.
      *
-     * @return bool True if transfer completed immediately, false if waiting for window
+     * @return bool Always false — completion is now deferred to a listener.
      */
     public function acceptOffer(TransferOffer $offer): bool
     {
@@ -611,20 +612,6 @@ class TransferService
             ->where('status', TransferOffer::STATUS_PENDING)
             ->update(['status' => TransferOffer::STATUS_REJECTED, 'resolved_at' => $game->current_date]);
 
-        // Pre-contract transfers always wait until end of season — the player's
-        // current contract is still valid until June regardless of window status.
-        if ($offer->isPreContract()) {
-            $offer->update(['status' => TransferOffer::STATUS_AGREED, 'resolved_at' => $game->current_date]);
-            return false;
-        }
-
-        // If transfer window is open, complete immediately
-        if ($game->isTransferWindowOpen()) {
-            $this->completeTransfer($offer, $game);
-            return true;
-        }
-
-        // Otherwise, mark as agreed (waiting for next transfer window)
         $offer->update(['status' => TransferOffer::STATUS_AGREED, 'resolved_at' => $game->current_date]);
         return false;
     }
@@ -1003,7 +990,8 @@ class TransferService
 
     /**
      * Complete all agreed incoming transfers (user buying/loaning players).
-     * Called when transfer window opens.
+     * Invoked both when a window opens (cross-window agreements) and when a
+     * match finalises during an open window (intra-window agreements).
      */
     public function completeIncomingTransfers(Game $game): Collection
     {
@@ -1030,6 +1018,11 @@ class TransferService
         foreach ($agreedIncoming as $offer) {
             if ($offer->offer_type === TransferOffer::TYPE_LOAN_IN) {
                 $this->loanService->completeLoanIn($offer, $game);
+            } elseif ($this->isFreeAgentOffer($offer)) {
+                // Free-agent signings (no selling club) need the free-agent
+                // completion path so the GameTransfer is logged as
+                // TYPE_FREE_AGENT and the career record uses ORIGIN_FREE_AGENT.
+                $this->completionService->completeFreeAgentSigning($game, $offer->gamePlayer, $offer);
             } else {
                 $this->completeIncomingTransfer($offer, $game);
             }
@@ -1044,28 +1037,23 @@ class TransferService
         return $completedTransfers;
     }
 
+    private function isFreeAgentOffer(TransferOffer $offer): bool
+    {
+        return $offer->offer_type === TransferOffer::TYPE_USER_BID
+            && $offer->selling_team_id === null
+            && (int) $offer->transfer_fee === 0;
+    }
+
     /**
-     * Accept an incoming transfer offer (user buying a player).
-     * If transfer window is open, completes immediately.
-     * If outside window, marks as agreed and completes when next window opens.
-     *
-     * @return bool True if transfer completed immediately, false if waiting for window
-     */
-    /**
-     * Sign a free agent: assign to team, create offer/transfer records.
+     * Sign a free agent: park a STATUS_AGREED offer so the player joins
+     * from the next matchday after the agreement (see
+     * CompleteAgreedTransfersOnMatchPlayed). The player record is not
+     * touched here — completion handles team_id, squad number, contract
+     * length and the GameTransfer entry.
      */
     public function signFreeAgent(Game $game, GamePlayer $player, int $wageDemand): TransferOffer
     {
-        $seasonYear = (int) $game->season;
         $contractYears = $player->age($game->current_date) >= 32 ? 1 : mt_rand(2, 3);
-        $newContractEnd = Carbon::createFromDate($seasonYear + $contractYears + 1, 6, 30);
-
-        $player->update([
-            'team_id' => $game->team_id,
-            'number' => $this->squadNumberService->assignNumberForNewPlayer($game, $player),
-            'contract_until' => $newContractEnd,
-            'annual_wage' => $wageDemand,
-        ]);
 
         $offer = TransferOffer::create([
             'game_id' => $game->id,
@@ -1076,51 +1064,25 @@ class TransferService
             'direction' => TransferOffer::DIRECTION_INCOMING,
             'transfer_fee' => 0,
             'offered_wage' => $wageDemand,
-            'status' => TransferOffer::STATUS_COMPLETED,
+            'offered_years' => $contractYears,
+            'status' => TransferOffer::STATUS_AGREED,
             'resolved_at' => $game->current_date,
             'expires_at' => $game->current_date,
             'game_date' => $game->current_date,
         ]);
 
-        GameTransfer::record(
-            gameId: $game->id,
-            gamePlayerId: $player->id,
-            fromTeamId: null,
-            toTeamId: $game->team_id,
-            transferFee: 0,
-            type: GameTransfer::TYPE_FREE_AGENT,
-            season: $game->season,
-            window: TransferWindowType::currentValue($game->current_date),
-        );
-
-        ShortlistedPlayer::removeForPlayer($game->id, $player->id);
-
         return $offer;
-    }
-
-    /**
-     * Complete a free agent signing from a negotiated offer (wage already agreed).
-     */
-    public function completeFreeAgentSigning(Game $game, GamePlayer $player, TransferOffer $offer): void
-    {
-        $this->completionService->completeFreeAgentSigning($game, $player, $offer);
     }
 
     public function acceptIncomingOffer(TransferOffer $offer): bool
     {
         $game = $offer->game;
 
-        // If transfer window is open, complete immediately
-        if ($game->isTransferWindowOpen()) {
-            if ($offer->offer_type === TransferOffer::TYPE_LOAN_IN) {
-                $this->loanService->completeLoanIn($offer, $game);
-                return true;
-            }
-
-            return $this->completeIncomingTransfer($offer, $game);
-        }
-
-        // Otherwise, mark as agreed (waiting for next transfer window)
+        // Park as agreed regardless of window state. Completion is handled
+        // by CompleteAgreedTransfersOnMatchPlayed (intra-window) or
+        // CompleteAgreedTransfersOnWindowOpen (cross-window) so that newly
+        // signed players never become available for the matchday they were
+        // signed during.
         $offer->update(['status' => TransferOffer::STATUS_AGREED, 'resolved_at' => $game->current_date]);
         return false;
     }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -41,6 +41,7 @@ use App\Modules\Season\Listeners\SoftDeleteCompletedTournamentGame;
 use App\Modules\Squad\Listeners\CheckRecoveredPlayers;
 use App\Modules\Squad\Listeners\EnforceSquadRegistration;
 use App\Modules\Transfer\Listeners\ApplyWageGapMoraleDrip;
+use App\Modules\Transfer\Listeners\CompleteAgreedTransfersOnMatchPlayed;
 use App\Modules\Transfer\Listeners\CompleteAgreedTransfersOnWindowOpen;
 use App\Modules\Transfer\Listeners\ProcessTransferWindowClose;
 use App\Modules\Transfer\Listeners\RollAIContractRenewals;
@@ -183,6 +184,7 @@ class AppServiceProvider extends ServiceProvider
         Event::listen(GameDateAdvanced::class, CheckRecoveredPlayers::class);
         Event::listen(GameDateAdvanced::class, NotifyTransferWindowOpen::class);
         Event::listen(GameDateAdvanced::class, CompleteAgreedTransfersOnWindowOpen::class);
+        Event::listen(GameDateAdvanced::class, CompleteAgreedTransfersOnMatchPlayed::class);
         Event::listen(GameDateAdvanced::class, NotifyTransferWindowClosing::class);
         Event::listen(GameDateAdvanced::class, NotifyUnenrolledPlayersBeforeWindowClose::class);
         Event::listen(GameDateAdvanced::class, ProcessTransferWindowClose::class);

--- a/lang/en/messages.php
+++ b/lang/en/messages.php
@@ -11,9 +11,11 @@ return [
     'offer_rejected' => ':team_de offer rejected.',
     'offer_accepted_sale' => ':player sold :team_a for :fee.',
     'offer_accepted_pre_contract' => 'Deal agreed! :player will sign for :team for :fee when the :window window opens.',
+    'offer_accepted_intra_window' => 'Deal agreed! :player will leave for :team for :fee after the next match.',
 
     // Free agent signing
     'free_agent_signed' => ':player has signed for your team as a free agent!',
+    'free_agent_agreed' => 'Deal agreed! :player will join your team as a free agent after the next match.',
     'not_free_agent' => 'This player is not a free agent.',
     'free_agent_reputation_too_low' => 'This player has no interest in joining a club of your reputation level.',
     'transfer_window_closed' => 'The transfer window is closed.',
@@ -31,6 +33,7 @@ return [
     'loan_search_active' => ':player already has an active loan search.',
     'loan_offer_accepted' => ':player loaned :team_a.',
     'loan_offer_accepted_pre_window' => ':player will be loaned to :team when the :window window opens.',
+    'loan_offer_agreed_intra_window' => ':player will be loaned to :team after the next match.',
     'loan_search_cancelled' => ':player loan search has been cancelled.',
 
     // Contract messages

--- a/lang/en/transfers.php
+++ b/lang/en/transfers.php
@@ -62,6 +62,8 @@ return [
     // Incoming transfers
     'incoming_transfers' => 'Incoming Transfers',
     'completing_when_window' => 'will be completed when the :window window opens',
+    'joining_after_next_match' => 'will join the squad after the next match is played',
+    'leaving_after_next_match' => 'will leave the squad after the next match is played',
     'deal_agreed' => 'Deal agreed',
 
     // Unsolicited offers
@@ -408,6 +410,7 @@ return [
     'chat_player_counter_transfer' => ':player\'s agent insists on :wage/year for :years years.',
     'chat_transfer_complete' => ':player has signed! Welcome to the team.',
     'chat_transfer_complete_pending' => ':player has signed! The player will join the team in the next transfer window.',
+    'chat_transfer_complete_intra_window' => ':player has signed! The player will join the squad after the next match.',
     'chat_terms_rejected' => ':player\'s agent has walked away. The deal is off.',
 
     // Counter-offer negotiation (user selling)

--- a/lang/es/finances.php
+++ b/lang/es/finances.php
@@ -192,10 +192,10 @@ return [
     'upgrade_insufficient_budget' => 'Presupuesto de fichajes insuficiente.',
 
     // Transaction descriptions
-    'tx_free_transfer_out' => ':player se fue libre a :team',
-    'tx_player_sold' => ':player vendido a :team',
-    'tx_player_signed' => ':player fichado de :team',
-    'tx_loan_in' => ':player cedido de :team (salario)',
+    'tx_free_transfer_out' => ':player se fue libre :team_a',
+    'tx_player_sold' => ':player vendido :team_a',
+    'tx_player_signed' => ':player fichado :team_de',
+    'tx_loan_in' => ':player cedido :team_de (salario)',
     'tx_player_released' => ':player liberado (indemnización)',
     'tx_cup_advancement' => ':competition - :round',
     'tx_league_phase_qualification' => ':competition - Fase de liga superada (:positionº)',

--- a/lang/es/messages.php
+++ b/lang/es/messages.php
@@ -11,7 +11,7 @@ return [
     'offer_rejected' => 'Oferta :team_de rechazada.',
     'offer_accepted_sale' => ':player vendido :team_a por :fee.',
     'offer_accepted_pre_contract' => '¡Acuerdo cerrado! :player fichará por :team por :fee cuando abra la ventana de :window.',
-    'offer_accepted_intra_window' => '¡Acuerdo cerrado! :player se marchará a :team por :fee tras el próximo partido.',
+    'offer_accepted_intra_window' => '¡Acuerdo cerrado! :player se marchará :team_a por :fee tras el próximo partido.',
 
     // Free agent signing
     'free_agent_signed' => '¡:player ha fichado por tu equipo como agente libre!',
@@ -33,8 +33,8 @@ return [
     'loan_search_active' => ':player ya tiene una búsqueda de cesión activa.',
     'loan_search_cancelled' => 'Se ha cancelado la búsqueda de cesión de :player.',
     'loan_offer_accepted' => ':player cedido :team_a.',
-    'loan_offer_accepted_pre_window' => ':player será cedido al :team cuando abra la ventana de :window.',
-    'loan_offer_agreed_intra_window' => ':player será cedido al :team tras el próximo partido.',
+    'loan_offer_accepted_pre_window' => ':player será cedido :team_a cuando abra la ventana de :window.',
+    'loan_offer_agreed_intra_window' => ':player será cedido :team_a tras el próximo partido.',
 
     // Contract messages
     'renewal_agreed' => ':player ha aceptado una extensión de :years años a :wage/año (efectivo desde la próxima temporada).',

--- a/lang/es/messages.php
+++ b/lang/es/messages.php
@@ -11,9 +11,11 @@ return [
     'offer_rejected' => 'Oferta :team_de rechazada.',
     'offer_accepted_sale' => ':player vendido :team_a por :fee.',
     'offer_accepted_pre_contract' => '¡Acuerdo cerrado! :player fichará por :team por :fee cuando abra la ventana de :window.',
+    'offer_accepted_intra_window' => '¡Acuerdo cerrado! :player se marchará a :team por :fee tras el próximo partido.',
 
     // Free agent signing
     'free_agent_signed' => '¡:player ha fichado por tu equipo como agente libre!',
+    'free_agent_agreed' => '¡Acuerdo cerrado! :player se incorporará como agente libre tras el próximo partido.',
     'not_free_agent' => 'Este jugador no es agente libre.',
     'free_agent_reputation_too_low' => 'Este jugador no tiene interés en fichar por un club de tu nivel de reputación.',
     'transfer_window_closed' => 'La ventana de fichajes está cerrada.',
@@ -32,6 +34,7 @@ return [
     'loan_search_cancelled' => 'Se ha cancelado la búsqueda de cesión de :player.',
     'loan_offer_accepted' => ':player cedido :team_a.',
     'loan_offer_accepted_pre_window' => ':player será cedido al :team cuando abra la ventana de :window.',
+    'loan_offer_agreed_intra_window' => ':player será cedido al :team tras el próximo partido.',
 
     // Contract messages
     'renewal_agreed' => ':player ha aceptado una extensión de :years años a :wage/año (efectivo desde la próxima temporada).',

--- a/lang/es/transfers.php
+++ b/lang/es/transfers.php
@@ -62,6 +62,8 @@ return [
     // Incoming transfers
     'incoming_transfers' => 'Fichajes Entrantes',
     'completing_when_window' => 'se completará cuando abra la ventana de :window',
+    'joining_after_next_match' => 'se incorporará a la plantilla tras el próximo partido',
+    'leaving_after_next_match' => 'abandonará la plantilla tras el próximo partido',
     'deal_agreed' => 'Acuerdo cerrado',
 
     // Unsolicited offers
@@ -413,6 +415,7 @@ return [
     'chat_player_counter_transfer' => 'El agente de :player insiste en :wage/año durante :years años.',
     'chat_transfer_complete' => '¡:player ha firmado! Bienvenido al equipo.',
     'chat_transfer_complete_pending' => '¡:player ha firmado! El jugador se incorporará al equipo en el próximo mercado de fichajes.',
+    'chat_transfer_complete_intra_window' => '¡:player ha firmado! Se incorporará a la plantilla tras el próximo partido.',
     'chat_terms_rejected' => 'El agente de :player se ha marchado. El acuerdo se ha roto.',
 
     // Counter-offer negotiation (user selling)

--- a/lang/es/transfers.php
+++ b/lang/es/transfers.php
@@ -426,7 +426,7 @@ return [
     'chat_buyer_counter_resume' => 'La última oferta de :team es :fee.',
     'chat_buyer_accepted' => '¡:team acepta tu precio de :fee por :player!',
     'chat_buyer_rejected' => ':team ha retirado su interés. La negociación ha fracasado.',
-    'chat_buyer_deal_complete' => '¡Venta acordada! :player se unirá a :team por :fee.',
+    'chat_buyer_deal_complete' => '¡Venta acordada! :player se unirá :team_a por :fee.',
     'chat_offer_rejected' => 'Has rechazado la oferta por :player. El jugador no está en venta.',
 
     // Pre-contract negotiation chat

--- a/resources/views/incoming-transfers.blade.php
+++ b/resources/views/incoming-transfers.blade.php
@@ -167,7 +167,13 @@
                             @if($incomingAgreedTransfers->isNotEmpty())
                             <div class="border-l-4 border-l-accent-green pl-5">
                                 <h4 class="font-semibold text-lg text-text-primary mb-1">{{ __('transfers.incoming_transfers') }}</h4>
-                                <p class="text-sm text-text-muted mb-3">{{ __('transfers.completing_when_window', ['window' => $game->getNextWindowName()]) }}</p>
+                                <p class="text-sm text-text-muted mb-3">
+                                    @if($game->isTransferWindowOpen())
+                                        {{ __('transfers.joining_after_next_match') }}
+                                    @else
+                                        {{ __('transfers.completing_when_window', ['window' => $game->getNextWindowName()]) }}
+                                    @endif
+                                </p>
                                 <div class="space-y-3">
                                     @foreach($incomingAgreedTransfers as $transfer)
                                     <div class="bg-accent-green/10 border border-accent-green/20 rounded-xl p-4">

--- a/resources/views/outgoing-transfers.blade.php
+++ b/resources/views/outgoing-transfers.blade.php
@@ -282,7 +282,13 @@
                             @if($agreedTransfers->isNotEmpty())
                             <div class="border-l-4 border-l-accent-green pl-5">
                                 <h4 class="font-semibold text-lg text-text-primary mb-1">{{ __('transfers.agreed_transfers') }}</h4>
-                                <p class="text-sm text-text-muted mb-3">{{ __('transfers.completing_when_window', ['window' => $game->getNextWindowName()]) }}</p>
+                                <p class="text-sm text-text-muted mb-3">
+                                    @if($game->isTransferWindowOpen())
+                                        {{ __('transfers.leaving_after_next_match') }}
+                                    @else
+                                        {{ __('transfers.completing_when_window', ['window' => $game->getNextWindowName()]) }}
+                                    @endif
+                                </p>
                                 <div class="space-y-3">
                                     @foreach($agreedTransfers as $transfer)
                                     <div class="bg-accent-green/10 border border-accent-green/20 rounded-xl p-4">

--- a/tests/Feature/CounterOfferTest.php
+++ b/tests/Feature/CounterOfferTest.php
@@ -193,8 +193,9 @@ class CounterOfferTest extends TestCase
         $response->assertJsonPath('negotiation_status', 'completed');
 
         $this->offer->refresh();
-        // Should be completed (window is open in August)
-        $this->assertEquals(TransferOffer::STATUS_COMPLETED, $this->offer->status);
+        // Deals reached during an open window are parked as STATUS_AGREED
+        // and completed after the next match (CompleteAgreedTransfersOnMatchPlayed).
+        $this->assertEquals(TransferOffer::STATUS_AGREED, $this->offer->status);
     }
 
     public function test_counter_must_be_higher_than_current_bid(): void

--- a/tests/Unit/CompleteAgreedTransfersOnWindowOpenTest.php
+++ b/tests/Unit/CompleteAgreedTransfersOnWindowOpenTest.php
@@ -181,10 +181,12 @@ class CompleteAgreedTransfersOnWindowOpenTest extends TestCase
     }
 
     /**
-     * Guard: the listener must not re-fire on subsequent advances that stay
-     * inside the same already-open window.
+     * Intra-window advance: an agreement reached while the window is open is
+     * completed after the next match (CompleteAgreedTransfersOnMatchPlayed).
+     * This is the core "skip next match" rule that closes the same-matchday
+     * signing exploit.
      */
-    public function test_listener_does_not_refire_on_intra_window_advances(): void
+    public function test_intra_window_agreed_transfer_completes_after_next_match(): void
     {
         $game = $this->setupGameWithFinances('2025-01-04', '2024');
         $userTeam = $game->team;
@@ -194,9 +196,6 @@ class CompleteAgreedTransfersOnWindowOpenTest extends TestCase
             'contract_until' => '2027-06-30',
         ]);
 
-        // Simulate a fresh offer that slipped into AGREED somehow while the
-        // window is already open (race / edge case). A Jan → Jan advance
-        // must NOT be treated as a window-open transition.
         $offer = TransferOffer::create([
             'game_id' => $game->id,
             'game_player_id' => $player->id,
@@ -218,8 +217,10 @@ class CompleteAgreedTransfersOnWindowOpenTest extends TestCase
         );
 
         $offer->refresh();
-        $this->assertSame(TransferOffer::STATUS_AGREED, $offer->status,
-            'Listener should only act on a closed→open transition, not on intra-window advances');
+        $player->refresh();
+        $this->assertSame(TransferOffer::STATUS_COMPLETED, $offer->status,
+            'Intra-window agreements should complete once the next match has been played');
+        $this->assertSame($buyerTeam->id, $player->team_id);
     }
 
     /**


### PR DESCRIPTION
Closes the "sign during the matchday, use immediately" exploit reported by
a user: agreements reached during an open window are now parked as
STATUS_AGREED with resolved_at = current_date. A new
CompleteAgreedTransfersOnMatchPlayed listener flushes them once the next
match finalises (intra-window) or the window closes (pre-season summer
signings), reusing the same completion methods as
CompleteAgreedTransfersOnWindowOpen.

Free-agent and loan-in entry points were folded into the same parking
flow; completeIncomingTransfers now routes selling_team_id-less offers
through completeFreeAgentSigning so the GameTransfer log and career
record stay correct. SkipPreSeason dispatches GameDateAdvanced so the new
listener (and the AI window-close handler) get a chance to run when the
user jumps straight to matchday 1.

The "agreed transfers" sections of both the incoming and outgoing market
views now show "joining/leaving after the next match" when the window is
open, and keep the "completing when window opens" copy for pre-window
agreements.

https://claude.ai/code/session_01PpFcZZSCN3yZ8gA8qNMbKn