### PR TITLE
Stamp pro-manager job offers with each club's next-season league

### DIFF
--- a/app/Modules/Competition/Promotions/PromotionRelegationQuery.php
+++ b/app/Modules/Competition/Promotions/PromotionRelegationQuery.php
@@ -66,6 +66,54 @@ class PromotionRelegationQuery
     }
 
     /**
+     * Where will $teamId be after this season's pending promotion/relegation
+     * has been applied? Returns the destination competition_id if the team has
+     * a pending move in the plan, or null otherwise (no move, country has no
+     * promotion rules, or planning failed).
+     *
+     * Used by JobOfferService to stamp the league a candidate team will play
+     * in next season — the value the offer card displays. Foreign teams (any
+     * country other than $game->country) always return null since
+     * PromotionRelegationProcessor only runs for the user's country, and
+     * callers should fall back to the team's current CompetitionEntry.
+     */
+    public function predictedCompetitionIdForTeam(Game $game, string $teamId): ?string
+    {
+        $plan = $this->planForGame($game);
+        if ($plan === null) {
+            return null;
+        }
+
+        foreach ($plan->moves as $move) {
+            if ($move->teamId === $teamId) {
+                return $move->toCompetitionId;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Build the promotion/relegation plan as it stands right now, or null when
+     * it can't be built (no country, no promotion rules, planner can't run —
+     * e.g. playoff in progress or incomplete snapshot). Callers that need to
+     * answer questions about many teams in one pass should hold onto the
+     * returned plan rather than calling predictedCompetitionIdForTeam() per
+     * team — that helper rebuilds the snapshot on every call.
+     */
+    public function planForGame(Game $game): ?PromotionRelegationPlan
+    {
+        if ($game->country === null) {
+            return null;
+        }
+
+        try {
+            return $this->planFor($game);
+        } catch (\Throwable) {
+            return null;
+        }
+    }
+
+    /**
      * Build the promoted/relegated team summary the season-end view renders.
      * Returns null when there are no moves to show or when planning isn't
      * possible (e.g. playoff in progress).

--- a/app/Modules/Manager/Services/JobOfferService.php
+++ b/app/Modules/Manager/Services/JobOfferService.php
@@ -4,12 +4,14 @@ namespace App\Modules\Manager\Services;
 
 use App\Models\ClubProfile;
 use App\Models\Competition;
+use App\Models\CompetitionEntry;
 use App\Models\CompetitionTeam;
 use App\Models\Game;
 use App\Models\GameStanding;
 use App\Models\ManagerJobOffer;
 use App\Models\Team;
 use App\Models\TeamReputation;
+use App\Modules\Competition\Promotions\PromotionRelegationPlan;
 use App\Modules\Competition\Promotions\PromotionRelegationQuery;
 use App\Modules\Competition\Services\CountryConfig;
 use App\Modules\Manager\ManagerReputation;
@@ -371,6 +373,13 @@ class JobOfferService
         $usedTeamIds = [$game->team_id];
         $created = collect();
 
+        // Pre-build the pending promotion/relegation plan once per generation
+        // so the stamped competition_id reflects the league each candidate
+        // will play in next season, not the one they finished this season in.
+        // ShowSeasonOffers blocks rendering until all playoffs have resolved,
+        // so the planner is safe to run here.
+        $promotionPlan = $this->promotionRelegationQuery->planForGame($game);
+
         foreach ($plan as $entry) {
             $targetRank = max(0, min($maxRank, $currentRank + $entry['shift']));
 
@@ -400,7 +409,7 @@ class JobOfferService
                     'user_id' => $game->user_id,
                     'game_id' => $game->id,
                     'team_id' => $teamId,
-                    'competition_id' => $this->resolveAcceptedCompetitionId($teamId),
+                    'competition_id' => $this->resolveOfferStampCompetitionId($game, $promotionPlan, $teamId),
                     'season' => $game->season,
                     'offer_type' => $offerType,
                     'status' => ManagerJobOffer::STATUS_PENDING,
@@ -419,6 +428,60 @@ class JobOfferService
         }
 
         return $created;
+    }
+
+    /**
+     * Resolve the competition_id to stamp onto a freshly generated offer.
+     *
+     * Three-tier chain, in order of priority:
+     *   1. The team's destination in the pending promotion/relegation plan —
+     *      covers teams about to move at the end of this season (the season
+     *      whose offers are being generated). Only fires for teams in the
+     *      user's country, since PromotionRelegationProcessor only runs
+     *      there.
+     *   2. The team's current CompetitionEntry for any league competition in
+     *      its own country — covers teams whose entry already reflects truth:
+     *      prior-season movements, foreign teams, unchanged teams.
+     *   3. The static seed cascade in resolveAcceptedCompetitionId() — final
+     *      defensive backstop for the rare team with no CompetitionEntry at
+     *      all (e.g. data drift from an aborted setup).
+     *
+     * The Competition query (control plane) and CompetitionEntry query
+     * (tenant plane) are issued separately to avoid a cross-plane JOIN.
+     */
+    private function resolveOfferStampCompetitionId(
+        Game $game,
+        ?PromotionRelegationPlan $promotionPlan,
+        string $teamId,
+    ): ?string {
+        if ($promotionPlan !== null) {
+            foreach ($promotionPlan->moves as $move) {
+                if ($move->teamId === $teamId) {
+                    return $move->toCompetitionId;
+                }
+            }
+        }
+
+        $team = Team::find($teamId);
+        if ($team !== null) {
+            $leagueIds = Competition::where('role', Competition::ROLE_LEAGUE)
+                ->where('country', $team->country)
+                ->pluck('id')
+                ->all();
+
+            if ($leagueIds !== []) {
+                $entryCompetitionId = CompetitionEntry::where('game_id', $game->id)
+                    ->where('team_id', $teamId)
+                    ->whereIn('competition_id', $leagueIds)
+                    ->value('competition_id');
+
+                if ($entryCompetitionId !== null) {
+                    return $entryCompetitionId;
+                }
+            }
+        }
+
+        return $this->resolveAcceptedCompetitionId($teamId);
     }
 
     /**

--- a/tests/Feature/JobOfferServiceTest.php
+++ b/tests/Feature/JobOfferServiceTest.php
@@ -4,13 +4,19 @@ namespace Tests\Feature;
 
 use App\Models\ClubProfile;
 use App\Models\Competition;
+use App\Models\CompetitionEntry;
 use App\Models\Game;
 use App\Models\ManagerJobOffer;
 use App\Models\Team;
 use App\Models\TeamReputation;
 use App\Models\User;
+use App\Modules\Competition\Promotions\PromotionMove;
+use App\Modules\Competition\Promotions\PromotionRelegationPlan;
+use App\Modules\Competition\Promotions\PromotionRelegationQuery;
 use App\Modules\Manager\Services\JobOfferService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use Tests\TestCase;
 
 /**
@@ -26,6 +32,7 @@ use Tests\TestCase;
  */
 class JobOfferServiceTest extends TestCase
 {
+    use MockeryPHPUnitIntegration;
     use RefreshDatabase;
 
     /**
@@ -113,6 +120,284 @@ class JobOfferServiceTest extends TestCase
                 );
             }
         }
+    }
+
+    /**
+     * League-label bug #1215: a rival whose CompetitionEntry already says
+     * "second division" because the planner is about to promote them this
+     * season must have that destination league stamped onto the offer — not
+     * the league they finished the season in. Drives the card under their
+     * name on /season-offers.
+     */
+    public function test_offer_stamp_uses_planner_destination_for_team_being_promoted_this_season(): void
+    {
+        [$game] = $this->seedScenario(
+            userClubProfileReputation: ClubProfile::REPUTATION_ELITE,
+            userTeamReputation: ClubProfile::REPUTATION_ELITE,
+        );
+
+        // Rival's seed (CompetitionTeam) sits them at tier-1 elite so they're
+        // in the bucketing pool. Their per-game entry says ESP2 — the league
+        // they actually played in this season after a prior relegation.
+        $rival = $this->seedRivalInEntry(
+            $game,
+            clubProfileReputation: ClubProfile::REPUTATION_ELITE,
+            teamReputation: ClubProfile::REPUTATION_ELITE,
+            seedCompetitionId: 'ESP1',
+            entryCompetitionId: 'ESP2',
+        );
+
+        $this->stubPlanWithMoves($game, [
+            new PromotionMove(
+                teamId: $rival->id,
+                fromCompetitionId: 'ESP2',
+                toCompetitionId: 'ESP1',
+                reason: PromotionMove::REASON_PROMOTION,
+            ),
+        ]);
+
+        $offers = app(JobOfferService::class)
+            ->generateEndOfSeasonOffers($game->refresh(), 'exceptional');
+
+        $rivalOffer = $offers->first(fn (ManagerJobOffer $o) => $o->team_id === $rival->id);
+        $this->assertNotNull($rivalOffer, 'Rival should have been picked for a lateral elite offer.');
+        $this->assertSame('ESP1', $rivalOffer->competition_id, 'Offer must be stamped with the planner destination (ESP1), not the league played this season (ESP2).');
+    }
+
+    /**
+     * Symmetric case: a rival currently in ESP1 but about to be relegated at
+     * the end of this season should have ESP2 stamped on the offer — not
+     * ESP1, even though that's what their CompetitionEntry still says
+     * (PromotionRelegationProcessor hasn't run yet at offer generation time).
+     */
+    public function test_offer_stamp_uses_planner_destination_for_team_being_relegated_this_season(): void
+    {
+        [$game] = $this->seedScenario(
+            userClubProfileReputation: ClubProfile::REPUTATION_ELITE,
+            userTeamReputation: ClubProfile::REPUTATION_ELITE,
+        );
+
+        $rival = $this->seedRivalInEntry(
+            $game,
+            clubProfileReputation: ClubProfile::REPUTATION_ELITE,
+            teamReputation: ClubProfile::REPUTATION_ELITE,
+            seedCompetitionId: 'ESP1',
+            entryCompetitionId: 'ESP1',
+        );
+
+        $this->stubPlanWithMoves($game, [
+            new PromotionMove(
+                teamId: $rival->id,
+                fromCompetitionId: 'ESP1',
+                toCompetitionId: 'ESP2',
+                reason: PromotionMove::REASON_RELEGATION,
+            ),
+        ]);
+
+        $offers = app(JobOfferService::class)
+            ->generateEndOfSeasonOffers($game->refresh(), 'exceptional');
+
+        $rivalOffer = $offers->first(fn (ManagerJobOffer $o) => $o->team_id === $rival->id);
+        $this->assertNotNull($rivalOffer);
+        $this->assertSame('ESP2', $rivalOffer->competition_id, 'Offer must be stamped with the planner destination (ESP2), not the league still recorded on the rival CompetitionEntry (ESP1).');
+    }
+
+    /**
+     * Baseline / regression guard: when the rival has no pending move and
+     * their CompetitionEntry matches the static seed, the stamped
+     * competition_id matches both. The fix must not regress the common case.
+     */
+    public function test_offer_stamp_matches_current_entry_when_no_pending_move(): void
+    {
+        [$game] = $this->seedScenario(
+            userClubProfileReputation: ClubProfile::REPUTATION_ELITE,
+            userTeamReputation: ClubProfile::REPUTATION_ELITE,
+        );
+
+        $rival = $this->seedRivalInEntry(
+            $game,
+            clubProfileReputation: ClubProfile::REPUTATION_ELITE,
+            teamReputation: ClubProfile::REPUTATION_ELITE,
+            seedCompetitionId: 'ESP1',
+            entryCompetitionId: 'ESP1',
+        );
+
+        $this->stubPlanWithMoves($game, []);
+
+        $offers = app(JobOfferService::class)
+            ->generateEndOfSeasonOffers($game->refresh(), 'exceptional');
+
+        $rivalOffer = $offers->first(fn (ManagerJobOffer $o) => $o->team_id === $rival->id);
+        $this->assertNotNull($rivalOffer);
+        $this->assertSame('ESP1', $rivalOffer->competition_id);
+    }
+
+    /**
+     * Cross-country regression for #1215: when a foreign club's
+     * CompetitionEntry has drifted from its editorial seed (e.g. they were
+     * moved between leagues in a previous save-session that ran the engine
+     * for their country, or the seed simply differs from the per-game state)
+     * the offer card must reflect the entry, not the seed. Planner only
+     * covers $game->country, so the entry-read path is what fires here.
+     */
+    public function test_offer_stamp_uses_current_entry_for_foreign_team_that_moved_leagues(): void
+    {
+        [$game] = $this->seedScenario(
+            userClubProfileReputation: ClubProfile::REPUTATION_ELITE,
+            userTeamReputation: ClubProfile::REPUTATION_ELITE,
+        );
+
+        // English tier-1 league exists separately so the foreign rival can sit
+        // in its own country's pool without polluting Spain.
+        Competition::factory()->league()->create([
+            'id' => 'ENG1',
+            'name' => 'Premier League',
+            'country' => 'EN',
+            'flag' => 'gb',
+            'tier' => 1,
+            'season' => $game->season,
+        ]);
+        // A second English league at a lower tier so the entry-vs-seed drift
+        // is observable.
+        Competition::factory()->league()->create([
+            'id' => 'ENG2',
+            'name' => 'Championship',
+            'country' => 'EN',
+            'flag' => 'gb',
+            'tier' => 2,
+            'season' => $game->season,
+        ]);
+
+        $rival = Team::factory()->create(['country' => 'EN']);
+
+        ClubProfile::create([
+            'team_id' => $rival->id,
+            'reputation_level' => ClubProfile::REPUTATION_ELITE,
+        ]);
+
+        // Seed pivot: ENG1 (editorial home). Per-game entry: ENG2 (drifted).
+        $rival->competitions()->attach('ENG1', ['season' => $game->season]);
+        CompetitionEntry::create([
+            'game_id' => $game->id,
+            'competition_id' => 'ENG2',
+            'team_id' => $rival->id,
+            'entry_round' => 1,
+        ]);
+
+        TeamReputation::create([
+            'game_id' => $game->id,
+            'team_id' => $rival->id,
+            'reputation_level' => ClubProfile::REPUTATION_ELITE,
+            'base_reputation_level' => ClubProfile::REPUTATION_ELITE,
+            'reputation_points' => TeamReputation::pointsForTier(ClubProfile::REPUTATION_ELITE),
+        ]);
+        TeamReputation::flushCacheFor($game->id, $rival->id);
+
+        // Planner only sees the user's country (ES); foreign team should not
+        // appear in any move. Stub explicitly so the test doesn't depend on
+        // the real snapshot builder, which would need full ES tier seeding.
+        $this->stubPlanWithMoves($game, []);
+
+        $offers = app(JobOfferService::class)
+            ->generateEndOfSeasonOffers($game->refresh(), 'exceptional');
+
+        $rivalOffer = $offers->first(fn (ManagerJobOffer $o) => $o->team_id === $rival->id);
+        $this->assertNotNull($rivalOffer, 'Foreign elite rival should be eligible for a lateral elite offer.');
+        $this->assertSame('ENG2', $rivalOffer->competition_id, 'Foreign rival should be stamped with their per-game CompetitionEntry (ENG2), not the seed (ENG1).');
+    }
+
+    /**
+     * Replace the bound PromotionRelegationQuery with a stub whose
+     * planForGame() returns a hand-built plan. Keeps tests deterministic and
+     * isolated from the (much heavier) real snapshot builder, which would
+     * require seeding every tier of the country to satisfy size assertions.
+     *
+     * @param array<int, PromotionMove> $moves
+     */
+    private function stubPlanWithMoves(Game $game, array $moves): void
+    {
+        $plan = new PromotionRelegationPlan(
+            countryCode: $game->country ?? 'ES',
+            moves: $moves,
+        );
+
+        $stub = Mockery::mock(PromotionRelegationQuery::class);
+        $stub->shouldReceive('planForGame')->andReturn($plan);
+        $stub->shouldReceive('wasTeamPromoted')->andReturn(false);
+        $stub->shouldReceive('predictedCompetitionIdForTeam')->andReturnUsing(
+            function (Game $g, string $teamId) use ($moves): ?string {
+                foreach ($moves as $move) {
+                    if ($move->teamId === $teamId) {
+                        return $move->toCompetitionId;
+                    }
+                }
+                return null;
+            }
+        );
+
+        $this->app->instance(PromotionRelegationQuery::class, $stub);
+    }
+
+    /**
+     * Variant of seedRival() that also creates the per-game CompetitionEntry
+     * row needed by the offer-stamp resolver. The seed competition (via the
+     * CompetitionTeam pivot) decides which bucket the rival lands in;
+     * $entryCompetitionId decides what the resolver reads when no plan
+     * override applies.
+     */
+    private function seedRivalInEntry(
+        Game $game,
+        string $clubProfileReputation,
+        string $teamReputation,
+        string $seedCompetitionId,
+        string $entryCompetitionId,
+    ): Team {
+        // Make sure both competitions exist — seedScenario only seeds ESP1.
+        if ($entryCompetitionId !== 'ESP1' && Competition::find($entryCompetitionId) === null) {
+            Competition::factory()->league()->create([
+                'id' => $entryCompetitionId,
+                'name' => $entryCompetitionId,
+                'country' => 'ES',
+                'tier' => $entryCompetitionId === 'ESP2' ? 2 : 3,
+                'season' => $game->season,
+            ]);
+        }
+        if ($seedCompetitionId !== 'ESP1' && Competition::find($seedCompetitionId) === null) {
+            Competition::factory()->league()->create([
+                'id' => $seedCompetitionId,
+                'name' => $seedCompetitionId,
+                'country' => 'ES',
+                'tier' => $seedCompetitionId === 'ESP2' ? 2 : 3,
+                'season' => $game->season,
+            ]);
+        }
+
+        $team = Team::factory()->create(['country' => 'ES']);
+
+        ClubProfile::create([
+            'team_id' => $team->id,
+            'reputation_level' => $clubProfileReputation,
+        ]);
+
+        $team->competitions()->attach($seedCompetitionId, ['season' => $game->season]);
+
+        CompetitionEntry::create([
+            'game_id' => $game->id,
+            'competition_id' => $entryCompetitionId,
+            'team_id' => $team->id,
+            'entry_round' => 1,
+        ]);
+
+        TeamReputation::create([
+            'game_id' => $game->id,
+            'team_id' => $team->id,
+            'reputation_level' => $teamReputation,
+            'base_reputation_level' => $clubProfileReputation,
+            'reputation_points' => TeamReputation::pointsForTier($teamReputation),
+        ]);
+        TeamReputation::flushCacheFor($game->id, $team->id);
+
+        return $team;
     }
 
     /**

--- a/tests/Feature/JobOfferServiceTest.php
+++ b/tests/Feature/JobOfferServiceTest.php
@@ -177,6 +177,19 @@ class JobOfferServiceTest extends TestCase
             userTeamReputation: ClubProfile::REPUTATION_ELITE,
         );
 
+        // The planner stub below points the move at ESP2, which is the
+        // competition_id that ends up on the offer row. seedRivalInEntry
+        // only creates ESP2 when the *entry* lives there — here the entry
+        // is ESP1, so we have to seed ESP2 explicitly to satisfy the
+        // manager_job_offers FK.
+        Competition::factory()->league()->create([
+            'id' => 'ESP2',
+            'name' => 'LaLiga 2',
+            'country' => 'ES',
+            'tier' => 2,
+            'season' => $game->season,
+        ]);
+
         $rival = $this->seedRivalInEntry(
             $game,
             clubProfileReputation: ClubProfile::REPUTATION_ELITE,


### PR DESCRIPTION
## Summary
- Fixes #1215 — `/season-offers` cards now show the league each rival club will play in *next* season, not the static `CompetitionTeam` seed (which was mislabelling any club promoted or relegated in this save — e.g. Depor shown as Primera while actually in Segunda).
- `JobOfferService::writeOffers()` now resolves the stamped `competition_id` via a 3-tier chain:
  1. **Pending promotion plan** — covers teams about to move at the end of this season (offer generation runs before `PromotionRelegationProcessor`, so the planner is used to *preview* the upcoming move).
  2. **Per-game `CompetitionEntry`** — covers prior-season movements, foreign teams, and unchanged teams. Reads `Competition` (control) + `CompetitionEntry` (tenant) as separate queries to avoid a cross-plane JOIN.
  3. **Static `CompetitionTeam` seed cascade** — existing `resolveAcceptedCompetitionId()` kept as the defensive backstop.
- `PromotionRelegationQuery` gains a public `planForGame()` (so callers can build the plan once per offer-generation pass) and `predictedCompetitionIdForTeam()` (single-team helper). `ApplyPendingTeamSwitchProcessor` is unchanged — its own `resolveCurrentLeagueForTeam()` still reads post-closing-pipeline state, so the in-pipeline reconciliation becomes a no-op safety net as the issue's acceptance criteria call for.

## Test plan
- [ ] `php artisan test --filter=JobOfferServiceTest` (4 new cases: pending promotion, pending relegation, no-pending-move baseline, cross-country drift)
- [ ] Manual: long-running Pro Manager save where a Spanish club was relegated in a prior season — open `/season-offers`, confirm the card shows the current league, not the seed
- [ ] Manual: Spanish club finishing 1st in Segunda or last in Primera this season — `/season-offers` card shows the *next-season* league (Primera / Segunda) before clicking Start New Season
- [ ] Manual: foreign club whose entry has drifted from its editorial seed — card reflects entry, not seed
- [ ] Verify both light/dark themes and 375px mobile viewport
- [ ] After accepting an offer + clicking Start New Season, confirm `ApplyPendingTeamSwitchProcessor::resolveCurrentLeagueForTeam()` returns the same value the offer was stamped with (reconciliation finds nothing to fix)

Closes #1215

🤖 Generated with [Claude Code](https://claude.com/claude-code)