### PR TITLE
Surface more quality expiring/free-agent players in the market

### DIFF
--- a/app/Modules/Season/Processors/ContractExpirationProcessor.php
+++ b/app/Modules/Season/Processors/ContractExpirationProcessor.php
@@ -6,8 +6,10 @@ use App\Modules\Player\PlayerAge;
 use App\Modules\Season\Contracts\SeasonProcessor;
 use App\Modules\Season\DTOs\SeasonTransitionData;
 use App\Modules\Transfer\Services\ContractService;
+use App\Models\ClubProfile;
 use App\Models\Game;
 use App\Models\GamePlayer;
+use App\Models\TeamReputation;
 use App\Models\TransferOffer;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\DB;
@@ -19,10 +21,12 @@ use Illuminate\Support\Facades\Log;
  *
  * Players with contract_until <= June 30 of the ending season:
  * - User's team: become free agents (team_id = null)
- * - AI teams: veterans (35+) have a 50% chance of non-renewal and become
- *   free agents (team_id = null). All others are auto-renewed.
- *   Free agents may be signed by AI teams when the new season starts
- *   (AIFreeAgentSigningProcessor).
+ * - AI teams: veterans (> PRIME_END) have a tunable chance of non-renewal;
+ *   non-veterans mostly auto-renew but a modest, tier-weighted minority run
+ *   their contracts down to free agency instead. Non-renewed players become
+ *   free agents (team_id = null) and may be signed by AI teams when the new
+ *   season starts (AIFreeAgentSigningProcessor). Rates live in
+ *   config/transfers.php (ai_contract_renewal).
  */
 class ContractExpirationProcessor implements SeasonProcessor
 {
@@ -51,10 +55,20 @@ class ContractExpirationProcessor implements SeasonProcessor
         $veteranCutoff = PlayerAge::dateOfBirthCutoff(PlayerAge::PRIME_END + 1, $game->current_date);
         $newContractEnd = Carbon::createFromDate($seasonYear + 3, 6, 30);
 
-        // AI non-veterans: auto-renew (~80% of expired contracts). Select the
-        // rows so the renewal can re-derive each player's wage from his current
-        // market value (renewAiContracts), not just extend contract_until — AI
-        // pay used to stay frozen at the seeded rookie wage for a whole career.
+        // Tunable AI renewal behaviour (config/transfers.php).
+        $renewalConfig = config('transfers.ai_contract_renewal');
+        $nonVeteranBase = (float) ($renewalConfig['non_veteran_non_renewal_base'] ?? 0.0);
+        $nonVeteranAboveClubBonus = (float) ($renewalConfig['non_veteran_above_club_bonus'] ?? 0.0);
+        $nonVeteranMax = (float) ($renewalConfig['non_veteran_non_renewal_max'] ?? 1.0);
+        $veteranNonRenewal = (float) ($renewalConfig['veteran_non_renewal'] ?? 0.5);
+
+        // AI non-veterans: most auto-renew so the renewal can re-derive each
+        // player's wage from his current market value (renewAiContracts), not just
+        // extend contract_until — AI pay used to stay frozen at the seeded rookie
+        // wage for a whole career. A modest, tier-weighted share instead run their
+        // contracts down to free agency (the non-renewal flip below), keeping a
+        // realistic supply of quality free agents on the market each season. The
+        // tier column feeds that flip's "too good for his club" weighting.
         $aiNonVeteranRows = DB::table('game_players')
             ->where('game_id', $game->id)
             ->whereNotNull('team_id')
@@ -63,11 +77,11 @@ class ContractExpirationProcessor implements SeasonProcessor
             ->where('contract_until', '<=', $expirationDate)
             ->whereNull('pending_annual_wage')
             ->where('date_of_birth', '>', $veteranCutoff->toDateString())
-            ->select('id', 'team_id', 'market_value_cents', 'date_of_birth')
+            ->select('id', 'team_id', 'market_value_cents', 'date_of_birth', 'tier')
             ->get();
 
-        // AI veterans: narrow SELECT, then 50% coin flip in PHP. Typically <30
-        // rows. Carries the same columns so the renewed half can be re-priced.
+        // AI veterans: narrow SELECT, then a tunable coin flip in PHP. Typically
+        // <30 rows. Carries the same columns so the renewed half can be re-priced.
         $aiVeteranRows = DB::table('game_players')
             ->where('game_id', $game->id)
             ->whereNotNull('team_id')
@@ -81,11 +95,33 @@ class ContractExpirationProcessor implements SeasonProcessor
 
         $veteranFreeAgentIds = [];
         $veteranAutoRenewedRows = [];
+        $veteranNonRenewalRoll = (int) round($veteranNonRenewal * 100);
         foreach ($aiVeteranRows as $row) {
-            if (mt_rand(1, 100) <= 50) {
+            if (mt_rand(1, 100) <= $veteranNonRenewalRoll) {
                 $veteranFreeAgentIds[] = $row->id;
             } else {
                 $veteranAutoRenewedRows[] = $row;
+            }
+        }
+
+        // AI non-veterans: a tier-weighted minority run their contracts down to
+        // free agency instead of auto-renewing. The non-renewal chance rises with
+        // how far the player's tier sits ABOVE his club's reputation, so the
+        // departures skew toward genuinely attractive "too good for his club"
+        // free agents rather than fringe squad filler.
+        $clubReputationIndices = $this->resolveClubReputationIndices($game, $aiNonVeteranRows);
+        $nonVeteranFreeAgentIds = [];
+        $nonVeteranRenewedRows = [];
+        foreach ($aiNonVeteranRows as $row) {
+            $playerTierIndex = ((int) ($row->tier ?? 1)) - 1;
+            $clubRepIndex = $clubReputationIndices[$row->team_id] ?? 0;
+            $aboveClubSteps = max(0, $playerTierIndex - $clubRepIndex);
+            $nonRenewalChance = min($nonVeteranMax, $nonVeteranBase + $aboveClubSteps * $nonVeteranAboveClubBonus);
+
+            if ($nonRenewalChance > 0 && mt_rand(1, 100) <= (int) round($nonRenewalChance * 100)) {
+                $nonVeteranFreeAgentIds[] = $row->id;
+            } else {
+                $nonVeteranRenewedRows[] = $row;
             }
         }
 
@@ -117,7 +153,7 @@ class ContractExpirationProcessor implements SeasonProcessor
             ->all();
 
         // Bulk operations
-        $freeAgentIds = array_merge($userTeamFreeAgentIds, $veteranFreeAgentIds);
+        $freeAgentIds = array_merge($userTeamFreeAgentIds, $veteranFreeAgentIds, $nonVeteranFreeAgentIds);
         if (!empty($freeAgentIds)) {
             // A release clause is a contract attribute: non-null ⟺ under
             // contract. Becoming a free agent nulls it (harmless no-op for saves
@@ -125,9 +161,10 @@ class ContractExpirationProcessor implements SeasonProcessor
             GamePlayer::whereIn('id', $freeAgentIds)->update(['team_id' => null, 'number' => null, 'release_clause' => null]);
         }
 
-        // Auto-renew all AI keepers (non-veterans + the renewed half of the
-        // veteran coin flip), re-deriving each wage from current market value.
-        $aiRenewedRows = $aiNonVeteranRows->concat($veteranAutoRenewedRows);
+        // Auto-renew all AI keepers (the non-veterans that didn't run down +
+        // the renewed half of the veteran coin flip), re-deriving each wage from
+        // current market value.
+        $aiRenewedRows = collect($nonVeteranRenewedRows)->concat($veteranAutoRenewedRows);
         $this->contractService->renewAiContracts(
             $aiRenewedRows,
             $newContractEnd->toDateString(),
@@ -138,5 +175,29 @@ class ContractExpirationProcessor implements SeasonProcessor
             . ', auto-renewed: ' . $aiRenewedRows->count());
 
         return $data;
+    }
+
+    /**
+     * Resolve each expiring non-veteran's club reputation to a 0-4 tier index,
+     * keyed by team_id. Mirrors the resolution used by the market services
+     * (TransferMarketService / AITransferMarketService) so a player's tier can
+     * be compared against his club's standing for the non-renewal weighting.
+     *
+     * @param  \Illuminate\Support\Collection<int, \stdClass>  $rows
+     * @return array<string, int>  team_id => reputation tier index (0-4)
+     */
+    private function resolveClubReputationIndices(Game $game, $rows): array
+    {
+        $teamIds = $rows->pluck('team_id')->unique()->values()->all();
+
+        if (empty($teamIds)) {
+            return [];
+        }
+
+        return TeamReputation::resolveLevels($game->id, $teamIds)
+            ->mapWithKeys(fn (string $level, string $teamId) => [
+                $teamId => ClubProfile::getReputationTierIndex($level),
+            ])
+            ->all();
     }
 }

