### PR TITLE
Show release clause as the market reference in mandatory-clause countries

### DIFF
--- a/app/Http/Views/ShowOutgoingTransfers.php
+++ b/app/Http/Views/ShowOutgoingTransfers.php
@@ -32,7 +32,7 @@ class ShowOutgoingTransfers
         $this->transferService->expireOffers($game);
 
         // Get all pending offers for user's players
-        $pendingOffers = TransferOffer::with(['gamePlayer.team', 'offeringTeam'])
+        $pendingOffers = TransferOffer::with(['gamePlayer.team', 'gamePlayer.activeLoan.parentTeam', 'offeringTeam'])
             ->where('game_id', $gameId)
             ->where('status', TransferOffer::STATUS_PENDING)
             ->whereHas('gamePlayer', function ($query) use ($game) {
@@ -82,6 +82,7 @@ class ShowOutgoingTransfers
         // Get listed players (even those without offers, excluding those with agreed deals)
         $agreedPlayerIds = $agreedTransfers->pluck('game_player_id')->toArray();
         $listedPlayers = GamePlayer::query()
+            ->with(['team', 'activeLoan.parentTeam'])
             ->where('game_id', $gameId)
             ->where('team_id', $game->team_id)
             ->whereHas('transferListing', fn ($q) => $q->where('status', TransferListing::STATUS_LISTED))
@@ -109,7 +110,7 @@ class ShowOutgoingTransfers
 
         // Pending loan-out offers for the "Loan Offers Received" section.
         // Each offer is a separate card, same UX as sale offers.
-        $loanOffers = TransferOffer::with(['offeringTeam', 'gamePlayer'])
+        $loanOffers = TransferOffer::with(['offeringTeam', 'gamePlayer.team', 'gamePlayer.activeLoan.parentTeam'])
             ->where('game_id', $gameId)
             ->where('direction', TransferOffer::DIRECTION_OUTGOING)
             ->where('offer_type', TransferOffer::TYPE_LOAN_OUT)

--- a/app/Http/Views/ShowScoutReportResults.php
+++ b/app/Http/Views/ShowScoutReportResults.php
@@ -33,7 +33,7 @@ class ShowScoutReportResults
         ];
 
         if (!empty($report->player_ids)) {
-            $players = GamePlayer::with(['team'])
+            $players = GamePlayer::with(['team', 'activeLoan.parentTeam'])
                 ->whereIn('id', $report->player_ids)
                 ->where(fn ($q) => $q
                     ->whereNull('team_id')

--- a/app/Http/Views/ShowScoutingHub.php
+++ b/app/Http/Views/ShowScoutingHub.php
@@ -36,7 +36,7 @@ class ShowScoutingHub
 
         // Shortlisted players with intel-gated data
         $shortlistedEntries = ShortlistedPlayer::where('game_id', $gameId)
-            ->with(['gamePlayer.team'])
+            ->with(['gamePlayer.team', 'gamePlayer.activeLoan.parentTeam'])
             ->get();
 
         $shortlistedPlayers = [];
@@ -96,8 +96,15 @@ class ShowScoutingHub
                 'isFreeAgent' => $gp->team_id === null,
                 'isExpiring' => $gp->team_id !== null && $gp->contract_until && $gp->contract_until <= $game->getSeasonEndDate(),
                 'contractYear' => $gp->contract_until?->format('Y'),
+                // `marketValue` (cents) drives client-side sorting and
+                // `formattedMarketValue` feeds the negotiation modal — both stay
+                // the TRUE market value. The shortlist's displayed figure uses
+                // `marketReference`, which swaps to the release clause where that
+                // is the market reference (mandatory-clause clubs, e.g. Spain).
                 'marketValue' => $gp->market_value_cents,
                 'formattedMarketValue' => Money::format($gp->market_value_cents),
+                'marketReference' => $gp->marketReferenceValue($game),
+                'showsClause' => $gp->displaysReleaseClauseAsMarketReference($game),
                 'intelLevel' => $entry->intel_level,
                 'isTracking' => $entry->is_tracking,
                 'matchdaysTracked' => $entry->matchdays_tracked,

--- a/app/Models/GamePlayer.php
+++ b/app/Models/GamePlayer.php
@@ -670,6 +670,60 @@ class GamePlayer extends Model
     }
 
     /**
+     * The country of the club that OWNS this player (uppercase 2-char code).
+     * Ownership follows the loan parent: a loaned-in player is owned by the club
+     * he is on loan FROM, not the club he currently plays for. Mirrors the
+     * relationLoaded() guard in isUserOwned() so it never lazy-loads in a loop —
+     * callers rendering lists must eager-load `activeLoan.parentTeam` and `team`.
+     */
+    public function ownerCountry(): ?string
+    {
+        $loan = $this->relationLoaded('activeLoan')
+            ? $this->activeLoan
+            : $this->activeLoan()->first();
+
+        if ($loan) {
+            $parent = $loan->relationLoaded('parentTeam')
+                ? $loan->parentTeam
+                : $loan->parentTeam()->first();
+
+            if ($parent) {
+                return $parent->country;
+            }
+        }
+
+        return $this->team?->country;
+    }
+
+    /**
+     * Whether list surfaces should display this player's release clause in place
+     * of his market value. True only when the feature is enabled for the game,
+     * the player carries a clause (⟹ under contract), AND his owning club sits in
+     * a country where clauses are mandatory (config-driven, currently only ES).
+     * Gated on the mandatory-country list rather than merely "has a clause" so a
+     * non-mandatory club that opts into an optional clause still shows market
+     * value — the clause is the market reference only where it is mandatory.
+     */
+    public function displaysReleaseClauseAsMarketReference(Game $game): bool
+    {
+        return $game->release_clauses_enabled
+            && $this->hasReleaseClause()
+            && in_array($this->ownerCountry(), config('finances.release_clause.mandatory_countries', []), true);
+    }
+
+    /**
+     * The formatted value to show wherever a player's market value is listed: the
+     * release clause in mandatory-clause countries (see
+     * displaysReleaseClauseAsMarketReference), otherwise the market value.
+     */
+    public function marketReferenceValue(Game $game): string
+    {
+        return $this->displaysReleaseClauseAsMarketReference($game)
+            ? ($this->formatted_release_clause ?? $this->formatted_market_value)
+            : $this->formatted_market_value;
+    }
+
+    /**
      * Check if player can be offered a contract renewal.
      * Any squad player can be renewed (early or expiring), unless blocked by another condition.
      *

--- a/app/Modules/Squad/Services/SquadService.php
+++ b/app/Modules/Squad/Services/SquadService.php
@@ -30,8 +30,10 @@ class SquadService
         $isCareerMode = $game->isCareerMode();
         $gameId = $game->id;
 
-        // Get all players for user's team with relationships
-        $allPlayers = GamePlayer::with(['game', 'team', 'matchState', 'activeLoan', 'transferOffers', 'suspensions', 'activeRenewalNegotiation', 'latestRenewalNegotiation', 'careerRecord', 'transferListing'])
+        // Get all players for user's team with relationships. `activeLoan.parentTeam`
+        // is loaded so GamePlayer::ownerCountry() (used for the clause-vs-market-value
+        // display) resolves the owning club without a per-row query.
+        $allPlayers = GamePlayer::with(['game', 'team', 'matchState', 'activeLoan.parentTeam', 'transferOffers', 'suspensions', 'activeRenewalNegotiation', 'latestRenewalNegotiation', 'careerRecord', 'transferListing'])
             ->where('game_id', $gameId)
             ->where('team_id', $game->team_id)
             ->get();
@@ -224,6 +226,11 @@ class SquadService
             'academyCount' => $academyCount,
             'mvpCounts' => $mvpCounts,
             'playerFlags' => $playerFlags,
+            // Whether the user's club operates under mandatory release clauses
+            // (e.g. Spain): the squad is uniformly owned, so the value column
+            // relabels its header to "Cláusula" rather than tagging each row.
+            'squadUsesClauses' => $game->release_clauses_enabled
+                && in_array($game->country, config('finances.release_clause.mandatory_countries', []), true),
         ];
     }
 

--- a/app/Modules/Transfer/Services/ContractService.php
+++ b/app/Modules/Transfer/Services/ContractService.php
@@ -37,13 +37,6 @@ class ContractService
     private const DEFAULT_MINIMUM_WAGE = 10_000_000; // €100K
 
     /**
-     * Country whose clubs MUST carry a release clause on every contract
-     * (mirrors Royal Decree 1006/1985 — buyout clauses are mandatory in Spain).
-     * Team.country stores uppercase 2-char codes (England is 'EN').
-     */
-    private const RELEASE_CLAUSE_MANDATORY_COUNTRY = 'ES';
-
-    /**
      * Club reputation multiplier on top of the competition tier baseline.
      * Applied only at tier 3+ because La Liga and La Liga 2 have sector-wide
      * minimums that don't meaningfully vary by club ambition — tier-3 wages,
@@ -445,11 +438,15 @@ class ContractService
     }
 
     /**
-     * Whether clubs of this country must carry a release clause on every contract.
+     * Whether clubs of this country must carry a release clause on every contract
+     * (mirrors Royal Decree 1006/1985 — buyout clauses are mandatory in Spain).
+     * The mandatory-country list is shared with the display layer
+     * (GamePlayer::displaysReleaseClauseAsMarketReference) via config so the two
+     * never diverge. Team.country stores uppercase 2-char codes (England is 'EN').
      */
     private function isReleaseClauseMandatory(?string $clubCountry): bool
     {
-        return $clubCountry === self::RELEASE_CLAUSE_MANDATORY_COUNTRY;
+        return in_array($clubCountry, config('finances.release_clause.mandatory_countries', []), true);
     }
 
     // =========================================

--- a/app/Modules/Transfer/Services/ExploreService.php
+++ b/app/Modules/Transfer/Services/ExploreService.php
@@ -206,7 +206,7 @@ class ExploreService
     {
         $players = GamePlayer::where('game_id', $game->id)
             ->where('team_id', $teamId)
-            ->with(['team'])
+            ->with(['team', 'activeLoan.parentTeam'])
             ->get();
 
         $playerIds = $players->pluck('id')->toArray();
@@ -306,7 +306,7 @@ class ExploreService
     public function advancedSearch(Game $game, array $filters): array
     {
         $query = GamePlayer::where('game_id', $game->id)
-            ->with(['team']);
+            ->with(['team', 'activeLoan.parentTeam']);
 
         if (!empty($filters['name']) && mb_strlen($filters['name']) >= 2) {
             $needle = mb_strtolower($filters['name']);

--- a/app/Modules/Transfer/Services/TransferMarketService.php
+++ b/app/Modules/Transfer/Services/TransferMarketService.php
@@ -178,7 +178,7 @@ class TransferMarketService
             ->where('status', TransferOffer::STATUS_AGREED)
             ->pluck('game_player_id');
 
-        return TransferListing::with(['gamePlayer.team'])
+        return TransferListing::with(['gamePlayer.team', 'gamePlayer.activeLoan.parentTeam'])
             ->where('game_id', $game->id)
             ->whereNotIn('team_id', $game->userTeamIds())
             ->where('status', TransferListing::STATUS_LISTED)

--- a/config/finances.php
+++ b/config/finances.php
@@ -40,6 +40,13 @@ return [
     // clubs, optional elsewhere. Multipliers are bare floats (multiples of
     // market value), NOT cents.
     'release_clause' => [
+        // Countries whose clubs MUST carry a release clause on every contract
+        // (mirrors Royal Decree 1006/1985 — buyout clauses are mandatory in
+        // Spain). In these countries the clause, not the market value, is the
+        // figure the transfer market operates on, so list surfaces display it
+        // in place of market value. Team.country stores uppercase 2-char codes.
+        'mandatory_countries' => ['ES'],
+
         // Mandatory minimum clause for ES clubs, as a multiple of market value.
         // The derived default at every agreement equals this floor.
         'es_floor_multiplier' => 1.25,

--- a/lang/en/transfers.php
+++ b/lang/en/transfers.php
@@ -468,6 +468,9 @@ return [
 
     // Release clauses (cláusulas de rescisión)
     'release_clause' => 'Release clause',
+    // Shown in place of market value on list surfaces for mandatory-clause clubs.
+    'clause_short' => 'Clause',
+    'market_reference_is_clause' => 'Shown as the release clause — the buyout this market operates on.',
     'pay_release_clause' => 'Pay release clause',
     'clause_not_available' => 'This player has no release clause you can trigger.',
     'clause_exceeds_budget' => 'The release clause exceeds your available transfer budget.',

--- a/lang/es/transfers.php
+++ b/lang/es/transfers.php
@@ -473,6 +473,9 @@ return [
 
     // Release clauses (cláusulas de rescisión)
     'release_clause' => 'Cláusula de rescisión',
+    // Shown in place of market value on list surfaces for mandatory-clause clubs.
+    'clause_short' => 'Cláusula',
+    'market_reference_is_clause' => 'Se muestra la cláusula de rescisión, el importe con el que opera este mercado.',
     'pay_release_clause' => 'Pagar cláusula de rescisión',
     'clause_not_available' => 'Este jugador no tiene una cláusula de rescisión que puedas activar.',
     'clause_exceeds_budget' => 'La cláusula de rescisión supera tu presupuesto de fichajes disponible.',

--- a/resources/views/components/explore-player-row.blade.php
+++ b/resources/views/components/explore-player-row.blade.php
@@ -83,7 +83,7 @@ $showAskingPrice = $showAskingPrice ?? ($askingPrice !== null);
             @endif
             <span>{{ $player->age($game->current_date) }} {{ __('app.years') }}</span>
             <span>&middot;</span>
-            <span>{{ \App\Support\Money::format($player->market_value_cents) }}</span>
+            <span><x-player-market-value :player="$player" :game="$game" /></span>
             @if($showOvr)
                 <span>&middot;</span>
                 <span>OVR {{ $player->effective_rating }}</span>
@@ -125,8 +125,8 @@ $showAskingPrice = $showAskingPrice ?? ($askingPrice !== null);
         </div>
     </td>
     @endif
-    {{-- Market value --}}
-    <td class="py-2 pr-3 hidden md:table-cell text-text-secondary tabular-nums">{{ \App\Support\Money::format($player->market_value_cents) }}</td>
+    {{-- Market value (release clause where mandatory) --}}
+    <td class="py-2 pr-3 hidden md:table-cell text-text-secondary tabular-nums"><x-player-market-value :player="$player" :game="$game" /></td>
     @if($showContract)
     {{-- Contract --}}
     <td class="py-2 pr-3 hidden md:table-cell text-text-secondary tabular-nums">{{ $isFreeAgent ? '—' : ($player->contract_until?->year ?? '—') }}</td>

--- a/resources/views/components/player-market-value.blade.php
+++ b/resources/views/components/player-market-value.blade.php
@@ -1,0 +1,17 @@
+{{--
+    Renders a player's "market reference" value for list surfaces: the release
+    clause in mandatory-clause countries (e.g. Spain), otherwise the market
+    value. The swap decision and the formatted value both come from the
+    GamePlayer model (single source of truth).
+
+    On mixed-owner lists (explore, scouting) leave `tooltip` on so swapped values
+    are flagged with an info icon. On uniform user-owned lists (your own squad)
+    pass `:tooltip="false"` and relabel the column header to "Cláusula" instead.
+--}}
+@props(['player', 'game', 'tooltip' => true])
+
+@if($tooltip && $player->displaysReleaseClauseAsMarketReference($game))
+<span class="inline-flex items-center gap-1">{{ $player->marketReferenceValue($game) }}<x-info-icon :tooltip="__('transfers.market_reference_is_clause')" /></span>
+@else
+{{ $player->marketReferenceValue($game) }}
+@endif

--- a/resources/views/design-system/sections/game-components.blade.php
+++ b/resources/views/design-system/sections/game-components.blade.php
@@ -122,6 +122,73 @@
         </div>
     </div>
 
+    {{-- Player Market Value --}}
+    <div class="mb-12">
+        <h3 class="text-lg font-semibold text-text-primary mb-2">Player Market Value <code class="text-xs text-accent-blue font-mono">&lt;x-player-market-value&gt;</code></h3>
+        <p class="text-sm text-text-secondary mb-4">Renders a player's "market reference" figure for list surfaces: the <strong>release clause</strong> in countries where clauses are mandatory (e.g. Spain), otherwise the <strong>market value</strong>. The swap decision and the formatted value both come from the <code class="text-xs bg-surface-700 px-1.5 py-0.5 rounded-sm text-text-body">GamePlayer</code> model, so display and clause-calculation never diverge. On mixed-owner lists (explore, scouting) a swapped value is flagged with an info-icon tooltip; on a uniform own-squad list pass <code class="text-xs bg-surface-700 px-1.5 py-0.5 rounded-sm text-text-body">:tooltip="false"</code> and relabel the column header to "Cláusula" instead.</p>
+
+        {{-- Visual anatomy --}}
+        <div class="bg-surface-700/30 border border-border-default rounded-xl p-6 mb-3">
+            <div class="flex items-center gap-10">
+                <div class="text-center">
+                    <div class="text-text-secondary tabular-nums">&euro; 45M</div>
+                    <div class="text-[10px] text-text-muted mt-1.5">Market value (non-mandatory club)</div>
+                </div>
+                <div class="text-center">
+                    <div class="inline-flex items-center gap-1 text-text-secondary tabular-nums">&euro; 80M <x-info-icon :tooltip="__('transfers.market_reference_is_clause')" /></div>
+                    <div class="text-[10px] text-text-muted mt-1.5">Release clause (mandatory club, tooltip on)</div>
+                </div>
+            </div>
+        </div>
+
+        {{-- Props table --}}
+        <div class="overflow-x-auto mt-4 mb-3">
+            <table class="w-full text-sm">
+                <thead class="text-left border-b border-border-strong">
+                    <tr>
+                        <th class="text-[10px] text-text-muted uppercase tracking-wider font-semibold py-2 pr-4">Prop</th>
+                        <th class="text-[10px] text-text-muted uppercase tracking-wider font-semibold py-2 pr-4">Type</th>
+                        <th class="text-[10px] text-text-muted uppercase tracking-wider font-semibold py-2 pr-4">Default</th>
+                        <th class="text-[10px] text-text-muted uppercase tracking-wider font-semibold py-2">Description</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr class="border-b border-border-default">
+                        <td class="py-2 pr-4 font-mono text-xs text-accent-blue">player</td>
+                        <td class="py-2 pr-4 text-text-secondary">GamePlayer</td>
+                        <td class="py-2 pr-4 font-mono text-xs text-text-muted">—</td>
+                        <td class="py-2 text-text-secondary">Player to value. Eager-load <code class="text-xs">team</code> + <code class="text-xs">activeLoan.parentTeam</code> to avoid N+1.</td>
+                    </tr>
+                    <tr class="border-b border-border-default">
+                        <td class="py-2 pr-4 font-mono text-xs text-accent-blue">game</td>
+                        <td class="py-2 pr-4 text-text-secondary">Game</td>
+                        <td class="py-2 pr-4 font-mono text-xs text-text-muted">—</td>
+                        <td class="py-2 text-text-secondary">Game (provides the release_clauses_enabled flag)</td>
+                    </tr>
+                    <tr class="border-b border-border-default">
+                        <td class="py-2 pr-4 font-mono text-xs text-accent-blue">tooltip</td>
+                        <td class="py-2 pr-4 text-text-secondary">bool</td>
+                        <td class="py-2 pr-4 font-mono text-xs text-text-muted">true</td>
+                        <td class="py-2 text-text-secondary">Show the info-icon on swapped values (mixed lists). Pass false on uniform lists that relabel the header.</td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+
+        <div x-data="{ copied: false }" class="relative">
+            <button @click="navigator.clipboard.writeText($refs.marketValueCode.textContent); copied = true; setTimeout(() => copied = false, 2000)"
+                    class="absolute top-3 right-3 px-2 py-1 text-[10px] font-medium text-text-secondary hover:text-slate-200 bg-surface-600 rounded-sm transition-colors">
+                <span x-show="!copied">Copy</span>
+                <span x-show="copied" x-cloak class="text-accent-green">Copied!</span>
+            </button>
+            <pre class="bg-surface-700 text-text-body rounded-lg p-4 overflow-x-auto text-xs leading-relaxed"><code x-ref="marketValueCode">&lt;!-- Mixed-owner list (explore, scouting): tooltip flags swapped values --&gt;
+&lt;x-player-market-value :player="$player" :game="$game" /&gt;
+
+&lt;!-- Uniform own-squad list: no per-row icon, relabel the column header instead --&gt;
+&lt;x-player-market-value :player="$gp" :game="$game" :tooltip="false" /&gt;</code></pre>
+        </div>
+    </div>
+
     {{-- Summary Card --}}
     <div class="mb-12">
         <h3 class="text-lg font-semibold text-text-primary mb-2">Summary Card</h3>

--- a/resources/views/outgoing-transfers.blade.php
+++ b/resources/views/outgoing-transfers.blade.php
@@ -115,7 +115,7 @@
                                                     </div>
                                                     <div class="text-sm text-text-secondary">
                                                         {{ $offer->gamePlayer->position_name }} &middot; {{ $offer->gamePlayer->age($game->current_date) }} {{ __('app.years') }} &middot;
-                                                        {{ __('app.value') }}: {{ $offer->gamePlayer->formatted_market_value }}
+                                                        {{ $offer->gamePlayer->displaysReleaseClauseAsMarketReference($game) ? __('transfers.release_clause') : __('app.value') }}: {{ $offer->gamePlayer->marketReferenceValue($game) }}
                                                     </div>
                                                 </div>
                                             </div>
@@ -237,7 +237,7 @@
                                                     </div>
                                                     <div class="text-sm text-text-secondary">
                                                         {{ $offer->gamePlayer->position_name }} &middot; {{ $offer->gamePlayer->age($game->current_date) }} {{ __('app.years') }} &middot;
-                                                        {{ __('app.value') }}: {{ $offer->gamePlayer->formatted_market_value }}
+                                                        {{ $offer->gamePlayer->displaysReleaseClauseAsMarketReference($game) ? __('transfers.release_clause') : __('app.value') }}: {{ $offer->gamePlayer->marketReferenceValue($game) }}
                                                     </div>
                                                 </div>
                                             </div>
@@ -363,7 +363,7 @@
                                                     </div>
                                                     <div class="text-sm text-text-secondary">
                                                         {{ $offer->gamePlayer->position_name }} &middot; {{ $offer->gamePlayer->age($game->current_date) }} {{ __('app.years') }} &middot;
-                                                        {{ __('app.value') }}: {{ $offer->gamePlayer->formatted_market_value }}
+                                                        {{ $offer->gamePlayer->displaysReleaseClauseAsMarketReference($game) ? __('transfers.release_clause') : __('app.value') }}: {{ $offer->gamePlayer->marketReferenceValue($game) }}
                                                     </div>
                                                 </div>
                                             </div>
@@ -448,7 +448,7 @@
                                                     <div class="font-semibold text-text-primary">{{ $player->name }}</div>
                                                     <div class="text-sm text-text-secondary">
                                                         {{ $player->position_name }} &middot; {{ $player->age($game->current_date) }} {{ __('app.years') }} &middot;
-                                                        {{ __('app.value') }}: {{ $player->formatted_market_value }}
+                                                        {{ $player->displaysReleaseClauseAsMarketReference($game) ? __('transfers.release_clause') : __('app.value') }}: {{ $player->marketReferenceValue($game) }}
                                                     </div>
                                                 </div>
                                             </div>

--- a/resources/views/partials/scout-report-player-row.blade.php
+++ b/resources/views/partials/scout-report-player-row.blade.php
@@ -121,10 +121,11 @@
                             <span class="text-xs text-text-muted w-16 shrink-0">{{ __('squad.overall_full') }}</span>
                             <x-ability-bar :range="$overallRange" size="sm" class="text-xs font-semibold tabular-nums text-text-body" />
                         </div>
-                        {{-- Market Value --}}
+                        {{-- Market value — or the release clause where it is the
+                             market reference (mandatory-clause clubs, e.g. Spain). --}}
                         <div class="flex items-center justify-between pt-1">
-                            <span class="text-xs text-text-muted">{{ __('transfers.market_value') }}</span>
-                            <span class="text-xs font-semibold text-text-body">{{ $player->formatted_market_value }}</span>
+                            <span class="text-xs text-text-muted">{{ $player->displaysReleaseClauseAsMarketReference($game) ? __('transfers.release_clause') : __('transfers.market_value') }}</span>
+                            <span class="text-xs font-semibold text-text-body">{{ $player->marketReferenceValue($game) }}</span>
                         </div>
                         {{-- Contract --}}
                         @if(!$isFreeAgent && $player->contract_until)

--- a/resources/views/scouting-hub.blade.php
+++ b/resources/views/scouting-hub.blade.php
@@ -355,7 +355,7 @@
                                                                     </div>
                                                                 </template>
                                                                 <div class="flex flex-wrap items-center gap-x-5 gap-y-1 text-xs text-text-muted mb-3">
-                                                                    <span>{{ __('transfers.market_value') }}: <span class="font-semibold text-text-body" x-text="player.formattedMarketValue"></span></span>
+                                                                    <span><span x-text="player.showsClause ? @js(__('transfers.release_clause')) : @js(__('transfers.market_value'))"></span>: <span class="font-semibold text-text-body" x-text="player.marketReference"></span></span>
                                                                     <template x-if="!player.isFreeAgent && player.contractYear">
                                                                         <span>{{ __('transfers.contract_until') }}: <span class="font-semibold text-text-body" x-text="player.contractYear"></span></span>
                                                                     </template>

--- a/resources/views/squad.blade.php
+++ b/resources/views/squad.blade.php
@@ -191,7 +191,7 @@
                                 </template>
                                 @if($isCareerMode)
                                 <template x-if="viewMode === 'tactical'">
-                                    <span class="text-right">{{ __('app.value') }}</span>
+                                    <span class="text-right">{{ $squadUsesClauses ? __('transfers.clause_short') : __('app.value') }}</span>
                                 </template>
                                 <template x-if="viewMode === 'tactical'">
                                     <span class="text-right">{{ __('app.wage') }}</span>
@@ -207,7 +207,7 @@
                                     <span class="text-center">{{ __('squad.potential') }}</span>
                                 </template>
                                 <template x-if="viewMode === 'planning'">
-                                    <span class="text-right">{{ __('app.value') }}</span>
+                                    <span class="text-right">{{ $squadUsesClauses ? __('transfers.clause_short') : __('app.value') }}</span>
                                 </template>
                                 <template x-if="viewMode === 'planning'">
                                     <span class="text-right">{{ __('app.wage') }}</span>
@@ -410,7 +410,7 @@
                                         </template>
                                         @if($isCareerMode)
                                         <template x-if="viewMode === 'tactical'">
-                                            <span class="text-xs text-text-body text-right tabular-nums">{{ $gp->formatted_market_value }}</span>
+                                            <span class="text-xs text-text-body text-right tabular-nums">{{ $gp->marketReferenceValue($game) }}</span>
                                         </template>
                                         <template x-if="viewMode === 'tactical'">
                                             <span class="text-xs text-text-muted text-right tabular-nums">{{ $gp->formatted_wage }}</span>
@@ -433,7 +433,7 @@
                                             </div>
                                         </template>
                                         <template x-if="viewMode === 'planning'">
-                                            <span class="text-xs text-text-body text-right tabular-nums">{{ $gp->formatted_market_value }}</span>
+                                            <span class="text-xs text-text-body text-right tabular-nums">{{ $gp->marketReferenceValue($game) }}</span>
                                         </template>
                                         <template x-if="viewMode === 'planning'">
                                             <span class="text-xs text-text-muted text-right tabular-nums">{{ $gp->formatted_wage }}</span>

--- a/tests/Feature/ReleaseClauseDisplayTest.php
+++ b/tests/Feature/ReleaseClauseDisplayTest.php
@@ -1,0 +1,177 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Competition;
+use App\Models\Game;
+use App\Models\GamePlayer;
+use App\Models\Loan;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+/**
+ * Display layer: list surfaces show a player's release clause in place of his
+ * market value when (and only when) the feature is enabled, the player carries a
+ * clause, and his OWNING club is in a mandatory-clause country (config-driven,
+ * currently only ES). The decision + value live on the GamePlayer model
+ * (displaysReleaseClauseAsMarketReference / marketReferenceValue / ownerCountry),
+ * which every surface routes through.
+ */
+class ReleaseClauseDisplayTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const MV = 5_000_000_000;        // €50M
+    private const CLAUSE = 6_250_000_000;    // €62.5M
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Spain is the only mandatory-clause country by default; pin it so the
+        // test is independent of future config tuning.
+        config()->set('finances.release_clause.mandatory_countries', ['ES']);
+        Competition::factory()->league()->create(['id' => 'ESP1']);
+    }
+
+    public function test_es_owned_contracted_player_shows_the_clause_as_market_reference(): void
+    {
+        [$game, $team] = $this->makeGame(country: 'ES', enabled: true);
+        $player = $this->clausePlayer($game, $team);
+
+        $this->assertTrue($player->displaysReleaseClauseAsMarketReference($game));
+        $this->assertSame($player->formatted_release_clause, $player->marketReferenceValue($game));
+    }
+
+    public function test_flag_off_keeps_the_market_value_for_existing_saves(): void
+    {
+        [$game, $team] = $this->makeGame(country: 'ES', enabled: false);
+        $player = $this->clausePlayer($game, $team);
+
+        $this->assertFalse($player->displaysReleaseClauseAsMarketReference($game));
+        $this->assertSame($player->formatted_market_value, $player->marketReferenceValue($game));
+    }
+
+    public function test_non_mandatory_country_keeps_market_value_even_with_a_clause(): void
+    {
+        // A clause is forced onto an EN-owned player: the gate is the
+        // mandatory-country list, NOT merely "has a clause", so he still shows
+        // his market value.
+        [$game, $team] = $this->makeGame(country: 'EN', enabled: true);
+        $player = $this->clausePlayer($game, $team);
+
+        $this->assertFalse($player->displaysReleaseClauseAsMarketReference($game));
+        $this->assertSame($player->formatted_market_value, $player->marketReferenceValue($game));
+    }
+
+    public function test_free_agent_keeps_market_value(): void
+    {
+        [$game] = $this->makeGame(country: 'ES', enabled: true);
+        $freeAgent = GamePlayer::factory()->forGame($game)->create([
+            'team_id' => null,
+            'market_value_cents' => self::MV,
+            'release_clause' => null,
+        ]);
+
+        $this->assertNull($freeAgent->ownerCountry());
+        $this->assertFalse($freeAgent->displaysReleaseClauseAsMarketReference($game));
+        $this->assertSame($freeAgent->formatted_market_value, $freeAgent->marketReferenceValue($game));
+    }
+
+    public function test_loaned_in_player_resolves_to_the_owning_clubs_country(): void
+    {
+        // Owner = Spanish club, currently on loan AT an English club. The owner
+        // governs, so the clause is the market reference.
+        [$game] = $this->makeGame(country: 'EN', enabled: true);
+        $owner = Team::factory()->create(['country' => 'ES']);
+        $host = Team::factory()->create(['country' => 'EN']);
+        $player = $this->clausePlayer($game, $host); // team_id = current location (host)
+        $this->activeLoan($game, $player, parent: $owner, host: $host);
+
+        $this->assertSame('ES', $player->ownerCountry());
+        $this->assertTrue($player->displaysReleaseClauseAsMarketReference($game));
+    }
+
+    public function test_loaned_in_from_non_mandatory_owner_keeps_market_value(): void
+    {
+        // Inverse: the player currently sits at a Spanish club but is OWNED by an
+        // English club, so he shows his market value despite playing in Spain.
+        [$game] = $this->makeGame(country: 'ES', enabled: true);
+        $owner = Team::factory()->create(['country' => 'EN']);
+        $host = Team::factory()->create(['country' => 'ES']);
+        $player = $this->clausePlayer($game, $host);
+        $this->activeLoan($game, $player, parent: $owner, host: $host);
+
+        $this->assertSame('EN', $player->ownerCountry());
+        $this->assertFalse($player->displaysReleaseClauseAsMarketReference($game));
+    }
+
+    public function test_owner_country_is_not_queried_per_row_when_relations_are_eager_loaded(): void
+    {
+        [$game, $team] = $this->makeGame(country: 'ES', enabled: true);
+        foreach (range(1, 5) as $i) {
+            $this->clausePlayer($game, $team);
+        }
+
+        // Mirror the eager-loading every list surface now applies.
+        $players = GamePlayer::with(['team', 'activeLoan.parentTeam'])
+            ->where('game_id', $game->id)
+            ->get();
+
+        DB::enableQueryLog();
+        foreach ($players as $player) {
+            $player->marketReferenceValue($game);
+        }
+        $queries = DB::getQueryLog();
+        DB::disableQueryLog();
+
+        $this->assertEmpty($queries, 'ownerCountry() must read eager-loaded relations, not query per row');
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────
+
+    /**
+     * @return array{0: Game, 1: Team}
+     */
+    private function makeGame(string $country, bool $enabled): array
+    {
+        $user = User::factory()->create();
+        $team = Team::factory()->create(['country' => $country]);
+
+        $game = Game::factory()->forTeam($team)->create([
+            'user_id' => $user->id,
+            'competition_id' => 'ESP1',
+            'country' => $country,
+            'season' => '2024',
+            'current_date' => '2025-02-15',
+            'release_clauses_enabled' => $enabled,
+        ]);
+
+        return [$game, $team];
+    }
+
+    private function clausePlayer(Game $game, Team $team): GamePlayer
+    {
+        return GamePlayer::factory()->forGame($game)->forTeam($team)->create([
+            'market_value_cents' => self::MV,
+            'release_clause' => self::CLAUSE,
+            'contract_until' => '2026-06-30',
+        ]);
+    }
+
+    private function activeLoan(Game $game, GamePlayer $player, Team $parent, Team $host): Loan
+    {
+        return Loan::create([
+            'game_id' => $game->id,
+            'game_player_id' => $player->id,
+            'parent_team_id' => $parent->id,
+            'loan_team_id' => $host->id,
+            'started_at' => '2025-01-01',
+            'return_at' => '2025-06-30',
+            'status' => Loan::STATUS_ACTIVE,
+        ]);
+    }
+}


### PR DESCRIPTION
## Context

In countries where buyout clauses are legally mandatory (today only Spain, `ES`), the **release clause** — not the market value — is the figure the transfer market actually operates on (it may sit above or below market value). Until now every player-list surface showed raw market value, so a Spanish-owned player's real price reference was invisible unless you opened his detail card.

This is a display-layer phase that precedes the deferred Phase 4 (renewal user-raise UI). For every surface that *lists* a player's market value, it shows the **release clause instead** when the player's owning club is in a mandatory-clause country. Clubs elsewhere — and any existing save (feature flag off) — are unchanged.

## Single source of truth

The swap decision and the formatted value live in one place so the display path can never drift from the existing clause-calculation path:

- **`config/finances.php` → `release_clause.mandatory_countries`** (`['ES']`) is now read by **both** `ContractService::isReleaseClauseMandatory` (the duplicate `RELEASE_CLAUSE_MANDATORY_COUNTRY` const is removed) and the new display path.
- **`GamePlayer`** gains `ownerCountry()`, `displaysReleaseClauseAsMarketReference(Game)`, `marketReferenceValue(Game)`. The predicate short-circuits on `hasReleaseClause()` *before* resolving owner country, so clause-less rows and existing saves never trigger a query.
- New **`<x-player-market-value>`** component (+ a design-system entry with a live preview).

Owner country = `activeLoan->parentTeam->country ?? team->country` (the owning/parent club governs). Gated on the mandatory-country list, **not** merely "has a clause", so a future non-ES club with an optional clause still shows market value.

## Surfaces & markers

| Surface | Treatment |
|---|---|
| Squad (uniform own club) | column header relabels to **"Cláusula"** via `$squadUsesClauses`; cells swap silently |
| Explore rows + transfer-market (mixed) | component renders an **info-icon tooltip** on swapped rows |
| Scout report / scouting hub / outgoing transfers | per-row field relabels to "Cláusula de rescisión" (clearer than a tooltip for label:value pairs) |
| Player-detail modal, negotiation chat, all negotiation payloads | **unchanged** — already show both figures; keep true market value |
| Explore free agents, admin editor, squad-value total | untouched (no-op / out of scope) |

## Performance

Every list query now eager-loads `activeLoan.parentTeam` (Squad, Scout report, Scouting hub, both Explore paths, transfer-market listings, outgoing transfers) so `ownerCountry()` never queries per row. A query-count assertion guards this.

## i18n

`transfers.clause_short`, `transfers.market_reference_is_clause` (es + en).

## Tests

`tests/Feature/ReleaseClauseDisplayTest.php`: predicate matrix (ES owner / flag-off / non-ES-with-clause / free agent), loaned-in owner-governs in both directions, `ownerCountry()` resolution, and an N+1 guard.

> Not run locally (CI runs the suite); PHP files lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)