### PR TITLE
Preserve first-half stoppage goals during half-time tactical changes

### DIFF
--- a/app/Modules/Match/Services/MatchResimulationService.php
+++ b/app/Modules/Match/Services/MatchResimulationService.php
@@ -79,7 +79,18 @@ class MatchResimulationService
         // Phases give us this for free: anywhere in regulation maps to a
         // SECOND_HALF_STOPPAGE-or-earlier tuple, and the simulator's remainder
         // restarts from the corresponding raw minute.
-        $resimAnchor = $minute >= 90 ? $stoppage->regulationEnd() : $minute;
+        //
+        // Same idea at half-time: a tactical action stamped at minute 45 must
+        // not wipe goals/cards that landed in 1H stoppage (raw minute 46..45+fhs).
+        // The live clock snaps back to 45 when entering half-time, so the
+        // frontend POSTs minute=45 even though the user has already watched
+        // events from the stoppage window — those events would be reverted
+        // without this lift.
+        $resimAnchor = match (true) {
+            $minute >= 90 => $stoppage->regulationEnd(),
+            $minute === 45 => 45 + $stoppage->firstHalf,
+            default => $minute,
+        };
 
         // 2. Revert all events that happened after the cutoff. Uses phase
         // tuple comparison so a 91' ET goal (phase=ET_FIRST_HALF) is not

--- a/resources/js/modules/match-phases.js
+++ b/resources/js/modules/match-phases.js
@@ -52,3 +52,21 @@ export function isHalfTimeLike(phase) {
     return phase === PHASE.HALF_TIME || phase === PHASE.EXTRA_TIME_HALF_TIME;
 }
 
+// Cutoff minute for "everything that has happened so far" when the user
+// submits a tactical action. During play, that's just the live clock. At
+// half-time the live clock has been snapped back to the half boundary
+// (45 / 105), which loses the stoppage-time events the user already
+// watched — so we lift the cutoff to the end of the half's stoppage
+// window. Used for both the POST payload to the resimulation endpoint
+// and the client-side event/feed filters; keeping them in sync prevents
+// stoppage goals from being reverted server-side or stripped client-side.
+export function effectiveSubmissionMinute(state) {
+    if (state.phase === PHASE.HALF_TIME) {
+        return MINUTE.FIRST_HALF_END + (state.firstHalfStoppage || 0);
+    }
+    if (state.phase === PHASE.EXTRA_TIME_HALF_TIME) {
+        return MINUTE.ET_FIRST_HALF_END + (state.etFirstHalfStoppage || 0);
+    }
+    return Math.floor(state.currentMinute);
+}
+

--- a/resources/js/modules/match-simulation.js
+++ b/resources/js/modules/match-simulation.js
@@ -1,4 +1,4 @@
-import { PHASE, MINUTE } from './match-phases.js';
+import { PHASE, MINUTE, effectiveSubmissionMinute } from './match-phases.js';
 
 /**
  * Match simulation module.
@@ -825,7 +825,7 @@ export function createMatchSimulation(ctx) {
         // The top-level _skipToEndFired guard ensures this can only fire once.
         // When the response arrives, autoSubUserTeamBeforeSkip replaces
         // state.events and rebuilds revealedEvents in one synchronous pass.
-        const skipMinute = Math.max(1, Math.min(89, Math.floor(state.currentMinute)));
+        const skipMinute = Math.max(1, Math.min(89, effectiveSubmissionMinute(state)));
         const skipPromise = (typeof state.autoSubUserTeamBeforeSkip === 'function')
             ? state.autoSubUserTeamBeforeSkip(skipMinute)
             : Promise.resolve(false);

--- a/resources/js/modules/tactical-submission.js
+++ b/resources/js/modules/tactical-submission.js
@@ -6,7 +6,7 @@
  * Isolated from the UI panel (tactical-panel.js) so the network + state-
  * reconciliation flow can be reasoned about on its own.
  */
-import { MINUTE, FREE_SUB_WINDOW_MINUTES } from './match-phases.js';
+import { MINUTE, FREE_SUB_WINDOW_MINUTES, effectiveSubmissionMinute } from './match-phases.js';
 import { regenerateShots, regenerateNarratives } from './atmosphere-generator.js';
 import { updateRosterPerformances } from './player-ratings.js';
 
