### PR TITLE
Make trackSubstitutionIfNeeded the sole writer of substitutionsMade

### DIFF
--- a/resources/js/modules/match-simulation.js
+++ b/resources/js/modules/match-simulation.js
@@ -937,5 +937,6 @@ export function createMatchSimulation(ctx) {
         synthesizeGoalsIfNeeded,
         recalculateScore,
         resetPossessionTarget,
+        trackSubstitutionIfNeeded,
     };
 }

--- a/resources/js/modules/tactical-submission.js
+++ b/resources/js/modules/tactical-submission.js
@@ -131,24 +131,6 @@ export function createTacticalSubmission(ctx) {
                 const result = await response.json();
                 const isET = result.isExtraTime || false;
 
-                // Record substitutions if any
-                if (result.substitutions && result.substitutions.length > 0) {
-                    for (const sub of result.substitutions) {
-                        c.substitutionsMade.push({
-                            playerOutId: sub.playerOutId,
-                            playerInId: sub.playerInId,
-                            playerOutName: sub.playerOutName,
-                            playerInName: sub.playerInName,
-                            minute,
-                        });
-
-                        const benchPlayer = c.benchPlayers.find(p => p.id === sub.playerInId);
-                        if (benchPlayer) {
-                            benchPlayer.minuteEntered = minute;
-                        }
-                    }
-                }
-
                 // Update active tactics
                 if (result.formation) {
                     // Custom pitch positions are keyed by slot IDs whose
@@ -195,34 +177,14 @@ export function createTacticalSubmission(ctx) {
                 c.revealedEvents = c.revealedEvents.filter(e => e.minute <= minute && e.type !== 'contextual');
 
                 if (result.substitutions) {
-                    for (const sub of result.substitutions) {
-                        const subRevealEvent = {
-                            minute,
-                            type: 'substitution',
-                            playerName: sub.playerOutName,
-                            playerInName: sub.playerInName,
-                            teamId: sub.teamId,
-                            displayMinute: sub.displayMinute,
-                            phase: sub.phase,
-                        };
-                        // At half-time, unshift would put the sub at the top
-                        // of revealedEvents — above the 1H-stoppage atmosphere
-                        // events still classified into the 2H bucket — so it
-                        // would render furthest from the half-time divider.
-                        // Push appends to the chronologically-oldest end of
-                        // the reverse-chronological feed, so the sub renders
-                        // immediately above the DESCANSO line. During regular
-                        // play it stays unshift = newest-on-top.
-                        if (isHalfTime) {
-                            c.revealedEvents.push(subRevealEvent);
-                        } else {
-                            c.revealedEvents.unshift(subRevealEvent);
-                        }
-                    }
-
                     // Client-injected substitution events ARE real events:
                     // they change who is on the pitch, and atmosphere must
-                    // honor them when picking shot actors.
+                    // honor them when picking shot actors. The same object is
+                    // routed into revealedEvents (live feed), realEvents
+                    // (canonical list for atmosphere), and
+                    // trackSubstitutionIfNeeded (substitutionsMade + bench
+                    // entry-minute bookkeeping) so a single conceptual sub
+                    // can't be counted twice.
                     const subEvents = result.substitutions.map(sub => ({
                         minute,
                         type: 'substitution',
@@ -234,6 +196,30 @@ export function createTacticalSubmission(ctx) {
                         displayMinute: sub.displayMinute,
                         phase: sub.phase,
                     }));
+
+                    for (const subEvent of subEvents) {
+                        // At half-time, unshift would put the sub at the top
+                        // of revealedEvents — above the 1H-stoppage atmosphere
+                        // events still classified into the 2H bucket — so it
+                        // would render furthest from the half-time divider.
+                        // Push appends to the chronologically-oldest end of
+                        // the reverse-chronological feed, so the sub renders
+                        // immediately above the DESCANSO line. During regular
+                        // play it stays unshift = newest-on-top.
+                        if (isHalfTime) {
+                            c.revealedEvents.push(subEvent);
+                        } else {
+                            c.revealedEvents.unshift(subEvent);
+                        }
+                        // Sole writer for newly-confirmed user subs:
+                        // lastRevealedIndex (recomputed below) covers this
+                        // event, so the reveal-loop helper won't fire for it
+                        // later. Invoking it here keeps substitutionsMade and
+                        // bench bookkeeping in lockstep with every other code
+                        // path that surfaces a sub (AI subs, injury auto-subs,
+                        // skip-to-end, page-refresh replay).
+                        c.trackSubstitutionIfNeeded(subEvent);
+                    }
 
                     if (isET) {
                         c.realExtraTimeEvents.push(...subEvents);

--- a/tests/js/tactical-submission.test.js
+++ b/tests/js/tactical-submission.test.js
@@ -144,6 +144,26 @@ function createMockState(overrides = {}) {
         resetPossessionTarget: vi.fn(),
         recalculatePlayerRatings: vi.fn(),
         synthesizeGoalsIfNeeded: (events) => events,
+        // Real implementation (mirrors match-simulation's exported helper) so
+        // the single-writer invariant for substitutionsMade is exercised here
+        // rather than masked behind a vi.fn().
+        trackSubstitutionIfNeeded(event) {
+            if (event.type !== 'substitution' || event.teamId !== this.userTeamId) return;
+            this.substitutionsMade.push({
+                playerOutId: event.gamePlayerId,
+                playerInId: event.metadata?.player_in_id ?? '',
+                minute: event.minute,
+                playerOutName: event.playerName ?? '',
+                playerInName: event.playerInName ?? '',
+            });
+            const playerInId = event.metadata?.player_in_id;
+            if (playerInId) {
+                const benchPlayer = this.benchPlayers.find(p => p.id === playerInId);
+                if (benchPlayer) {
+                    benchPlayer.minuteEntered = event.minute;
+                }
+            }
+        },
         ...overrides,
     };
 
@@ -275,5 +295,72 @@ describe('tactical-submission confirmAllChanges', () => {
             state.lastRevealedIndex,
             'lastRevealedIndex must include the half-time sub event so it is not re-revealed when 2H starts',
         ).toBeGreaterThanOrEqual(subIdx);
+    });
+
+    it('records a confirmed user sub in substitutionsMade exactly once', async () => {
+        // Regression for the duplicated row in the "SUSTITUCIONES REALIZADAS"
+        // panel: a user-confirmed sub at minute 95 (2H stoppage) used to be
+        // pushed once by confirmAllChanges' eager response handler AND a
+        // second time when the reveal loop later processed the same event.
+        // Now trackSubstitutionIfNeeded is the only writer; the eager path
+        // calls it inline at injection time.
+        const shs = 5;
+        const submissionMinute = 90 + shs;
+        const state = createMockState({
+            phase: 'second_half',
+            currentMinute: submissionMinute,
+            secondHalfStoppage: shs,
+        });
+
+        globalThis.fetch = vi.fn(() => Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve({
+                isExtraTime: false,
+                substitutions: [{
+                    playerOutId: 'home-cb1',
+                    playerInId: 'home-sub1',
+                    playerOutName: 'home cb1',
+                    playerInName: 'Sub Player',
+                    teamId: 'home-1',
+                    minute: submissionMinute,
+                    displayMinute: "90+5'",
+                    phase: 'second_half_stoppage',
+                }],
+                newEvents: [],
+                newScore: { home: 1, away: 0 },
+                homePossession: 50,
+                awayPossession: 50,
+            }),
+        }));
+
+        state.pendingSubs = [{
+            playerOut: { id: 'home-cb1' },
+            playerIn: { id: 'home-sub1' },
+        }];
+
+        const submission = createTacticalSubmission(() => state);
+        await submission.confirmAllChanges();
+
+        const homeSubs = state.substitutionsMade.filter(s => s.playerOutId === 'home-cb1');
+        expect(homeSubs.length, 'sub should be recorded exactly once').toBe(1);
+        expect(homeSubs[0].playerInId).toBe('home-sub1');
+        expect(homeSubs[0].minute).toBe(submissionMinute);
+
+        // Simulate the reveal-loop helper firing again for the same event
+        // (which is what happens when enterRegularTimeEnd / enterFullTime /
+        // skipToFullTimeImmediate walk c.events). With the single-writer
+        // invariant intact, lastRevealedIndex covers this event so the
+        // helper would never actually be called here in production — but
+        // exercising it directly catches a regression where the eager path
+        // and the reveal path both populate the array unconditionally.
+        const subEvent = state.events.find(e =>
+            e.type === 'substitution' && e.gamePlayerId === 'home-cb1'
+        );
+        expect(subEvent, 'sub event should be in the merged events array').toBeDefined();
+        // The production fix relies on lastRevealedIndex covering this event;
+        // verify that contract so the reveal loop's `for (i = lastRevealedIndex + 1; ...)`
+        // genuinely skips it on subsequent ticks.
+        const subIdx = state.events.indexOf(subEvent);
+        expect(state.lastRevealedIndex).toBeGreaterThanOrEqual(subIdx);
     });
 });


### PR DESCRIPTION
The "Sustituciones realizadas" panel was rendering a user-confirmed sub
twice — e.g. "95' OFF Rúben Dias ON Renato Veiga" appearing back-to-back
in late stoppage time.

substitutionsMade was being pushed from two independent code paths for
the same conceptual sub:

  - confirmAllChanges pushed eagerly when result.substitutions came back
    from the resimulation endpoint (tactical-submission.js).
  - trackSubstitutionIfNeeded pushed whenever the reveal loop processed
    a substitution event with teamId === userTeamId — invoked from
    revealEvent, enterRegularTimeEnd, enterFullTime, skipExtraTime,
    skipToHalfTime, skipToEnd's promise fallback, and effectively
    re-played by skipToFullTimeImmediate and autoSubUserTeamBeforeSkip.

#1130 patched one specific trigger of this duplication at half-time by
lifting lastRevealedIndex with the effective submission minute, but the
underlying two-writers shape stayed in place. The atmosphere-derivation
refactor (#1132) made the reveal flow deterministic, which let Source B
fire reliably for late stoppage subs (90 + shs) and amplified the
symptom.

Make trackSubstitutionIfNeeded the single writer:

  - Export it from createMatchSimulation so it's mixed into the Alpine
    component as c.trackSubstitutionIfNeeded.
  - Drop the eager push in confirmAllChanges. Build subEvents once (with
    gamePlayerId + metadata) and route each event through revealedEvents
    (live feed), realEvents (canonical list for atmosphere), and
    c.trackSubstitutionIfNeeded (panel + bench bookkeeping). The
    inline call is necessary because lastRevealedIndex (recomputed below)
    will mark the event as already-revealed, so the helper would never
    fire for it later.

Add a regression test in tactical-submission.test.js for a sub at
minute 90 + shs, and add a real trackSubstitutionIfNeeded stub to the
mock state so the existing half-time test still exercises the new
call site instead of crashing on an undefined method.