### PR TITLE
Add live duel feature: real-time human-vs-human matches

### DIFF
--- a/.env.docker
+++ b/.env.docker
@@ -35,7 +35,7 @@ SESSION_ENCRYPT=true
 SESSION_PATH=/
 SESSION_DOMAIN=null
 
-BROADCAST_CONNECTION=log
+BROADCAST_CONNECTION=reverb
 FILESYSTEM_DISK=local
 QUEUE_CONNECTION=redis
 CACHE_STORE=redis
@@ -45,6 +45,18 @@ REDIS_CLIENT=phpredis
 REDIS_HOST=redis
 REDIS_PASSWORD=null
 REDIS_PORT=6379
+
+# Reverb (real-time live duel). The reverb service in docker-compose.dev.yml
+# shares the `app` container's network namespace, so REVERB_HOST=localhost
+# resolves to the Reverb server for the browser, the web container and the
+# queue worker alike (see the reverb/horizon services). Local-only credentials
+# — server, broadcaster and client all read these same values.
+REVERB_APP_ID=virtuafc-local
+REVERB_APP_KEY=virtuafc-local-key
+REVERB_APP_SECRET=virtuafc-local-secret
+REVERB_HOST=localhost
+REVERB_PORT=8080
+REVERB_SCHEME=http
 
 OCTANE_SERVER=frankenphp
 

--- a/.env.example
+++ b/.env.example
@@ -39,6 +39,20 @@ SESSION_PATH=/
 SESSION_DOMAIN=null
 
 BROADCAST_CONNECTION=log
+# Reverb (WebSocket server for the live duel feature). Set
+# BROADCAST_CONNECTION=reverb and run `php artisan reverb:start` to enable
+# real-time broadcasts. Generate fresh secrets per environment.
+REVERB_APP_ID=
+REVERB_APP_KEY=
+REVERB_APP_SECRET=
+REVERB_HOST=127.0.0.1
+REVERB_PORT=8080
+REVERB_SCHEME=http
+# Frontend uses VITE_-prefixed mirrors of the above (read at build time).
+VITE_REVERB_APP_KEY="${REVERB_APP_KEY}"
+VITE_REVERB_HOST="${REVERB_HOST}"
+VITE_REVERB_PORT="${REVERB_PORT}"
+VITE_REVERB_SCHEME="${REVERB_SCHEME}"
 FILESYSTEM_DISK=local
 QUEUE_CONNECTION=redis
 CACHE_STORE=redis

--- a/app/Http/Actions/LiveDuel/AcknowledgePause.php
+++ b/app/Http/Actions/LiveDuel/AcknowledgePause.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Actions\LiveDuel;
+
+use App\Models\LiveMatchSession;
+use App\Modules\LiveMatch\Exceptions\LiveMatchStateException;
+use App\Modules\LiveMatch\Services\LiveMatchOrchestrator;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class AcknowledgePause
+{
+    public function __construct(
+        private readonly LiveMatchOrchestrator $orchestrator,
+    ) {}
+
+    public function __invoke(Request $request, string $session): JsonResponse
+    {
+        $live = LiveMatchSession::findOrFail($session);
+
+        try {
+            $live = $this->orchestrator->acknowledgePause($live, Auth::user());
+        } catch (LiveMatchStateException $e) {
+            return response()->json(['error' => $e->getMessage()], 422);
+        }
+
+        return response()->json([
+            'phase' => $live->phase->value,
+            'host_acked' => $live->pause_acked_by_host,
+            'guest_acked' => $live->pause_acked_by_guest,
+        ]);
+    }
+}

--- a/app/Http/Actions/LiveDuel/CreateLiveDuelSession.php
+++ b/app/Http/Actions/LiveDuel/CreateLiveDuelSession.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Http\Actions\LiveDuel;
+
+use App\Models\Team;
+use App\Modules\LiveMatch\Exceptions\NoEligibleSquadException;
+use App\Modules\LiveMatch\Services\LiveMatchOrchestrator;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class CreateLiveDuelSession
+{
+    public function __construct(
+        private readonly LiveMatchOrchestrator $orchestrator,
+    ) {}
+
+    public function __invoke(Request $request)
+    {
+        $data = $request->validate([
+            'team_id' => ['required', 'uuid'],
+        ]);
+
+        $team = Team::query()->worldCupEligible()->find($data['team_id']);
+        if ($team === null) {
+            return back()->withErrors(['team_id' => __('live_duel.unknown_nation')]);
+        }
+
+        try {
+            $session = $this->orchestrator->createSession(Auth::user(), $team);
+        } catch (NoEligibleSquadException $e) {
+            return back()->withErrors(['team_id' => $e->getMessage()]);
+        }
+
+        return redirect()->route('live.duel.show', ['session' => $session->id]);
+    }
+}

--- a/app/Http/Actions/LiveDuel/GetLiveDuelState.php
+++ b/app/Http/Actions/LiveDuel/GetLiveDuelState.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Http\Actions\LiveDuel;
+
+use App\Models\LiveMatchSession;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+/**
+ * Returns the current state of a live duel as JSON. Used as the canonical
+ * read after each Reverb event and as a recovery path when the WebSocket
+ * is unreachable.
+ */
+class GetLiveDuelState
+{
+    public function __invoke(Request $request, string $session): JsonResponse
+    {
+        $live = LiveMatchSession::find($session);
+        // Collapse "missing" and "not a participant" into the same response
+        // so an unauthenticated attacker can't enumerate session UUIDs by
+        // probing the endpoint.
+        if ($live === null || ! $live->isParticipant(Auth::id())) {
+            return response()->json(['error' => 'forbidden'], 403);
+        }
+
+        return response()->json([
+            'session_id' => $live->id,
+            'phase' => $live->phase->value,
+            'home_score' => $live->home_score,
+            'away_score' => $live->away_score,
+            'current_minute' => $live->current_minute,
+            'pause_reason' => $live->pause_reason,
+            'pause_acked_by_host' => $live->pause_acked_by_host,
+            'pause_acked_by_guest' => $live->pause_acked_by_guest,
+            'host_bot' => $live->host_bot,
+            'guest_bot' => $live->guest_bot,
+            'host_team_id' => $live->host_team_id,
+            'guest_team_id' => $live->guest_team_id,
+            'event_log' => $live->event_log ?? [],
+            'host_subs_used' => $live->context_state['home_subs_used'] ?? 0,
+            'guest_subs_used' => $live->context_state['away_subs_used'] ?? 0,
+            'home_on_pitch_ids' => $live->context_state['home_on_pitch_ids'] ?? [],
+            'away_on_pitch_ids' => $live->context_state['away_on_pitch_ids'] ?? [],
+        ]);
+    }
+}

--- a/app/Http/Actions/LiveDuel/PickGuestTeam.php
+++ b/app/Http/Actions/LiveDuel/PickGuestTeam.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Http\Actions\LiveDuel;
+
+use App\Models\LiveMatchSession;
+use App\Models\Team;
+use App\Modules\LiveMatch\Exceptions\LiveMatchStateException;
+use App\Modules\LiveMatch\Exceptions\NoEligibleSquadException;
+use App\Modules\LiveMatch\Services\LiveMatchOrchestrator;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class PickGuestTeam
+{
+    public function __construct(
+        private readonly LiveMatchOrchestrator $orchestrator,
+    ) {}
+
+    public function __invoke(Request $request, string $session)
+    {
+        $data = $request->validate([
+            'team_id' => ['required', 'uuid'],
+        ]);
+
+        $live = LiveMatchSession::findOrFail($session);
+        // Authorize before any DB or service work — the orchestrator also
+        // checks but we'd rather not even resolve the team for a non-guest.
+        abort_unless($live->isGuest(Auth::id()), 403);
+
+        $team = Team::query()->worldCupEligible()->find($data['team_id']);
+        if ($team === null) {
+            return back()->withErrors(['team_id' => __('live_duel.unknown_nation')]);
+        }
+        if ($live->host_team_id === $team->id) {
+            return back()->withErrors(['team_id' => __('live_duel.team_already_picked')]);
+        }
+
+        try {
+            $this->orchestrator->pickGuestTeam($live, Auth::user(), $team);
+        } catch (NoEligibleSquadException|LiveMatchStateException $e) {
+            return back()->withErrors(['team_id' => $e->getMessage()]);
+        }
+
+        return redirect()->route('live.duel.show', ['session' => $live->id]);
+    }
+}

--- a/app/Http/Actions/LiveDuel/QueueAction.php
+++ b/app/Http/Actions/LiveDuel/QueueAction.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Http\Actions\LiveDuel;
+
+use App\Models\LiveMatchSession;
+use App\Modules\LiveMatch\Enums\QueuedActionType;
+use App\Modules\LiveMatch\Events\LiveMatchActionQueuedBroadcast;
+use App\Modules\LiveMatch\Exceptions\InvalidLiveActionException;
+use App\Modules\LiveMatch\Services\LiveMatchActionQueue;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class QueueAction
+{
+    public function __construct(
+        private readonly LiveMatchActionQueue $queue,
+    ) {}
+
+    public function __invoke(Request $request, string $session): JsonResponse
+    {
+        $data = $request->validate([
+            'type' => ['required', 'string'],
+            'payload' => ['required', 'array'],
+        ]);
+
+        $type = QueuedActionType::tryFrom($data['type']);
+        if ($type === null) {
+            return response()->json(['error' => 'invalid_action_type'], 422);
+        }
+
+        $live = LiveMatchSession::findOrFail($session);
+
+        try {
+            $action = $this->queue->queue($live, Auth::user(), $type, $data['payload']);
+        } catch (InvalidLiveActionException $e) {
+            return response()->json(['error' => $e->getMessage()], 422);
+        }
+
+        LiveMatchActionQueuedBroadcast::dispatch($live, $action);
+
+        return response()->json([
+            'id' => $action->id,
+            'status' => $action->status,
+            'queued_at_minute' => $action->queued_at_minute,
+        ]);
+    }
+}

--- a/app/Http/Actions/LiveDuel/ShowLiveDuel.php
+++ b/app/Http/Actions/LiveDuel/ShowLiveDuel.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace App\Http\Actions\LiveDuel;
+
+use App\Models\LiveMatchSession;
+use App\Modules\LiveMatch\Enums\LiveMatchPhase;
+use App\Modules\LiveMatch\Exceptions\LiveMatchStateException;
+use App\Modules\LiveMatch\Services\LiveMatchOrchestrator;
+use App\Modules\LiveMatch\Services\NationalSquadBuilder;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+/**
+ * Single shareable page that adapts to viewer + session state:
+ *  - host alone:      "waiting for opponent" + share link
+ *  - guest, first visit (unauthenticated → login redirect handled by middleware):
+ *                     claims the guest slot and shows the team picker
+ *  - guest, after pick: "waiting for kickoff"
+ *  - host, while guest is picking: "opponent choosing"
+ *  - third visitor (different user, session already has a guest): "match full"
+ *  - in-play / paused / finished: render the live match view
+ */
+class ShowLiveDuel
+{
+    public function __construct(
+        private readonly LiveMatchOrchestrator $orchestrator,
+        private readonly NationalSquadBuilder $squadBuilder,
+    ) {}
+
+    public function __invoke(Request $request, string $session)
+    {
+        $user = Auth::user();
+        $live = LiveMatchSession::findOrFail($session);
+
+        // Third-visitor guard.
+        if (! $live->isParticipant($user->id) && $live->guest_user_id !== null) {
+            return response()->view('live.duel.full', ['session' => $live], 403);
+        }
+
+        // Claim guest slot for the first non-host visitor.
+        if (! $live->isParticipant($user->id) && $live->guest_user_id === null) {
+            try {
+                $live = $this->orchestrator->claimGuestSlot($live, $user);
+                $this->orchestrator->broadcastGuestJoined($live);
+            } catch (LiveMatchStateException $e) {
+                return response()->view('live.duel.full', ['session' => $live, 'reason' => $e->getMessage()], 403);
+            }
+        }
+
+        $viewerRole = $live->isHost($user->id) ? 'host' : 'guest';
+
+        if ($live->phase === LiveMatchPhase::Lobby) {
+            return $this->renderLobby($live, $user, $viewerRole);
+        }
+
+        return view('live.duel.show', [
+            'session' => $live,
+            'viewerRole' => $viewerRole,
+            'viewerSide' => $viewerRole === 'host' ? 'home' : 'away',
+            'reverbKey' => config('broadcasting.connections.reverb.key'),
+            'reverbHost' => config('broadcasting.connections.reverb.options.host'),
+            'reverbPort' => config('broadcasting.connections.reverb.options.port'),
+            'reverbScheme' => config('broadcasting.connections.reverb.options.scheme'),
+        ]);
+    }
+
+    private function renderLobby(LiveMatchSession $session, $user, string $viewerRole)
+    {
+        $iAmReady = $viewerRole === 'host'
+            ? $session->host_team_id !== null
+            : $session->guest_team_id !== null;
+
+        // Guest needs to pick a team — show the team picker with host's team marked taken.
+        if ($viewerRole === 'guest' && ! $iAmReady) {
+            $teams = ShowLiveDuelEntry::availableNationalTeams();
+            $eligibility = $teams->mapWithKeys(
+                fn ($t) => [$t->id => $this->squadBuilder->eligibleCountFor($user, $t)],
+            )->all();
+
+            return view('live.duel.entry', [
+                'teams' => $teams,
+                'eligibility' => $eligibility,
+                'role' => 'guest',
+                'takenTeamId' => $session->host_team_id,
+                'session' => $session,
+            ]);
+        }
+
+        return view('live.duel.lobby', [
+            'session' => $session,
+            'viewerRole' => $viewerRole,
+            'reverbKey' => config('broadcasting.connections.reverb.key'),
+            'reverbHost' => config('broadcasting.connections.reverb.options.host'),
+            'reverbPort' => config('broadcasting.connections.reverb.options.port'),
+            'reverbScheme' => config('broadcasting.connections.reverb.options.scheme'),
+        ]);
+    }
+}

--- a/app/Http/Actions/LiveDuel/ShowLiveDuelEntry.php
+++ b/app/Http/Actions/LiveDuel/ShowLiveDuelEntry.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Http\Actions\LiveDuel;
+
+use App\Models\Team;
+use App\Modules\LiveMatch\Services\NationalSquadBuilder;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class ShowLiveDuelEntry
+{
+    public function __construct(
+        private readonly NationalSquadBuilder $squadBuilder,
+    ) {}
+
+    public function __invoke(Request $request)
+    {
+        $teams = self::availableNationalTeams();
+        $user = Auth::user();
+        $eligibility = $teams->mapWithKeys(
+            fn (Team $t) => [$t->id => $this->squadBuilder->eligibleCountFor($user, $t)],
+        )->all();
+
+        return view('live.duel.entry', [
+            'teams' => $teams,
+            'eligibility' => $eligibility,
+            'role' => 'host',
+            'takenTeamId' => null,
+        ]);
+    }
+
+    /**
+     * National teams eligible for tournament mode — same scope used by
+     * SetupTournamentGame (Team::worldCupEligible).
+     *
+     * @return Collection<int, Team>
+     */
+    public static function availableNationalTeams(): Collection
+    {
+        return Team::query()
+            ->worldCupEligible()
+            ->orderBy('name')
+            ->get();
+    }
+}

--- a/app/Models/LiveMatchAction.php
+++ b/app/Models/LiveMatchAction.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Models;
+
+use App\Modules\LiveMatch\Enums\LiveMatchSide;
+use App\Modules\LiveMatch\Enums\QueuedActionType;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * Single queued in-match action (sub / formation / mentality change).
+ *
+ * Inserted by the action queue endpoint while a match is running; applied at
+ * the start of the next simulation window by LiveMatchEngineAdapter, then
+ * marked applied|rejected.
+ *
+ * @property string $id
+ * @property string $session_id
+ * @property int $user_id
+ * @property LiveMatchSide $side
+ * @property QueuedActionType $action_type
+ * @property array $payload
+ * @property int $queued_at_minute
+ * @property int|null $applied_at_minute
+ * @property string $status
+ * @property string|null $reject_reason
+ */
+class LiveMatchAction extends Model
+{
+    use HasUuids;
+
+    public $timestamps = false;
+
+    protected $guarded = [];
+
+    protected function casts(): array
+    {
+        return [
+            'side' => LiveMatchSide::class,
+            'action_type' => QueuedActionType::class,
+            'payload' => 'array',
+        ];
+    }
+
+    public function session(): BelongsTo
+    {
+        return $this->belongsTo(LiveMatchSession::class, 'session_id');
+    }
+}

--- a/app/Models/LiveMatchSession.php
+++ b/app/Models/LiveMatchSession.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace App\Models;
+
+use App\Modules\LiveMatch\Enums\LiveMatchPhase;
+use App\Modules\LiveMatch\Enums\LiveMatchSide;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+/**
+ * Live (real-time) human-vs-human match session.
+ *
+ * A duel does not belong to either player's Game; squads are snapshotted at
+ * team-pick time and the match runs entirely on those snapshots.
+ *
+ * @property string $id
+ * @property LiveMatchPhase $phase
+ * @property int $host_user_id
+ * @property int|null $guest_user_id
+ * @property string|null $host_team_id
+ * @property string|null $guest_team_id
+ * @property string|null $host_source_game_id
+ * @property string|null $guest_source_game_id
+ * @property array|null $host_squad
+ * @property array|null $guest_squad
+ * @property string $match_seed
+ * @property int $current_minute
+ * @property int $home_score
+ * @property int $away_score
+ * @property array|null $context_state
+ * @property array $event_log
+ * @property bool $host_bot
+ * @property bool $guest_bot
+ * @property string|null $pause_reason
+ * @property bool $pause_acked_by_host
+ * @property bool $pause_acked_by_guest
+ * @property int $clock_version
+ */
+class LiveMatchSession extends Model
+{
+    use HasUuids;
+
+    public $timestamps = false;
+
+    protected $guarded = [];
+
+    protected function casts(): array
+    {
+        return [
+            'phase' => LiveMatchPhase::class,
+            'host_squad' => 'array',
+            'guest_squad' => 'array',
+            'context_state' => 'array',
+            'event_log' => 'array',
+            'host_bot' => 'boolean',
+            'guest_bot' => 'boolean',
+            'pause_acked_by_host' => 'boolean',
+            'pause_acked_by_guest' => 'boolean',
+            'paused_at' => 'datetime',
+            'finished_at' => 'datetime',
+        ];
+    }
+
+    public function host(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'host_user_id');
+    }
+
+    public function guest(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'guest_user_id');
+    }
+
+    public function actions(): HasMany
+    {
+        return $this->hasMany(LiveMatchAction::class, 'session_id');
+    }
+
+    public function isHost(?int $userId): bool
+    {
+        return $userId !== null && $this->host_user_id === $userId;
+    }
+
+    public function isGuest(?int $userId): bool
+    {
+        return $userId !== null && $this->guest_user_id === $userId;
+    }
+
+    public function isParticipant(?int $userId): bool
+    {
+        return $this->isHost($userId) || $this->isGuest($userId);
+    }
+
+    public function bothTeamsPicked(): bool
+    {
+        return $this->host_team_id !== null && $this->guest_team_id !== null;
+    }
+
+    public function isBot(LiveMatchSide $side): bool
+    {
+        return $side === LiveMatchSide::Home ? $this->host_bot : $this->guest_bot;
+    }
+}

--- a/app/Modules/LiveMatch/DTOs/SquadSnapshot.php
+++ b/app/Modules/LiveMatch/DTOs/SquadSnapshot.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Modules\LiveMatch\DTOs;
+
+/**
+ * Frozen snapshot of one side's squad + auto-generated lineup.
+ *
+ * Stored as JSON on LiveMatchSession.{host,guest}_squad. The duel never
+ * touches tenant data after this snapshot is taken — the engine adapter
+ * rehydrates lightweight GamePlayer-like records from the JSON to feed
+ * MatchSimulator::simulateWindow.
+ */
+readonly class SquadSnapshot
+{
+    /**
+     * @param  array<int, array<string, mixed>>  $startingXi      Player records, ordered by slot.
+     * @param  array<int, array<string, mixed>>  $bench           Player records.
+     * @param  array<string, string>             $playerSlotMap   playerId → slot code (Formation::pitchSlots()).
+     */
+    public function __construct(
+        public string $teamId,
+        public string $teamName,
+        public ?string $country,
+        public string $formation,
+        public string $mentality,
+        public string $playingStyle,
+        public string $pressing,
+        public string $defensiveLine,
+        public array $startingXi,
+        public array $bench,
+        public array $playerSlotMap,
+    ) {}
+
+    public function toArray(): array
+    {
+        return [
+            'team_id' => $this->teamId,
+            'team_name' => $this->teamName,
+            'country' => $this->country,
+            'formation' => $this->formation,
+            'mentality' => $this->mentality,
+            'playing_style' => $this->playingStyle,
+            'pressing' => $this->pressing,
+            'defensive_line' => $this->defensiveLine,
+            'starting_xi' => $this->startingXi,
+            'bench' => $this->bench,
+            'player_slot_map' => $this->playerSlotMap,
+        ];
+    }
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            teamId: $data['team_id'],
+            teamName: $data['team_name'],
+            country: $data['country'] ?? null,
+            formation: $data['formation'],
+            mentality: $data['mentality'],
+            playingStyle: $data['playing_style'],
+            pressing: $data['pressing'],
+            defensiveLine: $data['defensive_line'],
+            startingXi: $data['starting_xi'],
+            bench: $data['bench'],
+            playerSlotMap: $data['player_slot_map'],
+        );
+    }
+}

--- a/app/Modules/LiveMatch/Enums/LiveMatchPhase.php
+++ b/app/Modules/LiveMatch/Enums/LiveMatchPhase.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Modules\LiveMatch\Enums;
+
+enum LiveMatchPhase: string
+{
+    case Lobby = 'lobby';
+    case Live = 'live';
+    case Paused = 'paused';
+    case Finished = 'finished';
+    case Abandoned = 'abandoned';
+
+    public function isTerminal(): bool
+    {
+        return $this === self::Finished || $this === self::Abandoned;
+    }
+
+    public function isInPlay(): bool
+    {
+        return $this === self::Live || $this === self::Paused;
+    }
+}

--- a/app/Modules/LiveMatch/Enums/LiveMatchSide.php
+++ b/app/Modules/LiveMatch/Enums/LiveMatchSide.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Modules\LiveMatch\Enums;
+
+enum LiveMatchSide: string
+{
+    case Home = 'home';
+    case Away = 'away';
+
+    public function opposite(): self
+    {
+        return $this === self::Home ? self::Away : self::Home;
+    }
+}

--- a/app/Modules/LiveMatch/Enums/QueuedActionType.php
+++ b/app/Modules/LiveMatch/Enums/QueuedActionType.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Modules\LiveMatch\Enums;
+
+enum QueuedActionType: string
+{
+    case Substitution = 'sub';
+    case Formation = 'formation';
+    case Mentality = 'mentality';
+}

--- a/app/Modules/LiveMatch/Events/LiveMatchActionQueuedBroadcast.php
+++ b/app/Modules/LiveMatch/Events/LiveMatchActionQueuedBroadcast.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Modules\LiveMatch\Events;
+
+use App\Models\LiveMatchAction;
+use App\Models\LiveMatchSession;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PresenceChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class LiveMatchActionQueuedBroadcast implements ShouldBroadcastNow
+{
+    use Dispatchable;
+    use InteractsWithSockets;
+    use SerializesModels;
+
+    public function __construct(
+        public LiveMatchSession $session,
+        public LiveMatchAction $action,
+    ) {}
+
+    public function broadcastOn(): PresenceChannel
+    {
+        return new PresenceChannel("live-match.{$this->session->id}");
+    }
+
+    public function broadcastAs(): string
+    {
+        return 'match.action_queued';
+    }
+
+    public function broadcastWith(): array
+    {
+        return [
+            'session_id' => $this->session->id,
+            'side' => $this->action->side->value,
+            'action_type' => $this->action->action_type->value,
+            // Deliberately do not leak full payload — opponent only sees that
+            // something is being prepared, not what.
+        ];
+    }
+}

