### PR TITLE
Round generated market values and release clauses to nice numbers

### DIFF
--- a/app/Modules/Player/Services/PlayerValuationService.php
+++ b/app/Modules/Player/Services/PlayerValuationService.php
@@ -3,6 +3,7 @@
 namespace App\Modules\Player\Services;
 
 use App\Modules\Player\PlayerAge;
+use App\Support\Money;
 
 /**
  * Single source of truth for all overall_score <-> market value conversions.
@@ -107,8 +108,8 @@ class PlayerValuationService
             $newValue = (int) round($newValue / self::GOALKEEPER_VALUE_MULTIPLIER);
         }
 
-        // Clamp to reasonable range: €100K to €150M
-        return max(100_000_00, min(150_000_000_00, $newValue));
+        // Clamp to reasonable range (€100K to €150M), then snap to a "nice" round number.
+        return Money::roundPrice(max(100_000_00, min(150_000_000_00, $newValue)));
     }
 
     /**

--- a/app/Modules/Transfer/Services/ContractService.php
+++ b/app/Modules/Transfer/Services/ContractService.php
@@ -408,7 +408,7 @@ class ContractService
             return null;
         }
 
-        $floor = (int) round($marketValueCents * (float) config('finances.release_clause.es_floor_multiplier', 1.25));
+        $floor = Money::roundPrice((int) round($marketValueCents * (float) config('finances.release_clause.es_floor_multiplier', 1.25)));
 
         // Derived default at agreement = the floor.
         if ($userRequestedCents === null) {
@@ -441,7 +441,7 @@ class ContractService
 
         $multiplier = min($hardCap, $base + $slope * max(0.0, $ratio - 1.0));
 
-        return (int) round($marketValueCents * $multiplier);
+        return Money::roundPrice((int) round($marketValueCents * $multiplier));
     }
 
     /**

--- a/tests/Unit/PlayerValuationRoundingTest.php
+++ b/tests/Unit/PlayerValuationRoundingTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Modules\Player\Services\PlayerValuationService;
+use App\Support\Money;
+use Tests\TestCase;
+
+/**
+ * Pure-math coverage proving overallScoreToMarketValue() always returns a
+ * "nice" round number. The value is snapped via Money::roundPrice() at the
+ * source so every generated/recomputed market value stays tidy in the UI.
+ */
+class PlayerValuationRoundingTest extends TestCase
+{
+    private PlayerValuationService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->service = new PlayerValuationService();
+    }
+
+    public function test_market_value_is_always_a_round_price(): void
+    {
+        // Sweep across the whole ability/age range and both position families;
+        // every result must already be idempotent under Money::roundPrice().
+        foreach (range(40, 95) as $overall) {
+            foreach ([17, 21, 24, 28, 32, 36] as $age) {
+                foreach (['ST', 'GK'] as $position) {
+                    $value = $this->service->overallScoreToMarketValue($overall, $age, null, $position);
+
+                    $this->assertSame(
+                        Money::roundPrice($value),
+                        $value,
+                        "Market value for overall {$overall}, age {$age}, {$position} must be a round price.",
+                    );
+                }
+            }
+        }
+    }
+}

--- a/tests/Unit/ReleaseClauseCalculationTest.php
+++ b/tests/Unit/ReleaseClauseCalculationTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Unit;
 
 use App\Modules\Transfer\Services\ContractService;
+use App\Support\Money;
 use Tests\TestCase;
 
 /**
@@ -103,5 +104,18 @@ class ReleaseClauseCalculationTest extends TestCase
             12_500_000_000,
             $this->service->maxTolerableReleaseClause(self::MV, 10_000_000_000, 1_000_000_000),
         );
+    }
+
+    public function test_clause_is_snapped_to_a_nice_round_number(): void
+    {
+        // Regression: an un-round market value (€453,340.43) used to yield an
+        // un-round €566,675.54 floor. The floor is now snapped via
+        // Money::roundPrice — €453,340 × 1.25 = €566,675 → nearest €50K = €550K.
+        $marketValue = 45_334_043; // cents
+
+        $clause = $this->service->calculateReleaseClause($marketValue, null, null, 'ES');
+
+        $this->assertSame(55_000_000, $clause);
+        $this->assertSame(Money::roundPrice($clause), $clause, 'Clause must already be a round price.');
     }
 }


### PR DESCRIPTION
## Problem

Generated players could surface un-round figures — e.g. a player with market value **€453,340.43** and release clause **€566,675.54** (= value × 1.25 ES floor). These look untidy in the UI.

## Fix

Snap both to "nice" numbers by **reusing the existing `Money::roundPrice()` helper** (`app/Support/Money.php`) — no new rounding logic. Its tiers already match the request: `≥€1M → nearest €100K`, `€100K–€1M → nearest €50K`, `<€100K → nearest €10K`.

Rounding is applied at the two central sources (global scope), so values stay round for a player's whole life — not just at creation:

- **`PlayerValuationService::overallScoreToMarketValue()`** rounds its clamped return. This is the single source of truth for market values (generation, academy promotion, filial `createBulk`, and season-end recalculation).
- **`ContractService::calculateReleaseClause()`** rounds the ES floor, and **`maxTolerableReleaseClause()`** rounds the tolerance cap. A manager's explicit request within the rounded `[floor, maxTolerable]` band is still honoured exactly — we round the derived bounds, not the human's deliberate choice.

The wage-anchoring twin method is left untouched (wages already round to €10K via their own logic).

### Reported case, after the fix
- Market value €453,340 → `roundPrice` (nearest €50K) → **€450,000**
- Clause = €450,000 × 1.25 = €562,500 → `roundPrice` → **€550,000**

## Tests

- `ReleaseClauseCalculationTest` — added a regression reproducing the exact reported case (€453,340.43 value → €550,000 clause).
- `PlayerValuationRoundingTest` (new) — sweeps the full ability/age range × outfield/GK and asserts every market value is idempotent under `roundPrice`.

Existing exact-value assertions use a €50M base whose ×1.25 / ×2.5 results are already €100K-granular, so `roundPrice` leaves them unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)