### PR TITLE
Randomize play factor for non-user-team players in development

### DIFF
--- a/app/Modules/Player/Services/DevelopmentCurve.php
+++ b/app/Modules/Player/Services/DevelopmentCurve.php
@@ -101,13 +101,29 @@ final class DevelopmentCurve
      *
      * Decline (negative baseChange) happens regardless, but active players decline slower.
      *
+     * When $randomize is true, $seasonAppearances is ignored and the play
+     * factor is drawn uniformly from [TRAINING_ONLY_GROWTH_FACTOR, 1.0].
+     * This is used for players outside the user's team, where real
+     * appearance counts aren't reliably tracked (AI-only matchdays and
+     * synthetic foreign leagues never feed into season_appearances), so
+     * every non-user-team player would otherwise be stuck at the
+     * training-only floor. Decliners are treated as active (half rate).
+     *
      * @param int $baseChange The age-based change (from AGE_CURVES)
      * @param int $seasonAppearances Number of appearances this season
+     * @param bool $randomize Use a randomized play factor in lieu of $seasonAppearances
      * @return int The final change in ability points
      */
-    public static function calculateChange(int $baseChange, int $seasonAppearances): int
+    public static function calculateChange(int $baseChange, int $seasonAppearances, bool $randomize = false): int
     {
         if ($baseChange > 0) {
+            if ($randomize) {
+                $playFactor = self::TRAINING_ONLY_GROWTH_FACTOR
+                    + mt_rand() / mt_getrandmax() * (1.0 - self::TRAINING_ONLY_GROWTH_FACTOR);
+
+                return (int) round($baseChange * $playFactor);
+            }
+
             if ($seasonAppearances < self::MIN_APPEARANCES_FOR_GROWTH) {
                 return (int) round($baseChange * self::TRAINING_ONLY_GROWTH_FACTOR);
             }
@@ -118,8 +134,11 @@ final class DevelopmentCurve
         }
 
         if ($baseChange < 0) {
-            // Decline happens regardless, but active players decline at half rate
-            if ($seasonAppearances >= self::MIN_APPEARANCES_FOR_GROWTH) {
+            // Decline happens regardless, but active players decline at half rate.
+            // Randomized players are always treated as active so non-user-team
+            // veterans don't get crushed by full-rate decline just because their
+            // appearances aren't tracked.
+            if ($randomize || $seasonAppearances >= self::MIN_APPEARANCES_FOR_GROWTH) {
                 return (int) round($baseChange * 0.5);
             }
 

--- a/app/Modules/Season/Processors/PlayerDevelopmentProcessor.php
+++ b/app/Modules/Season/Processors/PlayerDevelopmentProcessor.php
@@ -55,6 +55,7 @@ class PlayerDevelopmentProcessor implements SeasonProcessor
             ->whereNotNull('gp.date_of_birth')
             ->select([
                 'gp.id',
+                'gp.team_id',
                 'gp.date_of_birth',
                 'gp.overall_score',
                 'gp.potential',
@@ -64,6 +65,8 @@ class PlayerDevelopmentProcessor implements SeasonProcessor
                 DB::raw('COALESCE(gpms.season_appearances, 0) AS season_appearances'),
             ])
             ->get();
+
+        $userTeamId = $game->team_id;
 
         if ($inputs->isEmpty()) {
             return $data;
@@ -82,8 +85,15 @@ class PlayerDevelopmentProcessor implements SeasonProcessor
             $previousOverall = (int) $row->overall_score;
             $potential = $row->potential !== null ? (int) $row->potential : 99;
             $appearances = (int) $row->season_appearances;
+            // Only the user's team accumulates accurate season_appearances. For
+            // every other team — sibling AI clubs whose matchdays the user
+            // doesn't share, foreign leagues run by the synthetic resolver,
+            // and the user's reserve in a lower division — the real count is
+            // 0 or near-zero noise. Substitute a randomized play factor so
+            // those players don't all get stuck at the training-only floor.
+            $randomize = $row->team_id !== $userTeamId;
 
-            $newOverall = $this->computeNewOverall($age, $appearances, $previousOverall, $potential);
+            $newOverall = $this->computeNewOverall($age, $appearances, $previousOverall, $potential, $randomize);
             $newMarketValue = $this->valuationService->overallScoreToMarketValue($newOverall, $age, $previousOverall, $row->position ?? null);
             $newTier = PlayerTierService::tierFromMarketValue($newMarketValue);
 
@@ -115,10 +125,10 @@ class PlayerDevelopmentProcessor implements SeasonProcessor
      * Apply development arithmetic without hydrating a GamePlayer model.
      * Mirrors PlayerDevelopmentService::calculateDevelopment().
      */
-    private function computeNewOverall(int $age, int $appearances, int $currentOverall, int $potential): int
+    private function computeNewOverall(int $age, int $appearances, int $currentOverall, int $potential, bool $randomize = false): int
     {
         $baseChange = DevelopmentCurve::getChange($age);
-        $change = DevelopmentCurve::calculateChange($baseChange, $appearances);
+        $change = DevelopmentCurve::calculateChange($baseChange, $appearances, $randomize);
 
         if ($change > 0) {
             $change += DevelopmentCurve::gapBonus($age, $currentOverall, $potential);

--- a/tests/Unit/PlayerDevelopmentProcessorTest.php
+++ b/tests/Unit/PlayerDevelopmentProcessorTest.php
@@ -189,7 +189,12 @@ class PlayerDevelopmentProcessorTest extends TestCase
         ?int $marketValueCents = null,
         ?Game $game = null,
     ): GamePlayer {
-        $team = Team::factory()->create();
+        // Default to the game's own team so the deterministic real-appearances
+        // path is exercised. Non-user-team players hit the randomized play
+        // factor (see DevelopmentCurve::calculateChange), which is intentional
+        // but unsuitable for tests that lock specific output values.
+        $targetGame = $game ?? $this->game;
+        $team = Team::findOrFail($targetGame->team_id);
 
         $attributes = [
             'overall_score' => $overall,
@@ -202,7 +207,7 @@ class PlayerDevelopmentProcessorTest extends TestCase
         }
 
         return GamePlayer::factory()
-            ->forGame($game ?? $this->game)
+            ->forGame($targetGame)
             ->forTeam($team)
             ->age($age, self::SEASON_END)
             ->create($attributes);
@@ -210,7 +215,7 @@ class PlayerDevelopmentProcessorTest extends TestCase
 
     private function makePoolPlayer(int $age, int $overall, int $potential): GamePlayer
     {
-        $team = Team::factory()->create();
+        $team = Team::findOrFail($this->game->team_id);
 
         return GamePlayer::factory()
             ->forGame($this->game)


### PR DESCRIPTION
## Summary

Fixes player development for non-user-team players (AI siblings, foreign leagues, reserves in lower divisions) by introducing a randomized play factor when accurate season appearance counts aren't available. Previously, these players would be stuck at the training-only growth floor because their `season_appearances` are unreliably tracked (AI-only matchdays and synthetic foreign leagues don't feed into the counter).

## Key Changes

- **DevelopmentCurve.calculateChange()**: Added optional `$randomize` parameter that, when true, draws the play factor uniformly from `[TRAINING_ONLY_GROWTH_FACTOR, 1.0]` instead of using `$seasonAppearances`. Decliners are always treated as active (half-rate decline) when randomized, preventing non-user-team veterans from being crushed by full-rate decline.

- **PlayerDevelopmentProcessor**: 
  - Now selects `team_id` from the player query to identify which players belong to the user's team
  - Passes `$randomize = true` to `computeNewOverall()` for all players not on the user's team
  - Updated `computeNewOverall()` to accept and forward the `$randomize` flag

- **Tests**: Updated `makePlayer()` and `makePoolPlayer()` to default to the game's own team (ensuring deterministic test behavior), with a comment explaining why non-user-team players use randomization in production.

## Implementation Details

- The randomization uses `mt_rand() / mt_getrandmax()` to generate a uniform float in `[0, 1)`, then scales it to the desired range
- Only the user's team accumulates accurate `season_appearances`; all other teams (sibling AI clubs, foreign leagues, reserves) get the randomized treatment
- Decline logic treats randomized players as "active" to prevent unrealistic full-rate decline for players whose appearance counts can't be tracked

https://claude.ai/code/session_0132YqRLTcb5f32fHQAA4Q9J