### PR TITLE
Carry long-term injuries across the season transition (#1189)

### DIFF
--- a/app/Modules/Season/Processors/StatsResetProcessor.php
+++ b/app/Modules/Season/Processors/StatsResetProcessor.php
@@ -2,12 +2,15 @@
 
 namespace App\Modules\Season\Processors;
 
+use App\Modules\Notification\Services\NotificationService;
 use App\Modules\Season\Contracts\SeasonProcessor;
 use App\Modules\Season\DTOs\SeasonTransitionData;
 use App\Models\Game;
 use App\Models\GameNotification;
+use App\Models\GamePlayer;
 use App\Models\GamePlayerMatchState;
 use App\Models\PlayerSuspension;
+use Carbon\Carbon;
 
 /**
  * Resets player and game stats for the new season.
@@ -15,6 +18,10 @@ use App\Models\PlayerSuspension;
  */
 class StatsResetProcessor implements SeasonProcessor
 {
+    public function __construct(
+        private readonly NotificationService $notificationService,
+    ) {}
+
     public function priority(): int
     {
         return 65;
@@ -30,6 +37,12 @@ class StatsResetProcessor implements SeasonProcessor
         // Reset every active player's match-state. Pool players have no
         // satellite row to reset — and they have no stats to reset either,
         // so this is correct.
+        //
+        // injury_until / injury_type are intentionally NOT in this reset:
+        // they're date-driven and the day-to-day CheckRecoveredPlayers
+        // listener clears them once current_date passes injury_until.
+        // Wiping them here would silently heal long-term injuries whose
+        // recovery extends into the new season.
         GamePlayerMatchState::bulkResetForGame($game->id, [
             'appearances' => 0,
             'goals' => 0,
@@ -40,8 +53,6 @@ class StatsResetProcessor implements SeasonProcessor
             'goals_conceded' => 0,
             'clean_sheets' => 0,
             'season_appearances' => 0,
-            'injury_until' => null,
-            'injury_type' => null,
             'fitness' => 80,
             'morale' => 80,
         ]);
@@ -51,6 +62,38 @@ class StatsResetProcessor implements SeasonProcessor
             ->unread()
             ->update(['read_at' => now()]);
 
+        $this->notifyCarriedOverInjuries($game, $data);
+
         return $data;
+    }
+
+    /**
+     * Surface long-term injuries that carry into the new season in the
+     * notification feed, so the manager isn't surprised when an unavailable
+     * player shows up on matchday 1.
+     */
+    private function notifyCarriedOverInjuries(Game $game, SeasonTransitionData $data): void
+    {
+        $newSeasonStart = Carbon::createFromDate((int) $data->newSeason, 7, 1);
+
+        $injuredPlayers = GamePlayer::with('matchState')
+            ->joinMatchState()
+            ->where('game_players.game_id', $game->id)
+            ->where('game_players.team_id', $game->team_id)
+            ->whereMatchStatNotNull('injury_until')
+            ->whereMatchStat('injury_until', '>=', $newSeasonStart->toDateString())
+            ->get();
+
+        foreach ($injuredPlayers as $player) {
+            $weeksOut = max(1, (int) ceil($newSeasonStart->diffInDays($player->injury_until, false) / 7));
+
+            $this->notificationService->notifyInjury(
+                $game,
+                $player,
+                $player->injury_type ?? '',
+                $weeksOut,
+                duringMatch: false,
+            );
+        }
     }
 }

--- a/tests/Feature/Season/InjuryCarryOverTest.php
+++ b/tests/Feature/Season/InjuryCarryOverTest.php
@@ -1,0 +1,187 @@
+<?php
+
+namespace Tests\Feature\Season;
+
+use App\Models\Competition;
+use App\Models\Game;
+use App\Models\GameNotification;
+use App\Models\GamePlayer;
+use App\Models\Team;
+use App\Models\User;
+use App\Modules\Season\DTOs\SeasonTransitionData;
+use App\Modules\Season\Processors\StatsResetProcessor;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class InjuryCarryOverTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+    private Team $team;
+    private Game $game;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = User::factory()->create();
+        $this->team = Team::factory()->create();
+
+        Competition::factory()->league()->create([
+            'id' => 'ESP1',
+            'name' => 'LaLiga',
+        ]);
+
+        $this->game = Game::factory()->create([
+            'user_id' => $this->user->id,
+            'team_id' => $this->team->id,
+            'competition_id' => 'ESP1',
+            'season' => '2024',
+            'current_date' => '2025-05-28',
+        ]);
+    }
+
+    public function test_long_term_injury_extending_into_next_season_is_preserved(): void
+    {
+        $player = GamePlayer::factory()
+            ->forGame($this->game)
+            ->forTeam($this->team)
+            ->create([
+                'name' => 'Long Recovery',
+                'injury_until' => '2025-11-15',
+                'injury_type' => 'ACL tear',
+            ]);
+
+        $this->runStatsResetProcessor();
+
+        $player->refresh();
+        $this->assertSame('2025-11-15', $player->injury_until?->toDateString());
+        $this->assertSame('ACL tear', $player->injury_type);
+    }
+
+    public function test_short_term_injury_that_expires_before_new_season_is_also_preserved(): void
+    {
+        // The day-to-day CheckRecoveredPlayers listener — not this processor —
+        // is responsible for clearing past-dated injuries on the next
+        // GameDateAdvanced. Verify we don't preempt that contract here.
+        $player = GamePlayer::factory()
+            ->forGame($this->game)
+            ->forTeam($this->team)
+            ->create([
+                'name' => 'Short Recovery',
+                'injury_until' => '2025-06-10',
+                'injury_type' => 'Sprained ankle',
+            ]);
+
+        $this->runStatsResetProcessor();
+
+        $player->refresh();
+        $this->assertSame('2025-06-10', $player->injury_until?->toDateString());
+        $this->assertSame('Sprained ankle', $player->injury_type);
+    }
+
+    public function test_stats_are_still_reset_alongside_preserved_injury(): void
+    {
+        $player = GamePlayer::factory()
+            ->forGame($this->game)
+            ->forTeam($this->team)
+            ->create([
+                'name' => 'Stats Reset',
+                'injury_until' => '2025-11-15',
+                'injury_type' => 'ACL tear',
+                'goals' => 12,
+                'appearances' => 30,
+                'yellow_cards' => 4,
+                'fitness' => 55,
+            ]);
+
+        $this->runStatsResetProcessor();
+
+        $player->refresh()->load('matchState');
+        $matchState = $player->matchState;
+        $this->assertSame(0, $matchState->goals);
+        $this->assertSame(0, $matchState->appearances);
+        $this->assertSame(0, $matchState->yellow_cards);
+        $this->assertSame(80, $matchState->fitness);
+        $this->assertSame('2025-11-15', $player->injury_until?->toDateString());
+    }
+
+    public function test_carried_over_injury_is_surfaced_in_notification_feed(): void
+    {
+        $player = GamePlayer::factory()
+            ->forGame($this->game)
+            ->forTeam($this->team)
+            ->create([
+                'name' => 'Notified Player',
+                'injury_until' => '2025-11-15',
+                'injury_type' => 'ACL tear',
+            ]);
+
+        $this->runStatsResetProcessor();
+
+        $notification = GameNotification::where('game_id', $this->game->id)
+            ->where('type', GameNotification::TYPE_PLAYER_INJURED)
+            ->where('metadata->player_id', $player->id)
+            ->first();
+
+        $this->assertNotNull($notification, 'Expected a TYPE_PLAYER_INJURED notification for the carried-over injury');
+        $this->assertSame('ACL tear', $notification->metadata['injury_type']);
+        $this->assertGreaterThanOrEqual(1, $notification->metadata['weeks_out']);
+    }
+
+    public function test_no_injury_notification_when_player_injury_already_expired_before_new_season(): void
+    {
+        GamePlayer::factory()
+            ->forGame($this->game)
+            ->forTeam($this->team)
+            ->create([
+                'name' => 'Already Recovered',
+                'injury_until' => '2025-06-10',
+                'injury_type' => 'Sprained ankle',
+            ]);
+
+        $this->runStatsResetProcessor();
+
+        $injuryNotifications = GameNotification::where('game_id', $this->game->id)
+            ->where('type', GameNotification::TYPE_PLAYER_INJURED)
+            ->count();
+
+        $this->assertSame(0, $injuryNotifications);
+    }
+
+    public function test_only_user_team_players_get_carry_over_notification(): void
+    {
+        $otherTeam = Team::factory()->create();
+
+        GamePlayer::factory()
+            ->forGame($this->game)
+            ->forTeam($otherTeam)
+            ->create([
+                'name' => 'Rival Player',
+                'injury_until' => '2025-11-15',
+                'injury_type' => 'ACL tear',
+            ]);
+
+        $this->runStatsResetProcessor();
+
+        $this->assertSame(
+            0,
+            GameNotification::where('game_id', $this->game->id)
+                ->where('type', GameNotification::TYPE_PLAYER_INJURED)
+                ->count(),
+            'Rival-team injuries should not generate user-facing notifications',
+        );
+    }
+
+    private function runStatsResetProcessor(): void
+    {
+        $data = new SeasonTransitionData(
+            oldSeason: '2024',
+            newSeason: '2025',
+            competitionId: 'ESP1',
+        );
+
+        app(StatsResetProcessor::class)->process($this->game, $data);
+    }
+}


### PR DESCRIPTION
## Summary
- Drop `injury_until` / `injury_type` from `StatsResetProcessor`'s bulk reset so a serious injury whose recovery extends into the new season (e.g., torn ACL in May, return in November) is no longer silently healed at season close. The day-to-day `CheckRecoveredPlayers` listener already clears these fields once `current_date` passes `injury_until`, so the reset was the only thing standing between the player and a correct carry-over.
- Surface carried-over injuries in the notification feed via the existing `TYPE_PLAYER_INJURED` notification, so the manager sees a heads-up on the first matchday instead of being surprised by an unavailable starter.
- New feature test `tests/Feature/Season/InjuryCarryOverTest.php` covers: long-term injuries preserved, short-term past-dated injuries also preserved (cleared by the listener, not the processor), unrelated stats still reset, notification created with correct metadata, no notification when the injury is already expired, and rival-team injuries don't notify.

Closes #1189.

## Test plan
- [ ] `php artisan test --filter=InjuryCarryOverTest`
- [ ] In dev: inject a `GamePlayer` with `injury_until` in the next October via tinker, trigger the season transition, advance through the new pre-season — the player remains injured in the squad UI and the notification feed shows the "Out until …" entry on matchday 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)