### PR TITLE
Lock the transfer market while over the salary cap

### DIFF
--- a/app/Modules/Finance/Services/SalaryCapService.php
+++ b/app/Modules/Finance/Services/SalaryCapService.php
@@ -120,7 +120,22 @@ class SalaryCapService
     }
 
     /**
+     * Whether the club is currently over its cap — the transfer market is then
+     * locked (see canCommitWage). This is also the unlock threshold: as soon as
+     * the committed bill is back at/under the cap the lock lifts.
+     */
+    public function isOverCap(Game $game): bool
+    {
+        return $this->committedWageBill($game) > $this->cap($game);
+    }
+
+    /**
      * Whether committing $newWage would keep the club within its cap.
+     *
+     * While the club is already over the cap the market is frozen — no new wage
+     * commitment of any kind passes until the bill is back under the cap. The
+     * intended recovery path is selling players (which lowers committedWageBill),
+     * never being forced to release them for free.
      *
      * @param  int  $newWage    The wage being added (cents).
      * @param  int  $freedWage  Wage simultaneously freed by the same move
@@ -129,7 +144,14 @@ class SalaryCapService
      */
     public function canCommitWage(Game $game, int $newWage, int $freedWage = 0): bool
     {
-        return ($this->committedWageBill($game) - $freedWage + $newWage) <= $this->cap($game);
+        $committed = $this->committedWageBill($game);
+        $cap = $this->cap($game);
+
+        if ($committed > $cap) {
+            return false;
+        }
+
+        return ($committed - $freedWage + $newWage) <= $cap;
     }
 
     /**
@@ -144,9 +166,17 @@ class SalaryCapService
 
     /**
      * Localised "this would breach the cap" message for blocked signings.
+     *
+     * Two cases: if the club is already over the cap the market is locked, so we
+     * return the "sell players to get back under your limit" message; otherwise
+     * the move itself would tip the club over, so we spell out the shortfall.
      */
     public function blockMessage(Game $game, string $playerName, int $newWage, int $freedWage = 0): string
     {
+        if ($this->isOverCap($game)) {
+            return __('messages.salary_cap_locked');
+        }
+
         $projectedBill = $this->committedWageBill($game) - $freedWage + $newWage;
         $cap = $this->cap($game);
 

--- a/lang/en/finances.php
+++ b/lang/en/finances.php
@@ -95,6 +95,7 @@ return [
     'salary_cap' => 'Salary Limit',
     'wage_room' => 'Cap Room',
     'over_cap' => 'Over Limit',
+    'over_cap_lock_notice' => 'Market locked — sell players to get back under your limit.',
     'squad_size' => ':count players',
     'initial_budget_caption' => 'of :amount initial',
     'tooltip_salary_cap' => 'The most your club can commit to wages: :percent% of your projected recurring revenue. One-time cash (transfer surplus, player sales) does not raise it; grow your income to lift the limit.',

--- a/lang/en/messages.php
+++ b/lang/en/messages.php
@@ -20,7 +20,8 @@ return [
     'free_agent_reputation_too_low' => 'This player has no interest in joining a club of your reputation level.',
     'transfer_window_closed' => 'The transfer window is closed.',
     'wage_budget_exceeded' => 'Signing this player would exceed your wage budget.',
-    'signing_exceeds_salary_cap' => 'Signing :player at :wage/yr would push your wage bill to :total, over your :cap salary limit. Free up :shortfall by selling or releasing players first.',
+    'signing_exceeds_salary_cap' => 'Signing :player at :wage/yr would push your wage bill to :total, over your :cap salary limit. Free up :shortfall by selling players first.',
+    'salary_cap_locked' => "You're over your salary limit. Sell players to get back under the limit before signing or renewing.",
 
     // Bid/loan submission confirmations
     'bid_already_exists' => 'You already have a pending bid for this player.',

--- a/lang/es/finances.php
+++ b/lang/es/finances.php
@@ -95,6 +95,7 @@ return [
     'salary_cap' => 'Límite Salarial',
     'wage_room' => 'Margen Salarial',
     'over_cap' => 'Límite Superado',
+    'over_cap_lock_notice' => 'Mercado bloqueado — vende jugadores para volver bajo tu límite.',
     'squad_size' => ':count jugadores',
     'initial_budget_caption' => 'de :amount inicial',
     'tooltip_salary_cap' => 'Lo máximo que tu club puede destinar a salarios: el :percent% de tus ingresos recurrentes proyectados. El dinero puntual (superávit de fichajes, ventas de jugadores) no lo aumenta; haz crecer tus ingresos para elevar el límite.',

--- a/lang/es/messages.php
+++ b/lang/es/messages.php
@@ -20,7 +20,8 @@ return [
     'free_agent_reputation_too_low' => 'Este jugador no tiene interés en fichar por un club de tu nivel de reputación.',
     'transfer_window_closed' => 'La ventana de fichajes está cerrada.',
     'wage_budget_exceeded' => 'Fichar a este jugador superaría tu presupuesto salarial.',
-    'signing_exceeds_salary_cap' => 'Fichar a :player por :wage/año elevaría tu masa salarial a :total, por encima de tu límite salarial de :cap. Libera :shortfall vendiendo o liberando jugadores primero.',
+    'signing_exceeds_salary_cap' => 'Fichar a :player por :wage/año elevaría tu masa salarial a :total, por encima de tu límite salarial de :cap. Libera :shortfall vendiendo jugadores primero.',
+    'salary_cap_locked' => 'Estás por encima de tu límite salarial. Vende jugadores para volver por debajo del límite antes de fichar o renovar.',
 
     // Bid/loan submission confirmations
     'bid_already_exists' => 'Ya tienes una oferta pendiente por este jugador.',

--- a/resources/views/components/salary-cap-meter.blade.php
+++ b/resources/views/components/salary-cap-meter.blade.php
@@ -35,3 +35,6 @@
         <span class="text-text-faint">{{ \App\Support\Money::format($room) }} {{ __('finances.wage_room') }}</span>
     @endif
 </div>
+@if($status === 'over')
+    <div class="text-[11px] text-accent-red mt-1">{{ __('finances.over_cap_lock_notice') }}</div>
+@endif

--- a/tests/Feature/SalaryCapEnforcementTest.php
+++ b/tests/Feature/SalaryCapEnforcementTest.php
@@ -88,6 +88,53 @@ class SalaryCapEnforcementTest extends TestCase
         ]);
     }
 
+    public function test_over_cap_locks_signing_with_the_locked_message(): void
+    {
+        // Revenue €10M → cap €7M, but the squad already commits €8M → over cap.
+        [$user, $game] = $this->makeGame(projectedRevenue: 1_000_000_000, squadWage: 800_000_000);
+
+        $freeAgent = $this->freeAgent($game);
+
+        $response = $this->actingAs($user)->post(
+            route('game.scouting.sign-free-agent', [$game->id, $freeAgent->id])
+        );
+
+        $response->assertRedirect();
+        $response->assertSessionHas('error', __('messages.salary_cap_locked'));
+
+        $this->assertDatabaseMissing('transfer_offers', [
+            'game_id' => $game->id,
+            'game_player_id' => $freeAgent->id,
+        ]);
+    }
+
+    public function test_market_unlocks_once_the_bill_is_back_under_the_cap(): void
+    {
+        // Squad starts over the cap (€8M vs €7M cap).
+        [$user, $game] = $this->makeGame(projectedRevenue: 1_000_000_000, squadWage: 800_000_000);
+
+        // Simulate selling the high earner down to €1M — the bill is now under cap.
+        GamePlayer::query()
+            ->where('game_id', $game->id)
+            ->where('team_id', $game->team_id)
+            ->update(['annual_wage' => 100_000_000]);
+
+        $freeAgent = $this->freeAgent($game);
+
+        $response = $this->actingAs($user)->post(
+            route('game.scouting.sign-free-agent', [$game->id, $freeAgent->id])
+        );
+
+        $response->assertRedirect();
+        $response->assertSessionHas('success');
+
+        $this->assertDatabaseHas('transfer_offers', [
+            'game_id' => $game->id,
+            'game_player_id' => $freeAgent->id,
+            'status' => TransferOffer::STATUS_AGREED,
+        ]);
+    }
+
     // ── Helpers ───────────────────────────────────────────────────────────
 
     /**

--- a/tests/Unit/SalaryCapServiceTest.php
+++ b/tests/Unit/SalaryCapServiceTest.php
@@ -103,6 +103,32 @@ class SalaryCapServiceTest extends TestCase
         $this->assertFalse($this->service->canCommitWage($game, 200_000_001)); // €1 over blocks
     }
 
+    public function test_over_cap_locks_the_market_for_every_move(): void
+    {
+        $game = $this->makeGame(projectedRevenue: 1_000_000_000); // cap €7M
+        $player = $this->squadPlayer($game, annualWage: 800_000_000); // €8M committed → over
+
+        $this->assertTrue($this->service->isOverCap($game));
+
+        // No new commitment passes while over the cap — not a tiny signing…
+        $this->assertFalse($this->service->canCommitWage($game, 1));
+        // …and not even a wage-cut renewal that lowers the bill (the recovery
+        // path is selling, not renewing down).
+        $freed = $this->service->effectiveWageFor($player);
+        $this->assertFalse($this->service->canCommitWage($game, 100_000_000, $freed));
+    }
+
+    public function test_block_message_uses_locked_variant_when_over_cap(): void
+    {
+        $game = $this->makeGame(projectedRevenue: 1_000_000_000); // cap €7M
+        $this->squadPlayer($game, annualWage: 800_000_000); // over
+
+        $this->assertSame(
+            __('messages.salary_cap_locked'),
+            $this->service->blockMessage($game, 'Some Player', 100_000_000),
+        );
+    }
+
     public function test_renewal_freed_wage_charges_only_the_increase(): void
     {
         $game = $this->makeGame(projectedRevenue: 1_000_000_000); // cap €7M


### PR DESCRIPTION
## Why

A player gave feedback on the salary cap (commit `7c9ad763`, "Add squad salary cap — Límite de Coste de Plantilla"):

> "If you're over the limit you can't sign or renew until you drop back below 70%. Because that way you can **sell** players to recover. Having to **let them go for free** is a pain."

The player wants over-the-cap to act as a **soft market lock** whose escape valve is *selling* players, and is pushing back on anything that nudges you toward *releasing them for free*. The freeze-and-sell loop mostly already existed and nothing force-releases players — but the gate was a silent per-deal check, and the blocked-signing message literally said *"…vendiendo **o liberando** jugadores"*, planting the free-release idea.

## What

- **`SalaryCapService`**: add `isOverCap()` (the lock condition / unlock threshold = committed bill back ≤ cap). `canCommitWage()` now hard-blocks **every** new wage commitment while over the cap, on top of the existing marginal "would this push me over" check. Folded into the single gate, so all seven wage-commitment Actions (`SignFreeAgent`, `SubmitPreContractOffer`, `RequestLoan`, `Negotiate{FreeAgent,PreContract,Transfer,Renewal}`) inherit the lock with no per-Action changes. `blockMessage()` returns the new locked message when over.
- **i18n (es + en)**: reword `messages.signing_exceeds_salary_cap` to drop "or releasing players"; add `messages.salary_cap_locked` and `finances.over_cap_lock_notice`.
- **UI**: `salary-cap-meter` shows a "Market locked — sell players to get back under your limit" notice when over the cap.
- **Tests**: unit (over-cap locks every move incl. wage cuts; `isOverCap`; locked block message) + feature (over-cap signing blocked with the locked message; unlocks once the bill drops back under the cap).

## Tradeoff

While over the cap, even a wage-*cut* renewal is blocked (previously a deep cut could pass) — this matches the player's "ni renovar" wording; the intended recovery is selling. Free release stays available everywhere but is never required. AI clubs unchanged (cap is human-only by design).

## Verification

- `php artisan test --filter=SalaryCap`
- Manual: a club whose projected revenue dropped enough to be over cap shows the locked notice on Finances, signing/renewing is rejected with the locked message, and selling back under the cap re-opens the market. Checked at 375px and in light mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)