### PR TITLE
Fix half-time substitution display and event ordering

### DIFF
--- a/app/Http/Actions/ProcessTacticalActions.php
+++ b/app/Http/Actions/ProcessTacticalActions.php
@@ -41,6 +41,7 @@ class ProcessTacticalActions
 
         $validated = $request->validate([
             'minute' => 'required|integer|min:1|max:120',
+            'is_half_time' => 'sometimes|boolean',
             'substitutions' => 'array|max:'.SubstitutionService::MAX_ET_SUBSTITUTIONS,
             'substitutions.*.playerOutId' => 'required|string',
             'substitutions.*.playerInId' => 'required|string',
@@ -109,6 +110,7 @@ class ProcessTacticalActions
                     $validated['defensive_line'] ?? null,
                     isExtraTime: $isExtraTime,
                     manualSlotPins: $validated['manual_slot_pins'] ?? [],
+                    isHalfTime: $validated['is_half_time'] ?? false,
                 );
             }, attempts: 3);
         } catch (\Throwable $e) {

--- a/app/Modules/Lineup/Services/TacticalChangeService.php
+++ b/app/Modules/Lineup/Services/TacticalChangeService.php
@@ -8,6 +8,7 @@ use App\Models\GamePlayer;
 use App\Models\GamePlayerMatchState;
 use App\Models\MatchEvent;
 use App\Modules\Lineup\Enums\Formation;
+use App\Modules\Match\Enums\MatchPhase;
 use App\Modules\Match\Support\MinuteCoordinates;
 use App\Modules\Match\Support\StoppageDurations;
 use Illuminate\Support\Str;
@@ -42,6 +43,7 @@ class TacticalChangeService
         bool $isExtraTime = false,
         bool $autoSubUserTeam = false,
         array $manualSlotPins = [],
+        bool $isHalfTime = false,
     ): array {
         $isUserHome = $match->isHomeTeam($game->team_id);
         $prefix = $isUserHome ? 'home' : 'away';
@@ -228,9 +230,27 @@ class TacticalChangeService
         // clock minute into (phase, base minute, stoppage_minute) using the
         // match's persisted stoppage durations — same form the simulator
         // writes via MatchEventRepository.
+        //
+        // Halftime is a special case: stamping at FIRST_HALF_STOPPAGE 45+fhs
+        // would display as "45+4'" and sort into the 1H bucket (before the
+        // halftime divider). The convention for halftime subs is "45'" /
+        // "105'" rendered right after the halftime divider, so we override
+        // the phase to SECOND_HALF / ET_SECOND_HALF with the half-boundary
+        // minute. absoluteMinute round-trips correctly (45+fhs / 105+...)
+        // so resimulation revert windows still preserve the event.
         $substitutionDetails = [];
         if (! empty($newSubstitutions)) {
-            $coords = MinuteCoordinates::decomposeWith($minute, StoppageDurations::fromMatch($match));
+            if ($isHalfTime) {
+                $coords = $isExtraTime
+                    ? ['phase' => MatchPhase::ET_SECOND_HALF, 'minute' => 105, 'stoppage_minute' => null]
+                    : ['phase' => MatchPhase::SECOND_HALF, 'minute' => 45, 'stoppage_minute' => null];
+            } else {
+                $coords = MinuteCoordinates::decomposeWith($minute, StoppageDurations::fromMatch($match));
+            }
+
+            $displayMinute = $coords['stoppage_minute']
+                ? "{$coords['minute']}+{$coords['stoppage_minute']}'"
+                : "{$coords['minute']}'";
 
             $playerIds = [];
             $eventRows = [];
@@ -268,6 +288,8 @@ class TacticalChangeService
                 'playerOutName' => $players->get($sub['playerOutId'])?->name ?? '',
                 'playerInName' => $players->get($sub['playerInId'])?->name ?? '',
                 'minute' => $minute,
+                'displayMinute' => $displayMinute,
+                'phase' => $coords['phase']->value,
                 'teamId' => $game->team_id,
             ], $newSubstitutions);
         }

