### PR TITLE
Extract reserve/parent coexistence repair into reusable service

### DIFF
--- a/app/Console/Commands/RepairReserveParentCoexistence.php
+++ b/app/Console/Commands/RepairReserveParentCoexistence.php
@@ -2,55 +2,32 @@
 
 namespace App\Console\Commands;
 
-use App\Models\CompetitionEntry;
 use App\Models\Game;
-use App\Models\GameStanding;
-use App\Models\SimulatedSeason;
-use App\Models\Team;
-use App\Modules\Competition\Services\CountryConfig;
+use App\Modules\Competition\Promotions\RepairOutcome;
+use App\Modules\Competition\Promotions\ReserveParentCoexistenceRepairer;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\DB;
 
 /**
- * Repair reserve/parent league assignments for a game stuck mid season-transition
- * because CountryPromotionRelegationPlanner::validatePlan detected one of:
+ * Operator entry point for repairing reserve/parent league assignments on a
+ * game stuck mid season-transition because
+ * {@see \App\Modules\Competition\Promotions\CountryPromotionRelegationPlanner::validatePlan}
+ * detected an INVERTED or COEXISTENCE violation.
  *
- *   INVERTED:    reserve in a higher tier than its parent (e.g. Promesas ESP1,
- *                Osasuna ESP2). validatePlan seeds finalComp from snapshot
- *                standings before applying any plan moves, so the inversion
- *                gets carried into finalComp; once the planner emits any
- *                relegation that lands the reserve in the parent's tier, the
- *                pair collides.
+ * The detection/swap/apply logic lives in
+ * {@see ReserveParentCoexistenceRepairer} (also used for the in-band self-heal
+ * inside PromotionRelegationProcessor). This command is a thin CLI wrapper:
+ * it enforces the operator-facing guards (game transitioning, checkpointed at
+ * the step right before the planner runs), prints the planned swaps, and only
+ * writes when --apply is passed.
  *
- *   COEXISTENCE: reserve and parent already share a competition in the
- *                snapshot. validatePlan throws immediately, even when no
- *                relevant moves were emitted.
+ * Defaults to dry-run. Safe to leave in the tree — the guards guarantee it only
+ * acts on a game checkpointed at the pre-PromotionRelegation step, and the
+ * repairer only emits swaps for pairs that would currently trip validatePlan.
  *
- * For each detected issue, plans a 1:1 league swap:
- *
- *   - INVERTED:    swap reserve <-> parent. Reserve drops to parent's tier,
- *                  parent rises to reserve's tier — restores correct hierarchy
- *                  with no displacement of unrelated teams.
- *   - COEXISTENCE: swap parent with the bottom team of the next-higher tier.
- *                  Parent moves up; the displaced team drops into the shared
- *                  tier. Requires a single competition at the next-higher tier
- *                  (aborts when that tier has siblings — manual choice needed).
- *
- * For each swap, mutates whichever store backs each affected league:
- *   - played league:     game_standings row (team_id swap, position preserved)
- *   - non-played league: simulated_seasons.results array slot (team_id swap)
- *
- * Plus competition_entries rows in both directions.
- *
- * Defaults to dry-run; pass --apply to write. Safe to leave in the tree —
- * preconditions guarantee it only acts on a game checkpointed at the
- * pre-PromotionRelegation step, and the issue detector only emits swaps for
- * pairs that would currently trip validatePlan.
- *
- * After applying, run app:diagnose-stuck-game to confirm flags are gone,
- * then app:resume-season-transition to re-run the closing pipeline from
- * step 23 (PromotionRelegationProcessor builds a fresh snapshot, replans,
- * and validatePlan passes).
+ * After applying, run app:diagnose-stuck-game to confirm flags are gone, then
+ * app:resume-season-transition to re-run the closing pipeline (the planner
+ * builds a fresh snapshot, replans, and validatePlan passes).
  */
 class RepairReserveParentCoexistence extends Command
 {
@@ -67,7 +44,7 @@ class RepairReserveParentCoexistence extends Command
      */
     private const EXPECTED_STEP = 23;
 
-    public function __construct(private readonly CountryConfig $countryConfig)
+    public function __construct(private readonly ReserveParentCoexistenceRepairer $repairer)
     {
         parent::__construct();
     }
@@ -96,154 +73,31 @@ class RepairReserveParentCoexistence extends Command
             return self::FAILURE;
         }
 
