### PR TITLE
Reset financial carry-overs on Pro Manager team switch (#1220)

### DIFF
--- a/app/Modules/Finance/Services/BudgetProjectionService.php
+++ b/app/Modules/Finance/Services/BudgetProjectionService.php
@@ -11,7 +11,6 @@ use App\Models\GameFinances;
 use App\Models\GameInvestment;
 use App\Models\GameMatch;
 use App\Models\GamePlayer;
-use App\Models\ManagerJobHistory;
 use App\Models\Team;
 use App\Models\TeamReputation;
 use App\Modules\Squad\Services\SquadService;
@@ -79,8 +78,16 @@ class BudgetProjectionService
     /**
      * Generate season projections for a game.
      * Called at the start of each season during pre-season.
+     *
+     * When $freshClub is true, the projection treats the team as if this were
+     * its first season in the game: no carry-overs, no loan repayments, and
+     * commercial revenue uses the stadium-based baseline instead of the prior
+     * season's actuals. This is set during a Pro Manager team switch — the
+     * previous season's finances belong to the old club and must not follow
+     * the manager. See ApplyPendingTeamSwitchProcessor and
+     * BudgetProjectionProcessor for the signal flow.
      */
-    public function generateProjections(Game $game): GameFinances
+    public function generateProjections(Game $game, bool $freshClub = false): GameFinances
     {
         // Get user's team and league
         $team = $game->team;
@@ -96,7 +103,9 @@ class BudgetProjectionService
         $projectedTvRevenue = $this->calculateTvRevenue($projectedPosition, $league);
         $projectedMatchdayRevenue = $this->calculateMatchdayRevenue($team, $game);
         $projectedSolidarityFundsRevenue = self::SOLIDARITY_FUNDS_BY_TIER[$game->competition->tier] ?? 0;
-        $projectedCommercialRevenue = $this->getBaseCommercialRevenue($game, $team, $league);
+        $projectedCommercialRevenue = $freshClub
+            ? $this->firstSeasonCommercialRevenue($game, $team, $league)
+            : $this->getBaseCommercialRevenue($game, $team, $league);
         $projectedSeasonTicketRevenue = $this->seasonTicketPricingService->getCurrent($game)?->total_revenue ?? 0;
 
         $projectedTotalRevenue = $projectedTvRevenue
@@ -117,10 +126,12 @@ class BudgetProjectionService
         // Calculate projected surplus
         $projectedSurplus = $projectedTotalRevenue - $projectedWages - $projectedOperatingExpenses;
 
-        // Get carried debt, surplus, and loan repayment from previous season
-        $carriedDebt = $this->getCarriedDebt($game);
-        $carriedSurplus = $this->getCarriedSurplus($game);
-        $previousLoanRepayment = $this->getPreviousSeasonLoanRepayment($game);
+        // Get carried debt, surplus, and loan repayment from previous season.
+        // After a Pro Manager team switch the previous season's GameFinances
+        // and BudgetLoan rows belong to the old club, so we skip them.
+        $carriedDebt = $freshClub ? 0 : $this->getCarriedDebt($game);
+        $carriedSurplus = $freshClub ? 0 : $this->getCarriedSurplus($game);
+        $previousLoanRepayment = $freshClub ? 0 : $this->getPreviousSeasonLoanRepayment($game);
 
         // Stadium debt service: next instalment of every active stadium
         // loan. Treated like previous_loan_repayment — reduces available
@@ -304,39 +315,6 @@ class BudgetProjectionService
     }
 
     /**
-     * Whether the manager was at the current team during the previous season.
-     *
-     * GameFinances and BudgetLoan rows are keyed by (game_id, season) only —
-     * they don't carry a team_id. In Pro Manager mode the manager can change
-     * clubs between seasons, so the prior-season row may belong to a different
-     * club. ManagerJobHistory is the authority on which team the manager held
-     * in each season; if the previous season's tenure was at a different team
-     * (or no tenure covers it), the carry-overs don't belong to the current
-     * club and the service should fall back to first-season defaults.
-     *
-     * Always true outside Pro Manager mode, where the team never changes.
-     */
-    private function previousSeasonBelongsToCurrentTeam(Game $game): bool
-    {
-        if (!$game->isProManagerMode()) {
-            return true;
-        }
-
-        $previousSeason = (int) $game->season - 1;
-
-        $tenureTeamId = ManagerJobHistory::where('game_id', $game->id)
-            ->whereRaw('CAST(season_start AS INTEGER) <= ?', [$previousSeason])
-            ->where(function ($q) use ($previousSeason) {
-                $q->whereNull('season_end')
-                    ->orWhereRaw('CAST(season_end AS INTEGER) >= ?', [$previousSeason]);
-            })
-            ->orderByRaw('CAST(season_start AS INTEGER) DESC')
-            ->value('team_id');
-
-        return $tenureTeamId !== null && $tenureTeamId === $game->team_id;
-    }
-
-    /**
      * Calculate the net cash position at the end of the previous season.
      *
      * Net = actual_surplus + carried_surplus - carried_debt - infrastructure - transfer_purchases
@@ -346,13 +324,6 @@ class BudgetProjectionService
      */
     private function getPreviousSeasonNetPosition(Game $game): int
     {
-        // Pro Manager carry-overs stay with the previous club. If the manager
-        // managed a different team last season, the prior GameFinances row
-        // belongs to that club and must not bleed into the new club's budget.
-        if (!$this->previousSeasonBelongsToCurrentTeam($game)) {
-            return 0;
-        }
-
         $previousSeason = (int) $game->season - 1;
 
         $previousFinances = GameFinances::where('game_id', $game->id)
@@ -393,12 +364,6 @@ class BudgetProjectionService
      */
     public function getPreviousSeasonLoanRepayment(Game $game): int
     {
-        // The previous club's loan obligations don't follow the manager
-        // across a Pro Manager team switch.
-        if (!$this->previousSeasonBelongsToCurrentTeam($game)) {
-            return 0;
-        }
-
         $previousSeason = (int) $game->season - 1;
 
         return (int) BudgetLoan::where('game_id', $game->id)
@@ -414,21 +379,26 @@ class BudgetProjectionService
      */
     private function getBaseCommercialRevenue(Game $game, Team $team, Competition $league): int|float
     {
-        // Skip the prior-actual branch after a Pro Manager team switch: the
-        // previous season's commercial revenue was earned by the old club,
-        // so the new club starts from the stadium-based first-season calc.
-        if ($this->previousSeasonBelongsToCurrentTeam($game)) {
-            $previousSeason = (int) $game->season - 1;
-            $previousFinances = GameFinances::where('game_id', $game->id)
-                ->where('season', $previousSeason)
-                ->first();
+        // Check for prior season actual commercial revenue
+        $previousSeason = (int) $game->season - 1;
+        $previousFinances = GameFinances::where('game_id', $game->id)
+            ->where('season', $previousSeason)
+            ->first();
 
-            if ($previousFinances && $previousFinances->actual_commercial_revenue > 0) {
-                return $previousFinances->actual_commercial_revenue;
-            }
+        if ($previousFinances && $previousFinances->actual_commercial_revenue > 0) {
+            return $previousFinances->actual_commercial_revenue;
         }
 
-        // First season: calculate from stadium seats × config rate (capped)
+        return $this->firstSeasonCommercialRevenue($game, $team, $league);
+    }
+
+    /**
+     * Commercial revenue baseline when there is no prior-season actual to
+     * carry forward — used for season 1 of a new game and for the first
+     * season at a new club after a Pro Manager team switch.
+     */
+    private function firstSeasonCommercialRevenue(Game $game, Team $team, Competition $league): int|float
+    {
         $reputation = TeamReputation::resolveLevel($game->id, $team->id);
         $seats = min($team->stadium_seats, self::MAX_COMMERCIAL_SEATS);
 

--- a/app/Modules/Finance/Services/BudgetProjectionService.php
+++ b/app/Modules/Finance/Services/BudgetProjectionService.php
@@ -11,6 +11,7 @@ use App\Models\GameFinances;
 use App\Models\GameInvestment;
 use App\Models\GameMatch;
 use App\Models\GamePlayer;
+use App\Models\ManagerJobHistory;
 use App\Models\Team;
 use App\Models\TeamReputation;
 use App\Modules\Squad\Services\SquadService;
@@ -303,6 +304,39 @@ class BudgetProjectionService
     }
 
     /**
+     * Whether the manager was at the current team during the previous season.
+     *
+     * GameFinances and BudgetLoan rows are keyed by (game_id, season) only —
+     * they don't carry a team_id. In Pro Manager mode the manager can change
+     * clubs between seasons, so the prior-season row may belong to a different
+     * club. ManagerJobHistory is the authority on which team the manager held
+     * in each season; if the previous season's tenure was at a different team
+     * (or no tenure covers it), the carry-overs don't belong to the current
+     * club and the service should fall back to first-season defaults.
+     *
+     * Always true outside Pro Manager mode, where the team never changes.
+     */
+    private function previousSeasonBelongsToCurrentTeam(Game $game): bool
+    {
+        if (!$game->isProManagerMode()) {
+            return true;
+        }
+
+        $previousSeason = (int) $game->season - 1;
+
+        $tenureTeamId = ManagerJobHistory::where('game_id', $game->id)
+            ->whereRaw('CAST(season_start AS INTEGER) <= ?', [$previousSeason])
+            ->where(function ($q) use ($previousSeason) {
+                $q->whereNull('season_end')
+                    ->orWhereRaw('CAST(season_end AS INTEGER) >= ?', [$previousSeason]);
+            })
+            ->orderByRaw('CAST(season_start AS INTEGER) DESC')
+            ->value('team_id');
+
+        return $tenureTeamId !== null && $tenureTeamId === $game->team_id;
+    }
+
+    /**
      * Calculate the net cash position at the end of the previous season.
      *
      * Net = actual_surplus + carried_surplus - carried_debt - infrastructure - transfer_purchases
@@ -312,6 +346,13 @@ class BudgetProjectionService
      */
     private function getPreviousSeasonNetPosition(Game $game): int
     {
+        // Pro Manager carry-overs stay with the previous club. If the manager
+        // managed a different team last season, the prior GameFinances row
+        // belongs to that club and must not bleed into the new club's budget.
+        if (!$this->previousSeasonBelongsToCurrentTeam($game)) {
+            return 0;
+        }
+
         $previousSeason = (int) $game->season - 1;
 
         $previousFinances = GameFinances::where('game_id', $game->id)
@@ -352,6 +393,12 @@ class BudgetProjectionService
      */
     public function getPreviousSeasonLoanRepayment(Game $game): int
     {
+        // The previous club's loan obligations don't follow the manager
+        // across a Pro Manager team switch.
+        if (!$this->previousSeasonBelongsToCurrentTeam($game)) {
+            return 0;
+        }
+
         $previousSeason = (int) $game->season - 1;
 
         return (int) BudgetLoan::where('game_id', $game->id)
@@ -367,14 +414,18 @@ class BudgetProjectionService
      */
     private function getBaseCommercialRevenue(Game $game, Team $team, Competition $league): int|float
     {
-        // Check for prior season actual commercial revenue
-        $previousSeason = (int) $game->season - 1;
-        $previousFinances = GameFinances::where('game_id', $game->id)
-            ->where('season', $previousSeason)
-            ->first();
+        // Skip the prior-actual branch after a Pro Manager team switch: the
+        // previous season's commercial revenue was earned by the old club,
+        // so the new club starts from the stadium-based first-season calc.
+        if ($this->previousSeasonBelongsToCurrentTeam($game)) {
+            $previousSeason = (int) $game->season - 1;
+            $previousFinances = GameFinances::where('game_id', $game->id)
+                ->where('season', $previousSeason)
+                ->first();
 
-        if ($previousFinances && $previousFinances->actual_commercial_revenue > 0) {
-            return $previousFinances->actual_commercial_revenue;
+            if ($previousFinances && $previousFinances->actual_commercial_revenue > 0) {
+                return $previousFinances->actual_commercial_revenue;
+            }
         }
 
         // First season: calculate from stadium seats × config rate (capped)

--- a/app/Modules/Manager/Processors/ApplyPendingTeamSwitchProcessor.php
+++ b/app/Modules/Manager/Processors/ApplyPendingTeamSwitchProcessor.php
@@ -130,6 +130,10 @@ class ApplyPendingTeamSwitchProcessor implements SeasonProcessor
         // of the setup pipeline regenerate against the new club's league.
         $data->competitionId = $newCompetitionId;
 
+        // Signal the switch so BudgetProjectionProcessor knows to skip the
+        // previous club's carry-overs when projecting the new season.
+        $data->setMetadata(SeasonTransitionData::META_PRO_MANAGER_TEAM_SWITCHED, true);
+
         return $data;
     }
 

--- a/app/Modules/Season/DTOs/SeasonTransitionData.php
+++ b/app/Modules/Season/DTOs/SeasonTransitionData.php
@@ -11,6 +11,14 @@ final class SeasonTransitionData implements \JsonSerializable
     public const META_UCL_WINNER = 'uclWinner';
     public const META_UEL_WINNER = 'uelWinner';
 
+    /**
+     * Set by ApplyPendingTeamSwitchProcessor when a Pro Manager accepted an
+     * end-of-season offer and the pipeline just moved the game to the new
+     * club. Read by BudgetProjectionProcessor so the new season's projection
+     * skips the previous club's carry-overs.
+     */
+    public const META_PRO_MANAGER_TEAM_SWITCHED = 'proManagerTeamSwitched';
+
     public function __construct(
         public readonly string $oldSeason,
         public readonly string $newSeason,

--- a/app/Modules/Season/Processors/BudgetProjectionProcessor.php
+++ b/app/Modules/Season/Processors/BudgetProjectionProcessor.php
@@ -39,8 +39,13 @@ class BudgetProjectionProcessor implements SeasonProcessor
 
         $game->update(['season_goal' => $seasonGoal]);
 
+        // If ApplyPendingTeamSwitchProcessor signaled a Pro Manager team
+        // switch this transition, the previous season's finances belong to
+        // the old club — start the new club from a fresh-club baseline.
+        $freshClub = (bool) $data->getMetadata(SeasonTransitionData::META_PRO_MANAGER_TEAM_SWITCHED, false);
+
         // Generate projections for the new season
-        $finances = $this->projectionService->generateProjections($game);
+        $finances = $this->projectionService->generateProjections($game, $freshClub);
 
         // Store projections in metadata for season display
         $data->setMetadata('new_season_projections', [

--- a/tests/Unit/ApplyPendingTeamSwitchProcessorTest.php
+++ b/tests/Unit/ApplyPendingTeamSwitchProcessorTest.php
@@ -83,6 +83,70 @@ class ApplyPendingTeamSwitchProcessorTest extends TestCase
     }
 
     /**
+     * Regression for #1220: BudgetProjectionProcessor reads
+     * META_PRO_MANAGER_TEAM_SWITCHED to know whether to start the new club
+     * on a fresh-club baseline (no carry-overs). The flag must be set
+     * exactly when a team switch was actually applied.
+     */
+    public function test_publishes_team_switch_metadata_on_successful_switch(): void
+    {
+        [$processor, $game] = $this->buildScenario(
+            offerCompetitionId: 'ESP2',
+            actualEntryCompetitionId: 'ESP2',
+        );
+
+        $data = new SeasonTransitionData(
+            oldSeason: '2027',
+            newSeason: '2028',
+            competitionId: $game->competition_id,
+        );
+
+        $processor->process($game->refresh(), $data);
+
+        $this->assertTrue(
+            $data->getMetadata(SeasonTransitionData::META_PRO_MANAGER_TEAM_SWITCHED),
+            'A successful team switch must publish the metadata flag so the budget processor skips old-club carry-overs.',
+        );
+    }
+
+    /**
+     * If the game has no pending switch (or the switch is aborted because
+     * the offer/team/competition can't be resolved), the metadata flag must
+     * stay unset so BudgetProjectionProcessor keeps carry-overs intact.
+     */
+    public function test_does_not_publish_metadata_when_no_pending_switch(): void
+    {
+        $team = Team::factory()->create();
+        $competition = Competition::factory()->create([
+            'id' => 'ESP1',
+            'tier' => 1,
+            'role' => Competition::ROLE_LEAGUE,
+            'handler_type' => 'league',
+        ]);
+        $game = Game::factory()->create([
+            'game_mode' => Game::MODE_CAREER_PRO,
+            'team_id' => $team->id,
+            'competition_id' => $competition->id,
+            'pending_team_switch' => null,
+        ]);
+
+        $processor = new ApplyPendingTeamSwitchProcessor(
+            Mockery::mock(JobOfferService::class),
+            Mockery::mock(TeamReputationSeeder::class)->shouldIgnoreMissing(),
+        );
+
+        $data = new SeasonTransitionData(
+            oldSeason: '2027',
+            newSeason: '2028',
+            competitionId: $game->competition_id,
+        );
+
+        $processor->process($game, $data);
+
+        $this->assertNull($data->getMetadata(SeasonTransitionData::META_PRO_MANAGER_TEAM_SWITCHED));
+    }
+
+    /**
      * @return array{0: ApplyPendingTeamSwitchProcessor, 1: Game, 2: Team, 3: ManagerJobOffer, 4: Competition, 5: Competition}
      */
     private function buildScenario(string $offerCompetitionId, string $actualEntryCompetitionId): array

--- a/tests/Unit/BudgetProjectionProcessorTest.php
+++ b/tests/Unit/BudgetProjectionProcessorTest.php
@@ -108,6 +108,93 @@ class BudgetProjectionProcessorTest extends TestCase
         $this->assertSame('survival', $game->fresh()->season_goal);
     }
 
+    /**
+     * Regression for #1220: when ApplyPendingTeamSwitchProcessor sets the
+     * team-switch flag earlier in the pipeline, the budget processor must
+     * forward it as $freshClub so the service skips carry-overs.
+     */
+    public function test_forwards_pro_manager_team_switch_flag_to_service(): void
+    {
+        $team = Team::factory()->create();
+        $competition = Competition::factory()->league()->create();
+        $game = Game::factory()
+            ->forTeam($team)
+            ->inCompetition($competition->id)
+            ->create();
+
+        $seasonGoalService = Mockery::mock(SeasonGoalService::class);
+        $seasonGoalService->shouldReceive('determineGoalForTeam')
+            ->andReturn('champion');
+
+        $projectionService = Mockery::mock(BudgetProjectionService::class);
+        $projectionService->shouldReceive('generateProjections')
+            ->once()
+            ->with(Mockery::on(fn (Game $g) => $g->id === $game->id), true)
+            ->andReturn(new GameFinances([
+                'projected_position' => 10,
+                'projected_total_revenue' => 0,
+                'projected_wages' => 0,
+                'projected_surplus' => 0,
+                'carried_debt' => 0,
+                'carried_surplus' => 0,
+                'available_surplus' => 0,
+            ]));
+
+        $processor = new BudgetProjectionProcessor($projectionService, $seasonGoalService);
+
+        $data = new SeasonTransitionData(
+            oldSeason: '2025',
+            newSeason: '2026',
+            competitionId: $competition->id,
+        );
+        $data->setMetadata(SeasonTransitionData::META_PRO_MANAGER_TEAM_SWITCHED, true);
+
+        $processor->process($game, $data);
+    }
+
+    /**
+     * Absence of the team-switch flag must default to the existing carry-over
+     * behaviour (freshClub=false). Guards against accidental "always reset"
+     * regressions.
+     */
+    public function test_defaults_to_false_when_team_switch_flag_absent(): void
+    {
+        $team = Team::factory()->create();
+        $competition = Competition::factory()->league()->create();
+        $game = Game::factory()
+            ->forTeam($team)
+            ->inCompetition($competition->id)
+            ->create();
+
+        $seasonGoalService = Mockery::mock(SeasonGoalService::class);
+        $seasonGoalService->shouldReceive('determineGoalForTeam')
+            ->andReturn('champion');
+
+        $projectionService = Mockery::mock(BudgetProjectionService::class);
+        $projectionService->shouldReceive('generateProjections')
+            ->once()
+            ->with(Mockery::on(fn (Game $g) => $g->id === $game->id), false)
+            ->andReturn(new GameFinances([
+                'projected_position' => 10,
+                'projected_total_revenue' => 0,
+                'projected_wages' => 0,
+                'projected_surplus' => 0,
+                'carried_debt' => 0,
+                'carried_surplus' => 0,
+                'available_surplus' => 0,
+            ]));
+
+        $processor = new BudgetProjectionProcessor($projectionService, $seasonGoalService);
+
+        $data = new SeasonTransitionData(
+            oldSeason: '2025',
+            newSeason: '2026',
+            competitionId: $competition->id,
+        );
+
+        $processor->process($game, $data);
+    }
+
     protected function tearDown(): void
     {
         Mockery::close();

--- a/tests/Unit/BudgetProjectionServiceTest.php
+++ b/tests/Unit/BudgetProjectionServiceTest.php
@@ -1,0 +1,199 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\BudgetLoan;
+use App\Models\Competition;
+use App\Models\Game;
+use App\Models\GameFinances;
+use App\Models\ManagerJobHistory;
+use App\Models\Team;
+use App\Modules\Finance\Services\BudgetProjectionService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use ReflectionMethod;
+use Tests\TestCase;
+
+/**
+ * Regression tests for issue #1220 — Pro Manager financial carry-overs
+ * must stay with the previous club after a team switch.
+ *
+ * GameFinances / BudgetLoan are keyed by (game_id, season) only, so the
+ * service relies on ManagerJobHistory to detect when the previous-season
+ * row belongs to a different club.
+ */
+class BudgetProjectionServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const PREV_SEASON = 2025;
+    private const CUR_SEASON = '2026';
+    private const ACTUAL_SURPLUS = 10_000_000_00;        // €100K
+    private const CARRIED_SURPLUS = 2_000_000_00;        // €20K
+    private const ACTUAL_COMMERCIAL_REVENUE = 50_000_000_00;
+    private const ACTUAL_TOTAL_REVENUE = 200_000_000_00;
+    private const LOAN_REPAYMENT = 5_000_000_00;
+
+    public function test_pro_manager_switch_to_new_club_resets_carry_overs(): void
+    {
+        $oldClub = Team::factory()->create();
+        $newClub = Team::factory()->create();
+        $competition = Competition::factory()->league()->create();
+
+        $game = Game::factory()
+            ->forTeam($newClub)
+            ->inCompetition($competition->id)
+            ->create([
+                'season' => self::CUR_SEASON,
+                'game_mode' => Game::MODE_CAREER_PRO,
+            ]);
+
+        $this->seedPreviousSeasonFinances($game);
+        $this->seedPreviousSeasonRepaidLoan($game);
+
+        // Manager was at the old club for season 2025, then switched to the
+        // new club for season 2026.
+        ManagerJobHistory::create([
+            'game_id' => $game->id,
+            'user_id' => $game->user_id,
+            'team_id' => $oldClub->id,
+            'competition_id' => $competition->id,
+            'season_start' => (string) self::PREV_SEASON,
+            'season_end' => (string) self::PREV_SEASON,
+            'end_reason' => ManagerJobHistory::REASON_LEFT_VOLUNTARILY,
+        ]);
+        ManagerJobHistory::create([
+            'game_id' => $game->id,
+            'user_id' => $game->user_id,
+            'team_id' => $newClub->id,
+            'competition_id' => $competition->id,
+            'season_start' => self::CUR_SEASON,
+            'season_end' => null,
+            'end_reason' => ManagerJobHistory::REASON_STILL_ACTIVE,
+        ]);
+
+        $service = $this->makeService();
+
+        $this->assertSame(0, $service->getCarriedSurplus($game));
+        $this->assertSame(0, $service->getCarriedDebt($game));
+        $this->assertSame(0, $service->getPreviousSeasonLoanRepayment($game));
+
+        // AC #3: commercial revenue must fall back to the first-season
+        // stadium-based calc, NOT inherit the old club's actual figure.
+        $commercial = $this->invokeBaseCommercialRevenue($service, $game, $newClub, $competition);
+        $this->assertNotSame(self::ACTUAL_COMMERCIAL_REVENUE, $commercial);
+        $this->assertGreaterThan(0, $commercial);
+    }
+
+    public function test_pro_manager_continuous_tenure_keeps_carry_overs(): void
+    {
+        $club = Team::factory()->create();
+        $competition = Competition::factory()->league()->create();
+
+        $game = Game::factory()
+            ->forTeam($club)
+            ->inCompetition($competition->id)
+            ->create([
+                'season' => self::CUR_SEASON,
+                'game_mode' => Game::MODE_CAREER_PRO,
+            ]);
+
+        $this->seedPreviousSeasonFinances($game);
+        $this->seedPreviousSeasonRepaidLoan($game);
+
+        // Manager has been at this club since season 2025, no switch.
+        ManagerJobHistory::create([
+            'game_id' => $game->id,
+            'user_id' => $game->user_id,
+            'team_id' => $club->id,
+            'competition_id' => $competition->id,
+            'season_start' => (string) self::PREV_SEASON,
+            'season_end' => null,
+            'end_reason' => ManagerJobHistory::REASON_STILL_ACTIVE,
+        ]);
+
+        $service = $this->makeService();
+
+        // Net position = actual_surplus + carried_surplus = 120K → positive
+        $expectedSurplus = self::ACTUAL_SURPLUS + self::CARRIED_SURPLUS;
+        $this->assertSame($expectedSurplus, $service->getCarriedSurplus($game));
+        $this->assertSame(0, $service->getCarriedDebt($game));
+        $this->assertSame(self::LOAN_REPAYMENT, $service->getPreviousSeasonLoanRepayment($game));
+
+        $commercial = $this->invokeBaseCommercialRevenue($service, $game, $club, $competition);
+        $this->assertSame(self::ACTUAL_COMMERCIAL_REVENUE, $commercial);
+    }
+
+    public function test_club_manager_mode_carry_overs_flow_through(): void
+    {
+        $club = Team::factory()->create();
+        $competition = Competition::factory()->league()->create();
+
+        $game = Game::factory()
+            ->forTeam($club)
+            ->inCompetition($competition->id)
+            ->create([
+                'season' => self::CUR_SEASON,
+                'game_mode' => Game::MODE_CAREER,
+            ]);
+
+        $this->seedPreviousSeasonFinances($game);
+        $this->seedPreviousSeasonRepaidLoan($game);
+
+        // No ManagerJobHistory rows — Club Manager mode doesn't write them,
+        // and the helper must not require them for non-pro-manager games.
+
+        $service = $this->makeService();
+
+        $expectedSurplus = self::ACTUAL_SURPLUS + self::CARRIED_SURPLUS;
+        $this->assertSame($expectedSurplus, $service->getCarriedSurplus($game));
+        $this->assertSame(self::LOAN_REPAYMENT, $service->getPreviousSeasonLoanRepayment($game));
+
+        $commercial = $this->invokeBaseCommercialRevenue($service, $game, $club, $competition);
+        $this->assertSame(self::ACTUAL_COMMERCIAL_REVENUE, $commercial);
+    }
+
+    private function makeService(): BudgetProjectionService
+    {
+        return app(BudgetProjectionService::class);
+    }
+
+    private function seedPreviousSeasonFinances(Game $game): void
+    {
+        GameFinances::create([
+            'game_id' => $game->id,
+            'season' => self::PREV_SEASON,
+            'actual_surplus' => self::ACTUAL_SURPLUS,
+            'carried_surplus' => self::CARRIED_SURPLUS,
+            'carried_debt' => 0,
+            'actual_commercial_revenue' => self::ACTUAL_COMMERCIAL_REVENUE,
+            'actual_total_revenue' => self::ACTUAL_TOTAL_REVENUE,
+        ]);
+    }
+
+    private function seedPreviousSeasonRepaidLoan(Game $game): void
+    {
+        BudgetLoan::create([
+            'game_id' => $game->id,
+            'season' => self::PREV_SEASON,
+            'amount' => self::LOAN_REPAYMENT,
+            'interest_rate' => 0,
+            'repayment_amount' => self::LOAN_REPAYMENT,
+            'status' => BudgetLoan::STATUS_REPAID,
+        ]);
+    }
+
+    /**
+     * getBaseCommercialRevenue is private; invoke via reflection so we can
+     * directly assert AC #3 (first-season fallback after a team switch).
+     */
+    private function invokeBaseCommercialRevenue(
+        BudgetProjectionService $service,
+        Game $game,
+        Team $team,
+        Competition $competition,
+    ): int|float {
+        $method = new ReflectionMethod($service, 'getBaseCommercialRevenue');
+
+        return $method->invoke($service, $game, $team, $competition);
+    }
+}

--- a/tests/Unit/BudgetProjectionServiceTest.php
+++ b/tests/Unit/BudgetProjectionServiceTest.php
@@ -6,20 +6,22 @@ use App\Models\BudgetLoan;
 use App\Models\Competition;
 use App\Models\Game;
 use App\Models\GameFinances;
-use App\Models\ManagerJobHistory;
 use App\Models\Team;
 use App\Modules\Finance\Services\BudgetProjectionService;
+use App\Modules\Finance\Services\StadiumLoanService;
+use App\Modules\Squad\Services\SquadService;
+use App\Modules\Stadium\Services\MatchAttendanceService;
+use App\Modules\Stadium\Services\SeasonTicketPricingService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use ReflectionMethod;
+use Mockery;
 use Tests\TestCase;
 
 /**
- * Regression tests for issue #1220 — Pro Manager financial carry-overs
- * must stay with the previous club after a team switch.
- *
- * GameFinances / BudgetLoan are keyed by (game_id, season) only, so the
- * service relies on ManagerJobHistory to detect when the previous-season
- * row belongs to a different club.
+ * Regression tests for issue #1220. The previous season's carry-overs must
+ * not follow a Pro Manager across a team switch — the BudgetProjectionService
+ * receives an explicit $freshClub signal (published by
+ * ApplyPendingTeamSwitchProcessor, forwarded by BudgetProjectionProcessor)
+ * and skips carry-overs / prior-actual commercial revenue when set.
  */
 class BudgetProjectionServiceTest extends TestCase
 {
@@ -27,138 +29,60 @@ class BudgetProjectionServiceTest extends TestCase
 
     private const PREV_SEASON = 2025;
     private const CUR_SEASON = '2026';
-    private const ACTUAL_SURPLUS = 10_000_000_00;        // €100K
-    private const CARRIED_SURPLUS = 2_000_000_00;        // €20K
+    private const ACTUAL_SURPLUS = 10_000_000_00;
+    private const CARRIED_SURPLUS = 2_000_000_00;
     private const ACTUAL_COMMERCIAL_REVENUE = 50_000_000_00;
     private const ACTUAL_TOTAL_REVENUE = 200_000_000_00;
     private const LOAN_REPAYMENT = 5_000_000_00;
 
-    public function test_pro_manager_switch_to_new_club_resets_carry_overs(): void
+    public function test_fresh_club_skips_carry_overs_and_uses_stadium_commercial_baseline(): void
     {
-        $oldClub = Team::factory()->create();
-        $newClub = Team::factory()->create();
-        $competition = Competition::factory()->league()->create();
+        [$service, $game, $team] = $this->buildScenario();
 
+        $finances = $service->generateProjections($game, freshClub: true);
+
+        $this->assertSame(0, $finances->carried_surplus);
+        $this->assertSame(0, $finances->carried_debt);
+        $this->assertSame(0, $finances->previous_loan_repayment);
+
+        // First-season commercial baseline: stadium-seats × per-seat config
+        // (default reputation = 'local' → 24_000 cents/seat, league tier 1
+        // multiplier = 1.0). The exact figure depends on faker's seat count,
+        // so we assert against the formula and confirm it isn't the prior
+        // actual.
+        $expectedCommercial = $team->stadium_seats * 24_000;
+        $this->assertSame($expectedCommercial, $finances->projected_commercial_revenue);
+        $this->assertNotSame(self::ACTUAL_COMMERCIAL_REVENUE, $finances->projected_commercial_revenue);
+    }
+
+    public function test_default_call_preserves_carry_overs_from_previous_season(): void
+    {
+        [$service, $game] = $this->buildScenario();
+
+        $finances = $service->generateProjections($game);
+
+        $expectedSurplus = self::ACTUAL_SURPLUS + self::CARRIED_SURPLUS;
+        $this->assertSame($expectedSurplus, $finances->carried_surplus);
+        $this->assertSame(0, $finances->carried_debt);
+        $this->assertSame(self::LOAN_REPAYMENT, $finances->previous_loan_repayment);
+        $this->assertSame(self::ACTUAL_COMMERCIAL_REVENUE, $finances->projected_commercial_revenue);
+    }
+
+    /**
+     * @return array{0: BudgetProjectionService, 1: Game, 2: Team}
+     */
+    private function buildScenario(): array
+    {
+        $team = Team::factory()->create(['stadium_seats' => 30_000]);
+        $competition = Competition::factory()->league()->create();
         $game = Game::factory()
-            ->forTeam($newClub)
+            ->forTeam($team)
             ->inCompetition($competition->id)
             ->create([
                 'season' => self::CUR_SEASON,
                 'game_mode' => Game::MODE_CAREER_PRO,
             ]);
 
-        $this->seedPreviousSeasonFinances($game);
-        $this->seedPreviousSeasonRepaidLoan($game);
-
-        // Manager was at the old club for season 2025, then switched to the
-        // new club for season 2026.
-        ManagerJobHistory::create([
-            'game_id' => $game->id,
-            'user_id' => $game->user_id,
-            'team_id' => $oldClub->id,
-            'competition_id' => $competition->id,
-            'season_start' => (string) self::PREV_SEASON,
-            'season_end' => (string) self::PREV_SEASON,
-            'end_reason' => ManagerJobHistory::REASON_LEFT_VOLUNTARILY,
-        ]);
-        ManagerJobHistory::create([
-            'game_id' => $game->id,
-            'user_id' => $game->user_id,
-            'team_id' => $newClub->id,
-            'competition_id' => $competition->id,
-            'season_start' => self::CUR_SEASON,
-            'season_end' => null,
-            'end_reason' => ManagerJobHistory::REASON_STILL_ACTIVE,
-        ]);
-
-        $service = $this->makeService();
-
-        $this->assertSame(0, $service->getCarriedSurplus($game));
-        $this->assertSame(0, $service->getCarriedDebt($game));
-        $this->assertSame(0, $service->getPreviousSeasonLoanRepayment($game));
-
-        // AC #3: commercial revenue must fall back to the first-season
-        // stadium-based calc, NOT inherit the old club's actual figure.
-        $commercial = $this->invokeBaseCommercialRevenue($service, $game, $newClub, $competition);
-        $this->assertNotSame(self::ACTUAL_COMMERCIAL_REVENUE, $commercial);
-        $this->assertGreaterThan(0, $commercial);
-    }
-
-    public function test_pro_manager_continuous_tenure_keeps_carry_overs(): void
-    {
-        $club = Team::factory()->create();
-        $competition = Competition::factory()->league()->create();
-
-        $game = Game::factory()
-            ->forTeam($club)
-            ->inCompetition($competition->id)
-            ->create([
-                'season' => self::CUR_SEASON,
-                'game_mode' => Game::MODE_CAREER_PRO,
-            ]);
-
-        $this->seedPreviousSeasonFinances($game);
-        $this->seedPreviousSeasonRepaidLoan($game);
-
-        // Manager has been at this club since season 2025, no switch.
-        ManagerJobHistory::create([
-            'game_id' => $game->id,
-            'user_id' => $game->user_id,
-            'team_id' => $club->id,
-            'competition_id' => $competition->id,
-            'season_start' => (string) self::PREV_SEASON,
-            'season_end' => null,
-            'end_reason' => ManagerJobHistory::REASON_STILL_ACTIVE,
-        ]);
-
-        $service = $this->makeService();
-
-        // Net position = actual_surplus + carried_surplus = 120K → positive
-        $expectedSurplus = self::ACTUAL_SURPLUS + self::CARRIED_SURPLUS;
-        $this->assertSame($expectedSurplus, $service->getCarriedSurplus($game));
-        $this->assertSame(0, $service->getCarriedDebt($game));
-        $this->assertSame(self::LOAN_REPAYMENT, $service->getPreviousSeasonLoanRepayment($game));
-
-        $commercial = $this->invokeBaseCommercialRevenue($service, $game, $club, $competition);
-        $this->assertSame(self::ACTUAL_COMMERCIAL_REVENUE, $commercial);
-    }
-
-    public function test_club_manager_mode_carry_overs_flow_through(): void
-    {
-        $club = Team::factory()->create();
-        $competition = Competition::factory()->league()->create();
-
-        $game = Game::factory()
-            ->forTeam($club)
-            ->inCompetition($competition->id)
-            ->create([
-                'season' => self::CUR_SEASON,
-                'game_mode' => Game::MODE_CAREER,
-            ]);
-
-        $this->seedPreviousSeasonFinances($game);
-        $this->seedPreviousSeasonRepaidLoan($game);
-
-        // No ManagerJobHistory rows — Club Manager mode doesn't write them,
-        // and the helper must not require them for non-pro-manager games.
-
-        $service = $this->makeService();
-
-        $expectedSurplus = self::ACTUAL_SURPLUS + self::CARRIED_SURPLUS;
-        $this->assertSame($expectedSurplus, $service->getCarriedSurplus($game));
-        $this->assertSame(self::LOAN_REPAYMENT, $service->getPreviousSeasonLoanRepayment($game));
-
-        $commercial = $this->invokeBaseCommercialRevenue($service, $game, $club, $competition);
-        $this->assertSame(self::ACTUAL_COMMERCIAL_REVENUE, $commercial);
-    }
-
-    private function makeService(): BudgetProjectionService
-    {
-        return app(BudgetProjectionService::class);
-    }
-
-    private function seedPreviousSeasonFinances(Game $game): void
-    {
         GameFinances::create([
             'game_id' => $game->id,
             'season' => self::PREV_SEASON,
@@ -168,10 +92,7 @@ class BudgetProjectionServiceTest extends TestCase
             'actual_commercial_revenue' => self::ACTUAL_COMMERCIAL_REVENUE,
             'actual_total_revenue' => self::ACTUAL_TOTAL_REVENUE,
         ]);
-    }
 
-    private function seedPreviousSeasonRepaidLoan(Game $game): void
-    {
         BudgetLoan::create([
             'game_id' => $game->id,
             'season' => self::PREV_SEASON,
@@ -180,20 +101,36 @@ class BudgetProjectionServiceTest extends TestCase
             'repayment_amount' => self::LOAN_REPAYMENT,
             'status' => BudgetLoan::STATUS_REPAID,
         ]);
+
+        $squadService = Mockery::mock(SquadService::class);
+        $squadService->shouldReceive('calculateLeagueStrengths')->andReturn([]);
+        $squadService->shouldReceive('getProjectedPosition')->andReturn(10);
+
+        $seasonTicketPricingService = Mockery::mock(SeasonTicketPricingService::class);
+        $seasonTicketPricingService->shouldReceive('walkupRelevantSoldForGame')->andReturn(0);
+        $seasonTicketPricingService->shouldReceive('getCurrent')->andReturn(null);
+
+        $stadiumLoanService = Mockery::mock(StadiumLoanService::class);
+        $stadiumLoanService->shouldReceive('activePaymentsForGame')->andReturn(0);
+
+        // MatchAttendanceService is unused on this path — no league home
+        // matches are scheduled, so calculateMatchdayRevenue returns 0
+        // before touching it. shouldIgnoreMissing() guards future changes.
+        $matchAttendanceService = Mockery::mock(MatchAttendanceService::class)->shouldIgnoreMissing(0);
+
+        $service = new BudgetProjectionService(
+            $squadService,
+            $matchAttendanceService,
+            $seasonTicketPricingService,
+            $stadiumLoanService,
+        );
+
+        return [$service, $game, $team];
     }
 
-    /**
-     * getBaseCommercialRevenue is private; invoke via reflection so we can
-     * directly assert AC #3 (first-season fallback after a team switch).
-     */
-    private function invokeBaseCommercialRevenue(
-        BudgetProjectionService $service,
-        Game $game,
-        Team $team,
-        Competition $competition,
-    ): int|float {
-        $method = new ReflectionMethod($service, 'getBaseCommercialRevenue');
-
-        return $method->invoke($service, $game, $team, $competition);
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
     }
 }


### PR DESCRIPTION
Closes #1220

## Summary
- `GameFinances` and `BudgetLoan` are keyed by `(game_id, season)` only — no `team_id` — so after a Pro Manager mid-career team switch the new club was inheriting the previous club's `carried_surplus` / `carried_debt`, prior-season infrastructure spend, transfer spending, repaid loans, and `actual_commercial_revenue`.
- The signal flow is now explicit at every layer:
  - `ApplyPendingTeamSwitchProcessor` publishes `SeasonTransitionData::META_PRO_MANAGER_TEAM_SWITCHED = true` after successfully switching the team.
  - `BudgetProjectionProcessor` reads that flag and forwards it to `BudgetProjectionService::generateProjections($game, freshClub: …)`.
  - `BudgetProjectionService` skips carry-overs/loan-repayment and uses the stadium-based first-season commercial baseline when `$freshClub` is true.
- Club Manager mode is untouched — its pipeline doesn't run `ApplyPendingTeamSwitchProcessor`, so the metadata flag stays unset and the default `$freshClub = false` keeps carry-overs working.

## Test plan
- [ ] `php artisan test --filter=ApplyPendingTeamSwitchProcessorTest` — new cases assert the metadata flag is published on a successful switch and stays unset when there's no pending switch.
- [ ] `php artisan test --filter=BudgetProjectionProcessorTest` — new cases assert the flag is forwarded as `freshClub: true`, and is absent → `freshClub: false`.
- [ ] `php artisan test --filter=BudgetProjectionServiceTest` — confirms `generateProjections($game, freshClub: true)` writes a `GameFinances` row with zero carry-overs and the stadium-seats × per-seat commercial baseline; the default call preserves the previous season's carry-overs.
- [ ] Manual: accept an end-of-season offer in Pro Manager, advance, confirm the new club's budget shows `carried_surplus = 0`, `carried_debt = 0`, no leaked loan repayment, and a commercial revenue figure consistent with its own stadium tier rather than the old club's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)