### PR TITLE
Fix player wage asymmetry on contract renewal

### DIFF
--- a/app/Modules/Season/Processors/ContractExpirationProcessor.php
+++ b/app/Modules/Season/Processors/ContractExpirationProcessor.php
@@ -26,6 +26,10 @@ use Illuminate\Support\Facades\Log;
  */
 class ContractExpirationProcessor implements SeasonProcessor
 {
+    public function __construct(
+        private readonly ContractService $contractService,
+    ) {}
+
     public function priority(): int
     {
         return 20;
@@ -34,7 +38,7 @@ class ContractExpirationProcessor implements SeasonProcessor
     public function process(Game $game, SeasonTransitionData $data): SeasonTransitionData
     {
         // Clean up any stale renewal negotiations
-        app(ContractService::class)->expireStaleNegotiations($game);
+        $this->contractService->expireStaleNegotiations($game);
 
         // Clean up unsigned free agents from the previous season
         GamePlayer::where('game_id', $game->id)
@@ -47,12 +51,11 @@ class ContractExpirationProcessor implements SeasonProcessor
         $veteranCutoff = PlayerAge::dateOfBirthCutoff(PlayerAge::PRIME_END + 1, $game->current_date);
         $newContractEnd = Carbon::createFromDate($seasonYear + 3, 6, 30);
 
-        // AI non-veterans: auto-renew in a single set-based UPDATE. This is
-        // ~80% of expired contracts — handling them purely in SQL avoids
-        // hydrating hundreds of Eloquent models just to set one column.
-        // Filter mirrors the old PHP branch: not user team, contract expired,
-        // no pending wage, player not yet at the veteran cutoff.
-        $aiAutoRenewedCount = DB::table('game_players')
+        // AI non-veterans: auto-renew (~80% of expired contracts). Select the
+        // rows so the renewal can re-derive each player's wage from his current
+        // market value (renewAiContracts), not just extend contract_until — AI
+        // pay used to stay frozen at the seeded rookie wage for a whole career.
+        $aiNonVeteranRows = DB::table('game_players')
             ->where('game_id', $game->id)
             ->whereNotNull('team_id')
             ->where('team_id', '<>', $game->team_id)
@@ -60,11 +63,12 @@ class ContractExpirationProcessor implements SeasonProcessor
             ->where('contract_until', '<=', $expirationDate)
             ->whereNull('pending_annual_wage')
             ->where('date_of_birth', '>', $veteranCutoff->toDateString())
-            ->update(['contract_until' => $newContractEnd->toDateString()]);
+            ->select('id', 'team_id', 'market_value_cents', 'date_of_birth')
+            ->get();
 
-        // AI veterans: narrow SELECT of just the IDs, then 50% coin flip in
-        // PHP. Typically <30 rows.
-        $aiVeteranIds = DB::table('game_players')
+        // AI veterans: narrow SELECT, then 50% coin flip in PHP. Typically <30
+        // rows. Carries the same columns so the renewed half can be re-priced.
+        $aiVeteranRows = DB::table('game_players')
             ->where('game_id', $game->id)
             ->whereNotNull('team_id')
             ->where('team_id', '<>', $game->team_id)
@@ -72,15 +76,16 @@ class ContractExpirationProcessor implements SeasonProcessor
             ->where('contract_until', '<=', $expirationDate)
             ->whereNull('pending_annual_wage')
             ->where('date_of_birth', '<=', $veteranCutoff->toDateString())
-            ->pluck('id');
+            ->select('id', 'team_id', 'market_value_cents', 'date_of_birth')
+            ->get();
 
         $veteranFreeAgentIds = [];
-        $veteranAutoRenewedIds = [];
-        foreach ($aiVeteranIds as $id) {
+        $veteranAutoRenewedRows = [];
+        foreach ($aiVeteranRows as $row) {
             if (mt_rand(1, 100) <= 50) {
-                $veteranFreeAgentIds[] = $id;
+                $veteranFreeAgentIds[] = $row->id;
             } else {
-                $veteranAutoRenewedIds[] = $id;
+                $veteranAutoRenewedRows[] = $row;
             }
         }
 
@@ -119,12 +124,18 @@ class ContractExpirationProcessor implements SeasonProcessor
             // where the feature is off, since the column is already null).
             GamePlayer::whereIn('id', $freeAgentIds)->update(['team_id' => null, 'number' => null, 'release_clause' => null]);
         }
-        if (!empty($veteranAutoRenewedIds)) {
-            GamePlayer::whereIn('id', $veteranAutoRenewedIds)->update(['contract_until' => $newContractEnd]);
-        }
+
+        // Auto-renew all AI keepers (non-veterans + the renewed half of the
+        // veteran coin flip), re-deriving each wage from current market value.
+        $aiRenewedRows = $aiNonVeteranRows->concat($veteranAutoRenewedRows);
+        $this->contractService->renewAiContracts(
+            $aiRenewedRows,
+            $newContractEnd->toDateString(),
+            $game->current_date->toDateString(),
+        );
 
         Log::info('[ContractExpiration] Free agents created: ' . count($freeAgentIds)
-            . ', auto-renewed: ' . ($aiAutoRenewedCount + count($veteranAutoRenewedIds)));
+            . ', auto-renewed: ' . $aiRenewedRows->count());
 
         return $data;
     }

--- a/app/Modules/Transfer/Listeners/RollAIContractRenewals.php
+++ b/app/Modules/Transfer/Listeners/RollAIContractRenewals.php
@@ -7,6 +7,7 @@ use App\Models\Loan;
 use App\Models\TransferOffer;
 use App\Modules\Match\Events\GameDateAdvanced;
 use App\Modules\Player\PlayerAge;
+use App\Modules\Transfer\Services\ContractService;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\DB;
 
@@ -48,6 +49,10 @@ class RollAIContractRenewals
 
     private const TOP_IMPORTANCE_THRESHOLD = 0.70;
     private const MID_IMPORTANCE_THRESHOLD = 0.40;
+
+    public function __construct(
+        private readonly ContractService $contractService,
+    ) {}
 
     public function handle(GameDateAdvanced $event): void
     {
@@ -101,6 +106,7 @@ class RollAIContractRenewals
                 'game_players.overall_score',
                 'game_players.contract_until',
                 'game_players.date_of_birth',
+                'game_players.market_value_cents',
                 'game_players.pending_annual_wage',
                 DB::raw('CASE WHEN loans.id IS NULL THEN 0 ELSE 1 END AS on_loan'),
             )
@@ -149,9 +155,15 @@ class RollAIContractRenewals
         }
 
         if (!empty($renewIds)) {
-            DB::table('game_players')
-                ->whereIn('id', $renewIds)
-                ->update(['contract_until' => $newContractEnd->toDateString()]);
+            // Extend the contract AND re-derive the wage from current market
+            // value — without this AI pay stays frozen at the seeded rookie wage
+            // for the player's whole career while the user's wages track ability.
+            $renewSet = collect($renewIds)->flip();
+            $this->contractService->renewAiContracts(
+                $rows->filter(fn ($row) => $renewSet->has($row->id))->values(),
+                $newContractEnd->toDateString(),
+                $game->current_date->toDateString(),
+            );
         }
 
         return ['considered' => $considered, 'renewed' => count($renewIds)];

