### PR TITLE
Anchor wage demands to current ability, not potential

### DIFF
--- a/app/Modules/Player/Services/PlayerValuationService.php
+++ b/app/Modules/Player/Services/PlayerValuationService.php
@@ -75,17 +75,7 @@ class PlayerValuationService
         $baseValue = $this->abilityToBaseValue($overallScore);
 
         // Age multiplier (reduced youth premiums for realistic valuations)
-        $ageMultiplier = match (true) {
-            $age <= 19 => 1.3,
-            $age <= 21 => 1.2,
-            $age <= 23 => 1.1,
-            $age <= 26 => 1.05,
-            $age <= 31 => 1.0,
-            $age <= 33 => 0.75,
-            $age <= 35 => 0.45,
-            $age <= 37 => 0.30,
-            default => 0.15,
-        };
+        $ageMultiplier = $this->ageValueMultiplier($age);
 
         // Performance trend multiplier (only during season-end)
         $trendMultiplier = 1.0;
@@ -119,6 +109,53 @@ class PlayerValuationService
 
         // Clamp to reasonable range: €100K to €150M
         return max(100_000_00, min(150_000_000_00, $newValue));
+    }
+
+    /**
+     * Value used to anchor WAGE demands to a player's *current* ability rather
+     * than their (potential-inflated) market value.
+     *
+     * Identical to overallScoreToMarketValue() except the youth premium is
+     * stripped: the age multiplier is capped at 1.0 so a wonderkid is priced
+     * for who he is today, not for his ceiling — the headroom lives in
+     * potential, and wages should not pay for it. The veteran decline is
+     * deliberately preserved (multiplier < 1.0), because the veteran wage
+     * modifier in ContractService is calibrated against that depressed value.
+     *
+     * @param int $overallScore Player's current overall ability score
+     * @param int $age Player's current age
+     * @param string|null $position Primary position; goalkeepers are scaled like market value
+     * @return int Wage-anchoring value in cents
+     */
+    public function wageBaseValue(int $overallScore, int $age, ?string $position = null): int
+    {
+        $value = (int) round($this->abilityToBaseValue($overallScore) * min(1.0, $this->ageValueMultiplier($age)));
+
+        if ($this->isGoalkeeper($position)) {
+            $value = (int) round($value / self::GOALKEEPER_VALUE_MULTIPLIER);
+        }
+
+        // Clamp to the same range as overallScoreToMarketValue().
+        return max(100_000_00, min(150_000_000_00, $value));
+    }
+
+    /**
+     * Age multiplier applied to a player's ability-derived base value. Young
+     * players carry a premium (priced for their ceiling), veterans a discount.
+     */
+    private function ageValueMultiplier(int $age): float
+    {
+        return match (true) {
+            $age <= 19 => 1.3,
+            $age <= 21 => 1.2,
+            $age <= 23 => 1.1,
+            $age <= 26 => 1.05,
+            $age <= 31 => 1.0,
+            $age <= 33 => 0.75,
+            $age <= 35 => 0.45,
+            $age <= 37 => 0.30,
+            default => 0.15,
+        };
     }
 
     private function applyPositionMultiplier(int $marketValueCents, ?string $position): int

--- a/app/Modules/Squad/Services/SquadService.php
+++ b/app/Modules/Squad/Services/SquadService.php
@@ -156,20 +156,15 @@ class SquadService
         // --- Squad Health Alerts ---
         $alerts = $this->buildAlerts($allPlayers, $game, $depthChart, $injuredCount, $lowFitnessCount, $lowMoraleCount, $isCareerMode, $windowCountdown);
 