--- a/app/Modules/LiveMatch/Events/LiveMatchBotTakeoverBroadcast.php
+++ b/app/Modules/LiveMatch/Events/LiveMatchBotTakeoverBroadcast.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Modules\LiveMatch\Events;
+
+use App\Models\LiveMatchSession;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PresenceChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class LiveMatchBotTakeoverBroadcast implements ShouldBroadcastNow
+{
+    use Dispatchable;
+    use InteractsWithSockets;
+    use SerializesModels;
+
+    public function __construct(
+        public LiveMatchSession $session,
+        public int $userId,
+    ) {}
+
+    public function broadcastOn(): PresenceChannel
+    {
+        return new PresenceChannel("live-match.{$this->session->id}");
+    }
+
+    public function broadcastAs(): string
+    {
+        return 'match.bot_takeover';
+    }
+
+    public function broadcastWith(): array
+    {
+        return [
+            'session_id' => $this->session->id,
+            'user_id' => $this->userId,
+            'side' => $this->session->isHost($this->userId) ? 'home' : 'away',
+        ];
+    }
+}

--- a/app/Modules/LiveMatch/Events/LiveMatchEndedBroadcast.php
+++ b/app/Modules/LiveMatch/Events/LiveMatchEndedBroadcast.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Modules\LiveMatch\Events;
+
+use App\Models\LiveMatchSession;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PresenceChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class LiveMatchEndedBroadcast implements ShouldBroadcastNow
+{
+    use Dispatchable;
+    use InteractsWithSockets;
+    use SerializesModels;
+
+    public function __construct(public LiveMatchSession $session) {}
+
+    public function broadcastOn(): PresenceChannel
+    {
+        return new PresenceChannel("live-match.{$this->session->id}");
+    }
+
+    public function broadcastAs(): string
+    {
+        return 'match.ended';
+    }
+
+    public function broadcastWith(): array
+    {
+        return [
+            'session_id' => $this->session->id,
+            'home_score' => $this->session->home_score,
+            'away_score' => $this->session->away_score,
+        ];
+    }
+}

--- a/app/Modules/LiveMatch/Events/LiveMatchEventBroadcast.php
+++ b/app/Modules/LiveMatch/Events/LiveMatchEventBroadcast.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Modules\LiveMatch\Events;
+
+use App\Models\LiveMatchSession;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PresenceChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class LiveMatchEventBroadcast implements ShouldBroadcastNow
+{
+    use Dispatchable;
+    use InteractsWithSockets;
+    use SerializesModels;
+
+    public function __construct(
+        public LiveMatchSession $session,
+        public array $event,
+    ) {}
+
+    public function broadcastOn(): PresenceChannel
+    {
+        return new PresenceChannel("live-match.{$this->session->id}");
+    }
+
+    public function broadcastAs(): string
+    {
+        return 'match.event';
+    }
+
+    public function broadcastWith(): array
+    {
+        return [
+            'session_id' => $this->session->id,
+            'event' => $this->event,
+            'home_score' => $this->session->home_score,
+            'away_score' => $this->session->away_score,
+            'current_minute' => $this->session->current_minute,
+        ];
+    }
+}

--- a/app/Modules/LiveMatch/Events/LiveMatchGuestJoinedBroadcast.php
+++ b/app/Modules/LiveMatch/Events/LiveMatchGuestJoinedBroadcast.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Modules\LiveMatch\Events;
+
+use App\Models\LiveMatchSession;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PresenceChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class LiveMatchGuestJoinedBroadcast implements ShouldBroadcastNow
+{
+    use Dispatchable;
+    use InteractsWithSockets;
+    use SerializesModels;
+
+    public function __construct(public LiveMatchSession $session) {}
+
+    public function broadcastOn(): PresenceChannel
+    {
+        return new PresenceChannel("live-match.{$this->session->id}");
+    }
+
+    public function broadcastAs(): string
+    {
+        return 'match.guest_joined';
+    }
+
+    public function broadcastWith(): array
+    {
+        return [
+            'session_id' => $this->session->id,
+            'guest_user_id' => $this->session->guest_user_id,
+        ];
+    }
+}

--- a/app/Modules/LiveMatch/Events/LiveMatchPausedBroadcast.php
+++ b/app/Modules/LiveMatch/Events/LiveMatchPausedBroadcast.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Modules\LiveMatch\Events;
+
+use App\Models\LiveMatchSession;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PresenceChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class LiveMatchPausedBroadcast implements ShouldBroadcastNow
+{
+    use Dispatchable;
+    use InteractsWithSockets;
+    use SerializesModels;
+
+    public function __construct(public LiveMatchSession $session) {}
+
+    public function broadcastOn(): PresenceChannel
+    {
+        return new PresenceChannel("live-match.{$this->session->id}");
+    }
+
+    public function broadcastAs(): string
+    {
+        return 'match.paused';
+    }
+
+    public function broadcastWith(): array
+    {
+        return [
+            'session_id' => $this->session->id,
+            'pause_reason' => $this->session->pause_reason,
+            'current_minute' => $this->session->current_minute,
+        ];
+    }
+}

--- a/app/Modules/LiveMatch/Events/LiveMatchResumedBroadcast.php
+++ b/app/Modules/LiveMatch/Events/LiveMatchResumedBroadcast.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Modules\LiveMatch\Events;
+
+use App\Models\LiveMatchSession;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PresenceChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class LiveMatchResumedBroadcast implements ShouldBroadcastNow
+{
+    use Dispatchable;
+    use InteractsWithSockets;
+    use SerializesModels;
+
+    public function __construct(public LiveMatchSession $session) {}
+
+    public function broadcastOn(): PresenceChannel
+    {
+        return new PresenceChannel("live-match.{$this->session->id}");
+    }
+
+    public function broadcastAs(): string
+    {
+        return 'match.resumed';
+    }
+
+    public function broadcastWith(): array
+    {
+        return [
+            'session_id' => $this->session->id,
+            'current_minute' => $this->session->current_minute,
+        ];
+    }
+}

--- a/app/Modules/LiveMatch/Events/LiveMatchStartedBroadcast.php
+++ b/app/Modules/LiveMatch/Events/LiveMatchStartedBroadcast.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Modules\LiveMatch\Events;
+
+use App\Models\LiveMatchSession;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PresenceChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class LiveMatchStartedBroadcast implements ShouldBroadcastNow
+{
+    use Dispatchable;
+    use InteractsWithSockets;
+    use SerializesModels;
+
+    public function __construct(public LiveMatchSession $session) {}
+
+    public function broadcastOn(): PresenceChannel
+    {
+        return new PresenceChannel("live-match.{$this->session->id}");
+    }
+
+    public function broadcastAs(): string
+    {
+        return 'match.started';
+    }
+
+    public function broadcastWith(): array
+    {
+        return [
+            'session_id' => $this->session->id,
+            'phase' => $this->session->phase->value,
+            'current_minute' => $this->session->current_minute,
+        ];
+    }
+}

--- a/app/Modules/LiveMatch/Events/LiveMatchTeamPickedBroadcast.php
+++ b/app/Modules/LiveMatch/Events/LiveMatchTeamPickedBroadcast.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Modules\LiveMatch\Events;
+
+use App\Models\LiveMatchSession;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PresenceChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class LiveMatchTeamPickedBroadcast implements ShouldBroadcastNow
+{
+    use Dispatchable;
+    use InteractsWithSockets;
+    use SerializesModels;
+
+    public function __construct(public LiveMatchSession $session) {}
+
+    public function broadcastOn(): PresenceChannel
+    {
+        return new PresenceChannel("live-match.{$this->session->id}");
+    }
+
+    public function broadcastAs(): string
+    {
+        return 'match.team_picked';
+    }
+
+    public function broadcastWith(): array
+    {
+        return [
+            'session_id' => $this->session->id,
+            'host_team_id' => $this->session->host_team_id,
+            'guest_team_id' => $this->session->guest_team_id,
+            'both_picked' => $this->session->bothTeamsPicked(),
+        ];
+    }
+}

--- a/app/Modules/LiveMatch/Exceptions/InvalidLiveActionException.php
+++ b/app/Modules/LiveMatch/Exceptions/InvalidLiveActionException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace App\Modules\LiveMatch\Exceptions;
+
+use RuntimeException;
+
+class InvalidLiveActionException extends RuntimeException {}

--- a/app/Modules/LiveMatch/Exceptions/LiveMatchStateException.php
+++ b/app/Modules/LiveMatch/Exceptions/LiveMatchStateException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace App\Modules\LiveMatch\Exceptions;
+
+use RuntimeException;
+
+class LiveMatchStateException extends RuntimeException {}

--- a/app/Modules/LiveMatch/Exceptions/NoEligibleSquadException.php
+++ b/app/Modules/LiveMatch/Exceptions/NoEligibleSquadException.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Modules\LiveMatch\Exceptions;
+
+use RuntimeException;
+
+class NoEligibleSquadException extends RuntimeException
+{
+    public static function noActiveGame(string $iso): self
+    {
+        return new self("No active game found to draw players for {$iso}.");
+    }
+
+    public static function tooFewPlayers(string $iso, int $found): self
+    {
+        return new self("Only {$found} eligible players for {$iso} — pick a different nation (minimum is 11).");
+    }
+}

--- a/app/Modules/LiveMatch/Jobs/AdvanceLiveMatchWindowJob.php
+++ b/app/Modules/LiveMatch/Jobs/AdvanceLiveMatchWindowJob.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Modules\LiveMatch\Jobs;
+
+use App\Models\LiveMatchSession;
+use App\Modules\LiveMatch\Enums\LiveMatchPhase;
+use App\Modules\LiveMatch\Services\LiveMatchOrchestrator;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+/**
+ * Simulates a single ~10-minute window of a live match, then chains itself
+ * for the next window (or yields to a pause-ack flow).
+ *
+ * Idempotency: the session's `clock_version` is bumped on disconnect /
+ * resume / abort. Each job carries the version it was dispatched with and
+ * exits early if it no longer matches — cheap protection against double
+ * dispatch and races after reconnect.
+ */
+class AdvanceLiveMatchWindowJob implements ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    public function __construct(
+        public string $sessionId,
+        public int $clockVersion,
+        public int $fromMinute,
+    ) {}
+
+    public function handle(LiveMatchOrchestrator $orchestrator): void
+    {
+        $session = LiveMatchSession::find($this->sessionId);
+        if ($session === null) {
+            return;
+        }
+        if ($session->clock_version !== $this->clockVersion) {
+            // Stale — another job (or a resume) has taken over.
+            return;
+        }
+        if ($session->phase !== LiveMatchPhase::Live) {
+            return;
+        }
+
+        $shouldContinue = $orchestrator->advanceWindow($session, $this->fromMinute);
+        if (! $shouldContinue) {
+            return;
+        }
+
+        $session->refresh();
+        self::dispatch(
+            $session->id,
+            $session->clock_version,
+            $session->current_minute,
+        )->delay(now()->addSeconds(LiveMatchOrchestrator::WINDOW_DELAY_SECONDS));
+    }
+}

--- a/app/Modules/LiveMatch/Jobs/MarkAsBotJob.php
+++ b/app/Modules/LiveMatch/Jobs/MarkAsBotJob.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Modules\LiveMatch\Jobs;
+
+use App\Models\LiveMatchSession;
+use App\Modules\LiveMatch\Services\LiveMatchOrchestrator;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+class MarkAsBotJob implements ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    public function __construct(
+        public string $sessionId,
+        public int $userId,
+        public int $clockVersionAtDispatch,
+    ) {}
+
+    public function handle(LiveMatchOrchestrator $orchestrator): void
+    {
+        $session = LiveMatchSession::find($this->sessionId);
+        if ($session === null) {
+            return;
+        }
+        // Reconnect or any state change bumps clock_version — cancel the takeover.
+        if ($session->clock_version !== $this->clockVersionAtDispatch) {
+            return;
+        }
+        if ($session->phase->isTerminal()) {
+            return;
+        }
+
+        $orchestrator->markAsBot($session, $this->userId);
+    }
+}

--- a/app/Modules/LiveMatch/Services/AutoLineupBuilder.php
+++ b/app/Modules/LiveMatch/Services/AutoLineupBuilder.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace App\Modules\LiveMatch\Services;
+
+use App\Models\Team;
+use App\Modules\LiveMatch\DTOs\SquadSnapshot;
+use App\Modules\Lineup\Enums\DefensiveLineHeight;
+use App\Modules\Lineup\Enums\Formation;
+use App\Modules\Lineup\Enums\Mentality;
+use App\Modules\Lineup\Enums\PlayingStyle;
+use App\Modules\Lineup\Enums\PressingIntensity;
+use App\Modules\Lineup\Services\FormationRecommender;
+use Illuminate\Support\Collection;
+
+class AutoLineupBuilder
+{
+    public function __construct(
+        private readonly FormationRecommender $formationRecommender = new FormationRecommender,
+    ) {}
+
+    /**
+     * Pick the best formation for this squad, fill it with the best XI, and
+     * package the result as a frozen SquadSnapshot. Bench is everyone not in
+     * the XI, sorted by overall.
+     *
+     * @param  Collection  $rehydratedPlayers  Result of NationalSquadBuilder::rehydrate().
+     */
+    public function build(Team $team, Collection $rehydratedPlayers): SquadSnapshot
+    {
+        $formation = $this->formationRecommender->getBestFormation($rehydratedPlayers);
+        $bestXi = $this->formationRecommender->bestXIFor($formation, $rehydratedPlayers);
+
+        $startingIds = [];
+        $slotMap = [];
+        foreach ($bestXi as $assignment) {
+            if (($assignment['player'] ?? null) !== null) {
+                $playerId = $assignment['player']['id'];
+                $slotCode = $assignment['slot']['code'] ?? $assignment['slot']['id'] ?? '';
+                $startingIds[] = $playerId;
+                if ($slotCode !== '') {
+                    $slotMap[$playerId] = $slotCode;
+                }
+            }
+        }
+
+        $startingXi = $rehydratedPlayers
+            ->filter(fn ($p) => in_array($p->id, $startingIds, true))
+            ->map(fn ($p) => $this->summarize($p))
+            ->values()
+            ->all();
+
+        $bench = $rehydratedPlayers
+            ->filter(fn ($p) => ! in_array($p->id, $startingIds, true))
+            ->sortByDesc('overall_score')
+            ->map(fn ($p) => $this->summarize($p))
+            ->values()
+            ->all();
+
+        return new SquadSnapshot(
+            teamId: $team->id,
+            teamName: $team->name,
+            country: $team->getAttributes()['country'] ?? null,
+            formation: $formation->value,
+            mentality: Mentality::BALANCED->value,
+            playingStyle: PlayingStyle::BALANCED->value,
+            pressing: PressingIntensity::STANDARD->value,
+            defensiveLine: DefensiveLineHeight::NORMAL->value,
+            startingXi: $startingXi,
+            bench: $bench,
+            playerSlotMap: $slotMap,
+        );
+    }
+
+    /**
+     * Serialize a player into the frozen snapshot.
+     *
+     * This must carry every attribute LiveMatchEngineAdapter rehydrates back
+     * into a GamePlayer for the simulator — not just the UI-facing fields.
+     * In particular `date_of_birth` is mandatory: the simulator calls
+     * `$player->age()`, which dereferences it (a null DOB throws and kills the
+     * match window, so no events ever broadcast). Mirror NationalSquadBuilder::
+     * rehydrate()'s field set.
+     */
+    private function summarize($player): array
+    {
+        return [
+            'id' => $player->id,
+            'team_id' => $player->team_id,
+            'name' => $player->name,
+            'position' => $player->position,
+            'secondary_positions' => $player->secondary_positions ?? [],
+            'nationality' => $player->nationality ?? [],
+            'overall_score' => $player->overall_score,
+            'number' => $player->number,
+            'foot' => $player->foot,
+            'height' => $player->height,
+            'durability' => $player->durability,
+            'date_of_birth' => $player->date_of_birth?->toDateString(),
+            'tier' => $player->tier,
+            'potential' => $player->potential,
+            'potential_low' => $player->potential_low,
+            'potential_high' => $player->potential_high,
+        ];
+    }
+}

--- a/app/Modules/LiveMatch/Services/LiveMatchActionQueue.php
+++ b/app/Modules/LiveMatch/Services/LiveMatchActionQueue.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace App\Modules\LiveMatch\Services;
+
+use App\Models\LiveMatchAction;
+use App\Models\LiveMatchSession;
+use App\Models\User;
+use App\Modules\LiveMatch\Enums\LiveMatchPhase;
+use App\Modules\LiveMatch\Enums\LiveMatchSide;
+use App\Modules\LiveMatch\Enums\QueuedActionType;
+use App\Modules\LiveMatch\Exceptions\InvalidLiveActionException;
+use App\Modules\Lineup\Enums\Formation;
+use App\Modules\Lineup\Enums\Mentality;
+
+class LiveMatchActionQueue
+{
+    public const MAX_SUBS_PER_SIDE = 3;
+
+    /**
+     * Validate and persist a queued action. Returns the persisted row.
+     *
+     * Validation rules:
+     *  - Session must be in Live or Paused phase.
+     *  - User must be a participant.
+     *  - Subs require the target player to be on pitch and the incoming
+     *    player to be on bench.
+     *  - Sub count must be under MAX_SUBS_PER_SIDE.
+     *  - Formation/mentality changes are only allowed during a halftime pause.
+     */
+    public function queue(
+        LiveMatchSession $session,
+        User $user,
+        QueuedActionType $type,
+        array $payload,
+    ): LiveMatchAction {
+        if (! $session->phase->isInPlay()) {
+            throw new InvalidLiveActionException('Match is not in play.');
+        }
+
+        if (! $session->isParticipant($user->id)) {
+            throw new InvalidLiveActionException('You are not a participant in this match.');
+        }
+
+        $side = $session->isHost($user->id) ? LiveMatchSide::Home : LiveMatchSide::Away;
+        $state = $session->context_state ?? [];
+        $sideKey = $side->value;
+
+        if ($type === QueuedActionType::Substitution) {
+            $this->validateSub($state, $sideKey, $payload);
+        } else {
+            // Tactical changes are only allowed at a halftime pause.
+            if ($session->phase !== LiveMatchPhase::Paused || $session->pause_reason !== 'halftime') {
+                throw new InvalidLiveActionException('Tactical changes are only allowed at halftime.');
+            }
+            $this->validateTacticalChange($type, $payload);
+        }
+
+        return LiveMatchAction::create([
+            'session_id' => $session->id,
+            'user_id' => $user->id,
+            'side' => $side,
+            'action_type' => $type,
+            'payload' => $payload,
+            'queued_at_minute' => $session->current_minute,
+            'status' => 'queued',
+        ]);
+    }
+
+    private function validateSub(array $state, string $sideKey, array $payload): void
+    {
+        $out = $payload['player_out_id'] ?? null;
+        $in = $payload['player_in_id'] ?? null;
+
+        if (! is_string($out) || ! is_string($in)) {
+            throw new InvalidLiveActionException('Substitution requires player_out_id and player_in_id.');
+        }
+        $onPitch = $state["{$sideKey}_on_pitch_ids"] ?? [];
+        $bench = $state["{$sideKey}_bench_ids"] ?? [];
+        if (! in_array($out, $onPitch, true)) {
+            throw new InvalidLiveActionException('Selected player is not on the pitch.');
+        }
+        if (! in_array($in, $bench, true)) {
+            throw new InvalidLiveActionException('Selected replacement is not on the bench.');
+        }
+        $used = $state["{$sideKey}_subs_used"] ?? 0;
+        if ($used >= self::MAX_SUBS_PER_SIDE) {
+            throw new InvalidLiveActionException('No substitutions remaining.');
+        }
+    }
+
+    private function validateTacticalChange(QueuedActionType $type, array $payload): void
+    {
+        // Validate enum values here — the adapter calls Formation::from() /
+        // Mentality::from() on the next window and any unknown string would
+        // throw a ValueError that crashes the simulation job.
+        if ($type === QueuedActionType::Formation) {
+            $value = $payload['formation'] ?? null;
+            if (! is_string($value) || Formation::tryFrom($value) === null) {
+                throw new InvalidLiveActionException('Formation change requires a valid formation code.');
+            }
+        }
+        if ($type === QueuedActionType::Mentality) {
+            $value = $payload['mentality'] ?? null;
+            if (! is_string($value) || Mentality::tryFrom($value) === null) {
+                throw new InvalidLiveActionException('Mentality change requires a valid mentality code.');
+            }
+        }
+    }
+}