--- a/app/Modules/Transfer/Services/ContractService.php
+++ b/app/Modules/Transfer/Services/ContractService.php
@@ -581,6 +581,99 @@ class ContractService
     }
 
     /**
+     * Re-derive annual_wage from current market value and extend the contract
+     * for a batch of AI players being renewed.
+     *
+     * AI wages are seeded once from real market value and were then frozen —
+     * renewals only extended contract_until, so a rival's developing star kept
+     * his cheap rookie wage forever. Here the wage is re-derived from the
+     * player's *current* market value via the same calculateAnnualWage() used to
+     * seed wages, so AI pay tracks the market economy. Wages move both ways (a
+     * developed player earns more, a declining one less); the only downstream
+     * consumer is AITeamBudgetCalculator::financialPressure(), which keeps AI
+     * transfer budgets balanced as wage bills shift.
+     *
+     * @param  Collection<int, object>  $rows  each with id, team_id, market_value_cents, date_of_birth
+     */
+    public function renewAiContracts(Collection $rows, string $newContractEnd, string $referenceDate): void
+    {
+        if ($rows->isEmpty()) {
+            return;
+        }
+
+        // Resolve each distinct team's minimum wage once (the method caches, but
+        // it needs a hydrated Team with its clubProfile to read reputation).
+        // Key by string so lookups match regardless of whether the raw rows
+        // expose team_id as int or string.
+        $teamMinimums = Team::with('clubProfile')
+            ->whereIn('id', $rows->pluck('team_id')->unique()->filter()->all())
+            ->get()
+            ->mapWithKeys(fn (Team $team) => [(string) $team->id => $this->getMinimumWageForTeam($team)]);
+
+        $reference = Carbon::parse($referenceDate);
+
+        $updates = [];
+        foreach ($rows as $row) {
+            $marketValue = (int) $row->market_value_cents;
+            if ($marketValue <= 0 || $row->date_of_birth === null) {
+                // No reliable basis to re-derive a wage — extend the contract
+                // only, leaving the existing wage untouched.
+                $updates[] = ['id' => $row->id, 'wage' => null];
+                continue;
+            }
+
+            // diff()->y is absolute full years (int), avoiding Carbon 3's
+            // signed-float diffInYears().
+            $age = $reference->diff(Carbon::parse($row->date_of_birth))->y;
+            $minimumWage = $teamMinimums[(string) $row->team_id] ?? $this->getDefaultMinimumWage();
+
+            $updates[] = [
+                'id' => $row->id,
+                'wage' => $this->calculateAnnualWage($marketValue, $minimumWage, $age),
+            ];
+        }
+
+        foreach (array_chunk($updates, 500) as $chunk) {
+            $this->applyAiRenewalChunk($chunk, $newContractEnd);
+        }
+    }
+
+    /**
+     * Write one chunk of AI renewals: extend contract_until for every row, and
+     * set annual_wage where a new wage was computed (rows with a null wage keep
+     * their existing wage). Mirrors PlayerDevelopmentProcessor's UPDATE…FROM
+     * (VALUES …) pattern so each statement stays a plan-trivial PK lookup.
+     *
+     * @param  array<int, array{id:string, wage:int|null}>  $chunk
+     */
+    private function applyAiRenewalChunk(array $chunk, string $newContractEnd): void
+    {
+        if ($chunk === []) {
+            return;
+        }
+
+        $valueRows = [];
+        $valueBindings = [];
+        foreach ($chunk as $row) {
+            $valueRows[] = '(?::uuid, ?::bigint)';
+            $valueBindings[] = $row['id'];
+            $valueBindings[] = $row['wage'];
+        }
+        $values = implode(', ', $valueRows);
+
+        // COALESCE keeps the current annual_wage when v.wage is NULL. The
+        // contract_until placeholder binds first (it precedes the VALUES list
+        // in the statement text).
+        DB::update(<<<SQL
+            UPDATE game_players AS gp
+            SET annual_wage    = COALESCE(v.wage, gp.annual_wage),
+                contract_until = ?
+            FROM (VALUES {$values}) AS v(id, wage)
+            WHERE gp.id = v.id
+        SQL, [$newContractEnd, ...$valueBindings]);
+    }
+
+    /**
      * Get players eligible for contract renewal.
      *
      * @param Game $game

--- a/app/Modules/Transfer/Services/ContractService.php
+++ b/app/Modules/Transfer/Services/ContractService.php
@@ -295,8 +295,26 @@ class ContractService
         // that youth premium so the base wage tracks who the player is today.
         $abilityValue = $this->valuationService->wageBaseValue($player->overall_score, $age, $player->position);
 
+        // Cap the anchor at the player's *real* market value. The ability-derived
+        // value comes from generous anchors (overall 88 ≈ €80M) that sit well above
+        // the real market values rival clubs' wages are priced from — without this
+        // cap an established star renews at double/triple his current wage and far
+        // above what equivalent players earn elsewhere. Taking the lesser of the two
+        // keeps the wonderkid protection above (whose market value is the *higher*,
+        // potential-inflated figure, so the stripped ability value still wins) while
+        // pulling established players back in line with the market economy.
+        //
+        // Veterans (age > PRIME_END) are exempt: wageBaseValue() already preserves
+        // their age decline, and the veteran wage modifier in calculateAnnualWage()
+        // (AGE_WAGE_MODIFIERS['veteran'] = 5.0) is calibrated against that depressed
+        // ability value — capping by market value too would double-count the decline.
+        $anchorValue = $abilityValue;
+        if ($age <= PlayerAge::PRIME_END && $player->market_value_cents > 0) {
+            $anchorValue = min($abilityValue, $player->market_value_cents);
+        }
+
         $baseWage = $this->calculateAnnualWage(
-            $abilityValue,
+            $anchorValue,
             $minimumWage,
             $age,
             deterministic: true,

--- a/tests/Feature/AiRenewalWageTest.php
+++ b/tests/Feature/AiRenewalWageTest.php
@@ -1,0 +1,151 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Game;
+use App\Models\GamePlayer;
+use App\Models\Team;
+use App\Models\User;
+use App\Modules\Season\DTOs\SeasonTransitionData;
+use App\Modules\Season\Processors\ContractExpirationProcessor;
+use App\Modules\Transfer\Services\ContractService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * AI clubs used to renew contracts (RollAIContractRenewals + the season-end
+ * ContractExpirationProcessor) by only extending contract_until, leaving
+ * annual_wage frozen at the seeded rookie value for a player's whole career —
+ * the other half of the wage asymmetry (a rival star earned a pittance while
+ * the user's stars demanded fortunes). These cover re-deriving AI wages from
+ * current market value at renewal time, in both directions.
+ */
+class AiRenewalWageTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private ContractService $contractService;
+    private Game $game;
+    private Team $userTeam;
+    private Team $aiTeam;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->contractService = app(ContractService::class);
+
+        $user = User::factory()->create();
+        $this->userTeam = Team::factory()->create();
+        $this->aiTeam = Team::factory()->create();
+
+        $this->game = Game::factory()->forTeam($this->userTeam)->create([
+            'user_id' => $user->id,
+            'season' => '2026',
+            'current_date' => '2026-08-15',
+        ]);
+    }
+
+    public function test_renew_ai_contracts_recomputes_wage_both_ways(): void
+    {
+        // Underpaid: seeded cheap but now worth €50M → wage should rise.
+        $underpaid = GamePlayer::factory()->forGame($this->game)->forTeam($this->aiTeam)->create([
+            'date_of_birth' => '1996-01-01', // ~30, prime
+            'market_value_cents' => 5_000_000_000, // €50M
+            'annual_wage' => 10_000_000,           // €100K
+            'contract_until' => '2027-06-30',
+        ]);
+        // Overpaid: a faded star on €5M but now worth only €1M → wage should fall.
+        $overpaid = GamePlayer::factory()->forGame($this->game)->forTeam($this->aiTeam)->create([
+            'date_of_birth' => '1996-01-01',
+            'market_value_cents' => 100_000_000, // €1M
+            'annual_wage' => 500_000_000,        // €5M
+            'contract_until' => '2027-06-30',
+        ]);
+
+        $this->contractService->renewAiContracts(
+            $this->rowsFor($underpaid, $overpaid),
+            '2030-06-30',
+            '2026-08-15',
+        );
+
+        $underpaid->refresh();
+        $overpaid->refresh();
+
+        $this->assertSame('2030-06-30', $underpaid->contract_until->toDateString());
+        $this->assertSame('2030-06-30', $overpaid->contract_until->toDateString());
+
+        // €50M @ 15% ≈ €7.5M — far above the €100K seed.
+        $this->assertGreaterThan(500_000_000, $underpaid->annual_wage, 'Underpaid star wage should rise toward market value');
+        // €1M @ 8% ≈ €80K — well below the €5M legacy deal.
+        $this->assertLessThan(500_000_000, $overpaid->annual_wage, 'Faded star wage should fall toward market value');
+    }
+
+    public function test_renew_ai_contracts_keeps_wage_when_market_value_missing(): void
+    {
+        $player = GamePlayer::factory()->forGame($this->game)->forTeam($this->aiTeam)->create([
+            'date_of_birth' => '1996-01-01',
+            'market_value_cents' => 0,
+            'annual_wage' => 500_000_000, // €5M
+            'contract_until' => '2027-06-30',
+        ]);
+
+        $this->contractService->renewAiContracts($this->rowsFor($player), '2030-06-30', '2026-08-15');
+
+        $player->refresh();
+        $this->assertSame('2030-06-30', $player->contract_until->toDateString(), 'Contract still extends');
+        $this->assertSame(500_000_000, $player->annual_wage, 'Wage is left untouched when there is no market value to price from');
+    }
+
+    public function test_contract_expiration_recomputes_ai_wages_and_leaves_user_team_alone(): void
+    {
+        // AI non-veteran with an expiring contract: auto-renewed AND re-priced.
+        $aiPlayer = GamePlayer::factory()->forGame($this->game)->forTeam($this->aiTeam)->create([
+            'date_of_birth' => '1996-01-01', // ~30, non-veteran
+            'market_value_cents' => 3_000_000_000, // €30M
+            'annual_wage' => 20_000_000,           // €200K, seeded cheap
+            'contract_until' => '2027-06-30',
+            'pending_annual_wage' => null,
+        ]);
+
+        // User-team player with an expiring contract: becomes a free agent, and
+        // crucially his wage must NOT be recomputed by the AI renewal helper.
+        $userPlayer = GamePlayer::factory()->forGame($this->game)->forTeam($this->userTeam)->create([
+            'date_of_birth' => '1996-01-01',
+            'market_value_cents' => 3_000_000_000,
+            'annual_wage' => 20_000_000,
+            'contract_until' => '2027-06-30',
+            'pending_annual_wage' => null,
+        ]);
+
+        app(ContractExpirationProcessor::class)->process($this->game, new SeasonTransitionData(
+            oldSeason: '2026',
+            newSeason: '2027',
+            competitionId: $this->game->competition_id,
+        ));
+
+        $aiPlayer->refresh();
+        $userPlayer->refresh();
+
+        // seasonYear (2026) + 3 = 2029.
+        $this->assertSame('2029-06-30', $aiPlayer->contract_until->toDateString(), 'AI keeper is auto-renewed');
+        $this->assertGreaterThan(20_000_000, $aiPlayer->annual_wage, 'AI renewal re-derives the wage from market value');
+
+        $this->assertNull($userPlayer->team_id, 'Expiring user-team player becomes a free agent');
+        $this->assertSame(20_000_000, $userPlayer->annual_wage, 'AI wage recompute must never touch the user team');
+    }
+
+    /**
+     * Build the lightweight row objects renewAiContracts() consumes (mirrors the
+     * raw DB::table select the production callers pass in).
+     */
+    private function rowsFor(GamePlayer ...$players): \Illuminate\Support\Collection
+    {
+        return collect($players)->map(fn (GamePlayer $p) => (object) [
+            'id' => $p->id,
+            'team_id' => $p->team_id,
+            'market_value_cents' => $p->market_value_cents,
+            'date_of_birth' => $p->date_of_birth->toDateString(),
+        ]);
+    }
+}

