### PR TITLE
Recompute release clause on AI-to-AI transfers

### DIFF
--- a/app/Modules/Transfer/Services/AITransferMarketService.php
+++ b/app/Modules/Transfer/Services/AITransferMarketService.php
@@ -426,6 +426,12 @@ class AITransferMarketService
                 'position' => $freeAgent->position,
                 'contract_until' => $newContractEnd->toDateString(),
                 'annual_wage' => $newWage,
+                // Re-establish the clause for the signing club (it was nulled at
+                // contract expiry): ES floor / null elsewhere, mirroring
+                // completeFreeAgentSigning.
+                'release_clause' => $game->release_clauses_enabled
+                    ? $this->contractService->calculateReleaseClause($freeAgent->market_value_cents, null, null, $teams->get($teamId)?->country ?? $game->country)
+                    : null,
             ];
 
             $transferInserts[] = [
@@ -489,7 +495,7 @@ class AITransferMarketService
             ->whereNotIn('id', $teamRosters->keys())
             ->inRandomOrder()
             ->limit(40)
-            ->get(['id', 'name'])
+            ->get(['id', 'name', 'country'])
             ->all();
         $foreignIndex = 0;
 
@@ -548,7 +554,7 @@ class AITransferMarketService
                 $buyerRepIndex = $this->getReputationIndex($buyerTeamId, $teamReputations);
                 $maxFee = self::MAX_FEE_BY_REPUTATION_INDEX[$buyerRepIndex] ?? 500_000_000;
                 $fee = min($player->market_value_cents, $maxFee);
-                $this->prepareTransfer($game, $player, $sellerTeamId, $buyerTeamId, $window, $assignedNumber, $playerUpdates, $transferInserts, buyerReputationIndex: $buyerRepIndex);
+                $this->prepareTransfer($game, $player, $sellerTeamId, $buyerTeamId, $window, $assignedNumber, $playerUpdates, $transferInserts, buyerReputationIndex: $buyerRepIndex, toCountry: $teams->get($buyerTeamId)?->country ?? $game->country);
                 $count++;
                 $transferredPlayerIds[$player->id] = true;
 
@@ -579,7 +585,7 @@ class AITransferMarketService
                     $foreignTeam = $foreignTeams[$foreignIndex % count($foreignTeams)];
                     $foreignIndex++;
 
-                    $this->prepareTransfer($game, $player, $sellerTeamId, $foreignTeam->id, $window, null, $playerUpdates, $transferInserts, maxContractYears: 4, buyerReputationIndex: 1);
+                    $this->prepareTransfer($game, $player, $sellerTeamId, $foreignTeam->id, $window, null, $playerUpdates, $transferInserts, maxContractYears: 4, buyerReputationIndex: 1, toCountry: $foreignTeam->country);
                     $count++;
                     $transferredPlayerIds[$player->id] = true;
                     $this->incrementBudget($teamBudgets, $sellerTeamId, 'sells');
@@ -1111,6 +1117,7 @@ class AITransferMarketService
         int $minContractYears = 2,
         int $maxContractYears = 3,
         int $buyerReputationIndex = 4,
+        ?string $toCountry = null,
     ): void {
         $maxFee = self::MAX_FEE_BY_REPUTATION_INDEX[$buyerReputationIndex] ?? 500_000_000;
         $fee = min($player->market_value_cents, $maxFee);
@@ -1133,6 +1140,14 @@ class AITransferMarketService
             'position' => $player->position,
             'contract_until' => $newContractEnd->toDateString(),
             'annual_wage' => $newWage,
+            // Recompute the clause for the buying club's country (ES floor / null
+            // elsewhere), so a Spanish player moving abroad sheds his stale
+            // clause and an intra-Spain move re-anchors it — matching the
+            // user-facing completion paths. AI-to-AI moves bypass
+            // TransferCompletionService, so the recompute has to live here too.
+            'release_clause' => $game->release_clauses_enabled
+                ? $this->contractService->calculateReleaseClause($player->market_value_cents, null, null, $toCountry)
+                : null,
         ];
 
         $transferInserts[] = [
@@ -1312,6 +1327,13 @@ class AITransferMarketService
             'position' => $bestAgent->position,
             'contract_until' => $newContractEnd->toDateString(),
             'annual_wage' => $newWage,
+            // Re-establish the clause for the signing club (it was nulled at
+            // contract expiry). Free agents only sign for teams in the game's
+            // world, so the buying club's country is the game country: ES floor
+            // / null elsewhere, mirroring completeFreeAgentSigning.
+            'release_clause' => $game->release_clauses_enabled
+                ? $this->contractService->calculateReleaseClause($bestAgent->market_value_cents, null, null, $game->country)
+                : null,
         ];
 
         $transferInserts[] = [
@@ -1570,7 +1592,7 @@ class AITransferMarketService
         usort($playerUpdates, fn ($a, $b) => strcmp($a['id'], $b['id']));
 
         foreach (array_chunk($playerUpdates, 100) as $chunk) {
-            GamePlayer::upsert($chunk, ['id'], ['team_id', 'number', 'contract_until', 'annual_wage']);
+            GamePlayer::upsert($chunk, ['id'], ['team_id', 'number', 'contract_until', 'annual_wage', 'release_clause']);
         }
 
         foreach (array_chunk($transferInserts, 100) as $chunk) {

--- a/tests/Feature/ReleaseClauseAITransferTest.php
+++ b/tests/Feature/ReleaseClauseAITransferTest.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Competition;
+use App\Models\Game;
+use App\Models\GamePlayer;
+use App\Models\Team;
+use App\Models\User;
+use App\Modules\Transfer\Services\AITransferMarketService;
+use App\Modules\Transfer\Services\ContractService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * AI-to-AI transfers bypass TransferCompletionService, so the clause recompute
+ * lives in AITransferMarketService::prepareTransfer instead. These tests drive
+ * that method (and the real batched upsert) directly to prove a player's clause
+ * is re-anchored to the buying club's country: cleared when a Spanish player
+ * moves abroad, re-derived to the ES floor on an intra-Spain move, and left null
+ * when the feature is off.
+ */
+class ReleaseClauseAITransferTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const MV = 5_000_000_000;      // €50M
+    private const CLAUSE = 6_250_000_000;  // €50M × 1.25 = €62.5M (stale ES clause)
+
+    private AITransferMarketService $service;
+    private ContractService $contractService;
+    private Game $game;
+    private Team $spanishSeller;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->service = app(AITransferMarketService::class);
+        $this->contractService = app(ContractService::class);
+
+        $user = User::factory()->create();
+        $userTeam = Team::factory()->create(['name' => 'User Team', 'country' => 'ES']);
+        $this->spanishSeller = Team::factory()->create(['name' => 'Spanish Seller', 'country' => 'ES']);
+
+        Competition::factory()->league()->create(['id' => 'ESP1', 'name' => 'LaLiga']);
+
+        $this->game = Game::factory()->create([
+            'user_id' => $user->id,
+            'team_id' => $userTeam->id,
+            'competition_id' => 'ESP1',
+            'country' => 'ES',
+            'current_date' => '2025-08-01',
+            'release_clauses_enabled' => true,
+        ]);
+    }
+
+    public function test_clause_is_cleared_when_a_spanish_player_moves_to_a_foreign_club(): void
+    {
+        $foreignBuyer = Team::factory()->create(['name' => 'English Buyer', 'country' => 'EN']);
+        $player = $this->sellerPlayerWithClause();
+
+        $this->runAiTransfer($player, $foreignBuyer, 'EN');
+
+        $player->refresh();
+        $this->assertSame($foreignBuyer->id, $player->team_id);
+        $this->assertNull($player->release_clause, 'A foreign (non-ES) buyer carries no clause.');
+    }
+
+    public function test_clause_is_re_anchored_to_the_floor_on_an_intra_spain_move(): void
+    {
+        $spanishBuyer = Team::factory()->create(['name' => 'Spanish Buyer', 'country' => 'ES']);
+        $player = $this->sellerPlayerWithClause(clause: null);
+
+        $this->runAiTransfer($player, $spanishBuyer, 'ES');
+
+        $expected = $this->contractService->calculateReleaseClause(self::MV, null, null, 'ES');
+
+        $player->refresh();
+        $this->assertSame($spanishBuyer->id, $player->team_id);
+        $this->assertSame($expected, (int) $player->release_clause, 'An ES buyer re-derives the mandatory floor.');
+    }
+
+    public function test_clause_stays_null_when_the_feature_is_disabled(): void
+    {
+        $this->game->update(['release_clauses_enabled' => false]);
+        $spanishBuyer = Team::factory()->create(['name' => 'Spanish Buyer', 'country' => 'ES']);
+        $player = $this->sellerPlayerWithClause();
+
+        $this->runAiTransfer($player, $spanishBuyer, 'ES');
+
+        $player->refresh();
+        $this->assertNull($player->release_clause, 'Flag-off saves never carry a clause, even for an ES buyer.');
+    }
+
+    private function sellerPlayerWithClause(?int $clause = self::CLAUSE): GamePlayer
+    {
+        return GamePlayer::factory()->forGame($this->game)->forTeam($this->spanishSeller)->create([
+            'market_value_cents' => self::MV,
+            'release_clause' => $clause,
+        ]);
+    }
+
+    /**
+     * Invoke the private prepareTransfer + flushBatchedOperations pair the way
+     * processAITransfers does, so the recompute runs through the real upsert.
+     */
+    private function runAiTransfer(GamePlayer $player, Team $buyer, string $toCountry): void
+    {
+        $playerUpdates = [];
+        $transferInserts = [];
+
+        $prepare = new \ReflectionMethod(AITransferMarketService::class, 'prepareTransfer');
+        $prepare->setAccessible(true);
+        $prepare->invokeArgs($this->service, [
+            $this->game, $player, $this->spanishSeller->id, $buyer->id, 'summer', null,
+            &$playerUpdates, &$transferInserts, 2, 3, 4, $toCountry,
+        ]);
+
+        $flush = new \ReflectionMethod(AITransferMarketService::class, 'flushBatchedOperations');
+        $flush->setAccessible(true);
+        $flush->invoke($this->service, $playerUpdates, $transferInserts);
+    }
+}


