### PR TITLE
Add season-complete preview state before season transition

### DIFF
--- a/app/Http/Actions/AdvanceFastMatchday.php
+++ b/app/Http/Actions/AdvanceFastMatchday.php
@@ -42,10 +42,13 @@ class AdvanceFastMatchday
             // exhaustiveness. `blocked` only reaches here on the transient
             // career-actions-in-progress race, which ShowFastMode handles.
             'live_match', 'done', 'blocked' => redirect()->route('game.fast-mode', $gameId),
-            'season_complete' => redirect()->route(
-                $game->isTournamentMode() ? 'game.tournament-end' : 'game.season-end',
-                $gameId,
-            ),
+            // Tournament mode goes straight to tournament-end. Season-based
+            // modes return to fast-mode so the user can see the score of the
+            // just-simulated final match before being offered a Continue CTA
+            // (handled by fast-mode.blade.php when $nextMatch is null).
+            'season_complete' => $game->isTournamentMode()
+                ? redirect()->route('game.tournament-end', $gameId)
+                : redirect()->route('game.fast-mode', $gameId),
         };
     }
 }

--- a/app/Http/Views/ShowFastMode.php
+++ b/app/Http/Views/ShowFastMode.php
@@ -53,11 +53,13 @@ class ShowFastMode
         $lastMatch = $this->fastModeService->getLastPlayerMatch($game);
         $nextMatch = $this->loadNextPlayerMatch($game);
 
-        // No more matches — send the user to the season/tournament end screen.
-        if (! $nextMatch && ! $game->matches()->where('played', false)->exists()) {
-            return $game->isTournamentMode()
-                ? redirect()->route('game.tournament-end', $gameId)
-                : redirect()->route('game.season-end', $gameId);
+        // Tournament mode jumps straight to tournament-end. Season-based
+        // modes fall through and render the page so the user can see the
+        // score of their final simulated match; the template swaps the
+        // Advance CTA for a Continue button that exits fast mode and lands
+        // on the season-complete dashboard preview.
+        if (! $nextMatch && ! $game->matches()->where('played', false)->exists() && $game->isTournamentMode()) {
+            return redirect()->route('game.tournament-end', $gameId);
         }
 
         // Focus the standings panel on the competition just played; fall

--- a/app/Http/Views/ShowGame.php
+++ b/app/Http/Views/ShowGame.php
@@ -122,11 +122,15 @@ class ShowGame
                 ]);
             }
 
+            // User's team has finished the season but other competitions
+            // still have AI-only fixtures to simulate. Use a generic screen —
+            // no club crest, no "teams warming up" copy — because the user
+            // isn't playing.
             return view('game-loading', [
                 'game' => $game,
-                'title' => __('game.simulating_matches'),
-                'message' => __('game.simulating_matches_message'),
-                'showCrest' => true,
+                'title' => __('game.simulating_other_matches'),
+                'message' => __('game.simulating_other_matches_message'),
+                'showCrest' => false,
             ]);
         }
 

--- a/app/Http/Views/ShowGame.php
+++ b/app/Http/Views/ShowGame.php
@@ -73,7 +73,14 @@ class ShowGame
                     'gameId' => $gameId,
                     'matchId' => $result->matchId,
                 ]),
-                'season_complete' => redirect()->route($game->isTournamentMode() ? 'game.tournament-end' : 'game.season-end', $gameId),
+                // Tournament mode goes straight to tournament-end (no
+                // "between matches" dashboard exists). Season-based modes
+                // fall through to render the dashboard with $nextMatch=null
+                // so the user can browse their club one last time before
+                // committing to the season transition.
+                'season_complete' => $game->isTournamentMode()
+                    ? redirect()->route('game.tournament-end', $gameId)
+                    : redirect()->route('show-game', $gameId),
                 'done' => redirect()->route('show-game', $gameId),
                 'blocked' => $result->pendingAction && $result->pendingAction['route']
                     ? redirect()->route($result->pendingAction['route'], $gameId)->with('warning', __('messages.action_required'))
@@ -141,11 +148,12 @@ class ShowGame
             return redirect()->route('game.simulate-tournament', $gameId);
         }
 
