### PR TITLE
Fix playoff final home/away to follow Spanish lower-finisher rule

### DIFF
--- a/app/Modules/Competition/Playoffs/ESP2PlayoffGenerator.php
+++ b/app/Modules/Competition/Playoffs/ESP2PlayoffGenerator.php
@@ -10,6 +10,7 @@ use App\Modules\Competition\Services\LeagueFixtureGenerator;
 use App\Models\Competition;
 use App\Models\CupTie;
 use App\Models\Game;
+use App\Models\GameStanding;
 
 /**
  * Playoff generator for a two-round promotion playoff (semifinal + final).
@@ -138,7 +139,17 @@ class ESP2PlayoffGenerator implements PlayoffGenerator
 
     /**
      * Final matchup: Winners of the two semifinals.
-     * The winner from the higher-seed tie hosts the second leg.
+     *
+     * Spanish rule: "La ida se juega en el campo del equipo que acabó la
+     * competición en un puesto inferior" — first leg hosted by the team
+     * that finished lower in the regular-season table. Equivalently, the
+     * higher-finishing winner hosts the deciding second leg.
+     *
+     * Home/away can't be derived from bracket position alone because either
+     * semifinal can be won by the lower seed (e.g. pos 6 beats pos 3),
+     * which would flip which winner is the lower finisher. Look up each
+     * winner's actual ESP2 position and assign home of leg 1 to the one
+     * with the larger position number.
      */
     private function generateFinalMatchup(Game $game): array
     {
@@ -154,7 +165,25 @@ class ESP2PlayoffGenerator implements PlayoffGenerator
             throw new \RuntimeException('Cannot generate final: semifinals not complete');
         }
 
-        // Winner of lower-seed tie hosts first leg, winner of higher-seed tie hosts second leg
+        $positions = GameStanding::where('game_id', $game->id)
+            ->where('competition_id', $this->competitionId)
+            ->whereIn('team_id', $semifinalWinners)
+            ->pluck('position', 'team_id');
+
+        $posFirst = $positions[$semifinalWinners[0]] ?? null;
+        $posSecond = $positions[$semifinalWinners[1]] ?? null;
+
+        if ($posFirst === null || $posSecond === null) {
+            throw new \RuntimeException(
+                "Missing ESP2 standings for semifinal winner(s) when building playoff final."
+            );
+        }
+
+        // Lower finisher (larger position number) hosts leg 1.
+        if ($posFirst > $posSecond) {
+            return [[$semifinalWinners[0], $semifinalWinners[1]]];
+        }
+
         return [[$semifinalWinners[1], $semifinalWinners[0]]];
     }
 

--- a/app/Modules/Competition/Playoffs/PrimeraRFEFPlayoffGenerator.php
+++ b/app/Modules/Competition/Playoffs/PrimeraRFEFPlayoffGenerator.php
@@ -6,6 +6,7 @@ use App\Modules\Competition\Contracts\PlayoffGenerator;
 use App\Modules\Competition\DTOs\PlayoffRoundConfig;
 use App\Modules\Competition\Enums\PlayoffState;
 use App\Modules\Competition\Services\LeagueFixtureGenerator;
+use App\Modules\Competition\Services\PlayoffTiebreakerService;
 use App\Modules\Competition\Services\ReserveTeamFilter;
 use App\Modules\Finance\Services\SeasonSimulationService;
 use App\Models\Competition;
@@ -214,6 +215,15 @@ class PrimeraRFEFPlayoffGenerator implements PlayoffGenerator
      * Round 2 (Bracket Finals). The two semifinal winners inside each bracket
      * play a two-legged final. Both winners are promoted — one per bracket.
      *
+     * Home/away is determined dynamically by the regular-season finishing
+     * position of each winner (across both groups — a bracket-final pair can
+     * mix winners from either group). The lower-finishing team hosts leg 1
+     * so the higher finisher's stadium gets leg 2 (the deciding leg). This
+     * matches the Spanish rule: "la vuelta será en el estadio de aquel que
+     * finalizó la liga regular en un mejor puesto". Cross-group brackets
+     * make same-position pairings impossible, so the position lookup is
+     * always decisive.
+     *
      * @return array<array{0: string, 1: string, 2: int}>
      */
     private function generateBracketFinalMatchups(Game $game): array
