### PR TITLE
Make half-time formation changes editable before kickoff (#1161)

### DIFF
--- a/resources/js/live-match.js
+++ b/resources/js/live-match.js
@@ -356,14 +356,40 @@ export default function liveMatch(config) {
                         [String(draggedSlot.id)]: occupyingPlayerId,
                         [String(occupyingSlot.id)]: draggedPlayerId,
                     };
-                    // Mirror the swap in startingSlotMap so the no-pending-
-                    // subs render path (which reads it directly) reflects
-                    // the drag without going through bestFit.
-                    this.startingSlotMap = swapSlots(
-                        this.startingSlotMap,
-                        draggedSlot.id,
-                        occupyingSlot.id,
-                    );
+
+                    // While a formation change is staged the pitch renders
+                    // from `previewSlotMap` (see pitch-layout selectSlotMap),
+                    // NOT `startingSlotMap`. Mirroring the swap into
+                    // startingSlotMap here would leave the rendered preview
+                    // untouched, so the drag would visibly snap back and the
+                    // user couldn't rearrange the new shape before kickoff
+                    // (#1161). Swap within previewSlotMap so the rendered map
+                    // reflects the drag. previewSlotMap and currentPitchSlots
+                    // share the pending-formation slot-id space, so the swap
+                    // is valid. If previewSlotMap is still null (drag during
+                    // the brief /compute-slots fetch window), seed it from the
+                    // currently-rendered assignments first.
+                    const isFormationPreview =
+                        (this.pendingFormation ?? this.activeFormation) !== this._pitchPositionsFormation;
+                    if (isFormationPreview) {
+                        let baseMap = this.previewSlotMap;
+                        if (!baseMap) {
+                            baseMap = {};
+                            for (const a of assignments) {
+                                if (a.player) baseMap[String(a.id)] = a.player.id;
+                            }
+                        }
+                        this.previewSlotMap = swapSlots(baseMap, draggedSlot.id, occupyingSlot.id);
+                    } else {
+                        // Mirror the swap in startingSlotMap so the no-pending-
+                        // subs render path (which reads it directly) reflects
+                        // the drag without going through bestFit.
+                        this.startingSlotMap = swapSlots(
+                            this.startingSlotMap,
+                            draggedSlot.id,
+                            occupyingSlot.id,
+                        );
+                    }
                 },
                 swapOnly: true,
                 pitchElementId: 'live-pitch-field',