--- a/app/Modules/Transfer/Services/TransferService.php
+++ b/app/Modules/Transfer/Services/TransferService.php
@@ -102,24 +102,6 @@ class TransferService
     private const MAX_FEE_TO_SQUAD_VALUE_RATIO = 0.15;
 
     /**
-     * Default chance of pre-contract offer per expiring player per matchday.
-     */
-    private const PRE_CONTRACT_OFFER_CHANCE = 0.10; // 10%
-
-    /**
-     * Value-based pre-contract offer chance per matchday.
-     * Higher-value players attract more aggressive AI competition.
-     * [min_market_value_cents => chance]
-     */
-    private const PRE_CONTRACT_OFFER_CHANCE_BY_VALUE = [
-        5_000_000_000  => 0.35, // €50M+ → 35%
-        2_000_000_000  => 0.25, // €20M+ → 25%
-        1_000_000_000  => 0.20, // €10M+ → 20%
-        500_000_000    => 0.15, // €5M+  → 15%
-        0              => 0.10, // < €5M → 10%
-    ];
-
-    /**
      * Pre-contract offer expiry in days.
      */
     private const PRE_CONTRACT_OFFER_EXPIRY_DAYS = TransferOffer::PRE_CONTRACT_OFFER_EXPIRY_DAYS;