--- a/tests/Feature/RenewalWageDemandTest.php
+++ b/tests/Feature/RenewalWageDemandTest.php
@@ -1,0 +1,200 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Competition;
+use App\Models\Game;
+use App\Models\GamePlayer;
+use App\Models\Team;
+use App\Models\User;
+use App\Modules\Transfer\Enums\NegotiationScenario;
+use App\Modules\Transfer\Services\ContractService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Covers the renewal wage-demand re-anchoring: the base wage is anchored to the
+ * lesser of the player's ability-derived value and his *real* market value, so
+ * an established star no longer demands double/triple his wage off the generous
+ * ability anchors while equivalent players at rival clubs (priced off market
+ * value) earn far less. Wonderkids and veterans keep their existing treatment.
+ */
+class RenewalWageDemandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private ContractService $contractService;
+    private Competition $competition;
+    private Game $game;
+
+    private const REFERENCE_DATE = '2024-08-15';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->contractService = app(ContractService::class);
+
+        $this->competition = Competition::factory()->league()->create([
+            'id' => 'ESP1',
+            'name' => 'LaLiga',
+        ]);
+
+        $user = User::factory()->create();
+        $userTeam = Team::factory()->create();
+
+        $this->game = Game::factory()->create([
+            'user_id' => $user->id,
+            'team_id' => $userTeam->id,
+            'competition_id' => $this->competition->id,
+            'season' => '2024',
+            'current_date' => self::REFERENCE_DATE,
+        ]);
+    }
+
+    public function test_established_star_demand_is_capped_by_real_market_value(): void
+    {
+        // Same ability/age/wage/tier — only the real market value differs. The
+        // ability anchor for overall 85 (~€60M) sits well above a €40M market
+        // value, so the low-MV star is pulled down to the market rate while the
+        // high-MV star (whose MV exceeds the anchor) keeps the ability-based wage.
+        $lowMarketValueStar = $this->makePlayer(
+            overall: 85,
+            age: 27,
+            marketValueCents: 40_000_000_00,
+            wageCents: 4_000_000_00,
+            tier: 4,
+        );
+        $highMarketValueStar = $this->makePlayer(
+            overall: 85,
+            age: 27,
+            marketValueCents: 100_000_000_00,
+            wageCents: 4_000_000_00,
+            tier: 4,
+        );
+
+        $lowDemand = $this->contractService->calculateWageDemand($lowMarketValueStar, NegotiationScenario::RENEWAL)['wage'];
+        $highDemand = $this->contractService->calculateWageDemand($highMarketValueStar, NegotiationScenario::RENEWAL)['wage'];
+
+        $this->assertLessThan(
+            $highDemand,
+            $lowDemand,
+            'A star with a lower real market value should demand less than an identical star whose market value exceeds the ability anchor.'
+        );
+    }
+
+    public function test_established_star_renewal_is_not_double_or_triple_current_wage(): void
+    {
+        // The reported bug: a seeded star earning ~€4M demands €11-20M on renewal.
+        // With market-value anchoring the demand is a sane raise, not a multiple.
+        $star = $this->makePlayer(
+            overall: 85,
+            age: 27,
+            marketValueCents: 40_000_000_00,
+            wageCents: 4_000_000_00,
+            tier: 4,
+        );
+
+        $demand = $this->contractService->calculateWageDemand($star, NegotiationScenario::RENEWAL)['wage'];
+
+        $this->assertGreaterThan(
+            $star->annual_wage,
+            $demand,
+            'Renewal demand must still be a raise over the current wage.'
+        );
+        $this->assertLessThan(
+            $star->annual_wage * 2,
+            $demand,
+            'Renewal demand must not balloon to double (or triple) the current wage.'
+        );
+    }
+
+    public function test_wonderkid_demand_is_unaffected_by_potential_inflated_market_value(): void
+    {
+        // A wonderkid's market value carries a potential premium that sits ABOVE
+        // his (youth-stripped) ability value, so the min() cap binds to the ability
+        // value regardless of how high the market value is — the existing wonderkid
+        // protection. Two identical youths with very different market values must
+        // therefore demand the same wage.
+        $modestValueKid = $this->makePlayer(
+            overall: 70,
+            age: 18,
+            marketValueCents: 15_000_000_00,
+            wageCents: 50_000_00,
+            tier: 3,
+        );
+        $hypedKid = $this->makePlayer(
+            overall: 70,
+            age: 18,
+            marketValueCents: 80_000_000_00,
+            wageCents: 50_000_00,
+            tier: 3,
+        );
+
+        $modestDemand = $this->contractService->calculateWageDemand($modestValueKid, NegotiationScenario::RENEWAL)['wage'];
+        $hypedDemand = $this->contractService->calculateWageDemand($hypedKid, NegotiationScenario::RENEWAL)['wage'];
+
+        $this->assertSame(
+            $modestDemand,
+            $hypedDemand,
+            'A wonderkid demand should be anchored to ability, not his potential-inflated market value.'
+        );
+    }
+
+    public function test_veteran_demand_ignores_the_market_value_cap(): void
+    {
+        // Veterans are exempt from the market-value cap: wageBaseValue() already
+        // preserves their age decline and the veteran wage modifier is calibrated
+        // against that depressed value. A veteran with a market value BELOW his
+        // ability anchor must NOT be pulled down to it — so two veterans with
+        // different (one below-anchor) market values still demand the same wage.
+        $lowValueVeteran = $this->makePlayer(
+            overall: 80,
+            age: 36,
+            marketValueCents: 5_000_000_00,
+            wageCents: 6_000_000_00,
+            tier: 3,
+        );
+        $highValueVeteran = $this->makePlayer(
+            overall: 80,
+            age: 36,
+            marketValueCents: 50_000_000_00,
+            wageCents: 6_000_000_00,
+            tier: 3,
+        );
+
+        $lowDemand = $this->contractService->calculateWageDemand($lowValueVeteran, NegotiationScenario::RENEWAL)['wage'];
+        $highDemand = $this->contractService->calculateWageDemand($highValueVeteran, NegotiationScenario::RENEWAL)['wage'];
+
+        $this->assertSame(
+            $lowDemand,
+            $highDemand,
+            'A veteran demand must ignore the market-value cap so a below-anchor market value does not depress it.'
+        );
+    }
+
+    /**
+     * Create a player on his own team (attached to the league) inside the shared
+     * game. A dedicated team keeps each player out of the others' peer-median
+     * wage pool so demands stay independent.
+     */
+    private function makePlayer(int $overall, int $age, int $marketValueCents, int $wageCents, int $tier): GamePlayer
+    {
+        $team = Team::factory()->create();
+        $team->competitions()->attach($this->competition->id, ['season' => '2024']);
+
+        $player = GamePlayer::factory()->age($age, self::REFERENCE_DATE)->create([
+            'game_id' => $this->game->id,
+            'team_id' => $team->id,
+            'overall_score' => $overall,
+            'market_value_cents' => $marketValueCents,
+            'annual_wage' => $wageCents,
+            'tier' => $tier,
+            'position' => 'Central Midfield',
+        ]);
+
+        $player->load('team');
+
+        return $player;
+    }
+}

