### PR TITLE
Honor explicit overall_score and potential from source JSON

### DIFF
--- a/app/Modules/Player/Services/PlayerDevelopmentService.php
+++ b/app/Modules/Player/Services/PlayerDevelopmentService.php
@@ -106,23 +106,19 @@ class PlayerDevelopmentService
             // Base range 8-20, plus value bonus for proven youngsters
             $basePotentialRange = rand(8, 20);
             $potentialRange = $basePotentialRange + $valueBonus;
-            $uncertainty = rand(5, 10); // Higher uncertainty for young players
         } elseif ($age <= 24) {
             // Developing players: moderate potential
             $basePotentialRange = rand(4, 12);
             $potentialRange = $basePotentialRange + (int) ($valueBonus * 0.6);
-            $uncertainty = rand(4, 7);
         } elseif ($age <= PlayerAge::PRIME_END) {
             // Peak players: small headroom over current ability — elite peak
             // players (high market value) get a slightly higher visible ceiling.
             $basePotentialRange = rand(0, 2);
             $potentialRange = $basePotentialRange + (int) ($valueBonus * 0.3);
-            $uncertainty = rand(1, 2);
         } else {
             // Veterans: no upside left — current ability IS the ceiling.
             // UI hides the potential row for this branch (see player-detail view).
             $potentialRange = 0;
-            $uncertainty = 0;
         }
 
         // Diminishing returns for high-rated players past their growing
@@ -130,14 +126,10 @@ class PlayerDevelopmentService
         // many already-strong players to 95-99 ceilings, which is unrealistic
         // on a population basis.
         if ($age > PlayerAge::YOUNG_END && $currentAbility >= 80) {
-            $taperFactor = match (true) {
-                $currentAbility >= 88 => 0.25,
-                $currentAbility >= 84 => 0.5,
-                default => 0.75,
-            };
-            $potentialRange = (int) round($potentialRange * $taperFactor);
-            $uncertainty = (int) round($uncertainty * $taperFactor);
+            $potentialRange = (int) round($potentialRange * $this->highAbilityTaper($currentAbility));
         }
+
+        $uncertainty = $this->uncertaintyForAge($age, $currentAbility);
 
         // True potential (hidden from user). Clamp to what the development
         // curve can actually deliver from this age — otherwise displayed
@@ -154,6 +146,66 @@ class PlayerDevelopmentService
             'low' => $low,
             'high' => $high,
         ];