-        // Build tier maps from country config. Only league tier competitions
-        // count; cups, promotion playoffs, and continentals are excluded.
-        $tierToComps = [];
-        $compToTier = [];
-        foreach (array_keys($this->countryConfig->tiers($game->country)) as $tier) {
-            $ids = $this->countryConfig->tierCompetitionIds($game->country, (int) $tier);
-            $tierToComps[(int) $tier] = $ids;
-            foreach ($ids as $compId) {
-                $compToTier[$compId] = (int) $tier;
-            }
-        }
-        if (empty($compToTier)) {
-            $this->error("Country {$game->country} has no playable tiers configured. Aborting.");
+        $result = $this->repairer->plan($game);
+
+        if ($result->outcome === RepairOutcome::Unsafe) {
+            $this->error($result->reason ?? 'Cannot repair automatically — manual investigation required.');
             return self::FAILURE;
         }
-        $leagueIds = array_keys($compToTier);
-
-        // Detect issues.
-        $issues = [];
-        $reserves = Team::where('country', $game->country)
-            ->whereNotNull('parent_team_id')
-            ->get(['id', 'name', 'parent_team_id']);
-
-        foreach ($reserves as $reserve) {
-            $rLeagues = CompetitionEntry::where('game_id', $gameId)
-                ->where('team_id', $reserve->id)
-                ->whereIn('competition_id', $leagueIds)
-                ->pluck('competition_id')->all();
-            $pLeagues = CompetitionEntry::where('game_id', $gameId)
-                ->where('team_id', $reserve->parent_team_id)
-                ->whereIn('competition_id', $leagueIds)
-                ->pluck('competition_id')->all();
-
-            // Multi-league membership for a single team is a separate corruption.
-            // Bail rather than guess which league to swap.
-            if (count($rLeagues) > 1 || count($pLeagues) > 1) {
-                $this->error(sprintf(
-                    "Reserve %s or parent (%s) has multiple league entries — refusing to swap. Investigate competition_entries first.",
-                    $reserve->name,
-                    $reserve->parent_team_id,
-                ));
-                return self::FAILURE;
-            }
-
-            $rLeague = $rLeagues[0] ?? null;
-            $pLeague = $pLeagues[0] ?? null;
-            if ($rLeague === null || $pLeague === null) {
-                continue;
-            }
-
-            $rTier = $compToTier[$rLeague];
-            $pTier = $compToTier[$pLeague];
-            $parentName = Team::where('id', $reserve->parent_team_id)->value('name');
-
-            if ($rLeague === $pLeague) {
-                $issues[] = [
-                    'kind' => 'COEXISTENCE',
-                    'reserve' => ['id' => $reserve->id, 'name' => $reserve->name, 'league' => $rLeague, 'tier' => $rTier],
-                    'parent'  => ['id' => (string) $reserve->parent_team_id, 'name' => $parentName, 'league' => $pLeague, 'tier' => $pTier],
-                ];
-            } elseif ($rTier < $pTier) {
-                // Lower tier *number* = higher division. Reserve above parent is inverted.
-                $issues[] = [
-                    'kind' => 'INVERTED',
-                    'reserve' => ['id' => $reserve->id, 'name' => $reserve->name, 'league' => $rLeague, 'tier' => $rTier],
-                    'parent'  => ['id' => (string) $reserve->parent_team_id, 'name' => $parentName, 'league' => $pLeague, 'tier' => $pTier],
-                ];
-            }
-        }
-
-        if (empty($issues)) {
+        if ($result->outcome === RepairOutcome::NothingToFix) {
             $this->info('No reserve/parent inversions or coexistences detected. Nothing to repair.');
             return self::SUCCESS;
         }
 
         $this->info('--- Detected issues ---');
-        foreach ($issues as $i) {
+        foreach ($result->issues as $i) {
             $this->line("  {$i['kind']}: reserve {$i['reserve']['name']} ({$i['reserve']['league']}) <- parent {$i['parent']['name']} ({$i['parent']['league']})");
         }
         $this->line('');
 
-        // Plan a swap for each issue.
-        $swaps = [];
-        foreach ($issues as $issue) {
-            if ($issue['kind'] === 'INVERTED') {
-                $swaps[] = [
-                    'reason'     => "INVERTED: {$issue['reserve']['name']} ({$issue['reserve']['league']}) <-> {$issue['parent']['name']} ({$issue['parent']['league']})",
-                    'teamA'      => $issue['reserve']['id'],
-                    'teamA_name' => $issue['reserve']['name'],
-                    'leagueA'    => $issue['reserve']['league'],
-                    'teamB'      => $issue['parent']['id'],
-                    'teamB_name' => $issue['parent']['name'],
-                    'leagueB'    => $issue['parent']['league'],
-                ];
-                continue;
-            }
-
-            // COEXISTENCE: swap parent with the bottom team of the next-higher tier.
-            $parentTier = $issue['parent']['tier'];
-            $targetTier = $parentTier - 1;
-            $targetComps = $tierToComps[$targetTier] ?? [];
-            if (empty($targetComps)) {
-                $this->error("Cannot resolve COEXISTENCE for {$issue['parent']['name']} in tier {$parentTier}: no higher tier exists. Aborting.");
-                return self::FAILURE;
-            }
-            if (count($targetComps) > 1) {
-                $this->error("Cannot resolve COEXISTENCE for {$issue['parent']['name']}: tier {$targetTier} has siblings (" . implode(',', $targetComps) . "). Manual swap target required. Aborting.");
-                return self::FAILURE;
-            }
-            $targetComp = $targetComps[0];
-            $bottomTeamId = $this->bottomTeamOf($gameId, (string) $game->season, $targetComp);
-            if ($bottomTeamId === null) {
-                $this->error("Cannot resolve COEXISTENCE for {$issue['parent']['name']}: no bottom team found in {$targetComp}. Aborting.");
-                return self::FAILURE;
-            }
-            $bottomName = Team::where('id', $bottomTeamId)->value('name');
-            $swaps[] = [
-                'reason'     => "COEXISTENCE: {$issue['parent']['name']} ({$issue['parent']['league']}) <-> {$bottomName} ({$targetComp}) [parent moves up]",
-                'teamA'      => $issue['parent']['id'],
-                'teamA_name' => $issue['parent']['name'],
-                'leagueA'    => $issue['parent']['league'],
-                'teamB'      => $bottomTeamId,
-                'teamB_name' => $bottomName,
-                'leagueB'    => $targetComp,
-            ];
-        }
-
-        // Resolve slots for every swap so we can print the full mutation list
-        // up front and fail before any writes if a slot is unlocatable.
-        $mutations = [];
         $this->info('--- Planned swaps ---');
-        foreach ($swaps as $swap) {
+        foreach ($result->mutations as $m) {
+            $swap = $m['swap'];
             $this->line("  {$swap['reason']}");
-            $slotA = $this->locateSlot($gameId, (string) $game->season, $swap['leagueA'], $swap['teamA']);
-            $slotB = $this->locateSlot($gameId, (string) $game->season, $swap['leagueB'], $swap['teamB']);
-            if ($slotA === null) {
-                $this->error("    Cannot locate slot for {$swap['teamA_name']} in {$swap['leagueA']} (no game_standings or simulated_seasons entry). Aborting.");
-                return self::FAILURE;
-            }
-            if ($slotB === null) {
-                $this->error("    Cannot locate slot for {$swap['teamB_name']} in {$swap['leagueB']} (no game_standings or simulated_seasons entry). Aborting.");
-                return self::FAILURE;
-            }
             $this->line("    competition_entries: {$swap['teamA_name']} {$swap['leagueA']} -> {$swap['leagueB']}");
             $this->line("    competition_entries: {$swap['teamB_name']} {$swap['leagueB']} -> {$swap['leagueA']}");
-            $this->line("    {$swap['leagueA']} ({$slotA['kind']}): {$swap['teamA_name']} -> {$swap['teamB_name']}");
-            $this->line("    {$swap['leagueB']} ({$slotB['kind']}): {$swap['teamB_name']} -> {$swap['teamA_name']}");
-            $mutations[] = ['swap' => $swap, 'slotA' => $slotA, 'slotB' => $slotB];
+            $this->line("    {$swap['leagueA']} ({$m['slotA']['kind']}): {$swap['teamA_name']} -> {$swap['teamB_name']}");
+            $this->line("    {$swap['leagueB']} ({$m['slotB']['kind']}): {$swap['teamB_name']} -> {$swap['teamA_name']}");
         }
         $this->line('');
 
@@ -253,30 +107,7 @@ class RepairReserveParentCoexistence extends Command
         }
 
         try {
-            DB::transaction(function () use ($gameId, $mutations) {
-                foreach ($mutations as $m) {
-                    $swap = $m['swap'];
-
-                    $a = CompetitionEntry::where('game_id', $gameId)
-                        ->where('team_id', $swap['teamA'])
-                        ->where('competition_id', $swap['leagueA'])
-                        ->update(['competition_id' => $swap['leagueB']]);
-                    if ($a !== 1) {
-                        throw new \RuntimeException("Expected 1 competition_entries update for {$swap['teamA_name']} {$swap['leagueA']}->{$swap['leagueB']}, got {$a}.");
-                    }
-                    $b = CompetitionEntry::where('game_id', $gameId)
-                        ->where('team_id', $swap['teamB'])
-                        ->where('competition_id', $swap['leagueB'])
-                        ->update(['competition_id' => $swap['leagueA']]);
-                    if ($b !== 1) {
-                        throw new \RuntimeException("Expected 1 competition_entries update for {$swap['teamB_name']} {$swap['leagueB']}->{$swap['leagueA']}, got {$b}.");
-                    }
-
-                    // Slot A (was teamA) becomes teamB; slot B (was teamB) becomes teamA.
-                    $this->applySlotSwap($m['slotA'], $swap['teamB']);
-                    $this->applySlotSwap($m['slotB'], $swap['teamA']);
-                }
-            });
+            DB::transaction(fn () => $this->repairer->apply($game, $result));
         } catch (\Throwable $e) {
             $this->error("Repair failed: {$e->getMessage()}");
             return self::FAILURE;
@@ -287,81 +118,5 @@ class RepairReserveParentCoexistence extends Command
         $this->line("  php artisan app:resume-season-transition {$gameId}");
 
         return self::SUCCESS;
-    }
-
-    /**
-     * Locate a team's slot inside a league for the given game/season. Returns
-     * a descriptor for a game_standings row (played league) or a
-     * simulated_seasons.results index (non-played league), or null if the
-     * team isn't present in either store.
-     *
-     * @return array{kind: string, standing?: GameStanding, sim?: SimulatedSeason, index?: int}|null
-     */
-    private function locateSlot(string $gameId, string $season, string $competitionId, string $teamId): ?array
-    {
-        $standing = GameStanding::where('game_id', $gameId)
-            ->where('competition_id', $competitionId)
-            ->where('team_id', $teamId)
-            ->first();
-        if ($standing) {
-            return ['kind' => 'standing', 'standing' => $standing];
-        }
-
-        $sim = SimulatedSeason::where('game_id', $gameId)
-            ->where('season', $season)
-            ->where('competition_id', $competitionId)
-            ->first();
-        if ($sim && is_array($sim->results)) {
-            $idx = array_search($teamId, $sim->results, true);
-            if ($idx !== false) {
-                return ['kind' => 'sim', 'sim' => $sim, 'index' => $idx];
-            }
-        }
-
-        return null;
-    }
-
-    private function applySlotSwap(array $slot, string $newTeamId): void
-    {
-        if ($slot['kind'] === 'standing') {
-            $standing = $slot['standing'];
-            $standing->team_id = $newTeamId;
-            $standing->save();
-            return;
-        }
-        if ($slot['kind'] === 'sim') {
-            $sim = $slot['sim'];
-            $results = $sim->results;
-            $results[$slot['index']] = $newTeamId;
-            $sim->results = $results;
-            $sim->save();
-            return;
-        }
-        throw new \RuntimeException("Unknown slot kind: {$slot['kind']}.");
-    }
-
-    /**
-     * Bottom team of a league: last position by game_standings if played,
-     * otherwise last element of simulated_seasons.results.
-     */
-    private function bottomTeamOf(string $gameId, string $season, string $competitionId): ?string
-    {
-        $standing = GameStanding::where('game_id', $gameId)
-            ->where('competition_id', $competitionId)
-            ->orderByDesc('position')
-            ->first();
-        if ($standing) {
-            return (string) $standing->team_id;
-        }
-
-        $sim = SimulatedSeason::where('game_id', $gameId)
-            ->where('season', $season)
-            ->where('competition_id', $competitionId)
-            ->first();
-        if ($sim && is_array($sim->results) && !empty($sim->results)) {
-            return (string) $sim->results[array_key_last($sim->results)];
-        }
-
-        return null;
     }
 }

--- a/app/Modules/Competition/Exceptions/ReserveParentCoexistenceException.php
+++ b/app/Modules/Competition/Exceptions/ReserveParentCoexistenceException.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Modules\Competition\Exceptions;
+
+use LogicException;
+
+/**
+ * Thrown by {@see \App\Modules\Competition\Promotions\CountryPromotionRelegationPlanner}
+ * when the plan would leave a reserve team sharing a competition with its parent.
+ *
+ * In practice this is almost always reachable only when the *input* snapshot
+ * already has a reserve coexisting with (or inverted above) its parent — data
+ * drift left behind by a prior incomplete season transition. The
+ * PromotionRelegationProcessor catches this specific type to attempt an
+ * in-band, single-shot self-heal before falling back to manual repair.
+ *
+ * Extends LogicException so existing `catch (\LogicException)` / `catch
+ * (\Throwable)` sites keep working unchanged; only the planner's coexistence
+ * branch throws this subtype, leaving genuine planner-bug LogicExceptions
+ * (unbalanced plan, double move) as the bare base type.
+ */
+class ReserveParentCoexistenceException extends LogicException
+{
+    /**
+     * @param  list<array{reserve: string, parent: string, competition: string}>  $violations
+     */
+    private function __construct(string $message, private readonly array $violations)
+    {
+        parent::__construct($message);
+    }
+
+    /**
+     * @param  list<array{reserve: string, parent: string, competition: string}>  $violations
+     */
+    public static function forViolations(array $violations): self
+    {
+        $parts = array_map(
+            fn (array $v) => "reserve={$v['reserve']} parent={$v['parent']} competition={$v['competition']}",
+            $violations,
+        );
+
+        // Keep the historical "Planner produced a coexistence violation:" prefix
+        // so existing log searches / alerts continue to match.
+        return new self(
+            'Planner produced a coexistence violation: ' . implode('; ', $parts) . '.',
+            $violations,
+        );
+    }
+
+    /**
+     * @return list<array{reserve: string, parent: string, competition: string}>
+     */
+    public function violations(): array
+    {
+        return $this->violations;
+    }
+}

--- a/app/Modules/Competition/Promotions/CountryPromotionRelegationPlanner.php
+++ b/app/Modules/Competition/Promotions/CountryPromotionRelegationPlanner.php
@@ -4,6 +4,7 @@ namespace App\Modules\Competition\Promotions;
 
 use App\Modules\Competition\Enums\PlayoffState;
 use App\Modules\Competition\Exceptions\PlayoffInProgressException;
+use App\Modules\Competition\Exceptions\ReserveParentCoexistenceException;
 
 /**
  * Pure country-aware planner for end-of-season promotion/relegation.
@@ -1394,15 +1395,23 @@ class CountryPromotionRelegationPlanner
         foreach ($plan->moves as $m) {
             $finalComp[$m->teamId] = $m->toCompetitionId;
         }
+        // Collect every coexistence so the typed exception carries all pairs in
+        // one pass — the repairer that catches it can then resolve them together.
+        $violations = [];
         foreach ($snapshot->reserveToParent as $reserve => $parent) {
             if (!isset($finalComp[$reserve], $finalComp[$parent])) {
                 continue;
             }
             if ($finalComp[$reserve] === $finalComp[$parent]) {
-                throw new \LogicException(
-                    "Planner produced a coexistence violation: reserve={$reserve} parent={$parent} competition={$finalComp[$reserve]}.",
-                );
+                $violations[] = [
+                    'reserve' => (string) $reserve,
+                    'parent' => (string) $parent,
+                    'competition' => (string) $finalComp[$reserve],
+                ];
             }
+        }
+        if (!empty($violations)) {
+            throw ReserveParentCoexistenceException::forViolations($violations);
         }
     }
 }

--- a/app/Modules/Competition/Promotions/RepairOutcome.php
+++ b/app/Modules/Competition/Promotions/RepairOutcome.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Modules\Competition\Promotions;
+
+/**
+ * Result classification for {@see ReserveParentCoexistenceRepairer}.
+ *
+ *  - NothingToFix: no reserve/parent inversion or coexistence detected.
+ *  - Repaired:     a deterministic 1:1 swap was planned (and, after apply(),
+ *                  written) to restore the hierarchy.
+ *  - Unsafe:       a violation exists but cannot be resolved deterministically
+ *                  (multi-league corruption, sibling tier with no single swap
+ *                  target, unlocatable slot). The caller must escalate to
+ *                  manual repair rather than guess.
+ */
+enum RepairOutcome
+{
+    case NothingToFix;
+    case Repaired;
+    case Unsafe;
+}

--- a/app/Modules/Competition/Promotions/ReserveParentCoexistenceRepairer.php
+++ b/app/Modules/Competition/Promotions/ReserveParentCoexistenceRepairer.php
@@ -1,0 +1,356 @@
+<?php
+
+namespace App\Modules\Competition\Promotions;
+
+use App\Models\CompetitionEntry;
+use App\Models\Game;
+use App\Models\GameStanding;
+use App\Models\SimulatedSeason;
+use App\Models\Team;
+use App\Modules\Competition\Services\CountryConfig;
+
+/**
+ * Detects and repairs reserve/parent league corruption for a game stuck (or
+ * about to get stuck) mid season-transition because
+ * {@see CountryPromotionRelegationPlanner::validatePlan} would throw a
+ * {@see \App\Modules\Competition\Exceptions\ReserveParentCoexistenceException}.
+ *
+ * Two corruption shapes are handled:
+ *
+ *   INVERTED:    reserve sits in a higher tier than its parent (e.g. Promesas
+ *                ESP1, Osasuna ESP2). validatePlan seeds finalComp from
+ *                snapshot standings before applying any moves, so the inversion
+ *                is carried in; once any relegation lands the reserve in the
+ *                parent's tier, the pair collides.
+ *   COEXISTENCE: reserve and parent already share a competition in the
+ *                snapshot. validatePlan throws immediately.
+ *
+ * For each issue a 1:1 league swap is planned:
+ *   - INVERTED:    swap reserve <-> parent (reserve drops to parent's tier,
+ *                  parent rises to reserve's tier — restores hierarchy with no
+ *                  displacement of unrelated teams).
+ *   - COEXISTENCE: swap parent with the bottom team of the next-higher tier.
+ *                  Parent moves up; the displaced team drops into the shared
+ *                  tier. Requires a single competition at the next-higher tier
+ *                  (bails when that tier has siblings — a manual choice).
+ *
+ * Each swap mutates whichever store backs the affected league:
+ *   - played league:     game_standings row (team_id swap, position preserved)
+ *   - non-played league: simulated_seasons.results array slot (team_id swap)
+ * plus the two competition_entries rows.
+ *
+ * The repairer is deliberately conservative: anything it cannot resolve
+ * deterministically (multi-league membership, sibling next-tier, unlocatable
+ * slot) returns an Unsafe result rather than guessing, so callers escalate to
+ * manual repair. It is guard-free about transition state (the
+ * RepairReserveParentCoexistence command owns those CLI checks) and never opens
+ * its own transaction (callers supply one — the season pipeline's per-processor
+ * transaction in-band, or the command's DB::transaction on --apply).
+ */
+class ReserveParentCoexistenceRepairer
+{
+    public function __construct(private readonly CountryConfig $countryConfig) {}
+
+    /**
+     * Plan + apply in one call (used for the in-band self-heal). Returns the
+     * plan result unchanged when there is nothing to fix or the situation is
+     * unsafe to repair automatically.
+     */
+    public function repair(Game $game): ReserveRepairResult
+    {
+        $plan = $this->plan($game);
+
+        if ($plan->outcome !== RepairOutcome::Repaired) {
+            return $plan;
+        }
+
+        return $this->apply($game, $plan);
+    }
+
+    /**
+     * Detect issues and resolve the swaps + slots needed to fix them, without
+     * writing anything. Returns NothingToFix, Unsafe (with a reason), or
+     * Repaired (carrying the resolved mutations ready for apply()).
+     */
+    public function plan(Game $game): ReserveRepairResult
+    {
+        $gameId = (string) $game->id;
+        $season = (string) $game->season;
+
+        // Build tier maps from country config. Only league tier competitions
+        // count; cups, promotion playoffs, and continentals are excluded.
+        [$tierToComps, $compToTier] = $this->tierMaps((string) $game->country);
+        if (empty($compToTier)) {
+            return ReserveRepairResult::unsafe("Country {$game->country} has no playable tiers configured.");
+        }
+        $leagueIds = array_keys($compToTier);
+
+        // Detect issues.
+        $issues = [];
+        $reserves = Team::where('country', $game->country)
+            ->whereNotNull('parent_team_id')
+            ->get(['id', 'name', 'parent_team_id']);
+
+        foreach ($reserves as $reserve) {
+            $rLeagues = CompetitionEntry::where('game_id', $gameId)
+                ->where('team_id', $reserve->id)
+                ->whereIn('competition_id', $leagueIds)
+                ->pluck('competition_id')->all();
+            $pLeagues = CompetitionEntry::where('game_id', $gameId)
+                ->where('team_id', $reserve->parent_team_id)
+                ->whereIn('competition_id', $leagueIds)
+                ->pluck('competition_id')->all();
+
+            // Multi-league membership for a single team is a separate corruption.
+            // Bail rather than guess which league to swap.
+            if (count($rLeagues) > 1 || count($pLeagues) > 1) {
+                return ReserveRepairResult::unsafe(sprintf(
+                    'Reserve %s or parent (%s) has multiple league entries — refusing to swap. Investigate competition_entries first.',
+                    $reserve->name,
+                    $reserve->parent_team_id,
+                ));
+            }
+
+            $rLeague = $rLeagues[0] ?? null;
+            $pLeague = $pLeagues[0] ?? null;
+            if ($rLeague === null || $pLeague === null) {
+                continue;
+            }
+
+            $rTier = $compToTier[$rLeague];
+            $pTier = $compToTier[$pLeague];
+            $parentName = Team::where('id', $reserve->parent_team_id)->value('name');
+
+            if ($rLeague === $pLeague) {
+                $issues[] = [
+                    'kind' => 'COEXISTENCE',
+                    'reserve' => ['id' => $reserve->id, 'name' => $reserve->name, 'league' => $rLeague, 'tier' => $rTier],
+                    'parent'  => ['id' => (string) $reserve->parent_team_id, 'name' => $parentName, 'league' => $pLeague, 'tier' => $pTier],
+                ];
+            } elseif ($rTier < $pTier) {
+                // Lower tier *number* = higher division. Reserve above parent is inverted.
+                $issues[] = [
+                    'kind' => 'INVERTED',
+                    'reserve' => ['id' => $reserve->id, 'name' => $reserve->name, 'league' => $rLeague, 'tier' => $rTier],
+                    'parent'  => ['id' => (string) $reserve->parent_team_id, 'name' => $parentName, 'league' => $pLeague, 'tier' => $pTier],
+                ];
+            }
+        }
+
+        if (empty($issues)) {
+            return ReserveRepairResult::nothingToFix();
+        }
+
+        // Plan a swap for each issue.
+        $swaps = [];
+        foreach ($issues as $issue) {
+            if ($issue['kind'] === 'INVERTED') {
+                $swaps[] = [
+                    'reason'     => "INVERTED: {$issue['reserve']['name']} ({$issue['reserve']['league']}) <-> {$issue['parent']['name']} ({$issue['parent']['league']})",
+                    'teamA'      => $issue['reserve']['id'],
+                    'teamA_name' => $issue['reserve']['name'],
+                    'leagueA'    => $issue['reserve']['league'],
+                    'teamB'      => $issue['parent']['id'],
+                    'teamB_name' => $issue['parent']['name'],
+                    'leagueB'    => $issue['parent']['league'],
+                ];
+                continue;
+            }
+
+            // COEXISTENCE: swap parent with the bottom team of the next-higher tier.
+            $parentTier = $issue['parent']['tier'];
+            $targetTier = $parentTier - 1;
+            $targetComps = $tierToComps[$targetTier] ?? [];
+            if (empty($targetComps)) {
+                return ReserveRepairResult::unsafe(
+                    "Cannot resolve COEXISTENCE for {$issue['parent']['name']} in tier {$parentTier}: no higher tier exists.",
+                    $issues,
+                );
+            }
+            if (count($targetComps) > 1) {
+                return ReserveRepairResult::unsafe(
+                    "Cannot resolve COEXISTENCE for {$issue['parent']['name']}: tier {$targetTier} has siblings (" . implode(',', $targetComps) . "). Manual swap target required.",
+                    $issues,
+                );
+            }
+            $targetComp = $targetComps[0];
+            $bottomTeamId = $this->bottomTeamOf($gameId, $season, $targetComp);
+            if ($bottomTeamId === null) {
+                return ReserveRepairResult::unsafe(
+                    "Cannot resolve COEXISTENCE for {$issue['parent']['name']}: no bottom team found in {$targetComp}.",
+                    $issues,
+                );
+            }
+            $bottomName = Team::where('id', $bottomTeamId)->value('name');
+            $swaps[] = [
+                'reason'     => "COEXISTENCE: {$issue['parent']['name']} ({$issue['parent']['league']}) <-> {$bottomName} ({$targetComp}) [parent moves up]",
+                'teamA'      => $issue['parent']['id'],
+                'teamA_name' => $issue['parent']['name'],
+                'leagueA'    => $issue['parent']['league'],
+                'teamB'      => $bottomTeamId,
+                'teamB_name' => $bottomName,
+                'leagueB'    => $targetComp,
+            ];
+        }
+
+        // Resolve slots for every swap so we fail before any writes if a slot
+        // is unlocatable.
+        $mutations = [];
+        foreach ($swaps as $swap) {
+            $slotA = $this->locateSlot($gameId, $season, $swap['leagueA'], $swap['teamA']);
+            $slotB = $this->locateSlot($gameId, $season, $swap['leagueB'], $swap['teamB']);
+            if ($slotA === null) {
+                return ReserveRepairResult::unsafe(
+                    "Cannot locate slot for {$swap['teamA_name']} in {$swap['leagueA']} (no game_standings or simulated_seasons entry).",
+                    $issues,
+                );
+            }
+            if ($slotB === null) {
+                return ReserveRepairResult::unsafe(
+                    "Cannot locate slot for {$swap['teamB_name']} in {$swap['leagueB']} (no game_standings or simulated_seasons entry).",
+                    $issues,
+                );
+            }
+            $mutations[] = ['swap' => $swap, 'slotA' => $slotA, 'slotB' => $slotB];
+        }
+
+        return ReserveRepairResult::repaired($issues, $mutations);
+    }
+
+    /**
+     * Apply the swaps resolved by plan(). Does NOT open its own transaction —
+     * the caller wraps it (season pipeline transaction in-band, or the
+     * command's DB::transaction on --apply). Throws on an integrity mismatch
+     * (an "expected exactly one row" guard) so the caller's transaction rolls
+     * back cleanly.
+     */
+    public function apply(Game $game, ReserveRepairResult $plan): ReserveRepairResult
+    {
+        $gameId = (string) $game->id;
+
+        foreach ($plan->mutations as $m) {
+            $swap = $m['swap'];
+
+            $a = CompetitionEntry::where('game_id', $gameId)
+                ->where('team_id', $swap['teamA'])
+                ->where('competition_id', $swap['leagueA'])
+                ->update(['competition_id' => $swap['leagueB']]);
+            if ($a !== 1) {
+                throw new \RuntimeException("Expected 1 competition_entries update for {$swap['teamA_name']} {$swap['leagueA']}->{$swap['leagueB']}, got {$a}.");
+            }
+            $b = CompetitionEntry::where('game_id', $gameId)
+                ->where('team_id', $swap['teamB'])
+                ->where('competition_id', $swap['leagueB'])
+                ->update(['competition_id' => $swap['leagueA']]);
+            if ($b !== 1) {
+                throw new \RuntimeException("Expected 1 competition_entries update for {$swap['teamB_name']} {$swap['leagueB']}->{$swap['leagueA']}, got {$b}.");
+            }
+
+            // Slot A (was teamA) becomes teamB; slot B (was teamB) becomes teamA.
+            $this->applySlotSwap($m['slotA'], $swap['teamB']);
+            $this->applySlotSwap($m['slotB'], $swap['teamA']);
+        }
+
+        return $plan;
+    }
+
+    /**
+     * Build [tierToComps, compToTier] from country config. Only league tiers
+     * are included; cups, promotion playoffs, and continentals are excluded.
+     *
+     * @return array{0: array<int, list<string>>, 1: array<string, int>}
+     */
+    private function tierMaps(string $country): array
+    {
+        $tierToComps = [];
+        $compToTier = [];
+        foreach (array_keys($this->countryConfig->tiers($country)) as $tier) {
+            $ids = $this->countryConfig->tierCompetitionIds($country, (int) $tier);
+            $tierToComps[(int) $tier] = $ids;
+            foreach ($ids as $compId) {
+                $compToTier[$compId] = (int) $tier;
+            }
+        }
+
+        return [$tierToComps, $compToTier];
+    }
+
+    /**
+     * Locate a team's slot inside a league for the given game/season. Returns
+     * a descriptor for a game_standings row (played league) or a
+     * simulated_seasons.results index (non-played league), or null if the
+     * team isn't present in either store.
+     *
+     * @return array{kind: string, standing?: GameStanding, sim?: SimulatedSeason, index?: int}|null
+     */
+    private function locateSlot(string $gameId, string $season, string $competitionId, string $teamId): ?array
+    {
+        $standing = GameStanding::where('game_id', $gameId)
+            ->where('competition_id', $competitionId)
+            ->where('team_id', $teamId)
+            ->first();
+        if ($standing) {
+            return ['kind' => 'standing', 'standing' => $standing];
+        }
+
+        $sim = SimulatedSeason::where('game_id', $gameId)
+            ->where('season', $season)
+            ->where('competition_id', $competitionId)
+            ->first();
+        if ($sim && is_array($sim->results)) {
+            $idx = array_search($teamId, $sim->results, true);
+            if ($idx !== false) {
+                return ['kind' => 'sim', 'sim' => $sim, 'index' => $idx];
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param  array{kind: string, standing?: GameStanding, sim?: SimulatedSeason, index?: int}  $slot
+     */
+    private function applySlotSwap(array $slot, string $newTeamId): void
+    {
+        if ($slot['kind'] === 'standing') {
+            $standing = $slot['standing'];
+            $standing->team_id = $newTeamId;
+            $standing->save();
+            return;
+        }
+        if ($slot['kind'] === 'sim') {
+            $sim = $slot['sim'];
+            $results = $sim->results;
+            $results[$slot['index']] = $newTeamId;
+            $sim->results = $results;
+            $sim->save();
+            return;
+        }
+        throw new \RuntimeException("Unknown slot kind: {$slot['kind']}.");
+    }
+
+    /**
+     * Bottom team of a league: last position by game_standings if played,
+     * otherwise last element of simulated_seasons.results.
+     */
+    private function bottomTeamOf(string $gameId, string $season, string $competitionId): ?string
+    {
+        $standing = GameStanding::where('game_id', $gameId)
+            ->where('competition_id', $competitionId)
+            ->orderByDesc('position')
+            ->first();
+        if ($standing) {
+            return (string) $standing->team_id;
+        }
+
+        $sim = SimulatedSeason::where('game_id', $gameId)
+            ->where('season', $season)
+            ->where('competition_id', $competitionId)
+            ->first();
+        if ($sim && is_array($sim->results) && !empty($sim->results)) {
+            return (string) $sim->results[array_key_last($sim->results)];
+        }
+
+        return null;
+    }
+}

--- a/app/Modules/Competition/Promotions/ReserveRepairResult.php
+++ b/app/Modules/Competition/Promotions/ReserveRepairResult.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Modules\Competition\Promotions;
+
+/**
+ * Outcome of a {@see ReserveParentCoexistenceRepairer} run.
+ *
+ * Carries the detected issues and (for a Repaired result) the resolved
+ * mutation descriptors — each a swap plus the two located standings/sim slots —
+ * so apply() can execute them and console/alert callers can describe them.
+ * The Unsafe case carries a human-readable reason instead of throwing, so the
+ * processor can distinguish "could not safely heal" from "fixed".
+ */
+final class ReserveRepairResult
+{
+    /**
+     * @param  list<array{kind: string, reserve: array<string, mixed>, parent: array<string, mixed>}>  $issues
+     * @param  list<array{swap: array<string, mixed>, slotA: array<string, mixed>, slotB: array<string, mixed>}>  $mutations
+     */
+    private function __construct(
+        public readonly RepairOutcome $outcome,
+        public readonly array $issues = [],
+        public readonly array $mutations = [],
+        public readonly ?string $reason = null,
+    ) {}
+
+    public static function nothingToFix(): self
+    {
+        return new self(RepairOutcome::NothingToFix);
+    }
+
+    /**
+     * @param  list<array{kind: string, reserve: array<string, mixed>, parent: array<string, mixed>}>  $issues
+     */
+    public static function unsafe(string $reason, array $issues = []): self
+    {
+        return new self(RepairOutcome::Unsafe, $issues, [], $reason);
+    }
+
+    /**
+     * @param  list<array{kind: string, reserve: array<string, mixed>, parent: array<string, mixed>}>  $issues
+     * @param  list<array{swap: array<string, mixed>, slotA: array<string, mixed>, slotB: array<string, mixed>}>  $mutations
+     */
+    public static function repaired(array $issues, array $mutations): self
+    {
+        return new self(RepairOutcome::Repaired, $issues, $mutations);
+    }
+
+    /**
+     * Human-readable one-line summary per planned/applied swap, for logs/alerts.
+     *
+     * @return list<string>
+     */
+    public function swapSummaries(): array
+    {
+        return array_map(fn (array $m) => (string) $m['swap']['reason'], $this->mutations);
+    }
+}

--- a/app/Modules/Season/Alerts/ReserveCoexistenceHealAlert.php
+++ b/app/Modules/Season/Alerts/ReserveCoexistenceHealAlert.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace App\Modules\Season\Alerts;
+
+use App\Models\Game;
+use App\Modules\Competition\Promotions\ReserveRepairResult;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Facades\RateLimiter;
+
+/**
+ * Admin alerting for the in-band reserve/parent coexistence self-heal.
+ *
+ * Both outcomes are surfaced, by product decision:
+ *  - healed():     a coexistence violation was auto-repaired and the transition
+ *                  completed. Worth knowing so a recurring planner bug (the swap
+ *                  masks it) stays visible.
+ *  - unhealable(): a violation could not be auto-repaired; the game stays stuck
+ *                  and needs the manual repair commands.
+ *
+ * Mirrors the rate-limited, fail-soft mail pattern in AppServiceProvider's
+ * Queue::failing listener: a mail outage must never break a season transition.
+ */
+class ReserveCoexistenceHealAlert
+{
+    public function healed(Game $game, ReserveRepairResult $result): void
+    {
+        $swaps = implode("\n", array_map(fn (string $s) => "  - {$s}", $result->swapSummaries()));
+
+        $body = "Auto-healed a reserve/parent coexistence violation during season transition.\n\n"
+            . "Game: {$game->id}\n"
+            . "Country: {$game->country}\n"
+            . "Season: {$game->season}\n\n"
+            . "Swaps applied:\n{$swaps}\n\n"
+            . "The transition completed automatically. Review whether the planner "
+            . "should have produced an invariant-satisfying plan without intervention.";
+
+        $this->send(
+            'reserve_coexistence_heal_alert:healed',
+            "[VirtuaFC] Reserve/parent coexistence auto-healed (game {$game->id})",
+            $body,
+            ['game_id' => $game->id, 'outcome' => 'healed'],
+        );
+    }
+
+    public function unhealable(Game $game, \Throwable $original, ReserveRepairResult $result): void
+    {
+        $body = "A reserve/parent coexistence violation could NOT be auto-healed and needs manual intervention.\n\n"
+            . "Game: {$game->id}\n"
+            . "Country: {$game->country}\n"
+            . "Season: {$game->season}\n\n"
+            . "Planner error: {$original->getMessage()}\n\n"
+            . "Repair outcome: {$result->outcome->name}\n"
+            . 'Reason: ' . ($result->reason ?? 'n/a') . "\n\n"
+            . "Run:\n"
+            . "  php artisan app:diagnose-stuck-game {$game->id}\n"
+            . "  php artisan app:repair-reserve-parent-coexistence {$game->id} --apply\n"
+            . "  php artisan app:resume-season-transition {$game->id}";
+
+        $this->send(
+            'reserve_coexistence_heal_alert:unhealable',
+            "[VirtuaFC] Reserve/parent coexistence NEEDS MANUAL FIX (game {$game->id})",
+            $body,
+            ['game_id' => $game->id, 'outcome' => 'unhealable'],
+        );
+    }
+
+    /**
+     * @param  array<string, mixed>  $logContext
+     */
+    private function send(string $rateKey, string $subject, string $body, array $logContext): void
+    {
+        try {
+            // Distinct rate-limiter keys per outcome so a flood of one does not
+            // suppress the other. One mail per outcome per 5 minutes.
+            RateLimiter::attempt(
+                $rateKey,
+                1,
+                fn () => Mail::raw($body, function ($message) use ($subject) {
+                    $message->to(config('mail.from.address'))->subject($subject);
+                }),
+                300,
+            );
+        } catch (\Throwable $e) {
+            Log::error('Failed to send reserve coexistence heal alert', $logContext + [
+                'mail_error' => $e->getMessage(),
+            ]);
+        }
+    }
+}

--- a/app/Modules/Season/Processors/PromotionRelegationProcessor.php
+++ b/app/Modules/Season/Processors/PromotionRelegationProcessor.php
@@ -9,15 +9,20 @@ use App\Models\GameMatch;
 use App\Models\GameStanding;
 use App\Modules\Competition\Enums\PlayoffState;
 use App\Modules\Competition\Exceptions\PlayoffInProgressException;
+use App\Modules\Competition\Exceptions\ReserveParentCoexistenceException;
 use App\Modules\Competition\Playoffs\PlayoffGeneratorFactory;
 use App\Modules\Competition\Promotions\CountryPromotionRelegationPlanner;
 use App\Modules\Competition\Promotions\CountrySeasonSnapshotBuilder;
 use App\Modules\Competition\Promotions\PromotionMove;
 use App\Modules\Competition\Promotions\PromotionRelegationExecutor;
 use App\Modules\Competition\Promotions\PromotionRelegationPlan;
+use App\Modules\Competition\Promotions\RepairOutcome;
+use App\Modules\Competition\Promotions\ReserveParentCoexistenceRepairer;
 use App\Modules\Competition\Services\CountryConfig;
+use App\Modules\Season\Alerts\ReserveCoexistenceHealAlert;
 use App\Modules\Season\Contracts\SeasonProcessor;
 use App\Modules\Season\DTOs\SeasonTransitionData;
+use Illuminate\Support\Facades\DB;
 
 /**
  * Closing-pipeline processor for promotion/relegation.
@@ -51,6 +56,8 @@ class PromotionRelegationProcessor implements SeasonProcessor
         private readonly PromotionRelegationExecutor $executor,
         private readonly PlayoffGeneratorFactory $playoffFactory,
         private readonly CountryConfig $countryConfig,
+        private readonly ReserveParentCoexistenceRepairer $coexistenceRepairer,
+        private readonly ReserveCoexistenceHealAlert $healAlert,
     ) {}
 
     public function priority(): int
@@ -77,7 +84,37 @@ class PromotionRelegationProcessor implements SeasonProcessor
         }
 
         $snapshot = $this->snapshotBuilder->build($game);
-        $plan = $this->planner->planFromSnapshot($snapshot, $config);
+
+        try {
+            $plan = $this->planner->planFromSnapshot($snapshot, $config);
+        } catch (ReserveParentCoexistenceException $e) {
+            // In-band self-heal: a prior incomplete transition can leave a
+            // reserve coexisting with (or inverted above) its parent in the
+            // snapshot, which the planner refuses to plan around. Attempt a
+            // single deterministic repair, then replan exactly once. Everything
+            // here runs inside the pipeline's per-processor DB::transaction, so
+            // the repair is atomic with the rest of the processor.
+            $result = $this->coexistenceRepairer->repair($game);
+
+            if ($result->outcome !== RepairOutcome::Repaired) {
+                // Nothing safe to do (ambiguous corruption, or no fixable issue
+                // detected). Alert and rethrow the original so the job fails and
+                // the operator's manual repair path takes over.
+                $this->healAlert->unhealable($game, $e, $result);
+                throw $e;
+            }
+
+            // Replan against the repaired DB state. Deliberately NOT wrapped:
+            // if the swap did not actually resolve the violation, this throws
+            // again and propagates — single-shot, never a retry loop.
+            $snapshot = $this->snapshotBuilder->build($game);
+            $plan = $this->planner->planFromSnapshot($snapshot, $config);
+
+            // Fire the success alert only once the transaction commits, so a
+            // later rollback (e.g. the post-execution invariant below) doesn't
+            // leave us claiming a heal that was undone.
+            DB::afterCommit(fn () => $this->healAlert->healed($game, $result));
+        }
 
         $this->executor->apply($plan, $game);
 

--- a/tests/Feature/PromotionRelegationSelfHealTest.php
+++ b/tests/Feature/PromotionRelegationSelfHealTest.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Competition;
+use App\Models\Game;
+use App\Models\Team;
+use App\Models\User;
+use App\Modules\Competition\Exceptions\ReserveParentCoexistenceException;
+use App\Modules\Competition\Promotions\CountryPromotionRelegationPlanner;
+use App\Modules\Competition\Promotions\PromotionRelegationPlan;
+use App\Modules\Competition\Promotions\ReserveParentCoexistenceRepairer;
+use App\Modules\Competition\Promotions\ReserveRepairResult;
+use App\Modules\Season\Alerts\ReserveCoexistenceHealAlert;
+use App\Modules\Season\DTOs\SeasonTransitionData;
+use App\Modules\Season\Processors\PromotionRelegationProcessor;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Mockery;
+use Tests\TestCase;
+
+/**
+ * Control-flow tests for the in-band self-heal branch added to
+ * {@see PromotionRelegationProcessor}. The planner, repairer, and alert are
+ * mocked so each branch (heal+replan, unsafe rethrow, single-shot replan
+ * failure) is exercised precisely — the planner's own behaviour and the
+ * repairer's DB mutations are covered by their dedicated test suites.
+ *
+ * Note: the success alert fires via DB::afterCommit, which does not run under
+ * RefreshDatabase (the wrapping transaction rolls back), so healed() is only
+ * asserted permissively here. The synchronous unhealable() path is asserted
+ * strictly.
+ */
+class PromotionRelegationSelfHealTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Game $game;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Competition::factory()->league()->create(['id' => 'ESP1', 'tier' => 1, 'handler_type' => 'league']);
+        Competition::factory()->league()->create(['id' => 'ESP2', 'tier' => 2, 'handler_type' => 'league_with_playoff']);
+        Competition::factory()->league()->create(['id' => 'ESP3A', 'tier' => 3, 'handler_type' => 'league_with_playoff']);
+        Competition::factory()->league()->create(['id' => 'ESP3B', 'tier' => 3, 'handler_type' => 'league_with_playoff']);
+        Competition::factory()->knockoutCup()->create(['id' => 'ESP3PO', 'tier' => 3]);
+
+        $user = User::factory()->create();
+        $team = Team::factory()->create(['country' => 'ES']);
+        $this->game = Game::factory()->create([
+            'user_id' => $user->id,
+            'team_id' => $team->id,
+            'competition_id' => 'ESP2',
+            'season' => '2025',
+            'country' => 'ES',
+        ]);
+    }
+
+    public function test_self_heals_then_replans_and_completes(): void
+    {
+        $planner = Mockery::mock(CountryPromotionRelegationPlanner::class);
+        $calls = 0;
+        $planner->shouldReceive('planFromSnapshot')->twice()->andReturnUsing(function () use (&$calls) {
+            $calls++;
+            if ($calls === 1) {
+                throw $this->coexistenceException();
+            }
+            return $this->emptyPlan();
+        });
+
+        $repairer = Mockery::mock(ReserveParentCoexistenceRepairer::class);
+        $repairer->shouldReceive('repair')->once()->andReturn(ReserveRepairResult::repaired([], []));
+
+        $alert = Mockery::mock(ReserveCoexistenceHealAlert::class);
+        // healed() is scheduled via DB::afterCommit; under RefreshDatabase it
+        // never fires, so we only forbid the failure alert here.
+        $alert->shouldReceive('healed')->zeroOrMoreTimes();
+        $alert->shouldNotReceive('unhealable');
+
+        $result = $this->runProcessor($planner, $repairer, $alert);
+
+        $this->assertInstanceOf(SeasonTransitionData::class, $result);
+    }
+
+    public function test_rethrows_and_alerts_when_repair_is_unsafe(): void
+    {
+        $planner = Mockery::mock(CountryPromotionRelegationPlanner::class);
+        // Only the first plan attempt — no replan when the repair is unsafe.
+        $planner->shouldReceive('planFromSnapshot')->once()->andThrow($this->coexistenceException());
+
+        $repairer = Mockery::mock(ReserveParentCoexistenceRepairer::class);
+        $repairer->shouldReceive('repair')->once()->andReturn(
+            ReserveRepairResult::unsafe('tier has siblings — manual swap target required'),
+        );
+
+        $alert = Mockery::mock(ReserveCoexistenceHealAlert::class);
+        $alert->shouldReceive('unhealable')->once();
+        $alert->shouldNotReceive('healed');
+
+        $this->bind($planner, $repairer, $alert);
+
+        $this->expectException(ReserveParentCoexistenceException::class);
+        $this->app->make(PromotionRelegationProcessor::class)->process($this->game, $this->data());
+    }
+
+    public function test_replan_failure_propagates_without_looping(): void
+    {
+        $planner = Mockery::mock(CountryPromotionRelegationPlanner::class);
+        // Throws on both the initial plan and the single replan — never a 3rd.
+        $planner->shouldReceive('planFromSnapshot')->twice()->andThrow($this->coexistenceException());
+
+        $repairer = Mockery::mock(ReserveParentCoexistenceRepairer::class);
+        $repairer->shouldReceive('repair')->once()->andReturn(ReserveRepairResult::repaired([], []));
+
+        $alert = Mockery::mock(ReserveCoexistenceHealAlert::class);
+        $alert->shouldNotReceive('healed');
+        $alert->shouldNotReceive('unhealable');
+
+        $this->bind($planner, $repairer, $alert);
+
+        $this->expectException(ReserveParentCoexistenceException::class);
+        $this->app->make(PromotionRelegationProcessor::class)->process($this->game, $this->data());
+    }
+
+    private function runProcessor(
+        CountryPromotionRelegationPlanner $planner,
+        ReserveParentCoexistenceRepairer $repairer,
+        ReserveCoexistenceHealAlert $alert,
+    ): SeasonTransitionData {
+        $this->bind($planner, $repairer, $alert);
+
+        return $this->app->make(PromotionRelegationProcessor::class)->process($this->game, $this->data());
+    }
+
+    private function bind(
+        CountryPromotionRelegationPlanner $planner,
+        ReserveParentCoexistenceRepairer $repairer,
+        ReserveCoexistenceHealAlert $alert,
+    ): void {
+        $this->app->instance(CountryPromotionRelegationPlanner::class, $planner);
+        $this->app->instance(ReserveParentCoexistenceRepairer::class, $repairer);
+        $this->app->instance(ReserveCoexistenceHealAlert::class, $alert);
+    }
+
+    private function coexistenceException(): ReserveParentCoexistenceException
+    {
+        return ReserveParentCoexistenceException::forViolations([
+            ['reserve' => 'reserve-x', 'parent' => 'parent-y', 'competition' => 'ESP2'],
+        ]);
+    }
+
+    private function emptyPlan(): PromotionRelegationPlan
+    {
+        return new PromotionRelegationPlan('ES', [], [], []);
+    }
+
+    private function data(): SeasonTransitionData
+    {
+        return new SeasonTransitionData(oldSeason: '2025', newSeason: '2026', competitionId: 'ESP2');
+    }
+}

--- a/tests/Feature/ReserveCoexistenceHealAlertTest.php
+++ b/tests/Feature/ReserveCoexistenceHealAlertTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Game;
+use App\Modules\Competition\Promotions\ReserveRepairResult;
+use App\Modules\Season\Alerts\ReserveCoexistenceHealAlert;
+use Illuminate\Support\Facades\Mail;
+use Tests\TestCase;
+
+class ReserveCoexistenceHealAlertTest extends TestCase
+{
+    public function test_healed_and_unhealable_build_and_send_without_throwing(): void
+    {
+        Mail::fake();
+
+        $game = new Game();
+        $game->id = 'game-uuid';
+        $game->country = 'ES';
+        $game->season = '2025';
+
+        $alert = app(ReserveCoexistenceHealAlert::class);
+
+        $repaired = ReserveRepairResult::repaired([], [
+            ['swap' => ['reason' => 'INVERTED: Reserve <-> Parent'], 'slotA' => [], 'slotB' => []],
+        ]);
+        $unsafe = ReserveRepairResult::unsafe('tier has siblings — manual swap target required');
+
+        // The alert wraps mail in a fail-soft try/catch; both message builders
+        // (including swapSummaries rendering) must run cleanly.
+        $alert->healed($game, $repaired);
+        $alert->unhealable($game, new \RuntimeException('planner blew up'), $unsafe);
+
+        $this->assertTrue(true);
+    }
+}

--- a/tests/Feature/ReserveParentCoexistenceRepairerTest.php
+++ b/tests/Feature/ReserveParentCoexistenceRepairerTest.php
@@ -1,0 +1,260 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Competition;
+use App\Models\CompetitionEntry;
+use App\Models\Game;
+use App\Models\GameStanding;
+use App\Models\SimulatedSeason;
+use App\Models\Team;
+use App\Models\User;
+use App\Modules\Competition\Promotions\RepairOutcome;
+use App\Modules\Competition\Promotions\ReserveParentCoexistenceRepairer;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+/**
+ * Direct tests for the extracted repair service. Tier maps come from the
+ * (config-driven) Spain CountryConfig — ESP1=tier1, ESP2=tier2,
+ * ESP3A/ESP3B=tier3 — so only the per-game DB state is seeded here.
+ */
+class ReserveParentCoexistenceRepairerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Game $game;
+    private ReserveParentCoexistenceRepairer $repairer;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Competition::factory()->league()->create(['id' => 'ESP1', 'tier' => 1, 'handler_type' => 'league']);
+        Competition::factory()->league()->create(['id' => 'ESP2', 'tier' => 2, 'handler_type' => 'league_with_playoff']);
+        Competition::factory()->league()->create(['id' => 'ESP3A', 'tier' => 3, 'handler_type' => 'league_with_playoff']);
+        Competition::factory()->league()->create(['id' => 'ESP3B', 'tier' => 3, 'handler_type' => 'league_with_playoff']);
+
+        $user = User::factory()->create();
+        $team = Team::factory()->create(['country' => 'ES']);
+        $this->game = Game::factory()->create([
+            'user_id' => $user->id,
+            'team_id' => $team->id,
+            'competition_id' => 'ESP2',
+            'season' => '2025',
+            'country' => 'ES',
+        ]);
+
+        $this->repairer = app(ReserveParentCoexistenceRepairer::class);
+    }
+
+    public function test_plan_returns_nothing_to_fix_for_healthy_hierarchy(): void
+    {
+        [$parent, $reserve] = $this->reservePair();
+        $this->entry('ESP2', $parent->id);
+        $this->standing('ESP2', $parent->id, 5);
+        $this->entry('ESP3A', $reserve->id);
+        $this->standing('ESP3A', $reserve->id, 5);
+
+        $result = $this->repairer->plan($this->game);
+
+        $this->assertSame(RepairOutcome::NothingToFix, $result->outcome);
+    }
+
+    public function test_repair_swaps_inverted_reserve_and_parent(): void
+    {
+        [$parent, $reserve] = $this->reservePair();
+        // Inverted: reserve wrongly above parent (reserve ESP1, parent ESP2).
+        $this->entry('ESP1', $reserve->id);
+        $this->standing('ESP1', $reserve->id, 8);
+        $this->entry('ESP2', $parent->id);
+        $this->standing('ESP2', $parent->id, 4);
+
+        $result = $this->repairer->repair($this->game);
+
+        $this->assertSame(RepairOutcome::Repaired, $result->outcome);
+        // Hierarchy restored: parent above reserve.
+        $this->assertEntry('ESP1', $parent->id);
+        $this->assertEntry('ESP2', $reserve->id);
+        $this->assertNotEntry('ESP1', $reserve->id);
+        // Standings team_id swapped, positions preserved.
+        $this->assertSame($parent->id, $this->teamAt('ESP1', 8));
+        $this->assertSame($reserve->id, $this->teamAt('ESP2', 4));
+    }
+
+    public function test_repair_resolves_coexistence_by_promoting_parent(): void
+    {
+        [$parent, $reserve] = $this->reservePair();
+        // Both in ESP2.
+        $this->entry('ESP2', $parent->id);
+        $this->standing('ESP2', $parent->id, 6);
+        $this->entry('ESP2', $reserve->id);
+        $this->standing('ESP2', $reserve->id, 12);
+        // ESP1 bottom team to swap the parent up with.
+        $esp1Bottom = Team::factory()->create(['country' => 'ES']);
+        $this->entry('ESP1', $esp1Bottom->id);
+        $this->standing('ESP1', $esp1Bottom->id, 20);
+
+        $result = $this->repairer->repair($this->game);
+
+        $this->assertSame(RepairOutcome::Repaired, $result->outcome);
+        // Parent rises to ESP1; displaced bottom team drops to ESP2; reserve stays.
+        $this->assertEntry('ESP1', $parent->id);
+        $this->assertEntry('ESP2', $esp1Bottom->id);
+        $this->assertEntry('ESP2', $reserve->id);
+        $this->assertNotEntry('ESP2', $parent->id);
+    }
+
+    public function test_repair_handles_simulated_league_slots(): void
+    {
+        [$parent, $reserve] = $this->reservePair();
+        // Coexist in ESP2 (played standings).
+        $this->entry('ESP2', $parent->id);
+        $this->standing('ESP2', $parent->id, 6);
+        $this->entry('ESP2', $reserve->id);
+        $this->standing('ESP2', $reserve->id, 12);
+        // ESP1 is simulated (no game_standings) — exercises the sim-slot path.
+        $a = Team::factory()->create(['country' => 'ES']);
+        $b = Team::factory()->create(['country' => 'ES']);
+        $this->entry('ESP1', $a->id);
+        $this->entry('ESP1', $b->id);
+        SimulatedSeason::create([
+            'game_id' => $this->game->id, 'season' => '2025', 'competition_id' => 'ESP1', 'results' => [$a->id, $b->id],
+        ]);
+
+        $result = $this->repairer->repair($this->game);
+
+        $this->assertSame(RepairOutcome::Repaired, $result->outcome);
+        // Parent took the bottom sim slot (was $b); $b dropped to ESP2.
+        $sim = SimulatedSeason::where('game_id', $this->game->id)->where('competition_id', 'ESP1')->first();
+        $this->assertSame([$a->id, $parent->id], $sim->results);
+        $this->assertEntry('ESP1', $parent->id);
+        $this->assertEntry('ESP2', $b->id);
+    }
+
+    public function test_plan_is_unsafe_when_a_team_has_multiple_league_entries(): void
+    {
+        [$parent, $reserve] = $this->reservePair();
+        $this->entry('ESP1', $reserve->id);
+        $this->entry('ESP2', $reserve->id); // multi-league corruption
+        $this->entry('ESP2', $parent->id);
+
+        $result = $this->repairer->plan($this->game);
+
+        $this->assertSame(RepairOutcome::Unsafe, $result->outcome);
+        $this->assertStringContainsString('multiple league entries', (string) $result->reason);
+    }
+
+    public function test_plan_is_unsafe_for_coexistence_in_top_tier(): void
+    {
+        [$parent, $reserve] = $this->reservePair();
+        // Both in ESP1 — there is no higher tier to swap the parent up into.
+        $this->entry('ESP1', $parent->id);
+        $this->standing('ESP1', $parent->id, 3);
+        $this->entry('ESP1', $reserve->id);
+        $this->standing('ESP1', $reserve->id, 9);
+
+        $result = $this->repairer->plan($this->game);
+
+        $this->assertSame(RepairOutcome::Unsafe, $result->outcome);
+        $this->assertStringContainsString('no higher tier', (string) $result->reason);
+    }
+
+    public function test_plan_is_unsafe_when_slot_cannot_be_located(): void
+    {
+        [$parent, $reserve] = $this->reservePair();
+        // Inverted entries present but no standings/sim rows to swap.
+        $this->entry('ESP1', $reserve->id);
+        $this->entry('ESP2', $parent->id);
+
+        $result = $this->repairer->plan($this->game);
+
+        $this->assertSame(RepairOutcome::Unsafe, $result->outcome);
+        $this->assertStringContainsString('Cannot locate slot', (string) $result->reason);
+    }
+
+    public function test_apply_throws_when_entry_row_count_is_not_one(): void
+    {
+        [$parent, $reserve] = $this->reservePair();
+        $this->entry('ESP1', $reserve->id);
+        $this->standing('ESP1', $reserve->id, 8);
+        $this->entry('ESP2', $parent->id);
+        $this->standing('ESP2', $parent->id, 4);
+
+        $plan = $this->repairer->plan($this->game);
+        $this->assertSame(RepairOutcome::Repaired, $plan->outcome);
+
+        // Corrupt the state between plan and apply so the entry update hits 0 rows.
+        CompetitionEntry::where('game_id', $this->game->id)
+            ->where('team_id', $reserve->id)
+            ->where('competition_id', 'ESP1')
+            ->delete();
+
+        $this->expectException(\RuntimeException::class);
+        DB::transaction(fn () => $this->repairer->apply($this->game, $plan));
+    }
+
+    /**
+     * @return array{0: Team, 1: Team} [parent, reserve]
+     */
+    private function reservePair(): array
+    {
+        $parent = Team::factory()->create(['country' => 'ES']);
+        $reserve = Team::factory()->create(['country' => 'ES', 'parent_team_id' => $parent->id]);
+
+        return [$parent, $reserve];
+    }
+
+    private function entry(string $competitionId, string $teamId): void
+    {
+        CompetitionEntry::create([
+            'game_id' => $this->game->id,
+            'competition_id' => $competitionId,
+            'team_id' => $teamId,
+            'entry_round' => 1,
+        ]);
+    }
+
+    private function standing(string $competitionId, string $teamId, int $position): void
+    {
+        GameStanding::create([
+            'game_id' => $this->game->id,
+            'competition_id' => $competitionId,
+            'team_id' => $teamId,
+            'position' => $position,
+            'played' => 10, 'won' => 5, 'drawn' => 2, 'lost' => 3,
+            'goals_for' => 15, 'goals_against' => 10, 'points' => 17,
+        ]);
+    }
+
+    private function assertEntry(string $competitionId, string $teamId): void
+    {
+        $this->assertTrue(
+            CompetitionEntry::where('game_id', $this->game->id)
+                ->where('competition_id', $competitionId)
+                ->where('team_id', $teamId)
+                ->exists(),
+            "Expected {$teamId} to have a {$competitionId} entry.",
+        );
+    }
+
+    private function assertNotEntry(string $competitionId, string $teamId): void
+    {
+        $this->assertFalse(
+            CompetitionEntry::where('game_id', $this->game->id)
+                ->where('competition_id', $competitionId)
+                ->where('team_id', $teamId)
+                ->exists(),
+            "Expected {$teamId} to NOT have a {$competitionId} entry.",
+        );
+    }
+
+    private function teamAt(string $competitionId, int $position): ?string
+    {
+        return GameStanding::where('game_id', $this->game->id)
+            ->where('competition_id', $competitionId)
+            ->where('position', $position)
+            ->value('team_id');
+    }
+}

--- a/tests/Feature/SalaryCapEnforcementTest.php
+++ b/tests/Feature/SalaryCapEnforcementTest.php
@@ -178,11 +178,18 @@ class SalaryCapEnforcementTest extends TestCase
         // is always a willing destination and the reputation gate passes —
         // isolating the salary cap as the only thing that can block the deal.
         // (The factory derives `tier` from a random value, so pin it explicitly.)
+        //
+        // Pin `overall_score` too: the factory randomises it (40–90) and the
+        // wage demand is computed deterministically off ability, so an unpinned
+        // overall makes the demand swing wildly and can intermittently breach
+        // the modest (€6M) cap room the "allowed" cases rely on. A low ability
+        // keeps the demand comfortably under that room.
         return GamePlayer::factory()->age(26)->create([
             'game_id' => $game->id,
             'team_id' => null,
             'market_value_cents' => 20_000_000, // €200K
             'tier' => 1,
+            'overall_score' => 50,
         ]);
     }
 }