--- a/tests/Unit/RollAIContractRenewalsTest.php
+++ b/tests/Unit/RollAIContractRenewalsTest.php
@@ -225,6 +225,41 @@ class RollAIContractRenewalsTest extends TestCase
         }
     }
 
+    public function test_renewal_recomputes_wage_from_market_value(): void
+    {
+        // A player seeded cheap but worth €50M today must have his wage
+        // re-derived upward when the AI club renews him — not kept frozen.
+        $player = GamePlayer::factory()
+            ->forGame($this->game)
+            ->forTeam($this->aiTeam)
+            ->create([
+                'date_of_birth' => '1998-01-01',
+                'overall_score' => 90,
+                'market_value_cents' => 5_000_000_000, // €50M
+                'annual_wage' => 10_000_000,           // €100K, seeded cheap
+                'contract_until' => self::EXPIRING_CONTRACT,
+            ]);
+
+        // Sole squad member → mid importance (12‰/tick); roll until renewed.
+        for ($i = 0; $i < 3000; $i++) {
+            $this->listener->roll($this->game);
+            if ($player->refresh()->contract_until?->toDateString() === self::RENEWED_CONTRACT) {
+                break;
+            }
+        }
+
+        $this->assertSame(
+            self::RENEWED_CONTRACT,
+            $player->contract_until->toDateString(),
+            'Player should eventually be renewed',
+        );
+        $this->assertGreaterThan(
+            500_000_000, // €5M — far above the €100K seed; €50M @ 15% ≈ €7.5M
+            $player->annual_wage,
+            'Renewal must re-derive the wage from current market value, not keep the frozen seed wage',
+        );
+    }
+
     public function test_handle_invokes_roll(): void
     {
         $this->makeAiSquadOfFiveExpiring();


### PR DESCRIPTION
## Summary

Addresses player feedback that contract renewals are unbalanced: the user's stars demand
fortunes (€11–20M, often 2–3× their current wage) on renewal, while the best-paid players at
rival clubs earn far less (≤€5M). The root cause was a two-sided asymmetry in how wages
evolve:

1. **The user's renewal demands re-priced upward** — anchored to a generous *ability-derived*
   value, then marked up — while
2. **AI clubs' wages were frozen** at their seeded value forever, because AI renewals only
   extended the contract end date and never re-derived the wage.

This PR fixes both halves so the wage economy is consistent on both ends.

## Part 1 — Cap the user's renewal demand by real market value

`ContractService::calculateWageDemand()` anchored the base wage to
`PlayerValuationService::wageBaseValue()`, whose anchors are generous (overall 88 ≈ €80M),
sitting well above the real market values that price the rest of the economy. A seeded star
earning ~€4M therefore demanded ~€11M on renewal.

- The base-wage anchor is now `min(abilityValue, marketValue)` for players in their prime
  (age ≤ `PlayerAge::PRIME_END`), pulling established players back in line with the market.
- **Wonderkids** are preserved: their market value carries a potential premium and sits
  *above* the youth-stripped ability value, so `min()` still selects the (lower) ability
  value — they don't demand a star's wage.
- **Veterans** (age > `PRIME_END`) are exempt: their age decline is already baked into the
  ability value, and the veteran wage modifier (5.0×) is calibrated against that depressed
  figure, so capping by market value would double-count the decline.

This also applies to **new signings** (transfer / pre-contract / free-agent personal terms),
since they all flow through `calculateWageDemand()` — the cap sits before the scenario
branching. Scenario-specific premiums/floors (e.g. the pre-contract Bosman premium) are
unchanged.

## Part 2 — Re-derive AI wages when AI clubs renew

AI renewals (`RollAIContractRenewals` per-matchday, and the season-end
`ContractExpirationProcessor`) only extended `contract_until`, so a rival's developing star
kept his cheap seeded rookie wage for his entire career.

- New `ContractService::renewAiContracts()` re-derives each renewing AI player's
  `annual_wage` from his **current market value**, via the same `calculateAnnualWage()` used
  to seed wages (keeping AI pay on the market economy, not the inflated ability anchors), and
  extends the contract in one chunked `UPDATE … FROM (VALUES …)` (mirroring
  `PlayerDevelopmentProcessor`).
- Wages **track value in both directions** — they rise as a player develops and dip as he
  declines — so AI squad wage bills stay honest.
- Both AI renewal paths are routed through the helper: the per-matchday roll, and the
  season-end non-veteran auto-renew plus the renewed half of the veteran coin-flip. Freed
  veterans and user-team players are untouched.

### Why Part 2 is safe

The only AI-facing consumer of AI `annual_wage` is
`AITeamBudgetCalculator::financialPressure()`: a higher wage bill → more financial pressure →
a smaller AI transfer budget (self-regulating, floored at 30%). Every other reader
(`SalaryCapService`, `BudgetProjectionService`, settlement, squad summaries) filters on
`$game->team_id` and is unaffected. Because the recompute reuses the seeding formula and
tracks value both ways, net wage-bill drift per season is modest.

## Tests

- **`RenewalWageDemandTest`** (Part 1): market-value cap binds for established stars; renewal
  demands are sane raises (not 2–3×); wonderkid demands stay ability-anchored; veterans
  ignore the cap.
- **`AiRenewalWageTest`** (Part 2): `renewAiContracts()` re-prices both directions, leaves
  the wage untouched when there's no market value, and the season-end processor re-prices AI
  keepers while leaving user-team players alone.
- **`RollAIContractRenewalsTest`**: extended to assert the per-matchday roll re-derives the
  wage from market value on renewal.

https://claude.ai/code/session_018SaLczxFKKqLN2wceWToSM