--- a/app/Modules/LiveMatch/Services/LiveMatchEngineAdapter.php
+++ b/app/Modules/LiveMatch/Services/LiveMatchEngineAdapter.php
@@ -1,0 +1,343 @@
+<?php
+
+namespace App\Modules\LiveMatch\Services;
+
+use App\Models\LiveMatchAction;
+use App\Models\LiveMatchSession;
+use App\Models\Team;
+use App\Modules\LiveMatch\DTOs\SquadSnapshot;
+use App\Modules\LiveMatch\Enums\LiveMatchSide;
+use App\Modules\LiveMatch\Enums\QueuedActionType;
+use App\Modules\Lineup\Enums\DefensiveLineHeight;
+use App\Modules\Lineup\Enums\Formation;
+use App\Modules\Lineup\Enums\Mentality;
+use App\Modules\Lineup\Enums\PlayingStyle;
+use App\Modules\Lineup\Enums\PressingIntensity;
+use App\Modules\Match\DTOs\MatchSimulationContext;
+use App\Modules\Match\DTOs\WindowResult;
+use App\Modules\Match\Services\MatchSimulator;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Bridges LiveMatchSession persistence with MatchSimulator::simulateWindow.
+ *
+ * On each call:
+ *  1. Pulls queued actions from live_match_actions for this session.
+ *  2. Applies them to the in-memory lineup (sub-out/sub-in, formation change,
+ *     mentality change) and marks them applied|rejected.
+ *  3. Rehydrates MatchSimulationContext from session->context_state +
+ *     session->{host,guest}_squad.
+ *  4. Calls MatchSimulator::simulateWindow.
+ *  5. Persists the mutated context back to session->context_state and
+ *     appends the window's events to session->event_log.
+ */
+class LiveMatchEngineAdapter
+{
+    public function __construct(
+        private readonly MatchSimulator $simulator,
+        private readonly NationalSquadBuilder $squadBuilder,
+    ) {}
+
+    /**
+     * Build initial context_state JSON at kickoff. Called once when both
+     * teams are picked and the orchestrator transitions to Live.
+     */
+    public function buildInitialContextState(LiveMatchSession $session): array
+    {
+        $home = SquadSnapshot::fromArray($session->host_squad);
+        $away = SquadSnapshot::fromArray($session->guest_squad);
+
+        return [
+            'home_on_pitch_ids' => array_column($home->startingXi, 'id'),
+            'away_on_pitch_ids' => array_column($away->startingXi, 'id'),
+            'home_bench_ids' => array_column($home->bench, 'id'),
+            'away_bench_ids' => array_column($away->bench, 'id'),
+            'home_entry_minutes' => array_fill_keys(array_column($home->startingXi, 'id'), 0),
+            'away_entry_minutes' => array_fill_keys(array_column($away->startingXi, 'id'), 0),
+            'existing_injury_team_ids' => [],
+            'existing_yellow_player_ids' => [],
+            'home_subs_used' => 0,
+            'away_subs_used' => 0,
+            'home_formation' => $home->formation,
+            'away_formation' => $away->formation,
+            'home_mentality' => $home->mentality,
+            'away_mentality' => $away->mentality,
+            'home_playing_style' => $home->playingStyle,
+            'away_playing_style' => $away->playingStyle,
+            'home_pressing' => $home->pressing,
+            'away_pressing' => $away->pressing,
+            'home_def_line' => $home->defensiveLine,
+            'away_def_line' => $away->defensiveLine,
+            'home_player_slot_map' => $home->playerSlotMap,
+            'away_player_slot_map' => $away->playerSlotMap,
+            'match_performance' => [],
+            'home_xg_total' => 0.0,
+            'away_xg_total' => 0.0,
+        ];
+    }
+
+    /**
+     * Run one simulation window and persist results to the session row.
+     *
+     * The entire apply-queued-actions → simulate → persist sequence runs under
+     * a single row lock so applied action statuses and the resulting
+     * context_state can't desync if a second job (e.g. a duplicate dispatch)
+     * tries to run the same window in parallel.
+     */
+    public function runWindow(LiveMatchSession $session, int $fromMinute, int $toMinute): WindowResult
+    {
+        return DB::transaction(function () use ($session, $fromMinute, $toMinute) {
+            $locked = LiveMatchSession::lockForUpdate()->findOrFail($session->id);
+
+            $this->applyQueuedActions($locked, $fromMinute);
+            $locked->refresh();
+
+            $context = $this->hydrateContext($locked, $fromMinute, $toMinute);
+            $window = $this->simulator->simulateWindow($context, $fromMinute, $toMinute);
+
+            $this->persistContext($locked, $context, $window);
+
+            return $window;
+        });
+    }
+
+    /**
+     * The home-side tag the simulator stamps on events for this session.
+     * Used by the orchestrator to map event team ids back to 'home'/'away'.
+     */
+    public function homeTeamIdFor(LiveMatchSession $session): string
+    {
+        return $session->id . ':home';
+    }
+
+    private function hydrateContext(LiveMatchSession $session, int $from, int $to): MatchSimulationContext
+    {
+        $state = $session->context_state ?? $this->buildInitialContextState($session);
+
+        $home = SquadSnapshot::fromArray($session->host_squad);
+        $away = SquadSnapshot::fromArray($session->guest_squad);
+
+        $allHomePlayers = $this->squadBuilder->rehydrate(array_merge($home->startingXi, $home->bench));
+        $allAwayPlayers = $this->squadBuilder->rehydrate(array_merge($away->startingXi, $away->bench));
+
+        $homeOnPitch = $allHomePlayers
+            ->filter(fn ($p) => in_array($p->id, $state['home_on_pitch_ids'] ?? [], true))
+            ->values();
+        $awayOnPitch = $allAwayPlayers
+            ->filter(fn ($p) => in_array($p->id, $state['away_on_pitch_ids'] ?? [], true))
+            ->values();
+        $homeBench = $allHomePlayers
+            ->filter(fn ($p) => in_array($p->id, $state['home_bench_ids'] ?? [], true))
+            ->values();
+        $awayBench = $allAwayPlayers
+            ->filter(fn ($p) => in_array($p->id, $state['away_bench_ids'] ?? [], true))
+            ->values();
+
+        $homeTeam = $this->fakeTeam($session->id . ':home', $home->teamName);
+        $awayTeam = $this->fakeTeam($session->id . ':away', $away->teamName);
+
+        return new MatchSimulationContext(
+            homeTeam: $homeTeam,
+            awayTeam: $awayTeam,
+            homePlayers: $homeOnPitch,
+            awayPlayers: $awayOnPitch,
+            homeBenchPlayers: $homeBench,
+            awayBenchPlayers: $awayBench,
+            homeFormation: Formation::from($state['home_formation']),
+            awayFormation: Formation::from($state['away_formation']),
+            homeMentality: Mentality::from($state['home_mentality']),
+            awayMentality: Mentality::from($state['away_mentality']),
+            homePlayingStyle: PlayingStyle::from($state['home_playing_style']),
+            awayPlayingStyle: PlayingStyle::from($state['away_playing_style']),
+            homePressing: PressingIntensity::from($state['home_pressing']),
+            awayPressing: PressingIntensity::from($state['away_pressing']),
+            homeDefLine: DefensiveLineHeight::from($state['home_def_line']),
+            awayDefLine: DefensiveLineHeight::from($state['away_def_line']),
+            homeScore: $session->home_score,
+            awayScore: $session->away_score,
+            homeXGTotal: (float) ($state['home_xg_total'] ?? 0.0),
+            awayXGTotal: (float) ($state['away_xg_total'] ?? 0.0),
+            homeEntryMinutes: $state['home_entry_minutes'] ?? [],
+            awayEntryMinutes: $state['away_entry_minutes'] ?? [],
+            existingInjuryTeamIds: $state['existing_injury_team_ids'] ?? [],
+            existingYellowPlayerIds: $state['existing_yellow_player_ids'] ?? [],
+            homeSubsUsed: $state['home_subs_used'] ?? 0,
+            awaySubsUsed: $state['away_subs_used'] ?? 0,
+            homePlayerSlotMap: $state['home_player_slot_map'] ?? [],
+            awayPlayerSlotMap: $state['away_player_slot_map'] ?? [],
+            matchPerformance: $state['match_performance'] ?? [],
+            // Per-window seed fork — keeps each window's RNG noise distinct.
+            matchSeed: $session->match_seed . ':' . $from . '-' . $to,
+            userTeamId: $this->resolveUserTeamId($session, $homeTeam->id, $awayTeam->id),
+            game: null,
+            neutralVenue: true,
+        );
+    }
+
+    /**
+     * MatchSimulator's `userTeamId` arg gates AI substitutions for one side.
+     * If one human has gone bot, the still-human side is the "user". With both
+     * still human, queued-action subs cover both sides at the application
+     * layer; we pass home so AI subs stay quiet for it.
+     */
+    private function resolveUserTeamId(LiveMatchSession $session, string $homeTeamId, string $awayTeamId): ?string
+    {
+        if ($session->host_bot && ! $session->guest_bot) {
+            return $awayTeamId;
+        }
+        if ($session->guest_bot && ! $session->host_bot) {
+            return $homeTeamId;
+        }
+
+        return $homeTeamId;
+    }
+
+    private function persistContext(LiveMatchSession $session, MatchSimulationContext $ctx, WindowResult $window): void
+    {
+        $homeOnPitchIds = $ctx->homePlayers->pluck('id')->all();
+        $awayOnPitchIds = $ctx->awayPlayers->pluck('id')->all();
+        $homeBenchIds = $ctx->homeBenchPlayers?->pluck('id')->all() ?? [];
+        $awayBenchIds = $ctx->awayBenchPlayers?->pluck('id')->all() ?? [];
+
+        $state = $session->context_state ?? [];
+        $state['home_on_pitch_ids'] = $homeOnPitchIds;
+        $state['away_on_pitch_ids'] = $awayOnPitchIds;
+        $state['home_bench_ids'] = $homeBenchIds;
+        $state['away_bench_ids'] = $awayBenchIds;
+        $state['home_entry_minutes'] = $ctx->homeEntryMinutes;
+        $state['away_entry_minutes'] = $ctx->awayEntryMinutes;
+        $state['existing_injury_team_ids'] = $ctx->existingInjuryTeamIds;
+        $state['existing_yellow_player_ids'] = $ctx->existingYellowPlayerIds;
+        $state['home_subs_used'] = $ctx->homeSubsUsed;
+        $state['away_subs_used'] = $ctx->awaySubsUsed;
+        $state['home_formation'] = $ctx->homeFormation->value;
+        $state['away_formation'] = $ctx->awayFormation->value;
+        $state['home_mentality'] = $ctx->homeMentality->value;
+        $state['away_mentality'] = $ctx->awayMentality->value;
+        $state['home_playing_style'] = $ctx->homePlayingStyle->value;
+        $state['away_playing_style'] = $ctx->awayPlayingStyle->value;
+        $state['home_pressing'] = $ctx->homePressing->value;
+        $state['away_pressing'] = $ctx->awayPressing->value;
+        $state['home_def_line'] = $ctx->homeDefLine->value;
+        $state['away_def_line'] = $ctx->awayDefLine->value;
+        $state['home_player_slot_map'] = $ctx->homePlayerSlotMap;
+        $state['away_player_slot_map'] = $ctx->awayPlayerSlotMap;
+        $state['match_performance'] = $ctx->matchPerformance;
+        $state['home_xg_total'] = $ctx->homeXGTotal;
+        $state['away_xg_total'] = $ctx->awayXGTotal;
+
+        $eventLog = $session->event_log ?? [];
+        foreach ($window->newEvents as $event) {
+            $eventLog[] = [
+                'team_id' => $event->teamId,
+                'side' => $event->teamId === $ctx->homeTeam->id ? 'home' : 'away',
+                'game_player_id' => $event->gamePlayerId,
+                'minute' => $event->minute,
+                'type' => $event->type,
+                'metadata' => $event->metadata,
+            ];
+        }
+
+        $session->update([
+            'home_score' => $ctx->homeScore,
+            'away_score' => $ctx->awayScore,
+            'current_minute' => $window->toMinute,
+            'context_state' => $state,
+            'event_log' => $eventLog,
+        ]);
+    }
+
+    /**
+     * Apply queued actions whose queued_at_minute < $upToMinute. Mutates the
+     * session's context_state in-place (on-pitch lineup, bench, sub counts,
+     * tactics) and marks the actions applied|rejected.
+     */
+    private function applyQueuedActions(LiveMatchSession $session, int $upToMinute): void
+    {
+        $pending = LiveMatchAction::where('session_id', $session->id)
+            ->where('status', 'queued')
+            ->orderBy('queued_at_minute')
+            ->get();
+
+        if ($pending->isEmpty()) {
+            return;
+        }
+
+        $state = $session->context_state ?? $this->buildInitialContextState($session);
+
+        foreach ($pending as $action) {
+            $side = $action->side->value;
+            $key = $side === 'home' ? 'home' : 'away';
+            $onPitchKey = "{$key}_on_pitch_ids";
+            $benchKey = "{$key}_bench_ids";
+            $entryKey = "{$key}_entry_minutes";
+            $subsKey = "{$key}_subs_used";
+            $slotMapKey = "{$key}_player_slot_map";
+
+            try {
+                if ($action->action_type === QueuedActionType::Substitution) {
+                    $out = $action->payload['player_out_id'] ?? null;
+                    $in = $action->payload['player_in_id'] ?? null;
+
+                    if (! in_array($out, $state[$onPitchKey], true)) {
+                        $action->update(['status' => 'rejected', 'reject_reason' => 'player_not_on_pitch']);
+
+                        continue;
+                    }
+                    if (! in_array($in, $state[$benchKey], true)) {
+                        $action->update(['status' => 'rejected', 'reject_reason' => 'player_not_on_bench']);
+
+                        continue;
+                    }
+                    if (($state[$subsKey] ?? 0) >= 3) {
+                        $action->update(['status' => 'rejected', 'reject_reason' => 'subs_exhausted']);
+
+                        continue;
+                    }
+
+                    $state[$onPitchKey] = array_values(array_filter($state[$onPitchKey], fn ($id) => $id !== $out));
+                    $state[$onPitchKey][] = $in;
+                    $state[$benchKey] = array_values(array_filter($state[$benchKey], fn ($id) => $id !== $in));
+                    $state[$entryKey][$in] = $action->queued_at_minute;
+                    $state[$subsKey] = ($state[$subsKey] ?? 0) + 1;
+
+                    // Slot transfer: subbed-in inherits subbed-out's slot.
+                    if (isset($state[$slotMapKey][$out])) {
+                        $state[$slotMapKey][$in] = $state[$slotMapKey][$out];
+                        unset($state[$slotMapKey][$out]);
+                    }
+                } elseif ($action->action_type === QueuedActionType::Formation) {
+                    $state["{$key}_formation"] = $action->payload['formation'];
+                } elseif ($action->action_type === QueuedActionType::Mentality) {
+                    $state["{$key}_mentality"] = $action->payload['mentality'];
+                }
+
+                $action->update([
+                    'status' => 'applied',
+                    'applied_at_minute' => $upToMinute,
+                ]);
+            } catch (\Throwable $e) {
+                $action->update([
+                    'status' => 'rejected',
+                    'reject_reason' => substr($e->getMessage(), 0, 80),
+                ]);
+            }
+        }
+
+        $session->update(['context_state' => $state]);
+    }
+
+    /**
+     * Construct an unsaved Team instance for the simulator. Live matches
+     * don't have real teams.id rows — the simulator only reads team->id and
+     * uses it as a tagging key for events.
+     */
+    private function fakeTeam(string $id, string $name): Team
+    {
+        $team = new Team;
+        $team->forceFill(['id' => $id, 'name' => $name]);
+        $team->exists = true;
+
+        return $team;
+    }
+}

--- a/app/Modules/LiveMatch/Services/LiveMatchOrchestrator.php
+++ b/app/Modules/LiveMatch/Services/LiveMatchOrchestrator.php
@@ -1,0 +1,378 @@
+<?php
+
+namespace App\Modules\LiveMatch\Services;
+
+use App\Models\LiveMatchSession;
+use App\Models\Team;
+use App\Models\User;
+use App\Modules\LiveMatch\Enums\LiveMatchPhase;
+use App\Modules\LiveMatch\Events\LiveMatchBotTakeoverBroadcast;
+use App\Modules\LiveMatch\Events\LiveMatchEndedBroadcast;
+use App\Modules\LiveMatch\Events\LiveMatchEventBroadcast;
+use App\Modules\LiveMatch\Events\LiveMatchGuestJoinedBroadcast;
+use App\Modules\LiveMatch\Events\LiveMatchPausedBroadcast;
+use App\Modules\LiveMatch\Events\LiveMatchResumedBroadcast;
+use App\Modules\LiveMatch\Events\LiveMatchStartedBroadcast;
+use App\Modules\LiveMatch\Events\LiveMatchTeamPickedBroadcast;
+use App\Modules\LiveMatch\Exceptions\LiveMatchStateException;
+use App\Modules\LiveMatch\Jobs\AdvanceLiveMatchWindowJob;
+use App\Modules\LiveMatch\Jobs\MarkAsBotJob;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+
+class LiveMatchOrchestrator
+{
+    /**
+     * Each live match is split into this many simulation windows. ~10 minute
+     * slices keeps decisions (subs, tactical changes) responsive while
+     * avoiding too many job dispatches.
+     */
+    public const WINDOW_SIZE_MINUTES = 10;
+
+    public const TOTAL_MATCH_MINUTES = 93;
+
+    /**
+     * Wall-clock delay (seconds) between window jobs. Approximates a
+     * 60-second real-time match: 9 windows × ~6.7s = ~60s.
+     */
+    public const WINDOW_DELAY_SECONDS = 6;
+
+    public const BOT_TAKEOVER_TIMEOUT_SECONDS = 30;
+
+    public function __construct(
+        private readonly NationalSquadBuilder $squadBuilder,
+        private readonly AutoLineupBuilder $autoLineupBuilder,
+        private readonly LiveMatchEngineAdapter $engineAdapter,
+    ) {}
+
+    /**
+     * Host picks a national team. Creates the session and snapshots the
+     * host's squad in one shot. The session UUID is the share token.
+     */
+    public function createSession(User $host, Team $team): LiveMatchSession
+    {
+        $build = $this->squadBuilder->buildFor($host, $team);
+        $rehydrated = $this->squadBuilder->rehydrate($build['players']);
+        $snapshot = $this->autoLineupBuilder->build($team, $rehydrated);
+
+        return LiveMatchSession::create([
+            'phase' => LiveMatchPhase::Lobby,
+            'host_user_id' => $host->id,
+            'host_team_id' => $team->id,
+            'host_squad' => $snapshot->toArray(),
+            'match_seed' => Str::random(16),
+        ]);
+    }
+
+    /**
+     * First authenticated non-host visitor claims the guest slot. Idempotent
+     * for the existing guest. Rejects host (self-duel) and rejects when slot
+     * is already taken by someone else.
+     */
+    public function claimGuestSlot(LiveMatchSession $session, User $user): LiveMatchSession
+    {
+        return DB::transaction(function () use ($session, $user) {
+            $fresh = LiveMatchSession::lockForUpdate()->findOrFail($session->id);
+
+            if ($fresh->isHost($user->id)) {
+                throw new LiveMatchStateException('You cannot duel yourself.');
+            }
+            if ($fresh->guest_user_id !== null && $fresh->guest_user_id !== $user->id) {
+                throw new LiveMatchStateException('This match is already full.');
+            }
+            if ($fresh->phase->isTerminal()) {
+                throw new LiveMatchStateException('This match has ended.');
+            }
+            if ($fresh->guest_user_id === null) {
+                $fresh->update(['guest_user_id' => $user->id]);
+            }
+
+            return $fresh;
+        });
+    }
+
+    /**
+     * Guest picks their national team. Snapshots their squad and, since the
+     * guest must be on the page to make this call, kicks off immediately
+     * rather than wait for a presence-channel handshake.
+     */
+    public function pickGuestTeam(LiveMatchSession $session, User $user, Team $team): LiveMatchSession
+    {
+        if (! $session->isGuest($user->id)) {
+            throw new LiveMatchStateException('Only the guest can set the guest team.');
+        }
+        if ($session->phase !== LiveMatchPhase::Lobby) {
+            throw new LiveMatchStateException('Cannot change team once the match has started.');
+        }
+
+        $build = $this->squadBuilder->buildFor($user, $team);
+        $rehydrated = $this->squadBuilder->rehydrate($build['players']);
+        $snapshot = $this->autoLineupBuilder->build($team, $rehydrated);
+
+        $session->update([
+            'guest_team_id' => $team->id,
+            'guest_squad' => $snapshot->toArray(),
+        ]);
+
+        $session->refresh();
+        LiveMatchTeamPickedBroadcast::dispatch($session);
+
+        $this->attemptKickoff($session, bothPresent: true);
+
+        return $session->refresh();
+    }
+
+    /**
+     * Try to kick off the match. Called both after a team pick and after a
+     * presence-channel member_added event. Idempotent — does nothing unless
+     * both teams are picked AND both members are on the channel.
+     */
+    public function attemptKickoff(LiveMatchSession $session, bool $bothPresent): void
+    {
+        if (! $bothPresent) {
+            return;
+        }
+        if ($session->phase !== LiveMatchPhase::Lobby) {
+            return;
+        }
+        if (! $session->bothTeamsPicked()) {
+            return;
+        }
+
+        $initial = $this->engineAdapter->buildInitialContextState($session);
+
+        // Row lock + DB-side increment so two concurrent kickoff calls (e.g.
+        // simultaneous presence and pick-team triggers) can't both transition
+        // Lobby → Live and dispatch two AdvanceLiveMatchWindowJobs.
+        $newVersion = DB::transaction(function () use ($session, $initial) {
+            $locked = LiveMatchSession::lockForUpdate()->findOrFail($session->id);
+            if ($locked->phase !== LiveMatchPhase::Lobby) {
+                return null;
+            }
+            $locked->update([
+                'phase' => LiveMatchPhase::Live,
+                'context_state' => $initial,
+                'current_minute' => 0,
+                'clock_version' => DB::raw('clock_version + 1'),
+            ]);
+
+            return $locked->fresh()->clock_version;
+        });
+
+        if ($newVersion === null) {
+            return;
+        }
+
+        LiveMatchStartedBroadcast::dispatch($session->fresh());
+
+        AdvanceLiveMatchWindowJob::dispatch($session->id, $newVersion, 0);
+    }
+
+    /**
+     * Advance the match by one window. Called by AdvanceLiveMatchWindowJob.
+     * Returns true if the match continues, false if it has ended (caller
+     * should not dispatch the next window).
+     */
+    public function advanceWindow(LiveMatchSession $session, int $from): bool
+    {
+        if ($session->phase !== LiveMatchPhase::Live) {
+            return false;
+        }
+
+        $to = min($from + self::WINDOW_SIZE_MINUTES, self::TOTAL_MATCH_MINUTES);
+        $window = $this->engineAdapter->runWindow($session, $from, $to);
+        $session->refresh();
+
+        // Broadcast new events for this window.
+        $homeTeamId = $this->engineAdapter->homeTeamIdFor($session);
+        foreach ($window->newEvents as $event) {
+            LiveMatchEventBroadcast::dispatch($session, [
+                'minute' => $event->minute,
+                'type' => $event->type,
+                'team_id' => $event->teamId,
+                'side' => $event->teamId === $homeTeamId ? 'home' : 'away',
+                'game_player_id' => $event->gamePlayerId,
+                'metadata' => $event->metadata,
+            ]);
+        }
+
+        // Reached full time.
+        if ($to >= self::TOTAL_MATCH_MINUTES) {
+            $session->update([
+                'phase' => LiveMatchPhase::Finished,
+                'finished_at' => now(),
+            ]);
+            LiveMatchEndedBroadcast::dispatch($session->fresh());
+
+            return false;
+        }
+
+        // Trigger halftime pause once we cross minute 45.
+        if ($from < 45 && $to >= 45) {
+            $this->pause($session, 'halftime');
+
+            return false;
+        }
+
+        // Check for goal/red-card/injury that should pause the match.
+        $significantEvent = $window->newEvents->first(fn ($e) => in_array($e->type, ['goal', 'red_card', 'injury'], true));
+        if ($significantEvent !== null) {
+            $this->pause($session, $significantEvent->type);
+
+            return false;
+        }
+
+        return true;
+    }
+
+    private function pause(LiveMatchSession $session, string $reason): void
+    {
+        $session->update([
+            'phase' => LiveMatchPhase::Paused,
+            'pause_reason' => $reason,
+            'pause_acked_by_host' => false,
+            'pause_acked_by_guest' => false,
+            'paused_at' => now(),
+        ]);
+        LiveMatchPausedBroadcast::dispatch($session->fresh());
+    }
+
+    /**
+     * One side acknowledges the pause. When both acks land (or one side is
+     * bot), resumes and dispatches the next window.
+     */
+    public function acknowledgePause(LiveMatchSession $session, User $user): LiveMatchSession
+    {
+        if (! $session->isParticipant($user->id)) {
+            throw new LiveMatchStateException('You are not a participant.');
+        }
+
+        // Lock to serialize concurrent acks — without it, both sides can read
+        // each other as not-yet-acked and both trigger resume(), dispatching
+        // duplicate AdvanceLiveMatchWindowJobs.
+        [$resumePayload, $session] = DB::transaction(function () use ($session, $user) {
+            $locked = LiveMatchSession::lockForUpdate()->findOrFail($session->id);
+
+            if ($locked->phase !== LiveMatchPhase::Paused) {
+                throw new LiveMatchStateException('Match is not paused.');
+            }
+
+            $patch = $locked->isHost($user->id)
+                ? ['pause_acked_by_host' => true]
+                : ['pause_acked_by_guest' => true];
+            $locked->update($patch);
+            $locked->refresh();
+
+            $hostReady = $locked->pause_acked_by_host || $locked->host_bot;
+            $guestReady = $locked->pause_acked_by_guest || $locked->guest_bot;
+
+            if ($hostReady && $guestReady) {
+                $payload = $this->applyResume($locked);
+
+                return [$payload, $locked->fresh()];
+            }
+
+            return [null, $locked];
+        });
+
+        if ($resumePayload !== null) {
+            LiveMatchResumedBroadcast::dispatch($session);
+            AdvanceLiveMatchWindowJob::dispatch(
+                $resumePayload['session_id'],
+                $resumePayload['clock_version'],
+                $resumePayload['from_minute'],
+            );
+        }
+
+        return $session;
+    }
+
+    /**
+     * Transition Paused → Live and bump clock_version atomically. Caller must
+     * hold the row lock; returns the payload the post-commit dispatcher needs.
+     *
+     * @return array{session_id: string, clock_version: int, from_minute: int}
+     */
+    private function applyResume(LiveMatchSession $session): array
+    {
+        $session->update([
+            'phase' => LiveMatchPhase::Live,
+            'pause_reason' => null,
+            'pause_acked_by_host' => false,
+            'pause_acked_by_guest' => false,
+            'paused_at' => null,
+            'clock_version' => DB::raw('clock_version + 1'),
+        ]);
+        $session->refresh();
+
+        return [
+            'session_id' => $session->id,
+            'clock_version' => $session->clock_version,
+            'from_minute' => $session->current_minute,
+        ];
+    }
+
+    /**
+     * Member left the presence channel. Start a takeover timer; if they
+     * don't reconnect within BOT_TAKEOVER_TIMEOUT_SECONDS, MarkAsBotJob
+     * flips that side to bot and the match continues.
+     */
+    public function handleDisconnect(LiveMatchSession $session, int $userId): void
+    {
+        if (! $session->isParticipant($userId)) {
+            return;
+        }
+        if ($session->phase->isTerminal()) {
+            return;
+        }
+
+        MarkAsBotJob::dispatch($session->id, $userId, $session->clock_version)
+            ->delay(now()->addSeconds(self::BOT_TAKEOVER_TIMEOUT_SECONDS));
+    }
+
+    public function markAsBot(LiveMatchSession $session, int $userId): void
+    {
+        // Flip the bot flag + maybe-resume under the same row lock as the ack
+        // path; if the displaced user's pause-ack was the only thing blocking
+        // resume, this transition fires it.
+        $resumePayload = DB::transaction(function () use ($session, $userId) {
+            $locked = LiveMatchSession::lockForUpdate()->findOrFail($session->id);
+
+            if ($locked->isHost($userId)) {
+                $locked->update(['host_bot' => true]);
+            } elseif ($locked->isGuest($userId)) {
+                $locked->update(['guest_bot' => true]);
+            } else {
+                return null;
+            }
+            $locked->refresh();
+
+            if ($locked->phase !== LiveMatchPhase::Paused) {
+                return null;
+            }
+            $hostReady = $locked->pause_acked_by_host || $locked->host_bot;
+            $guestReady = $locked->pause_acked_by_guest || $locked->guest_bot;
+            if (! ($hostReady && $guestReady)) {
+                return null;
+            }
+
+            return $this->applyResume($locked);
+        });
+
+        LiveMatchBotTakeoverBroadcast::dispatch($session->fresh(), $userId);
+
+        if ($resumePayload !== null) {
+            LiveMatchResumedBroadcast::dispatch($session->fresh());
+            AdvanceLiveMatchWindowJob::dispatch(
+                $resumePayload['session_id'],
+                $resumePayload['clock_version'],
+                $resumePayload['from_minute'],
+            );
+        }
+    }
+
+    public function broadcastGuestJoined(LiveMatchSession $session): void
+    {
+        LiveMatchGuestJoinedBroadcast::dispatch($session);
+    }
+}