-        // Season/tournament complete: redirect to end-of-season summary
-        if (!$nextMatch && !$hasRemainingMatches) {
-            return $game->isTournamentMode()
-                ? redirect()->route('game.tournament-end', $gameId)
-                : redirect()->route('game.season-end', $gameId);
+        // Tournament complete: redirect to tournament-end. Season-based
+        // modes fall through and render the dashboard with $nextMatch=null
+        // so the user can browse their club before clicking through to the
+        // season summary (the irreversible "Start New Season" lives there).
+        if (!$nextMatch && !$hasRemainingMatches && $game->isTournamentMode()) {
+            return redirect()->route('game.tournament-end', $gameId);
         }
 
         $notifications = $this->notificationService->getNotifications($game->id, true, 15);

--- a/lang/en/game.php
+++ b/lang/en/game.php
@@ -262,6 +262,8 @@ return [
     'processing_career_actions_message' => 'This will only take a moment.',
     'simulating_matches' => 'Warm-up...',
     'simulating_matches_message' => 'The teams are warming up...',
+    'simulating_other_matches' => 'Simulating remaining matches...',
+    'simulating_other_matches_message' => 'Wrapping up fixtures in the other competitions still in progress.',
 
     // Live match
     'live_pre_match' => 'Pre-match',

--- a/lang/en/season.php
+++ b/lang/en/season.php
@@ -128,6 +128,8 @@ return [
     // Start new season
     'start_new_season' => 'Start Season :season',
     'new_season_coming_soon' => 'Next season will be available soon.',
+    'complete_title' => 'Season complete',
+    'complete_body' => 'Take a final look around the club. When you\'re ready, open the season summary to confirm the results and start the next season.',
 
     // Tournament end
     'tournament_champion' => 'World Champions!',

--- a/lang/es/game.php
+++ b/lang/es/game.php
@@ -262,6 +262,8 @@ return [
     'processing_career_actions_message' => 'Esto solo tardará un momento.',
     'simulating_matches' => 'Calentamiento...',
     'simulating_matches_message' => 'Los equipos están calentando...',
+    'simulating_other_matches' => 'Simulando partidos pendientes...',
+    'simulating_other_matches_message' => 'Terminando las jornadas de las otras competiciones aún en curso.',
 
     // Live match
     'live_pre_match' => 'Previo al partido',

--- a/lang/es/season.php
+++ b/lang/es/season.php
@@ -128,6 +128,8 @@ return [
     // Start new season
     'start_new_season' => 'Comenzar Temporada :season',
     'new_season_coming_soon' => 'La próxima temporada estará disponible próximamente.',
+    'complete_title' => 'Temporada finalizada',
+    'complete_body' => 'Echa un último vistazo al club. Cuando estés listo, abre el resumen de temporada para confirmar los resultados y comenzar la próxima temporada.',
 
     // Tournament end
     'tournament_champion' => '¡Campeones del Mundo!',

--- a/resources/views/fast-mode.blade.php
+++ b/resources/views/fast-mode.blade.php
@@ -212,6 +212,16 @@
                             <span x-show="submitting" x-cloak>{{ __('game.processing_short') }}</span>
                         </x-primary-button>
                     </form>
+                @else
+                    {{-- Season complete: fast mode is done. Continue exits fast
+                         mode and lands on the dashboard preview, which has its
+                         own "View Season Summary" CTA. --}}
+                    <form action="{{ route('game.fast-mode.exit', $game->id) }}" method="POST" class="flex-1">
+                        @csrf
+                        <x-primary-button color="amber" class="w-full">
+                            {{ __('app.continue') }}
+                        </x-primary-button>
+                    </form>
                 @endif
             </div>
         </div>

--- a/resources/views/game.blade.php
+++ b/resources/views/game.blade.php
@@ -202,6 +202,71 @@
                 </x-primary-button>
             </form>
         </div>
+        @else
+        {{-- Season Complete Preview State.
+             All matches are played but the user has not yet clicked "Start
+             New Season" on the summary page (the irreversible step that
+             closes the season). Show a card that points to the summary, but
+             leave the rest of the dashboard browsable so the user can take
+             one last look at the squad, finances, transfers, and standings. --}}
+        <div class="mt-6 grid grid-cols-1 md:grid-cols-3 gap-4 md:gap-8">
+            <div class="md:col-span-2 space-y-8">
+                <x-section-card>
+                    <div class="p-4 md:p-6 text-center">
+                        <div class="text-accent-gold mb-3 inline-flex">
+                            <svg class="w-10 h-10" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M11.48 3.499a.562.562 0 011.04 0l2.125 5.111a.563.563 0 00.475.345l5.518.442c.499.04.701.663.32.988l-4.204 3.602a.563.563 0 00-.182.557l1.285 5.385a.562.562 0 01-.84.61l-4.725-2.885a.563.563 0 00-.586 0L6.982 20.54a.562.562 0 01-.84-.61l1.285-5.386a.562.562 0 00-.182-.557l-4.204-3.602a.563.563 0 01.32-.988l5.518-.442a.563.563 0 00.475-.345L11.48 3.5z" />
+                            </svg>
+                        </div>
+                        <h2 class="text-2xl md:text-3xl font-bold text-text-primary mb-2">{{ __('season.complete_title') }}</h2>
+                        <p class="text-text-muted mb-6 max-w-xl mx-auto">{{ __('season.complete_body') }}</p>
+                        <x-primary-button-link color="amber" :href="route('game.season-end', $game->id)">
+                            {{ __('game.view_season_summary') }}
+                        </x-primary-button-link>
+                    </div>
+                </x-section-card>
+            </div>
+
+            <hr class="border-border-strong md:hidden" />
+
+            {{-- Right Column - Notifications (standings panel is hidden when
+                 there is no next match; the user can still reach it via the
+                 Competitions nav). --}}
+            <div class="space-y-8">
+                <x-section-card :title="__('notifications.inbox')">
+                    <x-slot name="badge">
+                        <div class="flex items-center gap-2">
+                            @if($unreadNotificationCount > 0)
+                            <span class="px-1.5 py-0.5 rounded-full bg-accent-blue/10 text-[9px] font-semibold text-accent-blue">
+                                {{ $unreadNotificationCount }} {{ __('notifications.new') }}
+                            </span>
+                            @endif
+                            <form action="{{ route('game.notifications.read-all', $game->id) }}" method="POST">
+                                @csrf
+                                <button type="submit" class="text-[10px] text-accent-blue hover:text-blue-400 transition-colors">{{ __('notifications.mark_all_read') }}</button>
+                            </form>
+                        </div>
+                    </x-slot>
+
+                    @if($groupedNotifications->isEmpty())
+                    <div class="text-center py-8 px-4">
+                        <div class="text-text-faint mb-2">
+                            <svg class="w-8 h-8 mx-auto" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"/>
+                            </svg>
+                        </div>
+                        <p class="text-xs text-text-muted">{{ __('notifications.all_caught_up') }}</p>
+                    </div>
+                    @else
+                    <div class="divide-y divide-border-default">
+                        @foreach($groupedNotifications->flatten() as $notification)
+                            <x-notification-row :notification="$notification" :game="$game" />
+                        @endforeach
+                    </div>
+                    @endif
+                </x-section-card>
+            </div>
+        </div>
         @endif
     </div>
 


### PR DESCRIPTION
## Summary

Adds a new dashboard state for season-based game modes that appears after all matches are played but before the user commits to starting a new season. This allows players to review their club one final time before the irreversible season transition.

## Key Changes

- **New preview state in game dashboard:** When a season is complete (`!$nextMatch && !$hasRemainingMatches`) in season-based modes, the dashboard now renders a "Season Complete" card with a link to the season summary, rather than immediately redirecting. Tournament mode continues to redirect immediately to tournament-end.

- **Updated routing logic:** Modified `ShowGame` view to distinguish between tournament and season-based modes:
  - Tournament mode: redirects to `game.tournament-end` immediately when complete
  - Season-based modes: renders dashboard with `$nextMatch=null` to allow browsing before season transition

- **New UI card:** Added a centered card with star icon, title, and description prompting the user to review their club and then open the season summary to confirm results and start the next season.

- **Notifications panel:** The right-column notifications panel is displayed in this state, allowing users to catch up on messages while reviewing.

- **Localization:** Added English and Spanish translations for the season-complete card (`season.complete_title` and `season.complete_body`).

## Implementation Details

- The change preserves the existing dashboard layout and browsability (squad, finances, transfers, standings remain accessible via navigation).
- The "Start New Season" action remains on the season summary page (`game.season-end`), maintaining it as the single irreversible step.
- Tournament mode behavior is unchanged—it still redirects immediately to tournament-end.
- The condition check now explicitly gates the redirect on `$game->isTournamentMode()`, making the intent clearer in the codebase.

https://claude.ai/code/session_011GmjhPAfZNbaaCgvSWHVJQ