### PR TITLE
Fix flaky RedCardSimulationTest AI-side reactive-sub assertion

### DIFF
--- a/tests/Unit/RedCardSimulationTest.php
+++ b/tests/Unit/RedCardSimulationTest.php
@@ -509,9 +509,13 @@ class RedCardSimulationTest extends TestCase
                     $this->assertNull($reactiveSub,
                         'User-team red card must not trigger a forced reactive substitution');
                     $verifiedUserGate = true;
-                } else {
-                    $this->assertNotNull($reactiveSub,
-                        'AI-team red card should still trigger a reactive substitution');
+                } elseif ($reactiveSub !== null) {
+                    // AI-team defender red cards normally trigger a reactive
+                    // sub, but applyRedCardTeamReactiveSub skips when subs or
+                    // windows are exhausted (3 windows / 5 subs total). With
+                    // direct_red_chance=50 the AI can run out before some
+                    // red cards land, so we only need to confirm the AI path
+                    // fires at least once across the run.
                     $verifiedAIPath = true;
                 }
             }
@@ -524,7 +528,7 @@ class RedCardSimulationTest extends TestCase
         $this->assertTrue($verifiedUserGate,
             'Expected at least one defender red card on the user team across 200 sims');
         $this->assertTrue($verifiedAIPath,
-            'Expected at least one defender red card on the AI team across 200 sims');
+            'Expected at least one defender red card on the AI team to trigger a reactive sub across 200 sims');
     }
 
     public function test_forward_red_card_does_not_trigger_reshape_sub(): void


### PR DESCRIPTION
The test asserted that every AI-team defender red card triggers a
reactive substitution, but with direct_red_chance=50 the AI can
exhaust its 3 substitution windows / 5 subs (via tactical subs,
injuries, or earlier red cards) before another red card lands, in
which case applyRedCardTeamReactiveSub correctly skips. The test
failed in ~1/15 full-class runs whenever any single AI red card
hit that path.

Weaken the AI branch to a "we saw at least one" check, matching the
intent: the user-team gate is still asserted strictly on every
defender red card (the actual behavior under test), and the
verifiedAIPath flag still requires at least one successful AI
reactive sub across 200 sims to confirm the AI path hasn't broken.