--- a/app/Modules/LiveMatch/Services/NationalSquadBuilder.php
+++ b/app/Modules/LiveMatch/Services/NationalSquadBuilder.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace App\Modules\LiveMatch\Services;
+
+use App\Models\GamePlayer;
+use App\Models\GamePlayerTemplate;
+use App\Models\Team;
+use App\Models\User;
+use App\Modules\LiveMatch\Exceptions\NoEligibleSquadException;
+use Illuminate\Support\Collection;
+
+class NationalSquadBuilder
+{
+    public const SQUAD_SIZE = 23;
+
+    public const MIN_FOR_VIABLE_SQUAD = 11;
+
+    /**
+     * Build a frozen national-team squad for the given Team.
+     *
+     * Data source is `GamePlayerTemplate` (the canonical real-world roster,
+     * shared across every user) — the same source tournament mode uses (see
+     * SetupTournamentGame). Players are linked to their national team via
+     * game_player_templates.team_id.
+     *
+     * The User param stays in the signature for the eventual per-save switch
+     * when the live duel feature wraps into tournament play.
+     *
+     * @return array{team_id: string, players: array<int, array<string, mixed>>}
+     */
+    public function buildFor(User $user, Team $team): array
+    {
+        $templates = $this->queryTemplates($team->id)
+            ->orderByDesc('overall_score')
+            ->limit(self::SQUAD_SIZE)
+            ->get();
+
+        if ($templates->count() < self::MIN_FOR_VIABLE_SQUAD) {
+            throw NoEligibleSquadException::tooFewPlayers($team->name, $templates->count());
+        }
+
+        return [
+            'team_id' => $team->id,
+            'players' => $templates->map(fn (GamePlayerTemplate $t) => $this->serializeTemplate($t))->all(),
+        ];
+    }
+
+    /**
+     * Eligible-player count for a team in the squad pool. Used to surface
+     * the "X eligible" hint on the team picker.
+     */
+    public function eligibleCountFor(User $user, Team $team): int
+    {
+        return $this->queryTemplates($team->id)->count();
+    }
+
+    /**
+     * Rehydrate stored player records as unsaved GamePlayer instances. The
+     * simulator only reads attributes (never relationships), so unsaved
+     * instances work fine.
+     *
+     * @param  array<int, array<string, mixed>>  $records
+     */
+    public function rehydrate(array $records): Collection
+    {
+        return collect($records)->map(function (array $r): GamePlayer {
+            $player = new GamePlayer;
+            $player->forceFill([
+                'id' => $r['id'],
+                'game_id' => $r['game_id'] ?? null,
+                'team_id' => $r['team_id'] ?? null,
+                'name' => $r['name'],
+                'position' => $r['position'],
+                'secondary_positions' => $r['secondary_positions'] ?? [],
+                'nationality' => $r['nationality'] ?? [],
+                'overall_score' => $r['overall_score'],
+                'durability' => $r['durability'] ?? 70,
+                'number' => $r['number'] ?? null,
+                'foot' => $r['foot'] ?? 'right',
+                'height' => $r['height'] ?? null,
+                'date_of_birth' => $r['date_of_birth'] ?? null,
+                'tier' => $r['tier'] ?? 3,
+                'potential' => $r['potential'] ?? $r['overall_score'],
+                'potential_low' => $r['potential_low'] ?? $r['overall_score'],
+                'potential_high' => $r['potential_high'] ?? $r['overall_score'],
+            ]);
+            $player->exists = true;
+
+            return $player;
+        });
+    }
+
+    /**
+     * Shared query: latest season of GamePlayerTemplate filtered by the
+     * picked national team. `season` is a string column on templates —
+     * pulling only the latest avoids mixing seasons.
+     */
+    private function queryTemplates(string $teamId)
+    {
+        $latestSeason = GamePlayerTemplate::where('team_id', $teamId)->max('season');
+        $query = GamePlayerTemplate::query()->where('team_id', $teamId);
+        if ($latestSeason !== null) {
+            $query->where('season', $latestSeason);
+        }
+
+        return $query;
+    }
+
+    private function serializeTemplate(GamePlayerTemplate $t): array
+    {
+        // GamePlayerTemplate doesn't cast `secondary_positions` to array
+        // (the cast lives on GamePlayer only). Reading the attribute hands
+        // back the raw JSON string — decode here so the rehydrate →
+        // forceFill chain doesn't double-encode through GamePlayer's cast.
+        $secondary = $t->getRawOriginal('secondary_positions');
+        if (is_string($secondary)) {
+            $secondary = json_decode($secondary, true) ?: [];
+        }
+
+        return [
+            // GamePlayer has UUID PKs; templates have bigint id + a stable
+            // UUID `player_id`. Use the UUID so rehydrated instances carry
+            // the same identifier shape the simulator expects.
+            'id' => $t->player_id,
+            'game_id' => null,
+            'team_id' => $t->team_id,
+            'name' => $t->name,
+            'position' => $t->position,
+            'secondary_positions' => is_array($secondary) ? $secondary : [],
+            'nationality' => $t->nationality ?? [],
+            'overall_score' => $t->overall_score,
+            'durability' => $t->durability,
+            'number' => $t->number,
+            'foot' => $t->foot,
+            'height' => $t->height,
+            'date_of_birth' => $t->date_of_birth?->toDateString(),
+            'tier' => $t->tier,
+            'potential' => $t->potential,
+            'potential_low' => $t->potential_low,
+            'potential_high' => $t->potential_high,
+        ];
+    }
+}

--- a/app/Modules/Match/DTOs/MatchSimulationContext.php
+++ b/app/Modules/Match/DTOs/MatchSimulationContext.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Modules\Match\DTOs;
+
+use App\Models\Game;
+use App\Models\Team;
+use App\Modules\Lineup\Enums\DefensiveLineHeight;
+use App\Modules\Lineup\Enums\Formation;
+use App\Modules\Lineup\Enums\Mentality;
+use App\Modules\Lineup\Enums\PlayingStyle;
+use App\Modules\Lineup\Enums\PressingIntensity;
+use Illuminate\Support\Collection;
+
+/**
+ * Mutable cross-window state for a windowed match simulation.
+ *
+ * Bundles everything that must survive across multiple
+ * MatchSimulator::simulateWindow() calls during a single match. The context
+ * is mutated in place by simulateWindow so the next window sees updated
+ * lineups, score, accumulated events, performance cache and accumulators.
+ *
+ * Intended for live multiplayer matches where each window runs in a
+ * separate queued job and the context is persisted to JSON between calls.
+ * The existing batch entry point (MatchSimulator::simulate) is unaffected.
+ */
+class MatchSimulationContext
+{
+    /** @var Collection<int, MatchEventData> */
+    public Collection $accumulatedEvents;
+
+    public function __construct(
+        public Team $homeTeam,
+        public Team $awayTeam,
+        public Collection $homePlayers,
+        public Collection $awayPlayers,
+        public ?Collection $homeBenchPlayers = null,
+        public ?Collection $awayBenchPlayers = null,
+        public Formation $homeFormation = Formation::F_4_4_2,
+        public Formation $awayFormation = Formation::F_4_4_2,
+        public Mentality $homeMentality = Mentality::BALANCED,
+        public Mentality $awayMentality = Mentality::BALANCED,
+        public PlayingStyle $homePlayingStyle = PlayingStyle::BALANCED,
+        public PlayingStyle $awayPlayingStyle = PlayingStyle::BALANCED,
+        public PressingIntensity $homePressing = PressingIntensity::STANDARD,
+        public PressingIntensity $awayPressing = PressingIntensity::STANDARD,
+        public DefensiveLineHeight $homeDefLine = DefensiveLineHeight::NORMAL,
+        public DefensiveLineHeight $awayDefLine = DefensiveLineHeight::NORMAL,
+        public int $homeScore = 0,
+        public int $awayScore = 0,
+        public float $homeXGTotal = 0.0,
+        public float $awayXGTotal = 0.0,
+        public array $homeEntryMinutes = [],
+        public array $awayEntryMinutes = [],
+        public array $existingInjuryTeamIds = [],
+        public array $existingYellowPlayerIds = [],
+        public int $homeSubsUsed = 0,
+        public int $awaySubsUsed = 0,
+        public array $homePlayerSlotMap = [],
+        public array $awayPlayerSlotMap = [],
+        public array $matchPerformance = [],
+        ?Collection $accumulatedEvents = null,
+        public string $matchSeed = '',
+        public ?string $userTeamId = null,
+        public ?Game $game = null,
+        public bool $neutralVenue = false,
+    ) {
+        $this->accumulatedEvents = $accumulatedEvents ?? collect();
+    }
+}

--- a/app/Modules/Match/DTOs/WindowResult.php
+++ b/app/Modules/Match/DTOs/WindowResult.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Modules\Match\DTOs;
+
+use Illuminate\Support\Collection;
+
+/**
+ * Output of a single MatchSimulator::simulateWindow() call.
+ *
+ * Carries the events generated during the window and the score/xG produced
+ * for that window only (deltas, not cumulative totals). Cumulative state
+ * lives on the owning MatchSimulationContext.
+ */
+readonly class WindowResult
+{
+    /**
+     * @param  Collection<int, MatchEventData>  $newEvents
+     */
+    public function __construct(
+        public Collection $newEvents,
+        public int $homeScoreDelta,
+        public int $awayScoreDelta,
+        public float $homeXG,
+        public float $awayXG,
+        public int $homePossession,
+        public int $awayPossession,
+        public int $fromMinute,
+        public int $toMinute,
+    ) {}
+}

--- a/app/Modules/Match/Services/MatchSimulator.php
+++ b/app/Modules/Match/Services/MatchSimulator.php
@@ -4,7 +4,9 @@ namespace App\Modules\Match\Services;
 
 use App\Modules\Match\DTOs\MatchEventData;
 use App\Modules\Match\DTOs\MatchResult;
+use App\Modules\Match\DTOs\MatchSimulationContext;
 use App\Modules\Match\DTOs\MatchSimulationOutput;
+use App\Modules\Match\DTOs\WindowResult;
 use App\Modules\Lineup\Enums\DefensiveLineHeight;
 use App\Modules\Lineup\Enums\Formation;
 use App\Modules\Lineup\Enums\Mentality;
@@ -238,6 +240,110 @@ class MatchSimulator
             neutralVenue: $neutralVenue,
             toMinute: $regulationEnd,
             userTeamId: $userTeamId,
+        );
+    }
+
+    /**
+     * Simulate a single window [from, to] of a match using a stateful context.
+     *
+     * Thin context-driven wrapper around simulateRemainder(). Lets callers run
+     * a match window by window — each call hydrates instance state from the
+     * context, delegates to simulateRemainder, and writes mutated state
+     * (performance cache, score, accumulated events, injury/yellow trackers)
+     * back into the context so the next window picks up where this one left off.
+     *
+     * Designed for live multiplayer matches where each window runs in a
+     * separate queued job and the context is persisted between calls. The
+     * existing batch entry points (simulate, simulateRemainder,
+     * simulateWithAISubstitutions) are unaffected.
+     *
+     * Caller responsibilities between windows:
+     *  - Apply queued substitutions / tactical changes to ctx->homePlayers,
+     *    ctx->awayPlayers, ctx->*BenchPlayers (use SubstitutionService::buildActiveLineup).
+     *  - Optionally fork ctx->matchSeed per window (e.g. "$seed:$from-$to") if
+     *    deterministic-per-window noise is desired. simulateWindow uses the
+     *    seed as-is.
+     */
+    public function simulateWindow(
+        MatchSimulationContext $ctx,
+        int $fromMinute,
+        int $toMinute,
+    ): WindowResult {
+        // Hydrate per-call instance state from the context. simulateRemainder
+        // reads from these fields directly (rather than just its parameters)
+        // for the slot maps and performance cache.
+        $this->homePlayerSlotMap = $ctx->homePlayerSlotMap;
+        $this->awayPlayerSlotMap = $ctx->awayPlayerSlotMap;
+        $this->matchPerformance = $ctx->matchPerformance;
+
+        $output = $this->simulateRemainder(
+            homeTeam: $ctx->homeTeam,
+            awayTeam: $ctx->awayTeam,
+            homePlayers: $ctx->homePlayers,
+            awayPlayers: $ctx->awayPlayers,
+            homeFormation: $ctx->homeFormation,
+            awayFormation: $ctx->awayFormation,
+            homeMentality: $ctx->homeMentality,
+            awayMentality: $ctx->awayMentality,
+            fromMinute: $fromMinute,
+            game: $ctx->game,
+            existingInjuryTeamIds: $ctx->existingInjuryTeamIds,
+            existingYellowPlayerIds: $ctx->existingYellowPlayerIds,
+            homeEntryMinutes: $ctx->homeEntryMinutes,
+            awayEntryMinutes: $ctx->awayEntryMinutes,
+            homePlayingStyle: $ctx->homePlayingStyle,
+            awayPlayingStyle: $ctx->awayPlayingStyle,
+            homePressing: $ctx->homePressing,
+            awayPressing: $ctx->awayPressing,
+            homeDefLine: $ctx->homeDefLine,
+            awayDefLine: $ctx->awayDefLine,
+            homeBenchPlayers: $ctx->homeBenchPlayers,
+            awayBenchPlayers: $ctx->awayBenchPlayers,
+            matchSeed: $ctx->matchSeed,
+            homeExistingSubstitutions: $ctx->homeSubsUsed,
+            awayExistingSubstitutions: $ctx->awaySubsUsed,
+            neutralVenue: $ctx->neutralVenue,
+            preservePerformance: true,
+            toMinute: $toMinute,
+            skipXGAdjustment: true,
+            userTeamId: $ctx->userTeamId,
+        );
+
+        $window = $output->result;
+
+        // Performance cache: simulateRemainder mutates instance state; write back.
+        $ctx->matchPerformance = $this->matchPerformance;
+
+        // Cumulative totals.
+        $ctx->homeScore += $window->homeScore;
+        $ctx->awayScore += $window->awayScore;
+        $ctx->homeXGTotal += $window->homeXG;
+        $ctx->awayXGTotal += $window->awayXG;
+
+        $ctx->accumulatedEvents = $ctx->accumulatedEvents->merge($window->events);
+
+        // First-injury-per-team and yellow-carded-players accumulators mirror
+        // what simulateWithAISubstitutions threads between simulateRemainder
+        // calls — without this the next window may regenerate them.
+        foreach ($window->events as $event) {
+            if ($event->type === 'injury' && ! in_array($event->teamId, $ctx->existingInjuryTeamIds, true)) {
+                $ctx->existingInjuryTeamIds[] = $event->teamId;
+            }
+            if ($event->type === 'yellow_card' && ! in_array($event->gamePlayerId, $ctx->existingYellowPlayerIds, true)) {
+                $ctx->existingYellowPlayerIds[] = $event->gamePlayerId;
+            }
+        }
+
+        return new WindowResult(
+            newEvents: $window->events,
+            homeScoreDelta: $window->homeScore,
+            awayScoreDelta: $window->awayScore,
+            homeXG: $window->homeXG,
+            awayXG: $window->awayXG,
+            homePossession: $window->homePossession,
+            awayPossession: $window->awayPossession,
+            fromMinute: $fromMinute,
+            toMinute: $toMinute,
         );
     }
 

--- a/app/Modules/Player/Services/InjuryService.php
+++ b/app/Modules/Player/Services/InjuryService.php
@@ -200,7 +200,7 @@ class InjuryService
         $baseProbability = (float) config('match_simulation.injury_chance', self::BASE_INJURY_CHANCE);
         // Get multipliers
         $durabilityMultiplier = $this->getDurabilityMultiplier($player);
-        $ageMultiplier = $this->getAgeMultiplier($player->age($player->game->current_date));
+        $ageMultiplier = $this->getAgeMultiplier($this->ageFor($player, $game));
         $fitnessMultiplier = $this->getFitnessMultiplier($player->fitness);
         $congestionMultiplier = $this->getCongestionMultiplier($lastMatchDate, $currentMatchDate);
         $medicalMultiplier = $this->getMedicalInjuryMultiplier($game);
@@ -233,6 +233,22 @@ class InjuryService
         $probability = $this->calculateInjuryProbability($player, $lastMatchDate, $currentMatchDate, $game);
 
         return $this->percentChance($probability);
