### PR TITLE
Allow sending U23 first-team players down to the reserve

### DIFF
--- a/app/Http/Actions/SendDownToReserve.php
+++ b/app/Http/Actions/SendDownToReserve.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Http\Actions;
+
+use App\Models\Game;
+use App\Models\GamePlayer;
+use App\Modules\ReserveTeam\Exceptions\FirstTeamSquadMinimumException;
+use App\Modules\ReserveTeam\Services\ReserveTeamService;
+
+class SendDownToReserve
+{
+    public function __construct(
+        private readonly ReserveTeamService $reserveTeamService,
+    ) {}
+
+    public function __invoke(string $gameId, string $playerId)
+    {
+        $game = Game::findOrFail($gameId);
+        abort_if($game->reserve_team_id === null, 404);
+
+        $player = GamePlayer::where('id', $playerId)
+            ->where('game_id', $gameId)
+            ->where('team_id', $game->team_id)
+            ->firstOrFail();
+
+        $playerName = $player->name ?? '';
+
+        try {
+            $this->reserveTeamService->sendDownToReserve($player, $game);
+        } catch (FirstTeamSquadMinimumException $e) {
+            return redirect()->route('game.squad', $gameId)
+                ->with('error', $this->formatBreachMessage($e));
+        } catch (\DomainException $e) {
+            return redirect()->route('game.squad', $gameId)
+                ->with('error', __('messages.send_down_not_allowed'));
+        }
+
+        return redirect()->route('game.squad', $gameId)
+            ->with('success', __('messages.player_sent_down_to_reserve', ['player' => $playerName]));
+    }
+
+    private function formatBreachMessage(FirstTeamSquadMinimumException $e): string
+    {
+        if ($e->type() === 'too_small') {
+            return __('messages.send_down_squad_too_small', ['min' => $e->min()]);
+        }
+
+        return __('messages.send_down_position_minimum', [
+            'group' => __('squad.' . strtolower($e->group()) . 's'),
+            'min'   => $e->min(),
+        ]);
+    }
+}

--- a/app/Http/Views/ShowPlayerDetail.php
+++ b/app/Http/Views/ShowPlayerDetail.php
@@ -69,6 +69,17 @@ class ShowPlayerDetail
         $isOnReserve = $game->reserve_team_id !== null
             && $gamePlayer->team_id === $game->reserve_team_id;
 
+        // U23 first-team players (not currently called up from the reserve)
+        // can be sent down to the reserve squad for development. Players on
+        // an active call-up loan have their own "send back" path which closes
+        // the loan cleanly; both can't be offered at the same time.
+        $canSendDownToReserve = $game->isCareerMode()
+            && $game->reserve_team_id !== null
+            && $gamePlayer->team_id === $game->team_id
+            && !$isCalledUpFromReserve
+            && $gamePlayer->date_of_birth !== null
+            && $gamePlayer->date_of_birth >= $game->getU23BirthCutoff();
+
         // Release is permitted for any user-owned player physically present
         // on a user roster (first team or reserve, including filial call-ups
         // who sit on the first team via internal loan). The team_id check
@@ -95,6 +106,7 @@ class ShowPlayerDetail
             'severance' => $severance,
             'isOnReserve' => $isOnReserve,
             'isCalledUpFromReserve' => $isCalledUpFromReserve,
+            'canSendDownToReserve' => $canSendDownToReserve,
             'incomingPreContract' => $incomingPreContract,
         ]);
     }

--- a/app/Models/GameTransfer.php
+++ b/app/Models/GameTransfer.php
@@ -31,6 +31,7 @@ class GameTransfer extends Model
     public const TYPE_FREE_AGENT = 'free_agent';
     public const TYPE_LOAN = 'loan';
     public const TYPE_INTERNAL_PROMOTION = 'internal_promotion';