--- a/tests/Unit/ReserveParentCoexistenceExceptionTest.php
+++ b/tests/Unit/ReserveParentCoexistenceExceptionTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Modules\Competition\Exceptions\ReserveParentCoexistenceException;
+use PHPUnit\Framework\TestCase;
+
+class ReserveParentCoexistenceExceptionTest extends TestCase
+{
+    public function test_for_violations_builds_message_and_exposes_tuples(): void
+    {
+        $violations = [
+            ['reserve' => 'r1', 'parent' => 'p1', 'competition' => 'ESP2'],
+            ['reserve' => 'r2', 'parent' => 'p2', 'competition' => 'ESP3A'],
+        ];
+
+        $e = ReserveParentCoexistenceException::forViolations($violations);
+
+        // Historical prefix preserved so existing log searches keep matching.
+        $this->assertStringContainsString('Planner produced a coexistence violation:', $e->getMessage());
+        $this->assertStringContainsString('reserve=r1 parent=p1 competition=ESP2', $e->getMessage());
+        $this->assertStringContainsString('reserve=r2 parent=p2 competition=ESP3A', $e->getMessage());
+        $this->assertSame($violations, $e->violations());
+    }
+
+    public function test_is_a_logic_exception_so_existing_catch_sites_still_work(): void
+    {
+        $e = ReserveParentCoexistenceException::forViolations([
+            ['reserve' => 'r', 'parent' => 'p', 'competition' => 'ESP2'],
+        ]);
+
+        $this->assertInstanceOf(\LogicException::class, $e);
+    }
+}