@@ -560,13 +542,15 @@ class TransferService
      */
     public function getPreContractOfferChance(GamePlayer $player): float
     {
-        foreach (self::PRE_CONTRACT_OFFER_CHANCE_BY_VALUE as $minValue => $chance) {
+        // Bands are matched high-to-low by market value (config/transfers.php).
+        $byValue = config('transfers.ai_pre_contract.offer_chance_by_value', []);
+        foreach ($byValue as $minValue => $chance) {
             if ($player->market_value_cents >= $minValue) {
-                return $chance;
+                return (float) $chance;
             }
         }
 
-        return self::PRE_CONTRACT_OFFER_CHANCE;
+        return (float) config('transfers.ai_pre_contract.offer_chance_default', 0.10);
     }
 
     /**

--- a/config/transfers.php
+++ b/config/transfers.php
@@ -1,0 +1,59 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | AI Contract Renewal
+    |--------------------------------------------------------------------------
+    |
+    | Controls what AI clubs do with their players whose contracts expire at
+    | season close (ContractExpirationProcessor). Most are auto-renewed for a
+    | fresh 3-year deal; a tunable minority instead run their contracts down to
+    | free agency, keeping a realistic supply of quality free agents on the
+    | market each season.
+    |
+    */
+    'ai_contract_renewal' => [
+        // Base chance an expiring AI non-veteran (age <= PlayerAge::PRIME_END)
+        // is NOT renewed and becomes a free agent instead of being re-upped.
+        'non_veteran_non_renewal_base' => 0.12,
+
+        // Extra non-renewal chance per tier the player sits ABOVE his club's
+        // reputation tier. A gem at a small/relegated club is realistically the
+        // one let go on a free — and the most attractive signing for the user.
+        'non_veteran_above_club_bonus' => 0.10,
+
+        // Hard ceiling on the combined non-renewal chance, so even the biggest
+        // tier mismatch still keeps most stars at their club.
+        'non_veteran_non_renewal_max' => 0.35,
+
+        // Chance an expiring AI veteran (age > PlayerAge::PRIME_END) is let go
+        // to free agency rather than re-signed (was hard-coded at 0.50).
+        'veteran_non_renewal' => 0.50,
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | AI Pre-Contract Offers
+    |--------------------------------------------------------------------------
+    |
+    | Per-matchday chance (Jan–May) that an AI club tables a free pre-contract
+    | for one of the USER's expiring players. Lower values leave the user more
+    | room to renew or sell their own expiring stars before they walk for free.
+    | Bands are matched high-to-low by market value (cents).
+    |
+    */
+    'ai_pre_contract' => [
+        'offer_chance_default' => 0.07,
+
+        'offer_chance_by_value' => [
+            5_000_000_000 => 0.20, // €50M+
+            2_000_000_000 => 0.15, // €20M+
+            1_000_000_000 => 0.12, // €10M+
+            500_000_000 => 0.10,   // €5M+
+            0 => 0.07,             // < €5M
+        ],
+    ],
+
+];

--- a/tests/Feature/AiRenewalWageTest.php
+++ b/tests/Feature/AiRenewalWageTest.php
@@ -99,6 +99,13 @@ class AiRenewalWageTest extends TestCase
 
     public function test_contract_expiration_recomputes_ai_wages_and_leaves_user_team_alone(): void
     {
+        // Pin the non-renewal chance to 0 so this AI keeper deterministically
+        // renews — the random run-down path is covered by its own tests below.
+        config([
+            'transfers.ai_contract_renewal.non_veteran_non_renewal_base' => 0.0,
+            'transfers.ai_contract_renewal.non_veteran_above_club_bonus' => 0.0,
+        ]);
+
         // AI non-veteran with an expiring contract: auto-renewed AND re-priced.
         $aiPlayer = GamePlayer::factory()->forGame($this->game)->forTeam($this->aiTeam)->create([
             'date_of_birth' => '1996-01-01', // ~30, non-veteran
@@ -133,6 +140,77 @@ class AiRenewalWageTest extends TestCase
 
         $this->assertNull($userPlayer->team_id, 'Expiring user-team player becomes a free agent');
         $this->assertSame(20_000_000, $userPlayer->annual_wage, 'AI wage recompute must never touch the user team');
+    }
+
+    public function test_ai_non_veteran_runs_contract_down_to_free_agency_when_configured(): void
+    {
+        // Force the non-renewal path so an expiring AI non-veteran walks for free
+        // instead of being re-upped — the new supply of quality free agents.
+        config([
+            'transfers.ai_contract_renewal.non_veteran_non_renewal_base' => 1.0,
+            'transfers.ai_contract_renewal.non_veteran_non_renewal_max' => 1.0,
+            'transfers.ai_contract_renewal.non_veteran_above_club_bonus' => 0.0,
+        ]);
+
+        $aiPlayer = GamePlayer::factory()->forGame($this->game)->forTeam($this->aiTeam)->create([
+            'date_of_birth' => '1996-01-01', // ~30, non-veteran
+            'market_value_cents' => 3_000_000_000,
+            'annual_wage' => 20_000_000,
+            'contract_until' => '2027-06-30',
+            'release_clause' => 100_000_000,
+            'pending_annual_wage' => null,
+        ]);
+
+        app(ContractExpirationProcessor::class)->process($this->game, new SeasonTransitionData(
+            oldSeason: '2026',
+            newSeason: '2027',
+            competitionId: $this->game->competition_id,
+        ));
+
+        $aiPlayer->refresh();
+        $this->assertNull($aiPlayer->team_id, 'A non-renewed AI non-veteran becomes a free agent');
+        $this->assertNull($aiPlayer->release_clause, 'A free agent carries no release clause');
+    }
+
+    public function test_non_renewal_chance_rises_for_players_above_their_club_tier(): void
+    {
+        // Base 0 so ONLY the "too good for his club" bonus drives non-renewal.
+        // The AI team has no reputation row → resolves to LOCAL (tier index 0).
+        config([
+            'transfers.ai_contract_renewal.non_veteran_non_renewal_base' => 0.0,
+            'transfers.ai_contract_renewal.non_veteran_above_club_bonus' => 1.0,
+            'transfers.ai_contract_renewal.non_veteran_non_renewal_max' => 1.0,
+        ]);
+
+        $star = GamePlayer::factory()->forGame($this->game)->forTeam($this->aiTeam)->create([
+            'date_of_birth' => '1996-01-01',
+            'market_value_cents' => 3_000_000_000,
+            'annual_wage' => 20_000_000,
+            'contract_until' => '2027-06-30',
+            'tier' => 5, // index 4 — well above a LOCAL club
+            'pending_annual_wage' => null,
+        ]);
+        $squadFiller = GamePlayer::factory()->forGame($this->game)->forTeam($this->aiTeam)->create([
+            'date_of_birth' => '1996-01-01',
+            'market_value_cents' => 50_000_000,
+            'annual_wage' => 20_000_000,
+            'contract_until' => '2027-06-30',
+            'tier' => 1, // index 0 — at the club's level
+            'pending_annual_wage' => null,
+        ]);
+
+        app(ContractExpirationProcessor::class)->process($this->game, new SeasonTransitionData(
+            oldSeason: '2026',
+            newSeason: '2027',
+            competitionId: $this->game->competition_id,
+        ));
+
+        $star->refresh();
+        $squadFiller->refresh();
+
+        $this->assertNull($star->team_id, 'A player far above his club tier runs his contract down to free agency');
+        $this->assertSame($this->aiTeam->id, $squadFiller->team_id, 'An at-tier squad player is auto-renewed');
+        $this->assertSame('2029-06-30', $squadFiller->contract_until->toDateString(), 'The retained player is renewed +3 years');
     }
 
     /**

--- a/tests/Feature/PreContractBalanceTest.php
+++ b/tests/Feature/PreContractBalanceTest.php
@@ -433,45 +433,82 @@ class PreContractBalanceTest extends TestCase
             'competition_id' => $this->competition->id,
         ]);
 
-        // €50M+ player → 35% chance
+        // Expected chances are the config/transfers.php defaults (softened from
+        // the old 0.10–0.35 ramp to leave the user more room to keep his stars).
+
+        // €50M+ player → 20% chance
         $highValue = GamePlayer::factory()->create([
             'game_id' => $game->id,
             'team_id' => $team->id,
             'market_value_cents' => 6_000_000_000,
         ]);
-        $this->assertEquals(0.35, $this->transferService->getPreContractOfferChance($highValue));
+        $this->assertEquals(0.20, $this->transferService->getPreContractOfferChance($highValue));
 
-        // €20M player → 25% chance
+        // €20M player → 15% chance
         $midValue = GamePlayer::factory()->create([
             'game_id' => $game->id,
             'team_id' => $team->id,
             'market_value_cents' => 2_000_000_000,
         ]);
-        $this->assertEquals(0.25, $this->transferService->getPreContractOfferChance($midValue));
+        $this->assertEquals(0.15, $this->transferService->getPreContractOfferChance($midValue));
 
-        // €10M player → 20% chance
+        // €10M player → 12% chance
         $midLow = GamePlayer::factory()->create([
             'game_id' => $game->id,
             'team_id' => $team->id,
             'market_value_cents' => 1_000_000_000,
         ]);
-        $this->assertEquals(0.20, $this->transferService->getPreContractOfferChance($midLow));
+        $this->assertEquals(0.12, $this->transferService->getPreContractOfferChance($midLow));
 
-        // €5M player → 15% chance
+        // €5M player → 10% chance
         $low = GamePlayer::factory()->create([
             'game_id' => $game->id,
             'team_id' => $team->id,
             'market_value_cents' => 500_000_000,
         ]);
-        $this->assertEquals(0.15, $this->transferService->getPreContractOfferChance($low));
+        $this->assertEquals(0.10, $this->transferService->getPreContractOfferChance($low));
 
-        // €2M player → 10% chance
+        // €2M player → 7% chance (below the €5M band → default)
         $veryLow = GamePlayer::factory()->create([
             'game_id' => $game->id,
             'team_id' => $team->id,
             'market_value_cents' => 200_000_000,
         ]);
-        $this->assertEquals(0.10, $this->transferService->getPreContractOfferChance($veryLow));
+        $this->assertEquals(0.07, $this->transferService->getPreContractOfferChance($veryLow));
+    }
+
+    public function test_pre_contract_offer_chance_reads_from_config(): void
+    {
+        // Custom bands prove the chance is config-driven, not hard-coded.
+        config([
+            'transfers.ai_pre_contract.offer_chance_default' => 0.03,
+            'transfers.ai_pre_contract.offer_chance_by_value' => [
+                1_000_000_000 => 0.50, // €10M+
+                0 => 0.03,
+            ],
+        ]);
+
+        $user = User::factory()->create();
+        $team = Team::factory()->create();
+        $game = Game::factory()->create([
+            'user_id' => $user->id,
+            'team_id' => $team->id,
+            'competition_id' => $this->competition->id,
+        ]);
+
+        $star = GamePlayer::factory()->create([
+            'game_id' => $game->id,
+            'team_id' => $team->id,
+            'market_value_cents' => 2_000_000_000, // ≥ €10M band → 0.50
+        ]);
+        $this->assertEquals(0.50, $this->transferService->getPreContractOfferChance($star));
+
+        $fringe = GamePlayer::factory()->create([
+            'game_id' => $game->id,
+            'team_id' => $team->id,
+            'market_value_cents' => 50_000_000, // below band → default 0.03
+        ]);
+        $this->assertEquals(0.03, $this->transferService->getPreContractOfferChance($fringe));
     }
 
     // =========================================


### PR DESCRIPTION
## Problem

By the time the transfer window opens, there are very few quality players in their final contract year to target. Three mechanics combine to cause it:

1. **Real data front-loads long contracts on good players** — imported Transfermarkt dates run to 2029–2031, so in the early seasons people actually play, almost none are near expiry.
2. **AI auto-renews 100% of non-veteran expiring players** — in `ContractExpirationProcessor`, every AI player aged ≤ `PRIME_END` whose contract expires is re-upped to a fresh +3-year deal. Only veterans (32+) had a 50% chance of being let go, so quality prime players essentially never reached free agency.
3. **AI aggressively free-poaches the user's own expiring stars** via pre-contracts (10–35%/matchday).

The market already *tries* to surface expiring quality (`scoreListable` lists tier-matched players only when ≤1 year remains). The bottleneck is **supply**, not surfacing.

## Changes

Two modest, **config-tunable** levers, both in a new `config/transfers.php`.

### Lever 1 — Relax AI auto-renewal (`ContractExpirationProcessor`)
A tier-weighted share of expiring AI non-veterans now run their contracts down to **free agency** instead of auto-renewing. The non-renewal chance rises with how far the player's tier sits **above his club's reputation tier**, so departures skew toward genuinely attractive "too good for his club" free agents rather than fringe filler. The veteran coin-flip threshold (was hard-coded `0.50`) also moves to config.

### Lever 2 — Curb AI pre-contract poaching (`TransferService::getPreContractOfferChance`)
Softens the per-matchday rate at which AI clubs free-poach the user's expiring players (0.10–0.35 → 0.07–0.20), giving the user more room to renew or sell. This system only ever targets the user's squad — there is no AI-to-AI pre-contract churn.

**Why it reaches the user:** `AITransferMarketService::processSeasonFreeAgentSignings` already reserves the best free agents per tier (`MIN_FREE_AGENTS_PER_TIER`), preserves a minimum pool, and caps AI signings at 50% — so the newly-freed quality players actually surface for the user.

### Defaults (`config/transfers.php`)
- `non_veteran_non_renewal_base` 0.12, `non_veteran_above_club_bonus` 0.10/tier, `non_veteran_non_renewal_max` 0.35, `veteran_non_renewal` 0.50
- pre-contract: 0.20 / 0.15 / 0.12 / 0.10 / 0.07 by value band

## Tests
- `AiRenewalWageTest`: pin config in the existing renewal test for determinism; add run-down-to-free-agency and tier-above-club bonus coverage.
- `PreContractBalanceTest`: update the scaling test to the softened defaults; add a test proving the chance is config-driven.

## Out of scope (declined)
- Shortening good players' *starting* contracts at game setup (would best fix early-game last-year-still-at-club supply, but trades real-data fidelity).
- Boosting market listing weights (supply, not surfacing, is the bottleneck).

## Notes
- No i18n or `docs/game-systems` changes — pure formula/behaviour tuning.
- No cached config in dev, so the new file loads automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)