--- a/resources/js/modules/tactical-submission.js
+++ b/resources/js/modules/tactical-submission.js
@@ -99,6 +99,16 @@ export function createTacticalSubmission(ctx) {
                     if (Object.keys(c._manualSlotPins).length > 0) {
                         payload.manual_slot_pins = { ...c._manualSlotPins };
                     }
+                    // For a formation change, lock in the EXACT arrangement
+                    // the user is looking at. previewSlotMap is the rendered
+                    // preview (server best-fit + any drag-swaps applied on top
+                    // of it); pinning every slot makes FormationRecommender
+                    // reproduce it verbatim instead of re-solving the shape and
+                    // scrambling positions at kickoff (#1161). This supersedes
+                    // the partial drag-only pins above.
+                    if (payload.formation && c.previewSlotMap) {
+                        payload.manual_slot_pins = { ...c.previewSlotMap };
+                    }
                 }
 
                 const response = await fetch(c.tacticalActionsUrl, {

--- a/tests/Feature/FormationChangeSlotPinningTest.php
+++ b/tests/Feature/FormationChangeSlotPinningTest.php
@@ -1,0 +1,163 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Competition;
+use App\Models\Game;
+use App\Models\GameMatch;
+use App\Models\GamePlayer;
+use App\Models\Team;
+use App\Models\User;
+use App\Modules\Lineup\Services\TacticalChangeService;
+use App\Modules\Match\DTOs\ResimulationResult;
+use App\Modules\Match\Services\MatchResimulationService;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Mockery;
+use Tests\TestCase;
+
+/**
+ * Regression for #1161 — half-time formation change scrambling positions.
+ *
+ * When the user changes formation at half-time the frontend now sends the
+ * FULL displayed XI (previewSlotMap) as manual_slot_pins, so the kickoff
+ * lineup must be EXACTLY that arrangement — no further auto-adjustment by
+ * FormationRecommender, even when a pin places a player out of position.
+ *
+ * This asserts the backend honors a complete pin map for a formation change:
+ * every slot in the persisted home_slot_assignments matches the submitted
+ * pins verbatim.
+ */
+class FormationChangeSlotPinningTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_formation_change_with_full_pins_is_applied_verbatim(): void
+    {
+        $user = User::factory()->create();
+        $playerTeam = Team::factory()->create();
+        $opponentTeam = Team::factory()->create();
+
+        $competition = Competition::factory()->league()->create([
+            'id' => 'ESP1',
+            'name' => 'LaLiga',
+        ]);
+
+        $game = Game::factory()->create([
+            'user_id' => $user->id,
+            'team_id' => $playerTeam->id,
+            'competition_id' => $competition->id,
+            'season' => '2024',
+            'current_date' => '2024-09-01',
+        ]);
+
+        // Starting XI in 4-3-3.
+        $gk = GamePlayer::factory()->forGame($game)->forTeam($playerTeam)->create(['position' => 'Goalkeeper']);
+        $lb = GamePlayer::factory()->forGame($game)->forTeam($playerTeam)->create(['position' => 'Left-Back']);
+        $cb1 = GamePlayer::factory()->forGame($game)->forTeam($playerTeam)->create(['position' => 'Centre-Back']);
+        $cb2 = GamePlayer::factory()->forGame($game)->forTeam($playerTeam)->create(['position' => 'Centre-Back']);
+        $rb = GamePlayer::factory()->forGame($game)->forTeam($playerTeam)->create(['position' => 'Right-Back']);
+        $cm1 = GamePlayer::factory()->forGame($game)->forTeam($playerTeam)->create(['position' => 'Central Midfield']);
+        $cm2 = GamePlayer::factory()->forGame($game)->forTeam($playerTeam)->create(['position' => 'Central Midfield']);
+        $cm3 = GamePlayer::factory()->forGame($game)->forTeam($playerTeam)->create(['position' => 'Central Midfield']);
+        $lw = GamePlayer::factory()->forGame($game)->forTeam($playerTeam)->create(['position' => 'Left Winger']);
+        $cf = GamePlayer::factory()->forGame($game)->forTeam($playerTeam)->create(['position' => 'Centre-Forward']);
+        $rw = GamePlayer::factory()->forGame($game)->forTeam($playerTeam)->create(['position' => 'Right Winger']);
+
+        // Opponent squad (needed by loadTeamsForResimulation).
+        GamePlayer::factory()->count(11)->forGame($game)->forTeam($opponentTeam)->create();
+
+        $lineupIds = [
+            $gk->id, $lb->id, $cb1->id, $cb2->id, $rb->id,
+            $cm1->id, $cm2->id, $cm3->id,
+            $lw->id, $cf->id, $rw->id,
+        ];
+
+        $startSlots = [
+            0 => $gk->id, 1 => $lb->id, 2 => $cb1->id, 3 => $cb2->id, 4 => $rb->id,
+            5 => $cm1->id, 6 => $cm2->id, 7 => $cm3->id,
+            8 => $lw->id, 9 => $cf->id, 10 => $rw->id,
+        ];
+
+        $match = GameMatch::factory()->create([
+            'game_id' => $game->id,
+            'competition_id' => $competition->id,
+            'round_number' => 1,
+            'home_team_id' => $playerTeam->id,
+            'away_team_id' => $opponentTeam->id,
+            'scheduled_date' => Carbon::parse('2024-09-01'),
+            'played' => false,
+            'home_formation' => '4-3-3',
+            'home_lineup' => $lineupIds,
+            'home_slot_assignments' => $startSlots,
+            'away_lineup' => GamePlayer::where('team_id', $opponentTeam->id)->pluck('id')->take(11)->all(),
+            'away_formation' => '4-3-3',
+        ]);
+
+        $game->update(['pending_finalization_match_id' => $match->id]);
+
+        // The exact 5-3-2 arrangement the user confirmed at half-time. It is
+        // deliberately NOT what the auto-solver would pick (the winger $lw is
+        // pinned into a CB slot, $cf into the extra CB slot) so a verbatim
+        // match proves the pins win over FormationRecommender.
+        $confirmedPins = [
+            0 => $gk->id,   // GK
+            1 => $lb->id,   // LB
+            2 => $cb1->id,  // CB
+            3 => $cb2->id,  // CB
+            4 => $lw->id,   // CB ← winger pinned out of position
+            5 => $rb->id,   // RB
+            6 => $cm1->id,  // CM
+            7 => $cm2->id,  // CM
+            8 => $cm3->id,  // CM
+            9 => $cf->id,   // CF
+            10 => $rw->id,  // CF
+        ];
+
+        $stubResult = new ResimulationResult(
+            newHomeScore: 0,
+            newAwayScore: 0,
+            oldHomeScore: 0,
+            oldAwayScore: 0,
+        );
+        $mockResimulation = Mockery::mock(MatchResimulationService::class);
+        $mockResimulation->shouldReceive('resimulate')->andReturn($stubResult);
+        $mockResimulation->shouldReceive('resimulateExtraTime')->andReturn($stubResult);
+        $mockResimulation->shouldReceive('buildEventsResponse')->andReturn([]);
+        $this->app->instance(MatchResimulationService::class, $mockResimulation);
+
+        /** @var TacticalChangeService $service */
+        $service = $this->app->make(TacticalChangeService::class);
+
+        $service->processLiveMatchChanges(
+            $match,
+            $game,
+            minute: 45,
+            previousSubstitutions: [],
+            newSubstitutions: [],
+            formation: '5-3-2',
+            manualSlotPins: $confirmedPins,
+            isHalfTime: true,
+        );
+
+        $match->refresh();
+
+        $this->assertSame('5-3-2', $match->home_formation);
+
+        // Every slot matches the confirmed arrangement verbatim — no slot was
+        // re-solved or shuffled by the recommender.
+        foreach ($confirmedPins as $slotId => $expectedPlayerId) {
+            $this->assertSame(
+                $expectedPlayerId,
+                $match->home_slot_assignments[$slotId] ?? null,
+                "Slot {$slotId} must match the user-confirmed lineup verbatim",
+            );
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+}

--- a/tests/js/pitch-layout.test.js
+++ b/tests/js/pitch-layout.test.js
@@ -81,7 +81,16 @@ function p(id, position, secondaryPositions = []) {
     };
 }
 
-function makeCtx({ startingSlotMap, lineupPlayers, benchPlayers, pendingSubs = [], manualSlotPins = {} }) {
+function makeCtx({
+    startingSlotMap,
+    lineupPlayers,
+    benchPlayers,
+    pendingSubs = [],
+    manualSlotPins = {},
+    pendingFormation = null,
+    previewSlotMap = null,
+    formationSlots = { '4-3-3': F_4_3_3_SLOTS },
+}) {
     return {
         lineupPlayers,
         benchPlayers,
@@ -91,9 +100,10 @@ function makeCtx({ startingSlotMap, lineupPlayers, benchPlayers, pendingSubs = [
         selectedPlayerIn: null,
         redCardedPlayerIds: [],
         activeFormation: '4-3-3',
-        pendingFormation: null,
+        pendingFormation,
+        previewSlotMap,
         _pitchPositionsFormation: '4-3-3',
-        formationSlots: { '4-3-3': F_4_3_3_SLOTS },
+        formationSlots,
         slotCompatibility: SLOT_COMPATIBILITY,
         startingSlotMap,
         _manualSlotPins: manualSlotPins,
@@ -313,5 +323,41 @@ describe('pitch-layout slotAssignments', () => {
         expect(mapById[1]).toBe(lb.id);
         expect(mapById[8]).toBe(lw.id);
         expect(mapById[10]).toBe(rw.id);
+    });
+
+    it('renders from previewSlotMap (not startingSlotMap) during a formation preview', () => {
+        // Regression for #1161. While a formation change is staged the pitch
+        // renders from previewSlotMap, so the drag-swap handler must mutate
+        // previewSlotMap (not startingSlotMap) for the swap to be visible.
+        // This guards that render-source invariant: a swap applied to
+        // previewSlotMap shows up, while startingSlotMap is ignored.
+        const scenario = setupPostDragSwapScenario();
+        const { playerA, playerB } = scenario.players;
+
+        // previewSlotMap = the new-shape best-fit with A and B swapped vs
+        // startingSlotMap (A at slot 4, B at slot 6). Reuse the 4-3-3 slot
+        // geometry under the pending '5-3-2' key — only slot-id placement
+        // matters for this assertion.
+        const previewSlotMap = {
+            ...scenario.startingSlotMap,
+            4: playerA.id,
+            6: playerB.id,
+        };
+
+        const ctx = makeCtx({
+            ...scenario,
+            pendingSubs: [],
+            pendingFormation: '5-3-2',
+            previewSlotMap,
+            formationSlots: { '4-3-3': F_4_3_3_SLOTS, '5-3-2': F_4_3_3_SLOTS },
+        });
+        const layout = createPitchLayout(() => ctx);
+        const mapById = Object.fromEntries(
+            layout.slotAssignments.map(a => [a.id, a.player?.id ?? null]),
+        );
+
+        // The render reflects previewSlotMap's swap, not startingSlotMap.
+        expect(mapById[4]).toBe(playerA.id);
+        expect(mapById[6]).toBe(playerB.id);
     });
 });

--- a/tests/js/tactical-submission.test.js
+++ b/tests/js/tactical-submission.test.js
@@ -363,4 +363,57 @@ describe('tactical-submission confirmAllChanges', () => {
         const subIdx = state.events.indexOf(subEvent);
         expect(state.lastRevealedIndex).toBeGreaterThanOrEqual(subIdx);
     });
+
+    it('half-time formation change pins the full displayed XI so kickoff is not re-solved', async () => {
+        // Regression for #1161. Changing formation at half-time used to send
+        // only the partial drag-swap pins (or none), letting the server
+        // re-solve the new shape — so the kickoff XI could differ from the
+        // arrangement the user was looking at. confirmAllChanges now sends the
+        // FULL previewSlotMap (the rendered preview) as manual_slot_pins, so
+        // FormationRecommender reproduces it verbatim.
+        const previewSlotMap = {
+            0: 'home-gk',
+            1: 'home-lb', 2: 'home-cb1', 3: 'home-cb2', 4: 'home-rb',
+            5: 'home-cm1', 6: 'home-cm2', 7: 'home-cm3',
+            8: 'home-fw1', 9: 'home-fw2', 10: 'home-fw3',
+        };
+        const state = createMockState({
+            phase: 'half_time',
+            currentMinute: 45,
+            firstHalfStoppage: 0,
+            hasTacticalChanges: true,
+            pendingFormation: '5-3-2',
+            activeFormation: '4-3-3',
+            previewSlotMap,
+            // A partial drag-swap pin that must be SUPERSEDED by the full map.
+            _manualSlotPins: { 4: 'home-rb', 1: 'home-lb' },
+        });
+
+        let capturedPayload = null;
+        globalThis.fetch = vi.fn((url, opts) => {
+            capturedPayload = JSON.parse(opts.body);
+            return Promise.resolve({
+                ok: true,
+                json: () => Promise.resolve({
+                    isExtraTime: false,
+                    formation: '5-3-2',
+                    slot_assignments: previewSlotMap,
+                    substitutions: [],
+                    newEvents: [],
+                    newScore: { home: 1, away: 0 },
+                    homePossession: 50,
+                    awayPossession: 50,
+                }),
+            });
+        });
+
+        const submission = createTacticalSubmission(() => state);
+        await submission.confirmAllChanges();
+
+        expect(capturedPayload).not.toBeNull();
+        expect(capturedPayload.formation).toBe('5-3-2');
+        expect(capturedPayload.is_half_time).toBe(true);
+        // The full displayed map is pinned — not just the two drag-swapped slots.
+        expect(capturedPayload.manual_slot_pins).toEqual(previewSlotMap);
+    });
 });


### PR DESCRIPTION
Closes #1161.

## Problem

Switching formation during the half-time pause (e.g. 4-2-3-1 → 5-3-2) auto-placed the new XI and **drag-swaps appeared to do nothing** — the pitch snapped back — so the user could not manually correct positions before the second half. The only workaround was to start the second half, pause, then fix.

## Root cause

While a formation change is staged, the live-match pitch renders from `previewSlotMap` (`pitch-layout.js` → `selectSlotMap`). But the drag-to-swap handler `onSwap` in `live-match.js` only wrote to `startingSlotMap` / `_manualSlotPins` — never `previewSlotMap`. So the rendered preview was untouched and the swap visibly reverted. The workaround worked because in the second half the formation is already applied and the pitch renders from `startingSlotMap`, which `onSwap` does mutate.

## Fix

- **`onSwap` (`resources/js/live-match.js`):** when a formation change is staged, swap within `previewSlotMap` (the rendered source) so drags are visible and editable. Seeds the map from the current render if a drag lands during the brief `/compute-slots` fetch window.
- **`confirmAllChanges` (`resources/js/modules/tactical-submission.js`):** for a formation change, send the full displayed `previewSlotMap` as `manual_slot_pins`, so the server reproduces the exact arrangement (`FormationRecommender` applies pins first and never evicts them) instead of re-solving and scrambling at kickoff.

Phase-agnostic, so it also covers extra-time half-time. No backend change was needed — `ProcessTacticalActions` already accepts `formation` + `manual_slot_pins` together.

## Acceptance criteria

- [x] After choosing a new formation at half-time, every player slot is editable before second-half kickoff.
- [x] Second-half kickoff uses the exact user-confirmed lineup with no further auto-adjustment.
- [x] Players whose slot vanishes drop to the bench — N/A by construction: every formation has 11 slots and the XI size is unchanged, so no on-pitch player is ever left unplaced.
- [x] Regression tests assert formation change at half-time preserves user adjustments.

## Tests

- `tests/js/tactical-submission.test.js` — a half-time formation change pins the full `previewSlotMap` (superseding partial drag pins).
- `tests/js/pitch-layout.test.js` — the preview renders from `previewSlotMap`, not `startingSlotMap`.
- `tests/Feature/FormationChangeSlotPinningTest.php` — a formation change with a full pin map is applied verbatim (a winger deliberately pinned into a CB slot stays there).

## Manual reproduction

1. Play a league match to the half-time pause.
2. Open the tactical panel, change formation (4-2-3-1 → 5-3-2).
3. Before: dragging one player onto another snaps back, no change.
4. After: the swap sticks; confirming starts the second half with exactly the arranged XI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)