+    }
+
+    /**
+     * Player age for injury math, resolved against the best available date.
+     *
+     * Prefer the game the caller already has (this is the authoritative match
+     * context and avoids an N+1 lazy-load of every player's `game` relation).
+     * Fall back to the player's own game, then to now() — live-duel players
+     * have no backing Game at all, and their national-squad DOBs make
+     * age-from-now correct.
+     */
+    private function ageFor(GamePlayer $player, ?Game $game): int
+    {
+        $referenceDate = $game?->current_date ?? $player->game?->current_date ?? now();
+
+        return $player->age($referenceDate);
     }
 
     /**
@@ -286,7 +302,7 @@ class InjuryService
         $baseWeeks = rand($minWeeks, $maxWeeks);
 
         // Older players take longer to recover (+1 or +2 extra weeks)
-        $age = $player->age($player->game->current_date);
+        $age = $this->ageFor($player, $game);
         if ($age > PlayerAge::PRIME_END) {
             $baseWeeks += 2;
         } elseif ($age > PlayerAge::YOUNG_END) {
@@ -507,7 +523,7 @@ class InjuryService
         $baseProbability = self::TRAINING_INJURY_CHANCE;
 
         $durabilityMultiplier = $this->getDurabilityMultiplier($player);
-        $ageMultiplier = $this->getAgeMultiplier($player->age($player->game->current_date));
+        $ageMultiplier = $this->getAgeMultiplier($this->ageFor($player, $game));
         $fitnessMultiplier = $this->getFitnessMultiplier($player->fitness);
         $medicalMultiplier = $this->getMedicalInjuryMultiplier($game);
 

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -10,11 +10,12 @@ return Application::configure(basePath: dirname(__DIR__))
         web: __DIR__.'/../routes/web.php',
         api: __DIR__.'/../routes/api.php',
         commands: __DIR__.'/../routes/console.php',
+        channels: __DIR__.'/../routes/channels.php',
         health: '/up',
     )
     ->booting(function () {
         $uuidPattern = '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}';
-        foreach (['gameId', 'matchId', 'playerId', 'offerId', 'reportId', 'teamId', 'presetId', 'notificationId', 'summaryId', 'auditId'] as $param) {
+        foreach (['gameId', 'matchId', 'playerId', 'offerId', 'reportId', 'teamId', 'presetId', 'notificationId', 'summaryId', 'auditId', 'session'] as $param) {
             Route::pattern($param, $uuidPattern);
         }
     })

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
         "laravel/nightwatch": "^1.22",
         "laravel/octane": "^2.13",
         "laravel/pulse": "^1.7",
+        "laravel/reverb": "^1.0",
         "laravel/telescope": "^5.17",
         "resend/resend-laravel": "^1.1"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "449ae2f1a673188b033811322fe86432",
+    "content-hash": "f4656593d4e51d1e0882b28464aec2e7",
     "packages": [
         {
             "name": "brick/math",
@@ -134,6 +134,136 @@
                 }
             ],
             "time": "2024-02-09T16:56:22+00:00"
+        },
+        {
+            "name": "clue/redis-protocol",
+            "version": "v0.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/clue/redis-protocol.git",
+                "reference": "6f565332f5531b7722d1e9c445314b91862f6d6c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/clue/redis-protocol/zipball/6f565332f5531b7722d1e9c445314b91862f6d6c",
+                "reference": "6f565332f5531b7722d1e9c445314b91862f6d6c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Clue\\Redis\\Protocol\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@lueck.tv"
+                }
+            ],
+            "description": "A streaming Redis protocol (RESP) parser and serializer written in pure PHP.",
+            "homepage": "https://github.com/clue/redis-protocol",
+            "keywords": [
+                "parser",
+                "protocol",
+                "redis",
+                "resp",
+                "serializer",
+                "streaming"
+            ],
+            "support": {
+                "issues": "https://github.com/clue/redis-protocol/issues",
+                "source": "https://github.com/clue/redis-protocol/tree/v0.3.2"
+            },
+            "funding": [
+                {
+                    "url": "https://clue.engineering/support",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/clue",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-08-07T11:06:28+00:00"
+        },
+        {
+            "name": "clue/redis-react",
+            "version": "v2.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/clue/reactphp-redis.git",
+                "reference": "84569198dfd5564977d2ae6a32de4beb5a24bdca"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/clue/reactphp-redis/zipball/84569198dfd5564977d2ae6a32de4beb5a24bdca",
+                "reference": "84569198dfd5564977d2ae6a32de4beb5a24bdca",
+                "shasum": ""
+            },
+            "require": {
+                "clue/redis-protocol": "^0.3.2",
+                "evenement/evenement": "^3.0 || ^2.0 || ^1.0",
+                "php": ">=5.3",
+                "react/event-loop": "^1.2",
+                "react/promise": "^3.2 || ^2.0 || ^1.1",
+                "react/promise-timer": "^1.11",
+                "react/socket": "^1.16"
+            },
+            "require-dev": {
+                "clue/block-react": "^1.5",
+                "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Clue\\React\\Redis\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering"
+                }
+            ],
+            "description": "Async Redis client implementation, built on top of ReactPHP.",
+            "homepage": "https://github.com/clue/reactphp-redis",
+            "keywords": [
+                "async",
+                "client",
+                "database",
+                "reactphp",
+                "redis"
+            ],
+            "support": {
+                "issues": "https://github.com/clue/reactphp-redis/issues",
+                "source": "https://github.com/clue/reactphp-redis/tree/v2.8.0"
+            },
+            "funding": [
+                {
+                    "url": "https://clue.engineering/support",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/clue",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-01-03T16:18:33+00:00"
         },
         {
             "name": "dflydev/dot-access-data",
@@ -562,6 +692,53 @@
                 }
             ],
             "time": "2025-03-06T22:45:56+00:00"
+        },
+        {
+            "name": "evenement/evenement",
+            "version": "v3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/igorw/evenement.git",
+                "reference": "0a16b0d71ab13284339abb99d9d2bd813640efbc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/igorw/evenement/zipball/0a16b0d71ab13284339abb99d9d2bd813640efbc",
+                "reference": "0a16b0d71ab13284339abb99d9d2bd813640efbc",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9 || ^6"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Evenement\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Igor Wiedler",
+                    "email": "igor@wiedler.ch"
+                }
+            ],
+            "description": "Événement is a very simple event dispatching library for PHP",
+            "keywords": [
+                "event-dispatcher",
+                "event-emitter"
+            ],
+            "support": {
+                "issues": "https://github.com/igorw/evenement/issues",
+                "source": "https://github.com/igorw/evenement/tree/v3.0.2"
+            },
+            "time": "2023-08-08T05:53:35+00:00"
         },
         {
             "name": "fakerphp/faker",
@@ -2025,6 +2202,85 @@
                 "source": "https://github.com/laravel/pulse"
             },
             "time": "2026-03-26T14:27:31+00:00"
+        },
+        {
+            "name": "laravel/reverb",
+            "version": "v1.10.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/reverb.git",
+                "reference": "43a5c0a99b1aaba33dc32f97fcf51f182dd8c8ac"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/reverb/zipball/43a5c0a99b1aaba33dc32f97fcf51f182dd8c8ac",
+                "reference": "43a5c0a99b1aaba33dc32f97fcf51f182dd8c8ac",
+                "shasum": ""
+            },
+            "require": {
+                "clue/redis-react": "^2.6",
+                "guzzlehttp/psr7": "^2.6",
+                "illuminate/console": "^10.47|^11.0|^12.0|^13.0",
+                "illuminate/contracts": "^10.47|^11.0|^12.0|^13.0",
+                "illuminate/http": "^10.47|^11.0|^12.0|^13.0",
+                "illuminate/support": "^10.47|^11.0|^12.0|^13.0",
+                "laravel/prompts": "^0.1.15|^0.2.0|^0.3.0",
+                "php": "^8.2",
+                "pusher/pusher-php-server": "^7.2",
+                "ratchet/rfc6455": "^0.4",
+                "react/promise-timer": "^1.10",
+                "react/socket": "^1.14",
+                "symfony/console": "^6.0|^7.0|^8.0",
+                "symfony/http-foundation": "^6.3|^7.0|^8.0"
+            },
+            "require-dev": {
+                "orchestra/testbench": "^8.36|^9.15|^10.8|^11.0",
+                "pestphp/pest": "^2.0|^3.0|^4.0",
+                "phpstan/phpstan": "^1.10",
+                "ratchet/pawl": "^0.4.1",
+                "react/async": "^4.2",
+                "react/http": "^1.9"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Laravel\\Reverb\\ApplicationManagerServiceProvider",
+                        "Laravel\\Reverb\\ReverbServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laravel\\Reverb\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                },
+                {
+                    "name": "Joe Dixon",
+                    "email": "joe@laravel.com"
+                }
+            ],
+            "description": "Laravel Reverb provides a real-time WebSocket communication backend for Laravel applications.",
+            "keywords": [
+                "WebSockets",
+                "laravel",
+                "real-time",
+                "websocket"
+            ],
+            "support": {
+                "issues": "https://github.com/laravel/reverb/issues",
+                "source": "https://github.com/laravel/reverb/tree/v1.10.2"
+            },
+            "time": "2026-05-10T15:47:52+00:00"
         },
         {
             "name": "laravel/sentinel",
@@ -3850,6 +4106,66 @@
             "time": "2021-10-29T13:26:27+00:00"
         },
         {
+            "name": "pusher/pusher-php-server",
+            "version": "7.2.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/pusher/pusher-http-php.git",
+                "reference": "4aa139ed2a2a805cd265449b691198beee1309d2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/pusher/pusher-http-php/zipball/4aa139ed2a2a805cd265449b691198beee1309d2",
+                "reference": "4aa139ed2a2a805cd265449b691198beee1309d2",
+                "shasum": ""
+            },
+            "require": {
+                "ext-curl": "*",
+                "ext-json": "*",
+                "guzzlehttp/guzzle": "^7.2",
+                "php": "^7.3|^8.0",
+                "psr/log": "^1.0|^2.0|^3.0"
+            },
+            "require-dev": {
+                "overtrue/phplint": "^2.3",
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Pusher\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Library for interacting with the Pusher REST API",
+            "keywords": [
+                "events",
+                "messaging",
+                "php-pusher-server",
+                "publish",
+                "push",
+                "pusher",
+                "real time",
+                "real-time",
+                "realtime",
+                "rest",
+                "trigger"
+            ],
+            "support": {
+                "issues": "https://github.com/pusher/pusher-http-php/issues",
+                "source": "https://github.com/pusher/pusher-http-php/tree/7.2.8"
+            },
+            "time": "2026-05-18T13:11:36+00:00"
+        },
+        {
             "name": "ralouphie/getallheaders",
             "version": "3.0.3",
             "source": {
@@ -4046,6 +4362,595 @@
                 "source": "https://github.com/ramsey/uuid/tree/4.9.2"
             },
             "time": "2025-12-14T04:43:48+00:00"
+        },
+        {
+            "name": "ratchet/rfc6455",
+            "version": "v0.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ratchetphp/RFC6455.git",
+                "reference": "859d95f85dda0912c6d5b936d036d044e3af47ef"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ratchetphp/RFC6455/zipball/859d95f85dda0912c6d5b936d036d044e3af47ef",
+                "reference": "859d95f85dda0912c6d5b936d036d044e3af47ef",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.4",
+                "psr/http-factory-implementation": "^1.0",
+                "symfony/polyfill-php80": "^1.15"
+            },
+            "require-dev": {
+                "guzzlehttp/psr7": "^2.7",
+                "phpunit/phpunit": "^9.5",
+                "react/socket": "^1.3"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Ratchet\\RFC6455\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Matt Bonneau",
+                    "role": "Developer"
+                }
+            ],
+            "description": "RFC6455 WebSocket protocol handler",
+            "homepage": "http://socketo.me",
+            "keywords": [
+                "WebSockets",
+                "rfc6455",
+                "websocket"
+            ],
+            "support": {
+                "chat": "https://gitter.im/reactphp/reactphp",
+                "issues": "https://github.com/ratchetphp/RFC6455/issues",
+                "source": "https://github.com/ratchetphp/RFC6455/tree/v0.4.0"
+            },
+            "time": "2025-02-24T01:18:22+00:00"
+        },
+        {
+            "name": "react/cache",
+            "version": "v1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/cache.git",
+                "reference": "d47c472b64aa5608225f47965a484b75c7817d5b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/cache/zipball/d47c472b64aa5608225f47965a484b75c7817d5b",
+                "reference": "d47c472b64aa5608225f47965a484b75c7817d5b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0",
+                "react/promise": "^3.0 || ^2.0 || ^1.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5 || ^5.7 || ^4.8.35"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "React\\Cache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering",
+                    "homepage": "https://clue.engineering/"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "reactphp@ceesjankiewiet.nl",
+                    "homepage": "https://wyrihaximus.net/"
+                },
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com/"
+                },
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "homepage": "https://cboden.dev/"
+                }
+            ],
+            "description": "Async, Promise-based cache interface for ReactPHP",
+            "keywords": [
+                "cache",
+                "caching",
+                "promise",
+                "reactphp"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/cache/issues",
+                "source": "https://github.com/reactphp/cache/tree/v1.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2022-11-30T15:59:55+00:00"
+        },
+        {
+            "name": "react/dns",
+            "version": "v1.14.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/dns.git",
+                "reference": "7562c05391f42701c1fccf189c8225fece1cd7c3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/dns/zipball/7562c05391f42701c1fccf189c8225fece1cd7c3",
+                "reference": "7562c05391f42701c1fccf189c8225fece1cd7c3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0",
+                "react/cache": "^1.0 || ^0.6 || ^0.5",
+                "react/event-loop": "^1.2",
+                "react/promise": "^3.2 || ^2.7 || ^1.2.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36",
+                "react/async": "^4.3 || ^3 || ^2",
+                "react/promise-timer": "^1.11"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "React\\Dns\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering",
+                    "homepage": "https://clue.engineering/"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "reactphp@ceesjankiewiet.nl",
+                    "homepage": "https://wyrihaximus.net/"
+                },
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com/"
+                },
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "homepage": "https://cboden.dev/"
+                }
+            ],
+            "description": "Async DNS resolver for ReactPHP",
+            "keywords": [
+                "async",
+                "dns",
+                "dns-resolver",
+                "reactphp"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/dns/issues",
+                "source": "https://github.com/reactphp/dns/tree/v1.14.0"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2025-11-18T19:34:28+00:00"
+        },
+        {
+            "name": "react/event-loop",
+            "version": "v1.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/event-loop.git",
+                "reference": "ba276bda6083df7e0050fd9b33f66ad7a4ac747a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/event-loop/zipball/ba276bda6083df7e0050fd9b33f66ad7a4ac747a",
+                "reference": "ba276bda6083df7e0050fd9b33f66ad7a4ac747a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36"
+            },
+            "suggest": {
+                "ext-pcntl": "For signal handling support when using the StreamSelectLoop"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "React\\EventLoop\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering",
+                    "homepage": "https://clue.engineering/"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "reactphp@ceesjankiewiet.nl",
+                    "homepage": "https://wyrihaximus.net/"
+                },
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com/"
+                },
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "homepage": "https://cboden.dev/"
+                }
+            ],
+            "description": "ReactPHP's core reactor event loop that libraries can use for evented I/O.",
+            "keywords": [
+                "asynchronous",
+                "event-loop"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/event-loop/issues",
+                "source": "https://github.com/reactphp/event-loop/tree/v1.6.0"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2025-11-17T20:46:25+00:00"
+        },
+        {
+            "name": "react/promise",
+            "version": "v3.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/promise.git",
+                "reference": "23444f53a813a3296c1368bb104793ce8d88f04a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/promise/zipball/23444f53a813a3296c1368bb104793ce8d88f04a",
+                "reference": "23444f53a813a3296c1368bb104793ce8d88f04a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "1.12.28 || 1.4.10",
+                "phpunit/phpunit": "^9.6 || ^7.5"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions_include.php"
+                ],
+                "psr-4": {
+                    "React\\Promise\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com/"
+                },
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering",
+                    "homepage": "https://clue.engineering/"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "reactphp@ceesjankiewiet.nl",
+                    "homepage": "https://wyrihaximus.net/"
+                },
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "homepage": "https://cboden.dev/"
+                }
+            ],
+            "description": "A lightweight implementation of CommonJS Promises/A for PHP",
+            "keywords": [
+                "promise",
+                "promises"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/promise/issues",
+                "source": "https://github.com/reactphp/promise/tree/v3.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2025-08-19T18:57:03+00:00"
+        },
+        {
+            "name": "react/promise-timer",
+            "version": "v1.11.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/promise-timer.git",
+                "reference": "4f70306ed66b8b44768941ca7f142092600fafc1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/promise-timer/zipball/4f70306ed66b8b44768941ca7f142092600fafc1",
+                "reference": "4f70306ed66b8b44768941ca7f142092600fafc1",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3",
+                "react/event-loop": "^1.2",
+                "react/promise": "^3.2 || ^2.7.0 || ^1.2.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions_include.php"
+                ],
+                "psr-4": {
+                    "React\\Promise\\Timer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering",
+                    "homepage": "https://clue.engineering/"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "reactphp@ceesjankiewiet.nl",
+                    "homepage": "https://wyrihaximus.net/"
+                },
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com/"
+                },
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "homepage": "https://cboden.dev/"
+                }
+            ],
+            "description": "A trivial implementation of timeouts for Promises, built on top of ReactPHP.",
+            "homepage": "https://github.com/reactphp/promise-timer",
+            "keywords": [
+                "async",
+                "event-loop",
+                "promise",
+                "reactphp",
+                "timeout",
+                "timer"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/promise-timer/issues",
+                "source": "https://github.com/reactphp/promise-timer/tree/v1.11.0"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2024-06-04T14:27:45+00:00"
+        },
+        {
+            "name": "react/socket",
+            "version": "v1.17.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/socket.git",
+                "reference": "ef5b17b81f6f60504c539313f94f2d826c5faa08"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/socket/zipball/ef5b17b81f6f60504c539313f94f2d826c5faa08",
+                "reference": "ef5b17b81f6f60504c539313f94f2d826c5faa08",
+                "shasum": ""
+            },
+            "require": {
+                "evenement/evenement": "^3.0 || ^2.0 || ^1.0",
+                "php": ">=5.3.0",
+                "react/dns": "^1.13",
+                "react/event-loop": "^1.2",
+                "react/promise": "^3.2 || ^2.6 || ^1.2.1",
+                "react/stream": "^1.4"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36",
+                "react/async": "^4.3 || ^3.3 || ^2",
+                "react/promise-stream": "^1.4",
+                "react/promise-timer": "^1.11"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "React\\Socket\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering",
+                    "homepage": "https://clue.engineering/"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "reactphp@ceesjankiewiet.nl",
+                    "homepage": "https://wyrihaximus.net/"
+                },
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com/"
+                },
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "homepage": "https://cboden.dev/"
+                }
+            ],
+            "description": "Async, streaming plaintext TCP/IP and secure TLS socket server and client connections for ReactPHP",
+            "keywords": [
+                "Connection",
+                "Socket",
+                "async",
+                "reactphp",
+                "stream"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/socket/issues",
+                "source": "https://github.com/reactphp/socket/tree/v1.17.0"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2025-11-19T20:47:34+00:00"
+        },
+        {
+            "name": "react/stream",
+            "version": "v1.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/stream.git",
+                "reference": "1e5b0acb8fe55143b5b426817155190eb6f5b18d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/stream/zipball/1e5b0acb8fe55143b5b426817155190eb6f5b18d",
+                "reference": "1e5b0acb8fe55143b5b426817155190eb6f5b18d",
+                "shasum": ""
+            },
+            "require": {
+                "evenement/evenement": "^3.0 || ^2.0 || ^1.0",
+                "php": ">=5.3.8",
+                "react/event-loop": "^1.2"
+            },
+            "require-dev": {
+                "clue/stream-filter": "~1.2",
+                "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "React\\Stream\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering",
+                    "homepage": "https://clue.engineering/"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "reactphp@ceesjankiewiet.nl",
+                    "homepage": "https://wyrihaximus.net/"
+                },
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com/"
+                },
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "homepage": "https://cboden.dev/"
+                }
+            ],
+            "description": "Event-driven readable and writable streams for non-blocking I/O in ReactPHP",
+            "keywords": [
+                "event-driven",
+                "io",
+                "non-blocking",
+                "pipe",
+                "reactphp",
+                "readable",
+                "stream",
+                "writable"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/stream/issues",
+                "source": "https://github.com/reactphp/stream/tree/v1.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2024-06-11T12:45:25+00:00"
         },
         {
             "name": "resend/resend-laravel",

--- a/config/broadcasting.php
+++ b/config/broadcasting.php
@@ -1,0 +1,66 @@
+<?php
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Default Broadcaster
+    |--------------------------------------------------------------------------
+    |
+    | This option controls the default broadcaster that will be used by the
+    | framework when an event needs to be broadcast. Supported: "reverb",
+    | "pusher", "ably", "redis", "log", "null".
+    |
+    */
+
+    'default' => env('BROADCAST_CONNECTION', 'log'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Broadcast Connections
+    |--------------------------------------------------------------------------
+    */
+
+    'connections' => [
+
+        'reverb' => [
+            'driver' => 'reverb',
+            'key' => env('REVERB_APP_KEY'),
+            'secret' => env('REVERB_APP_SECRET'),
+            'app_id' => env('REVERB_APP_ID'),
+            'options' => [
+                'host' => env('REVERB_HOST', '127.0.0.1'),
+                'port' => env('REVERB_PORT', 8080),
+                'scheme' => env('REVERB_SCHEME', 'http'),
+                'useTLS' => env('REVERB_SCHEME', 'http') === 'https',
+            ],
+            'client_options' => [
+                // Guzzle client options
+            ],
+        ],
+
+        'pusher' => [
+            'driver' => 'pusher',
+            'key' => env('PUSHER_APP_KEY'),
+            'secret' => env('PUSHER_APP_SECRET'),
+            'app_id' => env('PUSHER_APP_ID'),
+            'options' => [
+                'cluster' => env('PUSHER_APP_CLUSTER'),
+                'host' => env('PUSHER_HOST') ?: 'api-'.env('PUSHER_APP_CLUSTER', 'mt1').'.pusher.com',
+                'port' => env('PUSHER_PORT', 443),
+                'scheme' => env('PUSHER_SCHEME', 'https'),
+                'encrypted' => true,
+                'useTLS' => env('PUSHER_SCHEME', 'https') === 'https',
+            ],
+        ],
+
+        'log' => [
+            'driver' => 'log',
+        ],
+
+        'null' => [
+            'driver' => 'null',
+        ],
+
+    ],
+
+];

--- a/config/reverb.php
+++ b/config/reverb.php
@@ -1,0 +1,102 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Default Reverb Server
+    |--------------------------------------------------------------------------
+    |
+    | This option controls the default server used by Reverb to handle
+    | incoming messages as well as broadcasting message to all your
+    | connected clients. At this time only "reverb" is supported.
+    |
+    */
+
+    'default' => env('REVERB_SERVER', 'reverb'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Reverb Servers
+    |--------------------------------------------------------------------------
+    |
+    | Here you may define details for each of the supported Reverb servers.
+    | Each server has its own configuration options that are defined in
+    | the array below. You should ensure all the options are present.
+    |
+    */
+
+    'servers' => [
+
+        'reverb' => [
+            'host' => env('REVERB_SERVER_HOST', '0.0.0.0'),
+            'port' => env('REVERB_SERVER_PORT', 8080),
+            'path' => env('REVERB_SERVER_PATH', ''),
+            'hostname' => env('REVERB_HOST'),
+            'options' => [
+                'tls' => [],
+            ],
+            'max_request_size' => env('REVERB_MAX_REQUEST_SIZE', 10_000),
+            'scaling' => [
+                'enabled' => env('REVERB_SCALING_ENABLED', false),
+                'channel' => env('REVERB_SCALING_CHANNEL', 'reverb'),
+                'server' => [
+                    'url' => env('REDIS_URL'),
+                    'host' => env('REDIS_HOST', '127.0.0.1'),
+                    'port' => env('REDIS_PORT', '6379'),
+                    'username' => env('REDIS_USERNAME'),
+                    'password' => env('REDIS_PASSWORD'),
+                    'database' => env('REDIS_DB', '0'),
+                    'timeout' => env('REDIS_TIMEOUT', 60),
+                ],
+            ],
+            'pulse_ingest_interval' => env('REVERB_PULSE_INGEST_INTERVAL', 15),
+            'telescope_ingest_interval' => env('REVERB_TELESCOPE_INGEST_INTERVAL', 15),
+        ],
+
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Reverb Applications
+    |--------------------------------------------------------------------------
+    |
+    | Here you may define how Reverb applications are managed. If you choose
+    | to use the "config" provider, you may define an array of apps which
+    | your server will support, including their connection credentials.
+    |
+    */
+
+    'apps' => [
+
+        'provider' => 'config',
+
+        'apps' => [
+            [
+                'key' => env('REVERB_APP_KEY'),
+                'secret' => env('REVERB_APP_SECRET'),
+                'app_id' => env('REVERB_APP_ID'),
+                'options' => [
+                    'host' => env('REVERB_HOST'),
+                    'port' => env('REVERB_PORT', 443),
+                    'scheme' => env('REVERB_SCHEME', 'https'),
+                    'useTLS' => env('REVERB_SCHEME', 'https') === 'https',
+                ],
+                'allowed_origins' => ['*'],
+                'ping_interval' => env('REVERB_APP_PING_INTERVAL', 60),
+                'activity_timeout' => env('REVERB_APP_ACTIVITY_TIMEOUT', 30),
+                'max_connections' => env('REVERB_APP_MAX_CONNECTIONS'),
+                'max_message_size' => env('REVERB_APP_MAX_MESSAGE_SIZE', 10_000),
+                'accept_client_events_from' => env('REVERB_APP_ACCEPT_CLIENT_EVENTS_FROM', 'members'),
+                'rate_limiting' => [
+                    'enabled' => env('REVERB_APP_RATE_LIMITING_ENABLED', false),
+                    'max_attempts' => env('REVERB_APP_RATE_LIMIT_MAX_ATTEMPTS', 60),
+                    'decay_seconds' => env('REVERB_APP_RATE_LIMIT_DECAY_SECONDS', 60),
+                    'terminate_on_limit' => env('REVERB_APP_RATE_LIMIT_TERMINATE', false),
+                ],
+            ],
+        ],
+
+    ],
+
+];

--- a/database/migrations/2026_05_24_000000_create_live_match_tables.php
+++ b/database/migrations/2026_05_24_000000_create_live_match_tables.php
@@ -1,0 +1,76 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        // A live duel doesn't belong to either user's Game; squads are
+        // snapshotted at team-pick time and the match runs entirely on those
+        // snapshots, so the session row holds everything it needs.
+        Schema::create('live_match_sessions', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->string('phase', 20)->default('lobby');
+            $table->foreignId('host_user_id')->constrained('users')->cascadeOnDelete();
+            $table->foreignId('guest_user_id')->nullable()->constrained('users')->nullOnDelete();
+            // National team UUIDs (Team::worldCupEligible) per side. No FK
+            // so the session survives team-row deletion.
+            $table->uuid('host_team_id')->nullable();
+            $table->uuid('guest_team_id')->nullable();
+            // source_game_id columns intentionally have no FK — a duel must
+            // survive deletion of either user's save.
+            $table->uuid('host_source_game_id')->nullable();
+            $table->uuid('guest_source_game_id')->nullable();
+            $table->jsonb('host_squad')->nullable();
+            $table->jsonb('guest_squad')->nullable();
+            $table->string('match_seed', 64);
+            $table->smallInteger('current_minute')->default(0);
+            $table->smallInteger('home_score')->default(0);
+            $table->smallInteger('away_score')->default(0);
+            $table->jsonb('context_state')->nullable();
+            $table->jsonb('event_log')->default('[]');
+            $table->boolean('host_bot')->default(false);
+            $table->boolean('guest_bot')->default(false);
+            $table->string('pause_reason', 30)->nullable();
+            $table->boolean('pause_acked_by_host')->default(false);
+            $table->boolean('pause_acked_by_guest')->default(false);
+            $table->timestampTz('paused_at')->nullable();
+            $table->timestampTz('finished_at')->nullable();
+            $table->integer('clock_version')->default(0);
+
+            $table->index('phase');
+            $table->index('host_user_id');
+            $table->index('guest_user_id');
+        });
+
+        // DB-side default for UUID so bulk inserts also get one.
+        DB::statement('ALTER TABLE live_match_sessions ALTER COLUMN id SET DEFAULT gen_random_uuid()');
+
+        Schema::create('live_match_actions', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->foreignUuid('session_id')->constrained('live_match_sessions')->cascadeOnDelete();
+            $table->foreignId('user_id')->constrained('users')->cascadeOnDelete();
+            $table->string('side', 5);
+            $table->string('action_type', 20);
+            $table->jsonb('payload');
+            $table->smallInteger('queued_at_minute');
+            $table->smallInteger('applied_at_minute')->nullable();
+            $table->string('status', 15)->default('queued');
+            $table->string('reject_reason', 80)->nullable();
+
+            $table->index(['session_id', 'status']);
+        });
+
+        DB::statement('ALTER TABLE live_match_actions ALTER COLUMN id SET DEFAULT gen_random_uuid()');
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('live_match_actions');
+        Schema::dropIfExists('live_match_sessions');
+    }
+};

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -5,6 +5,9 @@ services:
       target: dev
     ports:
       - "8000:8000"