--- a/app/Modules/Lineup/Services/TacticalChangeService.php
+++ b/app/Modules/Lineup/Services/TacticalChangeService.php
@@ -170,7 +170,17 @@ class TacticalChangeService
 
         // Single re-simulation with all changes applied
         if ($isExtraTime) {
-            $result = $this->resimulationService->resimulateExtraTime($match, $game, $minute, $homePlayers, $awayPlayers, $allSubs, $homeBench, $awayBench);
+            $result = $this->resimulationService->resimulateExtraTime(
+                $match,
+                $game,
+                $minute,
+                $homePlayers,
+                $awayPlayers,
+                $allSubs,
+                $homeBench,
+                $awayBench,
+                isHalfTime: $isHalfTime,
+            );
         } else {
             $result = $this->resimulationService->resimulate(
                 $match,

--- a/app/Modules/Match/Services/MatchResimulationService.php
+++ b/app/Modules/Match/Services/MatchResimulationService.php
@@ -434,8 +434,9 @@ class MatchResimulationService
         array $allSubstitutions = [],
         ?Collection $homeBenchPlayers = null,
         ?Collection $awayBenchPlayers = null,
+        bool $isHalfTime = false,
     ): ResimulationResult {
-        return DB::transaction(function () use ($match, $game, $minute, $homePlayers, $awayPlayers, $allSubstitutions, $homeBenchPlayers, $awayBenchPlayers) {
+        return DB::transaction(function () use ($match, $game, $minute, $homePlayers, $awayPlayers, $allSubstitutions, $homeBenchPlayers, $awayBenchPlayers, $isHalfTime) {
             $competitionId = $match->competition_id;
             $stoppage = StoppageDurations::fromMatch($match);
 
@@ -447,8 +448,18 @@ class MatchResimulationService
             // end" upward. Pin the cutoff to no earlier than regulation end so
             // a sub stamped at the start of ET first half doesn't accidentally
             // wipe regulation-stoppage events.
+            //
+            // At ET half-time the frontend POSTs minute = 105 + etfhs in
+            // standard notation, but stored ET 1H-stoppage events have raw
+            // absolute minutes = 105 + fhs + shs + stoppage_minute. Using the
+            // frontend value directly as the cutoff would wipe those events
+            // when fhs+shs > 0. Lift to the actual raw end of ET 1H stoppage
+            // so revertEventsAfterMinute preserves everything the user has
+            // already watched.
             $regulationEnd = $stoppage->regulationEnd();
-            $resimAnchor = max($minute, $regulationEnd);
+            $resimAnchor = $isHalfTime
+                ? $stoppage->etFirstHalfEnd()
+                : max($minute, $regulationEnd);
 
             // 2. Revert all events after the cutoff (phase tuple comparison
             // — a 91' ET goal carries phase=ET_FIRST_HALF, not regulation

--- a/app/Modules/Match/Support/StoppageDurations.php
+++ b/app/Modules/Match/Support/StoppageDurations.php
@@ -43,6 +43,15 @@ final readonly class StoppageDurations
     }
 
     /**
+     * Last raw absolute minute of ET first half (including its stoppage).
+     * The moment the live clock reaches ET half-time.
+     */
+    public function etFirstHalfEnd(): int
+    {
+        return 105 + $this->firstHalf + $this->secondHalf + ($this->etFirstHalf ?? 0);
+    }
+
+    /**
      * Last raw absolute minute of extra time (regulation end + 30 + ET stoppage).
      */
     public function extraTimeEnd(): int

--- a/resources/js/modules/event-feed.js
+++ b/resources/js/modules/event-feed.js
@@ -22,19 +22,28 @@ const SECOND_HALF_PHASES    = new Set(['second_half', 'second_half_stoppage']);
 const ET_FIRST_HALF_PHASES  = new Set(['et_first_half', 'et_first_half_stoppage']);
 const ET_SECOND_HALF_PHASES = new Set(['et_second_half', 'et_second_half_stoppage', 'penalties']);
 
-function eventHalf(event) {
+function eventHalf(event, c) {
     if (event.phase) {
         if (FIRST_HALF_PHASES.has(event.phase))     return 'first';
         if (SECOND_HALF_PHASES.has(event.phase))    return 'second';
         if (ET_FIRST_HALF_PHASES.has(event.phase))  return 'etFirst';
         if (ET_SECOND_HALF_PHASES.has(event.phase)) return 'etSecond';
     }
-    // Fallback for client-injected events with no phase. These all land
-    // on or near a half boundary (45, 45.9, 90, 105) so the simple
-    // threshold check is sufficient.
-    if (event.minute <= MINUTE.FIRST_HALF_END)    return 'first';
-    if (event.minute <= MINUTE.REGULAR_TIME_END)  return 'second';
-    if (event.minute <= MINUTE.ET_FIRST_HALF_END) return 'etFirst';
+    // Fallback for client-injected events with no phase (atmosphere
+    // shots/narratives, stoppage announcements). The simulator clock
+    // crosses each half boundary first during the preceding half's
+    // stoppage window — e.g. with fhs=4, the clock hits minute 49 first
+    // at the end of 1H stoppage, so a shot generated for the 46-90
+    // range and revealed there belongs to 1H stoppage, not 2H. Use the
+    // match's sampled stoppage durations to put each fallback event
+    // in the right bucket.
+    const fhs = c.firstHalfStoppage || 0;
+    const shs = c.secondHalfStoppage || 0;
+    const etfhs = c.etFirstHalfStoppage || 0;
+
+    if (event.minute <= MINUTE.FIRST_HALF_END + fhs)      return 'first';
+    if (event.minute <= MINUTE.REGULAR_TIME_END + shs)    return 'second';
+    if (event.minute <= MINUTE.ET_FIRST_HALF_END + etfhs) return 'etFirst';
     return 'etSecond';
 }
 
@@ -78,19 +87,23 @@ export function createEventFeed(ctx) {
         // announcement, in-game substitutions) don't carry a phase, so
         // we fall back to a minute-threshold check for them.
         get firstHalfEvents() {
-            return groupSubstitutions(ctx().revealedEvents.filter(e => eventHalf(e) === 'first'));
+            const c = ctx();
+            return groupSubstitutions(c.revealedEvents.filter(e => eventHalf(e, c) === 'first'));
         },
 
         get secondHalfEvents() {
-            return groupSubstitutions(ctx().revealedEvents.filter(e => eventHalf(e) === 'second'));
+            const c = ctx();
+            return groupSubstitutions(c.revealedEvents.filter(e => eventHalf(e, c) === 'second'));
         },
 
         get etFirstHalfEvents() {
-            return groupSubstitutions(ctx().revealedEvents.filter(e => eventHalf(e) === 'etFirst'));
+            const c = ctx();
+            return groupSubstitutions(c.revealedEvents.filter(e => eventHalf(e, c) === 'etFirst'));
         },
 
         get etSecondHalfEvents() {
-            return groupSubstitutions(ctx().revealedEvents.filter(e => eventHalf(e) === 'etSecond'));
+            const c = ctx();
+            return groupSubstitutions(c.revealedEvents.filter(e => eventHalf(e, c) === 'etSecond'));
         },
 
         // --- Separators --------------------------------------------------

--- a/resources/js/modules/tactical-submission.js
+++ b/resources/js/modules/tactical-submission.js
@@ -6,7 +6,7 @@
  * Isolated from the UI panel (tactical-panel.js) so the network + state-
  * reconciliation flow can be reasoned about on its own.
  */
-import { MINUTE, FREE_SUB_WINDOW_MINUTES, effectiveSubmissionMinute } from './match-phases.js';
+import { MINUTE, FREE_SUB_WINDOW_MINUTES, effectiveSubmissionMinute, isHalfTimeLike } from './match-phases.js';
 import { regenerateShots, regenerateNarratives } from './atmosphere-generator.js';
 import { updateRosterPerformances } from './player-ratings.js';
 
@@ -40,10 +40,12 @@ export function createTacticalSubmission(ctx) {
             // would cause the backend revert and the local event filters
             // below to strip those events.
             const minute = effectiveSubmissionMinute(c);
+            const isHalfTime = isHalfTimeLike(c.phase);
 
             try {
                 const payload = {
                     minute,
+                    is_half_time: isHalfTime,
                     previousSubstitutions: c.substitutionsMade.map(s => ({
                         playerOutId: s.playerOutId,
                         playerInId: s.playerInId,
@@ -179,13 +181,28 @@ export function createTacticalSubmission(ctx) {
 
                 if (result.substitutions) {
                     for (const sub of result.substitutions) {
-                        c.revealedEvents.unshift({
+                        const subRevealEvent = {
                             minute,
                             type: 'substitution',
                             playerName: sub.playerOutName,
                             playerInName: sub.playerInName,
                             teamId: sub.teamId,
-                        });
+                            displayMinute: sub.displayMinute,
+                            phase: sub.phase,
+                        };
+                        // At half-time, unshift would put the sub at the top
+                        // of revealedEvents — above the 1H-stoppage atmosphere
+                        // events still classified into the 2H bucket — so it
+                        // would render furthest from the half-time divider.
+                        // Push appends to the chronologically-oldest end of
+                        // the reverse-chronological feed, so the sub renders
+                        // immediately above the DESCANSO line. During regular
+                        // play it stays unshift = newest-on-top.
+                        if (isHalfTime) {
+                            c.revealedEvents.push(subRevealEvent);
+                        } else {
+                            c.revealedEvents.unshift(subRevealEvent);
+                        }
                     }
 
                     // Also add substitution events to the main events array so
@@ -198,6 +215,8 @@ export function createTacticalSubmission(ctx) {
                         teamId: sub.teamId,
                         gamePlayerId: sub.playerOutId,
                         metadata: { player_in_id: sub.playerInId },
+                        displayMinute: sub.displayMinute,
+                        phase: sub.phase,
                     }));
 
                     if (isET) {
@@ -268,9 +287,17 @@ export function createTacticalSubmission(ctx) {
 
                     // Recalculate after all event modifications (synthesize, narratives)
                     // to avoid stale indices from array insertions and re-sorts.
+                    //
+                    // Compare against `minute` (the effective submission minute)
+                    // rather than c.currentMinute. At half-time enterHalfTime
+                    // snapped currentMinute back to 45, but the user has already
+                    // watched events up through 45+fhs. Using currentMinute here
+                    // leaves the 1H-stoppage events (and the just-pushed sub
+                    // event at minute=45+fhs) past the index, so the next 2H
+                    // tick re-reveals them — duplicating them in revealedEvents.
                     c.lastRevealedIndex = -1;
                     for (let i = 0; i < c.events.length; i++) {
-                        if (c.events[i].minute <= c.currentMinute) {
+                        if (c.events[i].minute <= minute) {
                             c.lastRevealedIndex = i;
                         } else {
                             break;


### PR DESCRIPTION
## Summary

Fixes substitution event ordering and display formatting at half-time. When substitutions are made during half-time, they now render immediately after the half-time divider (rather than at the top of the feed) and display with the correct minute notation ("45'" / "105'") instead of the effective submission minute with stoppage time.

## Key Changes

- **Frontend (tactical-submission.js)**
  - Import `isHalfTimeLike` helper to detect half-time submissions
  - Pass `is_half_time` flag in the tactical submission payload
  - Store `displayMinute` and `phase` from the backend response on substitution events
  - Use `push()` instead of `unshift()` for half-time subs to append them chronologically (rendering near the DESCANSO divider) rather than prepending them to the top of the reverse-chronological feed
  - Fix `lastRevealedIndex` calculation to use the effective submission `minute` instead of `c.currentMinute`, preventing duplicate event reveals when the minute has been snapped back to the half boundary

- **Backend (TacticalChangeService.php)**
  - Accept `isHalfTime` parameter in `processLiveMatchChanges()`
  - Override minute coordinate decomposition at half-time: stamp substitutions at the half boundary (45 / 105) with `SECOND_HALF` / `ET_SECOND_HALF` phase instead of using the effective submission minute with stoppage time
  - Calculate and return `displayMinute` (formatted as "45'" or "45+4'") and `phase` for each substitution
  - Include these fields in both the `revealedEvents` and main `events` arrays

- **Backend (ProcessTacticalActions.php)**
  - Validate the optional `is_half_time` boolean flag from the request
  - Pass it through to `TacticalChangeService`

## Implementation Details

At half-time, the effective submission minute includes first-half stoppage time (e.g., 45+4). Stamping substitutions at this minute would cause them to:
1. Display as "45+4'" instead of the conventional "45'"
2. Sort into the first-half bucket (before the half-time divider) due to phase classification

The fix overrides the phase and minute to the half boundary while preserving the absolute minute for resimulation revert windows. The frontend then uses `push()` to append these events to the chronologically-oldest end of the reverse-chronological feed, ensuring they render immediately above the DESCANSO line as expected.

https://claude.ai/code/session_01QBNqgD7e2cGYv7EUAxsHno