### PR TITLE
Group same-type critical alerts into one blocking popup

### DIFF
--- a/app/Http/Actions/AcknowledgeCriticalAlerts.php
+++ b/app/Http/Actions/AcknowledgeCriticalAlerts.php
@@ -13,9 +13,10 @@ class AcknowledgeCriticalAlerts
 
     public function __invoke(Request $request, string $gameId)
     {
-        // The popup shows one alert at a time and posts its id, so dismiss only
-        // that alert; the next pending critical surfaces on the following load.
-        $this->notificationService->markCriticalAsRead($gameId, $request->input('notification_id'));
+        // The popup groups all pending criticals of one type and posts that type,
+        // so dismiss clears the whole group at once; criticals of other types
+        // surface as their own group on the following load.
+        $this->notificationService->markCriticalAsRead($gameId, $request->input('type'));
 
         // Return to the page the user dismissed the popup from (falls back to
         // the dashboard) so the alert simply clears in place.

--- a/app/Http/Actions/ViewCriticalAlerts.php
+++ b/app/Http/Actions/ViewCriticalAlerts.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Http\Actions;
+
+use App\Models\GameNotification;
+use App\Modules\Notification\Services\NotificationService;
+use Illuminate\Http\Request;
+
+class ViewCriticalAlerts
+{
+    public function __construct(
+        private readonly NotificationService $notificationService,
+    ) {}
+
+    public function __invoke(Request $request, string $gameId)
+    {
+        $type = $request->input('type');
+
+        // Every critical in the group shares a type, so any one of them resolves
+        // the same destination — use the most recent as the navigation reference.
+        $alert = GameNotification::where('game_id', $gameId)
+            ->unread()
+            ->where('priority', GameNotification::PRIORITY_CRITICAL)
+            ->where('type', $type)
+            ->orderByDesc('game_date')
+            ->first();
+
+        // Clear the whole group, not just one: otherwise the rest would re-pop on
+        // the destination page. The underlying items (offers, competition) persist
+        // independently, so marking the notifications read on navigate is safe.
+        $this->notificationService->markCriticalAsRead($gameId, $type);
+
+        if (! $alert) {
+            return redirect()->route('show-game', $gameId);
+        }
+
+        return redirect()->route(
+            $alert->getNavigationRoute(),
+            $alert->getNavigationParams($gameId),
+        );
+    }
+}

--- a/app/Modules/Notification/Services/NotificationService.php
+++ b/app/Modules/Notification/Services/NotificationService.php
@@ -73,24 +73,47 @@ class NotificationService
 
     /**
      * Acknowledge (mark read) unread CRITICAL notifications for a game.
-     * Backs the critical-alert popup's dismiss button: once acknowledged the
-     * alert no longer pops on subsequent page loads. The popup shows one alert
-     * at a time, so it passes the shown alert's id to scope the dismiss to that
-     * single notification; with no id (legacy callers) every critical is cleared.
-     * Always game- and critical-scoped, so a foreign id posted in the form is a
+     * Backs the critical-alert popup's dismiss/action buttons: once acknowledged
+     * the alert no longer pops on subsequent page loads. The popup groups all
+     * pending criticals of one type, so it passes that type to clear the whole
+     * group at once; with no type (safe fallback) every critical is cleared.
+     * Always game- and critical-scoped, so a foreign type posted in the form is a
      * no-op rather than a way to clear unrelated notifications.
      */
-    public function markCriticalAsRead(string $gameId, ?string $notificationId = null): int
+    public function markCriticalAsRead(string $gameId, ?string $type = null): int
     {
         $query = GameNotification::where('game_id', $gameId)
             ->unread()
             ->where('priority', GameNotification::PRIORITY_CRITICAL);
 
-        if ($notificationId !== null) {
-            $query->where('id', $notificationId);
+        if ($type !== null) {
+            $query->where('type', $type);
         }
 
         return $query->update(['read_at' => now()]);
+    }
+
+    /**
+     * The pending critical-alert group to surface in the blocking popup: all
+     * unread CRITICAL notifications sharing the type of the most-recent one.
+     * Same-type criticals (e.g. several purchase offers) are shown together with
+     * a single dismiss/action since they all route to the same page; criticals of
+     * other types surface as their own group on a later load. Returns an empty
+     * collection when nothing is pending.
+     */
+    public function pendingCriticalAlertGroup(string $gameId): Collection
+    {
+        $criticals = GameNotification::where('game_id', $gameId)
+            ->unread()
+            ->where('priority', GameNotification::PRIORITY_CRITICAL)
+            ->orderByDesc('game_date')
+            ->get();
+
+        if ($criticals->isEmpty()) {
+            return $criticals;
+        }
+
+        return $criticals->where('type', $criticals->first()->type)->values();
     }
 
     /**

--- a/lang/en/notifications.php
+++ b/lang/en/notifications.php
@@ -9,8 +9,10 @@ return [
 
     // Critical-alert popup (blocking, must-dismiss)
     'alert_heading' => 'Important alert',
+    'alerts_heading' => ':count important alerts',
     'celebration_heading' => 'Congratulations!',
     'alert_dismiss' => 'Dismiss',
+    'dismiss_all' => 'Dismiss all',
     'alert_continue' => 'Continue',
     'action_review_offer' => 'Review offer',
     'action_view_competition' => 'View competition',

--- a/lang/es/notifications.php
+++ b/lang/es/notifications.php
@@ -9,8 +9,10 @@ return [
 
     // Critical-alert popup (blocking, must-dismiss)
     'alert_heading' => 'Aviso importante',
+    'alerts_heading' => ':count avisos importantes',
     'celebration_heading' => '¡Enhorabuena!',
     'alert_dismiss' => 'Descartar',
+    'dismiss_all' => 'Descartar todo',
     'alert_continue' => 'Continuar',
     'action_review_offer' => 'Revisar oferta',
     'action_view_competition' => 'Ver competición',

--- a/resources/views/components/critical-alert-modal.blade.php
+++ b/resources/views/components/critical-alert-modal.blade.php
@@ -1,26 +1,33 @@
-@props(['alert', 'game'])
+@props(['alerts', 'game'])
 
 {{-- Blocking, must-dismiss popup for the highest-stakes notifications
-     (PRIORITY_CRITICAL — see GameNotification). Shows one alert at a time (the
-     most recent unread critical) and auto-opens on page load via <x-modal :show>.
+     (PRIORITY_CRITICAL — see GameNotification). Shows all pending criticals of a
+     single type together (the type of the most-recent one), and auto-opens on
+     page load via <x-modal :show>. Same-type criticals (e.g. several purchase
+     offers) share one dismiss and one action because they all route to the same
+     page; criticals of other types surface as their own group on the next load.
 
-     The header adapts to the alert: positive events (isCelebratory — qualifying
-     or winning a cup) render in a green "¡Enhorabuena!" frame with a trophy icon;
-     everything else uses the red "important alert" frame. The primary button is
-     contextual to the alert type ("Review offer", "View competition", …): it posts
-     game.notifications.read, which marks this alert read and redirects to the
-     relevant page (reusing MarkNotificationRead). The quieter secondary button
-     marks this alert read without navigating. Either way, any other pending
-     critical surfaces on the next load. Closing via backdrop/escape only hides it
-     for this page view, so an unacknowledged alert returns on the next page — by
-     design, so a critical event can't be silently missed. --}}
-@if($alert)
-@php $celebratory = $alert->isCelebratory(); @endphp
+     The header adapts to the type: positive events (isCelebratory — qualifying or
+     winning a cup) render in a green "¡Enhorabuena!" frame with a trophy icon;
+     everything else uses the red "important alert" frame. Both footer buttons are
+     type-scoped: the primary one is contextual to the type ("Review offer", "View
+     competition", …) — it posts game.notifications.view-critical, which marks the
+     whole group read and redirects to the relevant page; the quieter secondary
+     button marks the group read without navigating. Closing via backdrop/escape
+     only hides it for this page view, so an unacknowledged group returns on the
+     next page — by design, so a critical event can't be silently missed. --}}
+@if($alerts->isNotEmpty())
+@php
+    $first = $alerts->first();
+    $celebratory = $first->isCelebratory();
+    $count = $alerts->count();
+    $type = $first->type;
+@endphp
 <div x-data>
     <x-modal name="critical-alert" :show="true" maxWidth="md">
         {{-- Header banner (no close button: must-act). The icon + eyebrow carry the
              tone — celebratory (green/trophy) for positive events, danger (red/alert)
-             otherwise — divided from the notification below so the alert content
+             otherwise — divided from the notifications below so the alert content
              reads as the focal point. --}}
         <x-modal-header :tone="$celebratory ? 'success' : 'danger'" eyebrow>
             <x-slot:icon>
@@ -34,27 +41,47 @@
                 </svg>
                 @endif
             </x-slot:icon>
-            {{ $celebratory ? __('notifications.celebration_heading') : __('notifications.alert_heading') }}
+            @if($count === 1)
+                {{ $celebratory ? __('notifications.celebration_heading') : __('notifications.alert_heading') }}
+            @else
+                {{ $celebratory ? __('notifications.celebration_heading') : __('notifications.alerts_heading', ['count' => $count]) }}
+            @endif
         </x-modal-header>
 
+        @if($count === 1)
         <div class="px-5 py-4">
-            <p class="font-heading text-lg font-semibold text-text-primary">{{ $alert->title }}</p>
-            @if($alert->message)
-            <p class="mt-1.5 text-sm text-text-muted leading-relaxed">{{ $alert->message }}</p>
+            <p class="font-heading text-lg font-semibold text-text-primary">{{ $first->title }}</p>
+            @if($first->message)
+            <p class="mt-1.5 text-sm text-text-muted leading-relaxed">{{ $first->message }}</p>
             @endif
         </div>
+        @else
+        {{-- One row per pending critical, scrollable so a long group never pushes
+             the footer off-screen on small viewports. --}}
+        <div class="max-h-[55vh] overflow-y-auto divide-y divide-border-default">
+            @foreach($alerts as $alert)
+            <div class="px-5 py-3">
+                <p class="font-semibold text-text-primary">{{ $alert->title }}</p>
+                @if($alert->message)
+                <p class="mt-0.5 text-sm text-text-muted leading-relaxed">{{ $alert->message }}</p>
+                @endif
+            </div>
+            @endforeach
+        </div>
+        @endif
 
         <div class="flex items-center justify-end gap-3 px-5 py-4 border-t border-border-default">
-            {{-- Quiet dismiss: marks this alert read without navigating. --}}
+            {{-- Quiet dismiss: marks every critical of this type read without navigating. --}}
             <form action="{{ route('game.notifications.acknowledge-critical', $game->id) }}" method="POST">
                 @csrf
-                <input type="hidden" name="notification_id" value="{{ $alert->id }}">
-                <x-secondary-button size="sm" type="submit">{{ $celebratory ? __('notifications.alert_continue') : __('notifications.alert_dismiss') }}</x-secondary-button>
+                <input type="hidden" name="type" value="{{ $type }}">
+                <x-secondary-button size="sm" type="submit">{{ $celebratory ? __('notifications.alert_continue') : ($count > 1 ? __('notifications.dismiss_all') : __('notifications.alert_dismiss')) }}</x-secondary-button>
             </form>
-            {{-- Contextual action: marks this alert read and jumps to its page. --}}
-            <form action="{{ route('game.notifications.read', [$game->id, $alert->id]) }}" method="POST">
+            {{-- Contextual action: marks every critical of this type read and jumps to its page. --}}
+            <form action="{{ route('game.notifications.view-critical', $game->id) }}" method="POST">
                 @csrf
-                <x-primary-button size="sm" type="submit">{{ $alert->getActionLabel() }}</x-primary-button>
+                <input type="hidden" name="type" value="{{ $type }}">
+                <x-primary-button size="sm" type="submit">{{ $first->getActionLabel() }}</x-primary-button>
             </form>
         </div>
     </x-modal>

--- a/resources/views/components/game-header.blade.php
+++ b/resources/views/components/game-header.blade.php
@@ -14,14 +14,12 @@
 
     // Highest-stakes (CRITICAL) notifications that haven't been acknowledged yet
     // surface as a blocking, must-dismiss popup on the next page load so they
-    // can't be missed (e.g. a purchase offer for one of your players). Shown one
-    // at a time — the most recent — so each gets its own contextual action; any
-    // others follow on subsequent loads.
-    $criticalAlert = $game->notifications()
-        ->whereNull('read_at')
-        ->where('priority', \App\Models\GameNotification::PRIORITY_CRITICAL)
-        ->orderByDesc('game_date')
-        ->first();
+    // can't be missed (e.g. a purchase offer for one of your players). All pending
+    // criticals of the most-recent type are shown together as one group (single
+    // dismiss + single action, since they route to the same page); other types
+    // follow as their own group on subsequent loads.
+    $criticalAlerts = app(\App\Modules\Notification\Services\NotificationService::class)
+        ->pendingCriticalAlertGroup($game->id);
 @endphp
 
 <div x-data>
@@ -334,7 +332,7 @@
 
     {{-- Critical-alert popup: blocking, must-dismiss alert for the highest-stakes
          (PRIORITY_CRITICAL) notifications. Renders nothing when none are pending. --}}
-    <x-critical-alert-modal :alert="$criticalAlert" :game="$game" />
+    <x-critical-alert-modal :alerts="$criticalAlerts" :game="$game" />
 
     {{-- Mobile Bottom Tab Bar --}}
     <x-bottom-tab-bar :game="$game" :next-match="$nextMatch" :team-competitions="$teamCompetitions" />

--- a/routes/web.php
+++ b/routes/web.php
@@ -45,6 +45,7 @@ use App\Http\Actions\AcknowledgeCriticalAlerts;
 use App\Http\Actions\MarkAllNotificationsRead;
 use App\Http\Actions\MarkNotificationRead;
 use App\Http\Actions\PreviewSeasonTicketPricing;
+use App\Http\Actions\ViewCriticalAlerts;
 use App\Http\Actions\SaveBudgetAllocation;
 use App\Http\Actions\SaveSeasonTicketPricing;
 use App\Http\Views\ShowBudgetAllocation;
@@ -332,6 +333,7 @@ Route::middleware('auth')->group(function () {
         Route::post('/game/{gameId}/notifications/{notificationId}/read', MarkNotificationRead::class)->name('game.notifications.read');
         Route::post('/game/{gameId}/notifications/read-all', MarkAllNotificationsRead::class)->name('game.notifications.read-all');
         Route::post('/game/{gameId}/notifications/acknowledge-critical', AcknowledgeCriticalAlerts::class)->name('game.notifications.acknowledge-critical');
+        Route::post('/game/{gameId}/notifications/view-critical', ViewCriticalAlerts::class)->name('game.notifications.view-critical');
     });
 });
 

--- a/tests/Feature/CriticalAlertPopupTest.php
+++ b/tests/Feature/CriticalAlertPopupTest.php
@@ -13,10 +13,11 @@ use Illuminate\Support\Facades\Blade;
 use Tests\TestCase;
 
 /**
- * Covers the critical-alert popup mechanism: PRIORITY_CRITICAL is now reserved
- * as the must-dismiss popup tier, so previously-critical notifications must have
- * been downgraded to WARNING, and the popup/acknowledge plumbing must target
- * only unread CRITICAL notifications.
+ * Covers the critical-alert popup mechanism: PRIORITY_CRITICAL is the must-dismiss
+ * popup tier, so previously-critical notifications must have been downgraded to
+ * WARNING. The popup groups all pending criticals of one type (the most recent),
+ * showing them together with a single dismiss/action since they route to the same
+ * page; criticals of other types surface as their own group on a later load.
  */
 class CriticalAlertPopupTest extends TestCase
 {
@@ -45,16 +46,20 @@ class CriticalAlertPopupTest extends TestCase
         string $priority,
         ?string $readAt = null,
         string $type = GameNotification::TYPE_TRANSFER_COMPLETE,
+        string $title = 'Alert',
+        ?string $gameDate = null,
     ): GameNotification {
-        // The popup is type-agnostic — it keys on priority, not type — but the
-        // primary button's label IS type-driven (getActionLabel), so tests that
-        // assert the label pass a concrete type.
+        // The popup is type-agnostic — it keys on priority/type, not the type's
+        // semantics — but the primary button's label IS type-driven (getActionLabel),
+        // so tests that assert the label pass a concrete type. game_date drives the
+        // "most recent type" grouping, so tests that exercise grouping set it.
         return GameNotification::create([
             'id' => fake()->uuid(),
             'game_id' => $this->game->id,
             'type' => $type,
-            'title' => 'Alert',
+            'title' => $title,
             'priority' => $priority,
+            'game_date' => $gameDate,
             'read_at' => $readAt,
         ]);
     }
@@ -88,6 +93,42 @@ class CriticalAlertPopupTest extends TestCase
         $this->assertEquals($readAtBefore, $alreadyReadCritical->fresh()->read_at, 'already-read criticals untouched');
     }
 
+    public function test_mark_critical_as_read_scopes_to_the_given_type(): void
+    {
+        $offer = $this->makeNotification(GameNotification::PRIORITY_CRITICAL, type: GameNotification::TYPE_TRANSFER_OFFER_RECEIVED);
+        $advancement = $this->makeNotification(GameNotification::PRIORITY_CRITICAL, type: GameNotification::TYPE_COMPETITION_ADVANCEMENT);
+
+        $affected = $this->service->markCriticalAsRead($this->game->id, GameNotification::TYPE_TRANSFER_OFFER_RECEIVED);
+
+        $this->assertSame(1, $affected);
+        $this->assertNotNull($offer->fresh()->read_at);
+        $this->assertNull($advancement->fresh()->read_at, 'a different type must stay pending');
+    }
+
+    public function test_pending_critical_alert_group_returns_only_the_most_recent_type(): void
+    {
+        // Older celebratory advancement, then two newer offers of the same type,
+        // plus noise (a warning and an already-read critical) that must be ignored.
+        $this->makeNotification(GameNotification::PRIORITY_CRITICAL, type: GameNotification::TYPE_COMPETITION_ADVANCEMENT, gameDate: '2024-09-10');
+        $offerA = $this->makeNotification(GameNotification::PRIORITY_CRITICAL, type: GameNotification::TYPE_TRANSFER_OFFER_RECEIVED, gameDate: '2024-09-15');
+        $offerB = $this->makeNotification(GameNotification::PRIORITY_CRITICAL, type: GameNotification::TYPE_TRANSFER_OFFER_RECEIVED, gameDate: '2024-09-14');
+        $this->makeNotification(GameNotification::PRIORITY_WARNING, type: GameNotification::TYPE_TRANSFER_OFFER_RECEIVED, gameDate: '2024-09-15');
+        $this->makeNotification(GameNotification::PRIORITY_CRITICAL, type: GameNotification::TYPE_TRANSFER_OFFER_RECEIVED, readAt: '2024-09-15', gameDate: '2024-09-15');
+
+        $group = $this->service->pendingCriticalAlertGroup($this->game->id);
+
+        $this->assertCount(2, $group);
+        $this->assertEqualsCanonicalizing([$offerA->id, $offerB->id], $group->pluck('id')->all());
+        $this->assertTrue($group->every(fn ($n) => $n->type === GameNotification::TYPE_TRANSFER_OFFER_RECEIVED));
+    }
+
+    public function test_pending_critical_alert_group_is_empty_when_nothing_pending(): void
+    {
+        $this->makeNotification(GameNotification::PRIORITY_WARNING);
+
+        $this->assertTrue($this->service->pendingCriticalAlertGroup($this->game->id)->isEmpty());
+    }
+
     public function test_acknowledge_route_marks_critical_notifications_read(): void
     {
         $this->withoutMiddleware(ValidateCsrfToken::class);
@@ -100,21 +141,41 @@ class CriticalAlertPopupTest extends TestCase
         $this->assertNotNull($critical->fresh()->read_at);
     }
 
-    public function test_dismiss_with_notification_id_scopes_to_that_single_alert(): void
+    public function test_dismiss_scopes_to_the_posted_type(): void
     {
-        // The popup shows one alert at a time and posts its id, so dismissing
-        // should clear only that alert — the other critical stays pending.
+        // The popup groups by type and posts that type, so dismissing clears the
+        // whole same-type group while criticals of other types stay pending.
         $this->withoutMiddleware(ValidateCsrfToken::class);
-        $shown = $this->makeNotification(GameNotification::PRIORITY_CRITICAL);
-        $other = $this->makeNotification(GameNotification::PRIORITY_CRITICAL);
+        $offerA = $this->makeNotification(GameNotification::PRIORITY_CRITICAL, type: GameNotification::TYPE_TRANSFER_OFFER_RECEIVED);
+        $offerB = $this->makeNotification(GameNotification::PRIORITY_CRITICAL, type: GameNotification::TYPE_TRANSFER_OFFER_RECEIVED);
+        $advancement = $this->makeNotification(GameNotification::PRIORITY_CRITICAL, type: GameNotification::TYPE_COMPETITION_ADVANCEMENT);
 
         $this->actingAs($this->user)->post(
             route('game.notifications.acknowledge-critical', $this->game->id),
-            ['notification_id' => $shown->id],
+            ['type' => GameNotification::TYPE_TRANSFER_OFFER_RECEIVED],
         );
 
-        $this->assertNotNull($shown->fresh()->read_at);
-        $this->assertNull($other->fresh()->read_at, 'only the posted alert should be dismissed');
+        $this->assertNotNull($offerA->fresh()->read_at, 'all of the posted type are cleared together');
+        $this->assertNotNull($offerB->fresh()->read_at, 'all of the posted type are cleared together');
+        $this->assertNull($advancement->fresh()->read_at, 'a different type should stay pending');
+    }
+
+    public function test_view_critical_route_clears_the_type_and_redirects_to_its_page(): void
+    {
+        $this->withoutMiddleware(ValidateCsrfToken::class);
+        $offerA = $this->makeNotification(GameNotification::PRIORITY_CRITICAL, type: GameNotification::TYPE_TRANSFER_OFFER_RECEIVED);
+        $offerB = $this->makeNotification(GameNotification::PRIORITY_CRITICAL, type: GameNotification::TYPE_TRANSFER_OFFER_RECEIVED);
+
+        $response = $this->actingAs($this->user)->post(
+            route('game.notifications.view-critical', $this->game->id),
+            ['type' => GameNotification::TYPE_TRANSFER_OFFER_RECEIVED],
+        );
+
+        // Transfer offers route to the outgoing transfers page; the whole group is
+        // cleared so it does not re-pop on the destination.
+        $response->assertRedirect(route('game.transfers.outgoing', ['gameId' => $this->game->id]));
+        $this->assertNotNull($offerA->fresh()->read_at);
+        $this->assertNotNull($offerB->fresh()->read_at);
     }
 
     public function test_action_label_is_contextual_to_the_notification_type(): void
@@ -142,8 +203,8 @@ class CriticalAlertPopupTest extends TestCase
         $heading = __('notifications.alert_heading');
 
         $empty = Blade::render(
-            '<x-critical-alert-modal :alert="$alert" :game="$game" />',
-            ['alert' => null, 'game' => $this->game],
+            '<x-critical-alert-modal :alerts="$alerts" :game="$game" />',
+            ['alerts' => collect(), 'game' => $this->game],
         );
         $this->assertStringNotContainsString($heading, $empty);
 
@@ -152,25 +213,59 @@ class CriticalAlertPopupTest extends TestCase
             type: GameNotification::TYPE_TRANSFER_OFFER_RECEIVED,
         );
         $withAlert = Blade::render(
-            '<x-critical-alert-modal :alert="$alert" :game="$game" />',
-            ['alert' => $alert, 'game' => $this->game],
+            '<x-critical-alert-modal :alerts="$alerts" :game="$game" />',
+            ['alerts' => collect([$alert]), 'game' => $this->game],
         );
 
         $this->assertStringContainsString($heading, $withAlert);