+      # Reverb shares this container's network namespace (see the `reverb`
+      # service below), so its WebSocket port is published here.
+      - "8080:8080"
     env_file: .env.docker
     environment:
       APP_ENV: local
@@ -41,11 +44,17 @@ services:
       - /app/node_modules
     restart: unless-stopped
 
+  # The queue worker runs AdvanceLiveMatchWindowJob, which broadcasts live-match
+  # events. It shares the `app` container's network namespace (same as `reverb`)
+  # so its broadcaster reaches the Reverb server at localhost:8080 — matching
+  # REVERB_HOST/REVERB_PORT. Without this, `localhost` from a standalone horizon
+  # container points at itself and broadcasts silently fail to publish.
   horizon:
     build:
       context: .
       target: dev
     command: ["php", "artisan", "horizon"]
+    network_mode: "service:app"
     env_file: .env.docker
     environment:
       APP_ENV: local
@@ -58,10 +67,42 @@ services:
       DB_SSLMODE: disable
       REDIS_HOST: redis
     depends_on:
+      app:
+        condition: service_started
       postgres:
         condition: service_healthy
       redis:
         condition: service_healthy
+    volumes:
+      - .:/app
+      - /app/vendor
+      - /app/node_modules
+    restart: unless-stopped
+
+  # Reverb WebSocket server. It shares the `app` container's network namespace
+  # so the browser and the PHP broadcaster both reach it at localhost:8080 —
+  # matching REVERB_HOST/REVERB_PORT in .env. The published 8080 port lives on
+  # the `app` service (a service using `network_mode: service:*` cannot declare
+  # its own ports).
+  reverb:
+    build:
+      context: .
+      target: dev
+    command: ["php", "artisan", "reverb:start", "--host=0.0.0.0", "--port=8080"]
+    network_mode: "service:app"
+    env_file: .env.docker
+    environment:
+      APP_ENV: local
+      APP_DEBUG: "true"
+      DB_HOST: postgres
+      DB_PORT: 5432
+      DB_DATABASE: virtua_fc
+      DB_USERNAME: virtua_fc
+      DB_PASSWORD: password
+      DB_SSLMODE: disable
+      REDIS_HOST: redis
+    depends_on:
+      - app
     volumes:
       - .:/app
       - /app/vendor

--- a/lang/en/live_duel.php
+++ b/lang/en/live_duel.php
@@ -1,0 +1,57 @@
+<?php
+
+return [
+    // Entry / lobby
+    'title' => 'Live Duel',
+    'pick_team' => 'Pick a national team',
+    'host_pick_prompt' => 'Choose your national team to create a duel. You\'ll get a link to share with a friend.',
+    'guest_pick_prompt' => 'Choose your national team. :host has already picked.',
+    'eligible_count' => ':count eligible',
+    'create_duel' => 'Create duel',
+    'join_duel' => 'Join duel',
+    'unknown_nation' => 'Unknown nation.',
+    'team_already_picked' => 'Your opponent already picked that team.',
+    'taken' => 'Taken',
+
+    // Lobby
+    'waiting_for_opponent' => 'Waiting for opponent…',
+    'share_link' => 'Share this link with a friend:',
+    'copy_link' => 'Copy link',
+    'link_copied' => 'Link copied!',
+    'opponent_choosing_team' => ':name is choosing a team…',
+    'waiting_for_kickoff' => 'Waiting for kickoff…',
+
+    // Match full
+    'match_full' => 'Match full',
+    'match_full_description' => 'This duel already has two players. You can start your own duel instead.',
+
+    // Live match
+    'kickoff' => 'Kickoff!',
+    'halftime' => 'Halftime',
+    'fulltime' => 'Full time',
+    'goal' => 'Goal',
+    'yellow_card' => 'Yellow card',
+    'red_card' => 'Red card',
+    'injury' => 'Injury',
+    'substitution' => 'Substitution',
+    'pause_reason_goal' => 'Goal!',
+    'pause_reason_red_card' => 'Red card',
+    'pause_reason_injury' => 'Injury',
+    'pause_reason_halftime' => 'Halftime',
+    'continue' => 'Continue',
+    'opponent_ready' => 'Opponent ready',
+    'waiting_opponent_ack' => 'Waiting for opponent to acknowledge…',
+    'sub' => 'Substitution',
+    'queue_sub' => 'Queue substitution',
+    'pick_player_out' => 'Player to come off',
+    'pick_player_in' => 'Player to come on',
+    'subs_remaining' => ':count subs remaining',
+    'bot_takeover' => ':name went bot — match continues with AI subs.',
+    'opponent_preparing_sub' => 'Opponent is preparing a substitution…',
+    'final_score' => 'Final score',
+    'connecting' => 'Connecting…',
+    'realtime_unavailable' => 'Real-time updates are unavailable. Reload the page if the match looks stalled.',
+
+    // Errors
+    'no_active_game' => 'You need an active save game to create a duel.',
+];

--- a/lang/es/live_duel.php
+++ b/lang/es/live_duel.php
@@ -1,0 +1,57 @@
+<?php
+
+return [
+    // Entry / lobby
+    'title' => 'Duelo en directo',
+    'pick_team' => 'Elige una selección nacional',
+    'host_pick_prompt' => 'Elige tu selección para crear un duelo. Recibirás un enlace para compartir con un amigo.',
+    'guest_pick_prompt' => 'Elige tu selección. :host ya ha elegido.',
+    'eligible_count' => ':count elegibles',
+    'create_duel' => 'Crear duelo',
+    'join_duel' => 'Unirse al duelo',
+    'unknown_nation' => 'Nación desconocida.',
+    'team_already_picked' => 'Tu rival ya eligió esa selección.',
+    'taken' => 'Elegido',
+
+    // Lobby
+    'waiting_for_opponent' => 'Esperando al rival…',
+    'share_link' => 'Comparte este enlace con un amigo:',
+    'copy_link' => 'Copiar enlace',
+    'link_copied' => '¡Enlace copiado!',
+    'opponent_choosing_team' => ':name está eligiendo selección…',
+    'waiting_for_kickoff' => 'Esperando el saque inicial…',
+
+    // Match full
+    'match_full' => 'Partido completo',
+    'match_full_description' => 'Este duelo ya tiene dos jugadores. Puedes empezar tu propio duelo.',
+
+    // Live match
+    'kickoff' => '¡Comienza el partido!',
+    'halftime' => 'Descanso',
+    'fulltime' => 'Final del partido',
+    'goal' => 'Gol',
+    'yellow_card' => 'Tarjeta amarilla',
+    'red_card' => 'Tarjeta roja',
+    'injury' => 'Lesión',
+    'substitution' => 'Cambio',
+    'pause_reason_goal' => '¡Gol!',
+    'pause_reason_red_card' => 'Tarjeta roja',
+    'pause_reason_injury' => 'Lesión',
+    'pause_reason_halftime' => 'Descanso',
+    'continue' => 'Continuar',
+    'opponent_ready' => 'Rival listo',
+    'waiting_opponent_ack' => 'Esperando que el rival confirme…',
+    'sub' => 'Cambio',
+    'queue_sub' => 'Programar cambio',
+    'pick_player_out' => 'Jugador que sale',
+    'pick_player_in' => 'Jugador que entra',
+    'subs_remaining' => ':count cambios disponibles',
+    'bot_takeover' => ':name pasó a IA — el partido continúa con cambios automáticos.',
+    'opponent_preparing_sub' => 'El rival está preparando un cambio…',
+    'final_score' => 'Marcador final',
+    'connecting' => 'Conectando…',
+    'realtime_unavailable' => 'Las actualizaciones en tiempo real no están disponibles. Recarga la página si el partido parece estancado.',
+
+    // Errors
+    'no_active_game' => 'Necesitas una partida activa para crear un duelo.',
+];

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "virtua-fc",
+    "name": "app",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
@@ -15,8 +15,10 @@
                 "alpinejs": "^3.4.2",
                 "axios": "^1.7.4",
                 "concurrently": "^9.0.1",
+                "laravel-echo": "^2.3.4",
                 "laravel-vite-plugin": "^2.0.0",
                 "playwright": "^1.58.2",
+                "pusher-js": "^8.5.0",
                 "tailwindcss": "^4.2.1",
                 "vite": "7.1.11",
                 "vitest": "^4.1.4"
@@ -887,6 +889,14 @@
                 "tippy.js": "^6.3.1"
             }
         },
+        "node_modules/@socket.io/component-emitter": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
+            "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
         "node_modules/@standard-schema/spec": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -1129,6 +1139,70 @@
             "engines": {
                 "node": ">=14.0.0"
             }
+        },
+        "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+            "version": "1.8.1",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@emnapi/wasi-threads": "1.1.0",
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+            "version": "1.8.1",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+            "version": "1.1.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+            "version": "1.1.1",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@emnapi/core": "^1.7.1",
+                "@emnapi/runtime": "^1.7.1",
+                "@tybys/wasm-util": "^0.10.1"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Brooooooklyn"
+            }
+        },
+        "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+            "version": "0.10.1",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+            "version": "2.8.1",
+            "dev": true,
+            "inBundle": true,
+            "license": "0BSD",
+            "optional": true
         },
         "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
             "version": "4.2.1",
@@ -1611,6 +1685,25 @@
                 "node": ">=4"
             }
         },
+        "node_modules/debug": {
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+            "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "ms": "^2.1.3"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/delayed-stream": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -1644,6 +1737,32 @@
             },
             "engines": {
                 "node": ">= 0.4"
+            }
+        },
+        "node_modules/engine.io-client": {
+            "version": "6.6.5",
+            "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.5.tgz",
+            "integrity": "sha512-QCwxUDULPlXv8F6tqMMKx5dNkTe6OaBYRMPYeXKBlyOoKvAmE0ac6pW7fFhSscJ/5SI7666/U/B+MElbsrJlIg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@socket.io/component-emitter": "~3.1.0",
+                "debug": "~4.4.1",
+                "engine.io-parser": "~5.2.1",
+                "ws": "~8.20.1",
+                "xmlhttprequest-ssl": "~2.1.1"
+            }
+        },
+        "node_modules/engine.io-parser": {
+            "version": "5.2.3",
+            "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
+            "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=10.0.0"
             }
         },
         "node_modules/enhanced-resolve": {
@@ -1983,6 +2102,20 @@
             "license": "MIT",
             "bin": {
                 "jiti": "lib/jiti-cli.mjs"
+            }
+        },
+        "node_modules/laravel-echo": {
+            "version": "2.3.4",
+            "resolved": "https://registry.npmjs.org/laravel-echo/-/laravel-echo-2.3.4.tgz",
+            "integrity": "sha512-rpALCIK1uw2SrttcK9P5JzItt5I85RcfXQKUNnkcorzhtKeXi5GS0PVFFBH8ppNo8wnbdBKuD1EtIHgTbXo9FQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=20"
+            },
+            "peerDependencies": {
+                "pusher-js": "*",
+                "socket.io-client": "*"
             }
         },
         "node_modules/laravel-vite-plugin": {
@@ -2325,6 +2458,14 @@
                 "mini-svg-data-uri": "cli.js"
             }
         },
+        "node_modules/ms": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
         "node_modules/nanoid": {
             "version": "3.3.11",
             "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -2462,6 +2603,16 @@
             "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
             "dev": true
         },
+        "node_modules/pusher-js": {
+            "version": "8.5.0",
+            "resolved": "https://registry.npmjs.org/pusher-js/-/pusher-js-8.5.0.tgz",
+            "integrity": "sha512-V7uzGi9bqOOOyM/6IkJdpFyjGZj7llz1v0oWnYkZKcYLvbz6VcHVLmzKqkvegjuMumpfIEKGLmWHwFb39XFCpw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tweetnacl": "^1.0.3"
+            }
+        },
         "node_modules/require-directory": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -2540,6 +2691,38 @@
             "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
             "dev": true,
             "license": "ISC"
+        },
+        "node_modules/socket.io-client": {
+            "version": "4.8.3",
+            "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.3.tgz",
+            "integrity": "sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@socket.io/component-emitter": "~3.1.0",
+                "debug": "~4.4.1",
+                "engine.io-client": "~6.6.1",
+                "socket.io-parser": "~4.2.4"
+            },
+            "engines": {
+                "node": ">=10.0.0"
+            }
+        },
+        "node_modules/socket.io-parser": {
+            "version": "4.2.6",
+            "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.6.tgz",
+            "integrity": "sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@socket.io/component-emitter": "~3.1.0",
+                "debug": "~4.4.1"
+            },
+            "engines": {
+                "node": ">=10.0.0"
+            }
         },
         "node_modules/source-map-js": {
             "version": "1.2.1",
@@ -2697,6 +2880,13 @@
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
             "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
             "dev": true
+        },
+        "node_modules/tweetnacl": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+            "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
+            "dev": true,
+            "license": "Unlicense"
         },
         "node_modules/util-deprecate": {
             "version": "1.0.2",
@@ -2938,6 +3128,39 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/ws": {
+            "version": "8.20.1",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+            "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=10.0.0"
+            },
+            "peerDependencies": {
+                "bufferutil": "^4.0.1",
+                "utf-8-validate": ">=5.0.2"
+            },
+            "peerDependenciesMeta": {
+                "bufferutil": {
+                    "optional": true
+                },
+                "utf-8-validate": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/xmlhttprequest-ssl": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.2.tgz",
+            "integrity": "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==",
+            "dev": true,
+            "peer": true,
+            "engines": {
+                "node": ">=0.4.0"
             }
         },
         "node_modules/y18n": {

--- a/package.json
+++ b/package.json
@@ -14,8 +14,10 @@
         "alpinejs": "^3.4.2",
         "axios": "^1.7.4",
         "concurrently": "^9.0.1",
+        "laravel-echo": "^2.3.4",
         "laravel-vite-plugin": "^2.0.0",
         "playwright": "^1.58.2",
+        "pusher-js": "^8.5.0",
         "tailwindcss": "^4.2.1",
         "vite": "7.1.11",
         "vitest": "^4.1.4"

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -13,6 +13,8 @@ import seasonSummary from './season-summary';
 import squadRegistration from './squad-registration';
 import explore from './explore';
 import seasonTicketEditor from './season-ticket-editor';
+import liveDuel from './live-duel';
+import liveDuelLobby from './live-duel-lobby';
 
 Alpine.plugin(Collapse);
 Alpine.plugin(Tooltip);
@@ -32,6 +34,8 @@ Alpine.data('tournamentSummary', tournamentSummary);
 Alpine.data('seasonSummary', seasonSummary);
 Alpine.data('explore', explore);
 Alpine.data('seasonTicketEditor', seasonTicketEditor);
+Alpine.data('liveDuel', liveDuel);
+Alpine.data('liveDuelLobby', liveDuelLobby);
 
 window.Alpine = Alpine;
 

--- a/resources/js/echo.js
+++ b/resources/js/echo.js
@@ -1,0 +1,40 @@
+/**
+ * Build an Echo instance configured for Laravel Reverb.
+ *
+ * `laravel-echo` and `pusher-js` are bundled through Vite (installed as npm
+ * deps by `php artisan install:broadcasting`). Pusher is exposed on `window`
+ * because Echo's reverb broadcaster resolves its client from `window.Pusher`.
+ *
+ * Each live-duel view builds its own Echo from server-injected Reverb config
+ * (key/host/port/scheme), so this is a factory rather than a shared
+ * singleton. Returns null when the Reverb key isn't configured — the page
+ * still renders, only real-time push is disabled.
+ */
+import Echo from 'laravel-echo';
+import Pusher from 'pusher-js';
+
+window.Pusher = Pusher;
+
+export function createEcho({ key, host, port, scheme }) {
+    if (!key) {
+        console.warn('[live-duel] Reverb key missing; skipping Echo wiring.');
+        return null;
+    }
+
+    // Pick the right default per scheme so a single REVERB_PORT (e.g. 8080)
+    // doesn't get used for both wss and ws ports unrelated to the configured
+    // scheme.
+    const isHttps = scheme === 'https';
+    const defaultPort = isHttps ? 443 : 80;
+    const effectivePort = port ?? defaultPort;
+
+    return new Echo({
+        broadcaster: 'reverb',
+        key,
+        wsHost: host ?? window.location.hostname,
+        wsPort: isHttps ? 80 : effectivePort,
+        wssPort: isHttps ? effectivePort : 443,
+        forceTLS: isHttps,
+        enabledTransports: ['ws', 'wss'],
+    });
+}

--- a/resources/js/live-duel-lobby.js
+++ b/resources/js/live-duel-lobby.js
@@ -1,0 +1,67 @@
+import { createEcho } from './echo';
+
+/**
+ * Lobby Alpine component for the live duel.
+ *
+ * Subscribes to the session's presence channel and listens for two events:
+ *  - match.guest_joined  → reload (guest needs to be redirected to picker)
+ *  - match.team_picked   → reload when both teams are now picked (kickoff)
+ *  - match.started       → reload to render the live match view
+ *
+ * Keep this dead simple — the lobby has very few states and full-page
+ * reloads on transitions avoid SPA-style state-management churn.
+ */
+export default function liveDuelLobby(config) {
+    return {
+        ...config,
+        copied: false,
+        echo: null,
+        channel: null,
+
+        async init() {
+            this.echo = await createEcho({
+                key: this.reverbKey,
+                host: this.reverbHost,
+                port: this.reverbPort ? Number(this.reverbPort) : undefined,
+                scheme: this.reverbScheme,
+            });
+            if (!this.echo) {
+                return;
+            }
+
+            this.channel = this.echo.join(`live-match.${this.sessionId}`);
+
+            this.channel
+                .listen('.match.guest_joined', () => {
+                    window.location.reload();
+                })
+                .listen('.match.team_picked', (payload) => {
+                    if (payload.both_picked) {
+                        // Kickoff is imminent; the next match.started broadcast
+                        // will land in a moment and we'll reload from that.
+                    } else {
+                        window.location.reload();
+                    }
+                })
+                .listen('.match.started', () => {
+                    window.location.reload();
+                });
+        },
+
+        async copyShareUrl() {
+            try {
+                await navigator.clipboard.writeText(this.shareUrl);
+            } catch (e) {
+                // Fallback for older browsers
+                const tmp = document.createElement('input');
+                tmp.value = this.shareUrl;
+                document.body.appendChild(tmp);
+                tmp.select();
+                document.execCommand('copy');
+                document.body.removeChild(tmp);
+            }
+            this.copied = true;
+            setTimeout(() => { this.copied = false; }, 2000);
+        },
+    };
+}

--- a/resources/js/live-duel.js
+++ b/resources/js/live-duel.js
@@ -1,0 +1,315 @@
+import { createEcho } from './echo';
+
+/**
+ * Live duel Alpine component.
+ *
+ * Subscribes to the session's presence channel and renders match state from
+ * server-pushed events. Local clock interpolation between server ticks keeps
+ * the minute counter feeling continuous; goals/cards/halftime arrive as
+ * pause broadcasts.
+ */
+export default function liveDuel(config) {
+    return {
+        // Static config
+        sessionId: config.sessionId,
+        viewerRole: config.viewerRole, // 'host' | 'guest'
+        viewerSide: config.viewerSide, // 'home' | 'away'
+        csrfToken: config.csrfToken,
+        reverbKey: config.reverbKey,
+        reverbHost: config.reverbHost,
+        reverbPort: config.reverbPort,
+        reverbScheme: config.reverbScheme,
+        labels: config.labels,
+
+        // Reactive state
+        phase: config.initial.phase,
+        homeScore: config.initial.homeScore,
+        awayScore: config.initial.awayScore,
+        currentMinute: config.initial.currentMinute,
+        displayMinute: config.initial.currentMinute,
+        pauseReason: config.initial.pauseReason,
+        hostBot: config.initial.hostBot,
+        guestBot: config.initial.guestBot,
+        events: [],
+        myAcked: false,
+        opponentPreparingSub: false,
+        opponentSubTimer: null,
+        connected: false,
+        realtimeDisabled: false,
+
+        // Squads
+        hostSquad: config.initial.hostSquad || {},
+        guestSquad: config.initial.guestSquad || {},
+        contextOnPitch: { home: [], away: [], homeBench: [], awayBench: [] },
+
+        // Sub modal
+        subModalOpen: false,
+        subPlayerOut: '',
+        subPlayerIn: '',
+        subError: '',
+        subsUsed: 0,
+
+        echo: null,
+        channel: null,
+        clockTimer: null,
+
+        async init() {
+            this.seedFromEventLog(config.initial.eventLog || []);
+            this.computeOnPitchFromSquads();
+            this.startClockInterpolation();
+
+            this.echo = await createEcho({
+                key: this.reverbKey,
+                host: this.reverbHost,
+                port: this.reverbPort ? Number(this.reverbPort) : undefined,
+                scheme: this.reverbScheme,
+            });
+
+            if (!this.echo) {
+                this.realtimeDisabled = true;
+                return;
+            }
+
+            this.channel = this.echo.join(`live-match.${this.sessionId}`);
+
+            this.channel
+                .here(() => { this.connected = true; })
+                .joining(() => { this.connected = true; })
+                .leaving(() => {})
+                .listen('.match.started', (e) => {
+                    this.phase = 'live';
+                    this.currentMinute = e.current_minute ?? 0;
+                    this.displayMinute = this.clampMinute(this.currentMinute);
+                })
+                .listen('.match.event', (e) => {
+                    this.homeScore = e.home_score;
+                    this.awayScore = e.away_score;
+                    this.currentMinute = e.current_minute ?? this.currentMinute;
+                    this.displayMinute = this.clampMinute(this.currentMinute);
+                    this.appendEvent(e.event);
+                })
+                .listen('.match.paused', (e) => {
+                    this.phase = 'paused';
+                    this.pauseReason = e.pause_reason;
+                    this.myAcked = false;
+                })
+                .listen('.match.resumed', (e) => {
+                    this.phase = 'live';
+                    this.pauseReason = null;
+                    this.myAcked = false;
+                    this.currentMinute = e.current_minute ?? this.currentMinute;
+                    this.displayMinute = this.clampMinute(this.currentMinute);
+                })
+                .listen('.match.ended', (e) => {
+                    this.phase = 'finished';
+                    this.homeScore = e.home_score;
+                    this.awayScore = e.away_score;
+                    this.stopClockInterpolation();
+                })
+                .listen('.match.bot_takeover', (e) => {
+                    if (e.side === 'home') this.hostBot = true;
+                    else this.guestBot = true;
+                })
+                .listen('.match.action_queued', (e) => {
+                    if (e.side !== this.viewerSide) {
+                        this.opponentPreparingSub = true;
+                        if (this.opponentSubTimer) clearTimeout(this.opponentSubTimer);
+                        this.opponentSubTimer = setTimeout(() => {
+                            this.opponentPreparingSub = false;
+                            this.opponentSubTimer = null;
+                        }, 4000);
+                    }
+                });
+        },
+
+        clampMinute(value) {
+            // Hard ceiling for the displayed clock — regular time runs to 93;
+            // an event after that should still display, but the interpolator
+            // can't tick past it.
+            return Math.min(Math.max(value, 0), 120);
+        },
+
+        seedFromEventLog(log) {
+            this.events = log.map((entry, idx) => ({
+                id: `${entry.minute}-${idx}-${entry.type}`,
+                minute: entry.minute,
+                type: entry.type,
+                side: entry.side,
+                team_id: entry.team_id,
+                game_player_id: entry.game_player_id,
+                metadata: entry.metadata,
+            }));
+            // Count subs used on viewer's side.
+            this.subsUsed = log.filter((e) => e.type === 'substitution' && e.side === this.viewerSide).length;
+        },
+
+        appendEvent(event) {
+            this.events.push({
+                id: `${event.minute}-${this.events.length}-${event.type}`,
+                ...event,
+            });
+            if (event.type === 'substitution' && event.side === this.viewerSide) {
+                this.subsUsed += 1;
+            }
+            this.recomputeOnPitchFromEvents();
+        },
+
+        computeOnPitchFromSquads() {
+            this.contextOnPitch = {
+                home: this.hostSquad.starting_xi || [],
+                away: this.guestSquad.starting_xi || [],
+                homeBench: this.hostSquad.bench || [],
+                awayBench: this.guestSquad.bench || [],
+            };
+            this.applySubsFromEvents();
+        },
+
+        recomputeOnPitchFromEvents() {
+            this.computeOnPitchFromSquads();
+        },
+
+        applySubsFromEvents() {
+            for (const event of this.events) {
+                if (event.type !== 'substitution') continue;
+                const out = event.game_player_id;
+                const inId = event.metadata?.player_in_id;
+                if (!out || !inId) continue;
+                const sideKey = event.side === 'home' ? 'home' : 'away';
+                const benchKey = sideKey === 'home' ? 'homeBench' : 'awayBench';
+                const onPitch = this.contextOnPitch[sideKey];
+                const bench = this.contextOnPitch[benchKey];
+                const subIn = bench.find((p) => p.id === inId);
+                if (!subIn) continue;
+                const idx = onPitch.findIndex((p) => p.id === out);
+                if (idx === -1) continue;
+                onPitch[idx] = subIn;
+                this.contextOnPitch[benchKey] = bench.filter((p) => p.id !== inId);
+            }
+        },
+
+        get myOnPitch() {
+            return this.viewerSide === 'home' ? this.contextOnPitch.home : this.contextOnPitch.away;
+        },
+
+        get myBench() {
+            return this.viewerSide === 'home' ? this.contextOnPitch.homeBench : this.contextOnPitch.awayBench;
+        },
+
+        eventIcon(type) {
+            return {
+                goal: '⚽',
+                own_goal: '⚽',
+                yellow_card: '🟨',
+                red_card: '🟥',
+                injury: '🚑',
+                substitution: '🔄',
+                penalty_missed: '❌',
+                assist: '🅰️',
+            }[type] || '·';
+        },
+
+        eventLabel(event) {
+            const label = {
+                goal: 'Goal',
+                own_goal: 'Own goal',
+                yellow_card: 'Yellow card',
+                red_card: 'Red card',
+                injury: 'Injury',
+                substitution: 'Substitution',
+                penalty_missed: 'Penalty missed',
+                assist: 'Assist',
+            }[event.type] || event.type;
+            const side = event.side === 'home' ? '🟦' : '🟥';
+            return `${side} ${label}`;
+        },
+
+        pauseLabel() {
+            return {
+                goal: this.labels.pauseReasonGoal,
+                red_card: this.labels.pauseReasonRedCard,
+                injury: this.labels.pauseReasonInjury,
+                halftime: this.labels.pauseReasonHalftime,
+            }[this.pauseReason] || '';
+        },
+
+        pauseIcon() {
+            return {
+                goal: '⚽',
+                red_card: '🟥',
+                injury: '🚑',
+                halftime: '⏸️',
+            }[this.pauseReason] || '⏸️';
+        },
+
+        startClockInterpolation() {
+            // Approximate sim-minute progression between server pushes.
+            // 1 real second ≈ 1.5 sim-minutes (matches WINDOW_DELAY_SECONDS).
+            this.clockTimer = setInterval(() => {
+                if (this.phase !== 'live') return;
+                if (this.displayMinute < 93) {
+                    this.displayMinute = Math.min(this.displayMinute + 0.25, 93);
+                }
+            }, 250);
+        },
+
+        stopClockInterpolation() {
+            if (this.clockTimer) {
+                clearInterval(this.clockTimer);
+                this.clockTimer = null;
+            }
+        },
+
+        openSubModal() {
+            this.subPlayerOut = '';
+            this.subPlayerIn = '';
+            this.subError = '';
+            this.subModalOpen = true;
+        },
+
+        async confirmSub() {
+            this.subError = '';
+            try {
+                const res = await fetch(`/live/duel/${this.sessionId}/actions`, {
+                    method: 'POST',
+                    credentials: 'same-origin',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'X-CSRF-TOKEN': this.csrfToken,
+                        'Accept': 'application/json',
+                        'X-Requested-With': 'XMLHttpRequest',
+                    },
+                    body: JSON.stringify({
+                        type: 'sub',
+                        payload: { player_out_id: this.subPlayerOut, player_in_id: this.subPlayerIn },
+                    }),
+                });
+                if (!res.ok) {
+                    const body = await res.json().catch(() => ({}));
+                    this.subError = body.error || `HTTP ${res.status}`;
+                    return;
+                }
+                this.subModalOpen = false;
+            } catch (e) {
+                this.subError = e.message || 'Request failed';
+            }
+        },
+
+        async ackPause() {
+            if (this.myAcked) return;
+            this.myAcked = true;
+            try {
+                await fetch(`/live/duel/${this.sessionId}/ack`, {
+                    method: 'POST',
+                    credentials: 'same-origin',
+                    headers: {
+                        'X-CSRF-TOKEN': this.csrfToken,
+                        'Accept': 'application/json',
+                        'X-Requested-With': 'XMLHttpRequest',
+                    },
+                });
+            } catch (e) {
+                this.myAcked = false;
+            }
+        },
+    };
+}