-        // Compute peer-median wages per tier once for the whole squad — reused
-        // by the renewal loop and the squad-flags builder so both avoid the
-        // per-player `peerMedianWage()` query that would otherwise fire.
-        $mediansByTier = $isCareerMode
-            ? $this->dispositionService->peerMedianWagesByTier($allPlayers)
-            : [];
-
         // --- Renewal data (career mode) ---
         $renewalData = [];
         if ($isCareerMode) {
             $renewalEligible = $allPlayers->filter(fn ($p) => $p->canBeOfferedRenewal($seasonEndDate))
                 ->sortBy('contract_until');
             foreach ($renewalEligible as $player) {
-                $peerMedian = $mediansByTier[$player->tier] ?? null;
+                // Compute the ability-band peer median in-memory from the
+                // already-loaded squad to avoid a per-player query.
+                $peerMedian = $this->dispositionService->abilityPeerMedian($player, $allPlayers);
                 $demand = $this->contractService->calculateWageDemand(
                     $player,
                     NegotiationScenario::RENEWAL,

--- a/app/Modules/Transfer/Services/ContractService.php
+++ b/app/Modules/Transfer/Services/ContractService.php
@@ -5,6 +5,7 @@ namespace App\Modules\Transfer\Services;
 use App\Models\ClubProfile;
 use App\Models\Competition;
 use App\Modules\Player\PlayerAge;
+use App\Modules\Player\Services\PlayerValuationService;
 use App\Modules\Transfer\Enums\NegotiationScenario;
 use App\Models\FinancialTransaction;
 use App\Models\Game;
@@ -66,6 +67,7 @@ class ContractService
         private readonly WageNegotiationEvaluator $wageNegotiationEvaluator,
         private readonly DispositionService $dispositionService,
         private readonly SquadMinimumService $squadMinimumService,
+        private readonly PlayerValuationService $valuationService,
     ) {}
 
     /**
@@ -293,13 +295,24 @@ class ContractService
 
         $age = $player->age($player->game->current_date);
 
+        // Anchor the demand to the player's *current* ability, not his
+        // market value: market value (and the tier derived from it) carries a
+        // youth premium that prices in potential, which is what makes a
+        // developing youngster demand a star's wage. wageBaseValue() strips
+        // that youth premium so the base wage tracks who the player is today.
+        $abilityValue = $this->valuationService->wageBaseValue($player->overall_score, $age, $player->position);
+
         $baseWage = $this->calculateAnnualWage(
-            $player->market_value_cents,
+            $abilityValue,
             $minimumWage,
             $age,
             deterministic: true,
         );
 
+        // The premium is a scenario markup tied to the player's market stature
+        // (what rival clubs would pay / the Bosman leverage), so it stays keyed
+        // off market value and tier — only the *base wage* is re-anchored to
+        // current ability above.
         $premium = $scenario->wagePremium($player->market_value_cents, $player->tier);
         $demandedWage = (int) ($baseWage * $premium);
 
@@ -316,17 +329,19 @@ class ContractService
             $demandedWage = max($demandedWage, $currentWageWithPremium);
         }
 
-        // Renewals: peg the demand at peer-median ("market rate") for every
-        // player, not just those who've voiced their unhappiness. An unflagged
-        // underpaid player hasn't *announced* anything but still negotiates at
-        // market — the salary_unhappy_since flag drives morale drip and the UI
-        // signal, it does not change renewal pricing. When the caller has
-        // already computed the peer median for the squad (e.g. squad page
-        // renewal loop), reuse it to avoid an N+1 of squad-wide queries.
+        // Renewals: nudge the demand toward the peer-median ("market rate") of
+        // similar-ability squadmates, for every player — not just those who've
+        // voiced their unhappiness (the salary_unhappy_since flag drives morale
+        // drip and the UI signal, not pricing). This is a *partial* pull, not a
+        // hard floor: it closes only a fraction of the gap so equally-able
+        // players don't fully converge and a manager can still run a wage
+        // scale. When the caller has already computed the peer median for the
+        // squad (e.g. squad page renewal loop), reuse it to avoid an N+1.
         if ($scenario === NegotiationScenario::RENEWAL) {
             $resolvedMedian = $peerMedian ?? $this->dispositionService->peerMedianWage($player);
             if ($resolvedMedian > $demandedWage) {
-                $demandedWage = $resolvedMedian;
+                $pullFactor = (float) config('finances.renewal_peer_pull_factor', 0.5);
+                $demandedWage += (int) round($pullFactor * ($resolvedMedian - $demandedWage));
             }
         }
 

--- a/app/Modules/Transfer/Services/DispositionService.php
+++ b/app/Modules/Transfer/Services/DispositionService.php
@@ -880,34 +880,77 @@ class DispositionService
     }
 
     /**
-     * Median annual wage of same-tier squad peers (excluding the player).
-     * Returns 0 if there are no comparable teammates.
+     * Median annual wage of squad peers of similar *current* ability
+     * (overall_score within ±band), excluding the player. Returns 0 if there
+     * are no comparable teammates.
+     *
+     * Grouping by ability rather than market-value tier is what stops a
+     * benchwarmer or developing youngster from being priced against the
+     * squad's stars: he only competes with squadmates who are as good as he
+     * is today.
      */
     public function peerMedianWage(GamePlayer $player): int
     {
-        if (!$player->team_id || !$player->tier) {
+        if (!$player->team_id) {
             return 0;
         }
 
+        $band = (int) config('finances.wage_peer_ability_band', 5);
+
         $wages = GamePlayer::where('game_id', $player->game_id)
             ->where('team_id', $player->team_id)
-            ->where('tier', $player->tier)
+            ->whereBetween('overall_score', [$player->overall_score - $band, $player->overall_score + $band])
             ->where('id', '!=', $player->id)
             ->where('annual_wage', '>', 0)
             ->pluck('annual_wage')
             ->sort()
             ->values();
 
-        if ($wages->isEmpty()) {
+        return $this->median($wages);
+    }
+
+    /**
+     * In-memory equivalent of peerMedianWage() for an already-loaded squad:
+     * median annual wage of squadmates whose overall_score is within ±band of
+     * the player's (excluding self, excluding zero wages). Lets batch callers
+     * (the per-matchday unhappiness roll, the squad-page renewal loop) avoid a
+     * per-player query.
+     *
+     * @param Collection<int, GamePlayer> $squad
+     */
+    public function abilityPeerMedian(GamePlayer $player, Collection $squad): int
+    {
+        $band = (int) config('finances.wage_peer_ability_band', 5);
+
+        $wages = $squad
+            ->filter(fn (GamePlayer $p) => $p->id !== $player->id
+                && $p->annual_wage > 0
+                && abs($p->overall_score - $player->overall_score) <= $band)
+            ->pluck('annual_wage')
+            ->sort()
+            ->values();
+
+        return $this->median($wages);
+    }
+
+    /**
+     * Median of an ascending-sorted, reindexed numeric collection. Returns 0
+     * when empty.
+     *
+     * @param Collection<int, int> $sortedWages
+     */
+    private function median(Collection $sortedWages): int
+    {
+        if ($sortedWages->isEmpty()) {
             return 0;
         }
 
-        $count = $wages->count();
+        $count = $sortedWages->count();
         if ($count % 2 === 1) {
-            return (int) $wages[intdiv($count, 2)];
+            return (int) $sortedWages[intdiv($count, 2)];
         }
 
-        return (int) (($wages[$count / 2 - 1] + $wages[$count / 2]) / 2);
+        return (int) (($sortedWages[$count / 2 - 1] + $sortedWages[$count / 2]) / 2);
     }
 
     /**
@@ -960,13 +1003,11 @@ class DispositionService
             ->where('team_id', $game->team_id)
             ->get();
 
-        $mediansByTier = $this->peerMedianWagesByTier($squad);
-
         $flagged = 0;
         $cleared = 0;
 
         foreach ($squad as $player) {
-            $isEligible = $this->hasWageGapAgainst($player, $mediansByTier[$player->tier] ?? 0);
+            $isEligible = $this->hasWageGapAgainst($player, $this->abilityPeerMedian($player, $squad));
             $isFlagged = $player->salary_unhappy_since !== null;
 
             if ($isFlagged && !$isEligible) {
@@ -1017,39 +1058,10 @@ class DispositionService
     }
 
     /**
-     * Compute median annual wage per tier from an already-loaded squad collection.
-     * Excludes zero-wage entries; a player is excluded from their own tier median
-     * by the caller (hasWageGapAgainst handles the comparison vs $effectiveWage).
-     *
-     * @param Collection<int, GamePlayer> $squad
-     * @return array<int|string, int> tier => median wage
-     */
-    public function peerMedianWagesByTier(Collection $squad): array
-    {
-        $medians = [];
-        foreach ($squad->groupBy('tier') as $tier => $group) {
-            $wages = $group->pluck('annual_wage')
-                ->filter(fn ($w) => $w > 0)
-                ->sort()
-                ->values();
-            if ($wages->isEmpty()) {
-                continue;
-            }
-            $count = $wages->count();
-            $medians[$tier] = $count % 2 === 1
-                ? (int) $wages[intdiv($count, 2)]
-                : (int) (($wages[$count / 2 - 1] + $wages[$count / 2]) / 2);
-        }
-        return $medians;
-    }
-
-    /**
      * Underlying wage-gap eligibility check: is this player materially
-     * underpaid vs same-tier squad peers? Drives both the per-tick
-     * salary-unhappiness roll and renewal pricing (peer-median demand
-     * floor). The median includes the player's own wage; for typical
-     * squad sizes (>3 same-tier peers) self-inclusion shifts the median
-     * by less than one slot and does not change the gap outcome.
+     * underpaid vs similar-ability squad peers? Drives both the per-tick
+     * salary-unhappiness roll and renewal pricing (the peer-median pull on
+     * the demand). The peer median excludes the player's own wage.
      *
      * For "has the player *announced* their unhappiness?", use
      * `isSalaryUnhappy()` instead — that reads the stochastic flag.

--- a/config/finances.php
+++ b/config/finances.php
@@ -21,6 +21,20 @@ return [
     // elite/continental/established/modest/local) if tuning calls for it.
     'wage_cap_ratio' => 0.70,
 
+    // Wage-demand "market rate" comparison. A player renewing (or being flagged
+    // as underpaid) is compared against squadmates of similar CURRENT ability —
+    // overall_score within ±this band — rather than against their market-value
+    // tier. Grouping by ability stops a benchwarmer or a developing youngster
+    // (whose market value is inflated by potential) from demanding a star's wage.
+    'wage_peer_ability_band' => 5,
+
+    // How far a renewal demand is pulled toward that peer median when the
+    // player is paid below it. A *partial* pull (not a hard floor): 0 ignores
+    // peers entirely, 1.0 matches the median exactly. 0.5 closes half the gap,
+    // so equally-able players don't fully converge and a manager can still run
+    // a salary scale.
+    'renewal_peer_pull_factor' => 0.5,
+
     // Release clauses (cláusulas de rescisión). The amount is a "golden
     // handcuffs" model anchored to market value. Mandatory for Spanish (ES)
     // clubs, optional elsewhere. Multipliers are bare floats (multiples of

--- a/tests/Feature/PreContractBalanceTest.php
+++ b/tests/Feature/PreContractBalanceTest.php
@@ -237,10 +237,16 @@ class PreContractBalanceTest extends TestCase
         // the factory's random 16-40 birthdate makes ~30% of runs land in
         // academy/young bands (modifier 0.25/0.65) and the market-based
         // demand falls below the assertion threshold.
+        //
+        // The base wage is anchored to *current ability*, so pin overall_score
+        // to a value (~61) whose ability-derived value matches the €1.5M market
+        // value — otherwise the factory's random 40-90 score decouples the
+        // demand from the market-based baseline this test asserts against.
         $player = GamePlayer::factory()->age(25)->create([
             'game_id' => $game->id,
             'team_id' => $sourceTeam->id,
             'market_value_cents' => 150_000_000,
+            'overall_score' => 61,
             'annual_wage' => 1_000_000, // €10K — well below market
         ]);
 

--- a/tests/Feature/PreContractBalanceTest.php
+++ b/tests/Feature/PreContractBalanceTest.php
@@ -147,11 +147,16 @@ class PreContractBalanceTest extends TestCase
             'competition_id' => $this->competition->id,
         ]);
 
-        // €50M player → 1.45x premium
-        $player = GamePlayer::factory()->create([
+        // €50M player → 1.45x premium. Base wage is now anchored to current
+        // ability, so pin overall_score (~83 ≈ €50M) and a prime age so the
+        // base matches the market value; keep the current wage low so neither
+        // the current-wage nor minimum-wage floor distorts the premium ratio.
+        $player = GamePlayer::factory()->age(27)->create([
             'game_id' => $game->id,
             'team_id' => $sourceTeam->id,
             'market_value_cents' => 5_000_000_000,
+            'overall_score' => 83,
+            'annual_wage' => 100_000_00,
         ]);
 
         // Run multiple times to account for wage variance and check average ratio

--- a/tests/Unit/PlayerValuationServiceTest.php
+++ b/tests/Unit/PlayerValuationServiceTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Modules\Player\Services\PlayerValuationService;
+use PHPUnit\Framework\TestCase;
+
+class PlayerValuationServiceTest extends TestCase
+{
+    private PlayerValuationService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = new PlayerValuationService();
+    }
+
+    public function test_wage_base_value_strips_the_youth_premium(): void
+    {
+        // overallScoreToMarketValue applies a ×1.3 youth premium for an 18yo;
+        // wageBaseValue caps the age multiplier at 1.0, so the wage anchor is
+        // lower than the (potential-inflated) market value.
+        $marketValue = $this->service->overallScoreToMarketValue(70, age: 18);
+        $wageValue = $this->service->wageBaseValue(70, age: 18);
+
+        $this->assertLessThan(
+            $marketValue,
+            $wageValue,
+            'A youngster should be priced for current ability, not the youth market premium',
+        );
+
+        // Capped at 1.0 → the same as a prime player of equal ability.
+        $this->assertSame(
+            $this->service->wageBaseValue(70, age: 28),
+            $wageValue,
+            'Youth and prime players of equal ability should anchor to the same wage value',
+        );
+    }
+
+    public function test_wage_base_value_preserves_the_veteran_decline(): void
+    {
+        $prime = $this->service->wageBaseValue(70, age: 28);
+        $veteran = $this->service->wageBaseValue(70, age: 35);
+
+        $this->assertLessThan(
+            $prime,
+            $veteran,
+            'The veteran value decline must be preserved (the veteran wage modifier is calibrated against it)',
+        );
+    }
+
+    public function test_wage_base_value_rises_with_current_ability(): void
+    {
+        $this->assertGreaterThan(
+            $this->service->wageBaseValue(60, age: 28),
+            $this->service->wageBaseValue(80, age: 28),
+        );
+    }
+}

--- a/tests/Unit/SalaryUnhappinessTest.php
+++ b/tests/Unit/SalaryUnhappinessTest.php
@@ -111,9 +111,9 @@ class SalaryUnhappinessTest extends TestCase
         $this->assertSame(80, $unflagged->fresh()->morale);
     }
 
-    public function test_renewal_demands_peer_median_for_unflagged_underpaid_player(): void
+    public function test_renewal_pulls_demand_partway_toward_peer_median_for_unflagged_player(): void
     {
-        // Build a tier of well-paid peers so peer median is high.
+        // Build a band of well-paid same-ability peers so the peer median is high.
         $this->buildPeers(wage: 1_000_000_00, count: 4);
         $player = $this->makePlayer(
             annualWage: 200_000_00,
@@ -122,14 +122,22 @@ class SalaryUnhappinessTest extends TestCase
 
         $demand = $this->contractService->calculateWageDemand($player, NegotiationScenario::RENEWAL);
 
-        $this->assertGreaterThanOrEqual(
+        // Partial pull (not a hard floor): the demand rises above the player's
+        // current wage toward the peer median, but stops short of fully matching
+        // it so a manager can still run a wage scale.
+        $this->assertGreaterThan(
+            200_000_00,
+            $demand['wage'],
+            'An underpaid player should demand a raise toward the peer median',
+        );
+        $this->assertLessThan(
             1_000_000_00,
             $demand['wage'],
-            'Even an unflagged underpaid player should demand at least the peer median at renewal',
+            'The peer median is a partial pull, not a hard floor — demand should stop short of it',
         );
     }
 
-    public function test_renewal_demands_peer_median_for_flagged_player(): void
+    public function test_renewal_pulls_demand_partway_toward_peer_median_for_flagged_player(): void
     {
         $this->buildPeers(wage: 1_000_000_00, count: 4);
         $player = $this->makePlayer(
@@ -139,7 +147,45 @@ class SalaryUnhappinessTest extends TestCase
 
         $demand = $this->contractService->calculateWageDemand($player, NegotiationScenario::RENEWAL);
 
-        $this->assertGreaterThanOrEqual(1_000_000_00, $demand['wage']);
+        $this->assertGreaterThan(200_000_00, $demand['wage']);
+        $this->assertLessThan(1_000_000_00, $demand['wage']);
+    }
+
+    public function test_low_ability_youth_is_not_priced_against_star_squadmates(): void
+    {
+        // A squad of well-paid stars (high ability) plus a modest-ability
+        // youngster on a youth wage. Grouping by current ability means the
+        // youth is NOT compared to the stars, so his renewal stays sane rather
+        // than exploding to the star median.
+        for ($i = 0; $i < 4; $i++) {
+            GamePlayer::factory()
+                ->forGame($this->game)
+                ->forTeam($this->team)
+                ->create([
+                    'overall_score' => 88,
+                    'date_of_birth' => self::PRIME_DOB,
+                    'annual_wage' => 1_400_000_00, // €14M stars
+                ]);
+        }
+
+        $youth = GamePlayer::factory()
+            ->forGame($this->game)
+            ->forTeam($this->team)
+            ->create([
+                'overall_score' => 58, // modest current ability
+                'date_of_birth' => '2006-06-01', // ~20yo
+                'annual_wage' => 7_000_00, // €70K youth wage
+            ]);
+
+        $demand = $this->contractService->calculateWageDemand($youth, NegotiationScenario::RENEWAL);
+
+        // Sanity, not savagery: a raise, but nowhere near the €14M star median.
+        $this->assertGreaterThan(7_000_00, $demand['wage']);
+        $this->assertLessThan(
+            1_400_000_00,
+            $demand['wage'],
+            'A low-ability youth must not be priced against high-ability squadmates',
+        );
     }
 
     public function test_renewal_clears_flag_synchronously_when_gap_closes(): void
@@ -178,13 +224,20 @@ class SalaryUnhappinessTest extends TestCase
 
     // ── helpers ──
 
+    // Peer medians are grouped by current ability (overall_score ± band), so
+    // every player/peer is pinned to the same score and a prime age (stable
+    // wage modifier) to keep the comparison deterministic.
+    private const PEER_OVERALL_SCORE = 70;
+    private const PRIME_DOB = '1997-06-01';
+
     private function makePlayer(
         int $annualWage,
         ?string $salaryUnhappySince = null,
         ?int $morale = null,
     ): GamePlayer {
         $attrs = [
-            'tier' => 3,
+            'overall_score' => self::PEER_OVERALL_SCORE,
+            'date_of_birth' => self::PRIME_DOB,
             'annual_wage' => $annualWage,
             'salary_unhappy_since' => $salaryUnhappySince,
         ];
@@ -204,7 +257,8 @@ class SalaryUnhappinessTest extends TestCase
                 ->forGame($this->game)
                 ->forTeam($this->team)
                 ->create([
-                    'tier' => 3,
+                    'overall_score' => self::PEER_OVERALL_SCORE,
+                    'date_of_birth' => self::PRIME_DOB,
                     'annual_wage' => $wage,
                 ]);
         }


### PR DESCRIPTION
## Problem

A frequent player complaint: wage demands are detached from a player's actual current ability.

- A benchwarmer who played 3 matches demands the same as the 35-goal / 15-assist star.
- Non-starters demand the "crack" salary.
- A youth/young signing renews for a savage jump (300k → 6M; **700k → 14M**).
- One €21M earner drags the whole squad's demands up to 18–21M — no room for a salary scale.

## Root cause

For renewals, `ContractService::calculateWageDemand()` computed `max(baseWage × premium, peerMedianWage, currentWage × premium)`. Both drivers were anchored to the **age-inflated market value**, which leaks *potential* into wages:

1. **Base wage** = `market_value × wage% × ageModifier`, and market value carries a youth premium (×1.3 for ≤19).
2. **Peer-median floor** (the dominant driver) grouped squadmates by **market-value `tier`** — so a developing youngster landed in a star tier and got floored to that tier's €14M median, even though his current ability (`overall_score`) was modest.

## Changes

- **`PlayerValuationService::wageBaseValue()`** (new) — prices a player off his age-neutral **current-ability** value with the youth premium stripped (`min(1.0, ageValueMultiplier)`), while **preserving the veteran decline** (the veteran wage modifier is calibrated against that depressed value). `calculateWageDemand()` now uses it for the base wage.
- The **scenario premium** stays keyed off market value/tier — it represents market stature / Bosman leverage and the pre-contract bands were calibrated against it. Deliberately not re-anchored.
- **Peer-median floor** now groups by `overall_score ± wage_peer_ability_band` (not market-value tier), and is a **softened partial pull** toward the median (`+ renewal_peer_pull_factor × (median − demand)`, default 0.5) instead of a hard floor — so equal-ability players don't fully converge and a manager can run a wage scale.
- The **salary-unhappiness roll** uses the same ability-band grouping, keeping the "wants raise" flag consistent with renewal pricing. Removed the now-dead `peerMedianWagesByTier()`.
- Two config tunables in `config/finances.php`: `wage_peer_ability_band` (5), `renewal_peer_pull_factor` (0.5).

No DB migration, no UI change. Transfer / free-agent / pre-contract demands inherit the ability-anchored base wage; only renewals use the peer pull.

## Tests

- New `PlayerValuationServiceTest`: youth premium stripped, veteran decline preserved, monotonic in ability.
- `SalaryUnhappinessTest`: rewrote the two renewal tests for the partial-pull semantics; added a low-ability-youth-in-a-star-squad case proving the demand no longer explodes.
- `PreContractBalanceTest`: pinned `overall_score` on the one test that baselines against market value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)