### PR TITLE
Import real-world loans from squad data

### DIFF
--- a/app/Models/GamePlayerTemplate.php
+++ b/app/Models/GamePlayerTemplate.php
@@ -21,6 +21,7 @@ class GamePlayerTemplate extends Model
         'height',
         'foot',
         'team_id',
+        'loan_from_transfermarkt_id',
         'number',
         'position',
         'market_value',

--- a/app/Modules/Season/Jobs/SetupNewGame.php
+++ b/app/Modules/Season/Jobs/SetupNewGame.php
@@ -17,6 +17,7 @@ use App\Models\CompetitionTeam;
 use App\Models\Game;
 use App\Models\GamePlayer;
 use App\Models\GameTactics;
+use App\Models\Loan;
 use App\Models\Team;
 use App\Models\TeamReputation;
 use App\Models\UserSquadCareerRecord;
@@ -103,6 +104,7 @@ class SetupNewGame implements ShouldQueue, ShouldBeUnique
         // Step 2: Initialize game players from templates (required)
         $this->initializeGamePlayersFromTemplates();
         $this->initializeUserSquadCareerRecords($game);
+        $this->initializeLoansFromTemplates($game);
         $this->markStep(2);
 
         // Step 3: Pick a default formation that fits the user's squad. Runs
@@ -412,6 +414,86 @@ class SetupNewGame implements ShouldQueue, ShouldBeUnique
               AND gp.team_id IN ($placeholders)
             ON CONFLICT (game_player_id) DO NOTHING
         SQL, [(int) $this->season, $this->gameId, ...$userTeamIds]);