+    public const TYPE_INTERNAL_DEMOTION = 'internal_demotion';
 
     /**
      * Record a completed transfer in the ledger.

--- a/app/Modules/ReserveTeam/Services/ReserveTeamService.php
+++ b/app/Modules/ReserveTeam/Services/ReserveTeamService.php
@@ -157,6 +157,66 @@ class ReserveTeamService
     }
 
     /**
+     * Permanently send a U23 first-team player down to the reserve squad.
+     * Flips team_id, nulls the squad number, and records the move as
+     * TYPE_INTERNAL_DEMOTION. Bringing the player back later goes through
+     * the regular callUpToFirstTeam() flow (which creates a new Loan).
+     *
+     * Strictly U23: birth date must fall on/after the current season's
+     * U23 cutoff. Players currently on an active call-up loan from the
+     * reserve must use sendBackToReserve() instead, so the loan closes
+     * cleanly.
+     *
+     * @throws FirstTeamSquadMinimumException when the first team would
+     *         fall below its squad-composition minimum after the move
+     */
+    public function sendDownToReserve(GamePlayer $player, Game $game): void
+    {
+        $this->assertFilial($game);
+
+        if ($player->team_id !== $game->team_id) {
+            throw new \DomainException('Player is not currently registered to the first team.');
+        }
+
+        if ($player->date_of_birth === null || $player->date_of_birth < $game->getU23BirthCutoff()) {
+            throw new \DomainException('Only U23 players can be sent down to the reserve.');
+        }
+
+        // Called-up reserve players have an open Loan (parent = reserve);
+        // closing that loan is what sendBackToReserve() is for. Don't
+        // shadow it here — otherwise the loan would be orphaned.
+        $existingCallUp = Loan::where('game_player_id', $player->id)
+            ->where('status', Loan::STATUS_ACTIVE)
+            ->where('parent_team_id', $game->reserve_team_id)
+            ->where('loan_team_id', $game->team_id)
+            ->exists();
+        if ($existingCallUp) {
+            throw new \DomainException('Player is on a reserve call-up loan; use sendBackToReserve() to return them.');
+        }
+
+        $breach = $this->squadMinimumService->validateRemoval($game, $player, $game->team_id);
+        if ($breach !== null) {
+            throw new FirstTeamSquadMinimumException($breach);
+        }
+
+        // Null the number first so flipping team_id can't violate the
+        // (game_id, team_id, number) unique constraint when a reserve
+        // player already wears the same shirt.
+        $player->update(['number' => null, 'team_id' => $game->reserve_team_id]);
+
+        GameTransfer::record(
+            gameId: $game->id,
+            gamePlayerId: $player->id,
+            fromTeamId: $game->team_id,
+            toTeamId: $game->reserve_team_id,
+            transferFee: 0,
+            type: GameTransfer::TYPE_INTERNAL_DEMOTION,
+            season: $game->season,
+            window: TransferWindowType::currentValue($game->current_date),
+        );
+    }
+
+    /**
      * At season close, permanently promote any reserve player who has aged
      * past the reserve cutoff (over 23) to the first team. One-way move,
      * recorded as a GameTransfer of type INTERNAL_PROMOTION. Any active

--- a/lang/en/messages.php
+++ b/lang/en/messages.php
@@ -101,6 +101,10 @@ return [
     'reserve_player_sent_back' => ':player has been sent back to the reserve team.',
     'reserve_player_call_up_blocked_full' => 'First-team squad is full. Release a player before calling up another.',
     'reserve_player_promoted' => ':player has been promoted to the first team.',
+    'player_sent_down_to_reserve' => ':player has been sent down to the reserve team.',
+    'send_down_not_allowed' => 'This player cannot be sent down to the reserve team.',
+    'send_down_squad_too_small' => 'Cannot send down — the first team must have at least :min players.',
+    'send_down_position_minimum' => 'Cannot send down — the first team needs at least :min :group.',
 
     // Player release messages
     'player_released' => ':player has been released. Severance paid: :severance.',

--- a/lang/en/squad.php
+++ b/lang/en/squad.php
@@ -235,6 +235,8 @@ return [
     'call_up_to_first_team' => 'Call up to first team',
     'send_back' => 'Send back',
     'send_back_to_reserve' => 'Send back to reserve',
+    'send_down_to_reserve' => 'Send down to reserve',
+    'send_down_to_reserve_confirm' => 'Send this U23 player down to the reserve team?',
     'called_up_indicator' => 'Called up',
     'homegrown_indicator' => 'Homegrown',
     'actions' => 'Actions',

--- a/lang/es/messages.php
+++ b/lang/es/messages.php
@@ -100,6 +100,10 @@ return [
     'reserve_player_called_up' => ':player ha sido convocado al primer equipo.',
     'reserve_player_sent_back' => ':player ha vuelto al filial.',
     'reserve_player_call_up_blocked_full' => 'La plantilla del primer equipo está completa. Libera un dorsal antes de subir más jugadores.',
+    'player_sent_down_to_reserve' => ':player ha sido enviado al filial.',
+    'send_down_not_allowed' => 'Este jugador no puede ser enviado al filial.',
+    'send_down_squad_too_small' => 'No se puede enviar al filial — el primer equipo debe tener al menos :min jugadores.',
+    'send_down_position_minimum' => 'No se puede enviar al filial — el primer equipo necesita al menos :min :group.',
     'reserve_player_promoted' => ':player ha subido al primer equipo.',
 
     // Player release messages

--- a/lang/es/squad.php
+++ b/lang/es/squad.php
@@ -235,6 +235,8 @@ return [
     'call_up_to_first_team' => 'Subir al primer equipo',
     'send_back' => 'Bajar',
     'send_back_to_reserve' => 'Bajar al filial',
+    'send_down_to_reserve' => 'Bajar al filial',
+    'send_down_to_reserve_confirm' => '¿Bajar este jugador sub-23 al filial?',
     'called_up_indicator' => 'En el primer equipo',
     'homegrown_indicator' => 'Canterano',
     'actions' => 'Acciones',

--- a/resources/views/partials/player-detail.blade.php
+++ b/resources/views/partials/player-detail.blade.php
@@ -4,6 +4,7 @@
 
     $isCareerMode = $game->isCareerMode();
     $isCalledUpFromReserve = $isCalledUpFromReserve ?? false;
+    $canSendDownToReserve = $canSendDownToReserve ?? false;
     $incomingPreContract = $incomingPreContract ?? false;
 
     // Transfer listing belongs to the player's owning club. For a pre-contract
@@ -303,7 +304,7 @@
 @endif
 
 {{-- Actions --}}
-@if($showActions || $canRenew || $renewalNegotiation || $renewalCooldown || ($isOnReserve ?? false) || $isCalledUpFromReserve)
+@if($showActions || $canRenew || $renewalNegotiation || $renewalCooldown || ($isOnReserve ?? false) || $isCalledUpFromReserve || $canSendDownToReserve)
     <div class="px-5 py-4 border-t border-border-default flex flex-wrap items-center gap-2">
         @if(($isOnReserve ?? false) && $isCareerMode)
             <form method="POST" action="{{ route('game.reserve.call-up', [$game->id, $gamePlayer->id]) }}">
@@ -324,6 +325,17 @@
                         <path fill-rule="evenodd" d="M8 2a.75.75 0 0 1 .75.75v8.69l3.22-3.22a.75.75 0 1 1 1.06 1.06l-4.5 4.5a.75.75 0 0 1-1.06 0l-4.5-4.5a.75.75 0 0 1 1.06-1.06l3.22 3.22V2.75A.75.75 0 0 1 8 2Z" clip-rule="evenodd" />
                     </svg>
                     {{ __('squad.send_back_to_reserve') }}
+                </x-action-button>
+            </form>
+        @endif
+        @if($canSendDownToReserve)
+            <form method="POST" action="{{ route('game.squad.send-down', [$game->id, $gamePlayer->id]) }}" onsubmit="return confirm('{{ __('squad.send_down_to_reserve_confirm') }}')">
+                @csrf
+                <x-action-button color="violet">
+                    <svg class="w-4 h-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor">
+                        <path fill-rule="evenodd" d="M8 2a.75.75 0 0 1 .75.75v8.69l3.22-3.22a.75.75 0 1 1 1.06 1.06l-4.5 4.5a.75.75 0 0 1-1.06 0l-4.5-4.5a.75.75 0 0 1 1.06-1.06l3.22 3.22V2.75A.75.75 0 0 1 8 2Z" clip-rule="evenodd" />
+                    </svg>
+                    {{ __('squad.send_down_to_reserve') }}
                 </x-action-button>
             </form>
         @endif

--- a/routes/web.php
+++ b/routes/web.php
@@ -139,6 +139,7 @@ use App\Http\Actions\ProcessTacticalActions;
 use App\Http\Actions\PromoteAcademyPlayer;
 use App\Http\Actions\CallUpReservePlayer;
 use App\Http\Actions\SendBackReservePlayer;
+use App\Http\Actions\SendDownToReserve;
 use App\Http\Views\ShowReserveTeam;
 use App\Http\Actions\SkipMatchToEnd;
 use App\Http\Actions\StartNewSeason;
@@ -188,6 +189,7 @@ Route::middleware('auth')->group(function () {
         Route::get('/game/{gameId}/squad/reserve', ShowReserveTeam::class)->name('game.squad.reserve');
         Route::post('/game/{gameId}/reserve/{playerId}/call-up', CallUpReservePlayer::class)->name('game.reserve.call-up');
         Route::post('/game/{gameId}/reserve/{playerId}/send-back', SendBackReservePlayer::class)->name('game.reserve.send-back');
+        Route::post('/game/{gameId}/squad/{playerId}/send-down', SendDownToReserve::class)->name('game.squad.send-down');
         // Club hub — Finances, Stadium, Reputation (and future non-sporting tenants)
         Route::get('/game/{gameId}/club', fn (string $gameId) => redirect()->route('game.club.finances', $gameId))->name('game.club');
         Route::get('/game/{gameId}/club/finances', ShowFinances::class)->name('game.club.finances');

--- a/tests/Unit/SendDownToReserveTest.php
+++ b/tests/Unit/SendDownToReserveTest.php
@@ -1,0 +1,257 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\Competition;
+use App\Models\Game;
+use App\Models\GamePlayer;
+use App\Models\GameTransfer;
+use App\Models\Loan;
+use App\Models\Team;
+use App\Modules\ReserveTeam\Exceptions\FirstTeamSquadMinimumException;
+use App\Modules\ReserveTeam\Services\ReserveTeamService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Covers ReserveTeamService::sendDownToReserve() — the user-initiated
+ * permanent demotion of a U23 first-team player to the reserve squad.
+ * Mirrors the reserve→first-team call-up so U23 movement stays symmetric
+ * in filial games.
+ */
+class SendDownToReserveTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private ReserveTeamService $service;
+    private Team $firstTeam;
+    private Team $reserveTeam;
+    private Game $game;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->service = app(ReserveTeamService::class);
+
+        $this->firstTeam = Team::factory()->create(['name' => 'Atlético de Madrid']);
+        $this->reserveTeam = Team::factory()->create([
+            'name' => 'Atlético Madrileño',
+            'parent_team_id' => $this->firstTeam->id,
+        ]);
+
+        Competition::factory()->league()->create(['id' => 'ESP1']);
+
+        $this->game = Game::factory()->create([
+            'team_id' => $this->firstTeam->id,
+            'reserve_team_id' => $this->reserveTeam->id,
+            'competition_id' => 'ESP1',
+            'season' => '2025',
+            'current_date' => '2025-08-15',
+        ]);
+
+        // Comfortable baseline: every position group sits well above its
+        // floor so a single send-down never trips the guard by default.
+        // Min-breach tests rebuild the squad to a tighter shape.
+        $this->fillFirstTeam([
+            'Goalkeeper'       => 3,
+            'Centre-Back'      => 8,
+            'Central Midfield' => 8,
+            'Centre-Forward'   => 6,
+        ]);
+    }
+
+    public function test_moves_a_u23_first_team_player_to_the_reserve_squad(): void
+    {
+        $u23 = $this->u23FirstTeamPlayer(['number' => 14]);
+
+        $this->service->sendDownToReserve($u23, $this->game);
+
+        $u23->refresh();
+        $this->assertSame($this->reserveTeam->id, $u23->team_id, 'team_id should flip to the reserve.');
+        $this->assertNull($u23->number, 'Squad number must be nulled so a reserve player wearing the same shirt does not collide.');
+
+        $transfer = GameTransfer::where('game_player_id', $u23->id)->first();
+        $this->assertNotNull($transfer, 'Demotion must be recorded as a GameTransfer row.');
+        $this->assertSame(GameTransfer::TYPE_INTERNAL_DEMOTION, $transfer->type);
+        $this->assertSame($this->firstTeam->id, $transfer->from_team_id);
+        $this->assertSame($this->reserveTeam->id, $transfer->to_team_id);
+        $this->assertSame(0, (int) $transfer->transfer_fee);
+        $this->assertSame('2025', $transfer->season);
+    }
+
+    public function test_refuses_when_game_is_not_a_filial(): void
+    {
+        $this->game->update(['reserve_team_id' => null]);
+        $u23 = $this->u23FirstTeamPlayer();
+
+        $this->expectException(\DomainException::class);
+        $this->expectExceptionMessage('filial');
+
+        $this->service->sendDownToReserve($u23, $this->game);
+    }
+
+    public function test_refuses_when_player_is_not_on_the_first_team(): void
+    {
+        $u23 = GamePlayer::factory()
+            ->forGame($this->game)
+            ->forTeam($this->reserveTeam)
+            ->create([
+                'date_of_birth' => '2003-06-15',
+                'position'      => 'Central Midfield',
+            ]);
+
+        $this->expectException(\DomainException::class);
+        $this->expectExceptionMessage('not currently registered to the first team');
+
+        $this->service->sendDownToReserve($u23, $this->game);
+    }
+
+    public function test_refuses_when_player_has_no_date_of_birth(): void
+    {
+        $player = $this->u23FirstTeamPlayer(['date_of_birth' => null]);
+
+        $this->expectException(\DomainException::class);
+        $this->expectExceptionMessage('Only U23 players');
+
+        $this->service->sendDownToReserve($player, $this->game);
+    }
+
+    public function test_refuses_when_player_is_over_the_u23_cutoff(): void
+    {
+        // Season 2025 cutoff is Jan 1 2002 (FIFA-style U-23 for season Y =
+        // born on/after Jan 1 of Y-23). Born 2000-06-15 sits clearly before
+        // the cutoff, so the U23 gate must reject the demotion.
+        $player = $this->u23FirstTeamPlayer(['date_of_birth' => '2000-06-15']);
+
+        $this->expectException(\DomainException::class);
+        $this->expectExceptionMessage('Only U23 players');
+
+        $this->service->sendDownToReserve($player, $this->game);
+    }
+
+    public function test_refuses_when_player_is_on_an_active_call_up_loan_from_reserve(): void
+    {
+        // A reserve player called up to the first team carries an active
+        // Loan row (parent=reserve, loan=first). Round-tripping them must
+        // go through sendBackToReserve() so the loan closes cleanly —
+        // send-down here would orphan the loan.
+        $player = $this->u23FirstTeamPlayer();
+        Loan::create([
+            'game_id'        => $this->game->id,
+            'game_player_id' => $player->id,
+            'parent_team_id' => $this->reserveTeam->id,
+            'loan_team_id'   => $this->firstTeam->id,
+            'started_at'     => $this->game->current_date,
+            'return_at'      => $this->game->getSeasonEndDate(),
+            'status'         => Loan::STATUS_ACTIVE,
+        ]);
+
+        $this->expectException(\DomainException::class);
+        $this->expectExceptionMessage('reserve call-up loan');
+
+        $this->service->sendDownToReserve($player, $this->game);
+    }
+
+    public function test_blocks_when_first_team_is_at_the_squad_minimum(): void
+    {
+        // Rebuild to exactly MIN_SQUAD_SIZE (20) on the first team — every
+        // position group sits at or above its per-group floor so the
+        // failure must surface as the total-squad guard, not the position
+        // guard which is evaluated after it.
+        $this->rebuildFirstTeam([
+            'Goalkeeper'       => 2,
+            'Centre-Back'      => 7,
+            'Central Midfield' => 5, // +1 U23 target below = 6 midfielders (at the group floor)
+            'Centre-Forward'   => 5,
+        ]);
+        $player = $this->u23FirstTeamPlayer();
+
+        try {
+            $this->service->sendDownToReserve($player, $this->game);
+            $this->fail('Expected FirstTeamSquadMinimumException when at the squad minimum.');
+        } catch (FirstTeamSquadMinimumException $e) {
+            $this->assertSame('too_small', $e->type());
+            $this->assertSame(20, $e->min());
+        }
+
+        $player->refresh();
+        $this->assertSame($this->firstTeam->id, $player->team_id, 'Player must stay on the first team when the guard blocks.');
+        $this->assertSame(0, GameTransfer::where('game_player_id', $player->id)->count());
+    }
+
+    public function test_blocks_when_send_down_would_breach_a_position_group_minimum(): void
+    {
+        // Total stays above 20 so the squad-size guard passes, but the
+        // target's position group sits exactly at its floor (6 midfielders
+        // including the target). Removing them would drop the group to 5,
+        // below the Midfielder minimum of 6 — the guard must catch this.
+        $this->rebuildFirstTeam([
+            'Goalkeeper'       => 3,
+            'Centre-Back'      => 8,
+            'Central Midfield' => 5, // +1 U23 target below = 6 midfielders (at the group floor)
+            'Centre-Forward'   => 6,
+        ]);
+        $player = $this->u23FirstTeamPlayer();
+
+        try {
+            $this->service->sendDownToReserve($player, $this->game);
+            $this->fail('Expected FirstTeamSquadMinimumException when a position group sits at its floor.');
+        } catch (FirstTeamSquadMinimumException $e) {
+            $this->assertSame('position_minimum', $e->type());
+            $this->assertSame('Midfielder', $e->group());
+            $this->assertSame(6, $e->min());
+        }
+
+        $player->refresh();
+        $this->assertSame($this->firstTeam->id, $player->team_id, 'Player must stay on the first team when the guard blocks.');
+        $this->assertSame(0, GameTransfer::where('game_player_id', $player->id)->count());
+    }
+
+    /**
+     * Seed first-team filler players in the given position mix. Every filler
+     * is aged well above the U23 cutoff so they can't accidentally satisfy
+     * the U23 gate if a test grabs one as the target by mistake.
+     *
+     * @param  array<string, int>  $positions  position-name → count
+     */
+    private function fillFirstTeam(array $positions): void
+    {
+        foreach ($positions as $position => $count) {
+            for ($i = 0; $i < $count; $i++) {
+                GamePlayer::factory()
+                    ->forGame($this->game)
+                    ->forTeam($this->firstTeam)
+                    ->create([
+                        'position'      => $position,
+                        'date_of_birth' => '1995-06-15',
+                    ]);
+            }
+        }
+    }
+
+    /**
+     * @param  array<string, int>  $positions  position-name → count
+     */
+    private function rebuildFirstTeam(array $positions): void
+    {
+        GamePlayer::where('game_id', $this->game->id)
+            ->where('team_id', $this->firstTeam->id)
+            ->delete();
+        $this->fillFirstTeam($positions);
+    }
+
+    /**
+     * @param  array<string, mixed>  $attrs  extra GamePlayer attribute overrides
+     */
+    private function u23FirstTeamPlayer(array $attrs = []): GamePlayer
+    {
+        return GamePlayer::factory()
+            ->forGame($this->game)
+            ->forTeam($this->firstTeam)
+            ->create(array_merge([
+                'date_of_birth' => '2003-06-15', // clearly inside the season-2025 U23 cutoff
+                'position'      => 'Central Midfield',
+            ], $attrs));
+    }
+}


### PR DESCRIPTION
Mirrors the existing reserve→first-team call-up so U23 movement is symmetric
in filial games. Adds a "Send down to reserve" action on the player-detail
modal for U23 first-team players (not currently on a call-up loan), recorded
as a new TYPE_INTERNAL_DEMOTION transfer. Squad-minimum guards on the first
team still apply.