### PR TITLE
Remove projected attendance from pre-match modal

### DIFF
--- a/app/Http/Views/ShowPreMatchData.php
+++ b/app/Http/Views/ShowPreMatchData.php
@@ -3,7 +3,6 @@
 namespace App\Http\Views;
 
 use App\Modules\Lineup\Services\LineupService;
-use App\Modules\Stadium\Services\MatchAttendanceService;
 use App\Models\Game;
 use App\Models\GamePlayer;
 use App\Models\PlayerSuspension;
@@ -12,7 +11,6 @@ class ShowPreMatchData
 {
     public function __construct(
         private readonly LineupService $lineupService,
-        private readonly MatchAttendanceService $matchAttendanceService,
     ) {}
 
     public function __invoke(string $gameId)
@@ -80,25 +78,11 @@ class ShowPreMatchData
             return response()->json(['lineupReady' => true]);
         }
 
-        // Show a projected attendance alongside the venue. The modal renders
-        // before advance() runs, so no MatchAttendance row exists yet — the
-        // orchestrator will persist the row (using the same demand curve) at
-        // the start of processBatch when the user commits to the match.
-        $attendance = $this->matchAttendanceService->describeForMatch($match, $game);
-        $attendanceFigure = $attendance['attendance'] ?? null;
-        $attendanceCapacity = $attendance['capacity'] ?? null;
-        $attendancePercent = $attendanceFigure !== null && $attendanceCapacity
-            ? (int) round(($attendanceFigure / $attendanceCapacity) * 100)
-            : null;
-
         return view('partials.pre-match-modal-content', [
             'game' => $game,
             'match' => $match,
             'issueMessage' => $issueMessage,
             'hasIssues' => $hasIssues,
-            'attendance' => $attendanceFigure,
-            'attendanceCapacity' => $attendanceCapacity,
-            'attendancePercent' => $attendancePercent,
         ]);
     }
 }

--- a/resources/views/partials/pre-match-modal-content.blade.php
+++ b/resources/views/partials/pre-match-modal-content.blade.php
@@ -9,9 +9,6 @@
     @endif
     <span class="text-xs text-text-muted">
         {{ $match->venueName() ?? '' }}
-        @if(!empty($attendance ?? null))
-            &middot; {{ __('game.attendance') }}: {{ number_format($attendance) }} ({{ $attendancePercent }}%)
-        @endif
         &middot; {{ $match->scheduled_date->locale(app()->getLocale())->translatedFormat('d M Y') }}
     </span>
 </div>


### PR DESCRIPTION
## Problem

The match preview modal ("Previa del Partido") renders **before** a match is played, but it displayed a *projected* attendance figure and fill percentage (e.g. `60,476 (86%)`). Showing attendance for a match that hasn't happened is misleading — attendance is only meaningful once the match has been played.

It also surfaced a literal, undefined translation key (`game.attendance:`), since that key was never defined in `lang/es` or `lang/en`.

## Changes

- **`resources/views/partials/pre-match-modal-content.blade.php`** — removed the attendance segment from the venue · date line. The line now reads just `Venue · Date`.
- **`app/Http/Views/ShowPreMatchData.php`** — removed the attendance projection block, the attendance view variables, and the now-unused `MatchAttendanceService` constructor dependency and import.

## Notes

- Attendance is still correctly shown on the live/played match view (`ShowLiveMatch` / `live-match.blade.php`), where it comes from a persisted `MatchAttendance` row rather than a projection. That legitimate display is untouched.
- `MatchAttendanceService::describeForMatch()` is still used internally by the service, so nothing dead was left behind.

https://claude.ai/code/session_01M8XQaZhmmjr2EqFfUNMkKQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01M8XQaZhmmjr2EqFfUNMkKQ)_