+    }
+
+    /**
+     * Materialise per-game loan records for players the source data marks as
+     * on loan. A loaned player is listed in the BORROWING club's squad (so his
+     * game_player team_id is that club), while the template carries the OWNING
+     * club's Transfermarkt id (loan.from). We create a season-long loan that
+     * LoanReturnProcessor closes at season end: the player returns to the
+     * owning club if it fields a squad in this game, otherwise the loan has no
+     * parent and returnLoan() frees him (team_id = null → free agent).
+     */
+    private function initializeLoansFromTemplates(Game $game): void
+    {
+        // Idempotency: setup is a re-entrant unique job, so skip if loans for
+        // this game already exist.
+        if (Loan::where('game_id', $this->gameId)->exists()) {
+            return;
+        }
+
+        $loanedTemplates = DB::table('game_player_templates')
+            ->where('season', $this->season)
+            ->whereNotNull('loan_from_transfermarkt_id')
+            ->get(['player_id', 'team_id', 'loan_from_transfermarkt_id']);
+
+        if ($loanedTemplates->isEmpty()) {
+            return;
+        }
+
+        // Transfermarkt id → team uuid, so loan.from resolves to an owner.
+        $teamIdByTransfermarktId = Team::whereNotNull('transfermarkt_id')
+            ->pluck('id', 'transfermarkt_id')
+            ->toArray();
+
+        // Teams that actually field a squad in this game. An owner outside this
+        // set (foreign/unknown club, or one excluded from the game) yields a
+        // null parent → the player becomes a free agent when the loan ends.
+        $participatingTeamIds = DB::table('game_players')
+            ->where('game_id', $this->gameId)
+            ->distinct()
+            ->pluck('team_id')
+            ->flip()
+            ->toArray();
+
+        // game_player id keyed by "player_id|team_id" for this game. The loaned
+        // player is listed once (at the borrowing club), so the pair is unique.
+        $gamePlayersByKey = DB::table('game_players')
+            ->where('game_id', $this->gameId)
+            ->whereIn('player_id', $loanedTemplates->pluck('player_id'))
+            ->get(['id', 'player_id', 'team_id'])
+            ->keyBy(fn ($row) => $row->player_id . '|' . $row->team_id);
+
+        $startedAt = $this->currentDate->toDateString();
+        $returnAt = $game->getSeasonEndDateFor($this->currentDate)->toDateString();
+
+        $rows = [];
+        foreach ($loanedTemplates as $template) {
+            $gamePlayer = $gamePlayersByKey->get($template->player_id . '|' . $template->team_id);
+            if (! $gamePlayer) {
+                // Borrowing club isn't materialised in this game — nothing to loan.
+                continue;
+            }
+
+            $ownerTeamId = $teamIdByTransfermarktId[$template->loan_from_transfermarkt_id] ?? null;
+            $ownerInGame = $ownerTeamId !== null && isset($participatingTeamIds[$ownerTeamId]);
+
+            $rows[] = [
+                'id' => Str::uuid()->toString(),
+                'game_id' => $this->gameId,
+                'game_player_id' => $gamePlayer->id,
+                'parent_team_id' => $ownerInGame ? $ownerTeamId : null,
+                'loan_team_id' => $template->team_id,
+                'started_at' => $startedAt,
+                'return_at' => $returnAt,
+                'status' => Loan::STATUS_ACTIVE,
+            ];
+        }
+
+        foreach (array_chunk($rows, 500) as $chunk) {
+            DB::table('loans')->insert($chunk);
+        }
     }
 
     /**

--- a/app/Modules/Season/Processors/LoanReturnProcessor.php
+++ b/app/Modules/Season/Processors/LoanReturnProcessor.php
@@ -43,7 +43,9 @@ class LoanReturnProcessor implements SeasonProcessor
             'playerId' => $loan->game_player_id,
             'playerName' => $loan->gamePlayer->name,
             'parentTeamId' => $loan->parent_team_id,
-            'parentTeamName' => $loan->parentTeam->name,
+            // Null for loans whose owning club isn't in the game — the player
+            // is freed rather than returned, so there is no parent team name.
+            'parentTeamName' => $loan->parentTeam?->name,
             'loanTeamId' => $loan->loan_team_id,
             'loanTeamName' => $loan->loanTeam->name,
         ])->toArray();

--- a/app/Modules/Season/Services/GamePlayerTemplateService.php
+++ b/app/Modules/Season/Services/GamePlayerTemplateService.php
@@ -496,6 +496,12 @@ class GamePlayerTemplateService
             'height' => $playerData['height'] ?? null,
             'foot' => $foot,
             'team_id' => $teamId,
+            // Owning club's Transfermarkt id when the player is on loan. He is
+            // listed in the borrowing club's squad (= $teamId), so this points
+            // at loan.from; SetupNewGame materialises it into a loan record.
+            'loan_from_transfermarkt_id' => isset($playerData['loan']['from']['id'])
+                ? (string) $playerData['loan']['from']['id']
+                : null,
             'number' => isset($playerData['number']) ? (int) $playerData['number'] : null,
             'position' => $position ?? 'Unknown',
             'secondary_positions' => json_encode($secondaryPositions),

--- a/database/migrations/2026_06_06_000001_add_loan_from_to_game_player_templates.php
+++ b/database/migrations/2026_06_06_000001_add_loan_from_to_game_player_templates.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('game_player_templates', function (Blueprint $table) {
+            // Owning club's Transfermarkt id when the player is on loan in the
+            // source data (he is listed in the BORROWING club's squad, so
+            // team_id is the borrowing club and this points at loan.from). A
+            // non-null value marks the template as "on loan"; SetupNewGame
+            // turns it into a per-game loan that returns the player to the
+            // owning club at season end (or frees him if that club isn't in
+            // the game).
+            $table->string('loan_from_transfermarkt_id')->nullable()->after('team_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('game_player_templates', function (Blueprint $table) {
+            $table->dropColumn('loan_from_transfermarkt_id');
+        });
+    }
+};

--- a/database/migrations/2026_06_06_000002_make_parent_team_id_nullable_on_loans.php
+++ b/database/migrations/2026_06_06_000002_make_parent_team_id_nullable_on_loans.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        // A loan whose owning club is not part of the game has no parent team:
+        // the player becomes a free agent when the loan ends. returnLoan()
+        // already turns a null parent into team_id = null (free agent), so the
+        // only thing missing was the column allowing null.
+        Schema::table('loans', function (Blueprint $table) {
+            $table->uuid('parent_team_id')->nullable()->change();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('loans', function (Blueprint $table) {
+            $table->uuid('parent_team_id')->nullable(false)->change();
+        });
+    }
+};

--- a/tests/Feature/LoanImportTest.php
+++ b/tests/Feature/LoanImportTest.php
@@ -32,6 +32,7 @@ class LoanImportTest extends TestCase
     private Team $ownerInGame;    // an owning club that fields a squad in the game
     private Team $ownerOutOfGame; // an owning club with no squad in the game
     private Game $game;
+    private int $nextSquadNumber = 7; // keep squad numbers unique per borrowing team
 
     protected function setUp(): void
     {
@@ -156,7 +157,7 @@ class LoanImportTest extends TestCase
         return GamePlayer::factory()
             ->forGame($this->game)
             ->forTeam($this->borrowingTeam)
-            ->create(['number' => 7]);
+            ->create(['number' => $this->nextSquadNumber++]);
     }
 
     private function createTemplate(string $playerId, ?string $loanFrom): GamePlayerTemplate

--- a/tests/Feature/LoanImportTest.php
+++ b/tests/Feature/LoanImportTest.php
@@ -1,0 +1,196 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Competition;
+use App\Models\Game;
+use App\Models\GamePlayer;
+use App\Models\GamePlayerTemplate;
+use App\Models\Loan;
+use App\Models\Team;
+use App\Models\User;
+use App\Modules\Season\Jobs\SetupNewGame;
+use App\Modules\Transfer\Services\LoanService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Covers importing real-world loans from the squad-template data: SetupNewGame
+ * turns a template's loan_from_transfermarkt_id into a per-game loan that
+ * returns the player to the owning club at season end — or, when that club
+ * isn't part of the game, leaves no parent so the player is freed.
+ */
+class LoanImportTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const SEASON = '2024';
+
+    private User $user;
+    private Team $userTeam;       // the manager's club
+    private Team $borrowingTeam;  // where loaned players currently play
+    private Team $ownerInGame;    // an owning club that fields a squad in the game
+    private Team $ownerOutOfGame; // an owning club with no squad in the game
+    private Game $game;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = User::factory()->create();
+        $this->userTeam = Team::factory()->create(['name' => 'User Team']);
+        $this->borrowingTeam = Team::factory()->create(['name' => 'Borrowing Team']);
+        $this->ownerInGame = Team::factory()->create(['name' => 'Owner In Game']);
+        $this->ownerOutOfGame = Team::factory()->create(['name' => 'Owner Out Of Game']);
+        Competition::factory()->league()->create(['id' => 'ESP1']);
+
+        $this->game = Game::factory()->create([
+            'user_id' => $this->user->id,
+            'team_id' => $this->userTeam->id,
+            'competition_id' => 'ESP1',
+            'season' => self::SEASON,
+            'current_date' => '2024-08-15',
+        ]);
+
+        // The owning club only counts as "in the game" if it fields a squad.
+        GamePlayer::factory()->forGame($this->game)->forTeam($this->ownerInGame)->create();
+    }
+
+    public function test_setup_materialises_loans_with_correct_parents(): void
+    {
+        // Player A: on loan at the borrowing club, owner IS in the game.
+        $playerA = $this->createGamePlayerOnBorrowingTeam();
+        $this->createTemplate($playerA->player_id, loanFrom: $this->ownerInGame->transfermarkt_id);
+
+        // Player B: on loan at the borrowing club, owner is NOT in the game.
+        $playerB = $this->createGamePlayerOnBorrowingTeam();
+        $this->createTemplate($playerB->player_id, loanFrom: $this->ownerOutOfGame->transfermarkt_id);
+
+        // Player C: a normal squad member, no loan info.
+        $playerC = $this->createGamePlayerOnBorrowingTeam();
+        $this->createTemplate($playerC->player_id, loanFrom: null);
+
+        $this->invokeLoanInit();
+
+        // A → returns to the owning club at season end.
+        $loanA = Loan::where('game_player_id', $playerA->id)->first();
+        $this->assertNotNull($loanA, 'A loan should be created for an in-game owner');
+        $this->assertSame($this->ownerInGame->id, $loanA->parent_team_id);
+        $this->assertSame($this->borrowingTeam->id, $loanA->loan_team_id);
+        $this->assertSame(Loan::STATUS_ACTIVE, $loanA->status);
+        $this->assertSame('2025-06-30', $loanA->return_at->toDateString(),
+            'Imported loans are season-long: they return at the first June 30');
+        $this->assertSame('2024-08-15', $loanA->started_at->toDateString());
+
+        // B → no parent, so the player will be freed when the loan ends.
+        $loanB = Loan::where('game_player_id', $playerB->id)->first();
+        $this->assertNotNull($loanB, 'A loan should still be created when the owner is out of game');
+        $this->assertNull($loanB->parent_team_id,
+            'An owner outside the game leaves the loan parentless (free agent on return)');
+        $this->assertSame($this->borrowingTeam->id, $loanB->loan_team_id);
+
+        // C → never on loan, so no loan record.
+        $this->assertFalse(Loan::where('game_player_id', $playerC->id)->exists(),
+            'Players with no loan info must not get a loan record');
+    }
+
+    public function test_initialize_loans_is_idempotent(): void
+    {
+        $player = $this->createGamePlayerOnBorrowingTeam();
+        $this->createTemplate($player->player_id, loanFrom: $this->ownerInGame->transfermarkt_id);
+
+        $this->invokeLoanInit();
+        $this->invokeLoanInit();
+
+        $this->assertSame(1, Loan::where('game_player_id', $player->id)->count(),
+            'Re-running setup must not duplicate loans');
+    }
+
+    public function test_returning_a_parentless_loan_frees_the_player(): void
+    {
+        $player = $this->createGamePlayerOnBorrowingTeam();
+        $loan = Loan::create([
+            'game_id' => $this->game->id,
+            'game_player_id' => $player->id,
+            'parent_team_id' => null,
+            'loan_team_id' => $this->borrowingTeam->id,
+            'started_at' => $this->game->current_date,
+            'return_at' => $this->game->getSeasonEndDateFor($this->game->current_date),
+            'status' => Loan::STATUS_ACTIVE,
+        ]);
+
+        app(LoanService::class)->returnLoan($loan);
+
+        $player->refresh();
+        $this->assertNull($player->team_id, 'A parentless loan frees the player (team_id = null)');
+        $this->assertNull($player->number);
+        $this->assertSame(Loan::STATUS_COMPLETED, $loan->refresh()->status);
+    }
+
+    public function test_return_all_loans_handles_parentless_loan_without_error(): void
+    {
+        $player = $this->createGamePlayerOnBorrowingTeam();
+        Loan::create([
+            'game_id' => $this->game->id,
+            'game_player_id' => $player->id,
+            'parent_team_id' => null,
+            'loan_team_id' => $this->borrowingTeam->id,
+            'started_at' => $this->game->current_date,
+            'return_at' => $this->game->getSeasonEndDateFor($this->game->current_date),
+            'status' => Loan::STATUS_ACTIVE,
+        ]);
+
+        // Eager-loads parentTeam (null here) then returns each loan — must not NPE.
+        $returned = app(LoanService::class)->returnAllLoans($this->game);
+
+        $this->assertCount(1, $returned);
+        $this->assertNull($player->refresh()->team_id);
+    }
+
+    // =====================================================
+    // Helpers
+    // =====================================================
+
+    private function createGamePlayerOnBorrowingTeam(): GamePlayer
+    {
+        return GamePlayer::factory()
+            ->forGame($this->game)
+            ->forTeam($this->borrowingTeam)
+            ->create(['number' => 7]);
+    }
+
+    private function createTemplate(string $playerId, ?string $loanFrom): GamePlayerTemplate
+    {
+        return GamePlayerTemplate::create([
+            'season' => self::SEASON,
+            'player_id' => $playerId,
+            'team_id' => $this->borrowingTeam->id,
+            'position' => 'Central Midfield',
+            'loan_from_transfermarkt_id' => $loanFrom === null ? null : (string) $loanFrom,
+        ]);
+    }
+
+    /**
+     * Invoke SetupNewGame::initializeLoansFromTemplates (private) with the
+     * job's currentDate primed, mirroring how handle() calls it after the
+     * game_players have been materialised.
+     */
+    private function invokeLoanInit(): void
+    {
+        $job = new SetupNewGame(
+            $this->game->id,
+            $this->userTeam->id,
+            'ESP1',
+            self::SEASON,
+            Game::MODE_CAREER,
+        );
+
+        $currentDate = new \ReflectionProperty(SetupNewGame::class, 'currentDate');
+        $currentDate->setAccessible(true);
+        $currentDate->setValue($job, $this->game->current_date);
+
+        $method = new \ReflectionMethod(SetupNewGame::class, 'initializeLoansFromTemplates');
+        $method->setAccessible(true);
+        $method->invoke($job, $this->game);
+    }
+}


### PR DESCRIPTION
Parse the optional `loan` block in squad-template JSON and turn it into a
per-game loan so a loaned player is returned to his owning club at season
end — or freed if that club isn't part of the game.

- game_player_templates: new nullable loan_from_transfermarkt_id (owning
  club's TM id; the player is listed in the borrowing club's squad, so
  team_id stays the borrowing club). Parsed in prepareTemplateRow.
- SetupNewGame::initializeLoansFromTemplates materialises season-long loans:
  loan_team_id = borrowing club; parent_team_id = owner if it fields a squad
  in the game, else null. Idempotent.
- loans.parent_team_id made nullable; returnLoan() already frees a null-parent
  loan (team_id = null), and LoanReturnProcessor uses parentTeam?->name.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>