+    }
+
+    /**
+     * Build the scouted potential band around an explicit, known true potential
+     * (e.g. supplied by a hand-curated source JSON during template import).
+     *
+     * Skips the random potential-range/value-bonus derivation but reuses the
+     * same age-based uncertainty and reachable-ceiling clamp as
+     * generatePotential() so explicit and heuristic players sit on the same
+     * curve.
+     *
+     * @return array{potential: int, low: int, high: int}
+     */
+    public function scoutedRangeForKnownPotential(int $age, int $currentAbility, int $truePotential): array
+    {
+        $reachableCeiling = min(99, $currentAbility + DevelopmentCurve::maxLifetimeGrowth($age));
+        $clampedTrue = min(99, $reachableCeiling, max($currentAbility, $truePotential));
+
+        $uncertainty = $this->uncertaintyForAge($age, $currentAbility);
+
+        $low = max($currentAbility, $clampedTrue - $uncertainty);
+        $high = min(99, $reachableCeiling, $clampedTrue + $uncertainty);
+
+        return [
+            'potential' => $clampedTrue,
+            'low' => $low,
+            'high' => $high,
+        ];
+    }
+
+    /**
+     * Age-based scouted-range uncertainty, with the same high-ability taper
+     * generatePotential() applies to its potential range.
+     */
+    private function uncertaintyForAge(int $age, int $currentAbility): int
+    {
+        if ($age <= PlayerAge::ACADEMY_END) {
+            $uncertainty = rand(5, 10);
+        } elseif ($age <= 24) {
+            $uncertainty = rand(4, 7);
+        } elseif ($age <= PlayerAge::PRIME_END) {
+            $uncertainty = rand(1, 2);
+        } else {
+            $uncertainty = 0;
+        }
+
+        if ($age > PlayerAge::YOUNG_END && $currentAbility >= 80) {
+            $uncertainty = (int) round($uncertainty * $this->highAbilityTaper($currentAbility));
+        }
+
+        return $uncertainty;
+    }
+
+    private function highAbilityTaper(int $currentAbility): float
+    {
+        return match (true) {
+            $currentAbility >= 88 => 0.25,
+            $currentAbility >= 84 => 0.5,
+            default => 0.75,
+        };
     }
 
     /**

--- a/app/Modules/Season/Services/GamePlayerTemplateService.php
+++ b/app/Modules/Season/Services/GamePlayerTemplateService.php
@@ -448,10 +448,14 @@ class GamePlayerTemplateService
         // ability baseline and a non-zero transfer price.
         $marketValueForOverall = $marketValueCents > 0 ? $marketValueCents : 10_000_000;
         $position = $playerData['position'] ?? null;
-        $overallScore = $this->valuationService->marketValueToOverallScore($marketValueForOverall, $age, $position);
+        $overallScore = $this->resolveExplicitAbility($playerData['overall_score'] ?? null)
+            ?? $this->valuationService->marketValueToOverallScore($marketValueForOverall, $age, $position);
         $annualWage = $this->contractService->calculateAnnualWage($marketValueCents, $minimumWage, $age);
 
-        $potentialData = $this->developmentService->generatePotential($age, $overallScore);
+        $explicitPotential = $this->resolveExplicitPotential($playerData['potential'] ?? null, $overallScore);
+        $potentialData = $explicitPotential !== null
+            ? $this->developmentService->scoutedRangeForKnownPotential($age, $overallScore, $explicitPotential)
+            : $this->developmentService->generatePotential($age, $overallScore);
 
         $secondaryPositions = $this->getSecondaryPositions($playerData['id']);
 
@@ -537,6 +541,36 @@ class GamePlayerTemplateService
             return $matches[1];
         }
         return null;
+    }
+
+    /**
+     * Validate a hand-curated `overall_score` from source JSON.
+     * Returns the clamped int, or null to signal "fall back to the heuristic".
+     */
+    private function resolveExplicitAbility(mixed $raw): ?int
+    {
+        if ($raw === null || $raw === '') {
+            return null;
+        }
+        $value = filter_var($raw, FILTER_VALIDATE_INT);
+        if ($value === false || $value < 1 || $value > 99) {
+            return null;
+        }
+        return $value;
+    }
+
+    /**
+     * Validate a hand-curated `potential` from source JSON. Must be a valid
+     * 1–99 integer and at least the current `overall_score` — a potential
+     * below current ability is meaningless and would break development math.
+     */
+    private function resolveExplicitPotential(mixed $raw, int $overallScore): ?int
+    {
+        $value = $this->resolveExplicitAbility($raw);
+        if ($value === null || $value < $overallScore) {
+            return null;
+        }
+        return $value;
     }
 
     /**

--- a/data/2025/WC2026/teams/3375.json
+++ b/data/2025/WC2026/teams/3375.json
@@ -14,7 +14,9 @@
       "id": "561613",
       "marketValue": "€40.00m",
       "name": "Joan García",
-      "position": "Goalkeeper"
+      "position": "Goalkeeper",
+      "overall_score": 86,
+      "potential": 89
     },
     {
       "calledUp": true,
@@ -28,7 +30,9 @@
       "id": "262749",
       "marketValue": "€35.00m",
       "name": "David Raya",
-      "position": "Goalkeeper"
+      "position": "Goalkeeper",
+      "overall_score": 87,
+      "potential": 87
     },
     {
       "calledUp": true,
@@ -42,7 +46,9 @@
       "id": "262396",
       "marketValue": "€25.00m",
       "name": "Unai Simón",
-      "position": "Goalkeeper"
+      "position": "Goalkeeper",
+      "overall_score": 84,
+      "potential": 85
     },
     {
       "calledUp": false,
@@ -84,7 +90,9 @@
       "id": "562742",
       "marketValue": "€6.00m",
       "name": "Leo Román",
-      "position": "Goalkeeper"
+      "position": "Goalkeeper",
+      "overall_score": 77,
+      "potential": 83
     },
     {
       "calledUp": true,
@@ -98,7 +106,9 @@
       "id": "962110",
       "marketValue": "€80.00m",
       "name": "Pau Cubarsí",
-      "position": "Centre-Back"
+      "position": "Centre-Back",
+      "overall_score": 83,
+      "potential": 89
     },
     {
       "calledUp": false,
@@ -112,7 +122,9 @@
       "id": "1018938",
       "marketValue": "€20.00m",
       "name": "Jon Martín",
-      "position": "Centre-Back"
+      "position": "Centre-Back",
+      "overall_score": 77,
+      "potential": 86
     },
     {
       "calledUp": false,
@@ -126,7 +138,9 @@
       "id": "1076815",
       "marketValue": "€15.00m",
       "name": "Javi Rodríguez",
-      "position": "Centre-Back"
+      "position": "Centre-Back",
+      "overall_score": 76,
+      "potential": 82
     },
     {
       "calledUp": false,
@@ -182,7 +196,9 @@
       "id": "176553",
       "marketValue": "€9.00m",
       "name": "Aymeric Laporte",
-      "position": "Centre-Back"
+      "position": "Centre-Back",
+      "overall_score": 82,
+      "potential": 82
     },
     {
       "calledUp": false,
@@ -224,7 +240,9 @@
       "id": "466794",
       "marketValue": "€35.00m",
       "name": "Eric García",
-      "position": "Centre-Back"
+      "position": "Centre-Back",
+      "overall_score": 83,
+      "potential": 86
     },
     {
       "calledUp": true,
@@ -238,7 +256,9 @@
       "id": "284857",
       "marketValue": "€50.00m",
       "name": "Marc Cucurella",
-      "position": "Left-Back"
+      "position": "Left-Back",
+      "overall_score": 85,
+      "potential": 85
     },
     {
       "calledUp": true,
@@ -252,7 +272,9 @@
       "id": "193082",
       "marketValue": "€24.00m",
       "name": "Alejandro Grimaldo",
-      "position": "Left-Back"
+      "position": "Left-Back",
+      "overall_score": 85,
+      "potential": 85
     },
     {
       "calledUp": true,
@@ -266,7 +288,9 @@
       "id": "553875",
       "marketValue": "€40.00m",
       "name": "Pedro Porro",
-      "position": "Right-Back"
+      "position": "Right-Back",
+      "overall_score": 82,
+      "potential": 85
     },
     {
       "calledUp": true,
@@ -280,7 +304,9 @@
       "id": "282411",
       "marketValue": "€22.00m",
       "name": "Marcos Llorente",
-      "position": "Right-Back"
+      "position": "Right-Back",
+      "overall_score": 85,
+      "potential": 85
     },
     {
       "calledUp": true,
@@ -294,7 +320,9 @@
       "id": "844637",
       "marketValue": "€15.00m",
       "name": "Marc Pubill",
-      "position": "Centre-Back"
+      "position": "Centre-Back",
+      "overall_score": 80,
+      "potential": 87
     },
     {
       "calledUp": false,
@@ -308,7 +336,9 @@
       "id": "366930",
       "marketValue": "€15.00m",
       "name": "Sergio Gómez",
-      "position": "Left-Back"
+      "position": "Left-Back",
+      "overall_score": 78,
+      "potential": 81
     },
     {
       "calledUp": false,
@@ -336,7 +366,9 @@
       "id": "423440",
       "marketValue": "€80.00m",
       "name": "Martín Zubimendi",
-      "position": "Defensive Midfield"
+      "position": "Defensive Midfield",
+      "overall_score": 85,
+      "potential": 87
     },
     {
       "calledUp": true,
@@ -350,7 +382,9 @@
       "id": "357565",
       "marketValue": "€65.00m",
       "name": "Rodri",
-      "position": "Defensive Midfield"
+      "position": "Defensive Midfield",
+      "overall_score": 89,
+      "potential": 89
     },
     {
       "calledUp": true,
@@ -364,7 +398,9 @@
       "id": "338424",
       "marketValue": "€30.00m",
       "name": "Mikel Merino",
-      "position": "Central Midfield"
+      "position": "Central Midfield",
+      "overall_score": 83,
+      "potential": 83
     },
     {
       "calledUp": false,
@@ -378,7 +414,9 @@
       "id": "1018920",
       "marketValue": "€30.00m",
       "name": "Marc Bernal",
-      "position": "Defensive Midfield"
+      "position": "Defensive Midfield",
+      "overall_score": 75,
+      "potential": 86
     },
     {
       "calledUp": false,
@@ -392,7 +430,9 @@
       "id": "834764",
       "marketValue": "€25.00m",
       "name": "Javi Guerra",
-      "position": "Central Midfield"
+      "position": "Central Midfield",
+      "overall_score": 76,
+      "potential": 84
     },
     {
       "calledUp": true,
@@ -406,7 +446,9 @@
       "id": "683840",
       "marketValue": "€150.00m",
       "name": "Pedri",
-      "position": "Central Midfield"
+      "position": "Central Midfield",
+      "overall_score": 90,
+      "potential": 93
     },
     {
       "calledUp": false,
@@ -476,7 +518,9 @@
       "id": "350219",
       "marketValue": "€40.00m",
       "name": "Fabián Ruiz",
-      "position": "Central Midfield"
+      "position": "Central Midfield",
+      "overall_score": 85,
+      "potential": 85
     },
     {
       "calledUp": false,
@@ -505,7 +549,9 @@
       "id": "646740",
       "marketValue": "€80.00m",
       "name": "Gavi",
-      "position": "Central Midfield"
+      "position": "Central Midfield",
+      "overall_score": 83,
+      "potential": 87
     },
     {
       "calledUp": false,
@@ -519,7 +565,9 @@
       "id": "634431",
       "marketValue": "€10.00m",
       "name": "Beñat Turrientes",
-      "position": "Central Midfield"
+      "position": "Central Midfield",
+      "overall_score": 76,
+      "potential": 82
     },
     {
       "calledUp": true,
@@ -533,7 +581,9 @@
       "id": "293385",
       "marketValue": "€60.00m",
       "name": "Dani Olmo",
-      "position": "Attacking Midfield"
+      "position": "Attacking Midfield",
+      "overall_score": 84,
+      "potential": 84
     },
     {
       "calledUp": true,
@@ -547,7 +597,9 @@
       "id": "548111",
       "marketValue": "€45.00m",
       "name": "Álex Baena",
-      "position": "Left Winger"
+      "position": "Left Winger",
+      "overall_score": 82,
+      "potential": 87
     },
     {
       "calledUp": true,
@@ -561,7 +613,9 @@
       "id": "935231",
       "marketValue": "€20.00m",
       "name": "Víctor Muñoz",
-      "position": "Left Winger"
+      "position": "Left Winger",
+      "overall_score": 78,
+      "potential": 86
     },
     {
       "calledUp": false,
@@ -589,7 +643,9 @@
       "id": "937958",
       "marketValue": "€200.00m",
       "name": "Lamine Yamal",
-      "position": "Right Winger"
+      "position": "Right Winger",
+      "overall_score": 89,
+      "potential": 95
     },
     {
       "calledUp": false,
@@ -617,7 +673,9 @@
       "id": "568157",
       "marketValue": "€35.00m",
       "name": "Yéremy Pino",
-      "position": "Right Winger"
+      "position": "Right Winger",
+      "overall_score": 79,
+      "potential": 86
     },
     {
       "calledUp": false,
@@ -631,7 +689,9 @@
       "id": "1190411",
       "marketValue": "€30.00m",
       "name": "Jesús Rodríguez",
-      "position": "Left Winger"
+      "position": "Left Winger",
+      "overall_score": 76,
+      "potential": 85
     },
     {
       "calledUp": true,
@@ -645,7 +705,9 @@
       "id": "709187",
       "marketValue": "€50.00m",
       "name": "Nico Williams",
-      "position": "Left Winger"
+      "position": "Left Winger",
+      "overall_score": 85,
+      "potential": 88
     },
     {
       "calledUp": true,
@@ -659,7 +721,9 @@
       "id": "398184",
       "marketValue": "€50.00m",
       "name": "Ferran Torres",
-      "position": "Centre-Forward"
+      "position": "Centre-Forward",
+      "overall_score": 84,
+      "potential": 86
     },
     {
       "calledUp": true,
@@ -673,7 +737,9 @@
       "id": "351478",
       "marketValue": "€25.00m",
       "name": "Mikel Oyarzabal",
-      "position": "Centre-Forward"
+      "position": "Centre-Forward",
+      "overall_score": 83,
+      "potential": 83
     },
     {
       "calledUp": true,
@@ -687,7 +753,9 @@
       "id": "278359",
       "marketValue": "€3.00m",
       "name": "Borja Iglesias",
-      "position": "Centre-Forward"
+      "position": "Centre-Forward",
+      "overall_score": 80,
+      "potential": 80
     },
     {
       "calledUp": false,
@@ -745,7 +813,9 @@
       "id": "935230",
       "marketValue": "€30.00m",
       "name": "Gonzalo García",
-      "position": "Centre-Forward"
+      "position": "Centre-Forward",
+      "overall_score": 74,
+      "potential": 84
     },
     {
       "calledUp": false,


### PR DESCRIPTION
## Summary
- Template import now reads optional `overall_score` and `potential` from source player JSON and uses them verbatim instead of deriving from market-value/age heuristics. Invalid values silently fall back to the existing derivation.
- Adds `PlayerDevelopmentService::scoutedRangeForKnownPotential()` so explicit-potential players still get an age-appropriate scouted `low`/`high` band around the supplied value, sharing the same uncertainty + reachable-ceiling rules as `generatePotential()`.
- Extracts shared `uncertaintyForAge()` / `highAbilityTaper()` helpers so the heuristic and explicit paths can't drift.

## Test plan
- [ ] Add `"overall_score": 92, "potential": 94` to a player in any `data/2025/{COMP}/*.json`, then run `php artisan app:refresh-player-templates --country=<XX> --season=2025`. Confirm the generated `game_player_templates` row stores `overall_score = 92`, `potential = 94`, and `potential_low`/`potential_high` form an age-appropriate band around 94.
- [ ] Try invalid overrides (`"overall_score": 150`, `"potential": "foo"`, `"potential": 70` paired with derived overall of 80). Confirm each silently falls back to the heuristic-derived values.
- [ ] Confirm a player JSON with neither field produces unchanged output vs. `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)