### PR TITLE
Make penalty shootouts follow real-football rules

### DIFF
--- a/app/Modules/Match/Services/CupTieResolver.php
+++ b/app/Modules/Match/Services/CupTieResolver.php
@@ -19,6 +19,7 @@ class CupTieResolver
         private readonly MatchSimulator $matchSimulator,
         private readonly MatchEventRepository $matchEventRepository,
         private readonly PlayoffTiebreakerService $playoffTiebreakerService,
+        private readonly MatchLineupResolver $lineupResolver = new MatchLineupResolver,
         private readonly StoppageCalculator $stoppageCalculator = new StoppageCalculator,
     ) {}
 
@@ -130,10 +131,10 @@ class CupTieResolver
             $homePens = $match->home_score_penalties;
             $awayPens = $match->away_score_penalties;
         } else {
-            $homePlayers = $homePlayers ?? $allPlayers->get($match->home_team_id, collect());
-            $awayPlayers = $awayPlayers ?? $allPlayers->get($match->away_team_id, collect());
+            // Only players on the pitch at the final whistle of ET can take penalties.
+            [$homePitch, $awayPitch] = $this->lineupResolver->playersOnPitchAtEnd($match);
 
-            [$homePens, $awayPens] = $this->matchSimulator->simulatePenalties($homePlayers, $awayPlayers);
+            [$homePens, $awayPens] = $this->matchSimulator->simulatePenalties($homePitch, $awayPitch);
 
             $match->update([
                 'home_score_penalties' => $homePens,
@@ -257,10 +258,10 @@ class CupTieResolver
             $homePens = $secondLeg->home_score_penalties;
             $awayPens = $secondLeg->away_score_penalties;
         } else {
-            $homePlayers = $homePlayers ?? $allPlayers->get($secondLeg->home_team_id, collect());
-            $awayPlayers = $awayPlayers ?? $allPlayers->get($secondLeg->away_team_id, collect());
+            // Only players on the pitch at the final whistle of ET can take penalties.
+            [$homePitch, $awayPitch] = $this->lineupResolver->playersOnPitchAtEnd($secondLeg);
 
-            [$homePens, $awayPens] = $this->matchSimulator->simulatePenalties($homePlayers, $awayPlayers);
+            [$homePens, $awayPens] = $this->matchSimulator->simulatePenalties($homePitch, $awayPitch);
 
             $secondLeg->update([
                 'home_score_penalties' => $homePens,

--- a/app/Modules/Match/Services/ExtraTimeAndPenaltyService.php
+++ b/app/Modules/Match/Services/ExtraTimeAndPenaltyService.php
@@ -5,7 +5,6 @@ namespace App\Modules\Match\Services;
 use App\Models\CupTie;
 use App\Models\Game;
 use App\Models\GameMatch;
-use App\Models\GamePlayer;
 use App\Models\MatchEvent;
 use App\Modules\Competition\Services\PlayoffTiebreakerService;
 use App\Modules\Match\DTOs\ExtraTimeProcessResult;
@@ -21,6 +20,7 @@ class ExtraTimeAndPenaltyService
         private readonly MatchSimulator $matchSimulator,
         private readonly MatchEventRepository $matchEventRepository,
         private readonly PlayoffTiebreakerService $playoffTiebreakerService,
+        private readonly MatchLineupResolver $lineupResolver = new MatchLineupResolver,
         private readonly StoppageCalculator $stoppageCalculator = new StoppageCalculator,
     ) {}
 
@@ -139,37 +139,7 @@ class ExtraTimeAndPenaltyService
      */
     private function loadPlayersByTeam(GameMatch $match): array
     {
-        $homeIds = $match->home_lineup ?? [];
-        $awayIds = $match->away_lineup ?? [];
-
-        foreach ($match->substitutions ?? [] as $sub) {
-            $isHome = $sub['team_id'] === $match->home_team_id;
-
-            if ($isHome) {
-                $homeIds = array_values(array_filter($homeIds, fn ($id) => $id !== $sub['player_out_id']));
-                $homeIds[] = $sub['player_in_id'];
-            } else {
-                $awayIds = array_values(array_filter($awayIds, fn ($id) => $id !== $sub['player_out_id']));
-                $awayIds[] = $sub['player_in_id'];
-            }
-        }
-
-        // Exclude red-carded players (from regular time and extra time)
-        $redCardedIds = MatchEvent::where('game_match_id', $match->id)
-            ->where('event_type', MatchEvent::TYPE_RED_CARD)
-            ->pluck('game_player_id')
-            ->all();
-
-        $homeIds = array_values(array_filter($homeIds, fn ($id) => ! in_array($id, $redCardedIds)));
-        $awayIds = array_values(array_filter($awayIds, fn ($id) => ! in_array($id, $redCardedIds)));
-
-        $allIds = array_merge($homeIds, $awayIds);
-        $players = GamePlayer::with(['matchState'])->whereIn('id', $allIds)->get()->keyBy('id');
-
-        return [
-            $players->only($homeIds)->values(),
-            $players->only($awayIds)->values(),
-        ];
+        return $this->lineupResolver->playersOnPitchAtEnd($match);
     }
 
     /**

--- a/app/Modules/Match/Services/MatchLineupResolver.php
+++ b/app/Modules/Match/Services/MatchLineupResolver.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\Modules\Match\Services;
+
+use App\Models\GameMatch;
+use App\Models\GamePlayer;
+use App\Models\MatchEvent;
+
+/**
+ * Resolves which players are on the pitch at the end of a match.
+ *
+ * Real-football rule: only the players on the field at the final whistle of
+ * extra time are eligible to take penalties. Starting XI minus subs out plus
+ * subs in, minus red-carded players.
+ */
+class MatchLineupResolver
+{
+    /**
+     * Return the player IDs on the pitch at the end of the match, keyed by side.
+     *
+     * @return array{home: list<string>, away: list<string>}
+     */
+    public function playerIdsOnPitchAtEnd(GameMatch $match): array
+    {
+        $homeIds = $match->home_lineup ?? [];
+        $awayIds = $match->away_lineup ?? [];
+
+        foreach ($match->substitutions ?? [] as $sub) {
+            $isHome = $sub['team_id'] === $match->home_team_id;
+
+            if ($isHome) {
+                $homeIds = array_values(array_filter($homeIds, fn ($id) => $id !== $sub['player_out_id']));
+                $homeIds[] = $sub['player_in_id'];
+            } else {
+                $awayIds = array_values(array_filter($awayIds, fn ($id) => $id !== $sub['player_out_id']));
+                $awayIds[] = $sub['player_in_id'];
+            }
+        }
+
+        $redCardedIds = MatchEvent::where('game_match_id', $match->id)
+            ->where('event_type', MatchEvent::TYPE_RED_CARD)
+            ->pluck('game_player_id')
+            ->all();
+
+        return [
+            'home' => array_values(array_filter($homeIds, fn ($id) => ! in_array($id, $redCardedIds))),
+            'away' => array_values(array_filter($awayIds, fn ($id) => ! in_array($id, $redCardedIds))),
+        ];
+    }
+
+    /**
+     * Return the players on the pitch at the end of the match as collections per side.
+     *
+     * Always queries the database for the exact on-pitch players (max ~22).
+     * Pre-loaded squads from callers may be incomplete (e.g. miss subbed-in
+     * players), so the resolver is the single source of truth.
+     *
+     * @return array{0: Collection<int, GamePlayer>, 1: Collection<int, GamePlayer>}  [homePlayers, awayPlayers]
+     */
+    public function playersOnPitchAtEnd(GameMatch $match): array
+    {
+        $ids = $this->playerIdsOnPitchAtEnd($match);
+        $allIds = array_merge($ids['home'], $ids['away']);
+        $players = GamePlayer::with(['matchState'])->whereIn('id', $allIds)->get()->keyBy('id');
+
+        return [
+            collect($ids['home'])->map(fn ($id) => $players->get($id))->filter()->values(),
+            collect($ids['away'])->map(fn ($id) => $players->get($id))->filter()->values(),
+        ];
+    }
+}

--- a/app/Modules/Match/Services/MatchSimulator.php
+++ b/app/Modules/Match/Services/MatchSimulator.php
@@ -2991,10 +2991,15 @@ class MatchSimulator
     }
 
     /**
-     * Simulate a detailed penalty shootout with kick-by-kick results (max 5 rounds).
+     * Simulate a detailed penalty shootout with kick-by-kick results.
      *
-     * Each kick is a kicker-vs-goalkeeper duel. If still tied after 5 rounds,
-     * round 5 is rigged so one team scores and the other misses.
+     * Mirrors real-football rules:
+     *   - A coin flip decides which side kicks first.
+     *   - 5 regular rounds. If a result is mathematically decided before all
+     *     kicks are taken, the shootout ends early.
+     *   - If still tied after 5 rounds, sudden death: both teams kick once per
+     *     round and the round in which one team scores and the other misses
+     *     decides the winner. Kickers cycle through the queue.
      *
      * @param  array<string>|null  $homeOrder  Ordered game_player IDs for home kickers
      * @param  array<string>|null  $awayOrder  Ordered game_player IDs for away kickers
@@ -3021,106 +3026,99 @@ class MatchSimulator
         }
 
         // Extract goalkeepers — home kickers face the away GK and vice versa
-        $homeGk = $homePlayers->firstWhere('position', 'Goalkeeper');
-        $awayGk = $awayPlayers->firstWhere('position', 'Goalkeeper');
+        $opponentGk = [
+            'home' => $awayPlayers->firstWhere('position', 'Goalkeeper'),
+            'away' => $homePlayers->firstWhere('position', 'Goalkeeper'),
+        ];
+        $kickerQueues = ['home' => $homeKickers, 'away' => $awayKickers];
 
-        $homeScore = 0;
-        $awayScore = 0;
+        // Coin flip decides who kicks first — mirrors the real-football coin toss
+        $firstSide = random_int(0, 1) === 0 ? 'home' : 'away';
+        $secondSide = $firstSide === 'home' ? 'away' : 'home';
+
+        $scores = ['home' => 0, 'away' => 0];
+        $taken = ['home' => 0, 'away' => 0];
         $kicks = [];
-        $round = 1;
-        $maxRounds = 5;
-        $homeIdx = 0;
-        $awayIdx = 0;
 
-        // 5 penalties each
-        for ($i = 0; $i < $maxRounds; $i++) {
-            $homeKicker = $homeKickers[$homeIdx % count($homeKickers)];
-            $homeScored = $this->penaltyScored($homeKicker, $awayGk);
-            if ($homeScored) {
-                $homeScore++;
+        $regularRounds = 5;
+        // Safety cap for sudden death. P(round doesn't end) ≈ 0.625 per round with
+        // 75% conversion, so reaching 50 rounds has probability ~1e-10.
+        $hardCap = 50;
+
+        for ($round = 1; $round <= $hardCap; $round++) {
+            $decided = false;
+
+            foreach ([$firstSide, $secondSide] as $side) {
+                $queue = $kickerQueues[$side];
+                $kicker = $queue[$taken[$side] % count($queue)];
+                $scored = $this->penaltyScored($kicker, $opponentGk[$side]);
+
+                if ($scored) {
+                    $scores[$side]++;
+                }
+                $taken[$side]++;
+
+                $kicks[] = [
+                    'round' => $round,
+                    'side' => $side,
+                    'playerId' => $kicker->id,
+                    'playerName' => $kicker->name ?? '',
+                    'scored' => $scored,
+                ];
+
+                // Mathematical early termination only applies in regular rounds
+                if ($round <= $regularRounds && $this->hasPenaltyShootoutWinner(
+                    $scores['home'],
+                    $scores['away'],
+                    $taken['home'],
+                    $taken['away'],
+                    $regularRounds,
+                )) {
+                    $decided = true;
+                    break;
+                }
             }
-            $kicks[] = [
-                'round' => $round,
-                'side' => 'home',
-                'playerId' => $homeKicker->id,
-                'playerName' => $homeKicker->name ?? '',
-                'scored' => $homeScored,
-            ];
-            $homeIdx++;
 
-            if ($this->hasPenaltyShootoutWinner($homeScore, $awayScore, $i + 1, $i, $maxRounds)) {
+            if ($decided) {
                 break;
             }
 
-            $awayKicker = $awayKickers[$awayIdx % count($awayKickers)];
-            $awayScored = $this->penaltyScored($awayKicker, $homeGk);
-            if ($awayScored) {
-                $awayScore++;
-            }
-            $kicks[] = [
-                'round' => $round,
-                'side' => 'away',
-                'playerId' => $awayKicker->id,
-                'playerName' => $awayKicker->name ?? '',
-                'scored' => $awayScored,
-            ];
-            $awayIdx++;
-
-            if ($this->hasPenaltyShootoutWinner($homeScore, $awayScore, $i + 1, $i + 1, $maxRounds)) {
+            // After both teams have completed the round: regular round 5 onwards,
+            // any non-tied score ends the shootout (sudden death from round 6+)
+            if ($round >= $regularRounds && $scores['home'] !== $scores['away']) {
                 break;
             }
-
-            $round++;
         }
 
-        // If still tied after 5 rounds, rig round 5 so one team wins
-        if ($homeScore === $awayScore) {
-            $homeWins = (bool) random_int(0, 1);
-            $winnerSide = $homeWins ? 'home' : 'away';
-            $loserSide = $homeWins ? 'away' : 'home';
+        // Astronomically rare safety net: hard cap hit while still tied. Coin-flip
+        // the last kick in the most recent round so we never return a tied result.
+        if ($scores['home'] === $scores['away'] && ! empty($kicks)) {
+            $winnerSide = random_int(0, 1) === 0 ? 'home' : 'away';
+            $loserSide = $winnerSide === 'home' ? 'away' : 'home';
 
-            // Find round-5 kicks
-            $r5WinnerIdx = null;
-            $r5LoserIdx = null;
-            foreach ($kicks as $idx => $kick) {
-                if ($kick['round'] === 5 && $kick['side'] === $winnerSide) {
-                    $r5WinnerIdx = $idx;
-                }
-                if ($kick['round'] === 5 && $kick['side'] === $loserSide) {
-                    $r5LoserIdx = $idx;
+            for ($i = count($kicks) - 1; $i >= 0; $i--) {
+                if ($kicks[$i]['side'] === $loserSide && $kicks[$i]['scored']) {
+                    $kicks[$i]['scored'] = false;
+                    $scores[$loserSide]--;
+                    break;
                 }
             }
 
-            // Set winner's R5 to scored, loser's R5 to missed
-            if ($r5WinnerIdx !== null) {
-                $kicks[$r5WinnerIdx]['scored'] = true;
-            }
-            if ($r5LoserIdx !== null) {
-                $kicks[$r5LoserIdx]['scored'] = false;
-            }
-
-            // Recalculate scores from the kicks array
-            $homeScore = collect($kicks)->where('side', 'home')->where('scored', true)->count();
-            $awayScore = collect($kicks)->where('side', 'away')->where('scored', true)->count();
-
-            // Edge case: still tied if earlier rounds compensated — flip one loser scored kick
-            if ($homeScore === $awayScore) {
-                foreach ($kicks as $idx => $kick) {
-                    if ($kick['side'] === $loserSide && $kick['scored'] && $kick['round'] < 5) {
-                        $kicks[$idx]['scored'] = false;
-
+            // Still tied? Flip the most recent winner-side miss to scored.
+            if ($scores['home'] === $scores['away']) {
+                for ($i = count($kicks) - 1; $i >= 0; $i--) {
+                    if ($kicks[$i]['side'] === $winnerSide && ! $kicks[$i]['scored']) {
+                        $kicks[$i]['scored'] = true;
+                        $scores[$winnerSide]++;
                         break;
                     }
                 }
-
-                $homeScore = collect($kicks)->where('side', 'home')->where('scored', true)->count();
-                $awayScore = collect($kicks)->where('side', 'away')->where('scored', true)->count();
             }
         }
 
         return [
-            'homeScore' => $homeScore,
-            'awayScore' => $awayScore,
+            'homeScore' => $scores['home'],
+            'awayScore' => $scores['away'],
             'kicks' => $kicks,
         ];
     }

--- a/app/Modules/Match/Services/MatchSimulator.php
+++ b/app/Modules/Match/Services/MatchSimulator.php
@@ -2999,7 +2999,9 @@ class MatchSimulator
      *     kicks are taken, the shootout ends early.
      *   - If still tied after 5 rounds, sudden death: both teams kick once per
      *     round and the round in which one team scores and the other misses
-     *     decides the winner. Kickers cycle through the queue.
+     *     decides the winner. A kicker cannot kick a second time until every
+     *     eligible player on the field has kicked once (queue capped at 11
+     *     in {@see self::buildKickerQueue()}, then it wraps around).
      *
      * @param  array<string>|null  $homeOrder  Ordered game_player IDs for home kickers
      * @param  array<string>|null  $awayOrder  Ordered game_player IDs for away kickers
@@ -3146,10 +3148,16 @@ class MatchSimulator
      * When an explicit order is given, those players go first, followed by
      * remaining players sorted by technical ability. Goalkeepers go last.
      *
+     * The queue is capped at 11 players — the maximum eligible to kick under
+     * real-football rules (the players on the field at the end of extra time).
+     * Once everyone in the queue has kicked, kickers cycle from the top.
+     *
      * @return list<GamePlayer>
      */
     private function buildKickerQueue(Collection $players, ?array $order = null): array
     {
+        $maxKickers = 11;
+
         if ($order) {
             $ordered = collect($order)
                 ->map(fn ($id) => $players->firstWhere('id', $id))
@@ -3161,7 +3169,7 @@ class MatchSimulator
                 ->sortByDesc(fn ($p) => $p->overall_score)
                 ->values();
 
-            return $ordered->merge($remaining)->all();
+            return $ordered->merge($remaining)->take($maxKickers)->all();
         }
 
         // Default: outfield sorted by technical ability desc, GK last
@@ -3175,6 +3183,7 @@ class MatchSimulator
 
                 return $b->overall_score - $a->overall_score;
             })
+            ->take($maxKickers)
             ->values()
             ->all();
     }

--- a/app/Modules/Match/Services/MatchSimulator.php
+++ b/app/Modules/Match/Services/MatchSimulator.php
@@ -3148,16 +3148,15 @@ class MatchSimulator
      * When an explicit order is given, those players go first, followed by
      * remaining players sorted by technical ability. Goalkeepers go last.
      *
-     * The queue is capped at 11 players — the maximum eligible to kick under
-     * real-football rules (the players on the field at the end of extra time).
-     * Once everyone in the queue has kicked, kickers cycle from the top.
+     * Callers are responsible for passing only the players on the pitch at
+     * the end of extra time — those are the only ones eligible under FIFA
+     * rules. The queue then wraps around once every kicker has taken one
+     * penalty (sudden death).
      *
      * @return list<GamePlayer>
      */
     private function buildKickerQueue(Collection $players, ?array $order = null): array
     {
-        $maxKickers = 11;
-
         if ($order) {
             $ordered = collect($order)
                 ->map(fn ($id) => $players->firstWhere('id', $id))
@@ -3169,7 +3168,7 @@ class MatchSimulator
                 ->sortByDesc(fn ($p) => $p->overall_score)
                 ->values();
 
-            return $ordered->merge($remaining)->take($maxKickers)->all();
+            return $ordered->merge($remaining)->all();
         }
 
         // Default: outfield sorted by technical ability desc, GK last
@@ -3183,7 +3182,6 @@ class MatchSimulator
 
                 return $b->overall_score - $a->overall_score;
             })
