### PR TITLE
Add UCL winner auto-qualification to next season

### DIFF
--- a/app/Modules/Season/Processors/UefaQualificationProcessor.php
+++ b/app/Modules/Season/Processors/UefaQualificationProcessor.php
@@ -30,6 +30,12 @@ use Illuminate\Support\Facades\Log;
  *   cascades to the next non-qualified team in standings.
  * - If cup winner qualifies for UECL via league, they get upgraded to UEL and
  *   the UECL spot cascades to the next non-qualified team.
+ *
+ * European holder rules:
+ * - The defending UCL winner auto-qualifies for next season's UCL.
+ * - The UEL winner is promoted into next season's UCL.
+ * In both cases, if the holder already has a UEL/UECL spot, that spot is
+ * vacated and cascades to the next non-qualified team from the same country.
  */
 class UefaQualificationProcessor implements SeasonProcessor
 {
@@ -59,6 +65,7 @@ class UefaQualificationProcessor implements SeasonProcessor
             }
         }
 
+        $this->qualifyUclWinner($game, $data);
         $this->qualifyUelWinner($game, $data);
         $this->fillRemainingContinentalSlots($game, $swissCompetitionIds);
 
@@ -315,6 +322,24 @@ class UefaQualificationProcessor implements SeasonProcessor
     }
 
     /**
+     * Qualify the defending UCL winner into next season's UCL.
+     *
+     * Mirrors qualifyUelWinner: if the holder did not already secure a UCL
+     * spot via their league finish, they are inserted in place of a
+     * non-configured-country filler, and any UEL/UECL spot they held
+     * cascades to the next non-qualified team from their country's league.
+     */
+    private function qualifyUclWinner(Game $game, SeasonTransitionData $data): void
+    {
+        $uclWinnerId = $data->getMetadata(SeasonTransitionData::META_UCL_WINNER);
+        if (!$uclWinnerId) {
+            return;
+        }
+
+        $this->promoteWinnerToUcl($game, $uclWinnerId);
+    }
+
+    /**
      * Qualify the UEL winner into next season's UCL.
      *
      * If the winner is already in UCL, do nothing.
@@ -329,15 +354,26 @@ class UefaQualificationProcessor implements SeasonProcessor
             return;
         }
 
+        $this->promoteWinnerToUcl($game, $uelWinnerId);
+    }
+
+    /**
+     * Insert a European holder into next season's UCL, replacing a
+     * non-configured-country filler to keep the field size stable, and
+     * cascade any UEL/UECL spot they previously held.
+     *
+     * No-op if UCL isn't seeded yet or the team is already in UCL.
+     */
+    private function promoteWinnerToUcl(Game $game, string $winnerId): void
+    {
         $uclCompetition = Competition::find('UCL');
         if (!$uclCompetition) {
             return;
         }
 
-        // Check if already in UCL
         $alreadyInUcl = CompetitionEntry::where('game_id', $game->id)
             ->where('competition_id', 'UCL')
-            ->where('team_id', $uelWinnerId)
+            ->where('team_id', $winnerId)
             ->exists();
 
         if ($alreadyInUcl) {
@@ -369,22 +405,21 @@ class UefaQualificationProcessor implements SeasonProcessor
                 ->delete();
         }
 
-        // Add UEL winner to UCL
         CompetitionEntry::updateOrCreate(
             [
                 'game_id' => $game->id,
                 'competition_id' => 'UCL',
-                'team_id' => $uelWinnerId,
+                'team_id' => $winnerId,
             ],
             [
                 'entry_round' => 1,
             ]
         );
 
-        // Cascade: if the UEL winner had a UEL or UECL spot (e.g. from cup winner),
-        // remove it and give that spot to the next non-qualified team from the
-        // same country's league standings.
-        $this->cascadeVacatedSpot($game, $uelWinnerId);
+        // Cascade: if the holder had a UEL or UECL spot (e.g. via league or cup
+        // winner cascade), remove it and give that spot to the next non-qualified
+        // team from the same country's league standings.
+        $this->cascadeVacatedSpot($game, $winnerId);
     }
 
     /**

--- a/tests/Feature/UefaQualificationTest.php
+++ b/tests/Feature/UefaQualificationTest.php
@@ -201,6 +201,94 @@ class UefaQualificationTest extends TestCase
         );
     }
 
+    public function test_ucl_winner_qualifies_for_next_ucl(): void
+    {
+        // Pick an EUR pool team as the UCL winner (not in any configured country's league)
+        $uclWinner = $this->eurPoolTeams[0];
+
+        // Make sure they are NOT already in next season's UCL
+        CompetitionEntry::where('game_id', $this->game->id)
+            ->where('competition_id', 'UCL')
+            ->where('team_id', $uclWinner->id)
+            ->delete();
+
+        $data = $this->makeTransitionData();
+        $data->setMetadata(SeasonTransitionData::META_UCL_WINNER, $uclWinner->id);
+
+        $processor = app(UefaQualificationProcessor::class);
+        $processor->process($this->game, $data);
+
+        $this->assertTrue(
+            CompetitionEntry::where('game_id', $this->game->id)
+                ->where('competition_id', 'UCL')
+                ->where('team_id', $uclWinner->id)
+                ->exists(),
+            'Defending UCL winner should auto-qualify for next season UCL'
+        );
+
+        $uclCount = CompetitionEntry::where('game_id', $this->game->id)
+            ->where('competition_id', 'UCL')
+            ->count();
+        $this->assertEquals(36, $uclCount, "UCL should still have exactly 36 entries, got {$uclCount}");
+    }
+
+    public function test_ucl_winner_already_qualified_via_league_is_not_duplicated(): void
+    {
+        // Position 1 in ESP1 — already qualifies for UCL via league finish
+        $uclWinner = $this->teamsByCountry['ES'][0];
+
+        $data = $this->makeTransitionData();
+        $data->setMetadata(SeasonTransitionData::META_UCL_WINNER, $uclWinner->id);
+
+        $processor = app(UefaQualificationProcessor::class);
+        $processor->process($this->game, $data);
+
+        $uclCount = CompetitionEntry::where('game_id', $this->game->id)
+            ->where('competition_id', 'UCL')
+            ->count();
+
+        $this->assertEquals(36, $uclCount, "UCL should still have exactly 36 entries, got {$uclCount}");
+    }
+
+    public function test_ucl_winner_in_uel_via_league_is_upgraded_and_uel_spot_cascades(): void
+    {
+        // Position 6 in ESP1 — qualifies for UEL via league. If they also win
+        // the UCL, they must move up to UCL and the vacated UEL spot must
+        // cascade to the next non-qualified Spanish team (position 8).
+        $uclWinner = $this->teamsByCountry['ES'][5]; // position 6 = UEL
+
+        $data = $this->makeTransitionData();
+        $data->setMetadata(SeasonTransitionData::META_UCL_WINNER, $uclWinner->id);
+
+        $processor = app(UefaQualificationProcessor::class);
+        $processor->process($this->game, $data);
+
+        $this->assertTrue(
+            CompetitionEntry::where('game_id', $this->game->id)
+                ->where('competition_id', 'UCL')
+                ->where('team_id', $uclWinner->id)
+                ->exists(),
+            'UCL winner from UEL slot should be upgraded to UCL'
+        );
+
+        $this->assertFalse(
+            CompetitionEntry::where('game_id', $this->game->id)
+                ->where('competition_id', 'UEL')
+                ->where('team_id', $uclWinner->id)
+                ->exists(),
+            'UCL winner should not still hold a UEL spot'
+        );
+
+        $nextTeam = $this->teamsByCountry['ES'][7]; // position 8
+        $this->assertTrue(
+            CompetitionEntry::where('game_id', $this->game->id)
+                ->where('competition_id', 'UEL')
+                ->where('team_id', $nextTeam->id)
+                ->exists(),
+            'Vacated UEL spot should cascade to next non-qualified Spanish team'
+        );
+    }
+
     public function test_uel_winner_already_in_ucl_is_not_duplicated(): void
     {
         // Pick a team that's already in UCL (from standings-based qualification)


### PR DESCRIPTION
## Summary

Implements auto-qualification of the defending UEFA Champions League (UCL) winner into the next season's UCL, mirroring the existing UEL winner promotion logic. The defending champion is inserted into next season's UCL field, and any UEL/UECL spot they previously held cascades to the next non-qualified team from their country.

## Key Changes

- **New `qualifyUclWinner()` method** in `UefaQualificationProcessor` to handle UCL winner qualification during season transition
- **Refactored promotion logic** into a shared `promoteWinnerToUcl()` method that handles both UCL and UEL winner promotion, eliminating code duplication
- **Cascade handling** ensures that if a UCL winner already held a UEL or UECL spot (e.g., via league finish or cup winner cascade), that spot is vacated and given to the next non-qualified team from the same country
- **Updated processor documentation** to clarify European holder rules for both UCL and UEL winners

## Implementation Details

- The UCL winner qualification is processed before UEL winner qualification in the season transition pipeline
- If the UCL winner already qualified for UCL via league finish, no duplicate entry is created
- If the UCL winner held a UEL/UECL spot, it is removed and cascaded to maintain field size stability
- The implementation reuses the existing `cascadeVacatedSpot()` logic to handle the cascade operation

## Tests Added

- `test_ucl_winner_qualifies_for_next_ucl()` — verifies defending champion auto-qualifies when not already in UCL
- `test_ucl_winner_already_qualified_via_league_is_not_duplicated()` — ensures no duplicate entry if already qualified via league
- `test_ucl_winner_in_uel_via_league_is_upgraded_and_uel_spot_cascades()` — validates cascade behavior when UCL winner held a UEL spot

https://claude.ai/code/session_01Wrk1bpThuzoQ2iph3H569V