### PR TITLE
Fix live-match feed leaking second-half events at half-time (#1158)

### DIFF
--- a/app/Modules/Match/Support/ScoreEventsAuditor.php
+++ b/app/Modules/Match/Support/ScoreEventsAuditor.php
@@ -4,6 +4,7 @@ namespace App\Modules\Match\Support;
 
 use App\Models\GameMatch;
 use App\Models\MatchEvent;
+use App\Modules\Match\Enums\MatchPhase;
 use Illuminate\Support\Facades\Log;
 
 /**
@@ -20,23 +21,47 @@ final class ScoreEventsAuditor
 {
     public static function audit(GameMatch $match, string $stage): void
     {
-        $eventCount = MatchEvent::where('game_match_id', $match->id)
+        $regulationPhases = array_map(fn (MatchPhase $p) => $p->value, MatchPhase::regulation());
+
+        $totalEventCount = MatchEvent::where('game_match_id', $match->id)
             ->whereIn('event_type', ['goal', 'own_goal'])
             ->count();
 
-        $expected = (int) $match->home_score + (int) $match->away_score
+        $regulationEventCount = MatchEvent::where('game_match_id', $match->id)
+            ->whereIn('event_type', ['goal', 'own_goal'])
+            ->whereIn('phase', $regulationPhases)
+            ->count();
+
+        $expectedTotal = (int) $match->home_score + (int) $match->away_score
             + (int) ($match->home_score_et ?? 0) + (int) ($match->away_score_et ?? 0);
 
-        if ($eventCount !== $expected) {
+        $expectedRegulation = (int) $match->home_score + (int) $match->away_score;
+
+        if ($totalEventCount !== $expectedTotal) {
             Log::warning('Match score/events mismatch', [
                 'stage' => $stage,
                 'match_id' => $match->id,
-                'goal_events' => $eventCount,
-                'expected_total' => $expected,
+                'goal_events' => $totalEventCount,
+                'expected_total' => $expectedTotal,
                 'home_score' => $match->home_score,
                 'away_score' => $match->away_score,
                 'home_score_et' => $match->home_score_et,
                 'away_score_et' => $match->away_score_et,
+            ]);
+        }
+
+        // Regulation-only check: catches drift between the regulation
+        // scoreboard and regulation-phase events even when the total
+        // happens to balance because of an offsetting mistake in ET.
+        // This is the regression check requested by issue #1158.
+        if ($regulationEventCount !== $expectedRegulation) {
+            Log::warning('Match regulation score/events mismatch', [
+                'stage' => $stage,
+                'match_id' => $match->id,
+                'regulation_goal_events' => $regulationEventCount,
+                'expected_regulation' => $expectedRegulation,
+                'home_score' => $match->home_score,
+                'away_score' => $match->away_score,
             ]);
         }
     }

--- a/resources/js/modules/match-simulation.js
+++ b/resources/js/modules/match-simulation.js
@@ -87,11 +87,27 @@ export function createMatchSimulation(ctx) {
         const etFirstHalfEnd = MINUTE.ET_FIRST_HALF_END + (state.etFirstHalfStoppage || 0);
         const etSecondHalfEnd = MINUTE.ET_END + (state.etSecondHalfStoppage || 0);
 
-        if (isExtraTime) {
-            state.currentMinute = Math.min(state.currentMinute + deltaMinutes, etSecondHalfEnd);
-        } else {
-            state.currentMinute = Math.min(state.currentMinute + deltaMinutes, secondHalfEnd);
+        // Clamp the clock to the END OF THE CURRENT HALF, not the end of the
+        // match. If rAF stalls (mobile tab throttling, OS suspension, GC pause,
+        // CPU starvation at 4× speed) the next tick's deltaMs can be huge.
+        // Clamping to the match-wide end let a single tick jump from minute 30
+        // to minute 95 — processEvents() (called below) would then reveal every
+        // regular-time event in one shot, increment scores via updateScore for
+        // each goal, and only after that would the half-time / full-time check
+        // notice the phase boundary had been crossed. The result was a
+        // half-time pause with the final scoreboard and second-half events
+        // already on screen (issue #1158). Clamping per half makes the reveal
+        // loop terminate at the boundary; the subsequent phase check still
+        // fires because currentMinute is allowed to reach exactly the half end.
+        let clockCap;
+        switch (state.phase) {
+            case PHASE.FIRST_HALF:               clockCap = firstHalfEnd;    break;
+            case PHASE.SECOND_HALF:              clockCap = secondHalfEnd;   break;
+            case PHASE.EXTRA_TIME_FIRST_HALF:    clockCap = etFirstHalfEnd;  break;
+            case PHASE.EXTRA_TIME_SECOND_HALF:   clockCap = etSecondHalfEnd; break;
+            default:                             clockCap = isExtraTime ? etSecondHalfEnd : secondHalfEnd;
         }
+        state.currentMinute = Math.min(state.currentMinute + deltaMinutes, clockCap);
 
         // Reveal events
         if (isExtraTime) {

--- a/tests/Feature/ScoreEventsAuditorTest.php
+++ b/tests/Feature/ScoreEventsAuditorTest.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Competition;
+use App\Models\Game;
+use App\Models\GameMatch;
+use App\Models\GamePlayer;
+use App\Models\MatchEvent;
+use App\Models\Team;
+use App\Models\User;
+use App\Modules\Match\Enums\MatchPhase;
+use App\Modules\Match\Support\ScoreEventsAuditor;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Log;
+use Tests\TestCase;
+
+/**
+ * Tests for the regulation-vs-events drift check added for issue #1158.
+ *
+ * The auditor stays quiet when persisted state is consistent and emits a
+ * `Log::warning(...)` (no throw — a user mid-match shouldn't see a 500)
+ * when regulation-phase goal events disagree with `home_score`/`away_score`.
+ */
+class ScoreEventsAuditorTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Game $game;
+    private GameMatch $match;
+    private GamePlayer $homePlayer;
+    private GamePlayer $awayPlayer;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $user = User::factory()->create();
+        $homeTeam = Team::factory()->create();
+        $awayTeam = Team::factory()->create();
+        $competition = Competition::factory()->league()->create();
+
+        $this->game = Game::factory()->create([
+            'user_id' => $user->id,
+            'team_id' => $homeTeam->id,
+            'competition_id' => $competition->id,
+        ]);
+
+        $this->homePlayer = GamePlayer::factory()->forGame($this->game)->forTeam($homeTeam)->create();
+        $this->awayPlayer = GamePlayer::factory()->forGame($this->game)->forTeam($awayTeam)->create();
+
+        $this->match = GameMatch::factory()->create([
+            'game_id' => $this->game->id,
+            'competition_id' => $competition->id,
+            'home_team_id' => $homeTeam->id,
+            'away_team_id' => $awayTeam->id,
+            'home_score' => 0,
+            'away_score' => 0,
+            'played' => true,
+        ]);
+    }
+
+    public function test_no_warning_when_regulation_events_match_scoreboard(): void
+    {
+        $this->match->update(['home_score' => 2, 'away_score' => 1]);
+        $this->seedRegulationGoal($this->homePlayer, minute: 20);
+        $this->seedRegulationGoal($this->homePlayer, minute: 40);
+        $this->seedRegulationGoal($this->awayPlayer, minute: 70);
+
+        Log::spy();
+
+        ScoreEventsAuditor::audit($this->match->refresh(), 'test_consistent');
+
+        Log::shouldNotHaveReceived('warning');
+    }
+
+    public function test_regulation_warning_fires_when_event_count_disagrees_with_score(): void
+    {
+        // Score says 2-1 but only one regulation goal event is persisted.
+        // The previous combined-only audit would *also* flag this (1 event
+        // vs expected total 3), but the new regulation-specific warning
+        // gives a clearer signal — regulation drift, not ET drift.
+        $this->match->update(['home_score' => 2, 'away_score' => 1]);
+        $this->seedRegulationGoal($this->homePlayer, minute: 30);
+
+        Log::spy();
+
+        ScoreEventsAuditor::audit($this->match->refresh(), 'test_regulation_drift');
+
+        Log::shouldHaveReceived('warning')
+            ->with('Match regulation score/events mismatch', \Mockery::on(function (array $ctx) {
+                return $ctx['regulation_goal_events'] === 1
+                    && $ctx['expected_regulation'] === 3
+                    && $ctx['home_score'] === 2
+                    && $ctx['away_score'] === 1;
+            }))
+            ->once();
+    }
+
+    public function test_regulation_warning_distinguishes_drift_when_total_balances_via_offsetting_et_mistake(): void
+    {
+        // Total: 1 event + 1 ET event = 2 events. Total expected =
+        // home(2) + away(0) + home_et(0) + away_et(0) = 2 — the combined
+        // audit is silent. But regulation alone is wrong (1 ev vs 2
+        // expected), and the new check catches it.
+        $this->match->update([
+            'home_score' => 2,
+            'away_score' => 0,
+            'home_score_et' => 0,
+            'away_score_et' => 0,
+        ]);
+        $this->seedRegulationGoal($this->homePlayer, minute: 30);
+        // One stray ET goal event with no ET on the scoreboard.
+        $this->seedExtraTimeGoal($this->homePlayer, minute: 95);
+
+        Log::spy();
+
+        ScoreEventsAuditor::audit($this->match->refresh(), 'test_offsetting_drift');
+
+        Log::shouldHaveReceived('warning')
+            ->with('Match regulation score/events mismatch', \Mockery::any())
+            ->once();
+    }
+
+    private function seedRegulationGoal(GamePlayer $player, int $minute): void
+    {
+        MatchEvent::create([
+            'game_id' => $this->game->id,
+            'game_match_id' => $this->match->id,
+            'game_player_id' => $player->id,
+            'team_id' => $player->team_id,
+            'minute' => $minute,
+            'phase' => MatchPhase::FIRST_HALF, // explicit; the value gets re-decomposed by the model only when phase is null
+            'event_type' => MatchEvent::TYPE_GOAL,
+        ]);
+    }
+
+    private function seedExtraTimeGoal(GamePlayer $player, int $minute): void
+    {
+        MatchEvent::create([
+            'game_id' => $this->game->id,
+            'game_match_id' => $this->match->id,
+            'game_player_id' => $player->id,
+            'team_id' => $player->team_id,
+            'minute' => $minute,
+            'phase' => MatchPhase::ET_FIRST_HALF,
+            'event_type' => MatchEvent::TYPE_GOAL,
+        ]);
+    }
+}