-            ->take($maxKickers)
             ->values()
             ->all();
     }

--- a/tests/Unit/PenaltyShootoutTest.php
+++ b/tests/Unit/PenaltyShootoutTest.php
@@ -2,7 +2,9 @@
 
 namespace Tests\Unit;
 
+use App\Models\GamePlayer;
 use App\Modules\Match\Services\MatchSimulator;
+use Illuminate\Support\Collection;
 use ReflectionMethod;
 use Tests\TestCase;
 
@@ -60,5 +62,106 @@ class PenaltyShootoutTest extends TestCase
         );
 
         $this->assertTrue($resolved);
+    }
+
+    public function test_shootout_never_returns_a_tied_score(): void
+    {
+        $home = $this->buildTeamPlayers('H');
+        $away = $this->buildTeamPlayers('A');
+
+        for ($i = 0; $i < 50; $i++) {
+            $result = $this->simulator->simulatePenaltyShootout($home, $away);
+
+            $this->assertNotSame(
+                $result['homeScore'],
+                $result['awayScore'],
+                'Shootout returned a tied score: '.json_encode($result),
+            );
+        }
+    }
+
+    public function test_first_kicker_is_decided_by_coin_flip(): void
+    {
+        $home = $this->buildTeamPlayers('H');
+        $away = $this->buildTeamPlayers('A');
+
+        $homeFirstCount = 0;
+        $awayFirstCount = 0;
+
+        for ($i = 0; $i < 200; $i++) {
+            $result = $this->simulator->simulatePenaltyShootout($home, $away);
+            $firstKick = $result['kicks'][0] ?? null;
+
+            $this->assertNotNull($firstKick);
+
+            if ($firstKick['side'] === 'home') {
+                $homeFirstCount++;
+            } else {
+                $awayFirstCount++;
+            }
+        }
+
+        // Both sides should appear as first kicker. With 200 trials at p=0.5,
+        // P(one side gets 0) = 2 * 0.5^200 — practically impossible.
+        $this->assertGreaterThan(0, $homeFirstCount, 'Home never kicked first across 200 shootouts');
+        $this->assertGreaterThan(0, $awayFirstCount, 'Away never kicked first across 200 shootouts');
+    }
+
+    public function test_sudden_death_can_extend_shootout_past_round_five(): void
+    {
+        $home = $this->buildTeamPlayers('H');
+        $away = $this->buildTeamPlayers('A');
+
+        $sawSuddenDeath = false;
+
+        // With 75% conversion, P(tied after 5 rounds) is ~22%, so 100 trials
+        // should virtually always include at least one sudden-death shootout.
+        for ($i = 0; $i < 100; $i++) {
+            $result = $this->simulator->simulatePenaltyShootout($home, $away);
+
+            $maxRound = 0;
+            foreach ($result['kicks'] as $kick) {
+                if ($kick['round'] > $maxRound) {
+                    $maxRound = $kick['round'];
+                }
+            }
+
+            if ($maxRound > 5) {
+                $sawSuddenDeath = true;
+                break;
+            }
+        }
+
+        $this->assertTrue($sawSuddenDeath, 'Expected sudden death to occur in at least one of 100 shootouts');
+    }
+
+    /**
+     * Build a balanced squad of outfield players + a goalkeeper.
+     */
+    private function buildTeamPlayers(string $prefix): Collection
+    {
+        $players = collect();
+
+        for ($i = 1; $i <= 10; $i++) {
+            $players->push($this->makePlayer($prefix.'-out-'.$i, 'Forward', 70));
+        }
+
+        $players->push($this->makePlayer($prefix.'-gk', 'Goalkeeper', 70));
+
+        return $players;
+    }
+
+    private function makePlayer(string $id, string $position, int $overall): GamePlayer
+    {
+        $player = new GamePlayer;
+        $player->forceFill([
+            'id' => $id,
+            'name' => $id,
+            'position' => $position,
+            'overall_score' => $overall,
+        ]);
+        $player->morale = 70;
+
+        return $player;
     }
 }