### PR DESCRIPTION
## Summary

Extracts the reserve/parent league corruption detection and repair logic from the `RepairReserveParentCoexistence` command into a standalone `ReserveParentCoexistenceRepairer` service. This enables reuse in the season transition pipeline for in-band self-healing, while keeping the command as a thin CLI wrapper for manual operator intervention.

## Key Changes

- **New `ReserveParentCoexistenceRepairer` service** (`app/Modules/Competition/Promotions/`)
  - Detects INVERTED (reserve above parent) and COEXISTENCE (reserve and parent in same league) violations
  - Plans deterministic 1:1 league swaps without writing to the database
  - Applies swaps to `competition_entries`, `game_standings`, and `simulated_seasons` rows
  - Returns structured `ReserveRepairResult` with outcome, issues, and mutations
  - Deliberately conservative: returns `Unsafe` rather than guessing when multi-league corruption, sibling tiers, or unlocatable slots are encountered

- **New `ReserveRepairResult` and `RepairOutcome`** value objects
  - `RepairOutcome` enum: `NothingToFix`, `Repaired`, `Unsafe`
  - `ReserveRepairResult` carries detected issues, resolved mutations, and human-readable reason for unsafe cases
  - Enables callers (processor, command, alert) to distinguish outcomes without exception handling