--- a/resources/views/live/duel/entry.blade.php
+++ b/resources/views/live/duel/entry.blade.php
@@ -1,0 +1,57 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h1 class="text-2xl md:text-3xl font-bold text-text-primary">{{ __('live_duel.title') }}</h1>
+        <p class="text-text-muted mt-1">
+            @if ($role === 'host')
+                {{ __('live_duel.host_pick_prompt') }}
+            @else
+                {{ __('live_duel.guest_pick_prompt', ['host' => $session->host->name ?? '']) }}
+            @endif
+        </p>
+    </x-slot>
+
+    <div class="max-w-5xl mx-auto p-4 md:p-6">
+        @if ($errors->any())
+            <div class="mb-4 p-4 bg-accent-red/10 border border-accent-red/30 rounded-lg text-text-primary">
+                {{ $errors->first() }}
+            </div>
+        @endif
+
+        <form
+            method="POST"
+            action="{{ $role === 'host' ? route('live.duel.create') : route('live.duel.pick-team', ['session' => $session->id]) }}"
+            class="space-y-4"
+        >
+            @csrf
+            <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3">
+                @foreach ($teams as $team)
+                    @php
+                        $count = $eligibility[$team->id] ?? 0;
+                        $taken = $takenTeamId === $team->id;
+                        $disabled = $taken || $count < \App\Modules\LiveMatch\Services\NationalSquadBuilder::MIN_FOR_VIABLE_SQUAD;
+                    @endphp
+                    <button
+                        type="submit"
+                        name="team_id"
+                        value="{{ $team->id }}"
+                        @if ($disabled) disabled @endif
+                        class="group flex flex-col items-center justify-center gap-2 p-4 rounded-xl border transition-all
+                            {{ $disabled
+                                ? 'bg-surface-800 border-border-default opacity-50 cursor-not-allowed'
+                                : 'bg-surface-700 border-border-default hover:border-accent-blue hover:bg-accent-blue/10 cursor-pointer' }}"
+                    >
+                        @if ($team->image)
+                            <img src="{{ $team->image }}" alt="{{ $team->name }}" class="w-12 h-12 object-contain" />
+                        @else
+                            <div class="text-3xl">⚽</div>
+                        @endif
+                        <div class="font-semibold text-text-primary">{{ $team->name }}</div>
+                        @if ($taken)
+                            <div class="text-xs text-text-muted">{{ __('live_duel.taken') }}</div>
+                        @endif
+                    </button>
+                @endforeach
+            </div>
+        </form>
+    </div>
+</x-app-layout>

--- a/resources/views/live/duel/full.blade.php
+++ b/resources/views/live/duel/full.blade.php
@@ -1,0 +1,17 @@
+<x-app-layout>
+    <div class="max-w-2xl mx-auto p-6 md:p-10">
+        <div class="bg-surface-800 border border-border-default rounded-2xl p-8 text-center">
+            <div class="text-6xl mb-4">🚫</div>
+            <h1 class="text-2xl font-bold text-text-primary mb-2">{{ __('live_duel.match_full') }}</h1>
+            <p class="text-text-muted mb-6">
+                {{ $reason ?? __('live_duel.match_full_description') }}
+            </p>
+            <a
+                href="{{ route('live.duel.entry') }}"
+                class="inline-block px-6 py-3 bg-accent-blue text-white rounded-lg font-semibold hover:bg-accent-blue/80 transition"
+            >
+                {{ __('live_duel.create_duel') }}
+            </a>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/live/duel/lobby.blade.php
+++ b/resources/views/live/duel/lobby.blade.php
@@ -1,0 +1,76 @@
+<x-app-layout>
+    {{-- Echo + Pusher are bundled through Vite (see show.blade.php). --}}
+    @php
+        $hostTeam = $session->host_team_id ? \App\Models\Team::find($session->host_team_id) : null;
+        $guestTeam = $session->guest_team_id ? \App\Models\Team::find($session->guest_team_id) : null;
+        $waitingForGuest = $viewerRole === 'host' && $session->guest_team_id === null;
+        $opponentChoosing = $viewerRole === 'host' && $session->guest_team_id !== null;
+        $waitingForKickoff = $viewerRole === 'guest' && $session->guest_team_id !== null;
+    @endphp
+
+    <div
+        x-data="liveDuelLobby({
+            sessionId: @js($session->id),
+            viewerRole: @js($viewerRole),
+            shareUrl: @js(url()->current()),
+            reverbKey: @js($reverbKey),
+            reverbHost: @js($reverbHost),
+            reverbPort: @js($reverbPort),
+            reverbScheme: @js($reverbScheme),
+        })"
+        class="max-w-3xl mx-auto p-6 md:p-10"
+    >
+        <div class="bg-surface-800 border border-border-default rounded-2xl p-6 md:p-10 text-center">
+            <h1 class="text-2xl md:text-3xl font-bold text-text-primary mb-6">
+                {{ __('live_duel.title') }}
+            </h1>
+
+            @if ($waitingForGuest && $hostTeam)
+                <div class="space-y-6">
+                    <p class="text-text-muted">{{ __('live_duel.waiting_for_opponent') }}</p>
+                    @if ($hostTeam->image)
+                        <img src="{{ $hostTeam->image }}" alt="{{ $hostTeam->name }}" class="w-24 h-24 mx-auto object-contain" />
+                    @endif
+                    <p class="text-text-primary font-semibold text-lg">{{ $hostTeam->name }}</p>
+
+                    <div class="pt-6 border-t border-border-default text-left">
+                        <p class="text-sm text-text-muted mb-2">{{ __('live_duel.share_link') }}</p>
+                        <div class="flex gap-2">
+                            <input
+                                type="text"
+                                readonly
+                                value="{{ url()->current() }}"
+                                class="flex-1 px-3 py-2 bg-surface-700 border border-border-default rounded-lg text-sm text-text-primary"
+                                @click="$event.target.select()"
+                            >
+                            <button
+                                type="button"
+                                @click="copyShareUrl"
+                                class="px-4 py-2 bg-accent-blue text-white rounded-lg font-semibold hover:bg-accent-blue/80 transition whitespace-nowrap"
+                                x-text="copied ? @js(__('live_duel.link_copied')) : @js(__('live_duel.copy_link'))"
+                            ></button>
+                        </div>
+                    </div>
+                </div>
+            @elseif ($opponentChoosing)
+                <div class="space-y-4">
+                    <p class="text-text-muted">
+                        {{ __('live_duel.opponent_choosing_team', ['name' => $session->guest->name ?? 'Opponent']) }}
+                    </p>
+                    <div class="text-3xl animate-pulse">⚽</div>
+                </div>
+            @elseif ($waitingForKickoff && $guestTeam)
+                <div class="space-y-4">
+                    <p class="text-text-muted">{{ __('live_duel.waiting_for_kickoff') }}</p>
+                    @if ($guestTeam->image)
+                        <img src="{{ $guestTeam->image }}" alt="{{ $guestTeam->name }}" class="w-24 h-24 mx-auto object-contain" />
+                    @endif
+                    <p class="text-text-primary font-semibold text-lg">{{ $guestTeam->name }}</p>
+                    <div class="text-3xl animate-pulse">⚽</div>
+                </div>
+            @else
+                <p class="text-text-muted">{{ __('live_duel.connecting') }}</p>
+            @endif
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/live/duel/show.blade.php
+++ b/resources/views/live/duel/show.blade.php
@@ -1,0 +1,229 @@
+<x-app-layout>
+    {{-- Echo + Pusher are bundled through Vite (app.js → live-duel.js → echo.js),
+         so no CDN script tags are needed here. --}}
+    @php
+        $hostTeam = $session->host_team_id ? \App\Models\Team::find($session->host_team_id) : null;
+        $guestTeam = $session->guest_team_id ? \App\Models\Team::find($session->guest_team_id) : null;
+    @endphp
+
+    <div
+        x-data="liveDuel({
+            sessionId: @js($session->id),
+            viewerRole: @js($viewerRole),
+            viewerSide: @js($viewerSide),
+            csrfToken: @js(csrf_token()),
+            reverbKey: @js($reverbKey),
+            reverbHost: @js($reverbHost),
+            reverbPort: @js($reverbPort),
+            reverbScheme: @js($reverbScheme),
+            initial: {
+                phase: @js($session->phase->value),
+                homeScore: @js($session->home_score),
+                awayScore: @js($session->away_score),
+                currentMinute: @js($session->current_minute),
+                pauseReason: @js($session->pause_reason),
+                hostBot: @js($session->host_bot),
+                guestBot: @js($session->guest_bot),
+                eventLog: @js($session->event_log ?? []),
+                hostSquad: @js($session->host_squad ?? []),
+                guestSquad: @js($session->guest_squad ?? []),
+            },
+            labels: {
+                pauseReasonGoal: @js(__('live_duel.pause_reason_goal')),
+                pauseReasonRedCard: @js(__('live_duel.pause_reason_red_card')),
+                pauseReasonInjury: @js(__('live_duel.pause_reason_injury')),
+                pauseReasonHalftime: @js(__('live_duel.pause_reason_halftime')),
+                fulltime: @js(__('live_duel.fulltime')),
+                continue: @js(__('live_duel.continue')),
+                opponentReady: @js(__('live_duel.opponent_ready')),
+                waitingOpponentAck: @js(__('live_duel.waiting_opponent_ack')),
+                queueSub: @js(__('live_duel.queue_sub')),
+                pickPlayerOut: @js(__('live_duel.pick_player_out')),
+                pickPlayerIn: @js(__('live_duel.pick_player_in')),
+                opponentPreparingSub: @js(__('live_duel.opponent_preparing_sub')),
+                connecting: @js(__('live_duel.connecting')),
+                realtimeUnavailable: @js(__('live_duel.realtime_unavailable')),
+            },
+        })"
+        x-init="init()"
+        class="min-h-screen bg-surface-900 text-text-primary"
+    >
+        <!-- Scoreboard -->
+        <div class="bg-surface-800 border-b border-border-default px-4 py-3">
+            <div class="max-w-5xl mx-auto flex items-center justify-between gap-4">
+                <div class="flex items-center gap-3 flex-1">
+                    @if ($hostTeam?->image)
+                        <img src="{{ $hostTeam->image }}" alt="{{ $hostTeam->name }}" class="w-8 h-8 object-contain">
+                    @endif
+                    <div class="font-semibold text-text-primary truncate">{{ $hostTeam?->name ?? '' }}</div>
+                    <span x-show="hostBot" class="text-xs px-2 py-0.5 bg-accent-amber/20 text-accent-amber rounded">BOT</span>
+                </div>
+                <div class="text-center">
+                    <div class="text-3xl md:text-4xl font-bold tabular-nums">
+                        <span x-text="homeScore"></span>
+                        <span class="text-text-muted">-</span>
+                        <span x-text="awayScore"></span>
+                    </div>
+                    <div class="text-xs text-text-muted tabular-nums mt-1">
+                        <span x-text="displayMinute + '\''"></span>
+                    </div>
+                </div>
+                <div class="flex items-center gap-3 flex-1 justify-end">
+                    <span x-show="guestBot" class="text-xs px-2 py-0.5 bg-accent-amber/20 text-accent-amber rounded">BOT</span>
+                    <div class="font-semibold text-text-primary truncate text-right">{{ $guestTeam?->name ?? '' }}</div>
+                    @if ($guestTeam?->image)
+                        <img src="{{ $guestTeam->image }}" alt="{{ $guestTeam->name }}" class="w-8 h-8 object-contain">
+                    @endif
+                </div>
+            </div>
+        </div>
+
+        <!-- Connection banner -->
+        <div x-show="!connected && !realtimeDisabled" class="bg-accent-amber/10 border-b border-accent-amber/30 px-4 py-2 text-center text-sm text-text-primary">
+            <span x-text="labels.connecting"></span>
+        </div>
+        <div x-show="realtimeDisabled" class="bg-accent-red/10 border-b border-accent-red/30 px-4 py-2 text-center text-sm text-text-primary">
+            <span x-text="labels.realtimeUnavailable"></span>
+        </div>
+
+        <div class="max-w-5xl mx-auto p-4 grid grid-cols-1 lg:grid-cols-3 gap-4">
+            <!-- Event ticker (left/center) -->
+            <div class="lg:col-span-2 bg-surface-800 border border-border-default rounded-xl p-4">
+                <h3 class="text-sm font-semibold text-text-muted mb-3 uppercase tracking-wide">Live</h3>
+                <ul class="space-y-2 max-h-96 overflow-y-auto">
+                    <template x-for="event in events.slice().reverse()" :key="event.id">
+                        <li class="flex items-start gap-3 p-2 rounded bg-surface-700/50">
+                            <span class="text-xs font-mono text-text-muted tabular-nums" x-text="event.minute + '\''"></span>
+                            <span class="text-xl" x-text="eventIcon(event.type)"></span>
+                            <span class="text-sm text-text-primary" x-text="eventLabel(event)"></span>
+                        </li>
+                    </template>
+                    <li x-show="events.length === 0" class="text-sm text-text-muted text-center py-4">
+                        Match starting…
+                    </li>
+                </ul>
+
+                <!-- Opponent activity hint -->
+                <div x-show="opponentPreparingSub" class="mt-3 text-xs text-text-muted italic" x-text="labels.opponentPreparingSub"></div>
+            </div>
+
+            <!-- Your control panel (right) -->
+            <div class="bg-surface-800 border border-border-default rounded-xl p-4">
+                <h3 class="text-sm font-semibold text-text-muted mb-3 uppercase tracking-wide">Your team</h3>
+
+                <!-- Subs remaining -->
+                <div class="text-sm mb-3" x-text="@js(__('live_duel.subs_remaining', ['count' => ''])) + (3 - subsUsed)"></div>
+
+                <!-- Queue sub -->
+                <button
+                    type="button"
+                    @click="openSubModal()"
+                    :disabled="subsUsed >= 3 || phase === 'finished'"
+                    class="w-full px-4 py-2 bg-accent-blue text-white rounded-lg font-semibold hover:bg-accent-blue/80 disabled:opacity-40 disabled:cursor-not-allowed transition"
+                    x-text="labels.queueSub"
+                ></button>
+
+                <!-- Your on-pitch list -->
+                <div class="mt-4 text-xs text-text-muted">On pitch:</div>
+                <ul class="text-sm space-y-1 mt-1 max-h-48 overflow-y-auto">
+                    <template x-for="player in myOnPitch" :key="player.id">
+                        <li class="flex justify-between">
+                            <span x-text="player.name"></span>
+                            <span class="text-text-muted tabular-nums" x-text="player.overall_score"></span>
+                        </li>
+                    </template>
+                </ul>
+            </div>
+        </div>
+
+        <!-- Pause overlay -->
+        <div
+            x-show="phase === 'paused'"
+            x-transition.opacity
+            role="dialog"
+            aria-modal="true"
+            class="fixed inset-0 z-50 bg-black/70 flex items-center justify-center p-4"
+        >
+            <div class="bg-surface-800 border border-border-default rounded-2xl p-6 md:p-8 max-w-md w-full text-center">
+                <div class="text-5xl mb-3" x-text="pauseIcon()"></div>
+                <h3 class="text-xl font-bold text-text-primary mb-2" x-text="pauseLabel()"></h3>
+                <p class="text-text-muted mb-6 text-sm" x-text="myAcked ? labels.waitingOpponentAck : ''"></p>
+                <button
+                    type="button"
+                    @click="ackPause()"
+                    :disabled="myAcked"
+                    class="w-full px-4 py-3 bg-accent-blue text-white rounded-lg font-semibold hover:bg-accent-blue/80 disabled:opacity-40 transition"
+                    x-text="myAcked ? labels.waitingOpponentAck : labels.continue"
+                ></button>
+            </div>
+        </div>
+
+        <!-- Sub modal -->
+        <div
+            x-show="subModalOpen"
+            x-transition.opacity
+            @keydown.escape.window="subModalOpen = false"
+            role="dialog"
+            aria-modal="true"
+            class="fixed inset-0 z-50 bg-black/70 flex items-center justify-center p-4"
+        >
+            <div class="bg-surface-800 border border-border-default rounded-2xl p-6 max-w-md w-full">
+                <h3 class="text-lg font-bold text-text-primary mb-4" x-text="labels.queueSub"></h3>
+
+                <label class="block text-xs text-text-muted mb-1" x-text="labels.pickPlayerOut"></label>
+                <select x-model="subPlayerOut" class="w-full mb-3 px-3 py-2 bg-surface-700 border border-border-default rounded-lg text-text-primary">
+                    <option value="">—</option>
+                    <template x-for="player in myOnPitch" :key="player.id">
+                        <option :value="player.id" x-text="player.name + ' (' + player.overall_score + ')'"></option>
+                    </template>
+                </select>
+
+                <label class="block text-xs text-text-muted mb-1" x-text="labels.pickPlayerIn"></label>
+                <select x-model="subPlayerIn" class="w-full mb-4 px-3 py-2 bg-surface-700 border border-border-default rounded-lg text-text-primary">
+                    <option value="">—</option>
+                    <template x-for="player in myBench" :key="player.id">
+                        <option :value="player.id" x-text="player.name + ' (' + player.overall_score + ')'"></option>
+                    </template>
+                </select>
+
+                <div class="flex gap-2">
+                    <button
+                        type="button"
+                        @click="subModalOpen = false"
+                        class="flex-1 px-4 py-2 bg-surface-700 text-text-primary rounded-lg hover:bg-surface-600 transition"
+                    >Cancel</button>
+                    <button
+                        type="button"
+                        @click="confirmSub()"
+                        :disabled="!subPlayerOut || !subPlayerIn"
+                        class="flex-1 px-4 py-2 bg-accent-blue text-white rounded-lg font-semibold hover:bg-accent-blue/80 disabled:opacity-40 transition"
+                    >OK</button>
+                </div>
+
+                <div x-show="subError" class="mt-3 text-sm text-accent-red" x-text="subError"></div>
+            </div>
+        </div>
+
+        <!-- Full-time overlay -->
+        <div
+            x-show="phase === 'finished'"
+            x-transition.opacity
+            role="dialog"
+            aria-modal="true"
+            class="fixed inset-0 z-50 bg-black/80 flex items-center justify-center p-4"
+        >
+            <div class="bg-surface-800 border border-border-default rounded-2xl p-8 max-w-md w-full text-center">
+                <h2 class="text-2xl font-bold text-text-primary mb-1" x-text="labels.fulltime"></h2>
+                <div class="text-5xl font-bold tabular-nums my-4">
+                    <span x-text="homeScore"></span>
+                    <span class="text-text-muted">-</span>
+                    <span x-text="awayScore"></span>
+                </div>
+                <a
+                    href="{{ route('live.duel.entry') }}"
+                    class="inline-block px-6 py-3 bg-accent-blue text-white rounded-lg font-semibold hover:bg-accent-blue/80 transition"
+                >{{ __('live_duel.create_duel') }}</a>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/routes/channels.php
+++ b/routes/channels.php
@@ -1,0 +1,22 @@
+<?php
+
+use App\Models\LiveMatchSession;
+use App\Models\User;
+use Illuminate\Support\Facades\Broadcast;
+
+Broadcast::channel('live-match.{sessionId}', function (User $user, string $sessionId) {
+    $session = LiveMatchSession::find($sessionId);
+    if ($session === null) {
+        return false;
+    }
+
+    if (! $session->isParticipant($user->id)) {
+        return false;
+    }
+
+    return [
+        'id' => $user->id,
+        'name' => $user->name,
+        'role' => $session->isHost($user->id) ? 'host' : 'guest',
+    ];
+});