--- a/tests/js/match-simulation.test.js
+++ b/tests/js/match-simulation.test.js
@@ -393,3 +393,114 @@ describe('skipToHalfTime atmosphere reveal', () => {
         expect(state.revealedEvents.map(e => e.minute)).toEqual([10]);
     });
 });
+
+// ============================================================================
+// tick() phase-aware clock clamp — regression for issue #1158
+// ============================================================================
+
+describe('tick() phase-aware clock clamp (#1158)', () => {
+    it('clamps currentMinute to firstHalfEnd when rAF stalls mid-first-half', () => {
+        // Regression: a backgrounded mobile tab (or any rAF stall) used to
+        // produce a giant deltaMs on the first resume tick. The clock was
+        // clamped to secondHalfEnd (90+stoppage) instead of firstHalfEnd
+        // (45+stoppage), so processEvents() revealed every regular-time
+        // event in one shot — including second-half goals, which then
+        // incremented homeScore/awayScore via updateScore — before the
+        // half-time check finally fired. The user was left looking at a
+        // HALF_TIME pause with the FINAL score and second-half events on
+        // screen. The fix clamps the clock to the END OF THE CURRENT HALF.
+        const capturedTicks = [];
+        const originalRaf = globalThis.requestAnimationFrame;
+        globalThis.requestAnimationFrame = vi.fn((cb) => {
+            capturedTicks.push(cb);
+            return capturedTicks.length;
+        });
+
+        const originalNow = globalThis.performance.now;
+        let mockNow = 0;
+        globalThis.performance.now = () => mockNow;
+
+        // Use fake timers BEFORE startSimulation so its 1000ms kickoff
+        // setTimeout is scheduled against the fake clock and can be
+        // advanced synchronously below.
+        vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
+
+        try {
+            const state = createMockState({
+                phase: 'pre_match',
+                currentMinute: 0,
+                firstHalfStoppage: 2,   // firstHalfEnd = 47
+                secondHalfStoppage: 3,  // secondHalfEnd = 93
+                finalHomeScore: 2,
+                finalAwayScore: 4,
+                events: [
+                    { minute: 30, type: 'goal', phase: 'first_half',  teamId: 'home-1', gamePlayerId: 'p1', metadata: {} },
+                    { minute: 40, type: 'goal', phase: 'first_half',  teamId: 'home-1', gamePlayerId: 'p2', metadata: {} },
+                    // Second-half goals — must NOT be revealed during 1H.
+                    { minute: 50, type: 'goal', phase: 'second_half', teamId: 'away-1', gamePlayerId: 'p3', metadata: {} },
+                    { minute: 60, type: 'goal', phase: 'second_half', teamId: 'away-1', gamePlayerId: 'p4', metadata: {} },
+                    { minute: 70, type: 'goal', phase: 'second_half', teamId: 'away-1', gamePlayerId: 'p5', metadata: {} },
+                    { minute: 80, type: 'goal', phase: 'second_half', teamId: 'away-1', gamePlayerId: 'p6', metadata: {} },
+                ],
+                otherMatches: [],
+                otherMatchScores: [],
+                speed: 4,
+                speedRates: { 1: 1.5, 2: 3.0, 4: 6.0 },
+                narrativeTemplates: {},
+                // Skip the "fourth official adds N" announcement so the
+                // tick falls straight through to the half-time check —
+                // we're testing the clamp, not the announcement path.
+                _announcedFirstHalfStoppage: true,
+            });
+
+            // realEvents = events: synthesizeGoalsIfNeeded would otherwise
+            // inject random ghost goals into realEvents based on the score
+            // gap. Aligning realEvents with the test's seeded score (2 home
+            // + 4 away = 2-4) makes the synthesizer a no-op so we control
+            // the event timeline exactly.
+            state.realEvents = [...state.events];
+
+            const sim = createMatchSimulation(() => state);
+            sim.startSimulation();
+            vi.advanceTimersByTime(1100); // fire the 1000ms kickoff
+
+            // Kickoff set phase=FIRST_HALF, _lastTick=performance.now()=0,
+            // and scheduled the first tick via rAF.
+            expect(state.phase).toBe('first_half');
+            expect(capturedTicks.length).toBeGreaterThan(0);
+            const tick = capturedTicks[capturedTicks.length - 1];
+
+            // Simulate a 20-second stall (mobile tab throttling resume,
+            // OS suspension, GC pause). At speed=4 that's 120 game-minutes
+            // worth of deltaMinutes — enough to vault past secondHalfEnd
+            // (93) pre-fix, exposing every regular-time event in one tick.
+            mockNow = 20000;
+            tick(mockNow);
+
+            // 1) The clock never went past firstHalfEnd. (enterHalfTime
+            // snaps currentMinute back to MINUTE.FIRST_HALF_END=45 once
+            // the boundary is crossed, but the key invariant — the clock
+            // was clamped during the tick before processEvents ran — is
+            // demonstrated by the score/feed assertions below.)
+            expect(state.currentMinute).toBeLessThanOrEqual(47);
+
+            // 2) No second-half goal leaked into revealedEvents.
+            const revealedMinutes = state.revealedEvents.map((e) => e.minute);
+            expect(revealedMinutes.length).toBeGreaterThan(0);
+            for (const m of revealedMinutes) {
+                expect(m).toBeLessThanOrEqual(47);
+            }
+
+            // 3) Score reflects only the two first-half home goals.
+            expect(state.homeScore).toBe(2);
+            expect(state.awayScore).toBe(0);
+
+            // 4) Phase transitioned to HALF_TIME (the boundary check fired).
+            expect(state.phase).toBe('half_time');
+        } finally {
+            vi.useRealTimers();
+            globalThis.requestAnimationFrame = originalRaf;
+            globalThis.performance.now = originalNow;
+        }
+    });
+});


