### PR TITLE
Use player initials instead of squad numbers in opponent analysis

### DIFF
--- a/resources/views/partials/opponent-analysis-content.blade.php
+++ b/resources/views/partials/opponent-analysis-content.blade.php
@@ -242,13 +242,27 @@
                                     $rating >= 60 => 'bg-accent-gold text-white',
                                     default => 'bg-accent-orange text-white',
                                 };
+                                // The opponent's squad numbers are rarely complete, so we
+                                // show initials derived from the player's name instead —
+                                // a stable identifier that doesn't fall back to a generic
+                                // position abbreviation (e.g., "MCD") when data is sparse.
+                                $shirtLabel = $slot['displayLabel'];
+                                if ($player) {
+                                    $initials = collect(preg_split('/\s+/', trim($player->name)))
+                                        ->filter()
+                                        ->map(fn ($w) => mb_substr($w, 0, 1))
+                                        ->join('');
+                                    $shirtLabel = mb_strlen($initials) > 2
+                                        ? mb_substr($initials, 0, 1) . mb_substr($initials, -1)
+                                        : $initials;
+                                }
                             @endphp
                             <div class="absolute transform -translate-x-1/2 -translate-y-1/2 flex flex-col items-center"
                                  style="left: {{ $xPct }}%; top: {{ $yPct }}%;">
                                 <div class="relative w-10 h-10 rounded-xl shadow-lg border border-white/20" style="{{ $shirtStyle }}">
                                     <div class="absolute inset-0 flex items-center justify-center">
                                         <span class="font-bold text-xs leading-none inline-flex items-center justify-center w-7 h-7 rounded-full" style="{{ $numberStyle }}">
-                                            {{ $player?->number ?? $slot['displayLabel'] }}
+                                            {{ $shirtLabel }}
                                         </span>
                                     </div>
                                     @if($rating !== null)


### PR DESCRIPTION
## Summary

Updates the opponent analysis view to display player initials derived from their name instead of relying on squad numbers, which are often incomplete in opponent data. This provides a more stable and reliable visual identifier for players in the tactical formation display.

## Changes

- **Player identification logic**: Added code to generate player initials from their full name by:
  - Splitting the name into words
  - Taking the first character of each word
  - Truncating to 2 characters if more than 2 initials exist (first + last)
  - Falling back to the full initials if 2 or fewer words

- **Display update**: Changed the shirt label from `$player?->number ?? $slot['displayLabel']` to use the computed `$shirtLabel` variable, ensuring initials are always displayed when a player is available

## Implementation Details

- The initials are computed only when a player object exists; otherwise the original `displayLabel` is preserved as fallback
- Uses `mb_substr()` and `mb_strlen()` for proper multibyte character handling
- The logic handles edge cases like single-word names and names with multiple words gracefully
- Added explanatory comments documenting why initials are preferred over squad numbers for opponent squads

https://claude.ai/code/session_01Jq1eGeuj7QvdUcGuD7GJmd