### PR TITLE
Fix phantom ET goals and add score/events audit

### DIFF
--- a/app/Modules/Match/Services/CupTieResolver.php
+++ b/app/Modules/Match/Services/CupTieResolver.php
@@ -9,7 +9,9 @@ use App\Models\CupTie;
 use App\Models\GameMatch;
 use App\Models\GamePlayer;
 use App\Models\Team;
+use App\Modules\Match\Support\ScoreEventsAuditor;
 use App\Modules\Match\Support\StoppageCalculator;
+use App\Modules\Match\Support\StoppageDurations;
 use Illuminate\Support\Collection;
 use App\Modules\Match\Services\MatchSimulator;
 
@@ -83,7 +85,7 @@ class CupTieResolver
                 neutralVenue: $match->isNeutralVenue(),
                 homePlayerSlots: $match->playerSlotMap('home'),
                 awayPlayerSlots: $match->playerSlotMap('away'),
-                regulationStoppage: (int) ($match->second_half_stoppage ?? 0),
+                stoppage: StoppageDurations::fromMatch($match),
             );
 
             $homeScoreEt = $extraTimeResult->homeScore;
@@ -92,7 +94,8 @@ class CupTieResolver
             // Derive ET stoppage from events, persist before event-insert.
             $etStoppage = $this->stoppageCalculator->calculateExtraTime(
                 $extraTimeResult->events,
-                regulationStoppage: (int) ($match->second_half_stoppage ?? 0),
+                regulationStoppage: (int) ($match->first_half_stoppage ?? 0)
+                    + (int) ($match->second_half_stoppage ?? 0),
             );
 
             $match->update([
@@ -112,6 +115,8 @@ class CupTieResolver
                 $match->game_id,
                 $match->id,
             );
+
+            ScoreEventsAuditor::audit($match->refresh(), 'cup_tie_single_leg_extra_time');
         }
 
         $totalHome = $homeScore + $homeScoreEt;
@@ -197,7 +202,7 @@ class CupTieResolver
                 neutralVenue: $secondLeg->isNeutralVenue(),
                 homePlayerSlots: $secondLeg->playerSlotMap('home'),
                 awayPlayerSlots: $secondLeg->playerSlotMap('away'),
-                regulationStoppage: (int) ($secondLeg->second_half_stoppage ?? 0),
+                stoppage: StoppageDurations::fromMatch($secondLeg),
             );
 
             $homeScoreEt = $extraTimeResult->homeScore;
@@ -205,7 +210,8 @@ class CupTieResolver
 
             $etStoppage = $this->stoppageCalculator->calculateExtraTime(
                 $extraTimeResult->events,
-                regulationStoppage: (int) ($secondLeg->second_half_stoppage ?? 0),
+                regulationStoppage: (int) ($secondLeg->first_half_stoppage ?? 0)
+                    + (int) ($secondLeg->second_half_stoppage ?? 0),
             );
 
             $secondLeg->update([
@@ -225,6 +231,8 @@ class CupTieResolver
                 $secondLeg->game_id,
                 $secondLeg->id,
             );
+
+            ScoreEventsAuditor::audit($secondLeg->refresh(), 'cup_tie_two_leg_extra_time');
         }
 
         // Extra time goals affect aggregate

--- a/app/Modules/Match/Services/ExtraTimeAndPenaltyService.php
+++ b/app/Modules/Match/Services/ExtraTimeAndPenaltyService.php
@@ -11,7 +11,9 @@ use App\Modules\Match\DTOs\ExtraTimeProcessResult;
 use App\Modules\Match\DTOs\PenaltyProcessResult;
 use App\Modules\Match\DTOs\TacticalConfig;
 use App\Modules\Match\Enums\MatchPhase;
+use App\Modules\Match\Support\ScoreEventsAuditor;
 use App\Modules\Match\Support\StoppageCalculator;
+use App\Modules\Match\Support\StoppageDurations;
 use Illuminate\Support\Collection;
 
 class ExtraTimeAndPenaltyService
@@ -69,14 +71,15 @@ class ExtraTimeAndPenaltyService
             neutralVenue: $match->isNeutralVenue(),
             homePlayerSlots: $homePlayerSlots,
             awayPlayerSlots: $awayPlayerSlots,