### PR DESCRIPTION
Fixes #1158.

## Summary
- `tick()` in `resources/js/modules/match-simulation.js` clamped `currentMinute` to `secondHalfEnd` during `FIRST_HALF`. When `requestAnimationFrame` stalled (mobile tab throttling, OS suspension, long GC pause) the next tick's `deltaMs` could be huge — the clock jumped past 90, `processEvents()` revealed every regular-time goal (incrementing the scoreboard via `updateScore`), and only then did the half-time check fire. Result: user sat on a `HALF_TIME` pause with the final score and second-half events already on screen (the screenshot in the issue).
- Clamp the clock to the END OF THE CURRENT HALF per phase. The reveal loop naturally terminates at the boundary; the half-time and full-time transitions keep working unchanged because `currentMinute` is still allowed to reach exactly the half end. The same clamp also hardens the symmetric ET first-half → ET second-half boundary.
- Extend `ScoreEventsAuditor` with a regulation-phase check (`MatchPhase::regulation()` filter) alongside the existing combined-total check. Catches drift even when an offsetting ET mistake happens to balance the combined total — the regression check requested in the issue's acceptance criteria.

## Out of scope
- The other acceptance criterion (explicitly surfacing engine result corrections in the live feed instead of silently overwriting) is a UX redesign — separate issue.

## Test plan
- [x] `npx vitest run tests/js/` — 42 tests pass, including the new `tick() phase-aware clock clamp (#1158)` case that drives `tick()` with a 20s simulated stall and asserts: clock ≤ `firstHalfEnd`, no second-half event in `revealedEvents`, score reflects only 1H goals, phase transitions to `half_time`.
- [x] Confirmed the new vitest case fails without the fix (`expected 80 to be less than or equal to 47`) and passes with it.
- [ ] CI runs `php artisan test --filter=ScoreEventsAuditorTest` against the new PHPUnit feature test (three cases: silent on consistent state, warns on regulation drift, warns when offsetting ET drift hides regulation drift from the combined check).
- [ ] Manual reproduction proxy: open a live match locally at speed 4×, throttle DevTools Performance → "CPU 6× slowdown" or pause on a breakpoint for several seconds during minute 20–30 of 1H. Pre-fix replays the bug; post-fix lands cleanly at half-time with only 1H content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)