-        // Contextual primary button navigates via the mark-read route...
+        // Contextual primary button navigates via the type-scoped view route...
         $this->assertStringContainsString(__('notifications.action_review_offer'), $withAlert);
         $this->assertStringContainsString(
-            route('game.notifications.read', [$this->game->id, $alert->id]),
+            route('game.notifications.view-critical', $this->game->id),
             $withAlert,
         );
-        // ...and the quiet dismiss posts the acknowledge route scoped to this alert.
+        // ...and the quiet dismiss posts the acknowledge route scoped to this type.
         $this->assertStringContainsString(
             route('game.notifications.acknowledge-critical', $this->game->id),
             $withAlert,
         );
-        $this->assertStringContainsString('name="notification_id" value="' . $alert->id . '"', $withAlert);
+        $this->assertStringContainsString('name="type" value="' . $alert->type . '"', $withAlert);
         // A transfer offer is not celebratory, so it uses the danger frame.
         $this->assertStringNotContainsString(__('notifications.celebration_heading'), $withAlert);
+    }
+
+    public function test_grouped_popup_lists_all_same_type_alerts(): void
+    {
+        $offerA = $this->makeNotification(
+            GameNotification::PRIORITY_CRITICAL,
+            type: GameNotification::TYPE_TRANSFER_OFFER_RECEIVED,
+            title: 'Offer for Pedri',
+        );
+        $offerB = $this->makeNotification(
+            GameNotification::PRIORITY_CRITICAL,
+            type: GameNotification::TYPE_TRANSFER_OFFER_RECEIVED,
+            title: 'Offer for Gavi',
+        );
+
+        $html = Blade::render(
+            '<x-critical-alert-modal :alerts="$alerts" :game="$game" />',
+            ['alerts' => collect([$offerA, $offerB]), 'game' => $this->game],
+        );
+
+        // Count-aware grouped heading, both alert titles, and a single shared
+        // dismiss/action pair scoped to the group's type.
+        $this->assertStringContainsString(__('notifications.alerts_heading', ['count' => 2]), $html);
+        $this->assertStringContainsString('Offer for Pedri', $html);
+        $this->assertStringContainsString('Offer for Gavi', $html);
+        $this->assertStringContainsString(__('notifications.dismiss_all'), $html);
+        $this->assertStringContainsString(__('notifications.action_review_offer'), $html);
+        $this->assertStringContainsString(
+            route('game.notifications.view-critical', $this->game->id),
+            $html,
+        );
+        $this->assertStringContainsString('name="type" value="' . GameNotification::TYPE_TRANSFER_OFFER_RECEIVED . '"', $html);
+        // The dismiss form posts a type, never a single notification id.
+        $this->assertStringNotContainsString('name="notification_id"', $html);
     }
 
     public function test_celebratory_critical_renders_the_celebration_frame(): void