--- a/routes/web.php
+++ b/routes/web.php
@@ -339,6 +339,18 @@ Route::middleware('auth')->group(function () {
     Route::delete('/profile', [ProfileController::class, 'destroy'])->name('profile.destroy');
 });
 
+// Live duel — real-time human-vs-human matches. Sits outside the game-shell
+// scope because a duel does not belong to either player's Game.
+Route::middleware('auth')->prefix('live/duel')->name('live.duel.')->group(function () {
+    Route::get('/', \App\Http\Actions\LiveDuel\ShowLiveDuelEntry::class)->name('entry');
+    Route::post('/', \App\Http\Actions\LiveDuel\CreateLiveDuelSession::class)->name('create');
+    Route::get('/{session}', \App\Http\Actions\LiveDuel\ShowLiveDuel::class)->name('show');
+    Route::get('/{session}/state', \App\Http\Actions\LiveDuel\GetLiveDuelState::class)->name('state');
+    Route::post('/{session}/pick-team', \App\Http\Actions\LiveDuel\PickGuestTeam::class)->name('pick-team');
+    Route::post('/{session}/actions', \App\Http\Actions\LiveDuel\QueueAction::class)->name('actions');
+    Route::post('/{session}/ack', \App\Http\Actions\LiveDuel\AcknowledgePause::class)->name('ack');
+});
+
 // Admin routes
 Route::middleware('auth')->prefix('admin')->name('admin.')->group(function () {
     // Accessible while impersonating (impersonated user may not be admin)

--- a/tests/Feature/LiveDuel/LiveMatchOrchestratorTest.php
+++ b/tests/Feature/LiveDuel/LiveMatchOrchestratorTest.php
@@ -1,0 +1,249 @@
+<?php
+
+namespace Tests\Feature\LiveDuel;
+
+use App\Models\GamePlayerTemplate;
+use App\Models\LiveMatchSession;
+use App\Models\Team;
+use App\Models\User;
+use App\Modules\LiveMatch\Enums\LiveMatchPhase;
+use App\Modules\LiveMatch\Enums\QueuedActionType;
+use App\Modules\LiveMatch\Exceptions\InvalidLiveActionException;
+use App\Modules\LiveMatch\Exceptions\LiveMatchStateException;
+use App\Modules\LiveMatch\Jobs\AdvanceLiveMatchWindowJob;
+use App\Modules\LiveMatch\Services\AutoLineupBuilder;
+use App\Modules\LiveMatch\Services\LiveMatchActionQueue;
+use App\Modules\LiveMatch\Services\LiveMatchEngineAdapter;
+use App\Modules\LiveMatch\Services\LiveMatchOrchestrator;
+use App\Modules\LiveMatch\Services\NationalSquadBuilder;
+use App\Modules\Match\Services\MatchSimulator;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+class LiveMatchOrchestratorTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_create_session_snapshots_host_squad_and_remains_in_lobby(): void
+    {
+        Queue::fake();
+        $host = User::factory()->create();
+        $team = $this->seedNationalTeam('Spain', 'ES');
+
+        $orchestrator = $this->makeOrchestrator();
+        $session = $orchestrator->createSession($host, $team);
+
+        $this->assertSame(LiveMatchPhase::Lobby, $session->phase);
+        $this->assertSame($host->id, $session->host_user_id);
+        $this->assertSame($team->id, $session->host_team_id);
+        $this->assertNull($session->guest_user_id);
+        $this->assertNotNull($session->host_squad);
+        $this->assertCount(11, $session->host_squad['starting_xi']);
+        $this->assertGreaterThanOrEqual(7, count($session->host_squad['bench']));
+    }
+
+    public function test_first_non_host_visitor_claims_guest_slot(): void
+    {
+        $host = User::factory()->create();
+        $guest = User::factory()->create();
+        $team = $this->seedNationalTeam('Spain', 'ES');
+        $orchestrator = $this->makeOrchestrator();
+        $session = $orchestrator->createSession($host, $team);
+
+        $orchestrator->claimGuestSlot($session, $guest);
+
+        $this->assertSame($guest->id, $session->fresh()->guest_user_id);
+    }
+
+    public function test_host_cannot_claim_guest_slot(): void
+    {
+        $host = User::factory()->create();
+        $team = $this->seedNationalTeam('Spain', 'ES');
+        $orchestrator = $this->makeOrchestrator();
+        $session = $orchestrator->createSession($host, $team);
+
+        $this->expectException(LiveMatchStateException::class);
+        $orchestrator->claimGuestSlot($session, $host);
+    }
+
+    public function test_third_visitor_cannot_take_guest_slot(): void
+    {
+        $host = User::factory()->create();
+        $guest = User::factory()->create();
+        $third = User::factory()->create();
+        $team = $this->seedNationalTeam('Spain', 'ES');
+        $orchestrator = $this->makeOrchestrator();
+        $session = $orchestrator->createSession($host, $team);
+        $orchestrator->claimGuestSlot($session, $guest);
+
+        $this->expectException(LiveMatchStateException::class);
+        $orchestrator->claimGuestSlot($session->fresh(), $third);
+    }
+
+    public function test_guest_picking_team_with_both_users_present_starts_the_match(): void
+    {
+        Queue::fake();
+        $host = User::factory()->create();
+        $guest = User::factory()->create();
+        $hostTeam = $this->seedNationalTeam('Spain', 'ES');
+        $guestTeam = $this->seedNationalTeam('Brazil', 'BR');
+
+        $orchestrator = $this->makeOrchestrator();
+        $session = $orchestrator->createSession($host, $hostTeam);
+        $orchestrator->claimGuestSlot($session, $guest);
+
+        $session = $orchestrator->pickGuestTeam($session->fresh(), $guest, $guestTeam);
+
+        $this->assertSame(LiveMatchPhase::Live, $session->phase);
+        $this->assertNotNull($session->context_state);
+        Queue::assertPushed(AdvanceLiveMatchWindowJob::class);
+    }
+
+    public function test_acknowledge_pause_only_resumes_once_when_acks_race(): void
+    {
+        Queue::fake();
+        $host = User::factory()->create();
+        $guest = User::factory()->create();
+        $hostTeam = $this->seedNationalTeam('Spain', 'ES');
+        $guestTeam = $this->seedNationalTeam('Brazil', 'BR');
+
+        $orchestrator = $this->makeOrchestrator();
+        $session = $orchestrator->createSession($host, $hostTeam);
+        $orchestrator->claimGuestSlot($session, $guest);
+        $session = $orchestrator->pickGuestTeam($session->fresh(), $guest, $guestTeam);
+        Queue::assertPushed(AdvanceLiveMatchWindowJob::class, 1);
+
+        // Force the session into a halftime-style pause to exercise the ack path.
+        $session->update([
+            'phase' => LiveMatchPhase::Paused,
+            'pause_reason' => 'halftime',
+            'pause_acked_by_host' => false,
+            'pause_acked_by_guest' => false,
+            'current_minute' => 50,
+        ]);
+
+        // Both acks arrive. Even though the second one observes both flags
+        // truthy, only the *first* commit transitions Paused→Live, so the
+        // adapter should only dispatch one advance job.
+        $orchestrator->acknowledgePause($session->fresh(), $host);
+        $orchestrator->acknowledgePause($session->fresh(), $guest);
+
+        $this->assertSame(LiveMatchPhase::Live, $session->fresh()->phase);
+        // 1 kickoff job + 1 resume job = 2 total.
+        Queue::assertPushed(AdvanceLiveMatchWindowJob::class, 2);
+    }
+
+    public function test_queue_rejects_invalid_formation_payload(): void
+    {
+        Queue::fake();
+        $host = User::factory()->create();
+        $guest = User::factory()->create();
+        $hostTeam = $this->seedNationalTeam('Spain', 'ES');
+        $guestTeam = $this->seedNationalTeam('Brazil', 'BR');
+
+        $orchestrator = $this->makeOrchestrator();
+        $session = $orchestrator->createSession($host, $hostTeam);
+        $orchestrator->claimGuestSlot($session, $guest);
+        $session = $orchestrator->pickGuestTeam($session->fresh(), $guest, $guestTeam);
+        $session->update([
+            'phase' => LiveMatchPhase::Paused,
+            'pause_reason' => 'halftime',
+        ]);
+
+        $queue = new LiveMatchActionQueue;
+
+        $this->expectException(InvalidLiveActionException::class);
+        $queue->queue($session->fresh(), $host, QueuedActionType::Formation, ['formation' => 'not-a-real-formation']);
+    }
+
+    public function test_squad_snapshot_carries_attributes_the_simulator_needs(): void
+    {
+        Queue::fake();
+        $host = User::factory()->create();
+        $team = $this->seedNationalTeam('Spain', 'ES');
+
+        $session = $this->makeOrchestrator()->createSession($host, $team);
+
+        // The snapshot is the engine's only data source; it must carry the
+        // simulation-relevant attributes (not just UI fields). A missing
+        // date_of_birth previously crashed the window via GamePlayer::age().
+        $player = $session->host_squad['starting_xi'][0];
+        $this->assertArrayHasKey('date_of_birth', $player);
+        $this->assertNotNull($player['date_of_birth']);
+        $this->assertArrayHasKey('durability', $player);
+    }
+
+    public function test_advance_window_simulates_without_null_date_of_birth_error(): void
+    {
+        Queue::fake();
+        $host = User::factory()->create();
+        $guest = User::factory()->create();
+        $hostTeam = $this->seedNationalTeam('Spain', 'ES');
+        $guestTeam = $this->seedNationalTeam('Brazil', 'BR');
+
+        $orchestrator = $this->makeOrchestrator();
+        $session = $orchestrator->createSession($host, $hostTeam);
+        $orchestrator->claimGuestSlot($session, $guest);
+        $session = $orchestrator->pickGuestTeam($session->fresh(), $guest, $guestTeam);
+
+        // Run the full match in one window: this rehydrates the frozen snapshot
+        // and feeds it to MatchSimulator across the whole 93 minutes, exercising
+        // the goal/card/injury paths. Before the fix, age() dereferenced a null
+        // DOB (and the injury path a null $player->game), so the window threw and
+        // no events ever broadcast.
+        $adapter = new LiveMatchEngineAdapter(new MatchSimulator, new NationalSquadBuilder);
+        $adapter->runWindow($session->fresh(), 0, 93);
+
+        $this->assertSame(93, $session->fresh()->current_minute);
+    }
+
+    private function makeOrchestrator(): LiveMatchOrchestrator
+    {
+        $squadBuilder = new NationalSquadBuilder;
+        $autoLineupBuilder = new AutoLineupBuilder;
+        $engineAdapter = new LiveMatchEngineAdapter(new MatchSimulator, $squadBuilder);
+
+        return new LiveMatchOrchestrator($squadBuilder, $autoLineupBuilder, $engineAdapter);
+    }
+
+    /**
+     * Seed a national Team and 23 GamePlayerTemplate rows linked to it.
+     * Mirrors what tournament mode expects: type=national + fifa_code +
+     * templates with team_id pointing at the Team.
+     */
+    private function seedNationalTeam(string $name, string $country): Team
+    {
+        $team = Team::factory()->create([
+            'type' => 'national',
+            'name' => $name,
+            'country' => $country,
+            'fifa_code' => strtoupper(substr($name, 0, 3)),
+        ]);
+
+        $positions = ['Goalkeeper', 'Centre-Back', 'Left-Back', 'Right-Back', 'Central Midfield', 'Attacking Midfield', 'Left Winger', 'Right Winger', 'Centre-Forward'];
+        for ($i = 0; $i < 23; $i++) {
+            GamePlayerTemplate::create([
+                'season' => '2025/2026',
+                'player_id' => (string) Str::uuid(),
+                'transfermarkt_id' => 'tm-'.Str::random(8),
+                'name' => "{$name} Player {$i}",
+                'date_of_birth' => '1995-01-01',
+                'nationality' => [$name],
+                'foot' => 'right',
+                'team_id' => $team->id,
+                'number' => $i + 1,
+                'position' => $positions[$i % count($positions)],
+                'overall_score' => 70 + ($i % 15),
+                'durability' => 70,
+                'tier' => 3,
+                'potential' => 80,
+                'potential_low' => 75,
+                'potential_high' => 85,
+            ]);
+        }
+
+        return $team;
+    }
+}

--- a/tests/Unit/MatchSimulatorWindowedDeterminismTest.php
+++ b/tests/Unit/MatchSimulatorWindowedDeterminismTest.php
@@ -1,0 +1,186 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\Game;
+use App\Models\Team;
+use App\Modules\Lineup\Enums\Formation;
+use App\Modules\Lineup\Enums\Mentality;
+use App\Modules\Match\DTOs\MatchSimulationContext;
+use App\Modules\Match\Services\MatchSimulator;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use Tests\Traits\CreatesLineups;
+
+/**
+ * Regression tests for the simulateWindow() refactor.
+ *
+ * simulateWindow is a thin context-driven wrapper around simulateRemainder.
+ * These tests pin the wrapper's bookkeeping: context accumulators, event
+ * appending, performance-cache survival, score/xG totals, and injury/yellow
+ * trackers all behave correctly across one and multiple windows.
+ *
+ * The simulator's internal randomness uses random_int (not seedable), so we
+ * test structural invariants of the wrapper rather than byte-equality with
+ * the existing batch path.
+ */
+class MatchSimulatorWindowedDeterminismTest extends TestCase
+{
+    use CreatesLineups;
+    use RefreshDatabase;
+
+    public function test_single_full_match_window_bookkeeping(): void
+    {
+        $simulator = new MatchSimulator;
+        $ctx = $this->buildContext('pin-single');
+
+        $result = $simulator->simulateWindow($ctx, 0, 93);
+
+        $this->assertSame($result->fromMinute, 0);
+        $this->assertSame($result->toMinute, 93);
+
+        // Cumulative state reflects exactly what the window produced.
+        $this->assertSame($result->homeScoreDelta, $ctx->homeScore);
+        $this->assertSame($result->awayScoreDelta, $ctx->awayScore);
+        $this->assertSame($result->homeXG, $ctx->homeXGTotal);
+        $this->assertSame($result->awayXG, $ctx->awayXGTotal);
+        $this->assertSame($result->newEvents->count(), $ctx->accumulatedEvents->count());
+
+        // Every generated event must fall within the requested minute range.
+        foreach ($result->newEvents as $event) {
+            $this->assertGreaterThanOrEqual(1, $event->minute);
+            $this->assertLessThanOrEqual(93, $event->minute);
+        }
+    }
+
+    public function test_two_windows_accumulate_state_and_partition_events_by_minute(): void
+    {
+        $simulator = new MatchSimulator;
+        $ctx = $this->buildContext('pin-two');
+
+        $first = $simulator->simulateWindow($ctx, 0, 45);
+        $second = $simulator->simulateWindow($ctx, 45, 93);
+
+        // Score and xG totals are sums of the per-window deltas.
+        $this->assertSame($first->homeScoreDelta + $second->homeScoreDelta, $ctx->homeScore);
+        $this->assertSame($first->awayScoreDelta + $second->awayScoreDelta, $ctx->awayScore);
+        $this->assertEqualsWithDelta(
+            $first->homeXG + $second->homeXG, $ctx->homeXGTotal, 1e-9,
+        );
+        $this->assertEqualsWithDelta(
+            $first->awayXG + $second->awayXG, $ctx->awayXGTotal, 1e-9,
+        );
+
+        // Accumulated event log is the union of both windows.
+        $this->assertSame(
+            $first->newEvents->count() + $second->newEvents->count(),
+            $ctx->accumulatedEvents->count(),
+        );
+
+        // Events generated in each window stay in that window's minute range.
+        // simulateRemainder generates events for (fromMinute, toMinute], so
+        // first-window events sit in (0, 45] and second-window in (45, 93].
+        foreach ($first->newEvents as $event) {
+            $this->assertGreaterThan(0, $event->minute);
+            $this->assertLessThanOrEqual(45, $event->minute);
+        }
+        foreach ($second->newEvents as $event) {
+            $this->assertGreaterThan(45, $event->minute);
+            $this->assertLessThanOrEqual(93, $event->minute);
+        }
+    }
+
+    public function test_performance_cache_survives_across_windows(): void
+    {
+        $simulator = new MatchSimulator;
+        $ctx = $this->buildContext('pin-perf');
+
+        $simulator->simulateWindow($ctx, 0, 45);
+        $performanceAfterFirstHalf = $ctx->matchPerformance;
+
+        // First half should have rolled performance for at least the starters.
+        $this->assertNotEmpty($performanceAfterFirstHalf);
+
+        $simulator->simulateWindow($ctx, 45, 93);
+
+        // Every player whose performance was rolled in the first half retains
+        // the same value in the second half (preservePerformance contract).
+        foreach ($performanceAfterFirstHalf as $playerId => $value) {
+            $this->assertArrayHasKey($playerId, $ctx->matchPerformance);
+            $this->assertSame(
+                $value,
+                $ctx->matchPerformance[$playerId],
+                "Performance for player {$playerId} must be preserved across windows",
+            );
+        }
+    }
+
+    public function test_injury_and_yellow_accumulators_carry_across_windows(): void
+    {
+        // Crank injury/yellow rates so we reliably hit both kinds of events
+        // in the first half and can observe the trackers being populated.
+        config([
+            'match_simulation.injury_chance' => 100,
+            'match_simulation.yellow_cards_per_team' => 6,
+        ]);
+
+        $simulator = new MatchSimulator;
+        $ctx = $this->buildContext('pin-trackers');
+
+        $first = $simulator->simulateWindow($ctx, 0, 45);
+
+        $expectedInjuryTeams = $first->newEvents
+            ->filter(fn ($e) => $e->type === 'injury')
+            ->pluck('teamId')
+            ->unique()
+            ->values()
+            ->all();
+        $expectedYellowPlayers = $first->newEvents
+            ->filter(fn ($e) => $e->type === 'yellow_card')
+            ->pluck('gamePlayerId')
+            ->unique()
+            ->values()
+            ->all();
+
+        foreach ($expectedInjuryTeams as $teamId) {
+            $this->assertContains($teamId, $ctx->existingInjuryTeamIds);
+        }
+        foreach ($expectedYellowPlayers as $playerId) {
+            $this->assertContains($playerId, $ctx->existingYellowPlayerIds);
+        }
+
+        // Trackers must not gain duplicates if the same team/player appears
+        // again in the second window.
+        $simulator->simulateWindow($ctx, 45, 93);
+        $this->assertSame(
+            array_values(array_unique($ctx->existingInjuryTeamIds)),
+            array_values($ctx->existingInjuryTeamIds),
+        );
+        $this->assertSame(
+            array_values(array_unique($ctx->existingYellowPlayerIds)),
+            array_values($ctx->existingYellowPlayerIds),
+        );
+    }
+
+    private function buildContext(string $seed): MatchSimulationContext
+    {
+        $game = Game::factory()->create(['current_date' => '2025-10-01']);
+        $homeTeam = Team::factory()->create();
+        $awayTeam = Team::factory()->create();
+        $homePlayers = $this->createLineup($game, $homeTeam, 11, 75);
+        $awayPlayers = $this->createLineup($game, $awayTeam, 11, 75);
+
+        return new MatchSimulationContext(
+            homeTeam: $homeTeam,
+            awayTeam: $awayTeam,
+            homePlayers: $homePlayers,
+            awayPlayers: $awayPlayers,
+            homeFormation: Formation::F_4_4_2,
+            awayFormation: Formation::F_4_4_2,
+            homeMentality: Mentality::BALANCED,
+            awayMentality: Mentality::BALANCED,
+            matchSeed: $seed,
+            game: $game,
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Implements a complete live duel system enabling real-time human-vs-human football matches. Players create shareable sessions, pick national teams from their squad, and play matches with real-time score/event updates via WebSocket broadcasts. The system uses a windowed simulation approach where each ~10-minute window runs as a queued job, allowing tactical decisions (substitutions, formation changes) to be queued and applied mid-match.

## Key Changes

### Core Services
- **LiveMatchOrchestrator** — orchestrates session lifecycle (creation, team picking, kickoff, pause/resume, bot takeover on timeout)
- **LiveMatchEngineAdapter** — bridges session persistence with `MatchSimulator::simulateWindow()`, applying queued actions and persisting context/events between windows
- **NationalSquadBuilder** — builds frozen 23-player national squads from a user's most recent active Game, with eligibility validation
- **AutoLineupBuilder** — auto-generates optimal XI and bench from squad using formation recommender
- **LiveMatchActionQueue** — validates and persists queued in-match actions (subs, formation/mentality changes)

### Match Simulation
- **MatchSimulator::simulateWindow()** — new windowed entry point for live matches; thin context-driven wrapper around `simulateRemainder()` that mutates state in place across multiple calls
- **MatchSimulationContext** DTO — mutable cross-window state (lineups, score, accumulated events, performance cache, injury/yellow trackers)
- **WindowResult** DTO — output of a single window (events, score/xG deltas)

### Data Models
- **LiveMatchSession** — control-plane model for session state (phase, squads, context, event log, pause acks, bot flags)
- **LiveMatchAction** — queued in-match actions with status tracking (pending/applied/rejected)
- **LiveMatchPhase** enum — Lobby, Live, Paused, Finished, Aborted
- **LiveMatchSide** enum — Home/Away with opposite() helper
- **QueuedActionType** enum — Substitution, Formation, Mentality

### Broadcasting & Real-Time
- **Reverb integration** — WebSocket server for real-time broadcasts
- **Presence channel** (`live-match.{sessionId}`) — tracks connected participants
- **Broadcast events** — LiveMatchStartedBroadcast, LiveMatchEventBroadcast, LiveMatchPausedBroadcast, LiveMatchResumedBroadcast, LiveMatchEndedBroadcast, LiveMatchBotTakeoverBroadcast, LiveMatchTeamPickedBroadcast, LiveMatchGuestJoinedBroadcast, LiveMatchActionQueuedBroadcast

### Frontend
- **Alpine.js components** — `liveDuel()` (main match view with clock interpolation, event rendering, sub modal) and `liveDuelLobby()` (lobby with presence tracking)
- **Blade views** — entry point picker, lobby (waiting for opponent), match display, full-session error page
- **Echo client** — configurable WebSocket connection with graceful degradation

### HTTP Actions
- **CreateLiveDuelSession** — host creates session with ISO code
- **PickGuestTeam** — guest claims slot and picks team
- **ShowLiveDuelEntry** — nation picker with eligibility counts
- **ShowLiveDuel** — adaptive view (lobby/match/full/error) based on session state and viewer role
- **QueueAction** — queue substitution/formation/mentality changes
- **AcknowledgePause** — both players ack pause before resuming

### Jobs
- **AdvanceLiveMatchWindowJob** — simulates one window, chains to next or yields to pause-ack flow; idempotent via `clock_version`
- **MarkAsBotJob** — marks a side as bot-controlled after 30s timeout

### Database
- **live_match_sessions** — control-plane table with UUID PK, phase, squads (JSON), context_state (JSON), event_log (JSON), pause acks, bot flags
- **live_match_actions** — control-plane table with UUID P

https://claude.ai/code/session_016k31ExyPV17fEZQGRdQreh