-            regulationStoppage: (int) ($match->second_half_stoppage ?? 0),
+            stoppage: StoppageDurations::fromMatch($match),
         );
 
         // Derive ET stoppage from the event mix; persist before storing events
         // so MatchEventRepository decomposes raw minutes correctly.
         $etStoppage = $this->stoppageCalculator->calculateExtraTime(
             $extraTimeResult->events,
-            regulationStoppage: (int) ($match->second_half_stoppage ?? 0),
+            regulationStoppage: (int) ($match->first_half_stoppage ?? 0)
+                + (int) ($match->second_half_stoppage ?? 0),
         );
 
         $match->update([
@@ -90,6 +93,8 @@ class ExtraTimeAndPenaltyService
         ]);
 
         $storedEvents = $this->storeExtraTimeEvents($match, $game, $extraTimeResult->events);
+
+        ScoreEventsAuditor::audit($match->refresh(), 'process_extra_time');
 
         $needsPenalties = $this->checkNeedsPenalties($match, $extraTimeResult->homeScore, $extraTimeResult->awayScore);
 

--- a/app/Modules/Match/Services/MatchResimulationService.php
+++ b/app/Modules/Match/Services/MatchResimulationService.php
@@ -8,6 +8,7 @@ use App\Modules\Match\DTOs\ResimulationResult;
 use App\Modules\Match\DTOs\TacticalConfig;
 use App\Modules\Match\Enums\MatchPhase;
 use App\Modules\Match\Support\MinuteCoordinates;
+use App\Modules\Match\Support\ScoreEventsAuditor;
 use App\Modules\Match\Support\StoppageDurations;
 use App\Models\Game;
 use App\Models\GameMatch;
@@ -413,6 +414,8 @@ class MatchResimulationService
             'mvp_player_id' => $mvpPlayerId,
         ]);
 
+        ScoreEventsAuditor::audit($match->refresh(), 'resimulate_regulation');
+
         return new ResimulationResult(
             $newHomeScore, $newAwayScore, $oldHomeScore, $oldAwayScore,
             $remainderResult->homePossession, $remainderResult->awayPossession,
@@ -573,7 +576,7 @@ class MatchResimulationService
                 neutralVenue: $match->isNeutralVenue(),
                 homePlayerSlots: $homePlayerSlots,
                 awayPlayerSlots: $awayPlayerSlots,
-                regulationStoppage: $stoppage->secondHalf,
+                stoppage: $stoppage,
             );
 
             // 8. Calculate new ET score
@@ -626,6 +629,8 @@ class MatchResimulationService
                 'away_possession' => $remainderResult->awayPossession,
                 'mvp_player_id' => $mvpPlayerId,
             ]);