@@ -227,6 +237,8 @@ class PrimeraRFEFPlayoffGenerator implements PlayoffGenerator
             ->get();
 
         $byBracket = $semifinals->groupBy('bracket_position');
+        $tiebreakerService = app(PlayoffTiebreakerService::class);
+        $sourceGroups = [self::GROUP_A_ID, self::GROUP_B_ID];
 
         $matchups = [];
         foreach ([self::BRACKET_A, self::BRACKET_B] as $bracket) {
@@ -246,10 +258,21 @@ class PrimeraRFEFPlayoffGenerator implements PlayoffGenerator
                 );
             }
 
-            // Insertion order of $ties matches bracket seeding: the first tie
-            // in the bracket was the lower-seed (5 vs 2 or 4 vs 3) matchup.
-            // Its winner hosts the first leg of the bracket final.
-            $matchups[] = [$winners[0], $winners[1], $bracket];
+            $posA = $tiebreakerService->positionInSource($game, $winners[0], $sourceGroups);
+            $posB = $tiebreakerService->positionInSource($game, $winners[1], $sourceGroups);
+
+            // Lower finisher (larger position number) hosts leg 1. If a
+            // position can't be resolved (shouldn't happen — both winners
+            // have group standings), preserve insertion order rather than
+            // throwing, so the bracket can still complete.
+            $homeFirst = $winners[0];
+            $awaySecond = $winners[1];
+            if ($posA !== null && $posB !== null && $posB > $posA) {
+                $homeFirst = $winners[1];
+                $awaySecond = $winners[0];
+            }
+
+            $matchups[] = [$homeFirst, $awaySecond, $bracket];
         }
 
         return $matchups;

--- a/app/Modules/Competition/Services/PlayoffTiebreakerService.php
+++ b/app/Modules/Competition/Services/PlayoffTiebreakerService.php
@@ -41,8 +41,8 @@ class PlayoffTiebreakerService
             return null;
         }
 