@@ -183,8 +278,8 @@ class CriticalAlertPopupTest extends TestCase
         );
 
         $html = Blade::render(
-            '<x-critical-alert-modal :alert="$alert" :game="$game" />',
-            ['alert' => $alert, 'game' => $this->game],
+            '<x-critical-alert-modal :alerts="$alerts" :game="$game" />',
+            ['alerts' => collect([$alert]), 'game' => $this->game],
         );
 
         $this->assertStringContainsString(__('notifications.celebration_heading'), $html);


### PR DESCRIPTION
## Problem

The blocking critical-alert popup (introduced in af989c22) showed **one alert at a time**. Dismissing or acting on one marked only that notification read, so the next critical popped on the following page load. When several criticals landed in the same matchday (e.g. multiple purchase offers), the user was forced through an annoying one-at-a-time cascade.

## Fix

Group **all pending criticals of the most-recent type** into a single popup. Because every alert in a same-type group routes to the same page, the footer keeps **one Dismiss** and **one contextual action** (e.g. "Review offer"), both scoped to that type. Criticals of *other* types still surface sequentially as their own group on a later load.

Only two notification types ever emit `PRIORITY_CRITICAL` — transfer offers received (danger frame) and competition advancement / trophy wins (celebratory frame) — so the frame tone is always uniform within a group; no mixed-tone case to handle.