+
+            ScoreEventsAuditor::audit($match->refresh(), 'resimulate_extra_time');
 
             return new ResimulationResult(
                 $newHomeScore, $newAwayScore, $oldHomeScore, $oldAwayScore,

--- a/app/Modules/Match/Services/MatchSimulator.php
+++ b/app/Modules/Match/Services/MatchSimulator.php
@@ -20,6 +20,7 @@ use App\Support\PositionMapper;
 use App\Support\PositionSlotMapper;
 use App\Modules\Player\Services\InjuryService;
 use App\Modules\Match\Services\EnergyCalculator;
+use App\Modules\Match\Support\StoppageDurations;
 
 class MatchSimulator
 {
@@ -2829,15 +2830,19 @@ class MatchSimulator
         bool $neutralVenue = false,
         ?array $homePlayerSlots = null,
         ?array $awayPlayerSlots = null,
-        int $regulationStoppage = 0,
+        ?StoppageDurations $stoppage = null,
     ): MatchResult {
-        // ET begins right after regulation finishes. Caller passes the
-        // *persisted* regulation stoppage so events generated here don't
-        // collide with regulation-stoppage events that occupy those raw
-        // minutes. Actual ET stoppage is computed from event mix after
-        // simulation by StoppageCalculator::calculateExtraTime.
-        $regulationEnd = 90 + $regulationStoppage;
-        $extraTimeEnd = self::EXTRA_TIME_NOMINAL_END + $regulationStoppage + self::EXTRA_TIME_HEADROOM;
+        // ET begins right after regulation finishes, in raw absolute minutes.
+        // The caller passes the *persisted* regulation stoppage (both halves)
+        // so events generated here don't collide with regulation-stoppage
+        // events that occupy those raw minutes — without first-half stoppage,
+        // ET events would be placed at raw minutes that decompose back into
+        // second-half stoppage and surface as phantom "90+N'" goals in the
+        // event feed. ET stoppage minutes are still computed after simulation
+        // by StoppageCalculator::calculateExtraTime.
+        $stoppage ??= new StoppageDurations(0, 0);
+        $regulationEnd = $stoppage->regulationEnd();
+        $extraTimeEnd = $regulationEnd + 30 + self::EXTRA_TIME_HEADROOM;
         $fromMinute ??= $regulationEnd;
         if ($homePlayerSlots !== null) {
             $this->homePlayerSlotMap = $homePlayerSlots;

--- a/app/Modules/Match/Support/ScoreEventsAuditor.php
+++ b/app/Modules/Match/Support/ScoreEventsAuditor.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Modules\Match\Support;
+
+use App\Models\GameMatch;
+use App\Models\MatchEvent;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Verify that the count of persisted goal events matches the persisted
+ * scoreboard for a match.
+ *
+ * The simulator derives score and events from the same Poisson roll, but in
+ * resimulation paths the two are stored and updated independently. A
+ * mismatch — events without a corresponding score increment, or vice versa —
+ * surfaces as a "phantom goal" in the UI. We don't throw (a user mid-match
+ * shouldn't see a 500), but we do log loudly so operations can investigate.
+ */
+final class ScoreEventsAuditor
+{
+    public static function audit(GameMatch $match, string $stage): void
+    {
+        $eventCount = MatchEvent::where('game_match_id', $match->id)
+            ->whereIn('event_type', ['goal', 'own_goal'])
+            ->count();
+
+        $expected = (int) $match->home_score + (int) $match->away_score
+            + (int) ($match->home_score_et ?? 0) + (int) ($match->away_score_et ?? 0);
+
+        if ($eventCount !== $expected) {
+            Log::warning('Match score/events mismatch', [
+                'stage' => $stage,
+                'match_id' => $match->id,
+                'goal_events' => $eventCount,
+                'expected_total' => $expected,
+                'home_score' => $match->home_score,
+                'away_score' => $match->away_score,
+                'home_score_et' => $match->home_score_et,
+                'away_score_et' => $match->away_score_et,
+            ]);
+        }
+    }
+}

--- a/app/Modules/Match/Support/StoppageCalculator.php
+++ b/app/Modules/Match/Support/StoppageCalculator.php
@@ -46,9 +46,13 @@ final class StoppageCalculator
      * stoppage to the second half for simplicity (etfhs = 0).
      *
      * @param  Collection|iterable  $events  ET events only.
-     * @param  int  $regulationStoppage  Persisted 2H stoppage value; ET 2H
-     *                                   officially ends at raw minute
-     *                                   (120 + regulationStoppage).
+     * @param  int  $regulationStoppage  Total persisted regulation stoppage
+     *                                   (first + second half). ET 2H ends at
+     *                                   raw minute (120 + regulationStoppage).
+     *                                   Both halves are required: omitting the
+     *                                   first-half value pulls the boundary
+     *                                   into ET 2H and inflates the overflow
+     *                                   estimate.
      * @return array{et_first_half:int, et_second_half:int}
      */
     public function calculateExtraTime($events, int $regulationStoppage = 0): array

--- a/lang/es/commentary.php
+++ b/lang/es/commentary.php
@@ -260,7 +260,7 @@ return [
     'goal_possession' => [
         ':team mueve el balón con paciencia hasta que :player encuentra el hueco. Posesión de manual',
         'Elaboración paciente de :team y :player elige el momento perfecto para golpear',
-        'Jugada trenzada de :del_team — :player pone el broche final',
+        'Jugada trenzada :del_team — :player pone el broche final',
     ],
     'goal_direct' => [
         '¡Balón largo y :player está ahí para definir por :team!',

--- a/tests/Unit/ExtraTimeStoppageBoundaryTest.php
+++ b/tests/Unit/ExtraTimeStoppageBoundaryTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\Game;
+use App\Models\Team;
+use App\Modules\Match\Services\MatchSimulator;
+use App\Modules\Match\Support\MinuteCoordinates;
+use App\Modules\Match\Support\StoppageDurations;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use Tests\Traits\CreatesLineups;
+
+/**
+ * Regression test for the "phantom 90+N' goal" bug.
+ *
+ * The simulator used to compute the end of regulation as `90 + secondHalfStoppage`,
+ * ignoring first-half stoppage. When a match had any first-half stoppage,
+ * ET goal events landed at raw minutes that decomposed back into
+ * SECOND_HALF_STOPPAGE — surfacing in the event feed as "90+N'" while
+ * counting toward `home_score_et`/`away_score_et`. An in-ET resimulation
+ * would then filter ET-only score by phase tag and silently drop the goal.
+ */
+class ExtraTimeStoppageBoundaryTest extends TestCase
+{
+    use RefreshDatabase;
+    use CreatesLineups;
+
+    public function test_et_goals_never_decompose_into_regulation_stoppage_phase(): void
+    {
+        $simulator = new MatchSimulator;
+        $game = Game::factory()->create(['current_date' => '2025-10-01']);
+        $homeTeam = Team::factory()->create();
+        $awayTeam = Team::factory()->create();
+        $homePlayers = $this->createLineup($game, $homeTeam, 11, 80);
+        $awayPlayers = $this->createLineup($game, $awayTeam, 11, 80);
+
+        // Pick a stoppage shape that would have triggered the bug: any
+        // first-half stoppage > 0 makes the old `90 + shs` boundary fall
+        // short of the real end of regulation by `fhs` minutes.
+        $stoppage = new StoppageDurations(firstHalf: 3, secondHalf: 5);
+
+        // Many iterations to make sure we exercise multiple goal-minute rolls.
+        for ($i = 0; $i < 30; $i++) {
+            $result = $simulator->simulateExtraTime(
+                $homeTeam, $awayTeam,
+                $homePlayers, $awayPlayers,
+                stoppage: $stoppage,
+            );
+
+            foreach ($result->events as $event) {
+                if (! in_array($event->type, ['goal', 'own_goal'], true)) {
+                    continue;
+                }
+
+                $decomposed = MinuteCoordinates::decomposeWith($event->minute, $stoppage);
+
+                $this->assertNotEquals(
+                    \App\Modules\Match\Enums\MatchPhase::SECOND_HALF_STOPPAGE,
+                    $decomposed['phase'],
+                    "ET goal event at raw minute {$event->minute} decomposed into SECOND_HALF_STOPPAGE — "
+                    . "would surface as a phantom '90+N\\'' goal in the feed."
+                );
+
+                $this->assertTrue(
+                    $decomposed['phase']->isExtraTime(),
+                    "ET goal event at raw minute {$event->minute} should be tagged with an ET_* phase, "
+                    . "got {$decomposed['phase']->value}."
+                );
+            }
+        }
+    }
+}

--- a/tests/Unit/GoalCommentaryTemplateTest.php
+++ b/tests/Unit/GoalCommentaryTemplateTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Tests\Unit;
+
+use Tests\TestCase;
+
+/**
+ * Guard against grammatical bugs in goal-narrative templates.
+ *
+ * The Spanish templates use placeholders like `:del_team` and `:el_team`
+ * that already include the article ("del CD Arenteiro", "de la Real
+ * Sociedad", "de Osasuna", "el Real Madrid"). A template that prefixes
+ * those placeholders with a literal "de " or "el " produces duplicated
+ * prepositions like "de del CD Arenteiro" — which is exactly what the
+ * `goal_possession` template did before this test was added.
+ */
+class GoalCommentaryTemplateTest extends TestCase
+{
+    public function test_goal_templates_do_not_duplicate_articles(): void
+    {
+        $sampleTeams = [
+            ['name' => 'CD Arenteiro',     'del' => 'del CD Arenteiro',     'el' => 'el CD Arenteiro',     'al' => 'al CD Arenteiro'],
+            ['name' => 'Real Sociedad',    'del' => 'de la Real Sociedad',  'el' => 'la Real Sociedad',    'al' => 'a la Real Sociedad'],
+            ['name' => 'Osasuna',          'del' => 'de Osasuna',           'el' => 'Osasuna',             'al' => 'a Osasuna'],
+        ];
+
+        $groups = [
+            'commentary.goal_possession',
+            'commentary.goal_counter_attack',
+            'commentary.goal_direct',
+            'commentary.goal_penalty',
+        ];
+
+        $forbiddenSubstrings = [
+            ' de del ', ' de de la ', ' de de ',
+            ' el el ', ' la la ', ' al al ', ' a la a la ',
+        ];
+
+        foreach ($groups as $key) {
+            $templates = trans($key, [], 'es');
+            $this->assertIsArray($templates, "{$key} should resolve to an array of templates");
+
+            foreach ($templates as $template) {
+                foreach ($sampleTeams as $team) {
+                    $rendered = strtr($template, [
+                        ':player'    => 'Player Name',
+                        ':team'      => $team['name'],
+                        ':del_team'  => $team['del'],
+                        ':el_team'   => $team['el'],
+                        ':al_team'   => $team['al'],
+                    ]);
+                    $padded = " {$rendered} ";
+
+                    foreach ($forbiddenSubstrings as $bad) {
+                        $this->assertStringNotContainsString(
+                            $bad,
+                            $padded,
+                            "Template '{$template}' renders with forbidden substring '{$bad}' for team {$team['name']}: \"{$rendered}\""
+                        );
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes a critical bug where extra-time goals could decompose into regulation stoppage phases and surface as phantom "90+N'" goals in the event feed. Also adds defensive auditing to catch score/events mismatches.

## Key Changes

- **MatchSimulator.simulateExtraTime()**: Changed signature from `int $regulationStoppage` to `?StoppageDurations $stoppage` to capture both first-half and second-half stoppage. The old code computed ET boundaries using only second-half stoppage, causing ET events to land at raw minutes that decomposed back into `SECOND_HALF_STOPPAGE` phase. Now uses `$stoppage->regulationEnd()` which accounts for both halves, ensuring ET events always decompose into ET phases.

- **StoppageCalculator.calculateExtraTime()**: Updated docstring to clarify that `regulationStoppage` parameter must include **both** first and second-half stoppage. Omitting first-half stoppage pulls the ET 2H boundary into ET 2H itself and inflates overflow estimates.

- **CupTieResolver & ExtraTimeAndPenaltyService & MatchResimulationService**: Updated all callers to pass `StoppageDurations::fromMatch($match)` instead of just `second_half_stoppage`, and fixed `calculateExtraTime()` calls to sum both halves when computing the regulation stoppage parameter.

- **ScoreEventsAuditor** (new): Defensive utility that verifies persisted goal event count matches the scoreboard (regulation + ET scores). Logs warnings (non-fatal) when mismatches occur, enabling operations to investigate phantom goals without blocking user gameplay.

- **GoalCommentaryTemplateTest** (new): Regression test guarding against grammatical bugs in Spanish goal templates. Validates that templates don't duplicate articles (e.g., "de del CD Arenteiro") when using pre-articled placeholders like `:del_team`.

- **ExtraTimeStoppageBoundaryTest** (new): Regression test for the phantom goal bug. Simulates ET 30 times with first-half stoppage and verifies all goal events decompose into ET phases, never into `SECOND_HALF_STOPPAGE`.

- **lang/es/commentary.php**: Fixed `goal_possession` template that was prefixing `:del_team` with a literal "de ", creating "de del" duplications.

## Implementation Details

The root cause was treating ET as starting at `90 + secondHalfStoppage`, which is correct only if first-half stoppage is zero. With first-half stoppage, the true regulation end is `90 + firstHalfStoppage + secondHalfStoppage`. ET events generated at raw minutes in the range `[90 + secondHalfStoppage, 90 + firstHalfStoppage + secondHalfStoppage)` would decompose back into the second-half stoppage phase, surfacing as "90+N'" in the feed while counting toward ET scores. Resimulation would then filter by phase tag and silently drop these goals.

The `StoppageDurations` value object encapsulates both stoppage values and provides `regulationEnd()` to compute the correct boundary. All ET simulation and stoppage calculation now uses this consistently.

https://claude.ai/code/session_01EMBmkUGWXZHKa1UsJNfbhz