@@ -34,7 +34,12 @@ export function createTacticalSubmission(ctx) {
             c.tacticalError = null;
             c.applyingChanges = true;
 
-            const minute = Math.floor(c.currentMinute);
+            // At half-time, c.currentMinute has been snapped back to 45 by
+            // enterHalfTime, but events revealed during 1H stoppage have
+            // absolute minutes > 45. Using floor(currentMinute) directly
+            // would cause the backend revert and the local event filters
+            // below to strip those events.
+            const minute = effectiveSubmissionMinute(c);
 
             try {
                 const payload = {

--- a/tests/Feature/HalfTimeResimulationPreservesStoppageGoalsTest.php
+++ b/tests/Feature/HalfTimeResimulationPreservesStoppageGoalsTest.php
@@ -1,0 +1,209 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Competition;
+use App\Models\Game;
+use App\Models\GameMatch;
+use App\Models\GamePlayer;
+use App\Models\MatchEvent;
+use App\Models\Team;
+use App\Models\User;
+use App\Modules\Match\Enums\MatchPhase;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Regression test for the "vanishing 45+2 goal" bug.
+ *
+ * When the live clock crosses into half-time, enterHalfTime() in the
+ * Alpine component snaps state.currentMinute back to 45 — destroying the
+ * absolute clock value that 1H-stoppage events were revealed at. If the
+ * user then submits a tactical action at the break (an extremely common
+ * pattern), the frontend POSTs minute=45 and the backend would revert
+ * every event whose absolute minute is > 45, deleting any goal stored
+ * with phase=FIRST_HALF_STOPPAGE from the DB.
+ *
+ * The fix lifts the resim anchor at minute=45 to 45 + first_half_stoppage,
+ * mirroring the existing 90-anchor that protects 2H stoppage events.
+ */
+class HalfTimeResimulationPreservesStoppageGoalsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+    private Team $playerTeam;
+    private Team $opponentTeam;
+    private Competition $competition;
+    private Game $game;
+    private GameMatch $match;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = User::factory()->create();
+        $this->playerTeam = Team::factory()->create(['name' => 'Player Team']);
+        $this->opponentTeam = Team::factory()->create(['name' => 'Opponent Team']);
+
+        $this->competition = Competition::factory()->league()->create([
+            'id' => 'ESP1',
+            'name' => 'LaLiga',
+        ]);
+
+        $this->playerTeam->competitions()->attach($this->competition->id, ['season' => '2024']);
+        $this->opponentTeam->competitions()->attach($this->competition->id, ['season' => '2024']);
+
+        $this->game = Game::factory()->create([
+            'user_id' => $this->user->id,
+            'team_id' => $this->playerTeam->id,
+            'competition_id' => $this->competition->id,
+            'season' => '2024',
+            'current_date' => '2024-08-15',
+        ]);
+
+        $this->createSquad($this->playerTeam, 18);
+        $this->createSquad($this->opponentTeam, 18);
+
+        $homeLineup = GamePlayer::where('game_id', $this->game->id)
+            ->where('team_id', $this->playerTeam->id)
+            ->limit(11)
+            ->pluck('id')
+            ->toArray();
+
+        $awayLineup = GamePlayer::where('game_id', $this->game->id)
+            ->where('team_id', $this->opponentTeam->id)
+            ->limit(11)
+            ->pluck('id')
+            ->toArray();
+
+        $this->match = GameMatch::factory()->create([
+            'game_id' => $this->game->id,
+            'competition_id' => $this->competition->id,
+            'round_number' => 1,
+            'home_team_id' => $this->playerTeam->id,
+            'away_team_id' => $this->opponentTeam->id,
+            'scheduled_date' => Carbon::parse('2024-08-16'),
+            'played' => true,
+            'home_score' => 1,
+            'away_score' => 0,
+            'home_lineup' => $homeLineup,
+            'away_lineup' => $awayLineup,
+            'home_possession' => 55,
+            'away_possession' => 45,
+            'substitutions' => [],
+            'first_half_stoppage' => 2,
+            'second_half_stoppage' => 3,
+        ]);
+
+        $this->game->update(['pending_finalization_match_id' => $this->match->id]);
+    }
+
+    public function test_first_half_stoppage_goal_survives_half_time_tactical_change(): void
+    {
+        $scorerId = $this->match->home_lineup[9]; // a forward
+
+        $goalEvent = MatchEvent::create([
+            'game_id' => $this->game->id,
+            'game_match_id' => $this->match->id,
+            'game_player_id' => $scorerId,
+            'team_id' => $this->playerTeam->id,
+            'minute' => 45,
+            'phase' => MatchPhase::FIRST_HALF_STOPPAGE,
+            'stoppage_minute' => 2,
+            'event_type' => MatchEvent::TYPE_GOAL,
+        ]);
+
+        $this->actingAs($this->user);
+
+        // Half-time tactical action: the frontend's live clock has been
+        // snapped back to 45 by enterHalfTime, so it POSTs minute=45 even
+        // though the user already watched the 45+2 goal during stoppage.
+        $response = $this->postJson(
+            route('game.match.tactical-actions', ['gameId' => $this->game->id, 'matchId' => $this->match->id]),
+            [
+                'minute' => 45,
+                'previousSubstitutions' => [],
+                'newSubstitutions' => [],
+                'formation' => '4-4-2',
+            ],
+        );
+
+        $response->assertOk();
+
+        // The goal event must still exist in the DB.
+        $this->assertNotNull(
+            MatchEvent::find($goalEvent->id),
+            'First-half stoppage goal was reverted by the half-time resimulation',
+        );
+
+        // And the match's home_score must still reflect it.
+        $this->match->refresh();
+        $this->assertGreaterThanOrEqual(
+            1,
+            $this->match->home_score,
+            'Home score dropped below 1 after half-time resim — the 45+2 goal was lost',
+        );
+    }
+
+    public function test_second_half_stoppage_goal_survives_minute_90_tactical_change(): void
+    {
+        // Pins the symmetric pre-existing safety net at minute=90 so a
+        // regression on either anchor surfaces here.
+        $scorerId = $this->match->home_lineup[9];
+
+        $goalEvent = MatchEvent::create([
+            'game_id' => $this->game->id,
+            'game_match_id' => $this->match->id,
+            'game_player_id' => $scorerId,
+            'team_id' => $this->playerTeam->id,
+            'minute' => 90,
+            'phase' => MatchPhase::SECOND_HALF_STOPPAGE,
+            'stoppage_minute' => 2,
+            'event_type' => MatchEvent::TYPE_GOAL,
+        ]);
+
+        $this->actingAs($this->user);
+
+        $response = $this->postJson(
+            route('game.match.tactical-actions', ['gameId' => $this->game->id, 'matchId' => $this->match->id]),
+            [
+                'minute' => 90,
+                'previousSubstitutions' => [],
+                'newSubstitutions' => [],
+                'formation' => '4-4-2',
+            ],
+        );
+
+        $response->assertOk();
+
+        $this->assertNotNull(
+            MatchEvent::find($goalEvent->id),
+            'Second-half stoppage goal was reverted by the minute-90 resimulation',
+        );
+    }
+
+    private function createSquad(Team $team, int $size): void
+    {
+        GamePlayer::factory()->forGame($this->game)->forTeam($team)->goalkeeper()->create();
+
+        foreach (['Centre-Back', 'Centre-Back', 'Left-Back', 'Right-Back'] as $pos) {
+            GamePlayer::factory()->forGame($this->game)->forTeam($team)->create(['position' => $pos]);
+        }
+
+        GamePlayer::factory()->forGame($this->game)->forTeam($team)->count(4)->create(['position' => 'Central Midfield']);
+
+        foreach (['Centre-Forward', 'Centre-Forward'] as $pos) {
+            GamePlayer::factory()->forGame($this->game)->forTeam($team)->create(['position' => $pos]);
+        }
+
+        $positionsCycle = ['Centre-Back', 'Left-Back', 'Right-Back', 'Central Midfield', 'Centre-Forward', 'Goalkeeper', 'Right Winger'];
+        $bench = $size - 11;
+        for ($i = 0; $i < $bench; $i++) {
+            GamePlayer::factory()->forGame($this->game)->forTeam($team)->create([
+                'position' => $positionsCycle[$i % count($positionsCycle)],
+            ]);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes a regression where goals scored during first-half stoppage time were deleted when the user submitted a tactical action at half-time. The bug occurred because the frontend's live clock snaps back to minute 45 when entering half-time, causing the backend's resimulation logic to revert all events with absolute minutes > 45.

## Root Cause

When `enterHalfTime()` fires in the Alpine component, `state.currentMinute` is reset to 45 to reflect the half-time boundary. If the user then submits a tactical action (a common pattern), the frontend POSTs `minute=45`. The backend's `MatchResimulationService` used this value directly as the resimulation anchor, reverting every event with an absolute minute > 45 — including goals stored with `phase=FIRST_HALF_STOPPAGE`.

## Changes

- **`app/Modules/Match/Services/MatchResimulationService.php`**: Lifted the resimulation anchor at `minute=45` to `45 + firstHalfStoppage`, mirroring the existing safety net at `minute=90` that protects second-half stoppage events. This prevents stoppage-time events from being reverted when a tactical action is submitted at half-time.

- **`resources/js/modules/match-phases.js`**: Added `effectiveSubmissionMinute()` helper that returns the true cutoff minute for tactical submissions. At half-time or extra-time half-time, it returns the half boundary plus the stoppage window; otherwise, it returns the floored current minute. This keeps the frontend and backend in sync.

- **`resources/js/modules/tactical-submission.js`**: Updated to use `effectiveSubmissionMinute()` instead of `Math.floor(currentMinute)` when building the tactical action payload. This ensures the backend receives the correct anchor minute.

- **`resources/js/modules/match-simulation.js`**: Updated the skip-to-end logic to use `effectiveSubmissionMinute()` so stoppage events are not stripped from the local event feed during the skip operation.

- **`tests/Feature/HalfTimeResimulationPreservesStoppageGoalsTest.php`**: Added comprehensive regression test covering both first-half and second-half stoppage goal preservation during tactical submissions.

## Implementation Details

The fix applies the same principle used for the minute=90 anchor (which protects 2H stoppage events) to the minute=45 anchor. Both anchors now account for their respective stoppage windows, ensuring that events revealed during stoppage time are not lost when a tactical action is submitted at the half boundary.

The `effectiveSubmissionMinute()` helper is used consistently across the frontend (tactical submission, skip-to-end, event filtering) and the backend (resimulation anchor), preventing any divergence between what the client sends and what the server expects.

https://claude.ai/code/session_01TmZkFoeY536w5yi6FitCDP