## Changes

- **`NotificationService`** — `markCriticalAsRead()` now scopes by `type` (was by id; `null` still clears all as a safe fallback). New `pendingCriticalAlertGroup()` returns the unread criticals sharing the most-recent's type (one query + in-PHP filter, so no extra header round-trips).
- **`AcknowledgeCriticalAlerts`** (Dismiss) — posts/reads `type` instead of `notification_id`.
- **New `ViewCriticalAlerts`** action + `game.notifications.view-critical` route — marks the whole type-group read, then navigates to that type's page. Marking only one read would let the rest re-pop on the destination; the underlying items (offers, competition) persist independently, so clearing the group is safe. `MarkNotificationRead` (shared with the inbox) is left untouched.
- **`game-header.blade.php`** — fetches the group via the service and passes `:alerts`.
- **`critical-alert-modal.blade.php`** — `:alert` → `:alerts`. A single alert looks exactly as before; 2+ render as a scrollable list (`max-h-[55vh]`) with a pinned footer that stays reachable at 375px. Type-scoped footer unified across both cases; semantic tokens throughout, both tones preserved.
- **i18n** — added `alerts_heading` (`:count important alerts` / `:count avisos importantes`) and `dismiss_all` in both `es` and `en`.

## Behavioral note

If a group of 3 offers is showing and you click "Review offer", **all three** notifications are marked read (you're sent to the transfers page that lists them all). The offers themselves persist there — only the popup notifications clear.

## Tests

`tests/Feature/CriticalAlertPopupTest.php` updated to the collection prop + type-scoped routes, plus new coverage:
- `pendingCriticalAlertGroup` returns only the most-recent type's unread group
- grouped popup lists all same-type alerts with a single dismiss/action
- dismiss is scoped to the posted type (other types stay pending)
- `view-critical` clears the whole type-group and redirects to its page

Verify locally: `php artisan test --filter=CriticalAlertPopupTest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)