- **New `ReserveParentCoexistenceException`** (extends `LogicException`)
  - Thrown by `CountryPromotionRelegationPlanner::validatePlan` when a plan would leave a reserve coexisting with its parent
  - Carries violation tuples for structured error reporting
  - Extends `LogicException` so existing catch sites remain compatible

- **In-band self-heal in `PromotionRelegationProcessor`**
  - Catches `ReserveParentCoexistenceException` from the planner's first attempt
  - Calls `repairer->repair()` in a transaction
  - If successful, replans once and continues the pipeline
  - If unsafe, alerts and rethrows; if replan fails, rethrows without looping
  - Prevents single-shot replan failures from triggering infinite retry

- **New `ReserveCoexistenceHealAlert`** for admin notification
  - Fires on both successful heal (for visibility into planner bugs) and unhealable violations (for manual intervention)
  - Rate-limited, fail-soft mail pattern (mail outage never breaks a transition)
  - Includes swap summaries and remediation commands

- **Refactored `RepairReserveParentCoexistence` command**
  - Now delegates all logic to `ReserveParentCoexistenceRepairer`
  - Enforces operator-facing guards (game at pre-PromotionRelegation step)
  - Prints planned swaps and only writes when `--apply` is passed
  - Defaults to dry-run for safety

## Implementation Details

- **Tier maps** built once from `CountryConfig` (league tiers only; cups and continentals excluded)
- **Slot location** handles both played leagues (`game_standings`) and simulated leagues (`simulated_seasons.results` array)
- **INVERTED swaps** restore hierarchy with no displacement of unrelated teams
- **COEXISTENCE swaps** promote the parent to the next-higher tier, displacing the bottom team of that tier into the shared tier (requires single competition at that tier)
- **No transaction ownership**: repairer is transaction-agnostic; callers supply one (pipeline's per-processor transaction in-band, or command's `DB::transaction` on `--apply`)
- **Comprehensive test coverage**: unit tests for the repairer, integration tests for the processor's self-heal branches, and alert tests

## Testing

- `ReserveParentCoexistenceRepairerTest`: direct service tests (healthy hierarchy, INVERTED swap, COEXISTENCE swap, simulated slots, unsafe cases)
- `PromotionRelegationSelfHealTest`: control-flow tests for processor

https://claude.ai/code/session_012pGsVwJLkCgbxdXjxzDuSj