### PR TITLE
Fix empty "last result" panel after silent fast-mode entry failure

### DIFF
--- a/app/Http/Actions/EnterFastMode.php
+++ b/app/Http/Actions/EnterFastMode.php
@@ -30,11 +30,30 @@ class EnterFastMode
                 ->with('warning', __('messages.fast_mode_blocked_live_match'));
         }
 
+        $alreadyInFastMode = $game->isFastMode();
         $this->fastModeService->enter($game);
 
         // Simulate the first match immediately so the user lands on a
         // populated view (last result + updated standings) instead of an
         // empty "simulate your first match" screen.
-        return ($this->advanceFastMatchday)($gameId);
+        $playedBefore = $game->matches()->where('played', true)->count();
+        $response = ($this->advanceFastMatchday)($gameId);
+        $playedAfter = $game->matches()->where('played', true)->count();
+
+        // If the inline advance didn't actually simulate anything (claim
+        // contention, swallowed exception, etc.), the user would land on
+        // game.fast-mode with fast_mode_entered_on snapshotted past every
+        // previously-played match — an empty "last result" panel with no
+        // explanation. Roll back the entry and surface a visible warning
+        // on show-game, where flash messages render. Skip the rollback if
+        // the user was already in fast mode before this request: we don't
+        // want to kick a healthy session out on a transient retry.
+        if ($playedAfter === $playedBefore && ! $alreadyInFastMode) {
+            $this->fastModeService->exit($game->fresh());
+            return redirect()->route('show-game', $gameId)
+                ->with('warning', __('messages.fast_mode_advance_failed_retry'));
+        }
+
+        return $response;
     }
 }

--- a/app/Modules/Match/Services/FastModeService.php
+++ b/app/Modules/Match/Services/FastModeService.php
@@ -9,10 +9,15 @@ class FastModeService
 {
     public function enter(Game $game): void
     {
-        // Reset fast_mode_entered_on on every (re-)entry so stepping out and
-        // back in clears the "last result" panel — the user should land on
-        // an empty session. The not-null marker also doubles as the
-        // is-fast-mode flag (Game::isFastMode()).
+        // No-op when already in fast mode. current_date is forward-looking
+        // (points to the next unplayed match), so re-snapshotting it mid-
+        // session would advance the marker past the just-played match and
+        // hide the "last result" panel. Exiting first (which nulls the
+        // column) is the supported way to clear the session.
+        if ($game->fast_mode_entered_on !== null) {
+            return;
+        }
+
         $game->update([
             'fast_mode_entered_on' => $game->current_date?->toDateString(),
         ]);

--- a/lang/en/messages.php
+++ b/lang/en/messages.php
@@ -174,6 +174,7 @@ return [
     'fast_mode_action_required' => 'An action requires your attention. Exit fast mode to resolve it.',
     'fast_mode_blocked_live_match' => 'Finish the current match before enabling fast mode.',
     'fast_mode_blocked_tournament' => 'Fast mode is not available in tournament mode.',
+    'fast_mode_advance_failed_retry' => 'Could not simulate the matchday. Please try again.',
 
     // Budget loan messages
     'budget_loan_approved' => 'Loan of :amount approved and added to your transfer budget.',

--- a/lang/es/messages.php
+++ b/lang/es/messages.php
@@ -174,6 +174,7 @@ return [
     'fast_mode_action_required' => 'Una acción requiere tu atención. Sal del modo rápido para resolverla.',
     'fast_mode_blocked_live_match' => 'Termina el partido actual antes de activar el modo rápido.',
     'fast_mode_blocked_tournament' => 'El modo rápido no está disponible en el modo torneo.',
+    'fast_mode_advance_failed_retry' => 'No se pudo simular la jornada. Inténtalo de nuevo.',
 
     // Budget loan messages
     'budget_loan_approved' => 'Préstamo de :amount aprobado y añadido a tu presupuesto de fichajes.',


### PR DESCRIPTION
EnterFastMode committed fast_mode_entered_on before invoking
AdvanceFastMatchday. If the inline advance returned without simulating
(claim contention on matchday_advancing_at / career_actions_processing_at
or a swallowed exception), the user landed on game.fast-mode with the
session marker snapshotted past every previously-played match — empty
panel, no flash message (the app layout doesn't render flashes).

Make enter() a no-op when already in fast mode so transient retries
don't leapfrog a healthy session, and roll back the entry in
EnterFastMode when the played-match count didn't increase, redirecting
to show-game with a visible warning instead.