-        $homePos = $this->regularSeasonPosition($game, $tie->home_team_id, $sources);
-        $awayPos = $this->regularSeasonPosition($game, $tie->away_team_id, $sources);
+        $homePos = $this->positionInSource($game, $tie->home_team_id, $sources);
+        $awayPos = $this->positionInSource($game, $tie->away_team_id, $sources);
 
         if ($homePos === null || $awayPos === null || $homePos === $awayPos) {
             return null;
@@ -57,9 +57,13 @@ class PlayoffTiebreakerService
      * so sister-group standings (e.g. the group the player isn't in under
      * Primera RFEF's split format) are still usable.
      *
+     * Public so playoff generators can reuse the same lookup when seeding
+     * later rounds — keeps the bracket draw and the in-match tiebreaker
+     * reading positions the same way.
+     *
      * @param string[] $sourceCompetitionIds
      */
-    private function regularSeasonPosition(Game $game, string $teamId, array $sourceCompetitionIds): ?int
+    public function positionInSource(Game $game, string $teamId, array $sourceCompetitionIds): ?int
     {
         foreach ($sourceCompetitionIds as $sourceId) {
             $standing = GameStanding::where('game_id', $game->id)

--- a/tests/Feature/ESP2PlayoffGeneratorTest.php
+++ b/tests/Feature/ESP2PlayoffGeneratorTest.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Competition;
+use App\Models\CompetitionEntry;
+use App\Models\CupTie;
+use App\Models\Game;
+use App\Models\GameStanding;
+use App\Models\Team;
+use App\Models\User;
+use App\Modules\Competition\Playoffs\ESP2PlayoffGenerator;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Integration tests for {@see ESP2PlayoffGenerator}, focused on the
+ * regular-season-position-aware home/away assignment for the playoff final.
+ *
+ * Spanish rule: in the final between the two semifinal winners, the first
+ * leg is hosted by the team that finished lower in the regular season —
+ * so the higher finisher's stadium gets the deciding second leg. Bracket
+ * order alone can't decide this because either semifinal can be won by
+ * its lower seed (e.g. pos 6 beats pos 3).
+ */
+class ESP2PlayoffGeneratorTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Game $game;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Competition::factory()->league()->create([
+            'id' => 'ESP2', 'tier' => 2, 'handler_type' => 'league_with_playoff',
+        ]);
+
+        $user = User::factory()->create();
+        $team = Team::factory()->create();
+        $this->game = Game::factory()->create([
+            'user_id' => $user->id,
+            'team_id' => $team->id,
+            'competition_id' => 'ESP2',
+            'season' => '2025',
+        ]);
+    }
+
+    public function test_final_lower_finisher_hosts_first_leg_when_both_higher_seeds_win(): void
+    {
+        $teams = $this->seedEsp2Standings();
+        // Bracket 1 (pos 6 v pos 3): pos 3 wins. Bracket 2 (pos 5 v pos 4): pos 4 wins.
+        // Final = pos 3 vs pos 4 → pos 4 (lower finisher) hosts leg 1.
+        $this->createCompletedSemifinal(1, $teams[6], $teams[3], winner: $teams[3]);
+        $this->createCompletedSemifinal(2, $teams[5], $teams[4], winner: $teams[4]);
+
+        $matchups = (new ESP2PlayoffGenerator('ESP2'))->generateMatchups($this->game, 2);
+
+        $this->assertCount(1, $matchups);
+        $this->assertEquals($teams[4]->id, $matchups[0][0], 'pos 4 (lower finisher) should host leg 1');
+        $this->assertEquals($teams[3]->id, $matchups[0][1]);
+    }
+
+    public function test_final_lower_finisher_hosts_first_leg_when_lower_seed_wins_first_bracket(): void
+    {
+        $teams = $this->seedEsp2Standings();
+        // Bracket 1 (pos 6 v pos 3): pos 6 wins. Bracket 2 (pos 5 v pos 4): pos 4 wins.
+        // Final = pos 6 vs pos 4 → pos 6 (lower finisher) hosts leg 1.
+        $this->createCompletedSemifinal(1, $teams[6], $teams[3], winner: $teams[6]);
+        $this->createCompletedSemifinal(2, $teams[5], $teams[4], winner: $teams[4]);
+
+        $matchups = (new ESP2PlayoffGenerator('ESP2'))->generateMatchups($this->game, 2);
+
+        $this->assertEquals($teams[6]->id, $matchups[0][0], 'pos 6 (lower finisher) should host leg 1');
+        $this->assertEquals($teams[4]->id, $matchups[0][1]);
+    }
+
+    public function test_final_lower_finisher_hosts_first_leg_when_lower_seed_wins_second_bracket(): void
+    {
+        $teams = $this->seedEsp2Standings();
+        // Bracket 1: pos 3 wins. Bracket 2: pos 5 wins. Final = pos 5 vs pos 3 → pos 5 hosts.
+        $this->createCompletedSemifinal(1, $teams[6], $teams[3], winner: $teams[3]);
+        $this->createCompletedSemifinal(2, $teams[5], $teams[4], winner: $teams[5]);
+
+        $matchups = (new ESP2PlayoffGenerator('ESP2'))->generateMatchups($this->game, 2);
+
+        $this->assertEquals($teams[5]->id, $matchups[0][0], 'pos 5 (lower finisher) should host leg 1');
+        $this->assertEquals($teams[3]->id, $matchups[0][1]);
+    }
+
+    public function test_final_lower_finisher_hosts_first_leg_when_both_lower_seeds_win(): void
+    {
+        $teams = $this->seedEsp2Standings();
+        // Bracket 1: pos 6 wins. Bracket 2: pos 5 wins. Final = pos 6 vs pos 5 → pos 6 hosts.
+        $this->createCompletedSemifinal(1, $teams[6], $teams[3], winner: $teams[6]);
+        $this->createCompletedSemifinal(2, $teams[5], $teams[4], winner: $teams[5]);
+
+        $matchups = (new ESP2PlayoffGenerator('ESP2'))->generateMatchups($this->game, 2);
+
+        $this->assertEquals($teams[6]->id, $matchups[0][0], 'pos 6 (lower finisher) should host leg 1');
+        $this->assertEquals($teams[5]->id, $matchups[0][1]);
+    }
+
+    /**
+     * @return array<int, Team> 1-indexed by ESP2 standings position.
+     */
+    private function seedEsp2Standings(int $count = 22): array
+    {
+        $teams = [];
+        for ($i = 1; $i <= $count; $i++) {
+            $team = Team::factory()->create();
+            $teams[$i] = $team;
+            CompetitionEntry::create([
+                'game_id' => $this->game->id,
+                'competition_id' => 'ESP2',
+                'team_id' => $team->id,
+                'entry_round' => 1,
+            ]);
+            GameStanding::create([
+                'game_id' => $this->game->id,
+                'competition_id' => 'ESP2',
+                'team_id' => $team->id,
+                'position' => $i,
+                'played' => 42,
+                'won' => max(0, 25 - $i),
+                'drawn' => 5,
+                'lost' => $i,
+                'goals_for' => 70 - $i,
+                'goals_against' => 20 + $i,
+                'points' => max(0, 25 - $i) * 3 + 5,
+            ]);
+        }
+        return $teams;
+    }
+
+    private function createCompletedSemifinal(int $bracketPosition, Team $home, Team $away, Team $winner): void
+    {
+        CupTie::factory()
+            ->forGame($this->game)
+            ->inRound(1)
+            ->between($home, $away)
+            ->completed($winner, 'aggregate')
+            ->create([
+                'competition_id' => 'ESP2',
+                'bracket_position' => $bracketPosition,
+            ]);
+    }
+}

--- a/tests/Feature/PrimeraRFEFPromotionTest.php
+++ b/tests/Feature/PrimeraRFEFPromotionTest.php
@@ -120,23 +120,24 @@ class PrimeraRFEFPromotionTest extends TestCase
         return $teams;
     }
 
-    private function createCompletedSemifinals(array $groupATeams, array $groupBTeams): void
+    private function createCompletedSemifinals(array $groupATeams, array $groupBTeams, array $bracketAWinners = ['high', 'high'], array $bracketBWinners = ['high', 'high']): void
     {
         $bracketASemiTies = [
-            [$groupBTeams[5], $groupATeams[2], PrimeraRFEFPlayoffGenerator::BRACKET_A],
-            [$groupBTeams[4], $groupATeams[3], PrimeraRFEFPlayoffGenerator::BRACKET_A],
+            [$groupBTeams[5], $groupATeams[2], PrimeraRFEFPlayoffGenerator::BRACKET_A, $bracketAWinners[0]],
+            [$groupBTeams[4], $groupATeams[3], PrimeraRFEFPlayoffGenerator::BRACKET_A, $bracketAWinners[1]],
         ];
         $bracketBSemiTies = [
-            [$groupATeams[5], $groupBTeams[2], PrimeraRFEFPlayoffGenerator::BRACKET_B],
-            [$groupATeams[4], $groupBTeams[3], PrimeraRFEFPlayoffGenerator::BRACKET_B],
+            [$groupATeams[5], $groupBTeams[2], PrimeraRFEFPlayoffGenerator::BRACKET_B, $bracketBWinners[0]],
+            [$groupATeams[4], $groupBTeams[3], PrimeraRFEFPlayoffGenerator::BRACKET_B, $bracketBWinners[1]],
         ];
 
-        foreach (array_merge($bracketASemiTies, $bracketBSemiTies) as [$home, $away, $bracket]) {
+        foreach (array_merge($bracketASemiTies, $bracketBSemiTies) as [$home, $away, $bracket, $winnerSide]) {
+            $winner = $winnerSide === 'low' ? $home : $away;
             CupTie::factory()
                 ->forGame($this->game)
                 ->inRound(1)
                 ->between($home, $away)
-                ->completed($away, 'aggregate')
+                ->completed($winner, 'aggregate')
                 ->create([
                     'competition_id' => 'ESP3PO',
                     'bracket_position' => $bracket,
@@ -281,6 +282,78 @@ class PrimeraRFEFPromotionTest extends TestCase
         $bracketBTeamIds = [$matchups[1][0], $matchups[1][1]];
         $this->assertContains($groupB[2]->id, $bracketBTeamIds);
         $this->assertContains($groupB[3]->id, $bracketBTeamIds);
+    }
+
+    public function test_round_2_bracket_final_lower_finisher_hosts_first_leg_when_higher_seeds_win(): void
+    {
+        $groupA = $this->createStandings('ESP3A', 20);
+        $groupB = $this->createStandings('ESP3B', 20);
+        // Default: higher seeds win all semis. Bracket A final = A2 vs A3 → A3 hosts leg 1.
+        $this->createCompletedSemifinals($groupA, $groupB);
+
+        $generator = new PrimeraRFEFPlayoffGenerator();
+        $matchups = $generator->generateMatchups($this->game, 2);
+
+        $this->assertEquals($groupA[3]->id, $matchups[0][0], 'A3 (lower finisher) should host leg 1');
+        $this->assertEquals($groupA[2]->id, $matchups[0][1]);
+        $this->assertEquals($groupB[3]->id, $matchups[1][0], 'B3 (lower finisher) should host leg 1');
+        $this->assertEquals($groupB[2]->id, $matchups[1][1]);
+    }
+
+    public function test_round_2_bracket_final_lower_finisher_hosts_first_leg_when_lower_seed_wins_one_semifinal(): void
+    {
+        $groupA = $this->createStandings('ESP3A', 20);
+        $groupB = $this->createStandings('ESP3B', 20);
+        // Bracket A: B5 beats A2 (low wins semi 1), A3 beats B4 (high wins semi 2)
+        // Final: B5 vs A3 → A3 (pos 3) is higher finisher, B5 (pos 5) hosts leg 1.
+        $this->createCompletedSemifinals($groupA, $groupB, ['low', 'high']);
+
+        $generator = new PrimeraRFEFPlayoffGenerator();
+        $matchups = $generator->generateMatchups($this->game, 2);
+
+        $bracketAFinal = $matchups[0];
+        $this->assertEquals($groupB[5]->id, $bracketAFinal[0], 'B5 (lower finisher) should host leg 1');
+        $this->assertEquals($groupA[3]->id, $bracketAFinal[1]);
+    }
+
+    public function test_round_2_bracket_final_lower_finisher_hosts_first_leg_when_both_lower_seeds_win(): void
+    {
+        $groupA = $this->createStandings('ESP3A', 20);
+        $groupB = $this->createStandings('ESP3B', 20);
+        // Bracket A: B5 beats A2, B4 beats A3. Final: B5 vs B4 → B4 (pos 4) higher, B5 (pos 5) hosts leg 1.
+        // Bracket B: A5 beats B2, A4 beats B3. Final: A5 vs A4 → A4 higher, A5 hosts leg 1.
+        $this->createCompletedSemifinals($groupA, $groupB, ['low', 'low'], ['low', 'low']);
+
+        $generator = new PrimeraRFEFPlayoffGenerator();
+        $matchups = $generator->generateMatchups($this->game, 2);
+
+        $this->assertEquals($groupB[5]->id, $matchups[0][0], 'B5 should host bracket A leg 1');
+        $this->assertEquals($groupB[4]->id, $matchups[0][1]);
+        $this->assertEquals($groupA[5]->id, $matchups[1][0], 'A5 should host bracket B leg 1');
+        $this->assertEquals($groupA[4]->id, $matchups[1][1]);
+    }
+
+    public function test_round_2_bracket_final_uses_simulated_standings_for_sister_group(): void
+    {
+        $groupA = $this->createStandings('ESP3A', 20);
+        $simulatedBTeams = $this->createSimulatedTeams(20);
+        $this->createSimulatedSeason('ESP3B', $simulatedBTeams);
+
+        // Build group B map by 1-indexed position to mirror createStandings' shape.
+        $groupB = [];
+        foreach ($simulatedBTeams as $index => $team) {
+            $groupB[$index + 1] = $team;
+        }
+
+        $this->createCompletedSemifinals($groupA, $groupB);
+
+        $generator = new PrimeraRFEFPlayoffGenerator();
+        $matchups = $generator->generateMatchups($this->game, 2);
+
+        // Bracket B final = B2 vs B3 (both from simulated standings). Position
+        // lookup must hit the SimulatedSeason fallback and pick B3 as host.
+        $this->assertEquals($groupB[3]->id, $matchups[1][0], 'B3 (sim pos 3) should host leg 1 against B2');
+        $this->assertEquals($groupB[2]->id, $matchups[1][1]);
     }
 
     // ──────────────────────────────────────────────────

--- a/tests/Feature/PromotionRelegationProcessorTest.php
+++ b/tests/Feature/PromotionRelegationProcessorTest.php
@@ -371,6 +371,184 @@ class PromotionRelegationProcessorTest extends TestCase
     }
 
     /**
+     * Locks in Rule 1: exactly three teams (positions 18-20) relegate from
+     * Primera División to Segunda División at season close.
+     */
+    public function test_esp1_bottom_three_are_relegated_to_esp2(): void
+    {
+        $esp1 = $this->seedRealTier('ESP1', 20);
+        $this->seedRealTier('ESP2', 22, userPosition: 11);
+        $this->seedSimulatedTier('ESP3A', 20);
+        $this->seedSimulatedTier('ESP3B', 20);
+
+        $relegated = [$esp1[18], $esp1[19], $esp1[20]];
+        $stayed = [$esp1[1], $esp1[17]];
+
+        $processor = app(PromotionRelegationProcessor::class);
+        $processor->process($this->game, new SeasonTransitionData(
+            oldSeason: '2025',
+            newSeason: '2026',
+            competitionId: 'ESP2',
+        ));
+
+        foreach ($relegated as $team) {
+            $this->assertTrue(
+                CompetitionEntry::where('game_id', $this->game->id)
+                    ->where('competition_id', 'ESP2')
+                    ->where('team_id', $team->id)
+                    ->exists(),
+                "ESP1 bottom-three team {$team->id} should land in ESP2",
+            );
+        }
+        foreach ($stayed as $team) {
+            $this->assertTrue(
+                CompetitionEntry::where('game_id', $this->game->id)
+                    ->where('competition_id', 'ESP1')
+                    ->where('team_id', $team->id)
+                    ->exists(),
+                "ESP1 mid-table team {$team->id} should remain in ESP1",
+            );
+        }
+
+        $this->assertSame(20, CompetitionEntry::where('game_id', $this->game->id)->where('competition_id', 'ESP1')->count());
+    }
+
+    /**
+     * Locks in Rule 3: exactly four teams (positions 19-22) relegate from
+     * Segunda División to Primera Federación, distributed across ESP3A/ESP3B.
+     */
+    public function test_esp2_bottom_four_are_relegated_to_primera_rfef(): void
+    {
+        $this->seedRealTier('ESP1', 20);
+        $esp2 = $this->seedRealTier('ESP2', 22, userPosition: 11);
+        $this->seedSimulatedTier('ESP3A', 20);
+        $this->seedSimulatedTier('ESP3B', 20);
+
+        $relegated = [$esp2[19], $esp2[20], $esp2[21], $esp2[22]];
+
+        $processor = app(PromotionRelegationProcessor::class);
+        $processor->process($this->game, new SeasonTransitionData(
+            oldSeason: '2025',
+            newSeason: '2026',
+            competitionId: 'ESP2',
+        ));
+
+        foreach ($relegated as $team) {
+            $landedIn = CompetitionEntry::where('game_id', $this->game->id)
+                ->whereIn('competition_id', ['ESP3A', 'ESP3B'])
+                ->where('team_id', $team->id)
+                ->value('competition_id');
+            $this->assertNotNull($landedIn, "ESP2 bottom-four team {$team->id} should land in ESP3A or ESP3B");
+        }
+
+        $this->assertSame(22, CompetitionEntry::where('game_id', $this->game->id)->where('competition_id', 'ESP2')->count());
+        $this->assertSame(20, CompetitionEntry::where('game_id', $this->game->id)->where('competition_id', 'ESP3A')->count());
+        $this->assertSame(20, CompetitionEntry::where('game_id', $this->game->id)->where('competition_id', 'ESP3B')->count());
+    }
+
+    /**
+     * End-to-end invariant covering Rules 1-4 simultaneously: after a full
+     * Spanish season closing, exactly 3 teams move into ESP1 (2 direct from
+     * ESP2 + 1 ESP2 playoff winner), exactly 4 teams move into ESP2 (1 from
+     * each ESP3 group + 2 ESP3PO bracket winners), and tier sizes are
+     * preserved.
+     */
+    public function test_full_spanish_cycle_promotes_3_to_esp1_and_4_to_esp2(): void
+    {
+        $esp1 = $this->seedRealTier('ESP1', 20);
+        $esp2 = $this->seedRealTier('ESP2', 22, userPosition: 11);
+        $esp3a = $this->seedRealTier('ESP3A', 20);
+        $esp3b = $this->seedRealTier('ESP3B', 20);
+
+        // ESP2 playoff (round 2): ESP2 pos 5 wins the playoff (3rd promotion).
+        // Choosing pos 5 (not the natural stand-in pos 3) catches a bug where
+        // the planner would ignore CupTie winners and just take the next
+        // available standings position.
+        CupTie::factory()->forGame($this->game)->inRound(2)
+            ->between($esp2[6], $esp2[5])
+            ->completed($esp2[5], 'aggregate')
+            ->create(['competition_id' => 'ESP2', 'bracket_position' => 1]);
+
+        // ESP3PO bracket finals: ESP3A pos 4 wins bracket A, ESP3B pos 5 wins bracket B.
+        CupTie::factory()->forGame($this->game)->inRound(2)
+            ->between($esp3a[4], $esp3a[2])
+            ->completed($esp3a[4], 'aggregate')
+            ->create(['competition_id' => 'ESP3PO', 'bracket_position' => PrimeraRFEFPlayoffGenerator::BRACKET_A]);
+        CupTie::factory()->forGame($this->game)->inRound(2)
+            ->between($esp3b[5], $esp3b[2])
+            ->completed($esp3b[5], 'aggregate')
+            ->create(['competition_id' => 'ESP3PO', 'bracket_position' => PrimeraRFEFPlayoffGenerator::BRACKET_B]);
+
+        $processor = app(PromotionRelegationProcessor::class);
+        $processor->process($this->game, new SeasonTransitionData(
+            oldSeason: '2025',
+            newSeason: '2026',
+            competitionId: 'ESP2',
+        ));
+
+        // Promoted to ESP1: ESP2 pos 1, 2 (direct) and pos 5 (playoff winner).
+        foreach ([$esp2[1], $esp2[2], $esp2[5]] as $team) {
+            $this->assertTrue(
+                CompetitionEntry::where('game_id', $this->game->id)
+                    ->where('competition_id', 'ESP1')
+                    ->where('team_id', $team->id)
+                    ->exists(),
+                "ESP2 team {$team->id} should be promoted to ESP1",
+            );
+        }
+
+        // ESP2 pos 3, 4, 6 stayed (they were in the playoff bracket but didn't
+        // win — confirms the planner respected the CupTie winner over standings).
+        foreach ([$esp2[3], $esp2[4], $esp2[6]] as $team) {
+            $this->assertFalse(
+                CompetitionEntry::where('game_id', $this->game->id)
+                    ->where('competition_id', 'ESP1')
+                    ->where('team_id', $team->id)
+                    ->exists(),
+                "ESP2 playoff loser {$team->id} should NOT be promoted",
+            );
+        }
+
+        // Promoted to ESP2: ESP3A pos 1 (direct), ESP3B pos 1 (direct),
+        // ESP3A pos 4 (bracket A winner), ESP3B pos 5 (bracket B winner).
+        foreach ([$esp3a[1], $esp3b[1], $esp3a[4], $esp3b[5]] as $team) {
+            $this->assertTrue(
+                CompetitionEntry::where('game_id', $this->game->id)
+                    ->where('competition_id', 'ESP2')
+                    ->where('team_id', $team->id)
+                    ->exists(),
+                "Primera RFEF team {$team->id} should be promoted to ESP2",
+            );
+        }
+
+        // Relegated from ESP1: positions 18-20.
+        foreach ([$esp1[18], $esp1[19], $esp1[20]] as $team) {
+            $this->assertTrue(
+                CompetitionEntry::where('game_id', $this->game->id)
+                    ->where('competition_id', 'ESP2')
+                    ->where('team_id', $team->id)
+                    ->exists(),
+                "ESP1 team {$team->id} should be relegated to ESP2",
+            );
+        }
+
+        // Relegated from ESP2: positions 19-22 land in ESP3A or ESP3B.
+        foreach ([$esp2[19], $esp2[20], $esp2[21], $esp2[22]] as $team) {
+            $landed = CompetitionEntry::where('game_id', $this->game->id)
+                ->whereIn('competition_id', ['ESP3A', 'ESP3B'])
+                ->where('team_id', $team->id)
+                ->exists();
+            $this->assertTrue($landed, "ESP2 team {$team->id} should be relegated to Primera RFEF");
+        }
+
+        // Tier sizes preserved.
+        $this->assertSame(20, CompetitionEntry::where('game_id', $this->game->id)->where('competition_id', 'ESP1')->count());
+        $this->assertSame(22, CompetitionEntry::where('game_id', $this->game->id)->where('competition_id', 'ESP2')->count());
+        $this->assertSame(20, CompetitionEntry::where('game_id', $this->game->id)->where('competition_id', 'ESP3A')->count());
+        $this->assertSame(20, CompetitionEntry::where('game_id', $this->game->id)->where('competition_id', 'ESP3B')->count());
+    }
+
+    /**
      * @return array<int, Team> 1-indexed by standings position.
      */
     private function seedRealTier(string $competitionId, int $count, ?int $userPosition = null): array


### PR DESCRIPTION
Both Segunda División and Primera Federación playoff finals assigned
the first leg's host based on bracket order, which only works when each
semifinal is won by its higher seed. When a lower seed advanced, the
final's leg-1 home went to the wrong team and the higher finisher lost
its earned home-stadium advantage for the deciding second leg.

Now both finals look up each winner's actual regular-season position
and assign leg 1 to the lower finisher per the Spanish rule
("la ida se juega en el campo del equipo que acabó la competición en un
puesto inferior"). PlayoffTiebreakerService::regularSeasonPosition is
extracted to a public positionInSource() helper so the cross-group
ESP3PO bracket reuses the same lookup the in-match tiebreaker uses.

Adds coverage for all four semifinal-outcome permutations on the
ESP2 final, the equivalent Primera RFEF bracket-final scenarios
(including sister-group standings sourced from SimulatedSeason),
the bottom-3 ESP1 and bottom-4 ESP2 relegations, and a full
Spanish-cycle invariant asserting exactly 3 promotions to ESP1 and
4 promotions to ESP2 with tier sizes preserved.

https://claude.ai/code/session_01L91aqvjJ5nhDZvyKrQdCJW