### PR TITLE
Soften AI buy-offer pricing for the user's players on sale

### DIFF
--- a/app/Modules/Transfer/Services/ScoutingService.php
+++ b/app/Modules/Transfer/Services/ScoutingService.php
@@ -634,10 +634,10 @@ class ScoutingService
 
     /**
      * Counter-offer willingness premium curve, applied to market value:
-     *   desire 0.0 → 0.85× MV  (no need: rejects premium counters, can go below market)
+     *   desire 0.0 → 0.95× MV  (no need: rejects premium counters, settles just below market)
      *   desire 1.0 → 1.50× MV  (clear need/upgrade: pays a real premium)
      */
-    private const COUNTER_PREMIUM_FLOOR = 0.85;
+    private const COUNTER_PREMIUM_FLOOR = 0.95;
     private const COUNTER_PREMIUM_CEIL = 1.50;
 
     /** Reproducible ±band variance on the premium, seeded from the offer uuid. */

--- a/app/Modules/Transfer/Services/TransferService.php
+++ b/app/Modules/Transfer/Services/TransferService.php
@@ -48,10 +48,10 @@ class TransferService
      * market value when it genuinely needs them. The ceiling sits below the
      * counter-offer premium ceiling (ScoutingService::COUNTER_PREMIUM_CEIL) so
      * there is always room to be negotiated upward.
-     *   desire 0.0 → 0.70× MV
+     *   desire 0.0 → 0.80× MV
      *   desire 1.0 → 1.10× MV
      */
-    private const OPEN_PRICE_FLOOR = 0.70;
+    private const OPEN_PRICE_FLOOR = 0.80;
     private const OPEN_PRICE_CEIL = 1.10;
 
     /** Reproducible ±band variance on the opening price, seeded per pairing. */

--- a/tests/Feature/CounterOfferDesireTest.php
+++ b/tests/Feature/CounterOfferDesireTest.php
@@ -98,12 +98,13 @@ class CounterOfferDesireTest extends TestCase
     public function test_low_need_deep_squad_buyer_rejects_above_market_counter(): void
     {
         // Deep at midfield (8) and the target wouldn't improve them →
-        // desire ≈ 0.08, willingness ≈ 0.9× MV. An above-market ask is rejected.
+        // desire ≈ 0.08, willingness ≈ 0.99× MV (just below market). A clearly
+        // above-market ask (1.3× MV) is still rejected: no need, no premium.
         $player = $this->target(overall: 50);
         $buyer = $this->buyer('Central Midfield', 70, 8, 10_000_000_00);
         $offer = $this->offer($player, $buyer, 9_000_000_00); // opened below market
 
-        $result = $this->scoutingService->evaluateCounterOffer($offer, 11_000_000_00, $this->game);
+        $result = $this->scoutingService->evaluateCounterOffer($offer, 13_000_000_00, $this->game);
 
         $this->assertSame('rejected', $result['result']);
     }


### PR DESCRIPTION
The desire-driven reluctance model was calibrated too harshly: a buyer with no need opened at 0.70x market value and its negotiable ceiling was 0.85x, so a counter at market value was rejected — players were hard to sell even at their own value.

Raise both floors (keeping the desire-scaled ceilings, so clubs that genuinely need a player still pay a premium):
- TransferService::OPEN_PRICE_FLOOR 0.70 -> 0.80 (less insulting openings)
- ScoutingService::COUNTER_PREMIUM_FLOOR 0.85 -> 0.95 (any club with even slight interest can be talked up to market value)

All three sell paths (listed, unsolicited, AI clause triggers) route through calculateOfferPrice, so they all benefit.

Update CounterOfferDesireTest: the no-need buyer's willingness rises from ~0.9x to ~0.99x MV, so an 11M counter now draws a counter instead of a rejection. Bump the ask to 13M (1.3x MV) so the test still asserts the intended behaviour — a club with no need refuses an above-market premium (robust across the full jitter range).