--- a/tests/Unit/PenaltyShootoutTest.php
+++ b/tests/Unit/PenaltyShootoutTest.php
@@ -135,54 +135,51 @@ class PenaltyShootoutTest extends TestCase
         $this->assertTrue($sawSuddenDeath, 'Expected sudden death to occur in at least one of 100 shootouts');
     }
 
-    public function test_kicker_queue_caps_at_eleven_players(): void
+    public function test_sudden_death_recycles_kickers_only_after_all_have_kicked(): void
     {
-        // Pass a full squad (25 players) — only the best 11 should be eligible.
-        $home = $this->buildSquad('H', 25);
-        $away = $this->buildSquad('A', 25);
+        // 11 distinct players — once everyone has kicked, the same order
+        // restarts. We verify recycling kicks in at kick 12 (not earlier).
+        $home = $this->buildTeamPlayers('H');
+        $away = $this->buildTeamPlayers('A');
 
-        $sawSuddenDeath = false;
+        $sawRecycle = false;
 
-        for ($i = 0; $i < 200 && ! $sawSuddenDeath; $i++) {
+        for ($i = 0; $i < 200 && ! $sawRecycle; $i++) {
             $result = $this->simulator->simulatePenaltyShootout($home, $away);
 
-            $homePlayerIds = collect($result['kicks'])
+            $homeIdsByOrder = collect($result['kicks'])
                 ->where('side', 'home')
                 ->pluck('playerId')
-                ->unique();
+                ->values();
 
-            $awayPlayerIds = collect($result['kicks'])
-                ->where('side', 'away')
-                ->pluck('playerId')
-                ->unique();
-
-            $this->assertLessThanOrEqual(11, $homePlayerIds->count(), 'More than 11 distinct home kickers used');
-            $this->assertLessThanOrEqual(11, $awayPlayerIds->count(), 'More than 11 distinct away kickers used');
-
-            $maxRound = collect($result['kicks'])->max('round') ?? 0;
-            if ($maxRound > 5) {
-                $sawSuddenDeath = true;
+            if ($homeIdsByOrder->count() >= 12) {
+                $this->assertSame(
+                    $homeIdsByOrder->take(11)->unique()->count(),
+                    $homeIdsByOrder->take(11)->count(),
+                    'The first 11 home kickers must all be distinct',
+                );
+                $this->assertSame(
+                    $homeIdsByOrder->get(0),
+                    $homeIdsByOrder->get(11),
+                    'Kicker #12 must be the same as kicker #1 (recycle)',
+                );
+                $sawRecycle = true;
             }
         }
 
-        $this->assertTrue($sawSuddenDeath, 'Expected at least one sudden-death shootout to validate the cap');
+        $this->assertTrue($sawRecycle, 'Expected at least one shootout to reach the 12th kick to validate recycling');
     }
 
     /**
-     * Build a balanced squad of outfield players + a goalkeeper.
+     * Build a balanced squad of 11 players (10 outfield + 1 GK).
      */
     private function buildTeamPlayers(string $prefix): Collection
-    {
-        return $this->buildSquad($prefix, 11);
-    }
-
-    private function buildSquad(string $prefix, int $size): Collection
     {
         $players = collect();
 
         $players->push($this->makePlayer($prefix.'-gk', 'Goalkeeper', 70));
 
-        for ($i = 1; $i < $size; $i++) {
+        for ($i = 1; $i <= 10; $i++) {
             $players->push($this->makePlayer($prefix.'-out-'.$i, 'Forward', 70));
         }
 

--- a/tests/Unit/PenaltyShootoutTest.php
+++ b/tests/Unit/PenaltyShootoutTest.php
@@ -135,18 +135,56 @@ class PenaltyShootoutTest extends TestCase
         $this->assertTrue($sawSuddenDeath, 'Expected sudden death to occur in at least one of 100 shootouts');
     }
 
+    public function test_kicker_queue_caps_at_eleven_players(): void
+    {
+        // Pass a full squad (25 players) — only the best 11 should be eligible.
+        $home = $this->buildSquad('H', 25);
+        $away = $this->buildSquad('A', 25);
+
+        $sawSuddenDeath = false;
+
+        for ($i = 0; $i < 200 && ! $sawSuddenDeath; $i++) {
+            $result = $this->simulator->simulatePenaltyShootout($home, $away);
+
+            $homePlayerIds = collect($result['kicks'])
+                ->where('side', 'home')
+                ->pluck('playerId')
+                ->unique();
+
+            $awayPlayerIds = collect($result['kicks'])
+                ->where('side', 'away')
+                ->pluck('playerId')
+                ->unique();
+
+            $this->assertLessThanOrEqual(11, $homePlayerIds->count(), 'More than 11 distinct home kickers used');
+            $this->assertLessThanOrEqual(11, $awayPlayerIds->count(), 'More than 11 distinct away kickers used');
+
+            $maxRound = collect($result['kicks'])->max('round') ?? 0;
+            if ($maxRound > 5) {
+                $sawSuddenDeath = true;
+            }
+        }
+
+        $this->assertTrue($sawSuddenDeath, 'Expected at least one sudden-death shootout to validate the cap');
+    }
+
     /**
      * Build a balanced squad of outfield players + a goalkeeper.
      */
     private function buildTeamPlayers(string $prefix): Collection
     {
+        return $this->buildSquad($prefix, 11);
+    }
+
+    private function buildSquad(string $prefix, int $size): Collection
+    {
         $players = collect();
 
-        for ($i = 1; $i <= 10; $i++) {
+        $players->push($this->makePlayer($prefix.'-gk', 'Goalkeeper', 70));
+
+        for ($i = 1; $i < $size; $i++) {
             $players->push($this->makePlayer($prefix.'-out-'.$i, 'Forward', 70));
         }
-
-        $players->push($this->makePlayer($prefix.'-gk', 'Goalkeeper', 70));
 
         return $players;
     }


### PR DESCRIPTION
The shootout always started with the home team and resolved ties after
5 rounds with a 50/50 coin flip, which made the result feel arbitrary
on long ties. Coin-flip the first kicker and continue with proper
sudden death past round 5 (both sides kick once per round, winner
decided when one scores and the other misses).