### PR DESCRIPTION
## Summary

AI-to-AI transfers (and AI free-agent signings) move players via `AITransferMarketService`'s batched upsert, which bypasses `TransferCompletionService` and so never touched `release_clause`. As a result a Spanish AI player sold to a foreign AI club kept his **stale ES clause**, and a free agent signing for an ES club regained no clause.

This change recomputes the clause from the **buying club's country** at every `AITransferMarketService` update site, mirroring the user-facing completion paths in `TransferCompletionService` (`completeOutgoingTransfer` / `completeIncomingTransfer` / `completeFreeAgentSigning`). It closes the documented "AI-to-AI stays untouched" gap noted in `docs/game-systems/release-clauses.md`.

## What changed

In `app/Modules/Transfer/Services/AITransferMarketService.php`:

- **`prepareTransfer` (AI-to-AI moves)** takes a new `?string $toCountry` and writes `release_clause`, recomputed via `ContractService::calculateReleaseClause(...)` — ES floor / `null` elsewhere, gated on `release_clauses_enabled`.
- **Both callers** pass the destination country: domestic buyer → `$teams->get($buyerTeamId)?->country ?? $game->country`; foreign departure → `$foreignTeam->country` (added `country` to that query's `select`).
- **The two AI free-agent signing sites** re-establish the clause for the signing club (it was nulled at contract expiry).
- **The batched upsert** now includes `release_clause` in its update-column list so the recomputed value persists.

## Behavior

| Scenario | Clause result |
|---|---|
| Spanish AI club → foreign AI club | cleared (`null`) |
| Intra-Spain AI move | re-derived to the mandatory ES floor |
| AI free-agent signing (ES) | re-established at the ES floor |
| Flag-off (existing) saves | `null` everywhere — no-op |

## Tests

Adds `tests/Feature/ReleaseClauseAITransferTest.php`, which drives the real `prepareTransfer` + batched upsert and asserts the clause is cleared on a move abroad, re-anchored to the floor intra-Spain, and stays `null` when the feature is off. All 3 pass locally.

## Note

This covers AI-to-AI permanent transfers and free-agent signings. AI-to-AI loans route through the same `prepareTransfer` builder, so they now recompute too — consistent with how that path already rewrites `team_id`/contract/wage on every move, though it differs slightly from `completeOutgoingTransfer`, which deliberately leaves loan clauses untouched.

https://claude.ai/code/session_017Fz8cqWtehYgWk5q7773Tp

---
_Generated by [Claude Code](https://claude.ai/code/session_017Fz8cqWtehYgWk5q7773Tp)_