### PR TITLE
Augment squad data with SoFIFA ratings

### DIFF
--- a/data/2025/DEU1/sofifa.json
+++ b/data/2025/DEU1/sofifa.json
@@ -1,0 +1,6254 @@
+{
+  "league": "Germany Bundesliga",
+  "scraped_at": "2026-06-12T14:26:10.239Z",
+  "team_count": 18,
+  "teams": [
+    {
+      "player_count": 45,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Manuel Neuer",
+          "name": "M. Neuer",
+          "overall_score": 82,
+          "potential": 82,
+          "value": 3400000,
+          "yearly_wage": 1196000
+        },
+        {
+          "currency": "€",
+          "full_name": "Konrad Laimer",
+          "name": "K. Laimer",
+          "overall_score": 84,
+          "potential": 84,
+          "value": 38000000,
+          "yearly_wage": 4680000
+        },
+        {
+          "currency": "€",
+          "full_name": "Dayot Upamecano",
+          "name": "D. Upamecano",
+          "overall_score": 86,
+          "potential": 88,
+          "value": 74000000,
+          "yearly_wage": 5200000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jonathan Tah",
+          "name": "J. Tah",
+          "overall_score": 87,
+          "potential": 87,
+          "value": 66500000,
+          "yearly_wage": 5980000
+        },
+        {
+          "currency": "€",
+          "full_name": "Josip Stanišić",
+          "name": "J. Stanišić",
+          "overall_score": 79,
+          "potential": 82,
+          "value": 21500000,
+          "yearly_wage": 2912000
+        },
+        {
+          "currency": "€",
+          "full_name": "Joshua Kimmich",
+          "name": "J. Kimmich",
+          "overall_score": 89,
+          "potential": 89,
+          "value": 86000000,
+          "yearly_wage": 7280000
+        },
+        {
+          "currency": "€",
+          "full_name": "Aleksandar Pavlović",
+          "name": "A. Pavlović",
+          "overall_score": 82,
+          "potential": 87,
+          "value": 43000000,
+          "yearly_wage": 2704000
+        },
+        {
+          "currency": "€",
+          "full_name": "Michael Olise",
+          "name": "M. Olise",
+          "overall_score": 89,
+          "potential": 91,
+          "value": 134000000,
+          "yearly_wage": 6240000
+        },
+        {
+          "currency": "€",
+          "full_name": "Luis Díaz",
+          "name": "L. Díaz",
+          "overall_score": 87,
+          "potential": 87,
+          "value": 80000000,
+          "yearly_wage": 6240000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jamal Musiala",
+          "name": "J. Musiala",
+          "overall_score": 87,
+          "potential": 91,
+          "value": 116500000,
+          "yearly_wage": 5200000
+        },
+        {
+          "currency": "€",
+          "full_name": "Harry Kane",
+          "name": "H. Kane",
+          "overall_score": 90,
+          "potential": 90,
+          "value": 101000000,
+          "yearly_wage": 8840000
+        },
+        {
+          "currency": "€",
+          "full_name": "Leon Goretzka",
+          "name": "L. Goretzka",
+          "overall_score": 81,
+          "potential": 81,
+          "value": 21500000,
+          "yearly_wage": 3588000
+        },
+        {
+          "currency": "€",
+          "full_name": "Tom Bischof",
+          "name": "T. Bischof",
+          "overall_score": 78,
+          "potential": 86,
+          "value": 30500000,
+          "yearly_wage": 2132000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alphonso Davies",
+          "name": "A. Davies",
+          "overall_score": 83,
+          "potential": 86,
+          "value": 46000000,
+          "yearly_wage": 3536000
+        },
+        {
+          "currency": "€",
+          "full_name": "Min Jae Kim",
+          "name": "Kim Min Jae",
+          "overall_score": 82,
+          "potential": 82,
+          "value": 26500000,
+          "yearly_wage": 3900000
+        },
+        {
+          "currency": "€",
+          "full_name": "Raphaël Guerreiro",
+          "name": "R. Guerreiro",
+          "overall_score": 79,
+          "potential": 79,
+          "value": 12500000,
+          "yearly_wage": 3172000
+        },
+        {
+          "currency": "€",
+          "full_name": "Hiroki Ito",
+          "name": "H. Ito",
+          "overall_score": 78,
+          "potential": 81,
+          "value": 16500000,
+          "yearly_wage": 2756000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jonas Urbig",
+          "name": "J. Urbig",
+          "overall_score": 77,
+          "potential": 85,
+          "value": 20500000,
+          "yearly_wage": 936000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lennart Karl",
+          "name": "L. Karl",
+          "overall_score": 75,
+          "potential": 88,
+          "value": 13000000,
+          "yearly_wage": 1300000
+        },
+        {
+          "currency": "€",
+          "full_name": "Nicolas Jackson",
+          "name": "N. Jackson",
+          "overall_score": 79,
+          "potential": 82,
+          "value": 24500000,
+          "yearly_wage": 5460000
+        },
+        {
+          "currency": "€",
+          "full_name": "Serge Gnabry",
+          "name": "S. Gnabry",
+          "overall_score": 83,
+          "potential": 83,
+          "value": 35500000,
+          "yearly_wage": 4524000
+        },
+        {
+          "currency": "€",
+          "full_name": "Wisdom Mike",
+          "name": "W. Mike",
+          "overall_score": 61,
+          "potential": 85,
+          "value": 1000000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Sven Ulreich",
+          "name": "S. Ulreich",
+          "overall_score": 73,
+          "potential": 73,
+          "value": 350000,
+          "yearly_wage": 780000
+        },
+        {
+          "currency": "€",
+          "full_name": "David Santos Daiber",
+          "name": "Santos Daiber",
+          "overall_score": 59,
+          "potential": 79,
+          "value": 600000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Maycon Douglas Normanha Cardozo",
+          "name": "Maycon Cardozo",
+          "overall_score": 59,
+          "potential": 79,
+          "value": 600000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Cassiano Kiala",
+          "name": "C. Kiala",
+          "overall_score": 58,
+          "potential": 82,
+          "value": 600000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Vincent Manuba",
+          "name": "V. Manuba",
+          "overall_score": 61,
+          "potential": 74,
+          "value": 750000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Deniz Ofli",
+          "name": "D. Ofli",
+          "overall_score": 60,
+          "potential": 80,
+          "value": 650000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jannis Bärtl",
+          "name": "J. Bärtl",
+          "overall_score": 58,
+          "potential": 73,
+          "value": 425000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Leon Klanac",
+          "name": "L. Klanac",
+          "overall_score": 56,
+          "potential": 75,
+          "value": 325000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Guido Della Rovere",
+          "name": "G. Della Rovere",
+          "overall_score": 61,
+          "potential": 80,
+          "value": 825000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Bara Sapoko Ndiaye",
+          "name": "B. Sapoko Ndiaye",
+          "overall_score": 61,
+          "potential": 81,
+          "value": 875000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Erblin Osmani",
+          "name": "E. Osmani",
+          "overall_score": 57,
+          "potential": 81,
+          "value": 500000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Noël Aséko",
+          "name": "N. Aséko",
+          "overall_score": 70,
+          "potential": 84,
+          "value": 3800000,
+          "yearly_wage": 1040000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jonah Kusi-Asare",
+          "name": "J. Kusi-Asare",
+          "overall_score": 62,
+          "potential": 84,
+          "value": 1300000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Daniel Peretz",
+          "name": "D. Peretz",
+          "overall_score": 74,
+          "potential": 80,
+          "value": 5500000,
+          "yearly_wage": 1092000
+        },
+        {
+          "currency": "€",
+          "full_name": "Bryan Zaragoza Martínez",
+          "name": "Bryan Zaragoza",
+          "overall_score": 77,
+          "potential": 83,
+          "value": 16500000,
+          "yearly_wage": 2548000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lovro Zvonarek",
+          "name": "L. Zvonarek",
+          "overall_score": 66,
+          "potential": 78,
+          "value": 2100000,
+          "yearly_wage": 676000
+        },
+        {
+          "currency": "€",
+          "full_name": "Maurice Krattenmacher",
+          "name": "M. Krattenmacher",
+          "overall_score": 69,
+          "potential": 81,
+          "value": 3300000,
+          "yearly_wage": 936000
+        },
+        {
+          "currency": "€",
+          "full_name": "Arijon Ibrahimović",
+          "name": "A. Ibrahimović",
+          "overall_score": 72,
+          "potential": 83,
+          "value": 5000000,
+          "yearly_wage": 1300000
+        },
+        {
+          "currency": "€",
+          "full_name": "Armindo Sieb",
+          "name": "A. Sieb",
+          "overall_score": 71,
+          "potential": 79,
+          "value": 4200000,
+          "yearly_wage": 1612000
+        },
+        {
+          "currency": "€",
+          "full_name": "Sacha Boey",
+          "name": "S. Boey",
+          "overall_score": 75,
+          "potential": 78,
+          "value": 7000000,
+          "yearly_wage": 1976000
+        },
+        {
+          "currency": "€",
+          "full_name": "João Maria Palhinha Gonçalves",
+          "name": "Palhinha",
+          "overall_score": 82,
+          "potential": 82,
+          "value": 26000000,
+          "yearly_wage": 3900000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alexander Nübel",
+          "name": "A. Nübel",
+          "overall_score": 80,
+          "potential": 81,
+          "value": 16500000,
+          "yearly_wage": 2184000
+        },
+        {
+          "currency": "€",
+          "full_name": "Felipe Chávez",
+          "name": "F. Chávez",
+          "overall_score": 62,
+          "potential": 80,
+          "value": 1000000,
+          "yearly_wage": 364000
+        }
+      ],
+      "team": "FC Bayern München",
+      "transfer_budget": 83800000,
+      "url": "https://sofifa.com/team/21/fc-bayern-munchen/260037/"
+    },
+    {
+      "player_count": 34,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Gregor Kobel",
+          "name": "G. Kobel",
+          "overall_score": 86,
+          "potential": 89,
+          "value": 66500000,
+          "yearly_wage": 2704000
+        },
+        {
+          "currency": "€",
+          "full_name": "Waldemar Anton",
+          "name": "W. Anton",
+          "overall_score": 83,
+          "potential": 83,
+          "value": 31500000,
+          "yearly_wage": 3432000
+        },
+        {
+          "currency": "€",
+          "full_name": "Nico Schlotterbeck",
+          "name": "N. Schlotterbeck",
+          "overall_score": 86,
+          "potential": 88,
+          "value": 75500000,
+          "yearly_wage": 4056000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ramy Bensebaini",
+          "name": "R. Bensebaini",
+          "overall_score": 79,
+          "potential": 79,
+          "value": 14500000,
+          "yearly_wage": 2548000
+        },
+        {
+          "currency": "€",
+          "full_name": "Julian Ryerson",
+          "name": "J. Ryerson",
+          "overall_score": 80,
+          "potential": 80,
+          "value": 20500000,
+          "yearly_wage": 2600000
+        },
+        {
+          "currency": "€",
+          "full_name": "Marcel Sabitzer",
+          "name": "M. Sabitzer",
+          "overall_score": 81,
+          "potential": 81,
+          "value": 18000000,
+          "yearly_wage": 2860000
+        },
+        {
+          "currency": "€",
+          "full_name": "Felix Nmecha",
+          "name": "F. Nmecha",
+          "overall_score": 84,
+          "potential": 86,
+          "value": 54500000,
+          "yearly_wage": 3276000
+        },
+        {
+          "currency": "€",
+          "full_name": "Daniel Svensson",
+          "name": "D. Svensson",
+          "overall_score": 79,
+          "potential": 83,
+          "value": 23500000,
+          "yearly_wage": 2132000
+        },
+        {
+          "currency": "€",
+          "full_name": "Julian Brandt",
+          "name": "J. Brandt",
+          "overall_score": 82,
+          "potential": 82,
+          "value": 30000000,
+          "yearly_wage": 3328000
+        },
+        {
+          "currency": "€",
+          "full_name": "Maximilian Beier",
+          "name": "M. Beier",
+          "overall_score": 80,
+          "potential": 84,
+          "value": 31000000,
+          "yearly_wage": 2600000
+        },
+        {
+          "currency": "€",
+          "full_name": "Serhou Guirassy",
+          "name": "S. Guirassy",
+          "overall_score": 85,
+          "potential": 85,
+          "value": 54000000,
+          "yearly_wage": 4628000
+        },
+        {
+          "currency": "€",
+          "full_name": "Fábio Daniel Soares Silva",
+          "name": "Fábio Silva",
+          "overall_score": 79,
+          "potential": 85,
+          "value": 28500000,
+          "yearly_wage": 2444000
+        },
+        {
+          "currency": "€",
+          "full_name": "Karim Adeyemi",
+          "name": "K. Adeyemi",
+          "overall_score": 82,
+          "potential": 86,
+          "value": 43500000,
+          "yearly_wage": 2704000
+        },
+        {
+          "currency": "€",
+          "full_name": "Carney Chukwuemeka",
+          "name": "C. Chukwuemeka",
+          "overall_score": 78,
+          "potential": 84,
+          "value": 22500000,
+          "yearly_wage": 1768000
+        },
+        {
+          "currency": "€",
+          "full_name": "Salih Özcan",
+          "name": "S. Özcan",
+          "overall_score": 74,
+          "potential": 75,
+          "value": 4300000,
+          "yearly_wage": 1716000
+        },
+        {
+          "currency": "€",
+          "full_name": "Niklas Süle",
+          "name": "N. Süle",
+          "overall_score": 78,
+          "potential": 78,
+          "value": 12000000,
+          "yearly_wage": 2288000
+        },
+        {
+          "currency": "€",
+          "full_name": "Yan Bueno Couto",
+          "name": "Yan Couto",
+          "overall_score": 77,
+          "potential": 81,
+          "value": 14000000,
+          "yearly_wage": 1768000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alexander Meyer",
+          "name": "A. Meyer",
+          "overall_score": 74,
+          "potential": 74,
+          "value": 725000,
+          "yearly_wage": 1144000
+        },
+        {
+          "currency": "€",
+          "full_name": "Luca Reggiani",
+          "name": "L. Reggiani",
+          "overall_score": 66,
+          "potential": 82,
+          "value": 2000000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Samuele Inacio",
+          "name": "S. Inacio",
+          "overall_score": 66,
+          "potential": 84,
+          "value": 2100000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Filippo Mane",
+          "name": "F. Mane",
+          "overall_score": 65,
+          "potential": 79,
+          "value": 1600000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "Patrick Drewes",
+          "name": "P. Drewes",
+          "overall_score": 71,
+          "potential": 71,
+          "value": 925000,
+          "yearly_wage": 884000
+        },
+        {
+          "currency": "€",
+          "full_name": "Almugera Kabar",
+          "name": "A. Kabar",
+          "overall_score": 65,
+          "potential": 80,
+          "value": 1600000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mussa Kaba",
+          "name": "M. Kaba",
+          "overall_score": 61,
+          "potential": 85,
+          "value": 975000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Emre Can",
+          "name": "E. Can",
+          "overall_score": 82,
+          "potential": 82,
+          "value": 21000000,
+          "yearly_wage": 3120000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jobe Bellingham",
+          "name": "J. Bellingham",
+          "overall_score": 77,
+          "potential": 83,
+          "value": 16000000,
+          "yearly_wage": 1508000
+        },
+        {
+          "currency": "€",
+          "full_name": "Elias Benkara",
+          "name": "E. Benkara",
+          "overall_score": 61,
+          "potential": 79,
+          "value": 775000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Danylo Krevsun",
+          "name": "D. Krevsun",
+          "overall_score": 63,
+          "potential": 77,
+          "value": 1200000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Silas Ostrzinski",
+          "name": "S. Ostrzinski",
+          "overall_score": 63,
+          "potential": 75,
+          "value": 1000000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mathis Albert",
+          "name": "M. Albert",
+          "overall_score": 66,
+          "potential": 88,
+          "value": 2700000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Julien Duranville",
+          "name": "J. Duranville",
+          "overall_score": 72,
+          "potential": 85,
+          "value": 5500000,
+          "yearly_wage": 1040000
+        },
+        {
+          "currency": "€",
+          "full_name": "Diant Ramaj",
+          "name": "D. Ramaj",
+          "overall_score": 75,
+          "potential": 81,
+          "value": 7000000,
+          "yearly_wage": 936000
+        },
+        {
+          "currency": "€",
+          "full_name": "Cole Campbell",
+          "name": "C. Campbell",
+          "overall_score": 67,
+          "potential": 82,
+          "value": 2400000,
+          "yearly_wage": 572000
+        },
+        {
+          "currency": "€",
+          "full_name": "Kjell Wätjen",
+          "name": "K. Wätjen",
+          "overall_score": 67,
+          "potential": 78,
+          "value": 2200000,
+          "yearly_wage": 572000
+        }
+      ],
+      "team": "Borussia Dortmund",
+      "transfer_budget": 53500000,
+      "url": "https://sofifa.com/team/22/borussia-dortmund/260037/"
+    },
+    {
+      "player_count": 38,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Maarten Vandevoordt",
+          "name": "M. Vandevoordt",
+          "overall_score": 77,
+          "potential": 85,
+          "value": 20000000,
+          "yearly_wage": 1196000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ridle Baku",
+          "name": "R. Baku",
+          "overall_score": 79,
+          "potential": 79,
+          "value": 17000000,
+          "yearly_wage": 2756000
+        },
+        {
+          "currency": "€",
+          "full_name": "Willi Orban",
+          "name": "W. Orban",
+          "overall_score": 83,
+          "potential": 83,
+          "value": 23500000,
+          "yearly_wage": 3848000
+        },
+        {
+          "currency": "€",
+          "full_name": "Castello Lukeba",
+          "name": "C. Lukeba",
+          "overall_score": 81,
+          "potential": 87,
+          "value": 37500000,
+          "yearly_wage": 2704000
+        },
+        {
+          "currency": "€",
+          "full_name": "David Raum",
+          "name": "D. Raum",
+          "overall_score": 83,
+          "potential": 83,
+          "value": 35000000,
+          "yearly_wage": 3692000
+        },
+        {
+          "currency": "€",
+          "full_name": "Nicolas Seiwald",
+          "name": "N. Seiwald",
+          "overall_score": 80,
+          "potential": 85,
+          "value": 29000000,
+          "yearly_wage": 2496000
+        },
+        {
+          "currency": "€",
+          "full_name": "Assan Ouédraogo",
+          "name": "A. Ouédraogo",
+          "overall_score": 74,
+          "potential": 87,
+          "value": 10000000,
+          "yearly_wage": 1404000
+        },
+        {
+          "currency": "€",
+          "full_name": "Christoph Baumgartner",
+          "name": "C. Baumgartner",
+          "overall_score": 81,
+          "potential": 83,
+          "value": 32500000,
+          "yearly_wage": 3172000
+        },
+        {
+          "currency": "€",
+          "full_name": "Yan Diomande",
+          "name": "Y. Diomande",
+          "overall_score": 81,
+          "potential": 89,
+          "value": 54500000,
+          "yearly_wage": 2340000
+        },
+        {
+          "currency": "€",
+          "full_name": "Rômulo José Cardoso da Cruz",
+          "name": "Rômulo",
+          "overall_score": 78,
+          "potential": 83,
+          "value": 21500000,
+          "yearly_wage": 2496000
+        },
+        {
+          "currency": "€",
+          "full_name": "Antonio Nusa",
+          "name": "A. Nusa",
+          "overall_score": 78,
+          "potential": 88,
+          "value": 31000000,
+          "yearly_wage": 2080000
+        },
+        {
+          "currency": "€",
+          "full_name": "Johan Bakayoko",
+          "name": "J. Bakayoko",
+          "overall_score": 77,
+          "potential": 84,
+          "value": 21500000,
+          "yearly_wage": 2288000
+        },
+        {
+          "currency": "€",
+          "full_name": "Conrad Harder",
+          "name": "C. Harder",
+          "overall_score": 75,
+          "potential": 85,
+          "value": 12500000,
+          "yearly_wage": 1768000
+        },
+        {
+          "currency": "€",
+          "full_name": "Brajan Gruda",
+          "name": "B. Gruda",
+          "overall_score": 75,
+          "potential": 85,
+          "value": 12500000,
+          "yearly_wage": 2652000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ezechiel Banzuzi",
+          "name": "E. Banzuzi",
+          "overall_score": 73,
+          "potential": 85,
+          "value": 7500000,
+          "yearly_wage": 1352000
+        },
+        {
+          "currency": "€",
+          "full_name": "Benjamin Henrichs",
+          "name": "B. Henrichs",
+          "overall_score": 80,
+          "potential": 80,
+          "value": 19000000,
+          "yearly_wage": 3016000
+        },
+        {
+          "currency": "€",
+          "full_name": "El Chadaille Bitshiabu",
+          "name": "E. Bitshiabu",
+          "overall_score": 75,
+          "potential": 85,
+          "value": 11500000,
+          "yearly_wage": 1508000
+        },
+        {
+          "currency": "€",
+          "full_name": "Leopold Zingerle",
+          "name": "L. Zingerle",
+          "overall_score": 69,
+          "potential": 69,
+          "value": 750000,
+          "yearly_wage": 780000
+        },
+        {
+          "currency": "€",
+          "full_name": "Andrija Maksimović",
+          "name": "A. Maksimović",
+          "overall_score": 71,
+          "potential": 81,
+          "value": 4000000,
+          "yearly_wage": 1092000
+        },
+        {
+          "currency": "€",
+          "full_name": "Kosta Nedeljković",
+          "name": "K. Nedeljković",
+          "overall_score": 72,
+          "potential": 83,
+          "value": 4800000,
+          "yearly_wage": 2028000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lukas Klostermann",
+          "name": "L. Klostermann",
+          "overall_score": 76,
+          "potential": 77,
+          "value": 7000000,
+          "yearly_wage": 2288000
+        },
+        {
+          "currency": "€",
+          "full_name": "Max Finkgräfe",
+          "name": "M. Finkgräfe",
+          "overall_score": 70,
+          "potential": 81,
+          "value": 3400000,
+          "yearly_wage": 936000
+        },
+        {
+          "currency": "€",
+          "full_name": "Suleman Sani",
+          "name": "S. Sani",
+          "overall_score": 68,
+          "potential": 83,
+          "value": 2800000,
+          "yearly_wage": 780000
+        },
+        {
+          "currency": "€",
+          "full_name": "Viggo Gebel",
+          "name": "V. Gebel",
+          "overall_score": 63,
+          "potential": 80,
+          "value": 1200000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Benno Kaltefleiter",
+          "name": "B. Kaltefleiter",
+          "overall_score": 59,
+          "potential": 79,
+          "value": 575000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Tidiam Gomis",
+          "name": "T. Gomis",
+          "overall_score": 70,
+          "potential": 85,
+          "value": 3700000,
+          "yearly_wage": 884000
+        },
+        {
+          "currency": "€",
+          "full_name": "Xaver Schlager",
+          "name": "X. Schlager",
+          "overall_score": 78,
+          "potential": 79,
+          "value": 14500000,
+          "yearly_wage": 2496000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ayodele Thomas",
+          "name": "A. Thomas",
+          "overall_score": 64,
+          "potential": 84,
+          "value": 1600000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Péter Gulácsi",
+          "name": "P. Gulácsi",
+          "overall_score": 84,
+          "potential": 84,
+          "value": 4700000,
+          "yearly_wage": 1664000
+        },
+        {
+          "currency": "€",
+          "full_name": "Samba Konaté",
+          "name": "S. Konaté",
+          "overall_score": 59,
+          "potential": 82,
+          "value": 700000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Timo Schlieck",
+          "name": "T. Schlieck",
+          "overall_score": 61,
+          "potential": 75,
+          "value": 675000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Arthur Vermeeren",
+          "name": "A. Vermeeren",
+          "overall_score": 77,
+          "potential": 86,
+          "value": 23000000,
+          "yearly_wage": 1820000
+        },
+        {
+          "currency": "€",
+          "full_name": "Frederik Jäkel",
+          "name": "F. Jäkel",
+          "overall_score": 68,
+          "potential": 72,
+          "value": 1600000,
+          "yearly_wage": 884000
+        },
+        {
+          "currency": "€",
+          "full_name": "Loïs Openda",
+          "name": "L. Openda",
+          "overall_score": 82,
+          "potential": 84,
+          "value": 38500000,
+          "yearly_wage": 3640000
+        },
+        {
+          "currency": "€",
+          "full_name": "Eljif Elmas",
+          "name": "E. Elmas",
+          "overall_score": 77,
+          "potential": 77,
+          "value": 11500000,
+          "yearly_wage": 2392000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lutsharel Geertruida",
+          "name": "L. Geertruida",
+          "overall_score": 78,
+          "potential": 82,
+          "value": 18000000,
+          "yearly_wage": 2132000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jonathan Norbye",
+          "name": "J. Norbye",
+          "overall_score": 61,
+          "potential": 77,
+          "value": 775000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Abdoul Koné",
+          "name": "A. Koné",
+          "overall_score": 67,
+          "potential": 79,
+          "value": 2300000,
+          "yearly_wage": 624000
+        }
+      ],
+      "team": "RB Leipzig",
+      "transfer_budget": 79500000,
+      "url": "https://sofifa.com/team/112172/rb-leipzig/260037/"
+    },
+    {
+      "player_count": 43,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Mark Flekken",
+          "name": "M. Flekken",
+          "overall_score": 78,
+          "potential": 78,
+          "value": 7000000,
+          "yearly_wage": 2236000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jarell Quansah",
+          "name": "J. Quansah",
+          "overall_score": 76,
+          "potential": 84,
+          "value": 15500000,
+          "yearly_wage": 2496000
+        },
+        {
+          "currency": "€",
+          "full_name": "Robert Andrich",
+          "name": "R. Andrich",
+          "overall_score": 79,
+          "potential": 79,
+          "value": 14500000,
+          "yearly_wage": 3796000
+        },
+        {
+          "currency": "€",
+          "full_name": "Edmond Tapsoba",
+          "name": "E. Tapsoba",
+          "overall_score": 82,
+          "potential": 83,
+          "value": 31500000,
+          "yearly_wage": 4472000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lucas Vázquez Iglesias",
+          "name": "Lucas Vázquez",
+          "overall_score": 77,
+          "potential": 77,
+          "value": 3900000,
+          "yearly_wage": 3224000
+        },
+        {
+          "currency": "€",
+          "full_name": "Aleix García Serrano",
+          "name": "Aleix García",
+          "overall_score": 84,
+          "potential": 84,
+          "value": 42000000,
+          "yearly_wage": 5720000
+        },
+        {
+          "currency": "€",
+          "full_name": "Exequiel Palacios",
+          "name": "E. Palacios",
+          "overall_score": 83,
+          "potential": 83,
+          "value": 39500000,
+          "yearly_wage": 5200000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alejandro Grimaldo García",
+          "name": "Grimaldo",
+          "overall_score": 85,
+          "potential": 85,
+          "value": 53000000,
+          "yearly_wage": 6240000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ibrahim Maza",
+          "name": "I. Maza",
+          "overall_score": 79,
+          "potential": 87,
+          "value": 38000000,
+          "yearly_wage": 2704000
+        },
+        {
+          "currency": "€",
+          "full_name": "Nathan Tella",
+          "name": "N. Tella",
+          "overall_score": 78,
+          "potential": 79,
+          "value": 17000000,
+          "yearly_wage": 3328000
+        },
+        {
+          "currency": "€",
+          "full_name": "Patrik Schick",
+          "name": "P. Schick",
+          "overall_score": 85,
+          "potential": 85,
+          "value": 54000000,
+          "yearly_wage": 7020000
+        },
+        {
+          "currency": "€",
+          "full_name": "Malik Tillman",
+          "name": "M. Tillman",
+          "overall_score": 79,
+          "potential": 84,
+          "value": 26500000,
+          "yearly_wage": 3380000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jonas Hofmann",
+          "name": "J. Hofmann",
+          "overall_score": 77,
+          "potential": 77,
+          "value": 8500000,
+          "yearly_wage": 3432000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ernest Poku",
+          "name": "E. Poku",
+          "overall_score": 76,
+          "potential": 85,
+          "value": 17000000,
+          "yearly_wage": 2236000
+        },
+        {
+          "currency": "€",
+          "full_name": "Eliesse Ben Seghir",
+          "name": "E. Ben Seghir",
+          "overall_score": 75,
+          "potential": 84,
+          "value": 12500000,
+          "yearly_wage": 2184000
+        },
+        {
+          "currency": "€",
+          "full_name": "Loïc Badé",
+          "name": "L. Badé",
+          "overall_score": 78,
+          "potential": 83,
+          "value": 18500000,
+          "yearly_wage": 3172000
+        },
+        {
+          "currency": "€",
+          "full_name": "Tim Oermann",
+          "name": "T. Oermann",
+          "overall_score": 72,
+          "potential": 80,
+          "value": 4900000,
+          "yearly_wage": 1560000
+        },
+        {
+          "currency": "€",
+          "full_name": "Janis Blaswich",
+          "name": "J. Blaswich",
+          "overall_score": 74,
+          "potential": 74,
+          "value": 725000,
+          "yearly_wage": 1768000
+        },
+        {
+          "currency": "€",
+          "full_name": "Christian Kofane",
+          "name": "C. Kofane",
+          "overall_score": 76,
+          "potential": 86,
+          "value": 16000000,
+          "yearly_wage": 2236000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ezequiel Fernández",
+          "name": "E. Fernández",
+          "overall_score": 76,
+          "potential": 84,
+          "value": 16000000,
+          "yearly_wage": 2496000
+        },
+        {
+          "currency": "€",
+          "full_name": "Montrell Culbreath",
+          "name": "M. Culbreath",
+          "overall_score": 67,
+          "potential": 83,
+          "value": 2500000,
+          "yearly_wage": 624000
+        },
+        {
+          "currency": "€",
+          "full_name": "Axel Tape",
+          "name": "A. Tape",
+          "overall_score": 67,
+          "potential": 84,
+          "value": 2400000,
+          "yearly_wage": 572000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jeremiah Mensah",
+          "name": "J. Mensah",
+          "overall_score": 62,
+          "potential": 82,
+          "value": 1100000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Martin Terrier",
+          "name": "M. Terrier",
+          "overall_score": 79,
+          "potential": 79,
+          "value": 17500000,
+          "yearly_wage": 4056000
+        },
+        {
+          "currency": "€",
+          "full_name": "Arthur Augusto de Matos Soares",
+          "name": "Arthur",
+          "overall_score": 73,
+          "potential": 78,
+          "value": 4700000,
+          "yearly_wage": 2080000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ben Hawighorst",
+          "name": "B. Hawighorst",
+          "overall_score": 60,
+          "potential": 82,
+          "value": 725000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jonas Omlin",
+          "name": "J. Omlin",
+          "overall_score": 73,
+          "potential": 73,
+          "value": 1600000,
+          "yearly_wage": 728000
+        },
+        {
+          "currency": "€",
+          "full_name": "Naba Mensah",
+          "name": "N. Mensah",
+          "overall_score": 60,
+          "potential": 79,
+          "value": 625000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Niklas Lomb",
+          "name": "N. Lomb",
+          "overall_score": 66,
+          "potential": 66,
+          "value": 450000,
+          "yearly_wage": 676000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jesper Schlich",
+          "name": "J. Schlich",
+          "overall_score": 57,
+          "potential": 73,
+          "value": 350000,
+          "yearly_wage": 52000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ferdinand Pohl",
+          "name": "F. Pohl",
+          "overall_score": 59,
+          "potential": 77,
+          "value": 550000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Emmanuel Chigozie Owen",
+          "name": "E. Chigozie Owen",
+          "overall_score": 60,
+          "potential": 79,
+          "value": 625000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Abdoulaye Faye",
+          "name": "A. Faye",
+          "overall_score": 69,
+          "potential": 81,
+          "value": 3200000,
+          "yearly_wage": 1092000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ken Izekor",
+          "name": "K. Izekor",
+          "overall_score": 60,
+          "potential": 78,
+          "value": 625000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jeanuël Belocian",
+          "name": "J. Belocian",
+          "overall_score": 70,
+          "potential": 81,
+          "value": 3300000,
+          "yearly_wage": 1248000
+        },
+        {
+          "currency": "€",
+          "full_name": "Noah Mbamba",
+          "name": "N. Mbamba",
+          "overall_score": 67,
+          "potential": 81,
+          "value": 2300000,
+          "yearly_wage": 884000
+        },
+        {
+          "currency": "€",
+          "full_name": "Piero Hincapié",
+          "name": "P. Hincapié",
+          "overall_score": 83,
+          "potential": 87,
+          "value": 48500000,
+          "yearly_wage": 4212000
+        },
+        {
+          "currency": "€",
+          "full_name": "Victor Boniface",
+          "name": "V. Boniface",
+          "overall_score": 79,
+          "potential": 83,
+          "value": 25500000,
+          "yearly_wage": 3640000
+        },
+        {
+          "currency": "€",
+          "full_name": "Farid Alfa-Ruprecht",
+          "name": "F. Alfa-Ruprecht",
+          "overall_score": 65,
+          "potential": 77,
+          "value": 1700000,
+          "yearly_wage": 624000
+        },
+        {
+          "currency": "€",
+          "full_name": "Andrea Natali",
+          "name": "A. Natali",
+          "overall_score": 60,
+          "potential": 82,
+          "value": 725000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Artem Stepanov",
+          "name": "A. Stepanov",
+          "overall_score": 67,
+          "potential": 83,
+          "value": 2600000,
+          "yearly_wage": 780000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alejo Sarco",
+          "name": "A. Sarco",
+          "overall_score": 64,
+          "potential": 81,
+          "value": 1500000,
+          "yearly_wage": 624000
+        },
+        {
+          "currency": "€",
+          "full_name": "Francis Onyeka",
+          "name": "F. Onyeka",
+          "overall_score": 67,
+          "potential": 86,
+          "value": 2600000,
+          "yearly_wage": 832000
+        }
+      ],
+      "team": "Bayer 04 Leverkusen",
+      "transfer_budget": 62000000,
+      "url": "https://sofifa.com/team/32/bayer-04-leverkusen/260037/"
+    },
+    {
+      "player_count": 38,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Michael Zetterer",
+          "name": "M. Zetterer",
+          "overall_score": 75,
+          "potential": 75,
+          "value": 3800000,
+          "yearly_wage": 936000
+        },
+        {
+          "currency": "€",
+          "full_name": "Rasmus Kristensen",
+          "name": "R. Kristensen",
+          "overall_score": 79,
+          "potential": 79,
+          "value": 17000000,
+          "yearly_wage": 1820000
+        },
+        {
+          "currency": "€",
+          "full_name": "Robin Koch",
+          "name": "R. Koch",
+          "overall_score": 80,
+          "potential": 80,
+          "value": 18000000,
+          "yearly_wage": 2028000
+        },
+        {
+          "currency": "€",
+          "full_name": "Arthur Theate",
+          "name": "A. Theate",
+          "overall_score": 78,
+          "potential": 83,
+          "value": 18500000,
+          "yearly_wage": 1560000
+        },
+        {
+          "currency": "€",
+          "full_name": "Nathaniel Brown",
+          "name": "N. Brown",
+          "overall_score": 80,
+          "potential": 86,
+          "value": 31500000,
+          "yearly_wage": 1664000
+        },
+        {
+          "currency": "€",
+          "full_name": "Hugo Larsson",
+          "name": "H. Larsson",
+          "overall_score": 77,
+          "potential": 85,
+          "value": 23500000,
+          "yearly_wage": 1196000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ritsu Doan",
+          "name": "R. Doan",
+          "overall_score": 81,
+          "potential": 81,
+          "value": 27500000,
+          "yearly_wage": 2184000
+        },
+        {
+          "currency": "€",
+          "full_name": "Can Uzun",
+          "name": "C. Uzun",
+          "overall_score": 78,
+          "potential": 85,
+          "value": 27500000,
+          "yearly_wage": 1248000
+        },
+        {
+          "currency": "€",
+          "full_name": "Oscar Højlund",
+          "name": "O. Højlund",
+          "overall_score": 74,
+          "potential": 84,
+          "value": 9000000,
+          "yearly_wage": 988000
+        },
+        {
+          "currency": "€",
+          "full_name": "Arnaud Kalimuendo",
+          "name": "A. Kalimuendo",
+          "overall_score": 78,
+          "potential": 82,
+          "value": 20500000,
+          "yearly_wage": 4004000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jonathan Burkardt",
+          "name": "J. Burkardt",
+          "overall_score": 82,
+          "potential": 85,
+          "value": 42000000,
+          "yearly_wage": 2236000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ellyes Skhiri",
+          "name": "E. Skhiri",
+          "overall_score": 77,
+          "potential": 77,
+          "value": 9000000,
+          "yearly_wage": 1612000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ansgar Knauff",
+          "name": "A. Knauff",
+          "overall_score": 77,
+          "potential": 81,
+          "value": 15000000,
+          "yearly_wage": 1404000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jean-Mattéo Bahoya",
+          "name": "J. Bahoya",
+          "overall_score": 75,
+          "potential": 85,
+          "value": 12500000,
+          "yearly_wage": 1092000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mahmoud Dahoud",
+          "name": "M. Dahoud",
+          "overall_score": 73,
+          "potential": 73,
+          "value": 3000000,
+          "yearly_wage": 1248000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ayoube Amaimouni",
+          "name": "A. Amaimouni",
+          "overall_score": 70,
+          "potential": 83,
+          "value": 3800000,
+          "yearly_wage": 676000
+        },
+        {
+          "currency": "€",
+          "full_name": "Aurèle Amenda",
+          "name": "A. Amenda",
+          "overall_score": 74,
+          "potential": 80,
+          "value": 6000000,
+          "yearly_wage": 936000
+        },
+        {
+          "currency": "€",
+          "full_name": "Kauã Morais Vieira dos Santos",
+          "name": "Kauã Santos",
+          "overall_score": 71,
+          "potential": 81,
+          "value": 3600000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "Farès Chaïbi",
+          "name": "F. Chaïbi",
+          "overall_score": 76,
+          "potential": 81,
+          "value": 11500000,
+          "yearly_wage": 1352000
+        },
+        {
+          "currency": "€",
+          "full_name": "Younes Ebnoutalib",
+          "name": "Y. Ebnoutalib",
+          "overall_score": 70,
+          "potential": 78,
+          "value": 3600000,
+          "yearly_wage": 728000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mario Götze",
+          "name": "M. Götze",
+          "overall_score": 78,
+          "potential": 78,
+          "value": 8500000,
+          "yearly_wage": 1820000
+        },
+        {
+          "currency": "€",
+          "full_name": "Michy Batshuayi",
+          "name": "M. Batshuayi",
+          "overall_score": 74,
+          "potential": 74,
+          "value": 3600000,
+          "yearly_wage": 1508000
+        },
+        {
+          "currency": "€",
+          "full_name": "Love Arrhov",
+          "name": "L. Arrhov",
+          "overall_score": 65,
+          "potential": 80,
+          "value": 1600000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Timmy Chandler",
+          "name": "T. Chandler",
+          "overall_score": 64,
+          "potential": 64,
+          "value": 180000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jens Grahl",
+          "name": "J. Grahl",
+          "overall_score": 63,
+          "potential": 63,
+          "value": 50000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Keita Kosugi",
+          "name": "K. Kosugi",
+          "overall_score": 71,
+          "potential": 81,
+          "value": 3900000,
+          "yearly_wage": 676000
+        },
+        {
+          "currency": "€",
+          "full_name": "Fousseny Doumbia",
+          "name": "F. Doumbia",
+          "overall_score": 60,
+          "potential": 75,
+          "value": 550000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Amil Šiljević",
+          "name": "A. Šiljević",
+          "overall_score": 60,
+          "potential": 78,
+          "value": 550000,
+          "yearly_wage": 52000
+        },
+        {
+          "currency": "€",
+          "full_name": "Nnamdi Collins",
+          "name": "N. Collins",
+          "overall_score": 74,
+          "potential": 83,
+          "value": 9000000,
+          "yearly_wage": 936000
+        },
+        {
+          "currency": "€",
+          "full_name": "Elias Baum",
+          "name": "E. Baum",
+          "overall_score": 72,
+          "potential": 84,
+          "value": 5500000,
+          "yearly_wage": 728000
+        },
+        {
+          "currency": "€",
+          "full_name": "Marvin Dills",
+          "name": "M. Dills",
+          "overall_score": 62,
+          "potential": 82,
+          "value": 1100000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alexander Staff",
+          "name": "A. Staff",
+          "overall_score": 62,
+          "potential": 85,
+          "value": 1300000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Simon Simoni",
+          "name": "S. Simoni",
+          "overall_score": 64,
+          "potential": 78,
+          "value": 1200000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Hrvoje Smolčić",
+          "name": "H. Smolčić",
+          "overall_score": 72,
+          "potential": 76,
+          "value": 3000000,
+          "yearly_wage": 936000
+        },
+        {
+          "currency": "€",
+          "full_name": "Elye Wahi",
+          "name": "E. Wahi",
+          "overall_score": 74,
+          "potential": 81,
+          "value": 8500000,
+          "yearly_wage": 1300000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jessic Ngankam",
+          "name": "J. Ngankam",
+          "overall_score": 69,
+          "potential": 74,
+          "value": 2100000,
+          "yearly_wage": 728000
+        },
+        {
+          "currency": "€",
+          "full_name": "Niels Nkounkou",
+          "name": "N. Nkounkou",
+          "overall_score": 73,
+          "potential": 76,
+          "value": 4200000,
+          "yearly_wage": 1040000
+        },
+        {
+          "currency": "€",
+          "full_name": "Junior Dina Ebimbe",
+          "name": "J. Dina Ebimbe",
+          "overall_score": 72,
+          "potential": 75,
+          "value": 3200000,
+          "yearly_wage": 988000
+        }
+      ],
+      "team": "Eintracht Frankfurt",
+      "transfer_budget": 44200000,
+      "url": "https://sofifa.com/team/1824/eintracht-frankfurt/260037/"
+    },
+    {
+      "player_count": 43,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Oliver Baumann",
+          "name": "O. Baumann",
+          "overall_score": 84,
+          "potential": 84,
+          "value": 4700000,
+          "yearly_wage": 1196000
+        },
+        {
+          "currency": "€",
+          "full_name": "Vladimír Coufal",
+          "name": "V. Coufal",
+          "overall_score": 78,
+          "potential": 78,
+          "value": 9500000,
+          "yearly_wage": 1924000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ozan Kabak",
+          "name": "O. Kabak",
+          "overall_score": 76,
+          "potential": 78,
+          "value": 8500000,
+          "yearly_wage": 1508000
+        },
+        {
+          "currency": "€",
+          "full_name": "Albian Hajdari",
+          "name": "A. Hajdari",
+          "overall_score": 75,
+          "potential": 79,
+          "value": 7500000,
+          "yearly_wage": 1300000
+        },
+        {
+          "currency": "€",
+          "full_name": "Bernardo Fernandes",
+          "name": "Bernardo",
+          "overall_score": 75,
+          "potential": 75,
+          "value": 4800000,
+          "yearly_wage": 1612000
+        },
+        {
+          "currency": "€",
+          "full_name": "Leon Avdullahu",
+          "name": "L. Avdullahu",
+          "overall_score": 77,
+          "potential": 83,
+          "value": 15500000,
+          "yearly_wage": 1248000
+        },
+        {
+          "currency": "€",
+          "full_name": "Andrej Kramarić",
+          "name": "A. Kramarić",
+          "overall_score": 81,
+          "potential": 81,
+          "value": 12000000,
+          "yearly_wage": 2548000
+        },
+        {
+          "currency": "€",
+          "full_name": "Wouter Burger",
+          "name": "W. Burger",
+          "overall_score": 77,
+          "potential": 79,
+          "value": 13500000,
+          "yearly_wage": 1560000
+        },
+        {
+          "currency": "€",
+          "full_name": "Tim Lemperle",
+          "name": "T. Lemperle",
+          "overall_score": 76,
+          "potential": 80,
+          "value": 11000000,
+          "yearly_wage": 1612000
+        },
+        {
+          "currency": "€",
+          "full_name": "Fisnik Asllani",
+          "name": "F. Asllani",
+          "overall_score": 79,
+          "potential": 83,
+          "value": 26000000,
+          "yearly_wage": 2028000
+        },
+        {
+          "currency": "€",
+          "full_name": "Bazoumana Touré",
+          "name": "B. Touré",
+          "overall_score": 77,
+          "potential": 86,
+          "value": 23000000,
+          "yearly_wage": 1248000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ihlas Bebou",
+          "name": "I. Bebou",
+          "overall_score": 74,
+          "potential": 74,
+          "value": 3600000,
+          "yearly_wage": 1664000
+        },
+        {
+          "currency": "€",
+          "full_name": "Max Moerstedt",
+          "name": "M. Moerstedt",
+          "overall_score": 69,
+          "potential": 81,
+          "value": 3300000,
+          "yearly_wage": 676000
+        },
+        {
+          "currency": "€",
+          "full_name": "Grischa Prömel",
+          "name": "G. Prömel",
+          "overall_score": 77,
+          "potential": 77,
+          "value": 10000000,
+          "yearly_wage": 1872000
+        },
+        {
+          "currency": "€",
+          "full_name": "Robin Hranáč",
+          "name": "R. Hranáč",
+          "overall_score": 76,
+          "potential": 77,
+          "value": 8000000,
+          "yearly_wage": 1508000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alexander Prass",
+          "name": "A. Prass",
+          "overall_score": 75,
+          "potential": 77,
+          "value": 6500000,
+          "yearly_wage": 1300000
+        },
+        {
+          "currency": "€",
+          "full_name": "Kevin Akpoguma",
+          "name": "K. Akpoguma",
+          "overall_score": 73,
+          "potential": 73,
+          "value": 2500000,
+          "yearly_wage": 1352000
+        },
+        {
+          "currency": "€",
+          "full_name": "Luca Philipp",
+          "name": "L. Philipp",
+          "overall_score": 68,
+          "potential": 72,
+          "value": 1400000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Muhammed Damar",
+          "name": "M. Damar",
+          "overall_score": 72,
+          "potential": 80,
+          "value": 5500000,
+          "yearly_wage": 936000
+        },
+        {
+          "currency": "€",
+          "full_name": "Cole Campbell",
+          "name": "C. Campbell",
+          "overall_score": 67,
+          "potential": 82,
+          "value": 2400000,
+          "yearly_wage": 572000
+        },
+        {
+          "currency": "€",
+          "full_name": "Adam Hložek",
+          "name": "A. Hložek",
+          "overall_score": 77,
+          "potential": 83,
+          "value": 17000000,
+          "yearly_wage": 1716000
+        },
+        {
+          "currency": "€",
+          "full_name": "Valentin Gendrey",
+          "name": "V. Gendrey",
+          "overall_score": 74,
+          "potential": 78,
+          "value": 5500000,
+          "yearly_wage": 1352000
+        },
+        {
+          "currency": "€",
+          "full_name": "Luca Erlein",
+          "name": "L. Erlein",
+          "overall_score": 65,
+          "potential": 78,
+          "value": 1600000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Yannick Eduardo",
+          "name": "Y. Eduardo",
+          "overall_score": 67,
+          "potential": 80,
+          "value": 2400000,
+          "yearly_wage": 520000
+        },
+        {
+          "currency": "€",
+          "full_name": "Koki Machida",
+          "name": "K. Machida",
+          "overall_score": 75,
+          "potential": 75,
+          "value": 5000000,
+          "yearly_wage": 1508000
+        },
+        {
+          "currency": "€",
+          "full_name": "Luis Engelns",
+          "name": "L. Engelns",
+          "overall_score": 65,
+          "potential": 80,
+          "value": 1700000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Florian Micheler",
+          "name": "F. Micheler",
+          "overall_score": 61,
+          "potential": 75,
+          "value": 775000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Kelven Frees",
+          "name": "K. Frees",
+          "overall_score": 61,
+          "potential": 71,
+          "value": 675000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lúkas Petersson",
+          "name": "L. Petersson",
+          "overall_score": 64,
+          "potential": 70,
+          "value": 775000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Deniz Zeitler",
+          "name": "D. Zeitler",
+          "overall_score": 67,
+          "potential": 79,
+          "value": 2400000,
+          "yearly_wage": 520000
+        },
+        {
+          "currency": "€",
+          "full_name": "Luka Đurić",
+          "name": "L. Đurić",
+          "overall_score": 66,
+          "potential": 70,
+          "value": 1200000,
+          "yearly_wage": 520000
+        },
+        {
+          "currency": "€",
+          "full_name": "Gift Orban",
+          "name": "G. Orban",
+          "overall_score": 74,
+          "potential": 81,
+          "value": 8500000,
+          "yearly_wage": 1404000
+        },
+        {
+          "currency": "€",
+          "full_name": "Umut Tohumcu",
+          "name": "U. Tohumcu",
+          "overall_score": 70,
+          "potential": 80,
+          "value": 3500000,
+          "yearly_wage": 728000
+        },
+        {
+          "currency": "€",
+          "full_name": "Bambasé Conté",
+          "name": "B. Conté",
+          "overall_score": 69,
+          "potential": 75,
+          "value": 2200000,
+          "yearly_wage": 676000
+        },
+        {
+          "currency": "€",
+          "full_name": "Nahuel Noll",
+          "name": "N. Noll",
+          "overall_score": 68,
+          "potential": 75,
+          "value": 2100000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Attila Szalai",
+          "name": "A. Szalai",
+          "overall_score": 70,
+          "potential": 71,
+          "value": 1600000,
+          "yearly_wage": 936000
+        },
+        {
+          "currency": "€",
+          "full_name": "Erencan Yardımcı",
+          "name": "E. Yardımcı",
+          "overall_score": 67,
+          "potential": 74,
+          "value": 2100000,
+          "yearly_wage": 676000
+        },
+        {
+          "currency": "€",
+          "full_name": "Stanley Nsoki",
+          "name": "S. Nsoki",
+          "overall_score": 71,
+          "potential": 74,
+          "value": 2200000,
+          "yearly_wage": 1040000
+        },
+        {
+          "currency": "€",
+          "full_name": "Dennis Geiger",
+          "name": "D. Geiger",
+          "overall_score": 72,
+          "potential": 73,
+          "value": 2400000,
+          "yearly_wage": 1144000
+        },
+        {
+          "currency": "€",
+          "full_name": "Haris Tabaković",
+          "name": "H. Tabaković",
+          "overall_score": 75,
+          "potential": 75,
+          "value": 4800000,
+          "yearly_wage": 1820000
+        },
+        {
+          "currency": "€",
+          "full_name": "Precious Benjamin",
+          "name": "P. Benjamin",
+          "overall_score": 56,
+          "potential": 69,
+          "value": 325000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Hennes Behrens",
+          "name": "H. Behrens",
+          "overall_score": 70,
+          "potential": 77,
+          "value": 3000000,
+          "yearly_wage": 676000
+        },
+        {
+          "currency": "€",
+          "full_name": "Arthur Largura Chaves",
+          "name": "Arthur Chaves",
+          "overall_score": 74,
+          "potential": 79,
+          "value": 6000000,
+          "yearly_wage": 1196000
+        }
+      ],
+      "team": "TSG 1899 Hoffenheim",
+      "transfer_budget": 34700000,
+      "url": "https://sofifa.com/team/10029/tsg-1899-hoffenheim/260037/"
+    },
+    {
+      "player_count": 39,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Alexander Nübel",
+          "name": "A. Nübel",
+          "overall_score": 80,
+          "potential": 81,
+          "value": 16500000,
+          "yearly_wage": 2184000
+        },
+        {
+          "currency": "€",
+          "full_name": "Josha Vagnoman",
+          "name": "J. Vagnoman",
+          "overall_score": 75,
+          "potential": 78,
+          "value": 7000000,
+          "yearly_wage": 1404000
+        },
+        {
+          "currency": "€",
+          "full_name": "Finn Jeltsch",
+          "name": "F. Jeltsch",
+          "overall_score": 74,
+          "potential": 87,
+          "value": 9000000,
+          "yearly_wage": 936000
+        },
+        {
+          "currency": "€",
+          "full_name": "Julian Chabot",
+          "name": "J. Chabot",
+          "overall_score": 80,
+          "potential": 80,
+          "value": 19500000,
+          "yearly_wage": 2236000
+        },
+        {
+          "currency": "€",
+          "full_name": "Maximilian Mittelstädt",
+          "name": "M. Mittelstädt",
+          "overall_score": 83,
+          "potential": 83,
+          "value": 33000000,
+          "yearly_wage": 2964000
+        },
+        {
+          "currency": "€",
+          "full_name": "Atakan Karazor",
+          "name": "A. Karazor",
+          "overall_score": 76,
+          "potential": 76,
+          "value": 6500000,
+          "yearly_wage": 1768000
+        },
+        {
+          "currency": "€",
+          "full_name": "Angelo Stiller",
+          "name": "A. Stiller",
+          "overall_score": 83,
+          "potential": 87,
+          "value": 47500000,
+          "yearly_wage": 2444000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jamie Leweling",
+          "name": "J. Leweling",
+          "overall_score": 78,
+          "potential": 81,
+          "value": 19000000,
+          "yearly_wage": 1768000
+        },
+        {
+          "currency": "€",
+          "full_name": "Chris Führich",
+          "name": "C. Führich",
+          "overall_score": 77,
+          "potential": 77,
+          "value": 11000000,
+          "yearly_wage": 1872000
+        },
+        {
+          "currency": "€",
+          "full_name": "Deniz Undav",
+          "name": "D. Undav",
+          "overall_score": 82,
+          "potential": 82,
+          "value": 31000000,
+          "yearly_wage": 3068000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ermedin Demirović",
+          "name": "E. Demirović",
+          "overall_score": 80,
+          "potential": 80,
+          "value": 23000000,
+          "yearly_wage": 2548000
+        },
+        {
+          "currency": "€",
+          "full_name": "Bilal El Khannouss",
+          "name": "B. El Khannouss",
+          "overall_score": 78,
+          "potential": 84,
+          "value": 22500000,
+          "yearly_wage": 1872000
+        },
+        {
+          "currency": "€",
+          "full_name": "Tiago B. de Melo Tomás",
+          "name": "Tiago Tomás",
+          "overall_score": 76,
+          "potential": 82,
+          "value": 12000000,
+          "yearly_wage": 1560000
+        },
+        {
+          "currency": "€",
+          "full_name": "Badredine Bouanani",
+          "name": "B. Bouanani",
+          "overall_score": 74,
+          "potential": 82,
+          "value": 9500000,
+          "yearly_wage": 1144000
+        },
+        {
+          "currency": "€",
+          "full_name": "Nikolas Nartey",
+          "name": "N. Nartey",
+          "overall_score": 73,
+          "potential": 76,
+          "value": 4000000,
+          "yearly_wage": 1352000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lorenz Assignon",
+          "name": "L. Assignon",
+          "overall_score": 75,
+          "potential": 80,
+          "value": 7500000,
+          "yearly_wage": 1560000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ramon Hendriks",
+          "name": "R. Hendriks",
+          "overall_score": 74,
+          "potential": 79,
+          "value": 6000000,
+          "yearly_wage": 1300000
+        },
+        {
+          "currency": "€",
+          "full_name": "Fabian Bredlow",
+          "name": "F. Bredlow",
+          "overall_score": 71,
+          "potential": 71,
+          "value": 1200000,
+          "yearly_wage": 780000
+        },
+        {
+          "currency": "€",
+          "full_name": "José María Andrés Baixauli",
+          "name": "Chema Andrés",
+          "overall_score": 73,
+          "potential": 82,
+          "value": 6500000,
+          "yearly_wage": 988000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jeremy Arévalo Mera",
+          "name": "Jeremy",
+          "overall_score": 66,
+          "potential": 80,
+          "value": 2100000,
+          "yearly_wage": 520000
+        },
+        {
+          "currency": "€",
+          "full_name": "Dan-Axel Zagadou",
+          "name": "D. Zagadou",
+          "overall_score": 74,
+          "potential": 77,
+          "value": 4900000,
+          "yearly_wage": 1508000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lazar Jovanović",
+          "name": "L. Jovanović",
+          "overall_score": 64,
+          "potential": 82,
+          "value": 1500000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Luca Jaquez",
+          "name": "L. Jaquez",
+          "overall_score": 71,
+          "potential": 79,
+          "value": 3900000,
+          "yearly_wage": 988000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ameen Al Dakhil",
+          "name": "A. Al Dakhil",
+          "overall_score": 72,
+          "potential": 79,
+          "value": 4400000,
+          "yearly_wage": 1092000
+        },
+        {
+          "currency": "€",
+          "full_name": "Pascal Stenzel",
+          "name": "P. Stenzel",
+          "overall_score": 69,
+          "potential": 69,
+          "value": 1200000,
+          "yearly_wage": 936000
+        },
+        {
+          "currency": "€",
+          "full_name": "Noah Darvich",
+          "name": "N. Darvich",
+          "overall_score": 63,
+          "potential": 82,
+          "value": 1200000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Stefan Drljača",
+          "name": "S. Drljača",
+          "overall_score": 66,
+          "potential": 70,
+          "value": 925000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Florian Hellstern",
+          "name": "F. Hellstern",
+          "overall_score": 63,
+          "potential": 82,
+          "value": 1100000,
+          "yearly_wage": 52000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mirza Ćatović",
+          "name": "M. Ćatović",
+          "overall_score": 62,
+          "potential": 78,
+          "value": 950000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Justin Diehl",
+          "name": "J. Diehl",
+          "overall_score": 66,
+          "potential": 80,
+          "value": 2100000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "Yanik Spalt",
+          "name": "Y. Spalt",
+          "overall_score": 58,
+          "potential": 74,
+          "value": 475000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Maximilian Herwerth",
+          "name": "M. Herwerth",
+          "overall_score": 63,
+          "potential": 77,
+          "value": 1100000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lauri Penna",
+          "name": "L. Penna",
+          "overall_score": 62,
+          "potential": 77,
+          "value": 925000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jovan Milošević",
+          "name": "J. Milošević",
+          "overall_score": 70,
+          "potential": 80,
+          "value": 3500000,
+          "yearly_wage": 832000
+        },
+        {
+          "currency": "€",
+          "full_name": "Dennis Seimen",
+          "name": "D. Seimen",
+          "overall_score": 69,
+          "potential": 84,
+          "value": 2900000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Laurin Ulrich",
+          "name": "L. Ulrich",
+          "overall_score": 69,
+          "potential": 80,
+          "value": 3000000,
+          "yearly_wage": 676000
+        },
+        {
+          "currency": "€",
+          "full_name": "Yannik Keitel",
+          "name": "Y. Keitel",
+          "overall_score": 71,
+          "potential": 74,
+          "value": 2200000,
+          "yearly_wage": 1040000
+        },
+        {
+          "currency": "€",
+          "full_name": "Leonidas Stergiou",
+          "name": "L. Stergiou",
+          "overall_score": 71,
+          "potential": 78,
+          "value": 3600000,
+          "yearly_wage": 988000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jarzinho Malanga",
+          "name": "J. Malanga",
+          "overall_score": 64,
+          "potential": 80,
+          "value": 1500000,
+          "yearly_wage": 312000
+        }
+      ],
+      "team": "VfB Stuttgart",
+      "transfer_budget": 27700000,
+      "url": "https://sofifa.com/team/36/vfb-stuttgart/260037/"
+    },
+    {
+      "player_count": 43,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Kamil Grabara",
+          "name": "K. Grabara",
+          "overall_score": 81,
+          "potential": 84,
+          "value": 26000000,
+          "yearly_wage": 1820000
+        },
+        {
+          "currency": "€",
+          "full_name": "Saël Kumbedi",
+          "name": "S. Kumbedi",
+          "overall_score": 75,
+          "potential": 81,
+          "value": 8000000,
+          "yearly_wage": 1404000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jeanuël Belocian",
+          "name": "J. Belocian",
+          "overall_score": 70,
+          "potential": 81,
+          "value": 3300000,
+          "yearly_wage": 1248000
+        },
+        {
+          "currency": "€",
+          "full_name": "Denis Vavro",
+          "name": "D. Vavro",
+          "overall_score": 76,
+          "potential": 76,
+          "value": 6500000,
+          "yearly_wage": 2080000
+        },
+        {
+          "currency": "€",
+          "full_name": "Konstantinos Koulierakis",
+          "name": "K. Koulierakis",
+          "overall_score": 76,
+          "potential": 85,
+          "value": 15500000,
+          "yearly_wage": 1456000
+        },
+        {
+          "currency": "€",
+          "full_name": "Joakim Mæhle",
+          "name": "J. Mæhle",
+          "overall_score": 77,
+          "potential": 77,
+          "value": 9500000,
+          "yearly_wage": 2236000
+        },
+        {
+          "currency": "€",
+          "full_name": "Vinicius de Souza Costa",
+          "name": "Vinicius Souza",
+          "overall_score": 75,
+          "potential": 78,
+          "value": 6500000,
+          "yearly_wage": 1924000
+        },
+        {
+          "currency": "€",
+          "full_name": "Patrick Wimmer",
+          "name": "P. Wimmer",
+          "overall_score": 77,
+          "potential": 83,
+          "value": 16500000,
+          "yearly_wage": 1924000
+        },
+        {
+          "currency": "€",
+          "full_name": "Christian Eriksen",
+          "name": "C. Eriksen",
+          "overall_score": 76,
+          "potential": 76,
+          "value": 4700000,
+          "yearly_wage": 2236000
+        },
+        {
+          "currency": "€",
+          "full_name": "Dženan Pejčinović",
+          "name": "D. Pejčinović",
+          "overall_score": 72,
+          "potential": 79,
+          "value": 4700000,
+          "yearly_wage": 1248000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mohamed Amoura",
+          "name": "M. Amoura",
+          "overall_score": 80,
+          "potential": 83,
+          "value": 28500000,
+          "yearly_wage": 2912000
+        },
+        {
+          "currency": "€",
+          "full_name": "Maximilian Arnold",
+          "name": "M. Arnold",
+          "overall_score": 79,
+          "potential": 79,
+          "value": 12500000,
+          "yearly_wage": 2652000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lovro Majer",
+          "name": "L. Majer",
+          "overall_score": 77,
+          "potential": 77,
+          "value": 11000000,
+          "yearly_wage": 2288000
+        },
+        {
+          "currency": "€",
+          "full_name": "Yannick Gerhardt",
+          "name": "Y. Gerhardt",
+          "overall_score": 74,
+          "potential": 74,
+          "value": 3500000,
+          "yearly_wage": 1924000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jesper Lindstrøm",
+          "name": "J. Lindstrøm",
+          "overall_score": 74,
+          "potential": 75,
+          "value": 5000000,
+          "yearly_wage": 3120000
+        },
+        {
+          "currency": "€",
+          "full_name": "Moritz Jenz",
+          "name": "M. Jenz",
+          "overall_score": 75,
+          "potential": 78,
+          "value": 6500000,
+          "yearly_wage": 1924000
+        },
+        {
+          "currency": "€",
+          "full_name": "Aaron Zehnter",
+          "name": "A. Zehnter",
+          "overall_score": 74,
+          "potential": 80,
+          "value": 6000000,
+          "yearly_wage": 1300000
+        },
+        {
+          "currency": "€",
+          "full_name": "Marius Müller",
+          "name": "M. Müller",
+          "overall_score": 74,
+          "potential": 74,
+          "value": 2200000,
+          "yearly_wage": 1196000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jonas Wind",
+          "name": "J. Wind",
+          "overall_score": 76,
+          "potential": 77,
+          "value": 9000000,
+          "yearly_wage": 2288000
+        },
+        {
+          "currency": "€",
+          "full_name": "Kento Shiogai",
+          "name": "K. Shiogai",
+          "overall_score": 68,
+          "potential": 82,
+          "value": 2900000,
+          "yearly_wage": 832000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jenson Seelt",
+          "name": "J. Seelt",
+          "overall_score": 68,
+          "potential": 77,
+          "value": 2500000,
+          "yearly_wage": 1040000
+        },
+        {
+          "currency": "€",
+          "full_name": "Adam Daghim",
+          "name": "A. Daghim",
+          "overall_score": 72,
+          "potential": 80,
+          "value": 5000000,
+          "yearly_wage": 520000
+        },
+        {
+          "currency": "€",
+          "full_name": "Kilian Fischer",
+          "name": "K. Fischer",
+          "overall_score": 73,
+          "potential": 76,
+          "value": 3800000,
+          "yearly_wage": 1404000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jan Bürger",
+          "name": "J. Bürger",
+          "overall_score": 62,
+          "potential": 75,
+          "value": 875000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jonas Adjetey",
+          "name": "J. Adjetey",
+          "overall_score": 70,
+          "potential": 82,
+          "value": 3700000,
+          "yearly_wage": 832000
+        },
+        {
+          "currency": "€",
+          "full_name": "Kevin Paredes",
+          "name": "K. Paredes",
+          "overall_score": 73,
+          "potential": 82,
+          "value": 7000000,
+          "yearly_wage": 1456000
+        },
+        {
+          "currency": "€",
+          "full_name": "Cleiton Santana dos Santos",
+          "name": "Cleiton",
+          "overall_score": 66,
+          "potential": 77,
+          "value": 1800000,
+          "yearly_wage": 624000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mattias Svanberg",
+          "name": "M. Svanberg",
+          "overall_score": 76,
+          "potential": 77,
+          "value": 9000000,
+          "yearly_wage": 2080000
+        },
+        {
+          "currency": "€",
+          "full_name": "Till Neininger",
+          "name": "T. Neininger",
+          "overall_score": 59,
+          "potential": 78,
+          "value": 550000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Pharell Hensel",
+          "name": "P. Hensel",
+          "overall_score": 61,
+          "potential": 76,
+          "value": 750000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Bence Dárdai",
+          "name": "B. Dárdai",
+          "overall_score": 72,
+          "potential": 82,
+          "value": 5000000,
+          "yearly_wage": 1092000
+        },
+        {
+          "currency": "€",
+          "full_name": "Rogério Oliveira da Silva",
+          "name": "Rogério",
+          "overall_score": 72,
+          "potential": 72,
+          "value": 2300000,
+          "yearly_wage": 1456000
+        },
+        {
+          "currency": "€",
+          "full_name": "Bruno Katz",
+          "name": "B. Katz",
+          "overall_score": 63,
+          "potential": 80,
+          "value": 1200000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Trevor Benedict",
+          "name": "T. Benedict",
+          "overall_score": 60,
+          "potential": 75,
+          "value": 575000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jakub Zieliński",
+          "name": "J. Zieliński",
+          "overall_score": 59,
+          "potential": 79,
+          "value": 550000,
+          "yearly_wage": 41600
+        },
+        {
+          "currency": "€",
+          "full_name": "Pavao Pervan",
+          "name": "P. Pervan",
+          "overall_score": 71,
+          "potential": 71,
+          "value": 210000,
+          "yearly_wage": 520000
+        },
+        {
+          "currency": "€",
+          "full_name": "Bartol Franjić",
+          "name": "B. Franjić",
+          "overall_score": 69,
+          "potential": 72,
+          "value": 1600000,
+          "yearly_wage": 988000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jakub Kamiński",
+          "name": "J. Kamiński",
+          "overall_score": 77,
+          "potential": 82,
+          "value": 16000000,
+          "yearly_wage": 1924000
+        },
+        {
+          "currency": "€",
+          "full_name": "Aster Vranckx",
+          "name": "A. Vranckx",
+          "overall_score": 72,
+          "potential": 77,
+          "value": 3600000,
+          "yearly_wage": 1300000
+        },
+        {
+          "currency": "€",
+          "full_name": "Andreas Skov Olsen",
+          "name": "A. Skov Olsen",
+          "overall_score": 75,
+          "potential": 76,
+          "value": 6500000,
+          "yearly_wage": 1924000
+        },
+        {
+          "currency": "€",
+          "full_name": "Nicolas Cozza",
+          "name": "N. Cozza",
+          "overall_score": 70,
+          "potential": 71,
+          "value": 1700000,
+          "yearly_wage": 1144000
+        },
+        {
+          "currency": "€",
+          "full_name": "Eryk Grzywacz",
+          "name": "E. Grzywacz",
+          "overall_score": 60,
+          "potential": 77,
+          "value": 600000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mathys Angély",
+          "name": "M. Angély",
+          "overall_score": 61,
+          "potential": 79,
+          "value": 775000,
+          "yearly_wage": 260000
+        }
+      ],
+      "team": "VfL Wolfsburg",
+      "transfer_budget": 40400000,
+      "url": "https://sofifa.com/team/175/vfl-wolfsburg/260037/"
+    },
+    {
+      "player_count": 38,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Daniel Batz",
+          "name": "D. Batz",
+          "overall_score": 72,
+          "potential": 72,
+          "value": 400000,
+          "yearly_wage": 676000
+        },
+        {
+          "currency": "€",
+          "full_name": "Silvan Widmer",
+          "name": "S. Widmer",
+          "overall_score": 73,
+          "potential": 73,
+          "value": 2100000,
+          "yearly_wage": 1092000
+        },
+        {
+          "currency": "€",
+          "full_name": "Danny da Costa",
+          "name": "D. da Costa",
+          "overall_score": 75,
+          "potential": 75,
+          "value": 3800000,
+          "yearly_wage": 1352000
+        },
+        {
+          "currency": "€",
+          "full_name": "Stefan Posch",
+          "name": "S. Posch",
+          "overall_score": 78,
+          "potential": 78,
+          "value": 12000000,
+          "yearly_wage": 4160000
+        },
+        {
+          "currency": "€",
+          "full_name": "Dominik Kohr",
+          "name": "D. Kohr",
+          "overall_score": 76,
+          "potential": 76,
+          "value": 5000000,
+          "yearly_wage": 1404000
+        },
+        {
+          "currency": "€",
+          "full_name": "Phillipp Mwene",
+          "name": "P. Mwene",
+          "overall_score": 75,
+          "potential": 75,
+          "value": 4100000,
+          "yearly_wage": 1352000
+        },
+        {
+          "currency": "€",
+          "full_name": "Kaishū Sano",
+          "name": "K. Sano",
+          "overall_score": 80,
+          "potential": 83,
+          "value": 26000000,
+          "yearly_wage": 1560000
+        },
+        {
+          "currency": "€",
+          "full_name": "Paul Nebel",
+          "name": "P. Nebel",
+          "overall_score": 76,
+          "potential": 83,
+          "value": 15000000,
+          "yearly_wage": 1248000
+        },
+        {
+          "currency": "€",
+          "full_name": "Nadiem Amiri",
+          "name": "N. Amiri",
+          "overall_score": 80,
+          "potential": 80,
+          "value": 21000000,
+          "yearly_wage": 1924000
+        },
+        {
+          "currency": "€",
+          "full_name": "Sheraldo Becker",
+          "name": "S. Becker",
+          "overall_score": 73,
+          "potential": 73,
+          "value": 3000000,
+          "yearly_wage": 1248000
+        },
+        {
+          "currency": "€",
+          "full_name": "Phillip Tietz",
+          "name": "P. Tietz",
+          "overall_score": 73,
+          "potential": 73,
+          "value": 3300000,
+          "yearly_wage": 1196000
+        },
+        {
+          "currency": "€",
+          "full_name": "Armindo Sieb",
+          "name": "A. Sieb",
+          "overall_score": 71,
+          "potential": 79,
+          "value": 4200000,
+          "yearly_wage": 1612000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jae Sung Lee",
+          "name": "Lee Jae Sung",
+          "overall_score": 76,
+          "potential": 76,
+          "value": 6000000,
+          "yearly_wage": 1456000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lennard Maloney",
+          "name": "L. Maloney",
+          "overall_score": 72,
+          "potential": 73,
+          "value": 2500000,
+          "yearly_wage": 936000
+        },
+        {
+          "currency": "€",
+          "full_name": "Andreas Hanche-Olsen",
+          "name": "A. Hanche-Olsen",
+          "overall_score": 74,
+          "potential": 75,
+          "value": 4000000,
+          "yearly_wage": 1248000
+        },
+        {
+          "currency": "€",
+          "full_name": "Stefan Bell",
+          "name": "S. Bell",
+          "overall_score": 73,
+          "potential": 73,
+          "value": 1500000,
+          "yearly_wage": 1092000
+        },
+        {
+          "currency": "€",
+          "full_name": "Kacper Potulski",
+          "name": "K. Potulski",
+          "overall_score": 68,
+          "potential": 83,
+          "value": 2600000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Robin Zentner",
+          "name": "R. Zentner",
+          "overall_score": 77,
+          "potential": 77,
+          "value": 7000000,
+          "yearly_wage": 988000
+        },
+        {
+          "currency": "€",
+          "full_name": "Nelson Weiper",
+          "name": "N. Weiper",
+          "overall_score": 70,
+          "potential": 83,
+          "value": 3900000,
+          "yearly_wage": 676000
+        },
+        {
+          "currency": "€",
+          "full_name": "Anthony Caci",
+          "name": "A. Caci",
+          "overall_score": 78,
+          "potential": 78,
+          "value": 12500000,
+          "yearly_wage": 1612000
+        },
+        {
+          "currency": "€",
+          "full_name": "Nikolas Veratschnig",
+          "name": "N. Veratschnig",
+          "overall_score": 69,
+          "potential": 76,
+          "value": 2700000,
+          "yearly_wage": 572000
+        },
+        {
+          "currency": "€",
+          "full_name": "Fabio Moreno Fell",
+          "name": "F. Moreno Fell",
+          "overall_score": 62,
+          "potential": 66,
+          "value": 550000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "William Bøving",
+          "name": "W. Bøving",
+          "overall_score": 71,
+          "potential": 78,
+          "value": 3800000,
+          "yearly_wage": 884000
+        },
+        {
+          "currency": "€",
+          "full_name": "Maxim Leitsch",
+          "name": "M. Leitsch",
+          "overall_score": 71,
+          "potential": 71,
+          "value": 1700000,
+          "yearly_wage": 884000
+        },
+        {
+          "currency": "€",
+          "full_name": "Niklas Tauer",
+          "name": "N. Tauer",
+          "overall_score": 66,
+          "potential": 70,
+          "value": 1100000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "Daniel Gleiber",
+          "name": "D. Gleiber",
+          "overall_score": 61,
+          "potential": 75,
+          "value": 775000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lasse Rieß",
+          "name": "L. Rieß",
+          "overall_score": 67,
+          "potential": 74,
+          "value": 1700000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Silas Katompa Mvumpa",
+          "name": "Silas",
+          "overall_score": 73,
+          "potential": 73,
+          "value": 3300000,
+          "yearly_wage": 1092000
+        },
+        {
+          "currency": "€",
+          "full_name": "Benedict Hollerbach",
+          "name": "B. Hollerbach",
+          "overall_score": 75,
+          "potential": 79,
+          "value": 8000000,
+          "yearly_wage": 1248000
+        },
+        {
+          "currency": "€",
+          "full_name": "Sota Kawasaki",
+          "name": "S. Kawasaki",
+          "overall_score": 71,
+          "potential": 75,
+          "value": 2700000,
+          "yearly_wage": 780000
+        },
+        {
+          "currency": "€",
+          "full_name": "Maxim Dal",
+          "name": "M. Dal",
+          "overall_score": 58,
+          "potential": 75,
+          "value": 500000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Kasey Bos",
+          "name": "K. Bos",
+          "overall_score": 65,
+          "potential": 75,
+          "value": 1500000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ben Bobzien",
+          "name": "B. Bobzien",
+          "overall_score": 67,
+          "potential": 76,
+          "value": 2300000,
+          "yearly_wage": 520000
+        },
+        {
+          "currency": "€",
+          "full_name": "Tom Krauß",
+          "name": "T. Krauß",
+          "overall_score": 74,
+          "potential": 77,
+          "value": 5000000,
+          "yearly_wage": 1040000
+        },
+        {
+          "currency": "€",
+          "full_name": "Hyun Seok Hong",
+          "name": "Hong Hyun Seok",
+          "overall_score": 72,
+          "potential": 74,
+          "value": 2900000,
+          "yearly_wage": 1040000
+        },
+        {
+          "currency": "€",
+          "full_name": "Marco Richter",
+          "name": "M. Richter",
+          "overall_score": 70,
+          "potential": 70,
+          "value": 1700000,
+          "yearly_wage": 832000
+        },
+        {
+          "currency": "€",
+          "full_name": "Arnaud Nordin",
+          "name": "A. Nordin",
+          "overall_score": 73,
+          "potential": 73,
+          "value": 3200000,
+          "yearly_wage": 1092000
+        },
+        {
+          "currency": "€",
+          "full_name": "Konstantin Schopp",
+          "name": "K. Schopp",
+          "overall_score": 59,
+          "potential": 74,
+          "value": 500000,
+          "yearly_wage": 156000
+        }
+      ],
+      "team": "1. FSV Mainz 05",
+      "transfer_budget": 11000000,
+      "url": "https://sofifa.com/team/169/1-fsv-mainz-05/260037/"
+    },
+    {
+      "player_count": 35,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Moritz Nicolas",
+          "name": "M. Nicolas",
+          "overall_score": 77,
+          "potential": 79,
+          "value": 9500000,
+          "yearly_wage": 936000
+        },
+        {
+          "currency": "€",
+          "full_name": "Philipp Sander",
+          "name": "P. Sander",
+          "overall_score": 75,
+          "potential": 76,
+          "value": 6000000,
+          "yearly_wage": 1248000
+        },
+        {
+          "currency": "€",
+          "full_name": "Nico Elvedi",
+          "name": "N. Elvedi",
+          "overall_score": 76,
+          "potential": 76,
+          "value": 6500000,
+          "yearly_wage": 1404000
+        },
+        {
+          "currency": "€",
+          "full_name": "Kevin Diks",
+          "name": "K. Diks",
+          "overall_score": 76,
+          "potential": 77,
+          "value": 7000000,
+          "yearly_wage": 1404000
+        },
+        {
+          "currency": "€",
+          "full_name": "Joe Scally",
+          "name": "J. Scally",
+          "overall_score": 75,
+          "potential": 78,
+          "value": 7000000,
+          "yearly_wage": 1092000
+        },
+        {
+          "currency": "€",
+          "full_name": "Rocco Reitz",
+          "name": "R. Reitz",
+          "overall_score": 77,
+          "potential": 83,
+          "value": 16500000,
+          "yearly_wage": 1300000
+        },
+        {
+          "currency": "€",
+          "full_name": "Yannik Engelhardt",
+          "name": "Y. Engelhardt",
+          "overall_score": 73,
+          "potential": 76,
+          "value": 3800000,
+          "yearly_wage": 2392000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jens Castrop",
+          "name": "J. Castrop",
+          "overall_score": 74,
+          "potential": 81,
+          "value": 8500000,
+          "yearly_wage": 936000
+        },
+        {
+          "currency": "€",
+          "full_name": "Franck Honorat",
+          "name": "F. Honorat",
+          "overall_score": 80,
+          "potential": 80,
+          "value": 21000000,
+          "yearly_wage": 1924000
+        },
+        {
+          "currency": "€",
+          "full_name": "Kevin Stöger",
+          "name": "K. Stöger",
+          "overall_score": 74,
+          "potential": 74,
+          "value": 3500000,
+          "yearly_wage": 1300000
+        },
+        {
+          "currency": "€",
+          "full_name": "Haris Tabaković",
+          "name": "H. Tabaković",
+          "overall_score": 75,
+          "potential": 75,
+          "value": 4800000,
+          "yearly_wage": 1820000
+        },
+        {
+          "currency": "€",
+          "full_name": "Shuto Machino",
+          "name": "S. Machino",
+          "overall_score": 73,
+          "potential": 76,
+          "value": 4100000,
+          "yearly_wage": 1144000
+        },
+        {
+          "currency": "€",
+          "full_name": "Florian Neuhaus",
+          "name": "F. Neuhaus",
+          "overall_score": 75,
+          "potential": 75,
+          "value": 5500000,
+          "yearly_wage": 1404000
+        },
+        {
+          "currency": "€",
+          "full_name": "Giovanni Reyna",
+          "name": "G. Reyna",
+          "overall_score": 73,
+          "potential": 78,
+          "value": 4700000,
+          "yearly_wage": 988000
+        },
+        {
+          "currency": "€",
+          "full_name": "Hugo Bolin",
+          "name": "H. Bolin",
+          "overall_score": 71,
+          "potential": 77,
+          "value": 3000000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lukas Ullrich",
+          "name": "L. Ullrich",
+          "overall_score": 73,
+          "potential": 79,
+          "value": 4600000,
+          "yearly_wage": 780000
+        },
+        {
+          "currency": "€",
+          "full_name": "Kota Takai",
+          "name": "K. Takai",
+          "overall_score": 72,
+          "potential": 79,
+          "value": 4300000,
+          "yearly_wage": 2028000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jan Olschowsky",
+          "name": "J. Olschowsky",
+          "overall_score": 67,
+          "potential": 74,
+          "value": 1700000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Robin Hack",
+          "name": "R. Hack",
+          "overall_score": 77,
+          "potential": 77,
+          "value": 11500000,
+          "yearly_wage": 1508000
+        },
+        {
+          "currency": "€",
+          "full_name": "Tim Kleindienst",
+          "name": "T. Kleindienst",
+          "overall_score": 80,
+          "potential": 80,
+          "value": 21000000,
+          "yearly_wage": 2080000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alejo Sarco",
+          "name": "A. Sarco",
+          "overall_score": 64,
+          "potential": 81,
+          "value": 1500000,
+          "yearly_wage": 624000
+        },
+        {
+          "currency": "€",
+          "full_name": "Fritz Fleck",
+          "name": "F. Fleck",
+          "overall_score": 62,
+          "potential": 77,
+          "value": 925000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Tiago Pereira Cardoso",
+          "name": "T. Pereira Cardoso",
+          "overall_score": 67,
+          "potential": 82,
+          "value": 2100000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Marvin Friedrich",
+          "name": "M. Friedrich",
+          "overall_score": 72,
+          "potential": 72,
+          "value": 2000000,
+          "yearly_wage": 1040000
+        },
+        {
+          "currency": "€",
+          "full_name": "Niklas Swider",
+          "name": "N. Swider",
+          "overall_score": 60,
+          "potential": 80,
+          "value": 650000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Fabio Chiarodia",
+          "name": "F. Chiarodia",
+          "overall_score": 69,
+          "potential": 79,
+          "value": 2900000,
+          "yearly_wage": 520000
+        },
+        {
+          "currency": "€",
+          "full_name": "Wael Mohya",
+          "name": "W. Mohya",
+          "overall_score": 70,
+          "potential": 85,
+          "value": 3600000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "Nathan Ngoumou",
+          "name": "N. Ngoumou",
+          "overall_score": 72,
+          "potential": 73,
+          "value": 2800000,
+          "yearly_wage": 988000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jan Urbich",
+          "name": "J. Urbich",
+          "overall_score": 62,
+          "potential": 74,
+          "value": 975000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Tobias Sippel",
+          "name": "T. Sippel",
+          "overall_score": 64,
+          "potential": 64,
+          "value": 60000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Grant-Leon Ranos",
+          "name": "G. Ranos",
+          "overall_score": 63,
+          "potential": 74,
+          "value": 1100000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Tomáš Čvančara",
+          "name": "T. Čvančara",
+          "overall_score": 72,
+          "potential": 76,
+          "value": 3400000,
+          "yearly_wage": 988000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jonas Omlin",
+          "name": "J. Omlin",
+          "overall_score": 73,
+          "potential": 73,
+          "value": 1600000,
+          "yearly_wage": 728000
+        },
+        {
+          "currency": "€",
+          "full_name": "Noah Pesch",
+          "name": "N. Pesch",
+          "overall_score": 64,
+          "potential": 77,
+          "value": 1400000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Shio Fukuda",
+          "name": "S. Fukuda",
+          "overall_score": 65,
+          "potential": 75,
+          "value": 1600000,
+          "yearly_wage": 364000
+        }
+      ],
+      "team": "Borussia Mönchengladbach",
+      "transfer_budget": 19900000,
+      "url": "https://sofifa.com/team/23/borussia-monchengladbach/260037/"
+    },
+    {
+      "player_count": 34,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Mio Backhaus",
+          "name": "M. Backhaus",
+          "overall_score": 75,
+          "potential": 84,
+          "value": 11000000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "Yukinari Sugawara",
+          "name": "Y. Sugawara",
+          "overall_score": 75,
+          "potential": 79,
+          "value": 7000000,
+          "yearly_wage": 2340000
+        },
+        {
+          "currency": "€",
+          "full_name": "Amos Pieper",
+          "name": "A. Pieper",
+          "overall_score": 76,
+          "potential": 78,
+          "value": 8000000,
+          "yearly_wage": 1352000
+        },
+        {
+          "currency": "€",
+          "full_name": "Karim Coulibaly",
+          "name": "K. Coulibaly",
+          "overall_score": 71,
+          "potential": 85,
+          "value": 4100000,
+          "yearly_wage": 572000
+        },
+        {
+          "currency": "€",
+          "full_name": "Olivier Deman",
+          "name": "O. Deman",
+          "overall_score": 71,
+          "potential": 74,
+          "value": 2300000,
+          "yearly_wage": 832000
+        },
+        {
+          "currency": "€",
+          "full_name": "Senne Lynen",
+          "name": "S. Lynen",
+          "overall_score": 76,
+          "potential": 79,
+          "value": 9000000,
+          "yearly_wage": 1352000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jens Stage",
+          "name": "J. Stage",
+          "overall_score": 79,
+          "potential": 79,
+          "value": 17500000,
+          "yearly_wage": 1820000
+        },
+        {
+          "currency": "€",
+          "full_name": "Cameron Puertas Castro",
+          "name": "Puertas",
+          "overall_score": 76,
+          "potential": 77,
+          "value": 9000000,
+          "yearly_wage": 1716000
+        },
+        {
+          "currency": "€",
+          "full_name": "Justin Njinmah",
+          "name": "J. Njinmah",
+          "overall_score": 72,
+          "potential": 77,
+          "value": 3600000,
+          "yearly_wage": 988000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jovan Milošević",
+          "name": "J. Milošević",
+          "overall_score": 70,
+          "potential": 80,
+          "value": 3500000,
+          "yearly_wage": 832000
+        },
+        {
+          "currency": "€",
+          "full_name": "Romano Schmid",
+          "name": "R. Schmid",
+          "overall_score": 78,
+          "potential": 81,
+          "value": 18500000,
+          "yearly_wage": 1560000
+        },
+        {
+          "currency": "€",
+          "full_name": "Samuel Mbangula",
+          "name": "S. Mbangula",
+          "overall_score": 74,
+          "potential": 85,
+          "value": 9500000,
+          "yearly_wage": 936000
+        },
+        {
+          "currency": "€",
+          "full_name": "Leonardo Bittencourt",
+          "name": "L. Bittencourt",
+          "overall_score": 73,
+          "potential": 73,
+          "value": 2500000,
+          "yearly_wage": 1196000
+        },
+        {
+          "currency": "€",
+          "full_name": "Marco Friedl",
+          "name": "M. Friedl",
+          "overall_score": 77,
+          "potential": 79,
+          "value": 11000000,
+          "yearly_wage": 1404000
+        },
+        {
+          "currency": "€",
+          "full_name": "Niklas Stark",
+          "name": "N. Stark",
+          "overall_score": 74,
+          "potential": 74,
+          "value": 3500000,
+          "yearly_wage": 1248000
+        },
+        {
+          "currency": "€",
+          "full_name": "Isaac Schmidt",
+          "name": "I. Schmidt",
+          "overall_score": 72,
+          "potential": 75,
+          "value": 2900000,
+          "yearly_wage": 1768000
+        },
+        {
+          "currency": "€",
+          "full_name": "Julián Malatini",
+          "name": "J. Malatini",
+          "overall_score": 69,
+          "potential": 76,
+          "value": 2600000,
+          "yearly_wage": 572000
+        },
+        {
+          "currency": "€",
+          "full_name": "Karl Hein",
+          "name": "K. Hein",
+          "overall_score": 73,
+          "potential": 81,
+          "value": 6000000,
+          "yearly_wage": 1820000
+        },
+        {
+          "currency": "€",
+          "full_name": "Keke Topp",
+          "name": "K. Topp",
+          "overall_score": 68,
+          "potential": 79,
+          "value": 2700000,
+          "yearly_wage": 520000
+        },
+        {
+          "currency": "€",
+          "full_name": "Marco Grüll",
+          "name": "M. Grüll",
+          "overall_score": 74,
+          "potential": 74,
+          "value": 4600000,
+          "yearly_wage": 1248000
+        },
+        {
+          "currency": "€",
+          "full_name": "Patrice Čović",
+          "name": "P. Čović",
+          "overall_score": 67,
+          "potential": 81,
+          "value": 2400000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mick Schmetgens",
+          "name": "M. Schmetgens",
+          "overall_score": 59,
+          "potential": 76,
+          "value": 525000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Maximilian Wöber",
+          "name": "M. Wöber",
+          "overall_score": 74,
+          "potential": 75,
+          "value": 4200000,
+          "yearly_wage": 2236000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mitchell Weiser",
+          "name": "M. Weiser",
+          "overall_score": 78,
+          "potential": 78,
+          "value": 10000000,
+          "yearly_wage": 1612000
+        },
+        {
+          "currency": "€",
+          "full_name": "Felix Agu",
+          "name": "F. Agu",
+          "overall_score": 75,
+          "potential": 78,
+          "value": 7000000,
+          "yearly_wage": 1196000
+        },
+        {
+          "currency": "€",
+          "full_name": "Salim Musah",
+          "name": "S. Musah",
+          "overall_score": 61,
+          "potential": 77,
+          "value": 850000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Stefan Smarkalev",
+          "name": "S. Smarkalev",
+          "overall_score": 59,
+          "potential": 77,
+          "value": 500000,
+          "yearly_wage": 52000
+        },
+        {
+          "currency": "€",
+          "full_name": "Wesley Adeh",
+          "name": "W. Adeh",
+          "overall_score": 60,
+          "potential": 77,
+          "value": 625000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Markus Kolke",
+          "name": "M. Kolke",
+          "overall_score": 67,
+          "potential": 67,
+          "value": 170000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Victor Boniface",
+          "name": "V. Boniface",
+          "overall_score": 79,
+          "potential": 83,
+          "value": 25500000,
+          "yearly_wage": 3640000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mats Heitmann",
+          "name": "M. Heitmann",
+          "overall_score": 57,
+          "potential": 74,
+          "value": 400000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Leon Opitz",
+          "name": "L. Opitz",
+          "overall_score": 64,
+          "potential": 79,
+          "value": 1400000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Skelly Alvero",
+          "name": "S. Alvero",
+          "overall_score": 68,
+          "potential": 76,
+          "value": 2500000,
+          "yearly_wage": 520000
+        },
+        {
+          "currency": "€",
+          "full_name": "Dawid Kownacki",
+          "name": "D. Kownacki",
+          "overall_score": 71,
+          "potential": 71,
+          "value": 1900000,
+          "yearly_wage": 1040000
+        }
+      ],
+      "team": "SV Werder Bremen",
+      "transfer_budget": 14000000,
+      "url": "https://sofifa.com/team/38/sv-werder-bremen/260037/"
+    },
+    {
+      "player_count": 35,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Noah Atubolu",
+          "name": "N. Atubolu",
+          "overall_score": 78,
+          "potential": 83,
+          "value": 17000000,
+          "yearly_wage": 780000
+        },
+        {
+          "currency": "€",
+          "full_name": "Philipp Treu",
+          "name": "P. Treu",
+          "overall_score": 74,
+          "potential": 77,
+          "value": 5500000,
+          "yearly_wage": 1040000
+        },
+        {
+          "currency": "€",
+          "full_name": "Matthias Ginter",
+          "name": "M. Ginter",
+          "overall_score": 83,
+          "potential": 83,
+          "value": 25000000,
+          "yearly_wage": 2340000
+        },
+        {
+          "currency": "€",
+          "full_name": "Philipp Lienhart",
+          "name": "P. Lienhart",
+          "overall_score": 78,
+          "potential": 78,
+          "value": 12000000,
+          "yearly_wage": 1612000
+        },
+        {
+          "currency": "€",
+          "full_name": "Christian Günter",
+          "name": "C. Günter",
+          "overall_score": 76,
+          "potential": 76,
+          "value": 5000000,
+          "yearly_wage": 1404000
+        },
+        {
+          "currency": "€",
+          "full_name": "Maximilian Eggestein",
+          "name": "M. Eggestein",
+          "overall_score": 76,
+          "potential": 76,
+          "value": 6500000,
+          "yearly_wage": 1404000
+        },
+        {
+          "currency": "€",
+          "full_name": "Johan Manzambi",
+          "name": "J. Manzambi",
+          "overall_score": 77,
+          "potential": 86,
+          "value": 22500000,
+          "yearly_wage": 1040000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jan-Niklas Beste",
+          "name": "J. Beste",
+          "overall_score": 76,
+          "potential": 76,
+          "value": 8000000,
+          "yearly_wage": 1404000
+        },
+        {
+          "currency": "€",
+          "full_name": "Vincenzo Grifo",
+          "name": "V. Grifo",
+          "overall_score": 79,
+          "potential": 79,
+          "value": 14000000,
+          "yearly_wage": 1820000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lucas Höler",
+          "name": "L. Höler",
+          "overall_score": 72,
+          "potential": 72,
+          "value": 2300000,
+          "yearly_wage": 1144000
+        },
+        {
+          "currency": "€",
+          "full_name": "Igor Matanović",
+          "name": "I. Matanović",
+          "overall_score": 74,
+          "potential": 78,
+          "value": 6000000,
+          "yearly_wage": 1196000
+        },
+        {
+          "currency": "€",
+          "full_name": "Derry Scherhant",
+          "name": "D. Scherhant",
+          "overall_score": 73,
+          "potential": 78,
+          "value": 4700000,
+          "yearly_wage": 988000
+        },
+        {
+          "currency": "€",
+          "full_name": "Cyriaque Irié",
+          "name": "C. Irié",
+          "overall_score": 70,
+          "potential": 82,
+          "value": 3800000,
+          "yearly_wage": 624000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lukas Kübler",
+          "name": "L. Kübler",
+          "overall_score": 75,
+          "potential": 75,
+          "value": 3900000,
+          "yearly_wage": 1352000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jordy Makengo",
+          "name": "J. Makengo",
+          "overall_score": 72,
+          "potential": 76,
+          "value": 3100000,
+          "yearly_wage": 832000
+        },
+        {
+          "currency": "€",
+          "full_name": "Anthony Jung",
+          "name": "A. Jung",
+          "overall_score": 71,
+          "potential": 71,
+          "value": 900000,
+          "yearly_wage": 936000
+        },
+        {
+          "currency": "€",
+          "full_name": "Bruno Ogbus",
+          "name": "B. Ogbus",
+          "overall_score": 69,
+          "potential": 78,
+          "value": 2800000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "Florian Müller",
+          "name": "F. Müller",
+          "overall_score": 72,
+          "potential": 73,
+          "value": 2000000,
+          "yearly_wage": 624000
+        },
+        {
+          "currency": "€",
+          "full_name": "Nicolas Höfler",
+          "name": "N. Höfler",
+          "overall_score": 71,
+          "potential": 71,
+          "value": 525000,
+          "yearly_wage": 676000
+        },
+        {
+          "currency": "€",
+          "full_name": "Max Rosenfelder",
+          "name": "M. Rosenfelder",
+          "overall_score": 73,
+          "potential": 79,
+          "value": 4400000,
+          "yearly_wage": 936000
+        },
+        {
+          "currency": "€",
+          "full_name": "Maximilian Philipp",
+          "name": "M. Philipp",
+          "overall_score": 69,
+          "potential": 69,
+          "value": 1200000,
+          "yearly_wage": 832000
+        },
+        {
+          "currency": "€",
+          "full_name": "Patrick Osterhage",
+          "name": "P. Osterhage",
+          "overall_score": 74,
+          "potential": 75,
+          "value": 4500000,
+          "yearly_wage": 1144000
+        },
+        {
+          "currency": "€",
+          "full_name": "Yuito Suzuki",
+          "name": "Y. Suzuki",
+          "overall_score": 75,
+          "potential": 78,
+          "value": 7500000,
+          "yearly_wage": 1196000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jannik Huth",
+          "name": "J. Huth",
+          "overall_score": 69,
+          "potential": 69,
+          "value": 750000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "Karl Steinmann",
+          "name": "K. Steinmann",
+          "overall_score": 63,
+          "potential": 74,
+          "value": 1000000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Rouven Tarnutzer",
+          "name": "R. Tarnutzer",
+          "overall_score": 59,
+          "potential": 75,
+          "value": 550000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Daniel-Kofi Kyereh",
+          "name": "D. Kyereh",
+          "overall_score": 70,
+          "potential": 70,
+          "value": 1600000,
+          "yearly_wage": 884000
+        },
+        {
+          "currency": "€",
+          "full_name": "Berkay Yilmaz",
+          "name": "B. Yilmaz",
+          "overall_score": 69,
+          "potential": 77,
+          "value": 2900000,
+          "yearly_wage": 520000
+        },
+        {
+          "currency": "€",
+          "full_name": "Yann Sturm",
+          "name": "Y. Sturm",
+          "overall_score": 64,
+          "potential": 76,
+          "value": 1400000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Robert Wagner",
+          "name": "R. Wagner",
+          "overall_score": 68,
+          "potential": 75,
+          "value": 2400000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "Noah Weißhaupt",
+          "name": "N. Weißhaupt",
+          "overall_score": 71,
+          "potential": 75,
+          "value": 2700000,
+          "yearly_wage": 780000
+        },
+        {
+          "currency": "€",
+          "full_name": "Merlin Röhl",
+          "name": "M. Röhl",
+          "overall_score": 74,
+          "potential": 82,
+          "value": 9500000,
+          "yearly_wage": 1092000
+        },
+        {
+          "currency": "€",
+          "full_name": "Eren Dinkçi",
+          "name": "E. Dinkçi",
+          "overall_score": 73,
+          "potential": 79,
+          "value": 4800000,
+          "yearly_wage": 988000
+        },
+        {
+          "currency": "€",
+          "full_name": "Junior Adamu",
+          "name": "J. Adamu",
+          "overall_score": 71,
+          "potential": 75,
+          "value": 2700000,
+          "yearly_wage": 884000
+        },
+        {
+          "currency": "€",
+          "full_name": "Florent Muslija",
+          "name": "F. Muslija",
+          "overall_score": 72,
+          "potential": 73,
+          "value": 2800000,
+          "yearly_wage": 1040000
+        }
+      ],
+      "team": "SC Freiburg",
+      "transfer_budget": 21600000,
+      "url": "https://sofifa.com/team/25/sc-freiburg/260037/"
+    },
+    {
+      "player_count": 31,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Frederik Rønnow",
+          "name": "F. Rønnow",
+          "overall_score": 79,
+          "potential": 79,
+          "value": 8500000,
+          "yearly_wage": 1352000
+        },
+        {
+          "currency": "€",
+          "full_name": "Danilho Doekhi",
+          "name": "D. Doekhi",
+          "overall_score": 80,
+          "potential": 81,
+          "value": 21000000,
+          "yearly_wage": 2132000
+        },
+        {
+          "currency": "€",
+          "full_name": "Leopold Querfeld",
+          "name": "L. Querfeld",
+          "overall_score": 77,
+          "potential": 84,
+          "value": 20000000,
+          "yearly_wage": 1248000
+        },
+        {
+          "currency": "€",
+          "full_name": "Diogo Filipe Pinto Leite",
+          "name": "Diogo Leite",
+          "overall_score": 76,
+          "potential": 79,
+          "value": 8500000,
+          "yearly_wage": 1612000
+        },
+        {
+          "currency": "€",
+          "full_name": "Christopher Trimmel",
+          "name": "C. Trimmel",
+          "overall_score": 75,
+          "potential": 75,
+          "value": 1200000,
+          "yearly_wage": 1196000
+        },
+        {
+          "currency": "€",
+          "full_name": "Rani Khedira",
+          "name": "R. Khedira",
+          "overall_score": 76,
+          "potential": 76,
+          "value": 5000000,
+          "yearly_wage": 1664000
+        },
+        {
+          "currency": "€",
+          "full_name": "Aljoscha Kemlein",
+          "name": "A. Kemlein",
+          "overall_score": 74,
+          "potential": 79,
+          "value": 6000000,
+          "yearly_wage": 1092000
+        },
+        {
+          "currency": "€",
+          "full_name": "Tom Rothe",
+          "name": "T. Rothe",
+          "overall_score": 73,
+          "potential": 81,
+          "value": 6500000,
+          "yearly_wage": 936000
+        },
+        {
+          "currency": "€",
+          "full_name": "Oliver Burke",
+          "name": "O. Burke",
+          "overall_score": 73,
+          "potential": 73,
+          "value": 3100000,
+          "yearly_wage": 1508000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ilyas Ansah",
+          "name": "I. Ansah",
+          "overall_score": 73,
+          "potential": 83,
+          "value": 6500000,
+          "yearly_wage": 1092000
+        },
+        {
+          "currency": "€",
+          "full_name": "Andrej Ilić",
+          "name": "A. Ilić",
+          "overall_score": 74,
+          "potential": 76,
+          "value": 5500000,
+          "yearly_wage": 1560000
+        },
+        {
+          "currency": "€",
+          "full_name": "Janik Haberer",
+          "name": "J. Haberer",
+          "overall_score": 74,
+          "potential": 74,
+          "value": 3500000,
+          "yearly_wage": 1560000
+        },
+        {
+          "currency": "€",
+          "full_name": "András Schäfer",
+          "name": "A. Schäfer",
+          "overall_score": 74,
+          "potential": 75,
+          "value": 4900000,
+          "yearly_wage": 1456000
+        },
+        {
+          "currency": "€",
+          "full_name": "Woo Yeong Jeong",
+          "name": "Jeong Woo Yeong",
+          "overall_score": 73,
+          "potential": 76,
+          "value": 4000000,
+          "yearly_wage": 1300000
+        },
+        {
+          "currency": "€",
+          "full_name": "Derrick Köhn",
+          "name": "D. Köhn",
+          "overall_score": 75,
+          "potential": 76,
+          "value": 6000000,
+          "yearly_wage": 1508000
+        },
+        {
+          "currency": "€",
+          "full_name": "Josip Juranović",
+          "name": "J. Juranović",
+          "overall_score": 73,
+          "potential": 73,
+          "value": 2700000,
+          "yearly_wage": 1352000
+        },
+        {
+          "currency": "€",
+          "full_name": "Stanley Nsoki",
+          "name": "S. Nsoki",
+          "overall_score": 71,
+          "potential": 74,
+          "value": 2200000,
+          "yearly_wage": 1040000
+        },
+        {
+          "currency": "€",
+          "full_name": "Matheo Raab",
+          "name": "M. Raab",
+          "overall_score": 70,
+          "potential": 74,
+          "value": 1700000,
+          "yearly_wage": 624000
+        },
+        {
+          "currency": "€",
+          "full_name": "Livan Burcu",
+          "name": "L. Burcu",
+          "overall_score": 70,
+          "potential": 78,
+          "value": 3500000,
+          "yearly_wage": 728000
+        },
+        {
+          "currency": "€",
+          "full_name": "Tim Skarke",
+          "name": "T. Skarke",
+          "overall_score": 73,
+          "potential": 73,
+          "value": 3100000,
+          "yearly_wage": 1508000
+        },
+        {
+          "currency": "€",
+          "full_name": "Robert Skov",
+          "name": "R. Skov",
+          "overall_score": 73,
+          "potential": 73,
+          "value": 2700000,
+          "yearly_wage": 1352000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alex Král",
+          "name": "A. Král",
+          "overall_score": 73,
+          "potential": 73,
+          "value": 3200000,
+          "yearly_wage": 1352000
+        },
+        {
+          "currency": "€",
+          "full_name": "Carl Klaus",
+          "name": "C. Klaus",
+          "overall_score": 67,
+          "potential": 67,
+          "value": 550000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "David Preu",
+          "name": "D. Preu",
+          "overall_score": 62,
+          "potential": 77,
+          "value": 950000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Dmytro Bogdanov",
+          "name": "D. Bogdanov",
+          "overall_score": 58,
+          "potential": 73,
+          "value": 475000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Andrik Markgraf",
+          "name": "A. Markgraf",
+          "overall_score": 63,
+          "potential": 78,
+          "value": 1100000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Tom Wisbereit",
+          "name": "T. Wisbereit",
+          "overall_score": 56,
+          "potential": 72,
+          "value": 325000,
+          "yearly_wage": 33800
+        },
+        {
+          "currency": "€",
+          "full_name": "Oluwaseun Ogbemudia",
+          "name": "O. Ogbemudia",
+          "overall_score": 63,
+          "potential": 78,
+          "value": 1000000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Marin Ljubičić",
+          "name": "M. Ljubičić",
+          "overall_score": 70,
+          "potential": 77,
+          "value": 3200000,
+          "yearly_wage": 936000
+        },
+        {
+          "currency": "€",
+          "full_name": "László Bénes",
+          "name": "L. Bénes",
+          "overall_score": 71,
+          "potential": 71,
+          "value": 2000000,
+          "yearly_wage": 1092000
+        },
+        {
+          "currency": "€",
+          "full_name": "Chris Bedia",
+          "name": "C. Bedia",
+          "overall_score": 71,
+          "potential": 71,
+          "value": 1900000,
+          "yearly_wage": 1248000
+        }
+      ],
+      "team": "1. FC Union Berlin",
+      "transfer_budget": 17900000,
+      "url": "https://sofifa.com/team/1831/1-fc-union-berlin/260037/"
+    },
+    {
+      "player_count": 41,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Marvin Schwäbe",
+          "name": "M. Schwäbe",
+          "overall_score": 78,
+          "potential": 78,
+          "value": 9500000,
+          "yearly_wage": 936000
+        },
+        {
+          "currency": "€",
+          "full_name": "Sebastian Sebulonsen",
+          "name": "S. Sebulonsen",
+          "overall_score": 73,
+          "potential": 76,
+          "value": 3700000,
+          "yearly_wage": 936000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jahmai Simpson-Pusey",
+          "name": "J. Simpson-Pusey",
+          "overall_score": 68,
+          "potential": 79,
+          "value": 2400000,
+          "yearly_wage": 1352000
+        },
+        {
+          "currency": "€",
+          "full_name": "Cenk Özkacar",
+          "name": "C. Özkacar",
+          "overall_score": 71,
+          "potential": 76,
+          "value": 2600000,
+          "yearly_wage": 988000
+        },
+        {
+          "currency": "€",
+          "full_name": "Kristoffer Lund",
+          "name": "K. Lund",
+          "overall_score": 72,
+          "potential": 79,
+          "value": 4500000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ísak Bergmann Jóhannesson",
+          "name": "Í. Jóhannesson",
+          "overall_score": 74,
+          "potential": 81,
+          "value": 8500000,
+          "yearly_wage": 988000
+        },
+        {
+          "currency": "€",
+          "full_name": "Eric Martel",
+          "name": "E. Martel",
+          "overall_score": 76,
+          "potential": 81,
+          "value": 10500000,
+          "yearly_wage": 1040000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jan Thielmann",
+          "name": "J. Thielmann",
+          "overall_score": 72,
+          "potential": 77,
+          "value": 3500000,
+          "yearly_wage": 832000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jakub Kamiński",
+          "name": "J. Kamiński",
+          "overall_score": 77,
+          "potential": 82,
+          "value": 16000000,
+          "yearly_wage": 1924000
+        },
+        {
+          "currency": "€",
+          "full_name": "Marius Bülter",
+          "name": "M. Bülter",
+          "overall_score": 75,
+          "potential": 75,
+          "value": 4600000,
+          "yearly_wage": 1352000
+        },
+        {
+          "currency": "€",
+          "full_name": "Said El Mala",
+          "name": "S. El Mala",
+          "overall_score": 76,
+          "potential": 87,
+          "value": 16000000,
+          "yearly_wage": 832000
+        },
+        {
+          "currency": "€",
+          "full_name": "Youssoupha Niang",
+          "name": "Y. Niang",
+          "overall_score": 62,
+          "potential": 79,
+          "value": 1000000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alessio Castro-Montes",
+          "name": "A. Castro-Montes",
+          "overall_score": 75,
+          "potential": 75,
+          "value": 5500000,
+          "yearly_wage": 1248000
+        },
+        {
+          "currency": "€",
+          "full_name": "Tom Krauß",
+          "name": "T. Krauß",
+          "overall_score": 74,
+          "potential": 77,
+          "value": 5000000,
+          "yearly_wage": 1040000
+        },
+        {
+          "currency": "€",
+          "full_name": "Luca Waldschmidt",
+          "name": "L. Waldschmidt",
+          "overall_score": 73,
+          "potential": 73,
+          "value": 3000000,
+          "yearly_wage": 1092000
+        },
+        {
+          "currency": "€",
+          "full_name": "Linton Maina",
+          "name": "L. Maina",
+          "overall_score": 73,
+          "potential": 74,
+          "value": 3600000,
+          "yearly_wage": 1040000
+        },
+        {
+          "currency": "€",
+          "full_name": "Rav van den Berg",
+          "name": "R. van den Berg",
+          "overall_score": 71,
+          "potential": 82,
+          "value": 3800000,
+          "yearly_wage": 572000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ron-Robert Zieler",
+          "name": "R. Zieler",
+          "overall_score": 74,
+          "potential": 74,
+          "value": 475000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ragnar Ache",
+          "name": "R. Ache",
+          "overall_score": 74,
+          "potential": 75,
+          "value": 5000000,
+          "yearly_wage": 1196000
+        },
+        {
+          "currency": "€",
+          "full_name": "Joël Schmied",
+          "name": "J. Schmied",
+          "overall_score": 72,
+          "potential": 74,
+          "value": 2600000,
+          "yearly_wage": 884000
+        },
+        {
+          "currency": "€",
+          "full_name": "Dominique Heintz",
+          "name": "D. Heintz",
+          "overall_score": 72,
+          "potential": 72,
+          "value": 1600000,
+          "yearly_wage": 936000
+        },
+        {
+          "currency": "€",
+          "full_name": "Fynn Schenten",
+          "name": "F. Schenten",
+          "overall_score": 62,
+          "potential": 79,
+          "value": 1000000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Florian Kainz",
+          "name": "F. Kainz",
+          "overall_score": 72,
+          "potential": 72,
+          "value": 1900000,
+          "yearly_wage": 988000
+        },
+        {
+          "currency": "€",
+          "full_name": "Timo Hübers",
+          "name": "T. Hübers",
+          "overall_score": 72,
+          "potential": 73,
+          "value": 2200000,
+          "yearly_wage": 936000
+        },
+        {
+          "currency": "€",
+          "full_name": "Denis Huseinbašić",
+          "name": "D. Huseinbašić",
+          "overall_score": 72,
+          "potential": 77,
+          "value": 3500000,
+          "yearly_wage": 832000
+        },
+        {
+          "currency": "€",
+          "full_name": "Felipe Chávez",
+          "name": "F. Chávez",
+          "overall_score": 62,
+          "potential": 80,
+          "value": 1000000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Malek El Mala",
+          "name": "M. El Mala",
+          "overall_score": 59,
+          "potential": 71,
+          "value": 550000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Fayssal Harchaoui",
+          "name": "F. Harchaoui",
+          "overall_score": 60,
+          "potential": 77,
+          "value": 600000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Matthias Köbbing",
+          "name": "M. Köbbing",
+          "overall_score": 56,
+          "potential": 59,
+          "value": 130000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "David Fürst",
+          "name": "D. Fürst",
+          "overall_score": 59,
+          "potential": 77,
+          "value": 550000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Sargis Adamyan",
+          "name": "S. Adamyan",
+          "overall_score": 66,
+          "potential": 66,
+          "value": 700000,
+          "yearly_wage": 520000
+        },
+        {
+          "currency": "€",
+          "full_name": "Cenny Neumann",
+          "name": "C. Neumann",
+          "overall_score": 61,
+          "potential": 77,
+          "value": 800000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Luca Kilian",
+          "name": "L. Kilian",
+          "overall_score": 68,
+          "potential": 69,
+          "value": 1300000,
+          "yearly_wage": 520000
+        },
+        {
+          "currency": "€",
+          "full_name": "Imad Rondić",
+          "name": "I. Rondić",
+          "overall_score": 66,
+          "potential": 67,
+          "value": 1000000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mansour Ouro-Tagba",
+          "name": "M. Ouro-Tagba",
+          "overall_score": 62,
+          "potential": 75,
+          "value": 975000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Elias Bakatukanda",
+          "name": "E. Bakatukanda",
+          "overall_score": 66,
+          "potential": 75,
+          "value": 1800000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jusuf Gazibegović",
+          "name": "J. Gazibegović",
+          "overall_score": 69,
+          "potential": 72,
+          "value": 1700000,
+          "yearly_wage": 624000
+        },
+        {
+          "currency": "€",
+          "full_name": "Rasmus Carstensen",
+          "name": "R. Carstensen",
+          "overall_score": 69,
+          "potential": 72,
+          "value": 1900000,
+          "yearly_wage": 572000
+        },
+        {
+          "currency": "€",
+          "full_name": "Emin Kujović",
+          "name": "E. Kujović",
+          "overall_score": 58,
+          "potential": 72,
+          "value": 500000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jaka Čuber Potočnik",
+          "name": "J. Čuber Potočnik",
+          "overall_score": 60,
+          "potential": 76,
+          "value": 650000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Julian Pauli",
+          "name": "J. Pauli",
+          "overall_score": 67,
+          "potential": 80,
+          "value": 2300000,
+          "yearly_wage": 364000
+        }
+      ],
+      "team": "1. FC Köln",
+      "transfer_budget": 13200000,
+      "url": "https://sofifa.com/team/31/1-fc-koln/260037/"
+    },
+    {
+      "player_count": 39,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Finn Dahmen",
+          "name": "F. Dahmen",
+          "overall_score": 76,
+          "potential": 77,
+          "value": 6500000,
+          "yearly_wage": 1040000
+        },
+        {
+          "currency": "€",
+          "full_name": "Chrislain Matsima",
+          "name": "C. Matsima",
+          "overall_score": 77,
+          "potential": 85,
+          "value": 22000000,
+          "yearly_wage": 1456000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jeffrey Gouweleeuw",
+          "name": "J. Gouweleeuw",
+          "overall_score": 77,
+          "potential": 77,
+          "value": 5000000,
+          "yearly_wage": 1768000
+        },
+        {
+          "currency": "€",
+          "full_name": "Cédric Zesiger",
+          "name": "C. Zesiger",
+          "overall_score": 74,
+          "potential": 76,
+          "value": 4500000,
+          "yearly_wage": 1404000
+        },
+        {
+          "currency": "€",
+          "full_name": "Robin Fellhauer",
+          "name": "R. Fellhauer",
+          "overall_score": 74,
+          "potential": 74,
+          "value": 4000000,
+          "yearly_wage": 1404000
+        },
+        {
+          "currency": "€",
+          "full_name": "Han-Noah Massengo",
+          "name": "H. Massengo",
+          "overall_score": 75,
+          "potential": 80,
+          "value": 8000000,
+          "yearly_wage": 1300000
+        },
+        {
+          "currency": "€",
+          "full_name": "Fabian Rieder",
+          "name": "F. Rieder",
+          "overall_score": 74,
+          "potential": 81,
+          "value": 8500000,
+          "yearly_wage": 1300000
+        },
+        {
+          "currency": "€",
+          "full_name": "Dimitris Giannoulis",
+          "name": "D. Giannoulis",
+          "overall_score": 76,
+          "potential": 76,
+          "value": 6500000,
+          "yearly_wage": 1664000
+        },
+        {
+          "currency": "€",
+          "full_name": "Anton Kade",
+          "name": "A. Kade",
+          "overall_score": 73,
+          "potential": 80,
+          "value": 6000000,
+          "yearly_wage": 988000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alexis Claude-Maurice",
+          "name": "A. Claude-Maurice",
+          "overall_score": 76,
+          "potential": 77,
+          "value": 8500000,
+          "yearly_wage": 1716000
+        },
+        {
+          "currency": "€",
+          "full_name": "Michael Gregoritsch",
+          "name": "M. Gregoritsch",
+          "overall_score": 75,
+          "potential": 75,
+          "value": 4800000,
+          "yearly_wage": 884000
+        },
+        {
+          "currency": "€",
+          "full_name": "Kristijan Jakić",
+          "name": "K. Jakić",
+          "overall_score": 75,
+          "potential": 75,
+          "value": 4900000,
+          "yearly_wage": 1612000
+        },
+        {
+          "currency": "€",
+          "full_name": "Elvis Rexhbeçaj",
+          "name": "E. Rexhbeçaj",
+          "overall_score": 73,
+          "potential": 73,
+          "value": 3200000,
+          "yearly_wage": 1352000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mert Kömür",
+          "name": "M. Kömür",
+          "overall_score": 72,
+          "potential": 82,
+          "value": 5000000,
+          "yearly_wage": 884000
+        },
+        {
+          "currency": "€",
+          "full_name": "Arthur Largura Chaves",
+          "name": "Arthur Chaves",
+          "overall_score": 74,
+          "potential": 79,
+          "value": 6000000,
+          "yearly_wage": 1196000
+        },
+        {
+          "currency": "€",
+          "full_name": "Marius Wolf",
+          "name": "M. Wolf",
+          "overall_score": 73,
+          "potential": 73,
+          "value": 2600000,
+          "yearly_wage": 1352000
+        },
+        {
+          "currency": "€",
+          "full_name": "Noahkai Banks",
+          "name": "N. Banks",
+          "overall_score": 71,
+          "potential": 83,
+          "value": 4100000,
+          "yearly_wage": 676000
+        },
+        {
+          "currency": "€",
+          "full_name": "Nediljko Labrović",
+          "name": "N. Labrović",
+          "overall_score": 72,
+          "potential": 73,
+          "value": 2100000,
+          "yearly_wage": 676000
+        },
+        {
+          "currency": "€",
+          "full_name": "Rodrigo Duarte Ribeiro",
+          "name": "Rodrigo Ribeiro",
+          "overall_score": 68,
+          "potential": 79,
+          "value": 2700000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Keven Schlotterbeck",
+          "name": "K. Schlotterbeck",
+          "overall_score": 75,
+          "potential": 76,
+          "value": 5500000,
+          "yearly_wage": 1612000
+        },
+        {
+          "currency": "€",
+          "full_name": "Yannik Keitel",
+          "name": "Y. Keitel",
+          "overall_score": 71,
+          "potential": 74,
+          "value": 2200000,
+          "yearly_wage": 1040000
+        },
+        {
+          "currency": "€",
+          "full_name": "Uchenna Ogundu",
+          "name": "U. Ogundu",
+          "overall_score": 64,
+          "potential": 77,
+          "value": 1400000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ismaël Gharbi",
+          "name": "I. Gharbi",
+          "overall_score": 72,
+          "potential": 80,
+          "value": 5500000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mads Pedersen",
+          "name": "M. Pedersen",
+          "overall_score": 71,
+          "potential": 71,
+          "value": 1700000,
+          "yearly_wage": 1092000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mahmut Kücüksahin",
+          "name": "M. Kücüksahin",
+          "overall_score": 60,
+          "potential": 72,
+          "value": 575000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Tim Schnitzer",
+          "name": "T. Schnitzer",
+          "overall_score": 58,
+          "potential": 78,
+          "value": 525000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Oliver Sorg",
+          "name": "O. Sorg",
+          "overall_score": 58,
+          "potential": 78,
+          "value": 525000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Felix Meiser",
+          "name": "F. Meiser",
+          "overall_score": 60,
+          "potential": 75,
+          "value": 525000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Daniel Klein",
+          "name": "D. Klein",
+          "overall_score": 61,
+          "potential": 67,
+          "value": 425000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Thomas Kastanaras",
+          "name": "T. Kastanaras",
+          "overall_score": 63,
+          "potential": 72,
+          "value": 1100000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "Yusuf Kabadayi",
+          "name": "Y. Kabadayi",
+          "overall_score": 65,
+          "potential": 76,
+          "value": 1600000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Marcel Łubik",
+          "name": "M. Łubik",
+          "overall_score": 65,
+          "potential": 72,
+          "value": 1200000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Elias Saad",
+          "name": "E. Saad",
+          "overall_score": 71,
+          "potential": 72,
+          "value": 2200000,
+          "yearly_wage": 1144000
+        },
+        {
+          "currency": "€",
+          "full_name": "Kyliane Dong",
+          "name": "K. Dong",
+          "overall_score": 64,
+          "potential": 76,
+          "value": 1400000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Henri Koudossou",
+          "name": "H. Koudossou",
+          "overall_score": 69,
+          "potential": 72,
+          "value": 1700000,
+          "yearly_wage": 780000
+        },
+        {
+          "currency": "€",
+          "full_name": "Tim Breithaupt",
+          "name": "T. Breithaupt",
+          "overall_score": 69,
+          "potential": 75,
+          "value": 2000000,
+          "yearly_wage": 728000
+        },
+        {
+          "currency": "€",
+          "full_name": "Nathanaël Mbuku",
+          "name": "N. Mbuku",
+          "overall_score": 70,
+          "potential": 76,
+          "value": 2500000,
+          "yearly_wage": 832000
+        },
+        {
+          "currency": "€",
+          "full_name": "Maximilian Bauer",
+          "name": "M. Bauer",
+          "overall_score": 69,
+          "potential": 73,
+          "value": 1700000,
+          "yearly_wage": 780000
+        },
+        {
+          "currency": "€",
+          "full_name": "Aiman Dardari",
+          "name": "A. Dardari",
+          "overall_score": 63,
+          "potential": 75,
+          "value": 1200000,
+          "yearly_wage": 312000
+        }
+      ],
+      "team": "FC Augsburg",
+      "transfer_budget": 16800000,
+      "url": "https://sofifa.com/team/100409/fc-augsburg/260037/"
+    },
+    {
+      "player_count": 36,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Daniel Heuer Fernandes",
+          "name": "D. Heuer Fernandes",
+          "overall_score": 78,
+          "potential": 78,
+          "value": 7000000,
+          "yearly_wage": 936000
+        },
+        {
+          "currency": "€",
+          "full_name": "Nicolás Capaldo",
+          "name": "N. Capaldo",
+          "overall_score": 73,
+          "potential": 74,
+          "value": 3600000,
+          "yearly_wage": 1040000
+        },
+        {
+          "currency": "€",
+          "full_name": "Luka Vušković",
+          "name": "L. Vušković",
+          "overall_score": 78,
+          "potential": 88,
+          "value": 27500000,
+          "yearly_wage": 2756000
+        },
+        {
+          "currency": "€",
+          "full_name": "Warmed Omari",
+          "name": "W. Omari",
+          "overall_score": 72,
+          "potential": 76,
+          "value": 2900000,
+          "yearly_wage": 832000
+        },
+        {
+          "currency": "€",
+          "full_name": "William Mikelbrencis",
+          "name": "W. Mikelbrencis",
+          "overall_score": 69,
+          "potential": 80,
+          "value": 3000000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "Albert Sambi Lokonga",
+          "name": "A. Sambi Lokonga",
+          "overall_score": 76,
+          "potential": 78,
+          "value": 9500000,
+          "yearly_wage": 1196000
+        },
+        {
+          "currency": "€",
+          "full_name": "Nicolai Remberg",
+          "name": "N. Remberg",
+          "overall_score": 73,
+          "potential": 76,
+          "value": 4000000,
+          "yearly_wage": 988000
+        },
+        {
+          "currency": "€",
+          "full_name": "Miro Muheim",
+          "name": "M. Muheim",
+          "overall_score": 75,
+          "potential": 75,
+          "value": 5500000,
+          "yearly_wage": 1144000
+        },
+        {
+          "currency": "€",
+          "full_name": "Fábio Daniel Ferreira Vieira",
+          "name": "Fábio Vieira",
+          "overall_score": 77,
+          "potential": 81,
+          "value": 14500000,
+          "yearly_wage": 4940000
+        },
+        {
+          "currency": "€",
+          "full_name": "Robert Glatzel",
+          "name": "R. Glatzel",
+          "overall_score": 72,
+          "potential": 72,
+          "value": 2000000,
+          "yearly_wage": 1040000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ransford-Yeboah Königsdörffer",
+          "name": "R. Königsdörffer",
+          "overall_score": 70,
+          "potential": 77,
+          "value": 3200000,
+          "yearly_wage": 728000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jean-Luc Dompé",
+          "name": "J. Dompé",
+          "overall_score": 74,
+          "potential": 74,
+          "value": 4100000,
+          "yearly_wage": 1248000
+        },
+        {
+          "currency": "€",
+          "full_name": "Rayan Philippe",
+          "name": "R. Philippe",
+          "overall_score": 72,
+          "potential": 77,
+          "value": 3600000,
+          "yearly_wage": 884000
+        },
+        {
+          "currency": "€",
+          "full_name": "Albert Grønbæk",
+          "name": "A. Grønbæk",
+          "overall_score": 73,
+          "potential": 78,
+          "value": 4600000,
+          "yearly_wage": 936000
+        },
+        {
+          "currency": "€",
+          "full_name": "Philip Otele",
+          "name": "P. Otele",
+          "overall_score": 73,
+          "potential": 73,
+          "value": 3300000,
+          "yearly_wage": 936000
+        },
+        {
+          "currency": "€",
+          "full_name": "Daniel Elfadli",
+          "name": "D. Elfadli",
+          "overall_score": 72,
+          "potential": 73,
+          "value": 2200000,
+          "yearly_wage": 936000
+        },
+        {
+          "currency": "€",
+          "full_name": "Giorgi Gocholeishvili",
+          "name": "G. Gocholeishvili",
+          "overall_score": 70,
+          "potential": 74,
+          "value": 2100000,
+          "yearly_wage": 520000
+        },
+        {
+          "currency": "€",
+          "full_name": "Sander Tangvik",
+          "name": "S. Tangvik",
+          "overall_score": 70,
+          "potential": 79,
+          "value": 3100000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Bakery Jatta",
+          "name": "B. Jatta",
+          "overall_score": 69,
+          "potential": 69,
+          "value": 1500000,
+          "yearly_wage": 676000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jordan Torunarigha",
+          "name": "J. Torunarigha",
+          "overall_score": 74,
+          "potential": 74,
+          "value": 3900000,
+          "yearly_wage": 1092000
+        },
+        {
+          "currency": "€",
+          "full_name": "Fabio Baldé",
+          "name": "F. Baldé",
+          "overall_score": 66,
+          "potential": 77,
+          "value": 1800000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Otto Stange",
+          "name": "O. Stange",
+          "overall_score": 64,
+          "potential": 81,
+          "value": 1500000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Yussuf Poulsen",
+          "name": "Y. Poulsen",
+          "overall_score": 72,
+          "potential": 72,
+          "value": 2000000,
+          "yearly_wage": 1040000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alexander Røssing-Lelesiit",
+          "name": "A. Røssing-Lelesiit",
+          "overall_score": 63,
+          "potential": 80,
+          "value": 1200000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Bilal Yalçınkaya",
+          "name": "B. Yalçınkaya",
+          "overall_score": 59,
+          "potential": 76,
+          "value": 575000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Hannes Hermann",
+          "name": "H. Hermann",
+          "overall_score": 57,
+          "potential": 68,
+          "value": 300000,
+          "yearly_wage": 52000
+        },
+        {
+          "currency": "€",
+          "full_name": "Damion Downs",
+          "name": "D. Downs",
+          "overall_score": 70,
+          "potential": 80,
+          "value": 3500000,
+          "yearly_wage": 1300000
+        },
+        {
+          "currency": "€",
+          "full_name": "Noah Katterbach",
+          "name": "N. Katterbach",
+          "overall_score": 68,
+          "potential": 73,
+          "value": 1700000,
+          "yearly_wage": 520000
+        },
+        {
+          "currency": "€",
+          "full_name": "Fernando Dickes",
+          "name": "F. Dickes",
+          "overall_score": 57,
+          "potential": 77,
+          "value": 400000,
+          "yearly_wage": 26000
+        },
+        {
+          "currency": "€",
+          "full_name": "Omar Megeed",
+          "name": "O. Megeed",
+          "overall_score": 58,
+          "potential": 76,
+          "value": 525000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Shafiq Nandja",
+          "name": "S. Nandja",
+          "overall_score": 59,
+          "potential": 73,
+          "value": 500000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Levin Öztunalı",
+          "name": "L. Öztunalı",
+          "overall_score": 67,
+          "potential": 67,
+          "value": 1000000,
+          "yearly_wage": 572000
+        },
+        {
+          "currency": "€",
+          "full_name": "Łukasz Poręba",
+          "name": "Ł. Poręba",
+          "overall_score": 69,
+          "potential": 74,
+          "value": 1900000,
+          "yearly_wage": 624000
+        },
+        {
+          "currency": "€",
+          "full_name": "Immanuel Pherai",
+          "name": "I. Pherai",
+          "overall_score": 69,
+          "potential": 74,
+          "value": 2100000,
+          "yearly_wage": 572000
+        },
+        {
+          "currency": "€",
+          "full_name": "Joel Agyekum",
+          "name": "J. Agyekum",
+          "overall_score": 59,
+          "potential": 72,
+          "value": 500000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Aboubaka Soumahoro",
+          "name": "A. Soumahoro",
+          "overall_score": 64,
+          "potential": 77,
+          "value": 1300000,
+          "yearly_wage": 260000
+        }
+      ],
+      "team": "Hamburger SV",
+      "transfer_budget": 13800000,
+      "url": "https://sofifa.com/team/28/hamburger-sv/260037/"
+    },
+    {
+      "player_count": 33,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Nikola Vasilj",
+          "name": "N. Vasilj",
+          "overall_score": 78,
+          "potential": 78,
+          "value": 9500000,
+          "yearly_wage": 936000
+        },
+        {
+          "currency": "€",
+          "full_name": "Hauke Wahl",
+          "name": "H. Wahl",
+          "overall_score": 74,
+          "potential": 74,
+          "value": 2900000,
+          "yearly_wage": 1144000
+        },
+        {
+          "currency": "€",
+          "full_name": "Eric Smith",
+          "name": "E. Smith",
+          "overall_score": 74,
+          "potential": 74,
+          "value": 3600000,
+          "yearly_wage": 1144000
+        },
+        {
+          "currency": "€",
+          "full_name": "Karol Mets",
+          "name": "K. Mets",
+          "overall_score": 71,
+          "potential": 71,
+          "value": 1200000,
+          "yearly_wage": 832000
+        },
+        {
+          "currency": "€",
+          "full_name": "Manolis Saliakas",
+          "name": "M. Saliakas",
+          "overall_score": 72,
+          "potential": 72,
+          "value": 2100000,
+          "yearly_wage": 936000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jackson Irvine",
+          "name": "J. Irvine",
+          "overall_score": 74,
+          "potential": 74,
+          "value": 3300000,
+          "yearly_wage": 1144000
+        },
+        {
+          "currency": "€",
+          "full_name": "Joel Chima Fujita",
+          "name": "J. Fujita",
+          "overall_score": 72,
+          "potential": 77,
+          "value": 3500000,
+          "yearly_wage": 832000
+        },
+        {
+          "currency": "€",
+          "full_name": "Arkadiusz Pyrka",
+          "name": "A. Pyrka",
+          "overall_score": 70,
+          "potential": 76,
+          "value": 2400000,
+          "yearly_wage": 624000
+        },
+        {
+          "currency": "€",
+          "full_name": "Danel Sinani",
+          "name": "D. Sinani",
+          "overall_score": 71,
+          "potential": 71,
+          "value": 1900000,
+          "yearly_wage": 884000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mathias Pereira Lage",
+          "name": "M. Pereira Lage",
+          "overall_score": 73,
+          "potential": 73,
+          "value": 3100000,
+          "yearly_wage": 1144000
+        },
+        {
+          "currency": "€",
+          "full_name": "Andréas Hountondji",
+          "name": "A. Hountondji",
+          "overall_score": 70,
+          "potential": 77,
+          "value": 3300000,
+          "yearly_wage": 1508000
+        },
+        {
+          "currency": "€",
+          "full_name": "Martijn Kaars",
+          "name": "M. Kaars",
+          "overall_score": 72,
+          "potential": 73,
+          "value": 2800000,
+          "yearly_wage": 988000
+        },
+        {
+          "currency": "€",
+          "full_name": "Abdoulie Ceesay",
+          "name": "A. Ceesay",
+          "overall_score": 66,
+          "potential": 74,
+          "value": 1900000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mathias Rasmussen",
+          "name": "M. Rasmussen",
+          "overall_score": 73,
+          "potential": 73,
+          "value": 3200000,
+          "yearly_wage": 1040000
+        },
+        {
+          "currency": "€",
+          "full_name": "Connor Metcalfe",
+          "name": "C. Metcalfe",
+          "overall_score": 69,
+          "potential": 71,
+          "value": 1700000,
+          "yearly_wage": 624000
+        },
+        {
+          "currency": "€",
+          "full_name": "Tomoya Andō",
+          "name": "T. Andō",
+          "overall_score": 70,
+          "potential": 73,
+          "value": 1800000,
+          "yearly_wage": 728000
+        },
+        {
+          "currency": "€",
+          "full_name": "Louis Oppie",
+          "name": "L. Oppie",
+          "overall_score": 70,
+          "potential": 75,
+          "value": 2200000,
+          "yearly_wage": 624000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ben Voll",
+          "name": "B. Voll",
+          "overall_score": 67,
+          "potential": 72,
+          "value": 1200000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Adam Dźwigała",
+          "name": "A. Dźwigała",
+          "overall_score": 69,
+          "potential": 69,
+          "value": 1200000,
+          "yearly_wage": 676000
+        },
+        {
+          "currency": "€",
+          "full_name": "Taichi Hara",
+          "name": "T. Hara",
+          "overall_score": 68,
+          "potential": 69,
+          "value": 1400000,
+          "yearly_wage": 624000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jannik Robatsch",
+          "name": "J. Robatsch",
+          "overall_score": 65,
+          "potential": 76,
+          "value": 1500000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "David Nemeth",
+          "name": "D. Nemeth",
+          "overall_score": 70,
+          "potential": 75,
+          "value": 2200000,
+          "yearly_wage": 624000
+        },
+        {
+          "currency": "€",
+          "full_name": "James Sands",
+          "name": "J. Sands",
+          "overall_score": 72,
+          "potential": 75,
+          "value": 2900000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ricky-Jade Jones",
+          "name": "R. Jones",
+          "overall_score": 68,
+          "potential": 72,
+          "value": 1800000,
+          "yearly_wage": 572000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lars Ritzka",
+          "name": "L. Ritzka",
+          "overall_score": 69,
+          "potential": 69,
+          "value": 1300000,
+          "yearly_wage": 624000
+        },
+        {
+          "currency": "€",
+          "full_name": "Marwin Schmitz",
+          "name": "M. Schmitz",
+          "overall_score": 59,
+          "potential": 77,
+          "value": 550000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Emil Gazdov",
+          "name": "E. Gazdov",
+          "overall_score": 62,
+          "potential": 71,
+          "value": 775000,
+          "yearly_wage": 36400
+        },
+        {
+          "currency": "€",
+          "full_name": "Romeo Aigbekaen",
+          "name": "R. Aigbekaen",
+          "overall_score": 59,
+          "potential": 70,
+          "value": 500000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Nick Schmidt",
+          "name": "N. Schmidt",
+          "overall_score": 58,
+          "potential": 75,
+          "value": 500000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Simon Spari",
+          "name": "S. Spari",
+          "overall_score": 61,
+          "potential": 71,
+          "value": 625000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Fin Stevens",
+          "name": "F. Stevens",
+          "overall_score": 63,
+          "potential": 72,
+          "value": 1000000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Erik Ahlstrand",
+          "name": "E. Ahlstrand",
+          "overall_score": 65,
+          "potential": 71,
+          "value": 1100000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Scott Banks",
+          "name": "S. Banks",
+          "overall_score": 63,
+          "potential": 68,
+          "value": 725000,
+          "yearly_wage": 260000
+        }
+      ],
+      "team": "FC St. Pauli",
+      "transfer_budget": 6600000,
+      "url": "https://sofifa.com/team/110329/fc-st-pauli/260037/"
+    },
+    {
+      "player_count": 33,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Diant Ramaj",
+          "name": "D. Ramaj",
+          "overall_score": 75,
+          "potential": 81,
+          "value": 7000000,
+          "yearly_wage": 936000
+        },
+        {
+          "currency": "€",
+          "full_name": "Marnon Busch",
+          "name": "M. Busch",
+          "overall_score": 72,
+          "potential": 72,
+          "value": 2000000,
+          "yearly_wage": 1092000
+        },
+        {
+          "currency": "€",
+          "full_name": "Patrick Mainka",
+          "name": "P. Mainka",
+          "overall_score": 76,
+          "potential": 76,
+          "value": 6000000,
+          "yearly_wage": 1508000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jonas Föhrenbach",
+          "name": "J. Föhrenbach",
+          "overall_score": 71,
+          "potential": 71,
+          "value": 1600000,
+          "yearly_wage": 988000
+        },
+        {
+          "currency": "€",
+          "full_name": "Hennes Behrens",
+          "name": "H. Behrens",
+          "overall_score": 70,
+          "potential": 77,
+          "value": 3000000,
+          "yearly_wage": 676000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jan Schöppner",
+          "name": "J. Schöppner",
+          "overall_score": 72,
+          "potential": 74,
+          "value": 2600000,
+          "yearly_wage": 1040000
+        },
+        {
+          "currency": "€",
+          "full_name": "Eren Dinkçi",
+          "name": "E. Dinkçi",
+          "overall_score": 73,
+          "potential": 79,
+          "value": 4800000,
+          "yearly_wage": 988000
+        },
+        {
+          "currency": "€",
+          "full_name": "Luca Kerber",
+          "name": "L. Kerber",
+          "overall_score": 69,
+          "potential": 76,
+          "value": 2600000,
+          "yearly_wage": 676000
+        },
+        {
+          "currency": "€",
+          "full_name": "Niklas Dorsch",
+          "name": "N. Dorsch",
+          "overall_score": 74,
+          "potential": 74,
+          "value": 4500000,
+          "yearly_wage": 1352000
+        },
+        {
+          "currency": "€",
+          "full_name": "Arijon Ibrahimović",
+          "name": "A. Ibrahimović",
+          "overall_score": 72,
+          "potential": 83,
+          "value": 5000000,
+          "yearly_wage": 1300000
+        },
+        {
+          "currency": "€",
+          "full_name": "Marvin Pieringer",
+          "name": "M. Pieringer",
+          "overall_score": 73,
+          "potential": 74,
+          "value": 3700000,
+          "yearly_wage": 1248000
+        },
+        {
+          "currency": "€",
+          "full_name": "Budu Zivzivadze",
+          "name": "B. Zivzivadze",
+          "overall_score": 72,
+          "potential": 72,
+          "value": 2000000,
+          "yearly_wage": 1248000
+        },
+        {
+          "currency": "€",
+          "full_name": "Sirlord Conteh",
+          "name": "S. Conteh",
+          "overall_score": 69,
+          "potential": 69,
+          "value": 1400000,
+          "yearly_wage": 884000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mathias Honsak",
+          "name": "M. Honsak",
+          "overall_score": 72,
+          "potential": 72,
+          "value": 2400000,
+          "yearly_wage": 1144000
+        },
+        {
+          "currency": "€",
+          "full_name": "Omar Haktab Traoré",
+          "name": "O. Traoré",
+          "overall_score": 72,
+          "potential": 72,
+          "value": 2300000,
+          "yearly_wage": 1040000
+        },
+        {
+          "currency": "€",
+          "full_name": "Benedikt Gimber",
+          "name": "B. Gimber",
+          "overall_score": 71,
+          "potential": 72,
+          "value": 1800000,
+          "yearly_wage": 988000
+        },
+        {
+          "currency": "€",
+          "full_name": "Tim Siersleben",
+          "name": "T. Siersleben",
+          "overall_score": 71,
+          "potential": 74,
+          "value": 2200000,
+          "yearly_wage": 936000
+        },
+        {
+          "currency": "€",
+          "full_name": "Frank Feller",
+          "name": "F. Feller",
+          "overall_score": 69,
+          "potential": 77,
+          "value": 2700000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Stefan Schimmer",
+          "name": "S. Schimmer",
+          "overall_score": 69,
+          "potential": 69,
+          "value": 1200000,
+          "yearly_wage": 884000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mikkel Kaufmann",
+          "name": "M. Kaufmann",
+          "overall_score": 68,
+          "potential": 73,
+          "value": 1800000,
+          "yearly_wage": 676000
+        },
+        {
+          "currency": "€",
+          "full_name": "Yannik Wagner",
+          "name": "Y. Wagner",
+          "overall_score": 60,
+          "potential": 77,
+          "value": 625000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Leonidas Stergiou",
+          "name": "L. Stergiou",
+          "overall_score": 71,
+          "potential": 78,
+          "value": 3600000,
+          "yearly_wage": 988000
+        },
+        {
+          "currency": "€",
+          "full_name": "Adam Kölle",
+          "name": "A. Kölle",
+          "overall_score": 63,
+          "potential": 74,
+          "value": 975000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Leart Paçarada",
+          "name": "L. Paçarada",
+          "overall_score": 72,
+          "potential": 72,
+          "value": 2000000,
+          "yearly_wage": 1092000
+        },
+        {
+          "currency": "€",
+          "full_name": "Christian Conteh",
+          "name": "C. Conteh",
+          "overall_score": 68,
+          "potential": 69,
+          "value": 1400000,
+          "yearly_wage": 676000
+        },
+        {
+          "currency": "€",
+          "full_name": "Julian Niehues",
+          "name": "J. Niehues",
+          "overall_score": 72,
+          "potential": 75,
+          "value": 2900000,
+          "yearly_wage": 936000
+        },
+        {
+          "currency": "€",
+          "full_name": "Adrian Beck",
+          "name": "A. Beck",
+          "overall_score": 71,
+          "potential": 71,
+          "value": 1900000,
+          "yearly_wage": 1040000
+        },
+        {
+          "currency": "€",
+          "full_name": "Paul Tschernuth",
+          "name": "P. Tschernuth",
+          "overall_score": 59,
+          "potential": 67,
+          "value": 425000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Tobias Weigel",
+          "name": "T. Weigel",
+          "overall_score": 59,
+          "potential": 73,
+          "value": 525000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Nick Rothweiler",
+          "name": "N. Rothweiler",
+          "overall_score": 59,
+          "potential": 73,
+          "value": 525000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Thomas Keller",
+          "name": "T. Keller",
+          "overall_score": 68,
+          "potential": 72,
+          "value": 1500000,
+          "yearly_wage": 676000
+        },
+        {
+          "currency": "€",
+          "full_name": "Maximilian Breunig",
+          "name": "M. Breunig",
+          "overall_score": 66,
+          "potential": 71,
+          "value": 1300000,
+          "yearly_wage": 520000
+        },
+        {
+          "currency": "€",
+          "full_name": "Kevin Müller",
+          "name": "K. Müller",
+          "overall_score": 72,
+          "potential": 72,
+          "value": 400000,
+          "yearly_wage": 728000
+        }
+      ],
+      "team": "1. FC Heidenheim 1846",
+      "transfer_budget": 8500000,
+      "url": "https://sofifa.com/team/111235/1-fc-heidenheim-1846/260037/"
+    }
+  ],
+  "total_players": 678
+}

--- a/data/2025/DEU1/teams.json
+++ b/data/2025/DEU1/teams.json
@@ -18,7 +18,11 @@
             "Switzerland"
           ],
           "number": "1",
-          "position": "Goalkeeper"
+          "overall_score": 86,
+          "position": "Goalkeeper",
+          "potential": 89,
+          "value": 66500000,
+          "yearly_wage": 2704000
         },
         {
           "contract": "Jun 30, 2027",
@@ -32,7 +36,11 @@
             "Germany"
           ],
           "number": "33",
-          "position": "Goalkeeper"
+          "overall_score": 74,
+          "position": "Goalkeeper",
+          "potential": 74,
+          "value": 725000,
+          "yearly_wage": 1144000
         },
         {
           "contract": "Jun 30, 2027",
@@ -46,7 +54,11 @@
             "Germany"
           ],
           "number": "30",
-          "position": "Goalkeeper"
+          "overall_score": 71,
+          "position": "Goalkeeper",
+          "potential": 71,
+          "value": 925000,
+          "yearly_wage": 884000
         },
         {
           "contract": "Jun 30, 2027",
@@ -61,7 +73,11 @@
             "Poland"
           ],
           "number": "31",
-          "position": "Goalkeeper"
+          "overall_score": 63,
+          "position": "Goalkeeper",
+          "potential": 75,
+          "value": 1000000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2027",
@@ -75,7 +91,11 @@
             "Germany"
           ],
           "number": "4",
-          "position": "Centre-Back"
+          "overall_score": 86,
+          "position": "Centre-Back",
+          "potential": 88,
+          "value": 75500000,
+          "yearly_wage": 4056000
         },
         {
           "contract": "Jun 30, 2028",
@@ -89,7 +109,11 @@
             "Germany"
           ],
           "number": "3",
-          "position": "Centre-Back"
+          "overall_score": 83,
+          "position": "Centre-Back",
+          "potential": 83,
+          "value": 31500000,
+          "yearly_wage": 3432000
         },
         {
           "contract": "Jun 30, 2027",
@@ -103,7 +127,11 @@
             "Algeria"
           ],
           "number": "5",
-          "position": "Centre-Back"
+          "overall_score": 79,
+          "position": "Centre-Back",
+          "potential": 79,
+          "value": 14500000,
+          "yearly_wage": 2548000
         },
         {
           "contract": "Jun 30, 2026",
@@ -118,7 +146,11 @@
             "Türkiye"
           ],
           "number": "23",
-          "position": "Centre-Back"
+          "overall_score": 82,
+          "position": "Centre-Back",
+          "potential": 82,
+          "value": 21000000,
+          "yearly_wage": 3120000
         },
         {
           "contract": "Jun 30, 2026",
@@ -132,7 +164,11 @@
             "Germany"
           ],
           "number": "25",
-          "position": "Centre-Back"
+          "overall_score": 78,
+          "position": "Centre-Back",
+          "potential": 78,
+          "value": 12000000,
+          "yearly_wage": 2288000
         },
         {
           "contract": "Jun 30, 2028",
@@ -147,7 +183,11 @@
             "Senegal"
           ],
           "number": "39",
-          "position": "Centre-Back"
+          "overall_score": 65,
+          "position": "Centre-Back",
+          "potential": 79,
+          "value": 1600000,
+          "yearly_wage": 416000
         },
         {
           "contract": "Jun 30, 2029",
@@ -161,7 +201,11 @@
             "Sweden"
           ],
           "number": "24",
-          "position": "Left-Back"
+          "overall_score": 79,
+          "position": "Left-Back",
+          "potential": 83,
+          "value": 23500000,
+          "yearly_wage": 2132000
         },
         {
           "contract": "Jun 30, 2028",
@@ -176,7 +220,11 @@
             "Libya"
           ],
           "number": "42",
-          "position": "Left-Back"
+          "overall_score": 65,
+          "position": "Left-Back",
+          "potential": 80,
+          "value": 1600000,
+          "yearly_wage": 364000
         },
         {
           "contract": "Jun 30, 2028",
@@ -191,7 +239,11 @@
             "United States"
           ],
           "number": "26",
-          "position": "Right-Back"
+          "overall_score": 80,
+          "position": "Right-Back",
+          "potential": 80,
+          "value": 20500000,
+          "yearly_wage": 2600000
         },
         {
           "contract": "Jun 30, 2026",
@@ -206,7 +258,11 @@
             "Germany"
           ],
           "number": "6",
-          "position": "Defensive Midfield"
+          "overall_score": 74,
+          "position": "Defensive Midfield",
+          "potential": 75,
+          "value": 4300000,
+          "yearly_wage": 1716000
         },
         {
           "contract": "Jun 30, 2028",
@@ -221,7 +277,11 @@
             "England"
           ],
           "number": "8",
-          "position": "Central Midfield"
+          "overall_score": 84,
+          "position": "Central Midfield",
+          "potential": 86,
+          "value": 54500000,
+          "yearly_wage": 3276000
         },
         {
           "contract": "Jun 30, 2030",
@@ -236,7 +296,11 @@
             "Ireland"
           ],
           "number": "7",
-          "position": "Central Midfield"
+          "overall_score": 77,
+          "position": "Central Midfield",
+          "potential": 83,
+          "value": 16000000,
+          "yearly_wage": 1508000
         },
         {
           "contract": "Jun 30, 2030",
@@ -251,7 +315,11 @@
             "Nigeria"
           ],
           "number": "17",
-          "position": "Central Midfield"
+          "overall_score": 78,
+          "position": "Central Midfield",
+          "potential": 84,
+          "value": 22500000,
+          "yearly_wage": 1768000
         },
         {
           "contract": "Jun 30, 2027",
@@ -265,7 +333,11 @@
             "Austria"
           ],
           "number": "20",
-          "position": "Central Midfield"
+          "overall_score": 81,
+          "position": "Central Midfield",
+          "potential": 81,
+          "value": 18000000,
+          "yearly_wage": 2860000
         },
         {
           "contract": "Jun 30, 2030",
@@ -280,7 +352,11 @@
             "Portugal"
           ],
           "number": "2",
-          "position": "Right Midfield"
+          "overall_score": 77,
+          "position": "Right Midfield",
+          "potential": 81,
+          "value": 14000000,
+          "yearly_wage": 1768000
         },
         {
           "contract": "Jun 30, 2026",
@@ -294,7 +370,11 @@
             "Germany"
           ],
           "number": "10",
-          "position": "Attacking Midfield"
+          "overall_score": 82,
+          "position": "Attacking Midfield",
+          "potential": 82,
+          "value": 30000000,
+          "yearly_wage": 3328000
         },
         {
           "contract": "Jun 30, 2027",
@@ -309,7 +389,11 @@
             "Nigeria"
           ],
           "number": "27",
-          "position": "Right Winger"
+          "overall_score": 82,
+          "position": "Right Winger",
+          "potential": 86,
+          "value": 43500000,
+          "yearly_wage": 2704000
         },
         {
           "contract": "Jun 30, 2028",
@@ -324,7 +408,11 @@
             "France"
           ],
           "number": "9",
-          "position": "Centre-Forward"
+          "overall_score": 85,
+          "position": "Centre-Forward",
+          "potential": 85,
+          "value": 54000000,
+          "yearly_wage": 4628000
         },
         {
           "contract": "Jun 30, 2029",
@@ -338,7 +426,11 @@
             "Germany"
           ],
           "number": "14",
-          "position": "Centre-Forward"
+          "overall_score": 80,
+          "position": "Centre-Forward",
+          "potential": 84,
+          "value": 31000000,
+          "yearly_wage": 2600000
         },
         {
           "contract": "Jun 30, 2030",
@@ -352,7 +444,11 @@
             "Portugal"
           ],
           "number": "21",
-          "position": "Centre-Forward"
+          "overall_score": 79,
+          "position": "Centre-Forward",
+          "potential": 85,
+          "value": 28500000,
+          "yearly_wage": 2444000
         }
       ],
       "stadiumName": "SIGNAL IDUNA PARK",
@@ -375,7 +471,11 @@
             "Germany"
           ],
           "number": "40",
-          "position": "Goalkeeper"
+          "overall_score": 77,
+          "position": "Goalkeeper",
+          "potential": 85,
+          "value": 20500000,
+          "yearly_wage": 936000
         },
         {
           "contract": "Jun 30, 2026",
@@ -389,7 +489,11 @@
             "Germany"
           ],
           "number": "1",
-          "position": "Goalkeeper"
+          "overall_score": 82,
+          "position": "Goalkeeper",
+          "potential": 82,
+          "value": 3400000,
+          "yearly_wage": 1196000
         },
         {
           "contract": "Jun 30, 2026",
@@ -403,7 +507,11 @@
             "Germany"
           ],
           "number": "26",
-          "position": "Goalkeeper"
+          "overall_score": 73,
+          "position": "Goalkeeper",
+          "potential": 73,
+          "value": 350000,
+          "yearly_wage": 780000
         },
         {
           "contract": "Jun 30, 2027",
@@ -418,7 +526,11 @@
             "Croatia"
           ],
           "number": "48",
-          "position": "Goalkeeper"
+          "overall_score": 56,
+          "position": "Goalkeeper",
+          "potential": 75,
+          "value": 325000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2026",
@@ -433,7 +545,11 @@
             "Guinea-Bissau"
           ],
           "number": "2",
-          "position": "Centre-Back"
+          "overall_score": 86,
+          "position": "Centre-Back",
+          "potential": 88,
+          "value": 74000000,
+          "yearly_wage": 5200000
         },
         {
           "contract": "Jun 30, 2029",
@@ -448,7 +564,11 @@
             "Cote d'Ivoire"
           ],
           "number": "4",
-          "position": "Centre-Back"
+          "overall_score": 87,
+          "position": "Centre-Back",
+          "potential": 87,
+          "value": 66500000,
+          "yearly_wage": 5980000
         },
         {
           "contract": "Jun 30, 2028",
@@ -462,7 +582,11 @@
             "Korea, South"
           ],
           "number": "3",
-          "position": "Centre-Back"
+          "overall_score": 82,
+          "position": "Centre-Back",
+          "potential": 82,
+          "value": 26500000,
+          "yearly_wage": 3900000
         },
         {
           "contract": "Jun 30, 2028",
@@ -476,7 +600,11 @@
             "Japan"
           ],
           "number": "21",
-          "position": "Centre-Back"
+          "overall_score": 78,
+          "position": "Centre-Back",
+          "potential": 81,
+          "value": 16500000,
+          "yearly_wage": 2756000
         },
         {
           "contract": "Jun 30, 2030",
@@ -491,7 +619,11 @@
             "Liberia"
           ],
           "number": "19",
-          "position": "Left-Back"
+          "overall_score": 83,
+          "position": "Left-Back",
+          "potential": 86,
+          "value": 46000000,
+          "yearly_wage": 3536000
         },
         {
           "contract": "Jun 30, 2026",
@@ -506,7 +638,11 @@
             "France"
           ],
           "number": "22",
-          "position": "Left-Back"
+          "overall_score": 79,
+          "position": "Left-Back",
+          "potential": 79,
+          "value": 12500000,
+          "yearly_wage": 3172000
         },
         {
           "contract": "Jun 30, 2027",
@@ -520,7 +656,11 @@
             "Austria"
           ],
           "number": "27",
-          "position": "Right-Back"
+          "overall_score": 84,
+          "position": "Right-Back",
+          "potential": 84,
+          "value": 38000000,
+          "yearly_wage": 4680000
         },
         {
           "contract": "Jun 30, 2029",
@@ -535,7 +675,11 @@
             "Germany"
           ],
           "number": "44",
-          "position": "Right-Back"
+          "overall_score": 79,
+          "position": "Right-Back",
+          "potential": 82,
+          "value": 21500000,
+          "yearly_wage": 2912000
         },
         {
           "contract": "Jun 30, 2029",
@@ -550,7 +694,11 @@
             "Serbia"
           ],
           "number": "45",
-          "position": "Defensive Midfield"
+          "overall_score": 82,
+          "position": "Defensive Midfield",
+          "potential": 87,
+          "value": 43000000,
+          "yearly_wage": 2704000
         },
         {
           "contract": "Jun 30, 2029",
@@ -564,7 +712,11 @@
             "Germany"
           ],
           "number": "6",
-          "position": "Defensive Midfield"
+          "overall_score": 89,
+          "position": "Defensive Midfield",
+          "potential": 89,
+          "value": 86000000,
+          "yearly_wage": 7280000
         },
         {
           "contract": "Jun 30, 2029",
@@ -578,7 +730,11 @@
             "Germany"
           ],
           "number": "20",
-          "position": "Central Midfield"
+          "overall_score": 78,
+          "position": "Central Midfield",
+          "potential": 86,
+          "value": 30500000,
+          "yearly_wage": 2132000
         },
         {
           "contract": "Jun 30, 2026",
@@ -592,7 +748,11 @@
             "Germany"
           ],
           "number": "8",
-          "position": "Central Midfield"
+          "overall_score": 81,
+          "position": "Central Midfield",
+          "potential": 81,
+          "value": 21500000,
+          "yearly_wage": 3588000
         },
         {
           "contract": "Jun 30, 2026",
@@ -606,7 +766,11 @@
             "Senegal"
           ],
           "number": "39",
-          "position": "Central Midfield"
+          "overall_score": 61,
+          "position": "Central Midfield",
+          "potential": 81,
+          "value": 875000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2030",
@@ -621,7 +785,11 @@
             "England"
           ],
           "number": "10",
-          "position": "Attacking Midfield"
+          "overall_score": 87,
+          "position": "Attacking Midfield",
+          "potential": 91,
+          "value": 116500000,
+          "yearly_wage": 5200000
         },
         {
           "contract": "Jun 30, 2028",
@@ -635,7 +803,11 @@
             "Germany"
           ],
           "number": "42",
-          "position": "Attacking Midfield"
+          "overall_score": 75,
+          "position": "Attacking Midfield",
+          "potential": 88,
+          "value": 13000000,
+          "yearly_wage": 1300000
         },
         {
           "contract": "Jun 30, 2029",
@@ -649,7 +821,11 @@
             "Colombia"
           ],
           "number": "14",
-          "position": "Left Winger"
+          "overall_score": 87,
+          "position": "Left Winger",
+          "potential": 87,
+          "value": 80000000,
+          "yearly_wage": 6240000
         },
         {
           "contract": "Jun 30, 2027",
@@ -664,7 +840,11 @@
             "Nigeria"
           ],
           "number": "36",
-          "position": "Left Winger"
+          "overall_score": 61,
+          "position": "Left Winger",
+          "potential": 85,
+          "value": 1000000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2029",
@@ -679,7 +859,11 @@
             "England"
           ],
           "number": "17",
-          "position": "Right Winger"
+          "overall_score": 89,
+          "position": "Right Winger",
+          "potential": 91,
+          "value": 134000000,
+          "yearly_wage": 6240000
         },
         {
           "contract": "Jun 30, 2028",
@@ -694,7 +878,11 @@
             "Cote d'Ivoire"
           ],
           "number": "7",
-          "position": "Second Striker"
+          "overall_score": 83,
+          "position": "Second Striker",
+          "potential": 83,
+          "value": 35500000,
+          "yearly_wage": 4524000
         },
         {
           "contract": "Jun 30, 2027",
@@ -709,7 +897,11 @@
             "Ireland"
           ],
           "number": "9",
-          "position": "Centre-Forward"
+          "overall_score": 90,
+          "position": "Centre-Forward",
+          "potential": 90,
+          "value": 101000000,
+          "yearly_wage": 8840000
         },
         {
           "contract": "Jun 30, 2026",
@@ -724,7 +916,11 @@
             "The Gambia"
           ],
           "number": "11",
-          "position": "Centre-Forward"
+          "overall_score": 79,
+          "position": "Centre-Forward",
+          "potential": 82,
+          "value": 24500000,
+          "yearly_wage": 5460000
         }
       ],
       "stadiumName": "Allianz Arena",
@@ -747,7 +943,11 @@
             "Germany"
           ],
           "number": "33",
-          "position": "Goalkeeper"
+          "overall_score": 80,
+          "position": "Goalkeeper",
+          "potential": 81,
+          "value": 16500000,
+          "yearly_wage": 2184000
         },
         {
           "contract": "Jun 30, 2027",
@@ -761,7 +961,11 @@
             "Germany"
           ],
           "number": "44",
-          "position": "Goalkeeper"
+          "overall_score": 63,
+          "position": "Goalkeeper",
+          "potential": 82,
+          "value": 1100000,
+          "yearly_wage": 52000
         },
         {
           "contract": "Jun 30, 2027",
@@ -775,7 +979,11 @@
             "Germany"
           ],
           "number": "1",
-          "position": "Goalkeeper"
+          "overall_score": 71,
+          "position": "Goalkeeper",
+          "potential": 71,
+          "value": 1200000,
+          "yearly_wage": 780000
         },
         {
           "contract": "Jun 30, 2027",
@@ -790,7 +998,11 @@
             "Serbia"
           ],
           "number": "21",
-          "position": "Goalkeeper"
+          "overall_score": 66,
+          "position": "Goalkeeper",
+          "potential": 70,
+          "value": 925000,
+          "yearly_wage": 364000
         },
         {
           "contract": "Jun 30, 2030",
@@ -804,7 +1016,11 @@
             "Germany"
           ],
           "number": "29",
-          "position": "Centre-Back"
+          "overall_score": 74,
+          "position": "Centre-Back",
+          "potential": 87,
+          "value": 9000000,
+          "yearly_wage": 936000
         },
         {
           "contract": "Jun 30, 2028",
@@ -819,7 +1035,11 @@
             "France"
           ],
           "number": "24",
-          "position": "Centre-Back"
+          "overall_score": 80,
+          "position": "Centre-Back",
+          "potential": 80,
+          "value": 19500000,
+          "yearly_wage": 2236000
         },
         {
           "contract": "Jun 30, 2029",
@@ -834,7 +1054,11 @@
             "Dominican Republic"
           ],
           "number": "14",
-          "position": "Centre-Back"
+          "overall_score": 71,
+          "position": "Centre-Back",
+          "potential": 79,
+          "value": 3900000,
+          "yearly_wage": 988000
         },
         {
           "contract": "Jun 30, 2028",
@@ -848,7 +1072,11 @@
             "Netherlands"
           ],
           "number": "3",
-          "position": "Centre-Back"
+          "overall_score": 74,
+          "position": "Centre-Back",
+          "potential": 79,
+          "value": 6000000,
+          "yearly_wage": 1300000
         },
         {
           "contract": "Jun 30, 2028",
@@ -863,7 +1091,11 @@
             "Iraq"
           ],
           "number": "2",
-          "position": "Centre-Back"
+          "overall_score": 72,
+          "position": "Centre-Back",
+          "potential": 79,
+          "value": 4400000,
+          "yearly_wage": 1092000
         },
         {
           "contract": "Jun 30, 2026",
@@ -878,7 +1110,11 @@
             "Cote d'Ivoire"
           ],
           "number": "23",
-          "position": "Centre-Back"
+          "overall_score": 74,
+          "position": "Centre-Back",
+          "potential": 77,
+          "value": 4900000,
+          "yearly_wage": 1508000
         },
         {
           "contract": "Jun 30, 2028",
@@ -892,7 +1128,11 @@
             "Germany"
           ],
           "number": "7",
-          "position": "Left-Back"
+          "overall_score": 83,
+          "position": "Left-Back",
+          "potential": 83,
+          "value": 33000000,
+          "yearly_wage": 2964000
         },
         {
           "contract": "Jun 30, 2029",
@@ -907,7 +1147,11 @@
             "Togo"
           ],
           "number": "22",
-          "position": "Right-Back"
+          "overall_score": 75,
+          "position": "Right-Back",
+          "potential": 80,
+          "value": 7500000,
+          "yearly_wage": 1560000
         },
         {
           "contract": "Jun 30, 2028",
@@ -922,7 +1166,11 @@
             "Cote d'Ivoire"
           ],
           "number": "4",
-          "position": "Right-Back"
+          "overall_score": 75,
+          "position": "Right-Back",
+          "potential": 78,
+          "value": 7000000,
+          "yearly_wage": 1404000
         },
         {
           "contract": "Jun 30, 2026",
@@ -936,7 +1184,11 @@
             "Germany"
           ],
           "number": "15",
-          "position": "Right-Back"
+          "overall_score": 69,
+          "position": "Right-Back",
+          "potential": 69,
+          "value": 1200000,
+          "yearly_wage": 936000
         },
         {
           "contract": "Jun 30, 2028",
@@ -950,7 +1202,11 @@
             "Germany"
           ],
           "number": "6",
-          "position": "Defensive Midfield"
+          "overall_score": 83,
+          "position": "Defensive Midfield",
+          "potential": 87,
+          "value": 47500000,
+          "yearly_wage": 2444000
         },
         {
           "contract": "Jun 30, 2030",
@@ -964,7 +1220,11 @@
             "Spain"
           ],
           "number": "30",
-          "position": "Defensive Midfield"
+          "overall_score": 73,
+          "position": "Defensive Midfield",
+          "potential": 82,
+          "value": 6500000,
+          "yearly_wage": 988000
         },
         {
           "contract": "Jun 30, 2028",
@@ -979,7 +1239,11 @@
             "Germany"
           ],
           "number": "16",
-          "position": "Defensive Midfield"
+          "overall_score": 76,
+          "position": "Defensive Midfield",
+          "potential": 76,
+          "value": 6500000,
+          "yearly_wage": 1768000
         },
         {
           "contract": "Jun 30, 2028",
@@ -994,7 +1258,11 @@
             "Bosnia-Herzegovina"
           ],
           "number": "35",
-          "position": "Defensive Midfield"
+          "overall_score": 62,
+          "position": "Defensive Midfield",
+          "potential": 78,
+          "value": 950000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2026",
@@ -1009,7 +1277,11 @@
             "Ghana"
           ],
           "number": "28",
-          "position": "Central Midfield"
+          "overall_score": 73,
+          "position": "Central Midfield",
+          "potential": 76,
+          "value": 4000000,
+          "yearly_wage": 1352000
         },
         {
           "contract": "Jun 30, 2026",
@@ -1024,7 +1296,11 @@
             "Belgium"
           ],
           "number": "11",
-          "position": "Attacking Midfield"
+          "overall_score": 78,
+          "position": "Attacking Midfield",
+          "potential": 84,
+          "value": 22500000,
+          "yearly_wage": 1872000
         },
         {
           "contract": "Jun 30, 2028",
@@ -1038,7 +1314,11 @@
             "Germany"
           ],
           "number": "10",
-          "position": "Left Winger"
+          "overall_score": 77,
+          "position": "Left Winger",
+          "potential": 77,
+          "value": 11000000,
+          "yearly_wage": 1872000
         },
         {
           "contract": "Jun 30, 2029",
@@ -1053,7 +1333,11 @@
             "Ghana"
           ],
           "number": "17",
-          "position": "Left Winger"
+          "overall_score": 66,
+          "position": "Left Winger",
+          "potential": 80,
+          "value": 2100000,
+          "yearly_wage": 468000
         },
         {
           "contract": "Jun 30, 2029",
@@ -1068,7 +1352,11 @@
             "Ghana"
           ],
           "number": "18",
-          "position": "Right Winger"
+          "overall_score": 78,
+          "position": "Right Winger",
+          "potential": 81,
+          "value": 19000000,
+          "yearly_wage": 1768000
         },
         {
           "contract": "Jun 30, 2030",
@@ -1083,7 +1371,11 @@
             "France"
           ],
           "number": "27",
-          "position": "Right Winger"
+          "overall_score": 74,
+          "position": "Right Winger",
+          "potential": 82,
+          "value": 9500000,
+          "yearly_wage": 1144000
         },
         {
           "contract": "Jun 30, 2029",
@@ -1097,7 +1389,11 @@
             "Serbia"
           ],
           "number": "45",
-          "position": "Right Winger"
+          "overall_score": 64,
+          "position": "Right Winger",
+          "potential": 82,
+          "value": 1500000,
+          "yearly_wage": 312000
         },
         {
           "contract": "Jun 30, 2029",
@@ -1111,7 +1407,11 @@
             "Germany"
           ],
           "number": "19",
-          "position": "Right Winger"
+          "overall_score": 63,
+          "position": "Right Winger",
+          "potential": 82,
+          "value": 1200000,
+          "yearly_wage": 312000
         },
         {
           "contract": "Jun 30, 2028",
@@ -1125,7 +1425,11 @@
             "Bosnia-Herzegovina"
           ],
           "number": "9",
-          "position": "Centre-Forward"
+          "overall_score": 80,
+          "position": "Centre-Forward",
+          "potential": 80,
+          "value": 23000000,
+          "yearly_wage": 2548000
         },
         {
           "contract": "Jun 30, 2027",
@@ -1139,7 +1443,11 @@
             "Germany"
           ],
           "number": "26",
-          "position": "Centre-Forward"
+          "overall_score": 82,
+          "position": "Centre-Forward",
+          "potential": 82,
+          "value": 31000000,
+          "yearly_wage": 3068000
         },
         {
           "contract": "Jun 30, 2029",
@@ -1153,7 +1461,11 @@
             "Portugal"
           ],
           "number": "8",
-          "position": "Centre-Forward"
+          "overall_score": 76,
+          "position": "Centre-Forward",
+          "potential": 82,
+          "value": 12000000,
+          "yearly_wage": 1560000
         },
         {
           "contract": "Jun 30, 2031",
@@ -1168,7 +1480,11 @@
             "Spain"
           ],
           "number": "25",
-          "position": "Centre-Forward"
+          "overall_score": 66,
+          "position": "Centre-Forward",
+          "potential": 80,
+          "value": 2100000,
+          "yearly_wage": 520000
         }
       ],
       "stadiumName": "MHPArena Stuttgart",
@@ -1192,7 +1508,11 @@
             "Portugal"
           ],
           "number": "40",
-          "position": "Goalkeeper"
+          "overall_score": 71,
+          "position": "Goalkeeper",
+          "potential": 81,
+          "value": 3600000,
+          "yearly_wage": 468000
         },
         {
           "contract": "Jun 30, 2029",
@@ -1206,7 +1526,11 @@
             "Germany"
           ],
           "number": "23",
-          "position": "Goalkeeper"
+          "overall_score": 75,
+          "position": "Goalkeeper",
+          "potential": 75,
+          "value": 3800000,
+          "yearly_wage": 936000
         },
         {
           "contract": "Jun 30, 2026",
@@ -1220,7 +1544,11 @@
             "Germany"
           ],
           "number": "33",
-          "position": "Goalkeeper"
+          "overall_score": 63,
+          "position": "Goalkeeper",
+          "potential": 63,
+          "value": 50000,
+          "yearly_wage": 156000
         },
         {
           "contract": "-",
@@ -1234,7 +1562,11 @@
             "Germany"
           ],
           "number": "39",
-          "position": "Goalkeeper"
+          "overall_score": 60,
+          "position": "Goalkeeper",
+          "potential": 78,
+          "value": 550000,
+          "yearly_wage": 52000
         },
         {
           "contract": "Jun 30, 2029",
@@ -1248,7 +1580,11 @@
             "Belgium"
           ],
           "number": "3",
-          "position": "Centre-Back"
+          "overall_score": 78,
+          "position": "Centre-Back",
+          "potential": 83,
+          "value": 18500000,
+          "yearly_wage": 1560000
         },
         {
           "contract": "Jun 30, 2030",
@@ -1262,7 +1598,11 @@
             "Germany"
           ],
           "number": "4",
-          "position": "Centre-Back"
+          "overall_score": 80,
+          "position": "Centre-Back",
+          "potential": 80,
+          "value": 18000000,
+          "yearly_wage": 2028000
         },
         {
           "contract": "Jun 30, 2030",
@@ -1277,7 +1617,11 @@
             "Nigeria"
           ],
           "number": "34",
-          "position": "Centre-Back"
+          "overall_score": 74,
+          "position": "Centre-Back",
+          "potential": 83,
+          "value": 9000000,
+          "yearly_wage": 936000
         },
         {
           "contract": "Jun 30, 2029",
@@ -1292,7 +1636,11 @@
             "Cameroon"
           ],
           "number": "5",
-          "position": "Centre-Back"
+          "overall_score": 74,
+          "position": "Centre-Back",
+          "potential": 80,
+          "value": 6000000,
+          "yearly_wage": 936000
         },
         {
           "contract": "Jun 30, 2030",
@@ -1307,7 +1655,11 @@
             "United States"
           ],
           "number": "21",
-          "position": "Left-Back"
+          "overall_score": 80,
+          "position": "Left-Back",
+          "potential": 86,
+          "value": 31500000,
+          "yearly_wage": 1664000
         },
         {
           "contract": "Jun 30, 2031",
@@ -1321,7 +1673,11 @@
             "Japan"
           ],
           "number": "26",
-          "position": "Left-Back"
+          "overall_score": 71,
+          "position": "Left-Back",
+          "potential": 81,
+          "value": 3900000,
+          "yearly_wage": 676000
         },
         {
           "contract": "Jun 30, 2029",
@@ -1335,7 +1691,11 @@
             "Denmark"
           ],
           "number": "13",
-          "position": "Right-Back"
+          "overall_score": 79,
+          "position": "Right-Back",
+          "potential": 79,
+          "value": 17000000,
+          "yearly_wage": 1820000
         },
         {
           "contract": "Jun 30, 2028",
@@ -1349,7 +1709,11 @@
             "Germany"
           ],
           "number": "2",
-          "position": "Right-Back"
+          "overall_score": 72,
+          "position": "Right-Back",
+          "potential": 84,
+          "value": 5500000,
+          "yearly_wage": 728000
         },
         {
           "contract": "Jun 30, 2026",
@@ -1364,7 +1728,11 @@
             "Germany"
           ],
           "number": "22",
-          "position": "Right-Back"
+          "overall_score": 64,
+          "position": "Right-Back",
+          "potential": 64,
+          "value": 180000,
+          "yearly_wage": 312000
         },
         {
           "contract": "Jun 30, 2027",
@@ -1379,7 +1747,11 @@
             "France"
           ],
           "number": "15",
-          "position": "Defensive Midfield"
+          "overall_score": 77,
+          "position": "Defensive Midfield",
+          "potential": 77,
+          "value": 9000000,
+          "yearly_wage": 1612000
         },
         {
           "contract": "Jun 30, 2029",
@@ -1393,7 +1765,11 @@
             "Sweden"
           ],
           "number": "16",
-          "position": "Central Midfield"
+          "overall_score": 77,
+          "position": "Central Midfield",
+          "potential": 85,
+          "value": 23500000,
+          "yearly_wage": 1196000
         },
         {
           "contract": "Jun 30, 2028",
@@ -1408,7 +1784,11 @@
             "France"
           ],
           "number": "8",
-          "position": "Central Midfield"
+          "overall_score": 76,
+          "position": "Central Midfield",
+          "potential": 81,
+          "value": 11500000,
+          "yearly_wage": 1352000
         },
         {
           "contract": "Jun 30, 2029",
@@ -1422,7 +1802,11 @@
             "Denmark"
           ],
           "number": "6",
-          "position": "Central Midfield"
+          "overall_score": 74,
+          "position": "Central Midfield",
+          "potential": 84,
+          "value": 9000000,
+          "yearly_wage": 988000
         },
         {
           "contract": "Jun 30, 2026",
@@ -1437,7 +1821,11 @@
             "Germany"
           ],
           "number": "18",
-          "position": "Central Midfield"
+          "overall_score": 73,
+          "position": "Central Midfield",
+          "potential": 73,
+          "value": 3000000,
+          "yearly_wage": 1248000
         },
         {
           "contract": "Jun 30, 2029",
@@ -1452,7 +1840,11 @@
             "Germany"
           ],
           "number": "42",
-          "position": "Attacking Midfield"
+          "overall_score": 78,
+          "position": "Attacking Midfield",
+          "potential": 85,
+          "value": 27500000,
+          "yearly_wage": 1248000
         },
         {
           "contract": "Jun 30, 2028",
@@ -1466,7 +1858,11 @@
             "Sweden"
           ],
           "number": "31",
-          "position": "Attacking Midfield"
+          "overall_score": 65,
+          "position": "Attacking Midfield",
+          "potential": 80,
+          "value": 1600000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2026",
@@ -1480,7 +1876,11 @@
             "Germany"
           ],
           "number": "27",
-          "position": "Attacking Midfield"
+          "overall_score": 78,
+          "position": "Attacking Midfield",
+          "potential": 78,
+          "value": 8500000,
+          "yearly_wage": 1820000
         },
         {
           "contract": "Jun 30, 2029",
@@ -1495,7 +1895,11 @@
             "Cameroon"
           ],
           "number": "19",
-          "position": "Left Winger"
+          "overall_score": 75,
+          "position": "Left Winger",
+          "potential": 85,
+          "value": 12500000,
+          "yearly_wage": 1092000
         },
         {
           "contract": "Jun 30, 2030",
@@ -1509,7 +1913,11 @@
             "Japan"
           ],
           "number": "20",
-          "position": "Right Winger"
+          "overall_score": 81,
+          "position": "Right Winger",
+          "potential": 81,
+          "value": 27500000,
+          "yearly_wage": 2184000
         },
         {
           "contract": "Jun 30, 2028",
@@ -1524,7 +1932,11 @@
             "Ghana"
           ],
           "number": "7",
-          "position": "Right Winger"
+          "overall_score": 77,
+          "position": "Right Winger",
+          "potential": 81,
+          "value": 15000000,
+          "yearly_wage": 1404000
         },
         {
           "contract": "Jun 30, 2031",
@@ -1539,7 +1951,11 @@
             "Spain"
           ],
           "number": "29",
-          "position": "Right Winger"
+          "overall_score": 70,
+          "position": "Right Winger",
+          "potential": 83,
+          "value": 3800000,
+          "yearly_wage": 676000
         },
         {
           "contract": "Jun 30, 2030",
@@ -1553,7 +1969,11 @@
             "Germany"
           ],
           "number": "9",
-          "position": "Centre-Forward"
+          "overall_score": 82,
+          "position": "Centre-Forward",
+          "potential": 85,
+          "value": 42000000,
+          "yearly_wage": 2236000
         },
         {
           "contract": "Jun 30, 2026",
@@ -1568,7 +1988,11 @@
             "DR Congo"
           ],
           "number": "25",
-          "position": "Centre-Forward"
+          "overall_score": 78,
+          "position": "Centre-Forward",
+          "potential": 82,
+          "value": 20500000,
+          "yearly_wage": 4004000
         },
         {
           "contract": "Jun 30, 2031",
@@ -1583,7 +2007,11 @@
             "Morocco"
           ],
           "number": "11",
-          "position": "Centre-Forward"
+          "overall_score": 70,
+          "position": "Centre-Forward",
+          "potential": 78,
+          "value": 3600000,
+          "yearly_wage": 728000
         },
         {
           "contract": "Jun 30, 2027",
@@ -1598,7 +2026,11 @@
             "DR Congo"
           ],
           "number": "30",
-          "position": "Centre-Forward"
+          "overall_score": 74,
+          "position": "Centre-Forward",
+          "potential": 74,
+          "value": 3600000,
+          "yearly_wage": 1508000
         }
       ],
       "stadiumName": "Deutsche Bank Park",
@@ -1621,7 +2053,11 @@
             "Norway"
           ],
           "number": "12",
-          "position": "Goalkeeper"
+          "overall_score": 70,
+          "position": "Goalkeeper",
+          "potential": 79,
+          "value": 3100000,
+          "yearly_wage": 364000
         },
         {
           "contract": "Jun 30, 2026",
@@ -1636,7 +2072,11 @@
             "Germany"
           ],
           "number": "1",
-          "position": "Goalkeeper"
+          "overall_score": 78,
+          "position": "Goalkeeper",
+          "potential": 78,
+          "value": 7000000,
+          "yearly_wage": 936000
         },
         {
           "contract": "Jun 30, 2027",
@@ -1650,7 +2090,11 @@
             "Germany"
           ],
           "number": "40",
-          "position": "Goalkeeper"
+          "overall_score": 57,
+          "position": "Goalkeeper",
+          "potential": 68,
+          "value": 300000,
+          "yearly_wage": 52000
         },
         {
           "contract": "Jun 30, 2028",
@@ -1663,7 +2107,11 @@
             "Germany"
           ],
           "number": "41",
-          "position": "Goalkeeper"
+          "overall_score": 57,
+          "position": "Goalkeeper",
+          "potential": 77,
+          "value": 400000,
+          "yearly_wage": 26000
         },
         {
           "contract": "Jun 30, 2026",
@@ -1677,7 +2125,11 @@
             "Croatia"
           ],
           "number": "44",
-          "position": "Centre-Back"
+          "overall_score": 78,
+          "position": "Centre-Back",
+          "potential": 88,
+          "value": 27500000,
+          "yearly_wage": 2756000
         },
         {
           "contract": "Jun 30, 2028",
@@ -1692,7 +2144,11 @@
             "Germany"
           ],
           "number": "25",
-          "position": "Centre-Back"
+          "overall_score": 74,
+          "position": "Centre-Back",
+          "potential": 74,
+          "value": 3900000,
+          "yearly_wage": 1092000
         },
         {
           "contract": "Jun 30, 2028",
@@ -1707,7 +2163,11 @@
             "Germany"
           ],
           "number": "8",
-          "position": "Centre-Back"
+          "overall_score": 72,
+          "position": "Centre-Back",
+          "potential": 73,
+          "value": 2200000,
+          "yearly_wage": 936000
         },
         {
           "contract": "Jun 30, 2030",
@@ -1722,7 +2182,11 @@
             "France"
           ],
           "number": "17",
-          "position": "Centre-Back"
+          "overall_score": 72,
+          "position": "Centre-Back",
+          "potential": 76,
+          "value": 2900000,
+          "yearly_wage": 832000
         },
         {
           "contract": "Jun 30, 2026",
@@ -1735,7 +2199,11 @@
             "Germany"
           ],
           "number": "43",
-          "position": "Centre-Back"
+          "overall_score": 59,
+          "position": "Centre-Back",
+          "potential": 73,
+          "value": 500000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2027",
@@ -1749,7 +2217,11 @@
             "Switzerland"
           ],
           "number": "28",
-          "position": "Left-Back"
+          "overall_score": 75,
+          "position": "Left-Back",
+          "potential": 75,
+          "value": 5500000,
+          "yearly_wage": 1144000
         },
         {
           "contract": "Jun 30, 2027",
@@ -1763,7 +2235,11 @@
             "Germany"
           ],
           "number": "3",
-          "position": "Left-Back"
+          "overall_score": 68,
+          "position": "Left-Back",
+          "potential": 73,
+          "value": 1700000,
+          "yearly_wage": 520000
         },
         {
           "contract": "-",
@@ -1789,7 +2265,11 @@
             "Georgia"
           ],
           "number": "16",
-          "position": "Right-Back"
+          "overall_score": 70,
+          "position": "Right-Back",
+          "potential": 74,
+          "value": 2100000,
+          "yearly_wage": 520000
         },
         {
           "contract": "Jun 30, 2026",
@@ -1803,7 +2283,11 @@
             "France"
           ],
           "number": "2",
-          "position": "Right-Back"
+          "overall_score": 69,
+          "position": "Right-Back",
+          "potential": 80,
+          "value": 3000000,
+          "yearly_wage": 468000
         },
         {
           "contract": "Jun 30, 2028",
@@ -1817,7 +2301,11 @@
             "Germany"
           ],
           "number": "21",
-          "position": "Defensive Midfield"
+          "overall_score": 73,
+          "position": "Defensive Midfield",
+          "potential": 76,
+          "value": 4000000,
+          "yearly_wage": 988000
         },
         {
           "contract": "Jun 30, 2028",
@@ -1832,7 +2320,11 @@
             "DR Congo"
           ],
           "number": "6",
-          "position": "Central Midfield"
+          "overall_score": 76,
+          "position": "Central Midfield",
+          "potential": 78,
+          "value": 9500000,
+          "yearly_wage": 1196000
         },
         {
           "contract": "Jun 30, 2028",
@@ -1847,7 +2339,11 @@
             "Italy"
           ],
           "number": "24",
-          "position": "Central Midfield"
+          "overall_score": 73,
+          "position": "Central Midfield",
+          "potential": 74,
+          "value": 3600000,
+          "yearly_wage": 1040000
         },
         {
           "contract": "Jun 30, 2026",
@@ -1861,7 +2357,11 @@
             "Portugal"
           ],
           "number": "20",
-          "position": "Attacking Midfield"
+          "overall_score": 77,
+          "position": "Attacking Midfield",
+          "potential": 81,
+          "value": 14500000,
+          "yearly_wage": 4940000
         },
         {
           "contract": "Jun 30, 2026",
@@ -1890,7 +2390,11 @@
             "Germany"
           ],
           "number": "39",
-          "position": "Attacking Midfield"
+          "overall_score": 58,
+          "position": "Attacking Midfield",
+          "potential": 76,
+          "value": 525000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2026",
@@ -1904,7 +2408,11 @@
             "Nigeria"
           ],
           "number": "27",
-          "position": "Left Winger"
+          "overall_score": 73,
+          "position": "Left Winger",
+          "potential": 73,
+          "value": 3300000,
+          "yearly_wage": 936000
         },
         {
           "contract": "Jun 30, 2030",
@@ -1918,7 +2426,11 @@
             "Norway"
           ],
           "number": "38",
-          "position": "Left Winger"
+          "overall_score": 63,
+          "position": "Left Winger",
+          "potential": 80,
+          "value": 1200000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2027",
@@ -1933,7 +2445,11 @@
             "Cote d'Ivoire"
           ],
           "number": "7",
-          "position": "Left Winger"
+          "overall_score": 74,
+          "position": "Left Winger",
+          "potential": 74,
+          "value": 4100000,
+          "yearly_wage": 1248000
         },
         {
           "contract": "Jun 30, 2029",
@@ -1948,7 +2464,11 @@
             "Germany"
           ],
           "number": "45",
-          "position": "Left Winger"
+          "overall_score": 66,
+          "position": "Left Winger",
+          "potential": 77,
+          "value": 1800000,
+          "yearly_wage": 364000
         },
         {
           "contract": "Jun 30, 2029",
@@ -1962,7 +2482,11 @@
             "France"
           ],
           "number": "14",
-          "position": "Right Winger"
+          "overall_score": 72,
+          "position": "Right Winger",
+          "potential": 77,
+          "value": 3600000,
+          "yearly_wage": 884000
         },
         {
           "contract": "Jun 30, 2029",
@@ -1976,7 +2500,11 @@
             "The Gambia"
           ],
           "number": "18",
-          "position": "Right Winger"
+          "overall_score": 69,
+          "position": "Right Winger",
+          "potential": 69,
+          "value": 1500000,
+          "yearly_wage": 676000
         },
         {
           "contract": "Jun 30, 2026",
@@ -1991,7 +2519,11 @@
             "Germany"
           ],
           "number": "19",
-          "position": "Centre-Forward"
+          "overall_score": 70,
+          "position": "Centre-Forward",
+          "potential": 80,
+          "value": 3500000,
+          "yearly_wage": 1300000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2006,7 +2538,11 @@
             "Germany"
           ],
           "number": "11",
-          "position": "Centre-Forward"
+          "overall_score": 70,
+          "position": "Centre-Forward",
+          "potential": 77,
+          "value": 3200000,
+          "yearly_wage": 728000
         },
         {
           "contract": "Jun 30, 2028",
@@ -2020,7 +2556,11 @@
             "Germany"
           ],
           "number": "49",
-          "position": "Centre-Forward"
+          "overall_score": 64,
+          "position": "Centre-Forward",
+          "potential": 81,
+          "value": 1500000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2027",
@@ -2035,7 +2575,11 @@
             "Eritrea"
           ],
           "number": "9",
-          "position": "Centre-Forward"
+          "overall_score": 72,
+          "position": "Centre-Forward",
+          "potential": 72,
+          "value": 2000000,
+          "yearly_wage": 1040000
         },
         {
           "contract": "Jun 30, 2027",
@@ -2050,7 +2594,11 @@
             "Tanzania"
           ],
           "number": "15",
-          "position": "Centre-Forward"
+          "overall_score": 72,
+          "position": "Centre-Forward",
+          "potential": 72,
+          "value": 2000000,
+          "yearly_wage": 1040000
         }
       ],
       "stadiumName": "Volksparkstadion",
@@ -2073,7 +2621,11 @@
             "Germany"
           ],
           "number": "33",
-          "position": "Goalkeeper"
+          "overall_score": 77,
+          "position": "Goalkeeper",
+          "potential": 79,
+          "value": 9500000,
+          "yearly_wage": 936000
         },
         {
           "contract": "-",
@@ -2088,7 +2640,11 @@
             "Portugal"
           ],
           "number": "42",
-          "position": "Goalkeeper"
+          "overall_score": 67,
+          "position": "Goalkeeper",
+          "potential": 82,
+          "value": 2100000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2027",
@@ -2102,7 +2658,11 @@
             "Germany"
           ],
           "number": "23",
-          "position": "Goalkeeper"
+          "overall_score": 67,
+          "position": "Goalkeeper",
+          "potential": 74,
+          "value": 1700000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2116,7 +2676,11 @@
             "Germany"
           ],
           "number": "21",
-          "position": "Goalkeeper"
+          "overall_score": 64,
+          "position": "Goalkeeper",
+          "potential": 64,
+          "value": 60000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2027",
@@ -2130,7 +2694,11 @@
             "Switzerland"
           ],
           "number": "30",
-          "position": "Centre-Back"
+          "overall_score": 76,
+          "position": "Centre-Back",
+          "potential": 76,
+          "value": 6500000,
+          "yearly_wage": 1404000
         },
         {
           "contract": "Jun 30, 2030",
@@ -2145,7 +2713,11 @@
             "Netherlands"
           ],
           "number": "4",
-          "position": "Centre-Back"
+          "overall_score": 76,
+          "position": "Centre-Back",
+          "potential": 77,
+          "value": 7000000,
+          "yearly_wage": 1404000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2159,7 +2731,11 @@
             "Japan"
           ],
           "number": "14",
-          "position": "Centre-Back"
+          "overall_score": 72,
+          "position": "Centre-Back",
+          "potential": 79,
+          "value": 4300000,
+          "yearly_wage": 2028000
         },
         {
           "contract": "Jun 30, 2027",
@@ -2174,7 +2750,11 @@
             "Germany"
           ],
           "number": "2",
-          "position": "Centre-Back"
+          "overall_score": 69,
+          "position": "Centre-Back",
+          "potential": 79,
+          "value": 2900000,
+          "yearly_wage": 520000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2188,7 +2768,11 @@
             "Germany"
           ],
           "number": "5",
-          "position": "Centre-Back"
+          "overall_score": 72,
+          "position": "Centre-Back",
+          "potential": 72,
+          "value": 2000000,
+          "yearly_wage": 1040000
         },
         {
           "contract": "Jun 30, 2029",
@@ -2202,7 +2786,11 @@
             "Germany"
           ],
           "number": "26",
-          "position": "Left-Back"
+          "overall_score": 73,
+          "position": "Left-Back",
+          "potential": 79,
+          "value": 4600000,
+          "yearly_wage": 780000
         },
         {
           "contract": "Jun 30, 2027",
@@ -2216,7 +2804,11 @@
             "United States"
           ],
           "number": "29",
-          "position": "Right-Back"
+          "overall_score": 75,
+          "position": "Right-Back",
+          "potential": 78,
+          "value": 7000000,
+          "yearly_wage": 1092000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2230,7 +2822,11 @@
             "Germany"
           ],
           "number": "6",
-          "position": "Defensive Midfield"
+          "overall_score": 73,
+          "position": "Defensive Midfield",
+          "potential": 76,
+          "value": 3800000,
+          "yearly_wage": 2392000
         },
         {
           "contract": "Jun 30, 2027",
@@ -2244,7 +2840,11 @@
             "Germany"
           ],
           "number": "39",
-          "position": "Defensive Midfield"
+          "overall_score": 60,
+          "position": "Defensive Midfield",
+          "potential": 80,
+          "value": 650000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2028",
@@ -2258,7 +2858,11 @@
             "Germany"
           ],
           "number": "27",
-          "position": "Central Midfield"
+          "overall_score": 77,
+          "position": "Central Midfield",
+          "potential": 83,
+          "value": 16500000,
+          "yearly_wage": 1300000
         },
         {
           "contract": "Jun 30, 2029",
@@ -2273,7 +2877,11 @@
             "Germany"
           ],
           "number": "17",
-          "position": "Central Midfield"
+          "overall_score": 74,
+          "position": "Central Midfield",
+          "potential": 81,
+          "value": 8500000,
+          "yearly_wage": 936000
         },
         {
           "contract": "Jun 30, 2028",
@@ -2287,7 +2895,11 @@
             "Germany"
           ],
           "number": "16",
-          "position": "Central Midfield"
+          "overall_score": 75,
+          "position": "Central Midfield",
+          "potential": 76,
+          "value": 6000000,
+          "yearly_wage": 1248000
         },
         {
           "contract": "Jun 30, 2027",
@@ -2301,7 +2913,11 @@
             "Germany"
           ],
           "number": "10",
-          "position": "Central Midfield"
+          "overall_score": 75,
+          "position": "Central Midfield",
+          "potential": 75,
+          "value": 5500000,
+          "yearly_wage": 1404000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2315,7 +2931,11 @@
             "Sweden"
           ],
           "number": "38",
-          "position": "Left Midfield"
+          "overall_score": 71,
+          "position": "Left Midfield",
+          "potential": 77,
+          "value": 3000000,
+          "yearly_wage": 312000
         },
         {
           "contract": "Jun 30, 2028",
@@ -2330,7 +2950,11 @@
             "Portugal"
           ],
           "number": "13",
-          "position": "Attacking Midfield"
+          "overall_score": 73,
+          "position": "Attacking Midfield",
+          "potential": 78,
+          "value": 4700000,
+          "yearly_wage": 988000
         },
         {
           "contract": "Jun 30, 2027",
@@ -2344,7 +2968,11 @@
             "Austria"
           ],
           "number": "7",
-          "position": "Attacking Midfield"
+          "overall_score": 74,
+          "position": "Attacking Midfield",
+          "potential": 74,
+          "value": 3500000,
+          "yearly_wage": 1300000
         },
         {
           "contract": "-",
@@ -2359,7 +2987,11 @@
             "Morocco"
           ],
           "number": "36",
-          "position": "Attacking Midfield"
+          "overall_score": 70,
+          "position": "Attacking Midfield",
+          "potential": 85,
+          "value": 3600000,
+          "yearly_wage": 468000
         },
         {
           "contract": "Jun 30, 2029",
@@ -2373,7 +3005,11 @@
             "Germany"
           ],
           "number": "25",
-          "position": "Left Winger"
+          "overall_score": 77,
+          "position": "Left Winger",
+          "potential": 77,
+          "value": 11500000,
+          "yearly_wage": 1508000
         },
         {
           "contract": "Jun 30, 2029",
@@ -2387,7 +3023,11 @@
             "France"
           ],
           "number": "9",
-          "position": "Right Winger"
+          "overall_score": 80,
+          "position": "Right Winger",
+          "potential": 80,
+          "value": 21000000,
+          "yearly_wage": 1924000
         },
         {
           "contract": "Jun 30, 2027",
@@ -2402,7 +3042,11 @@
             "France"
           ],
           "number": "19",
-          "position": "Right Winger"
+          "overall_score": 72,
+          "position": "Right Winger",
+          "potential": 73,
+          "value": 2800000,
+          "yearly_wage": 988000
         },
         {
           "contract": "Jun 30, 2029",
@@ -2416,7 +3060,11 @@
             "Germany"
           ],
           "number": "11",
-          "position": "Centre-Forward"
+          "overall_score": 80,
+          "position": "Centre-Forward",
+          "potential": 80,
+          "value": 21000000,
+          "yearly_wage": 2080000
         },
         {
           "contract": "Jun 30, 2029",
@@ -2430,7 +3078,11 @@
             "Japan"
           ],
           "number": "18",
-          "position": "Centre-Forward"
+          "overall_score": 73,
+          "position": "Centre-Forward",
+          "potential": 76,
+          "value": 4100000,
+          "yearly_wage": 1144000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2445,7 +3097,11 @@
             "Switzerland"
           ],
           "number": "15",
-          "position": "Centre-Forward"
+          "overall_score": 75,
+          "position": "Centre-Forward",
+          "potential": 75,
+          "value": 4800000,
+          "yearly_wage": 1820000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2460,7 +3116,11 @@
             "Italy"
           ],
           "number": "8",
-          "position": "Centre-Forward"
+          "overall_score": 64,
+          "position": "Centre-Forward",
+          "potential": 81,
+          "value": 1500000,
+          "yearly_wage": 624000
         },
         {
           "contract": "Jun 30, 2027",
@@ -2474,7 +3134,11 @@
             "Germany"
           ],
           "number": "40",
-          "position": "Centre-Forward"
+          "overall_score": 62,
+          "position": "Centre-Forward",
+          "potential": 74,
+          "value": 975000,
+          "yearly_wage": 260000
         }
       ],
       "stadiumName": "Stadion im Borussia-Park",
@@ -2497,7 +3161,11 @@
             "Germany"
           ],
           "number": "1",
-          "position": "Goalkeeper"
+          "overall_score": 78,
+          "position": "Goalkeeper",
+          "potential": 78,
+          "value": 9500000,
+          "yearly_wage": 936000
         },
         {
           "contract": "Jun 30, 2027",
@@ -2511,7 +3179,11 @@
             "Germany"
           ],
           "number": "20",
-          "position": "Goalkeeper"
+          "overall_score": 74,
+          "position": "Goalkeeper",
+          "potential": 74,
+          "value": 475000,
+          "yearly_wage": 468000
         },
         {
           "contract": "Jun 30, 2027",
@@ -2525,7 +3197,11 @@
             "Germany"
           ],
           "number": "44",
-          "position": "Goalkeeper"
+          "overall_score": 56,
+          "position": "Goalkeeper",
+          "potential": 59,
+          "value": 130000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2030",
@@ -2539,7 +3215,11 @@
             "Netherlands"
           ],
           "number": "33",
-          "position": "Centre-Back"
+          "overall_score": 71,
+          "position": "Centre-Back",
+          "potential": 82,
+          "value": 3800000,
+          "yearly_wage": 572000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2553,7 +3233,11 @@
             "England"
           ],
           "number": "22",
-          "position": "Centre-Back"
+          "overall_score": 68,
+          "position": "Centre-Back",
+          "potential": 79,
+          "value": 2400000,
+          "yearly_wage": 1352000
         },
         {
           "contract": "Jun 30, 2029",
@@ -2567,7 +3251,11 @@
             "Switzerland"
           ],
           "number": "2",
-          "position": "Centre-Back"
+          "overall_score": 72,
+          "position": "Centre-Back",
+          "potential": 74,
+          "value": 2600000,
+          "yearly_wage": 884000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2581,7 +3269,11 @@
             "Germany"
           ],
           "number": "4",
-          "position": "Centre-Back"
+          "overall_score": 72,
+          "position": "Centre-Back",
+          "potential": 73,
+          "value": 2200000,
+          "yearly_wage": 936000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2595,7 +3287,11 @@
             "Türkiye"
           ],
           "number": "39",
-          "position": "Centre-Back"
+          "overall_score": 71,
+          "position": "Centre-Back",
+          "potential": 76,
+          "value": 2600000,
+          "yearly_wage": 988000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2609,7 +3305,11 @@
             "Germany"
           ],
           "number": "3",
-          "position": "Centre-Back"
+          "overall_score": 72,
+          "position": "Centre-Back",
+          "potential": 72,
+          "value": 1600000,
+          "yearly_wage": 936000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2623,7 +3323,11 @@
             "Germany"
           ],
           "number": "15",
-          "position": "Centre-Back"
+          "overall_score": 68,
+          "position": "Centre-Back",
+          "potential": 69,
+          "value": 1300000,
+          "yearly_wage": 520000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2638,7 +3342,11 @@
             "Denmark"
           ],
           "number": "32",
-          "position": "Left-Back"
+          "overall_score": 72,
+          "position": "Left-Back",
+          "potential": 79,
+          "value": 4500000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2028",
@@ -2652,7 +3360,11 @@
             "Norway"
           ],
           "number": "28",
-          "position": "Right-Back"
+          "overall_score": 73,
+          "position": "Right-Back",
+          "potential": 76,
+          "value": 3700000,
+          "yearly_wage": 936000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2666,7 +3378,11 @@
             "Germany"
           ],
           "number": "6",
-          "position": "Defensive Midfield"
+          "overall_score": 76,
+          "position": "Defensive Midfield",
+          "potential": 81,
+          "value": 10500000,
+          "yearly_wage": 1040000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2680,7 +3396,11 @@
             "Germany"
           ],
           "number": "5",
-          "position": "Defensive Midfield"
+          "overall_score": 74,
+          "position": "Defensive Midfield",
+          "potential": 77,
+          "value": 5000000,
+          "yearly_wage": 1040000
         },
         {
           "contract": "Jun 30, 2028",
@@ -2695,7 +3415,11 @@
             "Morocco"
           ],
           "number": "34",
-          "position": "Defensive Midfield"
+          "overall_score": 60,
+          "position": "Defensive Midfield",
+          "potential": 77,
+          "value": 600000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2030",
@@ -2710,7 +3434,11 @@
             "England"
           ],
           "number": "18",
-          "position": "Central Midfield"
+          "overall_score": 74,
+          "position": "Central Midfield",
+          "potential": 81,
+          "value": 8500000,
+          "yearly_wage": 988000
         },
         {
           "contract": "Jun 30, 2027",
@@ -2725,7 +3453,11 @@
             "Germany"
           ],
           "number": "8",
-          "position": "Central Midfield"
+          "overall_score": 72,
+          "position": "Central Midfield",
+          "potential": 77,
+          "value": 3500000,
+          "yearly_wage": 832000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2740,7 +3472,11 @@
             "Germany"
           ],
           "number": "27",
-          "position": "Central Midfield"
+          "overall_score": 62,
+          "position": "Central Midfield",
+          "potential": 80,
+          "value": 1000000,
+          "yearly_wage": 364000
         },
         {
           "contract": "Jun 30, 2028",
@@ -2755,7 +3491,11 @@
             "Spain"
           ],
           "number": "17",
-          "position": "Right Midfield"
+          "overall_score": 75,
+          "position": "Right Midfield",
+          "potential": 75,
+          "value": 5500000,
+          "yearly_wage": 1248000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2769,7 +3509,11 @@
             "Austria"
           ],
           "number": "11",
-          "position": "Attacking Midfield"
+          "overall_score": 72,
+          "position": "Attacking Midfield",
+          "potential": 72,
+          "value": 1900000,
+          "yearly_wage": 988000
         },
         {
           "contract": "Jun 30, 2030",
@@ -2783,7 +3527,11 @@
             "Germany"
           ],
           "number": "13",
-          "position": "Left Winger"
+          "overall_score": 76,
+          "position": "Left Winger",
+          "potential": 87,
+          "value": 16000000,
+          "yearly_wage": 832000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2797,7 +3545,11 @@
             "Poland"
           ],
           "number": "16",
-          "position": "Left Winger"
+          "overall_score": 77,
+          "position": "Left Winger",
+          "potential": 82,
+          "value": 16000000,
+          "yearly_wage": 1924000
         },
         {
           "contract": "-",
@@ -2812,7 +3564,11 @@
             "Kenya"
           ],
           "number": "37",
-          "position": "Left Winger"
+          "overall_score": 73,
+          "position": "Left Winger",
+          "potential": 74,
+          "value": 3600000,
+          "yearly_wage": 1040000
         },
         {
           "contract": "Jun 30, 2027",
@@ -2826,7 +3582,11 @@
             "Germany"
           ],
           "number": "30",
-          "position": "Left Winger"
+          "overall_score": 75,
+          "position": "Left Winger",
+          "potential": 75,
+          "value": 4600000,
+          "yearly_wage": 1352000
         },
         {
           "contract": "Jun 30, 2028",
@@ -2840,7 +3600,11 @@
             "Germany"
           ],
           "number": "29",
-          "position": "Right Winger"
+          "overall_score": 72,
+          "position": "Right Winger",
+          "potential": 77,
+          "value": 3500000,
+          "yearly_wage": 832000
         },
         {
           "contract": "Jun 30, 2027",
@@ -2855,7 +3619,11 @@
             "Senegal"
           ],
           "number": "38",
-          "position": "Right Winger"
+          "overall_score": 62,
+          "position": "Right Winger",
+          "potential": 79,
+          "value": 1000000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2029",
@@ -2870,7 +3638,11 @@
             "Ghana"
           ],
           "number": "9",
-          "position": "Centre-Forward"
+          "overall_score": 74,
+          "position": "Centre-Forward",
+          "potential": 75,
+          "value": 5000000,
+          "yearly_wage": 1196000
         },
         {
           "contract": "Jun 30, 2027",
@@ -2884,7 +3656,11 @@
             "Germany"
           ],
           "number": "7",
-          "position": "Centre-Forward"
+          "overall_score": 73,
+          "position": "Centre-Forward",
+          "potential": 73,
+          "value": 3000000,
+          "yearly_wage": 1092000
         },
         {
           "contract": "Jun 30, 2030",
@@ -2899,7 +3675,11 @@
             "France"
           ],
           "number": "40",
-          "position": "Centre-Forward"
+          "overall_score": 62,
+          "position": "Centre-Forward",
+          "potential": 79,
+          "value": 1000000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2030",
@@ -2913,7 +3693,11 @@
             "Germany"
           ],
           "number": "19",
-          "position": "Centre-Forward"
+          "overall_score": 59,
+          "position": "Centre-Forward",
+          "potential": 71,
+          "value": 550000,
+          "yearly_wage": 156000
         }
       ],
       "stadiumName": "RheinEnergieSTADION",
@@ -2936,7 +3720,11 @@
             "Belgium"
           ],
           "number": "26",
-          "position": "Goalkeeper"
+          "overall_score": 77,
+          "position": "Goalkeeper",
+          "potential": 85,
+          "value": 20000000,
+          "yearly_wage": 1196000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2950,7 +3738,11 @@
             "Hungary"
           ],
           "number": "1",
-          "position": "Goalkeeper"
+          "overall_score": 84,
+          "position": "Goalkeeper",
+          "potential": 84,
+          "value": 4700000,
+          "yearly_wage": 1664000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2964,7 +3756,11 @@
             "Germany"
           ],
           "number": "25",
-          "position": "Goalkeeper"
+          "overall_score": 69,
+          "position": "Goalkeeper",
+          "potential": 69,
+          "value": 750000,
+          "yearly_wage": 780000
         },
         {
           "contract": "Jun 30, 2029",
@@ -2979,7 +3775,11 @@
             "Angola"
           ],
           "number": "23",
-          "position": "Centre-Back"
+          "overall_score": 81,
+          "position": "Centre-Back",
+          "potential": 87,
+          "value": 37500000,
+          "yearly_wage": 2704000
         },
         {
           "contract": "Jun 30, 2029",
@@ -2994,7 +3794,11 @@
             "DR Congo"
           ],
           "number": "5",
-          "position": "Centre-Back"
+          "overall_score": 75,
+          "position": "Centre-Back",
+          "potential": 85,
+          "value": 11500000,
+          "yearly_wage": 1508000
         },
         {
           "contract": "Jun 30, 2027",
@@ -3009,7 +3813,11 @@
             "Germany"
           ],
           "number": "4",
-          "position": "Centre-Back"
+          "overall_score": 83,
+          "position": "Centre-Back",
+          "potential": 83,
+          "value": 23500000,
+          "yearly_wage": 3848000
         },
         {
           "contract": "Jun 30, 2028",
@@ -3023,7 +3831,11 @@
             "Germany"
           ],
           "number": "16",
-          "position": "Centre-Back"
+          "overall_score": 76,
+          "position": "Centre-Back",
+          "potential": 77,
+          "value": 7000000,
+          "yearly_wage": 2288000
         },
         {
           "contract": "Jun 30, 2028",
@@ -3036,7 +3848,11 @@
           "nationality": [
             "Norway"
           ],
-          "position": "Centre-Back"
+          "overall_score": 61,
+          "position": "Centre-Back",
+          "potential": 77,
+          "value": 775000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2027",
@@ -3050,7 +3866,11 @@
             "Germany"
           ],
           "number": "22",
-          "position": "Left-Back"
+          "overall_score": 83,
+          "position": "Left-Back",
+          "potential": 83,
+          "value": 35000000,
+          "yearly_wage": 3692000
         },
         {
           "contract": "Jun 30, 2030",
@@ -3064,7 +3884,11 @@
             "Germany"
           ],
           "number": "35",
-          "position": "Left-Back"
+          "overall_score": 70,
+          "position": "Left-Back",
+          "potential": 81,
+          "value": 3400000,
+          "yearly_wage": 936000
         },
         {
           "contract": "Jun 30, 2027",
@@ -3079,7 +3903,11 @@
             "DR Congo"
           ],
           "number": "17",
-          "position": "Right-Back"
+          "overall_score": 79,
+          "position": "Right-Back",
+          "potential": 79,
+          "value": 17000000,
+          "yearly_wage": 2756000
         },
         {
           "contract": "Jun 30, 2028",
@@ -3094,7 +3922,11 @@
             "Ghana"
           ],
           "number": "39",
-          "position": "Right-Back"
+          "overall_score": 80,
+          "position": "Right-Back",
+          "potential": 80,
+          "value": 19000000,
+          "yearly_wage": 3016000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3108,7 +3940,11 @@
             "Serbia"
           ],
           "number": "19",
-          "position": "Right-Back"
+          "overall_score": 72,
+          "position": "Right-Back",
+          "potential": 83,
+          "value": 4800000,
+          "yearly_wage": 2028000
         },
         {
           "contract": "Jun 30, 2028",
@@ -3122,7 +3958,11 @@
             "Austria"
           ],
           "number": "13",
-          "position": "Defensive Midfield"
+          "overall_score": 80,
+          "position": "Defensive Midfield",
+          "potential": 85,
+          "value": 29000000,
+          "yearly_wage": 2496000
         },
         {
           "contract": "Jun 30, 2029",
@@ -3137,7 +3977,11 @@
             "Burkina Faso"
           ],
           "number": "20",
-          "position": "Central Midfield"
+          "overall_score": 74,
+          "position": "Central Midfield",
+          "potential": 87,
+          "value": 10000000,
+          "yearly_wage": 1404000
         },
         {
           "contract": "Jun 30, 2030",
@@ -3152,7 +3996,11 @@
             "DR Congo"
           ],
           "number": "6",
-          "position": "Central Midfield"
+          "overall_score": 73,
+          "position": "Central Midfield",
+          "potential": 85,
+          "value": 7500000,
+          "yearly_wage": 1352000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3166,7 +4014,11 @@
             "Austria"
           ],
           "number": "24",
-          "position": "Central Midfield"
+          "overall_score": 78,
+          "position": "Central Midfield",
+          "potential": 79,
+          "value": 14500000,
+          "yearly_wage": 2496000
         },
         {
           "contract": "Jun 30, 2027",
@@ -3193,7 +4045,11 @@
             "Austria"
           ],
           "number": "14",
-          "position": "Attacking Midfield"
+          "overall_score": 81,
+          "position": "Attacking Midfield",
+          "potential": 83,
+          "value": 32500000,
+          "yearly_wage": 3172000
         },
         {
           "contract": "Jun 30, 2030",
@@ -3207,7 +4063,11 @@
             "Serbia"
           ],
           "number": "33",
-          "position": "Attacking Midfield"
+          "overall_score": 71,
+          "position": "Attacking Midfield",
+          "potential": 81,
+          "value": 4000000,
+          "yearly_wage": 1092000
         },
         {
           "contract": "Jun 30, 2028",
@@ -3221,7 +4081,11 @@
             "Germany"
           ],
           "number": "47",
-          "position": "Attacking Midfield"
+          "overall_score": 63,
+          "position": "Attacking Midfield",
+          "potential": 80,
+          "value": 1200000,
+          "yearly_wage": 312000
         },
         {
           "contract": "Jun 30, 2030",
@@ -3235,7 +4099,11 @@
             "Cote d'Ivoire"
           ],
           "number": "49",
-          "position": "Left Winger"
+          "overall_score": 81,
+          "position": "Left Winger",
+          "potential": 89,
+          "value": 54500000,
+          "yearly_wage": 2340000
         },
         {
           "contract": "Jun 30, 2029",
@@ -3250,7 +4118,11 @@
             "Nigeria"
           ],
           "number": "7",
-          "position": "Left Winger"
+          "overall_score": 78,
+          "position": "Left Winger",
+          "potential": 88,
+          "value": 31000000,
+          "yearly_wage": 2080000
         },
         {
           "contract": "Jun 30, 2029",
@@ -3265,7 +4137,11 @@
             "Senegal"
           ],
           "number": "27",
-          "position": "Left Winger"
+          "overall_score": 70,
+          "position": "Left Winger",
+          "potential": 85,
+          "value": 3700000,
+          "yearly_wage": 884000
         },
         {
           "contract": "Jun 30, 2031",
@@ -3279,7 +4155,11 @@
             "Nigeria"
           ],
           "number": "18",
-          "position": "Left Winger"
+          "overall_score": 68,
+          "position": "Left Winger",
+          "potential": 83,
+          "value": 2800000,
+          "yearly_wage": 780000
         },
         {
           "contract": "Jun 30, 2031",
@@ -3294,7 +4174,11 @@
             "Nigeria"
           ],
           "number": "21",
-          "position": "Left Winger"
+          "overall_score": 64,
+          "position": "Left Winger",
+          "potential": 84,
+          "value": 1600000,
+          "yearly_wage": 364000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3309,7 +4193,11 @@
             "Albania"
           ],
           "number": "10",
-          "position": "Right Winger"
+          "overall_score": 75,
+          "position": "Right Winger",
+          "potential": 85,
+          "value": 12500000,
+          "yearly_wage": 2652000
         },
         {
           "contract": "Jun 30, 2030",
@@ -3324,7 +4212,11 @@
             "Cote d'Ivoire"
           ],
           "number": "9",
-          "position": "Right Winger"
+          "overall_score": 77,
+          "position": "Right Winger",
+          "potential": 84,
+          "value": 21500000,
+          "yearly_wage": 2288000
         },
         {
           "contract": "Jun 30, 2030",
@@ -3338,7 +4230,11 @@
             "Brazil"
           ],
           "number": "40",
-          "position": "Centre-Forward"
+          "overall_score": 78,
+          "position": "Centre-Forward",
+          "potential": 83,
+          "value": 21500000,
+          "yearly_wage": 2496000
         },
         {
           "contract": "Jun 30, 2030",
@@ -3352,7 +4248,11 @@
             "Denmark"
           ],
           "number": "11",
-          "position": "Centre-Forward"
+          "overall_score": 75,
+          "position": "Centre-Forward",
+          "potential": 85,
+          "value": 12500000,
+          "yearly_wage": 1768000
         },
         {
           "contract": "Jun 30, 2028",
@@ -3367,7 +4267,11 @@
             "Senegal"
           ],
           "number": "45",
-          "position": "Centre-Forward"
+          "overall_score": 59,
+          "position": "Centre-Forward",
+          "potential": 82,
+          "value": 700000,
+          "yearly_wage": 208000
         }
       ],
       "stadiumName": "Red Bull Arena",
@@ -3391,7 +4295,11 @@
             "Japan"
           ],
           "number": "30",
-          "position": "Goalkeeper"
+          "overall_score": 75,
+          "position": "Goalkeeper",
+          "potential": 84,
+          "value": 11000000,
+          "yearly_wage": 468000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3405,7 +4313,11 @@
             "Estonia"
           ],
           "number": "13",
-          "position": "Goalkeeper"
+          "overall_score": 73,
+          "position": "Goalkeeper",
+          "potential": 81,
+          "value": 6000000,
+          "yearly_wage": 1820000
         },
         {
           "contract": "Jun 30, 2027",
@@ -3419,7 +4331,11 @@
             "Germany"
           ],
           "number": "25",
-          "position": "Goalkeeper"
+          "overall_score": 67,
+          "position": "Goalkeeper",
+          "potential": 67,
+          "value": 170000,
+          "yearly_wage": 364000
         },
         {
           "contract": "Jun 30, 2027",
@@ -3433,7 +4349,11 @@
             "Bulgaria"
           ],
           "number": "37",
-          "position": "Goalkeeper"
+          "overall_score": 59,
+          "position": "Goalkeeper",
+          "potential": 77,
+          "value": 500000,
+          "yearly_wage": 52000
         },
         {
           "contract": "Jun 30, 2029",
@@ -3448,7 +4368,11 @@
             "Cote d'Ivoire"
           ],
           "number": "31",
-          "position": "Centre-Back"
+          "overall_score": 71,
+          "position": "Centre-Back",
+          "potential": 85,
+          "value": 4100000,
+          "yearly_wage": 572000
         },
         {
           "contract": "Jun 30, 2028",
@@ -3462,7 +4386,11 @@
             "Austria"
           ],
           "number": "32",
-          "position": "Centre-Back"
+          "overall_score": 77,
+          "position": "Centre-Back",
+          "potential": 79,
+          "value": 11000000,
+          "yearly_wage": 1404000
         },
         {
           "contract": "-",
@@ -3476,7 +4404,11 @@
             "Germany"
           ],
           "number": "5",
-          "position": "Centre-Back"
+          "overall_score": 76,
+          "position": "Centre-Back",
+          "potential": 78,
+          "value": 8000000,
+          "yearly_wage": 1352000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3490,7 +4422,11 @@
             "Austria"
           ],
           "number": "39",
-          "position": "Centre-Back"
+          "overall_score": 74,
+          "position": "Centre-Back",
+          "potential": 75,
+          "value": 4200000,
+          "yearly_wage": 2236000
         },
         {
           "contract": "-",
@@ -3504,7 +4440,11 @@
             "Germany"
           ],
           "number": "4",
-          "position": "Centre-Back"
+          "overall_score": 74,
+          "position": "Centre-Back",
+          "potential": 74,
+          "value": 3500000,
+          "yearly_wage": 1248000
         },
         {
           "contract": "-",
@@ -3518,7 +4458,11 @@
             "Argentina"
           ],
           "number": "22",
-          "position": "Centre-Back"
+          "overall_score": 69,
+          "position": "Centre-Back",
+          "potential": 76,
+          "value": 2600000,
+          "yearly_wage": 572000
         },
         {
           "contract": "-",
@@ -3532,7 +4476,11 @@
             "Germany"
           ],
           "number": "33",
-          "position": "Centre-Back"
+          "overall_score": 59,
+          "position": "Centre-Back",
+          "potential": 76,
+          "value": 525000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2027",
@@ -3547,7 +4495,11 @@
             "Germany"
           ],
           "number": "27",
-          "position": "Left-Back"
+          "overall_score": 75,
+          "position": "Left-Back",
+          "potential": 78,
+          "value": 7000000,
+          "yearly_wage": 1196000
         },
         {
           "contract": "Jun 30, 2028",
@@ -3561,7 +4513,11 @@
             "Belgium"
           ],
           "number": "2",
-          "position": "Left-Back"
+          "overall_score": 71,
+          "position": "Left-Back",
+          "potential": 74,
+          "value": 2300000,
+          "yearly_wage": 832000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3576,7 +4532,11 @@
             "Nigeria"
           ],
           "number": "23",
-          "position": "Left-Back"
+          "overall_score": 72,
+          "position": "Left-Back",
+          "potential": 75,
+          "value": 2900000,
+          "yearly_wage": 1768000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3590,7 +4550,11 @@
             "Japan"
           ],
           "number": "3",
-          "position": "Right-Back"
+          "overall_score": 75,
+          "position": "Right-Back",
+          "potential": 79,
+          "value": 7000000,
+          "yearly_wage": 2340000
         },
         {
           "contract": "-",
@@ -3605,7 +4569,11 @@
             "Algeria"
           ],
           "number": "8",
-          "position": "Right-Back"
+          "overall_score": 78,
+          "position": "Right-Back",
+          "potential": 78,
+          "value": 10000000,
+          "yearly_wage": 1612000
         },
         {
           "contract": "-",
@@ -3619,7 +4587,11 @@
             "Belgium"
           ],
           "number": "14",
-          "position": "Defensive Midfield"
+          "overall_score": 76,
+          "position": "Defensive Midfield",
+          "potential": 79,
+          "value": 9000000,
+          "yearly_wage": 1352000
         },
         {
           "contract": "-",
@@ -3634,7 +4606,11 @@
             "Nigeria"
           ],
           "number": "34",
-          "position": "Defensive Midfield"
+          "overall_score": 60,
+          "position": "Defensive Midfield",
+          "potential": 77,
+          "value": 625000,
+          "yearly_wage": 156000
         },
         {
           "contract": "-",
@@ -3648,7 +4624,11 @@
             "Denmark"
           ],
           "number": "6",
-          "position": "Central Midfield"
+          "overall_score": 79,
+          "position": "Central Midfield",
+          "potential": 79,
+          "value": 17500000,
+          "yearly_wage": 1820000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3663,7 +4643,11 @@
             "Brazil"
           ],
           "number": "10",
-          "position": "Central Midfield"
+          "overall_score": 73,
+          "position": "Central Midfield",
+          "potential": 73,
+          "value": 2500000,
+          "yearly_wage": 1196000
         },
         {
           "contract": "Jun 30, 2027",
@@ -3677,7 +4661,11 @@
             "Austria"
           ],
           "number": "20",
-          "position": "Attacking Midfield"
+          "overall_score": 78,
+          "position": "Attacking Midfield",
+          "potential": 81,
+          "value": 18500000,
+          "yearly_wage": 1560000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3691,7 +4679,11 @@
             "Spain"
           ],
           "number": "18",
-          "position": "Attacking Midfield"
+          "overall_score": 76,
+          "position": "Attacking Midfield",
+          "potential": 77,
+          "value": 9000000,
+          "yearly_wage": 1716000
         },
         {
           "contract": "-",
@@ -3706,7 +4698,11 @@
             "Germany"
           ],
           "number": "24",
-          "position": "Attacking Midfield"
+          "overall_score": 67,
+          "position": "Attacking Midfield",
+          "potential": 81,
+          "value": 2400000,
+          "yearly_wage": 364000
         },
         {
           "contract": "Jun 30, 2030",
@@ -3721,7 +4717,11 @@
             "DR Congo"
           ],
           "number": "7",
-          "position": "Left Winger"
+          "overall_score": 74,
+          "position": "Left Winger",
+          "potential": 85,
+          "value": 9500000,
+          "yearly_wage": 936000
         },
         {
           "contract": "-",
@@ -3735,7 +4735,11 @@
             "Austria"
           ],
           "number": "17",
-          "position": "Left Winger"
+          "overall_score": 74,
+          "position": "Left Winger",
+          "potential": 74,
+          "value": 4600000,
+          "yearly_wage": 1248000
         },
         {
           "contract": "Jun 30, 2027",
@@ -3750,7 +4754,11 @@
             "Nigeria"
           ],
           "number": "11",
-          "position": "Right Winger"
+          "overall_score": 72,
+          "position": "Right Winger",
+          "potential": 77,
+          "value": 3600000,
+          "yearly_wage": 988000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3764,7 +4772,11 @@
             "Nigeria"
           ],
           "number": "44",
-          "position": "Centre-Forward"
+          "overall_score": 79,
+          "position": "Centre-Forward",
+          "potential": 83,
+          "value": 25500000,
+          "yearly_wage": 3640000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3778,7 +4790,11 @@
             "Serbia"
           ],
           "number": "19",
-          "position": "Centre-Forward"
+          "overall_score": 70,
+          "position": "Centre-Forward",
+          "potential": 80,
+          "value": 3500000,
+          "yearly_wage": 832000
         },
         {
           "contract": "Jun 30, 2028",
@@ -3792,7 +4808,11 @@
             "Germany"
           ],
           "number": "9",
-          "position": "Centre-Forward"
+          "overall_score": 68,
+          "position": "Centre-Forward",
+          "potential": 79,
+          "value": 2700000,
+          "yearly_wage": 520000
         },
         {
           "contract": "-",
@@ -3807,7 +4827,11 @@
             "Ghana"
           ],
           "number": "29",
-          "position": "Centre-Forward"
+          "overall_score": 61,
+          "position": "Centre-Forward",
+          "potential": 77,
+          "value": 850000,
+          "yearly_wage": 208000
         }
       ],
       "stadiumName": "Weserstadion",
@@ -3831,7 +4855,11 @@
             "Nigeria"
           ],
           "number": "1",
-          "position": "Goalkeeper"
+          "overall_score": 78,
+          "position": "Goalkeeper",
+          "potential": 83,
+          "value": 17000000,
+          "yearly_wage": 780000
         },
         {
           "contract": "-",
@@ -3845,7 +4873,11 @@
             "Germany"
           ],
           "number": "21",
-          "position": "Goalkeeper"
+          "overall_score": 72,
+          "position": "Goalkeeper",
+          "potential": 73,
+          "value": 2000000,
+          "yearly_wage": 624000
         },
         {
           "contract": "-",
@@ -3859,7 +4891,11 @@
             "Germany"
           ],
           "number": "24",
-          "position": "Goalkeeper"
+          "overall_score": 69,
+          "position": "Goalkeeper",
+          "potential": 69,
+          "value": 750000,
+          "yearly_wage": 468000
         },
         {
           "contract": "-",
@@ -3873,7 +4909,11 @@
             "Austria"
           ],
           "number": "3",
-          "position": "Centre-Back"
+          "overall_score": 78,
+          "position": "Centre-Back",
+          "potential": 78,
+          "value": 12000000,
+          "yearly_wage": 1612000
         },
         {
           "contract": "-",
@@ -3887,7 +4927,11 @@
             "Germany"
           ],
           "number": "37",
-          "position": "Centre-Back"
+          "overall_score": 73,
+          "position": "Centre-Back",
+          "potential": 79,
+          "value": 4400000,
+          "yearly_wage": 936000
         },
         {
           "contract": "Jun 30, 2027",
@@ -3901,7 +4945,11 @@
             "Germany"
           ],
           "number": "28",
-          "position": "Centre-Back"
+          "overall_score": 83,
+          "position": "Centre-Back",
+          "potential": 83,
+          "value": 25000000,
+          "yearly_wage": 2340000
         },
         {
           "contract": "-",
@@ -3916,7 +4964,11 @@
             "Nigeria"
           ],
           "number": "43",
-          "position": "Centre-Back"
+          "overall_score": 69,
+          "position": "Centre-Back",
+          "potential": 78,
+          "value": 2800000,
+          "yearly_wage": 468000
         },
         {
           "contract": "-",
@@ -3931,7 +4983,11 @@
             "Spain"
           ],
           "number": "5",
-          "position": "Centre-Back"
+          "overall_score": 71,
+          "position": "Centre-Back",
+          "potential": 71,
+          "value": 900000,
+          "yearly_wage": 936000
         },
         {
           "contract": "-",
@@ -3946,7 +5002,11 @@
             "DR Congo"
           ],
           "number": "33",
-          "position": "Left-Back"
+          "overall_score": 72,
+          "position": "Left-Back",
+          "potential": 76,
+          "value": 3100000,
+          "yearly_wage": 832000
         },
         {
           "contract": "-",
@@ -3960,7 +5020,11 @@
             "Germany"
           ],
           "number": "30",
-          "position": "Left-Back"
+          "overall_score": 76,
+          "position": "Left-Back",
+          "potential": 76,
+          "value": 5000000,
+          "yearly_wage": 1404000
         },
         {
           "contract": "-",
@@ -3974,7 +5038,11 @@
             "Germany"
           ],
           "number": "29",
-          "position": "Right-Back"
+          "overall_score": 74,
+          "position": "Right-Back",
+          "potential": 77,
+          "value": 5500000,
+          "yearly_wage": 1040000
         },
         {
           "contract": "-",
@@ -3988,7 +5056,11 @@
             "Germany"
           ],
           "number": "17",
-          "position": "Right-Back"
+          "overall_score": 75,
+          "position": "Right-Back",
+          "potential": 75,
+          "value": 3900000,
+          "yearly_wage": 1352000
         },
         {
           "contract": "-",
@@ -4002,7 +5074,11 @@
             "Germany"
           ],
           "number": "6",
-          "position": "Defensive Midfield"
+          "overall_score": 74,
+          "position": "Defensive Midfield",
+          "potential": 75,
+          "value": 4500000,
+          "yearly_wage": 1144000
         },
         {
           "contract": "-",
@@ -4016,7 +5092,11 @@
             "Germany"
           ],
           "number": "27",
-          "position": "Defensive Midfield"
+          "overall_score": 71,
+          "position": "Defensive Midfield",
+          "potential": 71,
+          "value": 525000,
+          "yearly_wage": 676000
         },
         {
           "contract": "Jun 30, 2030",
@@ -4030,7 +5110,11 @@
             "Switzerland"
           ],
           "number": "44",
-          "position": "Central Midfield"
+          "overall_score": 77,
+          "position": "Central Midfield",
+          "potential": 86,
+          "value": 22500000,
+          "yearly_wage": 1040000
         },
         {
           "contract": "-",
@@ -4044,7 +5128,11 @@
             "Germany"
           ],
           "number": "8",
-          "position": "Central Midfield"
+          "overall_score": 76,
+          "position": "Central Midfield",
+          "potential": 76,
+          "value": 6500000,
+          "yearly_wage": 1404000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4059,7 +5147,11 @@
             "Germany"
           ],
           "number": "11",
-          "position": "Attacking Midfield"
+          "overall_score": 70,
+          "position": "Attacking Midfield",
+          "potential": 70,
+          "value": 1600000,
+          "yearly_wage": 884000
         },
         {
           "contract": "-",
@@ -4073,7 +5165,11 @@
             "Germany"
           ],
           "number": "7",
-          "position": "Left Winger"
+          "overall_score": 73,
+          "position": "Left Winger",
+          "potential": 78,
+          "value": 4700000,
+          "yearly_wage": 988000
         },
         {
           "contract": "Jun 30, 2027",
@@ -4087,7 +5183,11 @@
             "Italy"
           ],
           "number": "32",
-          "position": "Left Winger"
+          "overall_score": 79,
+          "position": "Left Winger",
+          "potential": 79,
+          "value": 14000000,
+          "yearly_wage": 1820000
         },
         {
           "contract": "-",
@@ -4102,7 +5202,11 @@
             "Cote d'Ivoire"
           ],
           "number": "22",
-          "position": "Right Winger"
+          "overall_score": 70,
+          "position": "Right Winger",
+          "potential": 82,
+          "value": 3800000,
+          "yearly_wage": 624000
         },
         {
           "contract": "Jun 30, 2030",
@@ -4116,7 +5220,11 @@
             "Germany"
           ],
           "number": "19",
-          "position": "Right Winger"
+          "overall_score": 76,
+          "position": "Right Winger",
+          "potential": 76,
+          "value": 8000000,
+          "yearly_wage": 1404000
         },
         {
           "contract": "-",
@@ -4130,7 +5238,11 @@
             "Japan"
           ],
           "number": "14",
-          "position": "Second Striker"
+          "overall_score": 75,
+          "position": "Second Striker",
+          "potential": 78,
+          "value": 7500000,
+          "yearly_wage": 1196000
         },
         {
           "contract": "-",
@@ -4144,7 +5256,11 @@
             "Germany"
           ],
           "number": "26",
-          "position": "Second Striker"
+          "overall_score": 69,
+          "position": "Second Striker",
+          "potential": 69,
+          "value": 1200000,
+          "yearly_wage": 832000
         },
         {
           "contract": "-",
@@ -4159,7 +5275,11 @@
             "Germany"
           ],
           "number": "31",
-          "position": "Centre-Forward"
+          "overall_score": 74,
+          "position": "Centre-Forward",
+          "potential": 78,
+          "value": 6000000,
+          "yearly_wage": 1196000
         },
         {
           "contract": "-",
@@ -4173,7 +5293,11 @@
             "Germany"
           ],
           "number": "9",
-          "position": "Centre-Forward"
+          "overall_score": 72,
+          "position": "Centre-Forward",
+          "potential": 72,
+          "value": 2300000,
+          "yearly_wage": 1144000
         }
       ],
       "stadiumName": "Europa-Park Stadion",
@@ -4196,7 +5320,11 @@
             "Germany"
           ],
           "number": "27",
-          "position": "Goalkeeper"
+          "overall_score": 77,
+          "position": "Goalkeeper",
+          "potential": 77,
+          "value": 7000000,
+          "yearly_wage": 988000
         },
         {
           "contract": "Jun 30, 2027",
@@ -4210,7 +5338,11 @@
             "Germany"
           ],
           "number": "1",
-          "position": "Goalkeeper"
+          "overall_score": 67,
+          "position": "Goalkeeper",
+          "potential": 74,
+          "value": 1700000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4224,7 +5356,11 @@
             "Germany"
           ],
           "number": "33",
-          "position": "Goalkeeper"
+          "overall_score": 72,
+          "position": "Goalkeeper",
+          "potential": 72,
+          "value": 400000,
+          "yearly_wage": 676000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4238,7 +5374,11 @@
             "Austria"
           ],
           "number": "4",
-          "position": "Centre-Back"
+          "overall_score": 78,
+          "position": "Centre-Back",
+          "potential": 78,
+          "value": 12000000,
+          "yearly_wage": 4160000
         },
         {
           "contract": "Jun 30, 2028",
@@ -4252,7 +5392,11 @@
             "Norway"
           ],
           "number": "25",
-          "position": "Centre-Back"
+          "overall_score": 74,
+          "position": "Centre-Back",
+          "potential": 75,
+          "value": 4000000,
+          "yearly_wage": 1248000
         },
         {
           "contract": "Jun 30, 2028",
@@ -4266,7 +5410,11 @@
             "Poland"
           ],
           "number": "48",
-          "position": "Centre-Back"
+          "overall_score": 68,
+          "position": "Centre-Back",
+          "potential": 83,
+          "value": 2600000,
+          "yearly_wage": 312000
         },
         {
           "contract": "Jun 30, 2028",
@@ -4280,7 +5428,11 @@
             "Germany"
           ],
           "number": "31",
-          "position": "Centre-Back"
+          "overall_score": 76,
+          "position": "Centre-Back",
+          "potential": 76,
+          "value": 5000000,
+          "yearly_wage": 1404000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4294,7 +5446,11 @@
             "Germany"
           ],
           "number": "5",
-          "position": "Centre-Back"
+          "overall_score": 71,
+          "position": "Centre-Back",
+          "potential": 71,
+          "value": 1700000,
+          "yearly_wage": 884000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4309,7 +5465,11 @@
             "Angola"
           ],
           "number": "21",
-          "position": "Centre-Back"
+          "overall_score": 75,
+          "position": "Centre-Back",
+          "potential": 75,
+          "value": 3800000,
+          "yearly_wage": 1352000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4323,7 +5483,11 @@
             "Germany"
           ],
           "number": "16",
-          "position": "Centre-Back"
+          "overall_score": 73,
+          "position": "Centre-Back",
+          "potential": 73,
+          "value": 1500000,
+          "yearly_wage": 1092000
         },
         {
           "contract": "Jun 30, 2027",
@@ -4338,7 +5502,11 @@
             "Türkiye"
           ],
           "number": "47",
-          "position": "Centre-Back"
+          "overall_score": 58,
+          "position": "Centre-Back",
+          "potential": 75,
+          "value": 500000,
+          "yearly_wage": 156000
         },
         {
           "contract": "-",
@@ -4353,7 +5521,11 @@
             "Kenya"
           ],
           "number": "2",
-          "position": "Left-Back"
+          "overall_score": 75,
+          "position": "Left-Back",
+          "potential": 75,
+          "value": 4100000,
+          "yearly_wage": 1352000
         },
         {
           "contract": "Jun 30, 2029",
@@ -4368,7 +5540,11 @@
             "Netherlands"
           ],
           "number": "18",
-          "position": "Left-Back"
+          "overall_score": 65,
+          "position": "Left-Back",
+          "potential": 75,
+          "value": 1500000,
+          "yearly_wage": 312000
         },
         {
           "contract": "Jun 30, 2028",
@@ -4382,7 +5558,11 @@
             "France"
           ],
           "number": "19",
-          "position": "Right-Back"
+          "overall_score": 78,
+          "position": "Right-Back",
+          "potential": 78,
+          "value": 12500000,
+          "yearly_wage": 1612000
         },
         {
           "contract": "Jun 30, 2028",
@@ -4396,7 +5576,11 @@
             "Austria"
           ],
           "number": "22",
-          "position": "Right-Back"
+          "overall_score": 69,
+          "position": "Right-Back",
+          "potential": 76,
+          "value": 2700000,
+          "yearly_wage": 572000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4410,7 +5594,11 @@
             "Switzerland"
           ],
           "number": "30",
-          "position": "Right-Back"
+          "overall_score": 73,
+          "position": "Right-Back",
+          "potential": 73,
+          "value": 2100000,
+          "yearly_wage": 1092000
         },
         {
           "contract": "Jun 30, 2028",
@@ -4424,7 +5612,11 @@
             "Japan"
           ],
           "number": "6",
-          "position": "Defensive Midfield"
+          "overall_score": 80,
+          "position": "Defensive Midfield",
+          "potential": 83,
+          "value": 26000000,
+          "yearly_wage": 1560000
         },
         {
           "contract": "Jun 30, 2028",
@@ -4439,7 +5631,11 @@
             "Germany"
           ],
           "number": "15",
-          "position": "Defensive Midfield"
+          "overall_score": 72,
+          "position": "Defensive Midfield",
+          "potential": 73,
+          "value": 2500000,
+          "yearly_wage": 936000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4453,7 +5649,11 @@
             "Japan"
           ],
           "number": "24",
-          "position": "Defensive Midfield"
+          "overall_score": 71,
+          "position": "Defensive Midfield",
+          "potential": 75,
+          "value": 2700000,
+          "yearly_wage": 780000
         },
         {
           "contract": "-",
@@ -4467,7 +5667,11 @@
             "Germany"
           ],
           "number": "28",
-          "position": "Defensive Midfield"
+          "overall_score": 66,
+          "position": "Defensive Midfield",
+          "potential": 70,
+          "value": 1100000,
+          "yearly_wage": 416000
         },
         {
           "contract": "Jun 30, 2028",
@@ -4481,7 +5685,11 @@
             "Germany"
           ],
           "number": "10",
-          "position": "Central Midfield"
+          "overall_score": 80,
+          "position": "Central Midfield",
+          "potential": 80,
+          "value": 21000000,
+          "yearly_wage": 1924000
         },
         {
           "contract": "Jun 30, 2028",
@@ -4495,7 +5703,11 @@
             "Germany"
           ],
           "number": "42",
-          "position": "Central Midfield"
+          "overall_score": 61,
+          "position": "Central Midfield",
+          "potential": 75,
+          "value": 775000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2027",
@@ -4510,7 +5722,11 @@
             "Ireland"
           ],
           "number": "8",
-          "position": "Attacking Midfield"
+          "overall_score": 76,
+          "position": "Attacking Midfield",
+          "potential": 83,
+          "value": 15000000,
+          "yearly_wage": 1248000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4524,7 +5740,11 @@
             "Korea, South"
           ],
           "number": "7",
-          "position": "Attacking Midfield"
+          "overall_score": 76,
+          "position": "Attacking Midfield",
+          "potential": 76,
+          "value": 6000000,
+          "yearly_wage": 1456000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4539,7 +5759,11 @@
             "Netherlands"
           ],
           "number": "23",
-          "position": "Left Winger"
+          "overall_score": 73,
+          "position": "Left Winger",
+          "potential": 73,
+          "value": 3000000,
+          "yearly_wage": 1248000
         },
         {
           "contract": "-",
@@ -4553,7 +5777,11 @@
             "DR Congo"
           ],
           "number": "26",
-          "position": "Right Winger"
+          "overall_score": 73,
+          "position": "Right Winger",
+          "potential": 73,
+          "value": 3300000,
+          "yearly_wage": 1092000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4568,7 +5796,11 @@
             "Mozambique"
           ],
           "number": "11",
-          "position": "Second Striker"
+          "overall_score": 71,
+          "position": "Second Striker",
+          "potential": 79,
+          "value": 4200000,
+          "yearly_wage": 1612000
         },
         {
           "contract": "Jun 30, 2029",
@@ -4583,7 +5815,11 @@
             "Albania"
           ],
           "number": "44",
-          "position": "Centre-Forward"
+          "overall_score": 70,
+          "position": "Centre-Forward",
+          "potential": 83,
+          "value": 3900000,
+          "yearly_wage": 676000
         },
         {
           "contract": "Jun 30, 2029",
@@ -4597,7 +5833,11 @@
             "Germany"
           ],
           "number": "17",
-          "position": "Centre-Forward"
+          "overall_score": 75,
+          "position": "Centre-Forward",
+          "potential": 79,
+          "value": 8000000,
+          "yearly_wage": 1248000
         },
         {
           "contract": "Jun 30, 2029",
@@ -4611,7 +5851,11 @@
             "Denmark"
           ],
           "number": "14",
-          "position": "Centre-Forward"
+          "overall_score": 71,
+          "position": "Centre-Forward",
+          "potential": 78,
+          "value": 3800000,
+          "yearly_wage": 884000
         },
         {
           "contract": "Jun 30, 2028",
@@ -4625,7 +5869,11 @@
             "Germany"
           ],
           "number": "20",
-          "position": "Centre-Forward"
+          "overall_score": 73,
+          "position": "Centre-Forward",
+          "potential": 73,
+          "value": 3300000,
+          "yearly_wage": 1196000
         },
         {
           "contract": "Jun 30, 2028",
@@ -4640,7 +5888,11 @@
             "Germany"
           ],
           "number": "36",
-          "position": "Centre-Forward"
+          "overall_score": 62,
+          "position": "Centre-Forward",
+          "potential": 66,
+          "value": 550000,
+          "yearly_wage": 312000
         }
       ],
       "stadiumName": "Mewa Arena",
@@ -4664,7 +5916,11 @@
             "England"
           ],
           "number": "1",
-          "position": "Goalkeeper"
+          "overall_score": 76,
+          "position": "Goalkeeper",
+          "potential": 77,
+          "value": 6500000,
+          "yearly_wage": 1040000
         },
         {
           "contract": "Jun 30, 2029",
@@ -4678,7 +5934,11 @@
             "Croatia"
           ],
           "number": "22",
-          "position": "Goalkeeper"
+          "overall_score": 72,
+          "position": "Goalkeeper",
+          "potential": 73,
+          "value": 2100000,
+          "yearly_wage": 676000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4692,7 +5952,11 @@
             "Germany"
           ],
           "number": "25",
-          "position": "Goalkeeper"
+          "overall_score": 61,
+          "position": "Goalkeeper",
+          "potential": 67,
+          "value": 425000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2030",
@@ -4707,7 +5971,11 @@
             "Congo"
           ],
           "number": "5",
-          "position": "Centre-Back"
+          "overall_score": 77,
+          "position": "Centre-Back",
+          "potential": 85,
+          "value": 22000000,
+          "yearly_wage": 1456000
         },
         {
           "contract": "Jun 30, 2029",
@@ -4722,7 +5990,11 @@
             "Germany"
           ],
           "number": "40",
-          "position": "Centre-Back"
+          "overall_score": 71,
+          "position": "Centre-Back",
+          "potential": 83,
+          "value": 4100000,
+          "yearly_wage": 676000
         },
         {
           "contract": "Jun 30, 2027",
@@ -4736,7 +6008,11 @@
             "Germany"
           ],
           "number": "31",
-          "position": "Centre-Back"
+          "overall_score": 75,
+          "position": "Centre-Back",
+          "potential": 76,
+          "value": 5500000,
+          "yearly_wage": 1612000
         },
         {
           "contract": "Jun 30, 2029",
@@ -4750,7 +6026,11 @@
             "Switzerland"
           ],
           "number": "16",
-          "position": "Centre-Back"
+          "overall_score": 74,
+          "position": "Centre-Back",
+          "potential": 76,
+          "value": 4500000,
+          "yearly_wage": 1404000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4764,7 +6044,11 @@
             "Brazil"
           ],
           "number": "34",
-          "position": "Centre-Back"
+          "overall_score": 74,
+          "position": "Centre-Back",
+          "potential": 79,
+          "value": 6000000,
+          "yearly_wage": 1196000
         },
         {
           "contract": "Jun 30, 2027",
@@ -4778,7 +6062,11 @@
             "Netherlands"
           ],
           "number": "6",
-          "position": "Centre-Back"
+          "overall_score": 77,
+          "position": "Centre-Back",
+          "potential": 77,
+          "value": 5000000,
+          "yearly_wage": 1768000
         },
         {
           "contract": "Jun 30, 2027",
@@ -4792,7 +6080,11 @@
             "Germany"
           ],
           "number": "41",
-          "position": "Centre-Back"
+          "overall_score": 60,
+          "position": "Centre-Back",
+          "potential": 75,
+          "value": 525000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2028",
@@ -4806,7 +6098,11 @@
             "Greece"
           ],
           "number": "13",
-          "position": "Left-Back"
+          "overall_score": 76,
+          "position": "Left-Back",
+          "potential": 76,
+          "value": 6500000,
+          "yearly_wage": 1664000
         },
         {
           "contract": "Jun 30, 2027",
@@ -4820,7 +6116,11 @@
             "Denmark"
           ],
           "number": "3",
-          "position": "Left-Back"
+          "overall_score": 71,
+          "position": "Left-Back",
+          "potential": 71,
+          "value": 1700000,
+          "yearly_wage": 1092000
         },
         {
           "contract": "Jun 30, 2027",
@@ -4834,7 +6134,11 @@
             "Austria"
           ],
           "number": "43",
-          "position": "Left-Back"
+          "overall_score": 58,
+          "position": "Left-Back",
+          "potential": 78,
+          "value": 525000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2027",
@@ -4848,7 +6152,11 @@
             "Germany"
           ],
           "number": "27",
-          "position": "Right-Back"
+          "overall_score": 73,
+          "position": "Right-Back",
+          "potential": 73,
+          "value": 2600000,
+          "yearly_wage": 1352000
         },
         {
           "contract": "Jun 30, 2028",
@@ -4862,7 +6170,11 @@
             "Croatia"
           ],
           "number": "17",
-          "position": "Defensive Midfield"
+          "overall_score": 75,
+          "position": "Defensive Midfield",
+          "potential": 75,
+          "value": 4900000,
+          "yearly_wage": 1612000
         },
         {
           "contract": "Jun 30, 2029",
@@ -4876,7 +6188,11 @@
             "Germany"
           ],
           "number": "19",
-          "position": "Defensive Midfield"
+          "overall_score": 74,
+          "position": "Defensive Midfield",
+          "potential": 74,
+          "value": 4000000,
+          "yearly_wage": 1404000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4890,7 +6206,11 @@
             "Germany"
           ],
           "number": "14",
-          "position": "Defensive Midfield"
+          "overall_score": 71,
+          "position": "Defensive Midfield",
+          "potential": 74,
+          "value": 2200000,
+          "yearly_wage": 1040000
         },
         {
           "contract": "Jun 30, 2027",
@@ -4905,7 +6225,11 @@
             "Germany"
           ],
           "number": "42",
-          "position": "Defensive Midfield"
+          "overall_score": 60,
+          "position": "Defensive Midfield",
+          "potential": 72,
+          "value": 575000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2030",
@@ -4920,7 +6244,11 @@
             "Congo"
           ],
           "number": "4",
-          "position": "Central Midfield"
+          "overall_score": 75,
+          "position": "Central Midfield",
+          "potential": 80,
+          "value": 8000000,
+          "yearly_wage": 1300000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4935,7 +6263,11 @@
             "Germany"
           ],
           "number": "8",
-          "position": "Central Midfield"
+          "overall_score": 73,
+          "position": "Central Midfield",
+          "potential": 73,
+          "value": 3200000,
+          "yearly_wage": 1352000
         },
         {
           "contract": "Jun 30, 2029",
@@ -4949,7 +6281,11 @@
             "Germany"
           ],
           "number": "30",
-          "position": "Right Midfield"
+          "overall_score": 73,
+          "position": "Right Midfield",
+          "potential": 80,
+          "value": 6000000,
+          "yearly_wage": 988000
         },
         {
           "contract": "Jun 30, 2027",
@@ -4964,7 +6300,11 @@
             "Guadeloupe"
           ],
           "number": "20",
-          "position": "Attacking Midfield"
+          "overall_score": 76,
+          "position": "Attacking Midfield",
+          "potential": 77,
+          "value": 8500000,
+          "yearly_wage": 1716000
         },
         {
           "contract": "Jun 30, 2029",
@@ -4979,7 +6319,11 @@
             "Türkiye"
           ],
           "number": "36",
-          "position": "Attacking Midfield"
+          "overall_score": 72,
+          "position": "Attacking Midfield",
+          "potential": 82,
+          "value": 5000000,
+          "yearly_wage": 884000
         },
         {
           "contract": "Jun 30, 2030",
@@ -4993,7 +6337,11 @@
             "Switzerland"
           ],
           "number": "32",
-          "position": "Attacking Midfield"
+          "overall_score": 74,
+          "position": "Attacking Midfield",
+          "potential": 81,
+          "value": 8500000,
+          "yearly_wage": 1300000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5008,7 +6356,11 @@
             "Spain"
           ],
           "number": "11",
-          "position": "Left Winger"
+          "overall_score": 72,
+          "position": "Left Winger",
+          "potential": 80,
+          "value": 5500000,
+          "yearly_wage": 416000
         },
         {
           "contract": "Jun 30, 2028",
@@ -5037,7 +6389,11 @@
             "Portugal"
           ],
           "number": "21",
-          "position": "Centre-Forward"
+          "overall_score": 68,
+          "position": "Centre-Forward",
+          "potential": 79,
+          "value": 2700000,
+          "yearly_wage": 364000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5051,7 +6407,11 @@
             "Austria"
           ],
           "number": "38",
-          "position": "Centre-Forward"
+          "overall_score": 75,
+          "position": "Centre-Forward",
+          "potential": 75,
+          "value": 4800000,
+          "yearly_wage": 884000
         },
         {
           "contract": "Jun 30, 2031",
@@ -5065,7 +6425,11 @@
             "Nigeria"
           ],
           "number": "39",
-          "position": "Centre-Forward"
+          "overall_score": 64,
+          "position": "Centre-Forward",
+          "potential": 77,
+          "value": 1400000,
+          "yearly_wage": 364000
         }
       ],
       "stadiumName": "WWK ARENA",
@@ -5088,7 +6452,11 @@
             "Netherlands"
           ],
           "number": "1",
-          "position": "Goalkeeper"
+          "overall_score": 78,
+          "position": "Goalkeeper",
+          "potential": 78,
+          "value": 7000000,
+          "yearly_wage": 2236000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5102,7 +6470,11 @@
             "Switzerland"
           ],
           "number": "18",
-          "position": "Goalkeeper"
+          "overall_score": 73,
+          "position": "Goalkeeper",
+          "potential": 73,
+          "value": 1600000,
+          "yearly_wage": 728000
         },
         {
           "contract": "Jun 30, 2027",
@@ -5116,7 +6488,11 @@
             "Germany"
           ],
           "number": "28",
-          "position": "Goalkeeper"
+          "overall_score": 74,
+          "position": "Goalkeeper",
+          "potential": 74,
+          "value": 725000,
+          "yearly_wage": 1768000
         },
         {
           "contract": "Jun 30, 2027",
@@ -5130,7 +6506,11 @@
             "Germany"
           ],
           "number": "36",
-          "position": "Goalkeeper"
+          "overall_score": 66,
+          "position": "Goalkeeper",
+          "potential": 66,
+          "value": 450000,
+          "yearly_wage": 676000
         },
         {
           "contract": "Jun 30, 2030",
@@ -5145,7 +6525,11 @@
             "Scotland"
           ],
           "number": "4",
-          "position": "Centre-Back"
+          "overall_score": 76,
+          "position": "Centre-Back",
+          "potential": 84,
+          "value": 15500000,
+          "yearly_wage": 2496000
         },
         {
           "contract": "Jun 30, 2028",
@@ -5159,7 +6543,11 @@
             "Burkina Faso"
           ],
           "number": "12",
-          "position": "Centre-Back"
+          "overall_score": 82,
+          "position": "Centre-Back",
+          "potential": 83,
+          "value": 31500000,
+          "yearly_wage": 4472000
         },
         {
           "contract": "Jun 30, 2030",
@@ -5174,7 +6562,11 @@
             "Cote d'Ivoire"
           ],
           "number": "5",
-          "position": "Centre-Back"
+          "overall_score": 78,
+          "position": "Centre-Back",
+          "potential": 83,
+          "value": 18500000,
+          "yearly_wage": 3172000
         },
         {
           "contract": "Jun 30, 2030",
@@ -5189,7 +6581,11 @@
             "Cote d'Ivoire"
           ],
           "number": "16",
-          "position": "Centre-Back"
+          "overall_score": 67,
+          "position": "Centre-Back",
+          "potential": 84,
+          "value": 2400000,
+          "yearly_wage": 572000
         },
         {
           "contract": "Jun 30, 2029",
@@ -5203,7 +6599,11 @@
             "Germany"
           ],
           "number": "15",
-          "position": "Centre-Back"
+          "overall_score": 72,
+          "position": "Centre-Back",
+          "potential": 80,
+          "value": 4900000,
+          "yearly_wage": 1560000
         },
         {
           "contract": "Jun 30, 2029",
@@ -5230,7 +6630,11 @@
             "Spain"
           ],
           "number": "20",
-          "position": "Left-Back"
+          "overall_score": 85,
+          "position": "Left-Back",
+          "potential": 85,
+          "value": 53000000,
+          "yearly_wage": 6240000
         },
         {
           "contract": "Jun 30, 2028",
@@ -5244,7 +6648,11 @@
             "Brazil"
           ],
           "number": "13",
-          "position": "Right-Back"
+          "overall_score": 73,
+          "position": "Right-Back",
+          "potential": 78,
+          "value": 4700000,
+          "yearly_wage": 2080000
         },
         {
           "contract": "Jun 30, 2027",
@@ -5258,7 +6666,11 @@
             "Spain"
           ],
           "number": "21",
-          "position": "Right-Back"
+          "overall_score": 77,
+          "position": "Right-Back",
+          "potential": 77,
+          "value": 3900000,
+          "yearly_wage": 3224000
         },
         {
           "contract": "Jun 30, 2030",
@@ -5273,7 +6685,11 @@
             "Paraguay"
           ],
           "number": "6",
-          "position": "Defensive Midfield"
+          "overall_score": 76,
+          "position": "Defensive Midfield",
+          "potential": 84,
+          "value": 16000000,
+          "yearly_wage": 2496000
         },
         {
           "contract": "Jun 30, 2028",
@@ -5287,7 +6703,11 @@
             "Germany"
           ],
           "number": "8",
-          "position": "Defensive Midfield"
+          "overall_score": 79,
+          "position": "Defensive Midfield",
+          "potential": 79,
+          "value": 14500000,
+          "yearly_wage": 3796000
         },
         {
           "contract": "Jun 30, 2030",
@@ -5301,7 +6721,11 @@
             "Argentina"
           ],
           "number": "25",
-          "position": "Central Midfield"
+          "overall_score": 83,
+          "position": "Central Midfield",
+          "potential": 83,
+          "value": 39500000,
+          "yearly_wage": 5200000
         },
         {
           "contract": "Jun 30, 2029",
@@ -5315,7 +6739,11 @@
             "Spain"
           ],
           "number": "24",
-          "position": "Central Midfield"
+          "overall_score": 84,
+          "position": "Central Midfield",
+          "potential": 84,
+          "value": 42000000,
+          "yearly_wage": 5720000
         },
         {
           "contract": "Jun 30, 2030",
@@ -5330,7 +6758,11 @@
             "Germany"
           ],
           "number": "10",
-          "position": "Attacking Midfield"
+          "overall_score": 79,
+          "position": "Attacking Midfield",
+          "potential": 84,
+          "value": 26500000,
+          "yearly_wage": 3380000
         },
         {
           "contract": "Jun 30, 2030",
@@ -5345,7 +6777,11 @@
             "Germany"
           ],
           "number": "30",
-          "position": "Attacking Midfield"
+          "overall_score": 79,
+          "position": "Attacking Midfield",
+          "potential": 87,
+          "value": 38000000,
+          "yearly_wage": 2704000
         },
         {
           "contract": "Jun 30, 2027",
@@ -5359,7 +6795,11 @@
             "Germany"
           ],
           "number": "7",
-          "position": "Attacking Midfield"
+          "overall_score": 77,
+          "position": "Attacking Midfield",
+          "potential": 77,
+          "value": 8500000,
+          "yearly_wage": 3432000
         },
         {
           "contract": "Jun 30, 2030",
@@ -5374,7 +6814,11 @@
             "France"
           ],
           "number": "17",
-          "position": "Left Winger"
+          "overall_score": 75,
+          "position": "Left Winger",
+          "potential": 84,
+          "value": 12500000,
+          "yearly_wage": 2184000
         },
         {
           "contract": "Jun 30, 2029",
@@ -5388,7 +6832,11 @@
             "France"
           ],
           "number": "11",
-          "position": "Left Winger"
+          "overall_score": 79,
+          "position": "Left Winger",
+          "potential": 79,
+          "value": 17500000,
+          "yearly_wage": 4056000
         },
         {
           "contract": "Jun 30, 2030",
@@ -5403,7 +6851,11 @@
             "Ghana"
           ],
           "number": "19",
-          "position": "Right Winger"
+          "overall_score": 76,
+          "position": "Right Winger",
+          "potential": 85,
+          "value": 17000000,
+          "yearly_wage": 2236000
         },
         {
           "contract": "Jun 30, 2028",
@@ -5418,7 +6870,11 @@
             "England"
           ],
           "number": "23",
-          "position": "Right Winger"
+          "overall_score": 78,
+          "position": "Right Winger",
+          "potential": 79,
+          "value": 17000000,
+          "yearly_wage": 3328000
         },
         {
           "contract": "Jun 30, 2030",
@@ -5433,7 +6889,11 @@
             "United States"
           ],
           "number": "42",
-          "position": "Right Winger"
+          "overall_score": 67,
+          "position": "Right Winger",
+          "potential": 83,
+          "value": 2500000,
+          "yearly_wage": 624000
         },
         {
           "contract": "Jun 30, 2030",
@@ -5447,7 +6907,11 @@
             "Czech Republic"
           ],
           "number": "14",
-          "position": "Centre-Forward"
+          "overall_score": 85,
+          "position": "Centre-Forward",
+          "potential": 85,
+          "value": 54000000,
+          "yearly_wage": 7020000
         },
         {
           "contract": "Jun 30, 2029",
@@ -5461,7 +6925,11 @@
             "Cameroon"
           ],
           "number": "35",
-          "position": "Centre-Forward"
+          "overall_score": 76,
+          "position": "Centre-Forward",
+          "potential": 86,
+          "value": 16000000,
+          "yearly_wage": 2236000
         }
       ],
       "stadiumName": "BayArena",
@@ -5484,7 +6952,11 @@
             "Germany"
           ],
           "number": "1",
-          "position": "Goalkeeper"
+          "overall_score": 84,
+          "position": "Goalkeeper",
+          "potential": 84,
+          "value": 4700000,
+          "yearly_wage": 1196000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5498,7 +6970,11 @@
             "Germany"
           ],
           "number": "37",
-          "position": "Goalkeeper"
+          "overall_score": 68,
+          "position": "Goalkeeper",
+          "potential": 72,
+          "value": 1400000,
+          "yearly_wage": 364000
         },
         {
           "contract": "-",
@@ -5513,7 +6989,11 @@
             "Germany"
           ],
           "number": "36",
-          "position": "Goalkeeper"
+          "overall_score": 64,
+          "position": "Goalkeeper",
+          "potential": 70,
+          "value": 775000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2029",
@@ -5528,7 +7008,11 @@
             "Switzerland"
           ],
           "number": "21",
-          "position": "Centre-Back"
+          "overall_score": 75,
+          "position": "Centre-Back",
+          "potential": 79,
+          "value": 7500000,
+          "yearly_wage": 1300000
         },
         {
           "contract": "Jun 30, 2028",
@@ -5542,7 +7026,11 @@
             "Czech Republic"
           ],
           "number": "2",
-          "position": "Centre-Back"
+          "overall_score": 76,
+          "position": "Centre-Back",
+          "potential": 77,
+          "value": 8000000,
+          "yearly_wage": 1508000
         },
         {
           "contract": "-",
@@ -5556,7 +7044,11 @@
             "Japan"
           ],
           "number": "28",
-          "position": "Centre-Back"
+          "overall_score": 75,
+          "position": "Centre-Back",
+          "potential": 75,
+          "value": 5000000,
+          "yearly_wage": 1508000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5570,7 +7062,11 @@
             "Türkiye"
           ],
           "number": "5",
-          "position": "Centre-Back"
+          "overall_score": 76,
+          "position": "Centre-Back",
+          "potential": 78,
+          "value": 8500000,
+          "yearly_wage": 1508000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5585,7 +7081,11 @@
             "Germany"
           ],
           "number": "25",
-          "position": "Centre-Back"
+          "overall_score": 73,
+          "position": "Centre-Back",
+          "potential": 73,
+          "value": 2500000,
+          "yearly_wage": 1352000
         },
         {
           "contract": "Jun 30, 2029",
@@ -5600,7 +7100,11 @@
             "Nigeria"
           ],
           "number": "45",
-          "position": "Centre-Back"
+          "overall_score": 61,
+          "position": "Centre-Back",
+          "potential": 71,
+          "value": 675000,
+          "yearly_wage": 208000
         },
         {
           "contract": "-",
@@ -5614,7 +7118,11 @@
             "Brazil"
           ],
           "number": "13",
-          "position": "Left-Back"
+          "overall_score": 75,
+          "position": "Left-Back",
+          "potential": 75,
+          "value": 4800000,
+          "yearly_wage": 1612000
         },
         {
           "contract": "Jun 30, 2028",
@@ -5629,7 +7137,11 @@
             "Guadeloupe"
           ],
           "number": "15",
-          "position": "Right-Back"
+          "overall_score": 74,
+          "position": "Right-Back",
+          "potential": 78,
+          "value": 5500000,
+          "yearly_wage": 1352000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5643,7 +7155,11 @@
             "Czech Republic"
           ],
           "number": "34",
-          "position": "Right-Back"
+          "overall_score": 78,
+          "position": "Right-Back",
+          "potential": 78,
+          "value": 9500000,
+          "yearly_wage": 1924000
         },
         {
           "contract": "Jun 30, 2029",
@@ -5658,7 +7174,11 @@
             "Switzerland"
           ],
           "number": "7",
-          "position": "Defensive Midfield"
+          "overall_score": 77,
+          "position": "Defensive Midfield",
+          "potential": 83,
+          "value": 15500000,
+          "yearly_wage": 1248000
         },
         {
           "contract": "Jun 30, 2030",
@@ -5672,7 +7192,11 @@
             "Netherlands"
           ],
           "number": "18",
-          "position": "Defensive Midfield"
+          "overall_score": 77,
+          "position": "Defensive Midfield",
+          "potential": 79,
+          "value": 13500000,
+          "yearly_wage": 1560000
         },
         {
           "contract": "-",
@@ -5686,7 +7210,11 @@
             "Germany"
           ],
           "number": "16",
-          "position": "Central Midfield"
+          "overall_score": 65,
+          "position": "Central Midfield",
+          "potential": 80,
+          "value": 1700000,
+          "yearly_wage": 312000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5700,7 +7228,11 @@
             "Germany"
           ],
           "number": "6",
-          "position": "Central Midfield"
+          "overall_score": 77,
+          "position": "Central Midfield",
+          "potential": 77,
+          "value": 10000000,
+          "yearly_wage": 1872000
         },
         {
           "contract": "-",
@@ -5728,7 +7260,11 @@
             "Austria"
           ],
           "number": "22",
-          "position": "Left Midfield"
+          "overall_score": 75,
+          "position": "Left Midfield",
+          "potential": 77,
+          "value": 6500000,
+          "yearly_wage": 1300000
         },
         {
           "contract": "Jun 30, 2029",
@@ -5743,7 +7279,11 @@
             "Türkiye"
           ],
           "number": "10",
-          "position": "Attacking Midfield"
+          "overall_score": 72,
+          "position": "Attacking Midfield",
+          "potential": 80,
+          "value": 5500000,
+          "yearly_wage": 936000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5757,7 +7297,11 @@
             "Croatia"
           ],
           "number": "27",
-          "position": "Attacking Midfield"
+          "overall_score": 81,
+          "position": "Attacking Midfield",
+          "potential": 81,
+          "value": 12000000,
+          "yearly_wage": 2548000
         },
         {
           "contract": "Jun 30, 2029",
@@ -5771,7 +7315,11 @@
             "Cote d'Ivoire"
           ],
           "number": "29",
-          "position": "Left Winger"
+          "overall_score": 77,
+          "position": "Left Winger",
+          "potential": 86,
+          "value": 23000000,
+          "yearly_wage": 1248000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5786,7 +7334,11 @@
             "Iceland"
           ],
           "number": "20",
-          "position": "Right Winger"
+          "overall_score": 67,
+          "position": "Right Winger",
+          "potential": 82,
+          "value": 2400000,
+          "yearly_wage": 572000
         },
         {
           "contract": "Jun 30, 2029",
@@ -5801,7 +7353,11 @@
             "Germany"
           ],
           "number": "11",
-          "position": "Centre-Forward"
+          "overall_score": 79,
+          "position": "Centre-Forward",
+          "potential": 83,
+          "value": 26000000,
+          "yearly_wage": 2028000
         },
         {
           "contract": "Jun 30, 2029",
@@ -5815,7 +7371,11 @@
             "Czech Republic"
           ],
           "number": "23",
-          "position": "Centre-Forward"
+          "overall_score": 77,
+          "position": "Centre-Forward",
+          "potential": 83,
+          "value": 17000000,
+          "yearly_wage": 1716000
         },
         {
           "contract": "Jun 30, 2029",
@@ -5829,7 +7389,11 @@
             "Germany"
           ],
           "number": "19",
-          "position": "Centre-Forward"
+          "overall_score": 76,
+          "position": "Centre-Forward",
+          "potential": 80,
+          "value": 11000000,
+          "yearly_wage": 1612000
         },
         {
           "contract": "Jun 30, 2030",
@@ -5843,7 +7407,11 @@
             "Germany"
           ],
           "number": "33",
-          "position": "Centre-Forward"
+          "overall_score": 69,
+          "position": "Centre-Forward",
+          "potential": 81,
+          "value": 3300000,
+          "yearly_wage": 676000
         },
         {
           "contract": "-",
@@ -5858,7 +7426,11 @@
             "Türkiye"
           ],
           "number": "38",
-          "position": "Centre-Forward"
+          "overall_score": 67,
+          "position": "Centre-Forward",
+          "potential": 79,
+          "value": 2400000,
+          "yearly_wage": 520000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5873,7 +7445,11 @@
             "Germany"
           ],
           "number": "9",
-          "position": "Centre-Forward"
+          "overall_score": 74,
+          "position": "Centre-Forward",
+          "potential": 74,
+          "value": 3600000,
+          "yearly_wage": 1664000
         },
         {
           "contract": "-",
@@ -5888,7 +7464,11 @@
             "Netherlands"
           ],
           "number": "31",
-          "position": "Centre-Forward"
+          "overall_score": 67,
+          "position": "Centre-Forward",
+          "potential": 80,
+          "value": 2400000,
+          "yearly_wage": 520000
         }
       ],
       "stadiumName": "PreZero Arena",
@@ -5912,7 +7492,11 @@
             "Croatia"
           ],
           "number": "22",
-          "position": "Goalkeeper"
+          "overall_score": 78,
+          "position": "Goalkeeper",
+          "potential": 78,
+          "value": 9500000,
+          "yearly_wage": 936000
         },
         {
           "contract": "-",
@@ -5926,7 +7510,11 @@
             "Germany"
           ],
           "number": "1",
-          "position": "Goalkeeper"
+          "overall_score": 67,
+          "position": "Goalkeeper",
+          "potential": 72,
+          "value": 1200000,
+          "yearly_wage": 260000
         },
         {
           "contract": "-",
@@ -5939,7 +7527,11 @@
             "Austria"
           ],
           "number": "30",
-          "position": "Goalkeeper"
+          "overall_score": 61,
+          "position": "Goalkeeper",
+          "potential": 71,
+          "value": 625000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5954,7 +7546,11 @@
             "Bulgaria"
           ],
           "number": "47",
-          "position": "Goalkeeper"
+          "overall_score": 62,
+          "position": "Goalkeeper",
+          "potential": 71,
+          "value": 775000,
+          "yearly_wage": 36400
         },
         {
           "contract": "-",
@@ -5968,7 +7564,11 @@
             "Sweden"
           ],
           "number": "8",
-          "position": "Centre-Back"
+          "overall_score": 74,
+          "position": "Centre-Back",
+          "potential": 74,
+          "value": 3600000,
+          "yearly_wage": 1144000
         },
         {
           "contract": "-",
@@ -5982,7 +7582,11 @@
             "Austria"
           ],
           "number": "4",
-          "position": "Centre-Back"
+          "overall_score": 70,
+          "position": "Centre-Back",
+          "potential": 75,
+          "value": 2200000,
+          "yearly_wage": 624000
         },
         {
           "contract": "-",
@@ -5996,7 +7600,11 @@
             "Germany"
           ],
           "number": "5",
-          "position": "Centre-Back"
+          "overall_score": 74,
+          "position": "Centre-Back",
+          "potential": 74,
+          "value": 2900000,
+          "yearly_wage": 1144000
         },
         {
           "contract": "-",
@@ -6010,7 +7618,11 @@
             "Japan"
           ],
           "number": "15",
-          "position": "Centre-Back"
+          "overall_score": 70,
+          "position": "Centre-Back",
+          "potential": 73,
+          "value": 1800000,
+          "yearly_wage": 728000
         },
         {
           "contract": "-",
@@ -6038,7 +7650,11 @@
             "Estonia"
           ],
           "number": "3",
-          "position": "Centre-Back"
+          "overall_score": 71,
+          "position": "Centre-Back",
+          "potential": 71,
+          "value": 1200000,
+          "yearly_wage": 832000
         },
         {
           "contract": "-",
@@ -6052,7 +7668,11 @@
             "Austria"
           ],
           "number": "34",
-          "position": "Centre-Back"
+          "overall_score": 65,
+          "position": "Centre-Back",
+          "potential": 76,
+          "value": 1500000,
+          "yearly_wage": 260000
         },
         {
           "contract": "-",
@@ -6066,7 +7686,11 @@
             "Germany"
           ],
           "number": "23",
-          "position": "Left-Back"
+          "overall_score": 70,
+          "position": "Left-Back",
+          "potential": 75,
+          "value": 2200000,
+          "yearly_wage": 624000
         },
         {
           "contract": "-",
@@ -6080,7 +7704,11 @@
             "Germany"
           ],
           "number": "21",
-          "position": "Left-Back"
+          "overall_score": 69,
+          "position": "Left-Back",
+          "potential": 69,
+          "value": 1300000,
+          "yearly_wage": 624000
         },
         {
           "contract": "-",
@@ -6093,7 +7721,11 @@
             "Poland"
           ],
           "number": "11",
-          "position": "Right-Back"
+          "overall_score": 70,
+          "position": "Right-Back",
+          "potential": 76,
+          "value": 2400000,
+          "yearly_wage": 624000
         },
         {
           "contract": "-",
@@ -6107,7 +7739,11 @@
             "Greece"
           ],
           "number": "2",
-          "position": "Right-Back"
+          "overall_score": 72,
+          "position": "Right-Back",
+          "potential": 72,
+          "value": 2100000,
+          "yearly_wage": 936000
         },
         {
           "contract": "-",
@@ -6122,7 +7758,11 @@
             "England"
           ],
           "number": "14",
-          "position": "Right-Back"
+          "overall_score": 63,
+          "position": "Right-Back",
+          "potential": 72,
+          "value": 1000000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6136,7 +7776,11 @@
             "United States"
           ],
           "number": "6",
-          "position": "Defensive Midfield"
+          "overall_score": 72,
+          "position": "Defensive Midfield",
+          "potential": 75,
+          "value": 2900000,
+          "yearly_wage": 312000
         },
         {
           "contract": "-",
@@ -6150,7 +7794,11 @@
             "Germany"
           ],
           "number": "42",
-          "position": "Defensive Midfield"
+          "overall_score": 59,
+          "position": "Defensive Midfield",
+          "potential": 77,
+          "value": 550000,
+          "yearly_wage": 104000
         },
         {
           "contract": "-",
@@ -6165,7 +7813,11 @@
             "Nigeria"
           ],
           "number": "16",
-          "position": "Central Midfield"
+          "overall_score": 72,
+          "position": "Central Midfield",
+          "potential": 77,
+          "value": 3500000,
+          "yearly_wage": 832000
         },
         {
           "contract": "Jun 30, 2029",
@@ -6179,7 +7831,11 @@
             "Norway"
           ],
           "number": "20",
-          "position": "Central Midfield"
+          "overall_score": 73,
+          "position": "Central Midfield",
+          "potential": 73,
+          "value": 3200000,
+          "yearly_wage": 1040000
         },
         {
           "contract": "-",
@@ -6193,7 +7849,11 @@
             "Australia"
           ],
           "number": "24",
-          "position": "Central Midfield"
+          "overall_score": 69,
+          "position": "Central Midfield",
+          "potential": 71,
+          "value": 1700000,
+          "yearly_wage": 624000
         },
         {
           "contract": "-",
@@ -6208,7 +7868,11 @@
             "Scotland"
           ],
           "number": "7",
-          "position": "Central Midfield"
+          "overall_score": 74,
+          "position": "Central Midfield",
+          "potential": 74,
+          "value": 3300000,
+          "yearly_wage": 1144000
         },
         {
           "contract": "-",
@@ -6223,7 +7887,11 @@
             "Germany"
           ],
           "number": "44",
-          "position": "Central Midfield"
+          "overall_score": 58,
+          "position": "Central Midfield",
+          "potential": 75,
+          "value": 500000,
+          "yearly_wage": 104000
         },
         {
           "contract": "-",
@@ -6238,7 +7906,11 @@
             "Serbia"
           ],
           "number": "10",
-          "position": "Attacking Midfield"
+          "overall_score": 71,
+          "position": "Attacking Midfield",
+          "potential": 71,
+          "value": 1900000,
+          "yearly_wage": 884000
         },
         {
           "contract": "Jun 30, 2028",
@@ -6253,7 +7925,11 @@
             "France"
           ],
           "number": "28",
-          "position": "Left Winger"
+          "overall_score": 73,
+          "position": "Left Winger",
+          "potential": 73,
+          "value": 3100000,
+          "yearly_wage": 1144000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6268,7 +7944,11 @@
             "France"
           ],
           "number": "27",
-          "position": "Centre-Forward"
+          "overall_score": 70,
+          "position": "Centre-Forward",
+          "potential": 77,
+          "value": 3300000,
+          "yearly_wage": 1508000
         },
         {
           "contract": "-",
@@ -6282,7 +7962,11 @@
             "Netherlands"
           ],
           "number": "19",
-          "position": "Centre-Forward"
+          "overall_score": 72,
+          "position": "Centre-Forward",
+          "potential": 73,
+          "value": 2800000,
+          "yearly_wage": 988000
         },
         {
           "contract": "-",
@@ -6296,7 +7980,11 @@
             "Japan"
           ],
           "number": "18",
-          "position": "Centre-Forward"
+          "overall_score": 68,
+          "position": "Centre-Forward",
+          "potential": 69,
+          "value": 1400000,
+          "yearly_wage": 624000
         },
         {
           "contract": "-",
@@ -6310,7 +7998,11 @@
             "England"
           ],
           "number": "26",
-          "position": "Centre-Forward"
+          "overall_score": 68,
+          "position": "Centre-Forward",
+          "potential": 72,
+          "value": 1800000,
+          "yearly_wage": 572000
         },
         {
           "contract": "-",
@@ -6323,7 +8015,11 @@
             "The Gambia"
           ],
           "number": "9",
-          "position": "Centre-Forward"
+          "overall_score": 66,
+          "position": "Centre-Forward",
+          "potential": 74,
+          "value": 1900000,
+          "yearly_wage": 364000
         }
       ],
       "stadiumName": "Millerntor-Stadion",
@@ -6346,7 +8042,11 @@
             "Poland"
           ],
           "number": "1",
-          "position": "Goalkeeper"
+          "overall_score": 81,
+          "position": "Goalkeeper",
+          "potential": 84,
+          "value": 26000000,
+          "yearly_wage": 1820000
         },
         {
           "contract": "Jun 30, 2027",
@@ -6360,7 +8060,11 @@
             "Germany"
           ],
           "number": "29",
-          "position": "Goalkeeper"
+          "overall_score": 74,
+          "position": "Goalkeeper",
+          "potential": 74,
+          "value": 2200000,
+          "yearly_wage": 1196000
         },
         {
           "contract": "Jun 30, 2028",
@@ -6374,7 +8078,11 @@
             "Poland"
           ],
           "number": "30",
-          "position": "Goalkeeper"
+          "overall_score": 59,
+          "position": "Goalkeeper",
+          "potential": 79,
+          "value": 550000,
+          "yearly_wage": 41600
         },
         {
           "contract": "Jun 30, 2026",
@@ -6388,7 +8096,11 @@
             "Austria"
           ],
           "number": "12",
-          "position": "Goalkeeper"
+          "overall_score": 71,
+          "position": "Goalkeeper",
+          "potential": 71,
+          "value": 210000,
+          "yearly_wage": 520000
         },
         {
           "contract": "Jun 30, 2029",
@@ -6402,7 +8114,11 @@
             "Greece"
           ],
           "number": "4",
-          "position": "Centre-Back"
+          "overall_score": 76,
+          "position": "Centre-Back",
+          "potential": 85,
+          "value": 15500000,
+          "yearly_wage": 1456000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6417,7 +8133,11 @@
             "Guadeloupe"
           ],
           "number": "6",
-          "position": "Centre-Back"
+          "overall_score": 70,
+          "position": "Centre-Back",
+          "potential": 81,
+          "value": 3300000,
+          "yearly_wage": 1248000
         },
         {
           "contract": "Jun 30, 2027",
@@ -6431,7 +8151,11 @@
             "Slovakia"
           ],
           "number": "3",
-          "position": "Centre-Back"
+          "overall_score": 76,
+          "position": "Centre-Back",
+          "potential": 76,
+          "value": 6500000,
+          "yearly_wage": 2080000
         },
         {
           "contract": "Jun 30, 2030",
@@ -6445,7 +8169,11 @@
             "Ghana"
           ],
           "number": "18",
-          "position": "Centre-Back"
+          "overall_score": 70,
+          "position": "Centre-Back",
+          "potential": 82,
+          "value": 3700000,
+          "yearly_wage": 832000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6459,7 +8187,11 @@
             "Netherlands"
           ],
           "number": "14",
-          "position": "Centre-Back"
+          "overall_score": 68,
+          "position": "Centre-Back",
+          "potential": 77,
+          "value": 2500000,
+          "yearly_wage": 1040000
         },
         {
           "contract": "Jun 30, 2027",
@@ -6474,7 +8206,11 @@
             "Nigeria"
           ],
           "number": "15",
-          "position": "Centre-Back"
+          "overall_score": 75,
+          "position": "Centre-Back",
+          "potential": 78,
+          "value": 6500000,
+          "yearly_wage": 1924000
         },
         {
           "contract": "Jun 30, 2030",
@@ -6488,7 +8224,11 @@
             "Brazil"
           ],
           "number": "33",
-          "position": "Centre-Back"
+          "overall_score": 66,
+          "position": "Centre-Back",
+          "potential": 77,
+          "value": 1800000,
+          "yearly_wage": 624000
         },
         {
           "contract": "Jun 30, 2027",
@@ -6516,7 +8256,11 @@
             "Germany"
           ],
           "number": "25",
-          "position": "Left-Back"
+          "overall_score": 74,
+          "position": "Left-Back",
+          "potential": 80,
+          "value": 6000000,
+          "yearly_wage": 1300000
         },
         {
           "contract": "Jun 30, 2027",
@@ -6531,7 +8275,11 @@
             "Italy"
           ],
           "number": "13",
-          "position": "Left-Back"
+          "overall_score": 72,
+          "position": "Left-Back",
+          "potential": 72,
+          "value": 2300000,
+          "yearly_wage": 1456000
         },
         {
           "contract": "Jun 30, 2029",
@@ -6546,7 +8294,11 @@
             "DR Congo"
           ],
           "number": "26",
-          "position": "Right-Back"
+          "overall_score": 75,
+          "position": "Right-Back",
+          "potential": 81,
+          "value": 8000000,
+          "yearly_wage": 1404000
         },
         {
           "contract": "Jun 30, 2027",
@@ -6560,7 +8312,11 @@
             "Germany"
           ],
           "number": "2",
-          "position": "Right-Back"
+          "overall_score": 73,
+          "position": "Right-Back",
+          "potential": 76,
+          "value": 3800000,
+          "yearly_wage": 1404000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6574,7 +8330,11 @@
             "Germany"
           ],
           "number": "41",
-          "position": "Right-Back"
+          "overall_score": 62,
+          "position": "Right-Back",
+          "potential": 75,
+          "value": 875000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2030",
@@ -6588,7 +8348,11 @@
             "Brazil"
           ],
           "number": "5",
-          "position": "Defensive Midfield"
+          "overall_score": 75,
+          "position": "Defensive Midfield",
+          "potential": 78,
+          "value": 6500000,
+          "yearly_wage": 1924000
         },
         {
           "contract": "Jun 30, 2027",
@@ -6602,7 +8366,11 @@
             "Sweden"
           ],
           "number": "32",
-          "position": "Central Midfield"
+          "overall_score": 76,
+          "position": "Central Midfield",
+          "potential": 77,
+          "value": 9000000,
+          "yearly_wage": 2080000
         },
         {
           "contract": "Jun 30, 2028",
@@ -6616,7 +8384,11 @@
             "Germany"
           ],
           "number": "27",
-          "position": "Central Midfield"
+          "overall_score": 79,
+          "position": "Central Midfield",
+          "potential": 79,
+          "value": 12500000,
+          "yearly_wage": 2652000
         },
         {
           "contract": "-",
@@ -6630,7 +8402,11 @@
             "Germany"
           ],
           "number": "31",
-          "position": "Central Midfield"
+          "overall_score": 74,
+          "position": "Central Midfield",
+          "potential": 74,
+          "value": 3500000,
+          "yearly_wage": 1924000
         },
         {
           "contract": "Jun 30, 2029",
@@ -6643,7 +8419,11 @@
             "Germany"
           ],
           "number": "37",
-          "position": "Central Midfield"
+          "overall_score": 61,
+          "position": "Central Midfield",
+          "potential": 76,
+          "value": 750000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6658,7 +8438,11 @@
             "Dominican Republic"
           ],
           "number": "40",
-          "position": "Left Midfield"
+          "overall_score": 73,
+          "position": "Left Midfield",
+          "potential": 82,
+          "value": 7000000,
+          "yearly_wage": 1456000
         },
         {
           "contract": "Jun 30, 2028",
@@ -6672,7 +8456,11 @@
             "Croatia"
           ],
           "number": "10",
-          "position": "Attacking Midfield"
+          "overall_score": 77,
+          "position": "Attacking Midfield",
+          "potential": 77,
+          "value": 11000000,
+          "yearly_wage": 2288000
         },
         {
           "contract": "Jun 30, 2029",
@@ -6687,7 +8475,11 @@
             "Germany"
           ],
           "number": "8",
-          "position": "Attacking Midfield"
+          "overall_score": 72,
+          "position": "Attacking Midfield",
+          "potential": 82,
+          "value": 5000000,
+          "yearly_wage": 1092000
         },
         {
           "contract": "Jun 30, 2027",
@@ -6701,7 +8493,11 @@
             "Denmark"
           ],
           "number": "24",
-          "position": "Attacking Midfield"
+          "overall_score": 76,
+          "position": "Attacking Midfield",
+          "potential": 76,
+          "value": 4700000,
+          "yearly_wage": 2236000
         },
         {
           "contract": "Jun 30, 2027",
@@ -6715,7 +8511,11 @@
             "Austria"
           ],
           "number": "39",
-          "position": "Right Winger"
+          "overall_score": 77,
+          "position": "Right Winger",
+          "potential": 83,
+          "value": 16500000,
+          "yearly_wage": 1924000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6729,7 +8529,11 @@
             "Denmark"
           ],
           "number": "19",
-          "position": "Right Winger"
+          "overall_score": 74,
+          "position": "Right Winger",
+          "potential": 75,
+          "value": 5000000,
+          "yearly_wage": 3120000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6743,7 +8547,11 @@
             "Denmark"
           ],
           "number": "11",
-          "position": "Right Winger"
+          "overall_score": 72,
+          "position": "Right Winger",
+          "potential": 80,
+          "value": 5000000,
+          "yearly_wage": 520000
         },
         {
           "contract": "Jun 30, 2029",
@@ -6757,7 +8565,11 @@
             "Algeria"
           ],
           "number": "9",
-          "position": "Centre-Forward"
+          "overall_score": 80,
+          "position": "Centre-Forward",
+          "potential": 83,
+          "value": 28500000,
+          "yearly_wage": 2912000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6771,7 +8583,11 @@
             "Denmark"
           ],
           "number": "23",
-          "position": "Centre-Forward"
+          "overall_score": 76,
+          "position": "Centre-Forward",
+          "potential": 77,
+          "value": 9000000,
+          "yearly_wage": 2288000
         },
         {
           "contract": "Jun 30, 2029",
@@ -6786,7 +8602,11 @@
             "Montenegro"
           ],
           "number": "17",
-          "position": "Centre-Forward"
+          "overall_score": 72,
+          "position": "Centre-Forward",
+          "potential": 79,
+          "value": 4700000,
+          "yearly_wage": 1248000
         },
         {
           "contract": "Jun 30, 2030",
@@ -6800,7 +8620,11 @@
             "Japan"
           ],
           "number": "7",
-          "position": "Centre-Forward"
+          "overall_score": 68,
+          "position": "Centre-Forward",
+          "potential": 82,
+          "value": 2900000,
+          "yearly_wage": 832000
         }
       ],
       "stadiumName": "Volkswagen Arena",
@@ -6837,7 +8661,11 @@
             "Germany"
           ],
           "number": "31",
-          "position": "Goalkeeper"
+          "overall_score": 70,
+          "position": "Goalkeeper",
+          "potential": 74,
+          "value": 1700000,
+          "yearly_wage": 624000
         },
         {
           "contract": "-",
@@ -6851,7 +8679,11 @@
             "Germany"
           ],
           "number": "25",
-          "position": "Goalkeeper"
+          "overall_score": 67,
+          "position": "Goalkeeper",
+          "potential": 67,
+          "value": 550000,
+          "yearly_wage": 468000
         },
         {
           "contract": "-",
@@ -6865,7 +8697,11 @@
             "Austria"
           ],
           "number": "14",
-          "position": "Centre-Back"
+          "overall_score": 77,
+          "position": "Centre-Back",
+          "potential": 84,
+          "value": 20000000,
+          "yearly_wage": 1248000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6880,7 +8716,11 @@
             "Suriname"
           ],
           "number": "5",
-          "position": "Centre-Back"
+          "overall_score": 80,
+          "position": "Centre-Back",
+          "potential": 81,
+          "value": 21000000,
+          "yearly_wage": 2132000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6894,7 +8734,11 @@
             "Portugal"
           ],
           "number": "4",
-          "position": "Centre-Back"
+          "overall_score": 76,
+          "position": "Centre-Back",
+          "potential": 79,
+          "value": 8500000,
+          "yearly_wage": 1612000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6909,7 +8753,11 @@
             "DR Congo"
           ],
           "number": "34",
-          "position": "Centre-Back"
+          "overall_score": 71,
+          "position": "Centre-Back",
+          "potential": 74,
+          "value": 2200000,
+          "yearly_wage": 1040000
         },
         {
           "contract": "-",
@@ -6923,7 +8771,11 @@
             "Germany"
           ],
           "number": "15",
-          "position": "Left-Back"
+          "overall_score": 73,
+          "position": "Left-Back",
+          "potential": 81,
+          "value": 6500000,
+          "yearly_wage": 936000
         },
         {
           "contract": "Jun 30, 2029",
@@ -6938,7 +8790,11 @@
             "Germany"
           ],
           "number": "39",
-          "position": "Left-Back"
+          "overall_score": 75,
+          "position": "Left-Back",
+          "potential": 76,
+          "value": 6000000,
+          "yearly_wage": 1508000
         },
         {
           "contract": "-",
@@ -6951,7 +8807,11 @@
             "Germany"
           ],
           "number": "3",
-          "position": "Left-Back"
+          "overall_score": 63,
+          "position": "Left-Back",
+          "potential": 78,
+          "value": 1100000,
+          "yearly_wage": 260000
         },
         {
           "contract": "-",
@@ -6965,7 +8825,11 @@
             "Croatia"
           ],
           "number": "18",
-          "position": "Right-Back"
+          "overall_score": 73,
+          "position": "Right-Back",
+          "potential": 73,
+          "value": 2700000,
+          "yearly_wage": 1352000
         },
         {
           "contract": "Jun 30, 2027",
@@ -6979,7 +8843,11 @@
             "Austria"
           ],
           "number": "28",
-          "position": "Right-Back"
+          "overall_score": 75,
+          "position": "Right-Back",
+          "potential": 75,
+          "value": 1200000,
+          "yearly_wage": 1196000
         },
         {
           "contract": "-",
@@ -6993,7 +8861,11 @@
             "Germany"
           ],
           "number": "6",
-          "position": "Defensive Midfield"
+          "overall_score": 74,
+          "position": "Defensive Midfield",
+          "potential": 79,
+          "value": 6000000,
+          "yearly_wage": 1092000
         },
         {
           "contract": "Jun 30, 2026",
@@ -7008,7 +8880,11 @@
             "Tunisia"
           ],
           "number": "8",
-          "position": "Defensive Midfield"
+          "overall_score": 76,
+          "position": "Defensive Midfield",
+          "potential": 76,
+          "value": 5000000,
+          "yearly_wage": 1664000
         },
         {
           "contract": "Jun 30, 2027",
@@ -7022,7 +8898,11 @@
             "Hungary"
           ],
           "number": "13",
-          "position": "Central Midfield"
+          "overall_score": 74,
+          "position": "Central Midfield",
+          "potential": 75,
+          "value": 4900000,
+          "yearly_wage": 1456000
         },
         {
           "contract": "Jun 30, 2026",
@@ -7036,7 +8916,11 @@
             "Czech Republic"
           ],
           "number": "33",
-          "position": "Central Midfield"
+          "overall_score": 73,
+          "position": "Central Midfield",
+          "potential": 73,
+          "value": 3200000,
+          "yearly_wage": 1352000
         },
         {
           "contract": "Jun 30, 2027",
@@ -7050,7 +8934,11 @@
             "Germany"
           ],
           "number": "19",
-          "position": "Central Midfield"
+          "overall_score": 74,
+          "position": "Central Midfield",
+          "potential": 74,
+          "value": 3500000,
+          "yearly_wage": 1560000
         },
         {
           "contract": "-",
@@ -7064,7 +8952,11 @@
             "Denmark"
           ],
           "number": "24",
-          "position": "Left Midfield"
+          "overall_score": 73,
+          "position": "Left Midfield",
+          "potential": 73,
+          "value": 2700000,
+          "yearly_wage": 1352000
         },
         {
           "contract": "-",
@@ -7078,7 +8970,11 @@
             "Korea, South"
           ],
           "number": "11",
-          "position": "Attacking Midfield"
+          "overall_score": 73,
+          "position": "Attacking Midfield",
+          "potential": 76,
+          "value": 4000000,
+          "yearly_wage": 1300000
         },
         {
           "contract": "-",
@@ -7093,7 +8989,11 @@
             "Germany"
           ],
           "number": "9",
-          "position": "Left Winger"
+          "overall_score": 70,
+          "position": "Left Winger",
+          "potential": 78,
+          "value": 3500000,
+          "yearly_wage": 728000
         },
         {
           "contract": "-",
@@ -7107,7 +9007,11 @@
             "Germany"
           ],
           "number": "17",
-          "position": "Left Winger"
+          "overall_score": 62,
+          "position": "Left Winger",
+          "potential": 77,
+          "value": 950000,
+          "yearly_wage": 260000
         },
         {
           "contract": "-",
@@ -7122,7 +9026,11 @@
             "Ghana"
           ],
           "number": "10",
-          "position": "Centre-Forward"
+          "overall_score": 73,
+          "position": "Centre-Forward",
+          "potential": 83,
+          "value": 6500000,
+          "yearly_wage": 1092000
         },
         {
           "contract": "Jun 30, 2027",
@@ -7136,7 +9044,11 @@
             "Serbia"
           ],
           "number": "23",
-          "position": "Centre-Forward"
+          "overall_score": 74,
+          "position": "Centre-Forward",
+          "potential": 76,
+          "value": 5500000,
+          "yearly_wage": 1560000
         },
         {
           "contract": "Jun 30, 2029",
@@ -7150,7 +9062,11 @@
             "Scotland"
           ],
           "number": "7",
-          "position": "Centre-Forward"
+          "overall_score": 73,
+          "position": "Centre-Forward",
+          "potential": 73,
+          "value": 3100000,
+          "yearly_wage": 1508000
         },
         {
           "contract": "-",
@@ -7164,7 +9080,11 @@
             "Germany"
           ],
           "number": "21",
-          "position": "Centre-Forward"
+          "overall_score": 73,
+          "position": "Centre-Forward",
+          "potential": 73,
+          "value": 3100000,
+          "yearly_wage": 1508000
         },
         {
           "contract": "Jun 30, 2029",
@@ -7178,7 +9098,11 @@
             "Ukraine"
           ],
           "number": "30",
-          "position": "Centre-Forward"
+          "overall_score": 58,
+          "position": "Centre-Forward",
+          "potential": 73,
+          "value": 475000,
+          "yearly_wage": 208000
         }
       ],
       "stadiumName": "Stadion An der Alten Försterei",
@@ -7202,7 +9126,11 @@
             "Kosovo"
           ],
           "number": "41",
-          "position": "Goalkeeper"
+          "overall_score": 75,
+          "position": "Goalkeeper",
+          "potential": 81,
+          "value": 7000000,
+          "yearly_wage": 936000
         },
         {
           "contract": "Jun 30, 2029",
@@ -7216,7 +9144,11 @@
             "Germany"
           ],
           "number": "40",
-          "position": "Goalkeeper"
+          "overall_score": 69,
+          "position": "Goalkeeper",
+          "potential": 77,
+          "value": 2700000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2027",
@@ -7230,7 +9162,11 @@
             "Austria"
           ],
           "number": "34",
-          "position": "Goalkeeper"
+          "overall_score": 59,
+          "position": "Goalkeeper",
+          "potential": 67,
+          "value": 425000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2028",
@@ -7244,7 +9180,11 @@
             "Germany"
           ],
           "number": "4",
-          "position": "Centre-Back"
+          "overall_score": 71,
+          "position": "Centre-Back",
+          "potential": 74,
+          "value": 2200000,
+          "yearly_wage": 936000
         },
         {
           "contract": "Jun 30, 2028",
@@ -7258,7 +9198,11 @@
             "Germany"
           ],
           "number": "5",
-          "position": "Centre-Back"
+          "overall_score": 71,
+          "position": "Centre-Back",
+          "potential": 72,
+          "value": 1800000,
+          "yearly_wage": 988000
         },
         {
           "contract": "Jun 30, 2029",
@@ -7272,7 +9216,11 @@
             "Germany"
           ],
           "number": "6",
-          "position": "Centre-Back"
+          "overall_score": 76,
+          "position": "Centre-Back",
+          "potential": 76,
+          "value": 6000000,
+          "yearly_wage": 1508000
         },
         {
           "contract": "Jun 30, 2029",
@@ -7286,7 +9234,11 @@
             "Germany"
           ],
           "number": "28",
-          "position": "Centre-Back"
+          "overall_score": 63,
+          "position": "Centre-Back",
+          "potential": 74,
+          "value": 975000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2027",
@@ -7300,7 +9252,11 @@
             "Germany"
           ],
           "number": "19",
-          "position": "Left-Back"
+          "overall_score": 71,
+          "position": "Left-Back",
+          "potential": 71,
+          "value": 1600000,
+          "yearly_wage": 988000
         },
         {
           "contract": "Jun 30, 2027",
@@ -7315,7 +9271,11 @@
             "Germany"
           ],
           "number": "32",
-          "position": "Left-Back"
+          "overall_score": 72,
+          "position": "Left-Back",
+          "potential": 72,
+          "value": 2000000,
+          "yearly_wage": 1092000
         },
         {
           "contract": "Jun 30, 2026",
@@ -7329,7 +9289,11 @@
             "Germany"
           ],
           "number": "26",
-          "position": "Left-Back"
+          "overall_score": 70,
+          "position": "Left-Back",
+          "potential": 77,
+          "value": 3000000,
+          "yearly_wage": 676000
         },
         {
           "contract": "Jun 30, 2026",
@@ -7344,7 +9308,11 @@
             "Greece"
           ],
           "number": "25",
-          "position": "Right-Back"
+          "overall_score": 71,
+          "position": "Right-Back",
+          "potential": 78,
+          "value": 3600000,
+          "yearly_wage": 988000
         },
         {
           "contract": "Jun 30, 2026",
@@ -7359,7 +9327,11 @@
             "Togo"
           ],
           "number": "23",
-          "position": "Right-Back"
+          "overall_score": 72,
+          "position": "Right-Back",
+          "potential": 72,
+          "value": 2300000,
+          "yearly_wage": 1040000
         },
         {
           "contract": "Jun 30, 2027",
@@ -7373,7 +9345,11 @@
             "Germany"
           ],
           "number": "2",
-          "position": "Right-Back"
+          "overall_score": 72,
+          "position": "Right-Back",
+          "potential": 72,
+          "value": 2000000,
+          "yearly_wage": 1092000
         },
         {
           "contract": "Jun 30, 2028",
@@ -7387,7 +9363,11 @@
             "Germany"
           ],
           "number": "30",
-          "position": "Defensive Midfield"
+          "overall_score": 74,
+          "position": "Defensive Midfield",
+          "potential": 74,
+          "value": 4500000,
+          "yearly_wage": 1352000
         },
         {
           "contract": "Jun 30, 2027",
@@ -7401,7 +9381,11 @@
             "Germany"
           ],
           "number": "16",
-          "position": "Defensive Midfield"
+          "overall_score": 72,
+          "position": "Defensive Midfield",
+          "potential": 75,
+          "value": 2900000,
+          "yearly_wage": 936000
         },
         {
           "contract": "Jun 30, 2028",
@@ -7415,7 +9399,11 @@
             "Germany"
           ],
           "number": "3",
-          "position": "Central Midfield"
+          "overall_score": 72,
+          "position": "Central Midfield",
+          "potential": 74,
+          "value": 2600000,
+          "yearly_wage": 1040000
         },
         {
           "contract": "Jun 30, 2027",
@@ -7429,7 +9417,11 @@
             "Germany"
           ],
           "number": "20",
-          "position": "Central Midfield"
+          "overall_score": 69,
+          "position": "Central Midfield",
+          "potential": 76,
+          "value": 2600000,
+          "yearly_wage": 676000
         },
         {
           "contract": "Jun 30, 2027",
@@ -7443,7 +9435,11 @@
             "Germany"
           ],
           "number": "33",
-          "position": "Central Midfield"
+          "overall_score": 59,
+          "position": "Central Midfield",
+          "potential": 73,
+          "value": 525000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2026",
@@ -7458,7 +9454,11 @@
             "Kosovo"
           ],
           "number": "22",
-          "position": "Attacking Midfield"
+          "overall_score": 72,
+          "position": "Attacking Midfield",
+          "potential": 83,
+          "value": 5000000,
+          "yearly_wage": 1300000
         },
         {
           "contract": "Jun 30, 2028",
@@ -7472,7 +9472,11 @@
             "Germany"
           ],
           "number": "21",
-          "position": "Attacking Midfield"
+          "overall_score": 71,
+          "position": "Attacking Midfield",
+          "potential": 71,
+          "value": 1900000,
+          "yearly_wage": 1040000
         },
         {
           "contract": "Jun 30, 2027",
@@ -7486,7 +9490,11 @@
             "Austria"
           ],
           "number": "17",
-          "position": "Left Winger"
+          "overall_score": 72,
+          "position": "Left Winger",
+          "potential": 72,
+          "value": 2400000,
+          "yearly_wage": 1144000
         },
         {
           "contract": "Jun 30, 2029",
@@ -7500,7 +9508,11 @@
             "Germany"
           ],
           "number": "38",
-          "position": "Left Winger"
+          "overall_score": 60,
+          "position": "Left Winger",
+          "potential": 77,
+          "value": 625000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2026",
@@ -7515,7 +9527,11 @@
             "Germany"
           ],
           "number": "8",
-          "position": "Right Winger"
+          "overall_score": 73,
+          "position": "Right Winger",
+          "potential": 79,
+          "value": 4800000,
+          "yearly_wage": 988000
         },
         {
           "contract": "Jun 30, 2027",
@@ -7530,7 +9546,11 @@
             "Ghana"
           ],
           "number": "31",
-          "position": "Right Winger"
+          "overall_score": 69,
+          "position": "Right Winger",
+          "potential": 69,
+          "value": 1400000,
+          "yearly_wage": 884000
         },
         {
           "contract": "Jun 30, 2029",
@@ -7544,7 +9564,11 @@
             "Germany"
           ],
           "number": "10",
-          "position": "Right Winger"
+          "overall_score": 68,
+          "position": "Right Winger",
+          "potential": 69,
+          "value": 1400000,
+          "yearly_wage": 676000
         },
         {
           "contract": "Jun 30, 2027",
@@ -7558,7 +9582,11 @@
             "Germany"
           ],
           "number": "18",
-          "position": "Centre-Forward"
+          "overall_score": 73,
+          "position": "Centre-Forward",
+          "potential": 74,
+          "value": 3700000,
+          "yearly_wage": 1248000
         },
         {
           "contract": "Jun 30, 2028",
@@ -7572,7 +9600,11 @@
             "Denmark"
           ],
           "number": "29",
-          "position": "Centre-Forward"
+          "overall_score": 68,
+          "position": "Centre-Forward",
+          "potential": 73,
+          "value": 1800000,
+          "yearly_wage": 676000
         },
         {
           "contract": "Jun 30, 2029",
@@ -7586,7 +9618,11 @@
             "Georgia"
           ],
           "number": "11",
-          "position": "Centre-Forward"
+          "overall_score": 72,
+          "position": "Centre-Forward",
+          "potential": 72,
+          "value": 2000000,
+          "yearly_wage": 1248000
         },
         {
           "contract": "Jun 30, 2026",
@@ -7600,7 +9636,11 @@
             "Germany"
           ],
           "number": "9",
-          "position": "Centre-Forward"
+          "overall_score": 69,
+          "position": "Centre-Forward",
+          "potential": 69,
+          "value": 1200000,
+          "yearly_wage": 884000
         }
       ],
       "stadiumName": "Voith-Arena",

--- a/data/2025/ENG1/sofifa.json
+++ b/data/2025/ENG1/sofifa.json
@@ -1,0 +1,7035 @@
+{
+  "league": "England Premier League",
+  "scraped_at": "2026-06-12T14:24:56.150Z",
+  "team_count": 20,
+  "teams": [
+    {
+      "player_count": 30,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "David Raya Martín",
+          "name": "David Raya",
+          "overall_score": 87,
+          "potential": 87,
+          "value": 54500000,
+          "yearly_wage": 7540000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jurriën Timber",
+          "name": "J. Timber",
+          "overall_score": 84,
+          "potential": 87,
+          "value": 53500000,
+          "yearly_wage": 7280000
+        },
+        {
+          "currency": "€",
+          "full_name": "William Saliba",
+          "name": "W. Saliba",
+          "overall_score": 88,
+          "potential": 90,
+          "value": 105500000,
+          "yearly_wage": 10400000
+        },
+        {
+          "currency": "€",
+          "full_name": "Gabriel dos S. Magalhães",
+          "name": "Gabriel",
+          "overall_score": 89,
+          "potential": 90,
+          "value": 104000000,
+          "yearly_wage": 13000000
+        },
+        {
+          "currency": "€",
+          "full_name": "Riccardo Calafiori",
+          "name": "R. Calafiori",
+          "overall_score": 82,
+          "potential": 86,
+          "value": 40500000,
+          "yearly_wage": 6240000
+        },
+        {
+          "currency": "€",
+          "full_name": "Martín Zubimendi Ibáñez",
+          "name": "Zubimendi",
+          "overall_score": 85,
+          "potential": 87,
+          "value": 60000000,
+          "yearly_wage": 9360000
+        },
+        {
+          "currency": "€",
+          "full_name": "Declan Rice",
+          "name": "D. Rice",
+          "overall_score": 88,
+          "potential": 89,
+          "value": 96000000,
+          "yearly_wage": 11960000
+        },
+        {
+          "currency": "€",
+          "full_name": "Bukayo Saka",
+          "name": "B. Saka",
+          "overall_score": 87,
+          "potential": 89,
+          "value": 103500000,
+          "yearly_wage": 10920000
+        },
+        {
+          "currency": "€",
+          "full_name": "Leandro Trossard",
+          "name": "L. Trossard",
+          "overall_score": 83,
+          "potential": 83,
+          "value": 35000000,
+          "yearly_wage": 9100000
+        },
+        {
+          "currency": "€",
+          "full_name": "Eberechi Eze",
+          "name": "E. Eze",
+          "overall_score": 84,
+          "potential": 85,
+          "value": 48500000,
+          "yearly_wage": 9100000
+        },
+        {
+          "currency": "€",
+          "full_name": "Viktor Gyökeres",
+          "name": "V. Gyökeres",
+          "overall_score": 86,
+          "potential": 86,
+          "value": 73500000,
+          "yearly_wage": 11440000
+        },
+        {
+          "currency": "€",
+          "full_name": "Gabriel Teodoro Martinelli Silva",
+          "name": "Gabriel Martinelli",
+          "overall_score": 81,
+          "potential": 84,
+          "value": 35000000,
+          "yearly_wage": 6500000
+        },
+        {
+          "currency": "€",
+          "full_name": "Noni Madueke",
+          "name": "N. Madueke",
+          "overall_score": 80,
+          "potential": 84,
+          "value": 30000000,
+          "yearly_wage": 5980000
+        },
+        {
+          "currency": "€",
+          "full_name": "Martin Ødegaard",
+          "name": "M. Ødegaard",
+          "overall_score": 86,
+          "potential": 87,
+          "value": 79500000,
+          "yearly_wage": 10400000
+        },
+        {
+          "currency": "€",
+          "full_name": "Christian Nørgaard",
+          "name": "C. Nørgaard",
+          "overall_score": 80,
+          "potential": 80,
+          "value": 15000000,
+          "yearly_wage": 6500000
+        },
+        {
+          "currency": "€",
+          "full_name": "Piero Hincapié",
+          "name": "P. Hincapié",
+          "overall_score": 83,
+          "potential": 87,
+          "value": 48500000,
+          "yearly_wage": 4212000
+        },
+        {
+          "currency": "€",
+          "full_name": "Benjamin White",
+          "name": "B. White",
+          "overall_score": 82,
+          "potential": 82,
+          "value": 29500000,
+          "yearly_wage": 7020000
+        },
+        {
+          "currency": "€",
+          "full_name": "Kepa Arrizabalaga",
+          "name": "Kepa",
+          "overall_score": 79,
+          "potential": 79,
+          "value": 11500000,
+          "yearly_wage": 3952000
+        },
+        {
+          "currency": "€",
+          "full_name": "Kai Havertz",
+          "name": "K. Havertz",
+          "overall_score": 82,
+          "potential": 84,
+          "value": 38000000,
+          "yearly_wage": 8060000
+        },
+        {
+          "currency": "€",
+          "full_name": "Gabriel Fernando de Jesus",
+          "name": "Gabriel Jesus",
+          "overall_score": 80,
+          "potential": 80,
+          "value": 21500000,
+          "yearly_wage": 7280000
+        },
+        {
+          "currency": "€",
+          "full_name": "Cristhian Mosquera Ibargüen",
+          "name": "Cristhian Mosquera",
+          "overall_score": 77,
+          "potential": 85,
+          "value": 22000000,
+          "yearly_wage": 3588000
+        },
+        {
+          "currency": "€",
+          "full_name": "Myles Lewis-Skelly",
+          "name": "M. Lewis-Skelly",
+          "overall_score": 78,
+          "potential": 87,
+          "value": 28000000,
+          "yearly_wage": 3328000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mikel Merino Zazón",
+          "name": "Mikel Merino",
+          "overall_score": 83,
+          "potential": 83,
+          "value": 35500000,
+          "yearly_wage": 8320000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ethan Nwaneri",
+          "name": "E. Nwaneri",
+          "overall_score": 76,
+          "potential": 87,
+          "value": 16000000,
+          "yearly_wage": 3484000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jakub Kiwior",
+          "name": "J. Kiwior",
+          "overall_score": 80,
+          "potential": 85,
+          "value": 28000000,
+          "yearly_wage": 5720000
+        },
+        {
+          "currency": "€",
+          "full_name": "Fábio Daniel Ferreira Vieira",
+          "name": "Fábio Vieira",
+          "overall_score": 77,
+          "potential": 81,
+          "value": 14500000,
+          "yearly_wage": 4940000
+        },
+        {
+          "currency": "€",
+          "full_name": "Karl Hein",
+          "name": "K. Hein",
+          "overall_score": 73,
+          "potential": 81,
+          "value": 6000000,
+          "yearly_wage": 1820000
+        },
+        {
+          "currency": "€",
+          "full_name": "Reiss Nelson",
+          "name": "R. Nelson",
+          "overall_score": 75,
+          "potential": 76,
+          "value": 6500000,
+          "yearly_wage": 4368000
+        },
+        {
+          "currency": "€",
+          "full_name": "Louie Copley",
+          "name": "L. Copley",
+          "overall_score": 60,
+          "potential": 76,
+          "value": 625000,
+          "yearly_wage": 520000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ismeal Kabia",
+          "name": "I. Kabia",
+          "overall_score": 63,
+          "potential": 72,
+          "value": 1000000,
+          "yearly_wage": 780000
+        }
+      ],
+      "team": "Arsenal",
+      "transfer_budget": 153300000,
+      "url": "https://sofifa.com/team/1/arsenal/260037/"
+    },
+    {
+      "player_count": 38,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Alisson Ramses Becker",
+          "name": "Alisson",
+          "overall_score": 88,
+          "potential": 88,
+          "value": 45000000,
+          "yearly_wage": 6760000
+        },
+        {
+          "currency": "€",
+          "full_name": "Dominik Szoboszlai",
+          "name": "D. Szoboszlai",
+          "overall_score": 86,
+          "potential": 88,
+          "value": 88000000,
+          "yearly_wage": 7540000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ibrahima Konaté",
+          "name": "I. Konaté",
+          "overall_score": 84,
+          "potential": 85,
+          "value": 43500000,
+          "yearly_wage": 7020000
+        },
+        {
+          "currency": "€",
+          "full_name": "Virgil van Dijk",
+          "name": "V. van Dijk",
+          "overall_score": 88,
+          "potential": 88,
+          "value": 43500000,
+          "yearly_wage": 10140000
+        },
+        {
+          "currency": "€",
+          "full_name": "Andrew Robertson",
+          "name": "A. Robertson",
+          "overall_score": 81,
+          "potential": 81,
+          "value": 18500000,
+          "yearly_wage": 5460000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ryan Gravenberch",
+          "name": "R. Gravenberch",
+          "overall_score": 86,
+          "potential": 89,
+          "value": 84000000,
+          "yearly_wage": 7020000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alexis Mac Allister",
+          "name": "A. Mac Allister",
+          "overall_score": 85,
+          "potential": 86,
+          "value": 63000000,
+          "yearly_wage": 7800000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mohamed Salah",
+          "name": "M. Salah",
+          "overall_score": 89,
+          "potential": 89,
+          "value": 64000000,
+          "yearly_wage": 11440000
+        },
+        {
+          "currency": "€",
+          "full_name": "Cody Gakpo",
+          "name": "C. Gakpo",
+          "overall_score": 83,
+          "potential": 83,
+          "value": 39500000,
+          "yearly_wage": 6500000
+        },
+        {
+          "currency": "€",
+          "full_name": "Florian Wirtz",
+          "name": "F. Wirtz",
+          "overall_score": 87,
+          "potential": 91,
+          "value": 116500000,
+          "yearly_wage": 8320000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alexander Isak",
+          "name": "A. Isak",
+          "overall_score": 87,
+          "potential": 88,
+          "value": 96500000,
+          "yearly_wage": 9620000
+        },
+        {
+          "currency": "€",
+          "full_name": "Curtis Jones",
+          "name": "C. Jones",
+          "overall_score": 80,
+          "potential": 83,
+          "value": 28500000,
+          "yearly_wage": 4524000
+        },
+        {
+          "currency": "€",
+          "full_name": "Trey Nyoni",
+          "name": "T. Nyoni",
+          "overall_score": 65,
+          "potential": 84,
+          "value": 1800000,
+          "yearly_wage": 728000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jeremie Frimpong",
+          "name": "J. Frimpong",
+          "overall_score": 82,
+          "potential": 84,
+          "value": 36500000,
+          "yearly_wage": 4940000
+        },
+        {
+          "currency": "€",
+          "full_name": "Milos Kerkez",
+          "name": "M. Kerkez",
+          "overall_score": 81,
+          "potential": 85,
+          "value": 35000000,
+          "yearly_wage": 3900000
+        },
+        {
+          "currency": "€",
+          "full_name": "Joe Gomez",
+          "name": "J. Gomez",
+          "overall_score": 79,
+          "potential": 79,
+          "value": 15000000,
+          "yearly_wage": 4940000
+        },
+        {
+          "currency": "€",
+          "full_name": "Calvin Ramsay",
+          "name": "C. Ramsay",
+          "overall_score": 65,
+          "potential": 73,
+          "value": 1500000,
+          "yearly_wage": 780000
+        },
+        {
+          "currency": "€",
+          "full_name": "Giorgi Mamardashvili",
+          "name": "G. Mamardashvili",
+          "overall_score": 83,
+          "potential": 86,
+          "value": 38500000,
+          "yearly_wage": 3172000
+        },
+        {
+          "currency": "€",
+          "full_name": "Rio Ngumoha",
+          "name": "R. Ngumoha",
+          "overall_score": 72,
+          "potential": 88,
+          "value": 6000000,
+          "yearly_wage": 1508000
+        },
+        {
+          "currency": "€",
+          "full_name": "Federico Chiesa",
+          "name": "F. Chiesa",
+          "overall_score": 80,
+          "potential": 80,
+          "value": 22500000,
+          "yearly_wage": 5200000
+        },
+        {
+          "currency": "€",
+          "full_name": "Freddie Woodman",
+          "name": "F. Woodman",
+          "overall_score": 71,
+          "potential": 71,
+          "value": 1300000,
+          "yearly_wage": 1664000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ármin Pécsi",
+          "name": "Á. Pécsi",
+          "overall_score": 64,
+          "potential": 78,
+          "value": 1200000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Stefan Bajcetic Maquieira",
+          "name": "Stefan Bajcetic",
+          "overall_score": 73,
+          "potential": 82,
+          "value": 6500000,
+          "yearly_wage": 2184000
+        },
+        {
+          "currency": "€",
+          "full_name": "James McConnell",
+          "name": "J. McConnell",
+          "overall_score": 68,
+          "potential": 79,
+          "value": 2500000,
+          "yearly_wage": 1248000
+        },
+        {
+          "currency": "€",
+          "full_name": "Harvey Davies",
+          "name": "H. Davies",
+          "overall_score": 61,
+          "potential": 72,
+          "value": 650000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Rhys Williams",
+          "name": "R. Williams",
+          "overall_score": 61,
+          "potential": 66,
+          "value": 450000,
+          "yearly_wage": 624000
+        },
+        {
+          "currency": "€",
+          "full_name": "Hugo Ekitiké",
+          "name": "H. Ekitiké",
+          "overall_score": 85,
+          "potential": 88,
+          "value": 74500000,
+          "yearly_wage": 7540000
+        },
+        {
+          "currency": "€",
+          "full_name": "Conor Bradley",
+          "name": "C. Bradley",
+          "overall_score": 79,
+          "potential": 84,
+          "value": 25000000,
+          "yearly_wage": 3432000
+        },
+        {
+          "currency": "€",
+          "full_name": "Wataru Endo",
+          "name": "W. Endo",
+          "overall_score": 79,
+          "potential": 79,
+          "value": 11500000,
+          "yearly_wage": 4940000
+        },
+        {
+          "currency": "€",
+          "full_name": "Giovanni Leoni",
+          "name": "G. Leoni",
+          "overall_score": 69,
+          "potential": 82,
+          "value": 3000000,
+          "yearly_wage": 1248000
+        },
+        {
+          "currency": "€",
+          "full_name": "Calum Scanlon",
+          "name": "C. Scanlon",
+          "overall_score": 61,
+          "potential": 75,
+          "value": 750000,
+          "yearly_wage": 520000
+        },
+        {
+          "currency": "€",
+          "full_name": "Isaac Mabaya",
+          "name": "I. Mabaya",
+          "overall_score": 61,
+          "potential": 75,
+          "value": 750000,
+          "yearly_wage": 520000
+        },
+        {
+          "currency": "€",
+          "full_name": "Luca Stephenson",
+          "name": "L. Stephenson",
+          "overall_score": 66,
+          "potential": 76,
+          "value": 1800000,
+          "yearly_wage": 936000
+        },
+        {
+          "currency": "€",
+          "full_name": "Luke Chambers",
+          "name": "L. Chambers",
+          "overall_score": 66,
+          "potential": 78,
+          "value": 2000000,
+          "yearly_wage": 936000
+        },
+        {
+          "currency": "€",
+          "full_name": "Vítězslav Jaroš",
+          "name": "V. Jaroš",
+          "overall_score": 72,
+          "potential": 79,
+          "value": 4000000,
+          "yearly_wage": 1352000
+        },
+        {
+          "currency": "€",
+          "full_name": "Harvey Elliott",
+          "name": "H. Elliott",
+          "overall_score": 78,
+          "potential": 83,
+          "value": 21500000,
+          "yearly_wage": 3952000
+        },
+        {
+          "currency": "€",
+          "full_name": "Kostas Tsimikas",
+          "name": "K. Tsimikas",
+          "overall_score": 77,
+          "potential": 77,
+          "value": 9500000,
+          "yearly_wage": 4160000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lewis Koumas",
+          "name": "L. Koumas",
+          "overall_score": 69,
+          "potential": 83,
+          "value": 3300000,
+          "yearly_wage": 1404000
+        }
+      ],
+      "team": "Liverpool",
+      "transfer_budget": 124400000,
+      "url": "https://sofifa.com/team/9/liverpool/260037/"
+    },
+    {
+      "player_count": 44,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Gianluigi Donnarumma",
+          "name": "G. Donnarumma",
+          "overall_score": 89,
+          "potential": 91,
+          "value": 97000000,
+          "yearly_wage": 7800000
+        },
+        {
+          "currency": "€",
+          "full_name": "Matheus Luiz Nunes",
+          "name": "Matheus Nunes",
+          "overall_score": 82,
+          "potential": 83,
+          "value": 33000000,
+          "yearly_wage": 6760000
+        },
+        {
+          "currency": "€",
+          "full_name": "Abdukodir Khusanov",
+          "name": "A. Khusanov",
+          "overall_score": 80,
+          "potential": 86,
+          "value": 31000000,
+          "yearly_wage": 4160000
+        },
+        {
+          "currency": "€",
+          "full_name": "Marc Guéhi",
+          "name": "M. Guéhi",
+          "overall_score": 84,
+          "potential": 86,
+          "value": 48500000,
+          "yearly_wage": 6760000
+        },
+        {
+          "currency": "€",
+          "full_name": "Nico O'Reilly",
+          "name": "N. O'Reilly",
+          "overall_score": 81,
+          "potential": 86,
+          "value": 35500000,
+          "yearly_wage": 4472000
+        },
+        {
+          "currency": "€",
+          "full_name": "Bernardo Mota Carvalho e Silva",
+          "name": "Bernardo Silva",
+          "overall_score": 83,
+          "potential": 83,
+          "value": 34500000,
+          "yearly_wage": 7800000
+        },
+        {
+          "currency": "€",
+          "full_name": "Rodrigo Hernández Cascante",
+          "name": "Rodri",
+          "overall_score": 89,
+          "potential": 89,
+          "value": 88000000,
+          "yearly_wage": 13000000
+        },
+        {
+          "currency": "€",
+          "full_name": "Antoine Semenyo",
+          "name": "A. Semenyo",
+          "overall_score": 84,
+          "potential": 85,
+          "value": 50500000,
+          "yearly_wage": 8580000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jérémy Doku",
+          "name": "J. Doku",
+          "overall_score": 83,
+          "potential": 86,
+          "value": 49500000,
+          "yearly_wage": 7020000
+        },
+        {
+          "currency": "€",
+          "full_name": "Rayan Cherki",
+          "name": "R. Cherki",
+          "overall_score": 84,
+          "potential": 88,
+          "value": 61500000,
+          "yearly_wage": 6760000
+        },
+        {
+          "currency": "€",
+          "full_name": "Erling Haaland",
+          "name": "E. Haaland",
+          "overall_score": 91,
+          "potential": 93,
+          "value": 172500000,
+          "yearly_wage": 20280000
+        },
+        {
+          "currency": "€",
+          "full_name": "Omar Marmoush",
+          "name": "O. Marmoush",
+          "overall_score": 83,
+          "potential": 83,
+          "value": 39500000,
+          "yearly_wage": 8060000
+        },
+        {
+          "currency": "€",
+          "full_name": "Tijjani Reijnders",
+          "name": "T. Reijnders",
+          "overall_score": 85,
+          "potential": 86,
+          "value": 63000000,
+          "yearly_wage": 9100000
+        },
+        {
+          "currency": "€",
+          "full_name": "Nicolás González Iglesias",
+          "name": "Nico González",
+          "overall_score": 81,
+          "potential": 85,
+          "value": 33500000,
+          "yearly_wage": 5200000
+        },
+        {
+          "currency": "€",
+          "full_name": "Rúben Santos Gato Alves Dias",
+          "name": "Rúben Dias",
+          "overall_score": 87,
+          "potential": 87,
+          "value": 68500000,
+          "yearly_wage": 10920000
+        },
+        {
+          "currency": "€",
+          "full_name": "Rayan Aït-Nouri",
+          "name": "R. Aït-Nouri",
+          "overall_score": 81,
+          "potential": 85,
+          "value": 34500000,
+          "yearly_wage": 5200000
+        },
+        {
+          "currency": "€",
+          "full_name": "Rico Lewis",
+          "name": "R. Lewis",
+          "overall_score": 77,
+          "potential": 84,
+          "value": 20000000,
+          "yearly_wage": 3380000
+        },
+        {
+          "currency": "€",
+          "full_name": "James Trafford",
+          "name": "J. Trafford",
+          "overall_score": 77,
+          "potential": 84,
+          "value": 18500000,
+          "yearly_wage": 2288000
+        },
+        {
+          "currency": "€",
+          "full_name": "Phil Foden",
+          "name": "P. Foden",
+          "overall_score": 85,
+          "potential": 88,
+          "value": 71500000,
+          "yearly_wage": 8840000
+        },
+        {
+          "currency": "€",
+          "full_name": "Sávio Moreira de Oliveira",
+          "name": "Savinho",
+          "overall_score": 81,
+          "potential": 86,
+          "value": 39500000,
+          "yearly_wage": 5200000
+        },
+        {
+          "currency": "€",
+          "full_name": "Nathan Aké",
+          "name": "N. Aké",
+          "overall_score": 82,
+          "potential": 82,
+          "value": 25000000,
+          "yearly_wage": 7020000
+        },
+        {
+          "currency": "€",
+          "full_name": "John Stones",
+          "name": "J. Stones",
+          "overall_score": 82,
+          "potential": 82,
+          "value": 21000000,
+          "yearly_wage": 7020000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mateo Kovačić",
+          "name": "M. Kovačić",
+          "overall_score": 82,
+          "potential": 82,
+          "value": 25000000,
+          "yearly_wage": 7280000
+        },
+        {
+          "currency": "€",
+          "full_name": "Max Alleyne",
+          "name": "M. Alleyne",
+          "overall_score": 68,
+          "potential": 80,
+          "value": 2700000,
+          "yearly_wage": 1352000
+        },
+        {
+          "currency": "€",
+          "full_name": "Marcus Bettinelli",
+          "name": "M. Bettinelli",
+          "overall_score": 70,
+          "potential": 70,
+          "value": 525000,
+          "yearly_wage": 1716000
+        },
+        {
+          "currency": "€",
+          "full_name": "Sverre Nypan",
+          "name": "S. Nypan",
+          "overall_score": 70,
+          "potential": 86,
+          "value": 4000000,
+          "yearly_wage": 1716000
+        },
+        {
+          "currency": "€",
+          "full_name": "Joško Gvardiol",
+          "name": "J. Gvardiol",
+          "overall_score": 85,
+          "potential": 88,
+          "value": 66000000,
+          "yearly_wage": 7540000
+        },
+        {
+          "currency": "€",
+          "full_name": "Claudio Echeverri",
+          "name": "C. Echeverri",
+          "overall_score": 73,
+          "potential": 85,
+          "value": 7000000,
+          "yearly_wage": 2548000
+        },
+        {
+          "currency": "€",
+          "full_name": "Divin Mubama",
+          "name": "D. Mubama",
+          "overall_score": 67,
+          "potential": 79,
+          "value": 2500000,
+          "yearly_wage": 1508000
+        },
+        {
+          "currency": "€",
+          "full_name": "Finley Burns",
+          "name": "F. Burns",
+          "overall_score": 64,
+          "potential": 70,
+          "value": 850000,
+          "yearly_wage": 988000
+        },
+        {
+          "currency": "€",
+          "full_name": "Joshua Wilson-Esbrand",
+          "name": "J. Wilson-Esbrand",
+          "overall_score": 67,
+          "potential": 74,
+          "value": 2000000,
+          "yearly_wage": 1508000
+        },
+        {
+          "currency": "€",
+          "full_name": "Issa Kaboré",
+          "name": "I. Kaboré",
+          "overall_score": 72,
+          "potential": 77,
+          "value": 3300000,
+          "yearly_wage": 2704000
+        },
+        {
+          "currency": "€",
+          "full_name": "Manuel Akanji",
+          "name": "M. Akanji",
+          "overall_score": 83,
+          "potential": 83,
+          "value": 30500000,
+          "yearly_wage": 7540000
+        },
+        {
+          "currency": "€",
+          "full_name": "Kalvin Phillips",
+          "name": "K. Phillips",
+          "overall_score": 74,
+          "potential": 74,
+          "value": 3600000,
+          "yearly_wage": 3952000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jack Grealish",
+          "name": "J. Grealish",
+          "overall_score": 82,
+          "potential": 82,
+          "value": 30000000,
+          "yearly_wage": 7280000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jaden Heskey",
+          "name": "J. Heskey",
+          "overall_score": 64,
+          "potential": 80,
+          "value": 1500000,
+          "yearly_wage": 832000
+        },
+        {
+          "currency": "€",
+          "full_name": "Emilio Lawrence",
+          "name": "E. Lawrence",
+          "overall_score": 63,
+          "potential": 80,
+          "value": 1200000,
+          "yearly_wage": 780000
+        },
+        {
+          "currency": "€",
+          "full_name": "Divine Mukasa",
+          "name": "D. Mukasa",
+          "overall_score": 68,
+          "potential": 85,
+          "value": 3000000,
+          "yearly_wage": 1144000
+        },
+        {
+          "currency": "€",
+          "full_name": "Stephen Mfuni",
+          "name": "S. Mfuni",
+          "overall_score": 66,
+          "potential": 84,
+          "value": 2000000,
+          "yearly_wage": 728000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lakyle Samuel",
+          "name": "L. Samuel",
+          "overall_score": 60,
+          "potential": 73,
+          "value": 550000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "Vitor Reis",
+          "name": "Vitor Reis",
+          "overall_score": 76,
+          "potential": 86,
+          "value": 15000000,
+          "yearly_wage": 2912000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jahmai Simpson-Pusey",
+          "name": "J. Simpson-Pusey",
+          "overall_score": 68,
+          "potential": 79,
+          "value": 2400000,
+          "yearly_wage": 1352000
+        },
+        {
+          "currency": "€",
+          "full_name": "Abdulai Juma Bah",
+          "name": "A. Bah",
+          "overall_score": 73,
+          "potential": 81,
+          "value": 6000000,
+          "yearly_wage": 2340000
+        },
+        {
+          "currency": "€",
+          "full_name": "Joel Ndala",
+          "name": "J. Ndala",
+          "overall_score": 66,
+          "potential": 80,
+          "value": 2000000,
+          "yearly_wage": 1092000
+        }
+      ],
+      "team": "Manchester City",
+      "transfer_budget": 176900000,
+      "url": "https://sofifa.com/team/10/manchester-city/260037/"
+    },
+    {
+      "player_count": 45,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Emiliano Martínez",
+          "name": "E. Martínez",
+          "overall_score": 85,
+          "potential": 85,
+          "value": 26500000,
+          "yearly_wage": 5460000
+        },
+        {
+          "currency": "€",
+          "full_name": "Matty Cash",
+          "name": "M. Cash",
+          "overall_score": 81,
+          "potential": 81,
+          "value": 25000000,
+          "yearly_wage": 5720000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ezri Konsa",
+          "name": "E. Konsa",
+          "overall_score": 84,
+          "potential": 85,
+          "value": 42500000,
+          "yearly_wage": 7540000
+        },
+        {
+          "currency": "€",
+          "full_name": "Pau Francisco Torres",
+          "name": "Pau Torres",
+          "overall_score": 80,
+          "potential": 80,
+          "value": 18000000,
+          "yearly_wage": 5720000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lucas Digne",
+          "name": "L. Digne",
+          "overall_score": 80,
+          "potential": 80,
+          "value": 15500000,
+          "yearly_wage": 5720000
+        },
+        {
+          "currency": "€",
+          "full_name": "Amadou Onana",
+          "name": "A. Onana",
+          "overall_score": 81,
+          "potential": 84,
+          "value": 32000000,
+          "yearly_wage": 4940000
+        },
+        {
+          "currency": "€",
+          "full_name": "Youri Tielemans",
+          "name": "Y. Tielemans",
+          "overall_score": 85,
+          "potential": 85,
+          "value": 54000000,
+          "yearly_wage": 8840000
+        },
+        {
+          "currency": "€",
+          "full_name": "John McGinn",
+          "name": "J. McGinn",
+          "overall_score": 81,
+          "potential": 81,
+          "value": 25000000,
+          "yearly_wage": 6240000
+        },
+        {
+          "currency": "€",
+          "full_name": "Emiliano Buendía",
+          "name": "E. Buendía",
+          "overall_score": 78,
+          "potential": 78,
+          "value": 14000000,
+          "yearly_wage": 4940000
+        },
+        {
+          "currency": "€",
+          "full_name": "Morgan Rogers",
+          "name": "M. Rogers",
+          "overall_score": 84,
+          "potential": 86,
+          "value": 56000000,
+          "yearly_wage": 7020000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ollie Watkins",
+          "name": "O. Watkins",
+          "overall_score": 82,
+          "potential": 82,
+          "value": 30500000,
+          "yearly_wage": 7280000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jadon Sancho",
+          "name": "J. Sancho",
+          "overall_score": 79,
+          "potential": 80,
+          "value": 21000000,
+          "yearly_wage": 4160000
+        },
+        {
+          "currency": "€",
+          "full_name": "Douglas Luiz Soares de Paulo",
+          "name": "Douglas Luiz",
+          "overall_score": 79,
+          "potential": 79,
+          "value": 16500000,
+          "yearly_wage": 5200000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ross Barkley",
+          "name": "R. Barkley",
+          "overall_score": 77,
+          "potential": 77,
+          "value": 8500000,
+          "yearly_wage": 4680000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lamare Bogarde",
+          "name": "L. Bogarde",
+          "overall_score": 74,
+          "potential": 81,
+          "value": 8000000,
+          "yearly_wage": 2600000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ian Maatsen",
+          "name": "I. Maatsen",
+          "overall_score": 79,
+          "potential": 84,
+          "value": 24500000,
+          "yearly_wage": 4420000
+        },
+        {
+          "currency": "€",
+          "full_name": "Victor Lindelöf",
+          "name": "V. Lindelöf",
+          "overall_score": 76,
+          "potential": 76,
+          "value": 6000000,
+          "yearly_wage": 4212000
+        },
+        {
+          "currency": "€",
+          "full_name": "Marco Bizot",
+          "name": "M. Bizot",
+          "overall_score": 78,
+          "potential": 78,
+          "value": 2400000,
+          "yearly_wage": 3172000
+        },
+        {
+          "currency": "€",
+          "full_name": "Leon Bailey",
+          "name": "L. Bailey",
+          "overall_score": 78,
+          "potential": 78,
+          "value": 15000000,
+          "yearly_wage": 4940000
+        },
+        {
+          "currency": "€",
+          "full_name": "Tammy Abraham",
+          "name": "T. Abraham",
+          "overall_score": 77,
+          "potential": 77,
+          "value": 11500000,
+          "yearly_wage": 4940000
+        },
+        {
+          "currency": "€",
+          "full_name": "Tyrone Mings",
+          "name": "T. Mings",
+          "overall_score": 78,
+          "potential": 78,
+          "value": 9000000,
+          "yearly_wage": 4940000
+        },
+        {
+          "currency": "€",
+          "full_name": "Harvey Elliott",
+          "name": "H. Elliott",
+          "overall_score": 78,
+          "potential": 83,
+          "value": 21500000,
+          "yearly_wage": 3952000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alysson Edward F. da R. dos Santos",
+          "name": "Alysson",
+          "overall_score": 70,
+          "potential": 83,
+          "value": 3800000,
+          "yearly_wage": 1716000
+        },
+        {
+          "currency": "€",
+          "full_name": "George Hemmings",
+          "name": "G. Hemmings",
+          "overall_score": 65,
+          "potential": 80,
+          "value": 1600000,
+          "yearly_wage": 728000
+        },
+        {
+          "currency": "€",
+          "full_name": "Bradley Burrowes",
+          "name": "B. Burrowes",
+          "overall_score": 65,
+          "potential": 82,
+          "value": 1800000,
+          "yearly_wage": 624000
+        },
+        {
+          "currency": "€",
+          "full_name": "Andrés García Robledo",
+          "name": "Andrés García",
+          "overall_score": 73,
+          "potential": 81,
+          "value": 6500000,
+          "yearly_wage": 2808000
+        },
+        {
+          "currency": "€",
+          "full_name": "Boubacar Kamara",
+          "name": "B. Kamara",
+          "overall_score": 84,
+          "potential": 86,
+          "value": 47500000,
+          "yearly_wage": 7280000
+        },
+        {
+          "currency": "€",
+          "full_name": "Kadan Young",
+          "name": "K. Young",
+          "overall_score": 61,
+          "potential": 76,
+          "value": 775000,
+          "yearly_wage": 572000
+        },
+        {
+          "currency": "€",
+          "full_name": "Samuel Iling-Junior",
+          "name": "S. Iling-Junior",
+          "overall_score": 72,
+          "potential": 80,
+          "value": 5500000,
+          "yearly_wage": 2288000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lino Sousa",
+          "name": "L. Sousa",
+          "overall_score": 62,
+          "potential": 74,
+          "value": 925000,
+          "yearly_wage": 624000
+        },
+        {
+          "currency": "€",
+          "full_name": "Oliwier Zych",
+          "name": "O. Zych",
+          "overall_score": 68,
+          "potential": 78,
+          "value": 2300000,
+          "yearly_wage": 676000
+        },
+        {
+          "currency": "€",
+          "full_name": "Yasin Özcan",
+          "name": "Y. Özcan",
+          "overall_score": 69,
+          "potential": 82,
+          "value": 3100000,
+          "yearly_wage": 1404000
+        },
+        {
+          "currency": "€",
+          "full_name": "Josh Feeney",
+          "name": "J. Feeney",
+          "overall_score": 64,
+          "potential": 77,
+          "value": 1300000,
+          "yearly_wage": 780000
+        },
+        {
+          "currency": "€",
+          "full_name": "Tommi O'Reilly",
+          "name": "T. O'Reilly",
+          "overall_score": 64,
+          "potential": 71,
+          "value": 1200000,
+          "yearly_wage": 832000
+        },
+        {
+          "currency": "€",
+          "full_name": "Sil Swinkels",
+          "name": "S. Swinkels",
+          "overall_score": 63,
+          "potential": 74,
+          "value": 1000000,
+          "yearly_wage": 728000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lewis Dobbin",
+          "name": "L. Dobbin",
+          "overall_score": 71,
+          "potential": 80,
+          "value": 4200000,
+          "yearly_wage": 2392000
+        },
+        {
+          "currency": "€",
+          "full_name": "Louie Barry",
+          "name": "L. Barry",
+          "overall_score": 68,
+          "potential": 76,
+          "value": 2700000,
+          "yearly_wage": 1716000
+        },
+        {
+          "currency": "€",
+          "full_name": "Evann Guessand",
+          "name": "E. Guessand",
+          "overall_score": 78,
+          "potential": 83,
+          "value": 21000000,
+          "yearly_wage": 4524000
+        },
+        {
+          "currency": "€",
+          "full_name": "Enzo Barrenechea",
+          "name": "E. Barrenechea",
+          "overall_score": 77,
+          "potential": 82,
+          "value": 14500000,
+          "yearly_wage": 3744000
+        },
+        {
+          "currency": "€",
+          "full_name": "Joe Gauci",
+          "name": "J. Gauci",
+          "overall_score": 66,
+          "potential": 71,
+          "value": 1000000,
+          "yearly_wage": 728000
+        },
+        {
+          "currency": "€",
+          "full_name": "Donyell Malen",
+          "name": "D. Malen",
+          "overall_score": 80,
+          "potential": 80,
+          "value": 23500000,
+          "yearly_wage": 6240000
+        },
+        {
+          "currency": "€",
+          "full_name": "Triston Rowe",
+          "name": "T. Rowe",
+          "overall_score": 63,
+          "potential": 82,
+          "value": 1200000,
+          "yearly_wage": 624000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jamaldeen Jimoh-Aloba",
+          "name": "J. Jimoh-Aloba",
+          "overall_score": 65,
+          "potential": 79,
+          "value": 1700000,
+          "yearly_wage": 832000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ben Broggio",
+          "name": "B. Broggio",
+          "overall_score": 62,
+          "potential": 76,
+          "value": 925000,
+          "yearly_wage": 676000
+        },
+        {
+          "currency": "€",
+          "full_name": "Kosta Nedeljković",
+          "name": "K. Nedeljković",
+          "overall_score": 72,
+          "potential": 83,
+          "value": 4800000,
+          "yearly_wage": 2028000
+        }
+      ],
+      "team": "Aston Villa",
+      "transfer_budget": 77600000,
+      "url": "https://sofifa.com/team/2/aston-villa/260037/"
+    },
+    {
+      "player_count": 43,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Robert Lynch Sánchez",
+          "name": "Robert Sánchez",
+          "overall_score": 81,
+          "potential": 82,
+          "value": 22000000,
+          "yearly_wage": 3952000
+        },
+        {
+          "currency": "€",
+          "full_name": "Malo Gusto",
+          "name": "M. Gusto",
+          "overall_score": 79,
+          "potential": 84,
+          "value": 25000000,
+          "yearly_wage": 4680000
+        },
+        {
+          "currency": "€",
+          "full_name": "Wesley Fofana",
+          "name": "W. Fofana",
+          "overall_score": 79,
+          "potential": 82,
+          "value": 21500000,
+          "yearly_wage": 4680000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jorrel Hato",
+          "name": "J. Hato",
+          "overall_score": 78,
+          "potential": 87,
+          "value": 29000000,
+          "yearly_wage": 3380000
+        },
+        {
+          "currency": "€",
+          "full_name": "Marc Cucurella Saseta",
+          "name": "Marc Cucurella",
+          "overall_score": 85,
+          "potential": 85,
+          "value": 53500000,
+          "yearly_wage": 8840000
+        },
+        {
+          "currency": "€",
+          "full_name": "Reece James",
+          "name": "R. James",
+          "overall_score": 84,
+          "potential": 86,
+          "value": 48500000,
+          "yearly_wage": 7540000
+        },
+        {
+          "currency": "€",
+          "full_name": "Moisés Caicedo",
+          "name": "M. Caicedo",
+          "overall_score": 88,
+          "potential": 90,
+          "value": 107000000,
+          "yearly_wage": 9620000
+        },
+        {
+          "currency": "€",
+          "full_name": "Cole Palmer",
+          "name": "C. Palmer",
+          "overall_score": 86,
+          "potential": 89,
+          "value": 93000000,
+          "yearly_wage": 8840000
+        },
+        {
+          "currency": "€",
+          "full_name": "Pedro Lomba Neto",
+          "name": "Pedro Neto",
+          "overall_score": 82,
+          "potential": 83,
+          "value": 36500000,
+          "yearly_wage": 6760000
+        },
+        {
+          "currency": "€",
+          "full_name": "Enzo Fernández",
+          "name": "E. Fernández",
+          "overall_score": 85,
+          "potential": 88,
+          "value": 73000000,
+          "yearly_wage": 7800000
+        },
+        {
+          "currency": "€",
+          "full_name": "João Pedro Junqueira de Jesus",
+          "name": "João Pedro",
+          "overall_score": 82,
+          "potential": 86,
+          "value": 44000000,
+          "yearly_wage": 6760000
+        },
+        {
+          "currency": "€",
+          "full_name": "Andrey N. dos Santos",
+          "name": "Andrey Santos",
+          "overall_score": 80,
+          "potential": 87,
+          "value": 42500000,
+          "yearly_wage": 4472000
+        },
+        {
+          "currency": "€",
+          "full_name": "Romeo Lavia",
+          "name": "R. Lavia",
+          "overall_score": 78,
+          "potential": 85,
+          "value": 27000000,
+          "yearly_wage": 3588000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alejandro Garnacho",
+          "name": "A. Garnacho",
+          "overall_score": 78,
+          "potential": 84,
+          "value": 22500000,
+          "yearly_wage": 3796000
+        },
+        {
+          "currency": "€",
+          "full_name": "Dário Cassia Luís Essugo",
+          "name": "Dário Essugo",
+          "overall_score": 75,
+          "potential": 83,
+          "value": 11500000,
+          "yearly_wage": 3016000
+        },
+        {
+          "currency": "€",
+          "full_name": "Trevoh Chalobah",
+          "name": "T. Chalobah",
+          "overall_score": 80,
+          "potential": 82,
+          "value": 23500000,
+          "yearly_wage": 5460000
+        },
+        {
+          "currency": "€",
+          "full_name": "Tosin Adarabioyo",
+          "name": "T. Adarabioyo",
+          "overall_score": 78,
+          "potential": 79,
+          "value": 14000000,
+          "yearly_wage": 4940000
+        },
+        {
+          "currency": "€",
+          "full_name": "Filip Jörgensen",
+          "name": "F. Jörgensen",
+          "overall_score": 77,
+          "potential": 83,
+          "value": 13500000,
+          "yearly_wage": 2340000
+        },
+        {
+          "currency": "€",
+          "full_name": "Marc Guiu Paz",
+          "name": "Marc Guiu",
+          "overall_score": 71,
+          "potential": 84,
+          "value": 4500000,
+          "yearly_wage": 2340000
+        },
+        {
+          "currency": "€",
+          "full_name": "Liam Delap",
+          "name": "L. Delap",
+          "overall_score": 77,
+          "potential": 83,
+          "value": 17000000,
+          "yearly_wage": 4628000
+        },
+        {
+          "currency": "€",
+          "full_name": "Levi Colwill",
+          "name": "L. Colwill",
+          "overall_score": 80,
+          "potential": 84,
+          "value": 27500000,
+          "yearly_wage": 4940000
+        },
+        {
+          "currency": "€",
+          "full_name": "Josh Acheampong",
+          "name": "J. Acheampong",
+          "overall_score": 74,
+          "potential": 85,
+          "value": 8500000,
+          "yearly_wage": 2600000
+        },
+        {
+          "currency": "€",
+          "full_name": "Benoît Badiashile",
+          "name": "B. Badiashile",
+          "overall_score": 76,
+          "potential": 80,
+          "value": 9500000,
+          "yearly_wage": 3744000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mamadou Sarr",
+          "name": "M. Sarr",
+          "overall_score": 77,
+          "potential": 84,
+          "value": 19000000,
+          "yearly_wage": 3172000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jesse Derry",
+          "name": "J. Derry",
+          "overall_score": 68,
+          "potential": 85,
+          "value": 3100000,
+          "yearly_wage": 1352000
+        },
+        {
+          "currency": "€",
+          "full_name": "Shumaira Mheuka",
+          "name": "S. Mheuka",
+          "overall_score": 66,
+          "potential": 84,
+          "value": 2100000,
+          "yearly_wage": 936000
+        },
+        {
+          "currency": "€",
+          "full_name": "Gabriel Slonina",
+          "name": "G. Slonina",
+          "overall_score": 68,
+          "potential": 80,
+          "value": 2600000,
+          "yearly_wage": 728000
+        },
+        {
+          "currency": "€",
+          "full_name": "Teddy Sharman-Lowe",
+          "name": "T. Sharman-Lowe",
+          "overall_score": 64,
+          "potential": 74,
+          "value": 1100000,
+          "yearly_wage": 572000
+        },
+        {
+          "currency": "€",
+          "full_name": "Estêvão Willian Almeida",
+          "name": "Estêvão",
+          "overall_score": 79,
+          "potential": 89,
+          "value": 37000000,
+          "yearly_wage": 3692000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jamie Gittens",
+          "name": "J. Gittens",
+          "overall_score": 78,
+          "potential": 84,
+          "value": 22000000,
+          "yearly_wage": 3796000
+        },
+        {
+          "currency": "€",
+          "full_name": "Aarón Anselmino",
+          "name": "A. Anselmino",
+          "overall_score": 73,
+          "potential": 81,
+          "value": 6000000,
+          "yearly_wage": 2496000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ronnie Stutter",
+          "name": "R. Stutter",
+          "overall_score": 60,
+          "potential": 72,
+          "value": 600000,
+          "yearly_wage": 572000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jimmy-Jay Morgan",
+          "name": "J. Morgan",
+          "overall_score": 65,
+          "potential": 79,
+          "value": 1700000,
+          "yearly_wage": 1040000
+        },
+        {
+          "currency": "€",
+          "full_name": "Omari Kellyman",
+          "name": "O. Kellyman",
+          "overall_score": 65,
+          "potential": 80,
+          "value": 1700000,
+          "yearly_wage": 936000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ishé Samuels-Smith",
+          "name": "I. Samuels-Smith",
+          "overall_score": 68,
+          "potential": 77,
+          "value": 2500000,
+          "yearly_wage": 1352000
+        },
+        {
+          "currency": "€",
+          "full_name": "Kendry Páez",
+          "name": "K. Páez",
+          "overall_score": 73,
+          "potential": 84,
+          "value": 6500000,
+          "yearly_wage": 2392000
+        },
+        {
+          "currency": "€",
+          "full_name": "Brodi Hughes",
+          "name": "B. Hughes",
+          "overall_score": 59,
+          "potential": 72,
+          "value": 525000,
+          "yearly_wage": 520000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mike Penders",
+          "name": "M. Penders",
+          "overall_score": 77,
+          "potential": 86,
+          "value": 19500000,
+          "yearly_wage": 1456000
+        },
+        {
+          "currency": "€",
+          "full_name": "David Datro Fofana",
+          "name": "D. Fofana",
+          "overall_score": 72,
+          "potential": 80,
+          "value": 5500000,
+          "yearly_wage": 3120000
+        },
+        {
+          "currency": "€",
+          "full_name": "Nicolas Jackson",
+          "name": "N. Jackson",
+          "overall_score": 79,
+          "potential": 82,
+          "value": 24500000,
+          "yearly_wage": 5460000
+        },
+        {
+          "currency": "€",
+          "full_name": "Axel Disasi",
+          "name": "A. Disasi",
+          "overall_score": 77,
+          "potential": 78,
+          "value": 10500000,
+          "yearly_wage": 4628000
+        },
+        {
+          "currency": "€",
+          "full_name": "Dujuan Richards",
+          "name": "D. Richards",
+          "overall_score": 62,
+          "potential": 79,
+          "value": 1000000,
+          "yearly_wage": 780000
+        },
+        {
+          "currency": "€",
+          "full_name": "Tyrique George",
+          "name": "T. George",
+          "overall_score": 71,
+          "potential": 84,
+          "value": 4400000,
+          "yearly_wage": 2080000
+        }
+      ],
+      "team": "Chelsea",
+      "transfer_budget": 168900000,
+      "url": "https://sofifa.com/team/5/chelsea/260037/"
+    },
+    {
+      "player_count": 35,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Aaron Ramsdale",
+          "name": "A. Ramsdale",
+          "overall_score": 77,
+          "potential": 79,
+          "value": 9500000,
+          "yearly_wage": 1768000
+        },
+        {
+          "currency": "€",
+          "full_name": "Kieran Trippier",
+          "name": "K. Trippier",
+          "overall_score": 79,
+          "potential": 79,
+          "value": 6500000,
+          "yearly_wage": 5720000
+        },
+        {
+          "currency": "€",
+          "full_name": "Malick Thiaw",
+          "name": "M. Thiaw",
+          "overall_score": 81,
+          "potential": 85,
+          "value": 33000000,
+          "yearly_wage": 5200000
+        },
+        {
+          "currency": "€",
+          "full_name": "Sven Botman",
+          "name": "S. Botman",
+          "overall_score": 81,
+          "potential": 83,
+          "value": 28500000,
+          "yearly_wage": 5980000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lewis Hall",
+          "name": "L. Hall",
+          "overall_score": 81,
+          "potential": 86,
+          "value": 35500000,
+          "yearly_wage": 4472000
+        },
+        {
+          "currency": "€",
+          "full_name": "Sandro Tonali",
+          "name": "S. Tonali",
+          "overall_score": 85,
+          "potential": 87,
+          "value": 60500000,
+          "yearly_wage": 8320000
+        },
+        {
+          "currency": "€",
+          "full_name": "Bruno Guimarães Moura",
+          "name": "Bruno Guimarães",
+          "overall_score": 86,
+          "potential": 86,
+          "value": 72000000,
+          "yearly_wage": 9880000
+        },
+        {
+          "currency": "€",
+          "full_name": "Joelinton Apolinário de Lira",
+          "name": "Joelinton",
+          "overall_score": 81,
+          "potential": 81,
+          "value": 25500000,
+          "yearly_wage": 6760000
+        },
+        {
+          "currency": "€",
+          "full_name": "Harvey Barnes",
+          "name": "H. Barnes",
+          "overall_score": 80,
+          "potential": 80,
+          "value": 22500000,
+          "yearly_wage": 6500000
+        },
+        {
+          "currency": "€",
+          "full_name": "William Osula",
+          "name": "W. Osula",
+          "overall_score": 73,
+          "potential": 81,
+          "value": 7000000,
+          "yearly_wage": 2964000
+        },
+        {
+          "currency": "€",
+          "full_name": "Anthony Gordon",
+          "name": "A. Gordon",
+          "overall_score": 82,
+          "potential": 85,
+          "value": 41500000,
+          "yearly_wage": 6500000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jacob Murphy",
+          "name": "J. Murphy",
+          "overall_score": 79,
+          "potential": 79,
+          "value": 17000000,
+          "yearly_wage": 6240000
+        },
+        {
+          "currency": "€",
+          "full_name": "Anthony Elanga",
+          "name": "A. Elanga",
+          "overall_score": 79,
+          "potential": 82,
+          "value": 24000000,
+          "yearly_wage": 5460000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jacob Ramsey",
+          "name": "J. Ramsey",
+          "overall_score": 77,
+          "potential": 81,
+          "value": 15000000,
+          "yearly_wage": 4212000
+        },
+        {
+          "currency": "€",
+          "full_name": "Joe Willock",
+          "name": "J. Willock",
+          "overall_score": 76,
+          "potential": 78,
+          "value": 9500000,
+          "yearly_wage": 4316000
+        },
+        {
+          "currency": "€",
+          "full_name": "Dan Burn",
+          "name": "D. Burn",
+          "overall_score": 80,
+          "potential": 80,
+          "value": 10000000,
+          "yearly_wage": 5980000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alex Murphy",
+          "name": "A. Murphy",
+          "overall_score": 65,
+          "potential": 79,
+          "value": 1700000,
+          "yearly_wage": 884000
+        },
+        {
+          "currency": "€",
+          "full_name": "Nick Pope",
+          "name": "N. Pope",
+          "overall_score": 79,
+          "potential": 79,
+          "value": 5500000,
+          "yearly_wage": 3692000
+        },
+        {
+          "currency": "€",
+          "full_name": "Nick Woltemade",
+          "name": "N. Woltemade",
+          "overall_score": 80,
+          "potential": 85,
+          "value": 32000000,
+          "yearly_wage": 5720000
+        },
+        {
+          "currency": "€",
+          "full_name": "Yoane Wissa",
+          "name": "Y. Wissa",
+          "overall_score": 81,
+          "potential": 81,
+          "value": 26500000,
+          "yearly_wage": 7280000
+        },
+        {
+          "currency": "€",
+          "full_name": "Sean Neave",
+          "name": "S. Neave",
+          "overall_score": 59,
+          "potential": 79,
+          "value": 625000,
+          "yearly_wage": 520000
+        },
+        {
+          "currency": "€",
+          "full_name": "Leo Shahar",
+          "name": "L. Shahar",
+          "overall_score": 60,
+          "potential": 79,
+          "value": 600000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "John Ruddy",
+          "name": "J. Ruddy",
+          "overall_score": 68,
+          "potential": 68,
+          "value": 130000,
+          "yearly_wage": 832000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mark Gillespie",
+          "name": "M. Gillespie",
+          "overall_score": 62,
+          "potential": 62,
+          "value": 130000,
+          "yearly_wage": 624000
+        },
+        {
+          "currency": "€",
+          "full_name": "Fabian Schär",
+          "name": "F. Schär",
+          "overall_score": 82,
+          "potential": 82,
+          "value": 14500000,
+          "yearly_wage": 7020000
+        },
+        {
+          "currency": "€",
+          "full_name": "Tino Livramento",
+          "name": "T. Livramento",
+          "overall_score": 80,
+          "potential": 86,
+          "value": 31500000,
+          "yearly_wage": 4940000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lewis Miley",
+          "name": "L. Miley",
+          "overall_score": 76,
+          "potential": 86,
+          "value": 16000000,
+          "yearly_wage": 3120000
+        },
+        {
+          "currency": "€",
+          "full_name": "Emil Krafth",
+          "name": "E. Krafth",
+          "overall_score": 72,
+          "potential": 72,
+          "value": 2000000,
+          "yearly_wage": 3276000
+        },
+        {
+          "currency": "€",
+          "full_name": "Travis Hernes",
+          "name": "T. Hernes",
+          "overall_score": 61,
+          "potential": 77,
+          "value": 850000,
+          "yearly_wage": 624000
+        },
+        {
+          "currency": "€",
+          "full_name": "Trevan Sanusi",
+          "name": "T. Sanusi",
+          "overall_score": 61,
+          "potential": 82,
+          "value": 1000000,
+          "yearly_wage": 624000
+        },
+        {
+          "currency": "€",
+          "full_name": "Harrison Ashby",
+          "name": "H. Ashby",
+          "overall_score": 63,
+          "potential": 70,
+          "value": 925000,
+          "yearly_wage": 884000
+        },
+        {
+          "currency": "€",
+          "full_name": "Joe White",
+          "name": "J. White",
+          "overall_score": 63,
+          "potential": 70,
+          "value": 975000,
+          "yearly_wage": 936000
+        },
+        {
+          "currency": "€",
+          "full_name": "Matt Targett",
+          "name": "M. Targett",
+          "overall_score": 72,
+          "potential": 72,
+          "value": 2100000,
+          "yearly_wage": 3276000
+        },
+        {
+          "currency": "€",
+          "full_name": "Odysseas Vlachodimos",
+          "name": "O. Vlachodimos",
+          "overall_score": 79,
+          "potential": 79,
+          "value": 9500000,
+          "yearly_wage": 3692000
+        },
+        {
+          "currency": "€",
+          "full_name": "Antonio José Cordero Campillo",
+          "name": "Antoñito Cordero",
+          "overall_score": 67,
+          "potential": 77,
+          "value": 2100000,
+          "yearly_wage": 1352000
+        }
+      ],
+      "team": "Newcastle United",
+      "transfer_budget": 97200000,
+      "url": "https://sofifa.com/team/13/newcastle-united/260037/"
+    },
+    {
+      "player_count": 45,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Antonín Kinský",
+          "name": "A. Kinský",
+          "overall_score": 75,
+          "potential": 81,
+          "value": 7500000,
+          "yearly_wage": 1820000
+        },
+        {
+          "currency": "€",
+          "full_name": "Pedro Antonio Porro Sauceda",
+          "name": "Pedro Porro",
+          "overall_score": 82,
+          "potential": 85,
+          "value": 37000000,
+          "yearly_wage": 5460000
+        },
+        {
+          "currency": "€",
+          "full_name": "Cristian Romero",
+          "name": "C. Romero",
+          "overall_score": 82,
+          "potential": 84,
+          "value": 32500000,
+          "yearly_wage": 5980000
+        },
+        {
+          "currency": "€",
+          "full_name": "Micky van de Ven",
+          "name": "M. van de Ven",
+          "overall_score": 82,
+          "potential": 85,
+          "value": 37000000,
+          "yearly_wage": 4940000
+        },
+        {
+          "currency": "€",
+          "full_name": "Djed Spence",
+          "name": "D. Spence",
+          "overall_score": 79,
+          "potential": 83,
+          "value": 23500000,
+          "yearly_wage": 4160000
+        },
+        {
+          "currency": "€",
+          "full_name": "João Maria Palhinha Gonçalves",
+          "name": "Palhinha",
+          "overall_score": 82,
+          "potential": 82,
+          "value": 26000000,
+          "yearly_wage": 3900000
+        },
+        {
+          "currency": "€",
+          "full_name": "Rodrigo Bentancur",
+          "name": "R. Bentancur",
+          "overall_score": 80,
+          "potential": 81,
+          "value": 20500000,
+          "yearly_wage": 5200000
+        },
+        {
+          "currency": "€",
+          "full_name": "Randal Kolo Muani",
+          "name": "R. Kolo Muani",
+          "overall_score": 79,
+          "potential": 80,
+          "value": 21000000,
+          "yearly_wage": 4420000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mathys Tel",
+          "name": "M. Tel",
+          "overall_score": 77,
+          "potential": 85,
+          "value": 23500000,
+          "yearly_wage": 3536000
+        },
+        {
+          "currency": "€",
+          "full_name": "Conor Gallagher",
+          "name": "C. Gallagher",
+          "overall_score": 79,
+          "potential": 81,
+          "value": 22000000,
+          "yearly_wage": 4680000
+        },
+        {
+          "currency": "€",
+          "full_name": "Richarlison de Andrade",
+          "name": "Richarlison",
+          "overall_score": 79,
+          "potential": 79,
+          "value": 18000000,
+          "yearly_wage": 5720000
+        },
+        {
+          "currency": "€",
+          "full_name": "James Maddison",
+          "name": "J. Maddison",
+          "overall_score": 83,
+          "potential": 83,
+          "value": 36500000,
+          "yearly_wage": 7020000
+        },
+        {
+          "currency": "€",
+          "full_name": "Yves Bissouma",
+          "name": "Y. Bissouma",
+          "overall_score": 78,
+          "potential": 78,
+          "value": 12500000,
+          "yearly_wage": 4524000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lucas Bergvall",
+          "name": "L. Bergvall",
+          "overall_score": 78,
+          "potential": 87,
+          "value": 30000000,
+          "yearly_wage": 3172000
+        },
+        {
+          "currency": "€",
+          "full_name": "Archie Gray",
+          "name": "A. Gray",
+          "overall_score": 77,
+          "potential": 86,
+          "value": 21500000,
+          "yearly_wage": 2756000
+        },
+        {
+          "currency": "€",
+          "full_name": "Kevin Danso",
+          "name": "K. Danso",
+          "overall_score": 79,
+          "potential": 82,
+          "value": 20500000,
+          "yearly_wage": 4680000
+        },
+        {
+          "currency": "€",
+          "full_name": "Destiny Udogie",
+          "name": "D. Udogie",
+          "overall_score": 79,
+          "potential": 83,
+          "value": 24000000,
+          "yearly_wage": 4160000
+        },
+        {
+          "currency": "€",
+          "full_name": "Guglielmo Vicario",
+          "name": "G. Vicario",
+          "overall_score": 81,
+          "potential": 82,
+          "value": 20500000,
+          "yearly_wage": 3692000
+        },
+        {
+          "currency": "€",
+          "full_name": "Pape Matar Sarr",
+          "name": "P. Sarr",
+          "overall_score": 80,
+          "potential": 85,
+          "value": 32000000,
+          "yearly_wage": 4576000
+        },
+        {
+          "currency": "€",
+          "full_name": "Dominic Solanke",
+          "name": "D. Solanke",
+          "overall_score": 80,
+          "potential": 80,
+          "value": 23000000,
+          "yearly_wage": 5720000
+        },
+        {
+          "currency": "€",
+          "full_name": "Radu Drăgușin",
+          "name": "R. Drăgușin",
+          "overall_score": 75,
+          "potential": 81,
+          "value": 8000000,
+          "yearly_wage": 3120000
+        },
+        {
+          "currency": "€",
+          "full_name": "Callum Olusesi",
+          "name": "C. Olusesi",
+          "overall_score": 62,
+          "potential": 81,
+          "value": 1000000,
+          "yearly_wage": 572000
+        },
+        {
+          "currency": "€",
+          "full_name": "João Victor de Souza Menezes",
+          "name": "Souza",
+          "overall_score": 70,
+          "potential": 82,
+          "value": 3600000,
+          "yearly_wage": 1508000
+        },
+        {
+          "currency": "€",
+          "full_name": "Brandon Austin",
+          "name": "B. Austin",
+          "overall_score": 67,
+          "potential": 71,
+          "value": 1100000,
+          "yearly_wage": 988000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jun'ai Byfield",
+          "name": "J. Byfield",
+          "overall_score": 62,
+          "potential": 80,
+          "value": 925000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "James Rowswell",
+          "name": "J. Rowswell",
+          "overall_score": 61,
+          "potential": 76,
+          "value": 725000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "Dejan Kulusevski",
+          "name": "D. Kulusevski",
+          "overall_score": 83,
+          "potential": 86,
+          "value": 47500000,
+          "yearly_wage": 6500000
+        },
+        {
+          "currency": "€",
+          "full_name": "Xavi Simons",
+          "name": "X. Simons",
+          "overall_score": 82,
+          "potential": 85,
+          "value": 42500000,
+          "yearly_wage": 5460000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mohammed Kudus",
+          "name": "M. Kudus",
+          "overall_score": 81,
+          "potential": 83,
+          "value": 33500000,
+          "yearly_wage": 5200000
+        },
+        {
+          "currency": "€",
+          "full_name": "Wilson Odobert",
+          "name": "W. Odobert",
+          "overall_score": 77,
+          "potential": 84,
+          "value": 21000000,
+          "yearly_wage": 3432000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ben Davies",
+          "name": "B. Davies",
+          "overall_score": 75,
+          "potential": 75,
+          "value": 3600000,
+          "yearly_wage": 3796000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jamie Donley",
+          "name": "J. Donley",
+          "overall_score": 67,
+          "potential": 80,
+          "value": 2500000,
+          "yearly_wage": 1248000
+        },
+        {
+          "currency": "€",
+          "full_name": "Luka Vušković",
+          "name": "L. Vušković",
+          "overall_score": 78,
+          "potential": 88,
+          "value": 27500000,
+          "yearly_wage": 2756000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alejo Veliz",
+          "name": "A. Veliz",
+          "overall_score": 72,
+          "potential": 79,
+          "value": 4800000,
+          "yearly_wage": 2392000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ashley Phillips",
+          "name": "A. Phillips",
+          "overall_score": 71,
+          "potential": 81,
+          "value": 3800000,
+          "yearly_wage": 1820000
+        },
+        {
+          "currency": "€",
+          "full_name": "Kota Takai",
+          "name": "K. Takai",
+          "overall_score": 72,
+          "potential": 79,
+          "value": 4300000,
+          "yearly_wage": 2028000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alfie Devine",
+          "name": "A. Devine",
+          "overall_score": 73,
+          "potential": 84,
+          "value": 6500000,
+          "yearly_wage": 2392000
+        },
+        {
+          "currency": "€",
+          "full_name": "Dane Scarlett",
+          "name": "D. Scarlett",
+          "overall_score": 65,
+          "potential": 76,
+          "value": 1600000,
+          "yearly_wage": 936000
+        },
+        {
+          "currency": "€",
+          "full_name": "Manor Solomon",
+          "name": "M. Solomon",
+          "overall_score": 77,
+          "potential": 77,
+          "value": 11500000,
+          "yearly_wage": 4056000
+        },
+        {
+          "currency": "€",
+          "full_name": "Oliver Irow",
+          "name": "O. Irow",
+          "overall_score": 63,
+          "potential": 80,
+          "value": 1200000,
+          "yearly_wage": 676000
+        },
+        {
+          "currency": "€",
+          "full_name": "Will Lankshear",
+          "name": "W. Lankshear",
+          "overall_score": 67,
+          "potential": 81,
+          "value": 2500000,
+          "yearly_wage": 1352000
+        },
+        {
+          "currency": "€",
+          "full_name": "George Abbott",
+          "name": "G. Abbott",
+          "overall_score": 65,
+          "potential": 78,
+          "value": 1700000,
+          "yearly_wage": 780000
+        },
+        {
+          "currency": "€",
+          "full_name": "Tyrese Hall",
+          "name": "T. Hall",
+          "overall_score": 64,
+          "potential": 79,
+          "value": 1400000,
+          "yearly_wage": 728000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mikey Moore",
+          "name": "M. Moore",
+          "overall_score": 74,
+          "potential": 88,
+          "value": 9500000,
+          "yearly_wage": 2080000
+        },
+        {
+          "currency": "€",
+          "full_name": "Min Hyeok Yang",
+          "name": "Yang Min Hyeok",
+          "overall_score": 69,
+          "potential": 82,
+          "value": 3300000,
+          "yearly_wage": 1404000
+        }
+      ],
+      "team": "Tottenham Hotspur",
+      "transfer_budget": 127000000,
+      "url": "https://sofifa.com/team/18/tottenham-hotspur/260037/"
+    },
+    {
+      "player_count": 45,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Senne Lammens",
+          "name": "S. Lammens",
+          "overall_score": 81,
+          "potential": 87,
+          "value": 33500000,
+          "yearly_wage": 2340000
+        },
+        {
+          "currency": "€",
+          "full_name": "José Diogo Dalot Teixeira",
+          "name": "Diogo Dalot",
+          "overall_score": 78,
+          "potential": 79,
+          "value": 15000000,
+          "yearly_wage": 3744000
+        },
+        {
+          "currency": "€",
+          "full_name": "Harry Maguire",
+          "name": "H. Maguire",
+          "overall_score": 81,
+          "potential": 81,
+          "value": 16500000,
+          "yearly_wage": 4940000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ayden Heaven",
+          "name": "A. Heaven",
+          "overall_score": 74,
+          "potential": 85,
+          "value": 8500000,
+          "yearly_wage": 1872000
+        },
+        {
+          "currency": "€",
+          "full_name": "Luke Shaw",
+          "name": "L. Shaw",
+          "overall_score": 79,
+          "potential": 79,
+          "value": 15500000,
+          "yearly_wage": 4316000
+        },
+        {
+          "currency": "€",
+          "full_name": "Carlos Henrique Venancio Casimiro",
+          "name": "Casemiro",
+          "overall_score": 82,
+          "potential": 82,
+          "value": 15000000,
+          "yearly_wage": 5200000
+        },
+        {
+          "currency": "€",
+          "full_name": "Kobbie Mainoo",
+          "name": "K. Mainoo",
+          "overall_score": 79,
+          "potential": 85,
+          "value": 25000000,
+          "yearly_wage": 3016000
+        },
+        {
+          "currency": "€",
+          "full_name": "Amad Diallo",
+          "name": "Amad",
+          "overall_score": 80,
+          "potential": 85,
+          "value": 32500000,
+          "yearly_wage": 4004000
+        },
+        {
+          "currency": "€",
+          "full_name": "Matheus Santos Carneiro da Cunha",
+          "name": "Matheus Cunha",
+          "overall_score": 83,
+          "potential": 84,
+          "value": 43000000,
+          "yearly_wage": 5980000
+        },
+        {
+          "currency": "€",
+          "full_name": "Bruno Miguel Borges Fernandes",
+          "name": "Bruno Fernandes",
+          "overall_score": 88,
+          "potential": 88,
+          "value": 88000000,
+          "yearly_wage": 9620000
+        },
+        {
+          "currency": "€",
+          "full_name": "Bryan Mbeumo",
+          "name": "B. Mbeumo",
+          "overall_score": 85,
+          "potential": 86,
+          "value": 64500000,
+          "yearly_wage": 7020000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mason Mount",
+          "name": "M. Mount",
+          "overall_score": 78,
+          "potential": 79,
+          "value": 16500000,
+          "yearly_wage": 4004000
+        },
+        {
+          "currency": "€",
+          "full_name": "Manuel Ugarte",
+          "name": "M. Ugarte",
+          "overall_score": 78,
+          "potential": 82,
+          "value": 18500000,
+          "yearly_wage": 3224000
+        },
+        {
+          "currency": "€",
+          "full_name": "Patrick Dorgu",
+          "name": "P. Dorgu",
+          "overall_score": 77,
+          "potential": 84,
+          "value": 21000000,
+          "yearly_wage": 2704000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lisandro Martínez",
+          "name": "L. Martínez",
+          "overall_score": 81,
+          "potential": 82,
+          "value": 26000000,
+          "yearly_wage": 4680000
+        },
+        {
+          "currency": "€",
+          "full_name": "Noussair Mazraoui",
+          "name": "N. Mazraoui",
+          "overall_score": 80,
+          "potential": 80,
+          "value": 20500000,
+          "yearly_wage": 4368000
+        },
+        {
+          "currency": "€",
+          "full_name": "Leny Yoro",
+          "name": "L. Yoro",
+          "overall_score": 78,
+          "potential": 86,
+          "value": 28500000,
+          "yearly_wage": 2548000
+        },
+        {
+          "currency": "€",
+          "full_name": "Altay Bayındır",
+          "name": "A. Bayındır",
+          "overall_score": 75,
+          "potential": 77,
+          "value": 5000000,
+          "yearly_wage": 1976000
+        },
+        {
+          "currency": "€",
+          "full_name": "Benjamin Šeško",
+          "name": "B. Šeško",
+          "overall_score": 80,
+          "potential": 87,
+          "value": 43000000,
+          "yearly_wage": 4368000
+        },
+        {
+          "currency": "€",
+          "full_name": "Joshua Zirkzee",
+          "name": "J. Zirkzee",
+          "overall_score": 77,
+          "potential": 82,
+          "value": 16000000,
+          "yearly_wage": 3536000
+        },
+        {
+          "currency": "€",
+          "full_name": "Matthijs de Ligt",
+          "name": "M. de Ligt",
+          "overall_score": 82,
+          "potential": 84,
+          "value": 34000000,
+          "yearly_wage": 4940000
+        },
+        {
+          "currency": "€",
+          "full_name": "Tyrell Malacia",
+          "name": "T. Malacia",
+          "overall_score": 75,
+          "potential": 76,
+          "value": 6000000,
+          "yearly_wage": 3016000
+        },
+        {
+          "currency": "€",
+          "full_name": "Shea Lacey",
+          "name": "S. Lacey",
+          "overall_score": 65,
+          "potential": 84,
+          "value": 1800000,
+          "yearly_wage": 676000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jack Fletcher",
+          "name": "J. Fletcher",
+          "overall_score": 63,
+          "potential": 81,
+          "value": 1200000,
+          "yearly_wage": 520000
+        },
+        {
+          "currency": "€",
+          "full_name": "Tyler Fredricson",
+          "name": "T. Fredricson",
+          "overall_score": 65,
+          "potential": 78,
+          "value": 1600000,
+          "yearly_wage": 676000
+        },
+        {
+          "currency": "€",
+          "full_name": "Bendito Mantato",
+          "name": "B. Mantato",
+          "overall_score": 62,
+          "potential": 83,
+          "value": 1200000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "Tyler Fletcher",
+          "name": "T. Fletcher",
+          "overall_score": 62,
+          "potential": 80,
+          "value": 1000000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "Tom Heaton",
+          "name": "T. Heaton",
+          "overall_score": 67,
+          "potential": 67,
+          "value": 110000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "Diego León",
+          "name": "D. León",
+          "overall_score": 64,
+          "potential": 83,
+          "value": 1400000,
+          "yearly_wage": 572000
+        },
+        {
+          "currency": "€",
+          "full_name": "Chido Obi",
+          "name": "C. Obi",
+          "overall_score": 65,
+          "potential": 84,
+          "value": 1800000,
+          "yearly_wage": 624000
+        },
+        {
+          "currency": "€",
+          "full_name": "Gabriele Biancheri",
+          "name": "G. Biancheri",
+          "overall_score": 60,
+          "potential": 78,
+          "value": 625000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "Harry Amass",
+          "name": "H. Amass",
+          "overall_score": 69,
+          "potential": 83,
+          "value": 3100000,
+          "yearly_wage": 1092000
+        },
+        {
+          "currency": "€",
+          "full_name": "Radek Vítek",
+          "name": "R. Vítek",
+          "overall_score": 73,
+          "potential": 80,
+          "value": 5500000,
+          "yearly_wage": 988000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ethan Ennis",
+          "name": "E. Ennis",
+          "overall_score": 61,
+          "potential": 72,
+          "value": 725000,
+          "yearly_wage": 520000
+        },
+        {
+          "currency": "€",
+          "full_name": "Daniel Gore",
+          "name": "D. Gore",
+          "overall_score": 64,
+          "potential": 75,
+          "value": 1300000,
+          "yearly_wage": 676000
+        },
+        {
+          "currency": "€",
+          "full_name": "Toby Collyer",
+          "name": "T. Collyer",
+          "overall_score": 70,
+          "potential": 78,
+          "value": 3400000,
+          "yearly_wage": 1404000
+        },
+        {
+          "currency": "€",
+          "full_name": "Rasmus Højlund",
+          "name": "R. Højlund",
+          "overall_score": 78,
+          "potential": 83,
+          "value": 22000000,
+          "yearly_wage": 3744000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jadon Sancho",
+          "name": "J. Sancho",
+          "overall_score": 79,
+          "potential": 80,
+          "value": 21000000,
+          "yearly_wage": 4160000
+        },
+        {
+          "currency": "€",
+          "full_name": "Marcus Rashford",
+          "name": "M. Rashford",
+          "overall_score": 82,
+          "potential": 82,
+          "value": 32500000,
+          "yearly_wage": 5720000
+        },
+        {
+          "currency": "€",
+          "full_name": "André Onana",
+          "name": "A. Onana",
+          "overall_score": 79,
+          "potential": 79,
+          "value": 12000000,
+          "yearly_wage": 2860000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jacob Devaney",
+          "name": "J. Devaney",
+          "overall_score": 63,
+          "potential": 81,
+          "value": 1200000,
+          "yearly_wage": 520000
+        },
+        {
+          "currency": "€",
+          "full_name": "James Scanlon",
+          "name": "J. Scanlon",
+          "overall_score": 61,
+          "potential": 78,
+          "value": 825000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "Sékou Koné",
+          "name": "S. Koné",
+          "overall_score": 61,
+          "potential": 76,
+          "value": 725000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ethan Williams",
+          "name": "E. Williams",
+          "overall_score": 61,
+          "potential": 79,
+          "value": 850000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ethan Wheatley",
+          "name": "E. Wheatley",
+          "overall_score": 63,
+          "potential": 79,
+          "value": 1300000,
+          "yearly_wage": 676000
+        }
+      ],
+      "team": "Manchester United",
+      "transfer_budget": 122700000,
+      "url": "https://sofifa.com/team/11/manchester-united/260037/"
+    },
+    {
+      "player_count": 40,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Matz Sels",
+          "name": "M. Sels",
+          "overall_score": 81,
+          "potential": 81,
+          "value": 8500000,
+          "yearly_wage": 3432000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ola Aina",
+          "name": "O. Aina",
+          "overall_score": 80,
+          "potential": 80,
+          "value": 19000000,
+          "yearly_wage": 4940000
+        },
+        {
+          "currency": "€",
+          "full_name": "Nikola Milenković",
+          "name": "N. Milenković",
+          "overall_score": 80,
+          "potential": 81,
+          "value": 21000000,
+          "yearly_wage": 4680000
+        },
+        {
+          "currency": "€",
+          "full_name": "Murillo Costa dos Santos",
+          "name": "Murillo",
+          "overall_score": 82,
+          "potential": 86,
+          "value": 40000000,
+          "yearly_wage": 4680000
+        },
+        {
+          "currency": "€",
+          "full_name": "Neco Williams",
+          "name": "N. Williams",
+          "overall_score": 80,
+          "potential": 82,
+          "value": 25000000,
+          "yearly_wage": 4056000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ibrahim Sangaré",
+          "name": "I. Sangaré",
+          "overall_score": 78,
+          "potential": 79,
+          "value": 14500000,
+          "yearly_wage": 4004000
+        },
+        {
+          "currency": "€",
+          "full_name": "Elliot Anderson",
+          "name": "E. Anderson",
+          "overall_score": 82,
+          "potential": 86,
+          "value": 40500000,
+          "yearly_wage": 4680000
+        },
+        {
+          "currency": "€",
+          "full_name": "Omari Hutchinson",
+          "name": "O. Hutchinson",
+          "overall_score": 76,
+          "potential": 84,
+          "value": 17000000,
+          "yearly_wage": 2704000
+        },
+        {
+          "currency": "€",
+          "full_name": "Callum Hudson-Odoi",
+          "name": "C. Hudson-Odoi",
+          "overall_score": 78,
+          "potential": 81,
+          "value": 19000000,
+          "yearly_wage": 3640000
+        },
+        {
+          "currency": "€",
+          "full_name": "Morgan Gibbs-White",
+          "name": "M. Gibbs-White",
+          "overall_score": 81,
+          "potential": 83,
+          "value": 32500000,
+          "yearly_wage": 5200000
+        },
+        {
+          "currency": "€",
+          "full_name": "Igor Jesus Maciel da Cruz",
+          "name": "Igor Jesus",
+          "overall_score": 77,
+          "potential": 81,
+          "value": 15500000,
+          "yearly_wage": 3744000
+        },
+        {
+          "currency": "€",
+          "full_name": "Nicolás Domínguez",
+          "name": "N. Domínguez",
+          "overall_score": 78,
+          "potential": 79,
+          "value": 14500000,
+          "yearly_wage": 4004000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ryan Yates",
+          "name": "R. Yates",
+          "overall_score": 76,
+          "potential": 77,
+          "value": 7500000,
+          "yearly_wage": 3536000
+        },
+        {
+          "currency": "€",
+          "full_name": "Dilane Bakwa",
+          "name": "D. Bakwa",
+          "overall_score": 76,
+          "potential": 82,
+          "value": 12000000,
+          "yearly_wage": 3172000
+        },
+        {
+          "currency": "€",
+          "full_name": "James McAtee",
+          "name": "J. McAtee",
+          "overall_score": 73,
+          "potential": 81,
+          "value": 7000000,
+          "yearly_wage": 2548000
+        },
+        {
+          "currency": "€",
+          "full_name": "Felipe Rodrigues da Silva",
+          "name": "Morato",
+          "overall_score": 76,
+          "potential": 80,
+          "value": 9500000,
+          "yearly_wage": 3016000
+        },
+        {
+          "currency": "€",
+          "full_name": "Luca Netz",
+          "name": "L. Netz",
+          "overall_score": 73,
+          "potential": 77,
+          "value": 4100000,
+          "yearly_wage": 2444000
+        },
+        {
+          "currency": "€",
+          "full_name": "Stefan Ortega",
+          "name": "S. Ortega",
+          "overall_score": 79,
+          "potential": 79,
+          "value": 8500000,
+          "yearly_wage": 3016000
+        },
+        {
+          "currency": "€",
+          "full_name": "Dan Ndoye",
+          "name": "D. Ndoye",
+          "overall_score": 77,
+          "potential": 80,
+          "value": 14500000,
+          "yearly_wage": 3432000
+        },
+        {
+          "currency": "€",
+          "full_name": "Chris Wood",
+          "name": "C. Wood",
+          "overall_score": 81,
+          "potential": 81,
+          "value": 16500000,
+          "yearly_wage": 5980000
+        },
+        {
+          "currency": "€",
+          "full_name": "Taiwo Awoniyi",
+          "name": "T. Awoniyi",
+          "overall_score": 74,
+          "potential": 74,
+          "value": 4600000,
+          "yearly_wage": 3536000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lorenzo Lucca",
+          "name": "L. Lucca",
+          "overall_score": 75,
+          "potential": 79,
+          "value": 8000000,
+          "yearly_wage": 884000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jair Paula da Cunha Filho",
+          "name": "Jair Cunha",
+          "overall_score": 75,
+          "potential": 82,
+          "value": 10500000,
+          "yearly_wage": 2444000
+        },
+        {
+          "currency": "€",
+          "full_name": "Angus Gunn",
+          "name": "A. Gunn",
+          "overall_score": 72,
+          "potential": 73,
+          "value": 1800000,
+          "yearly_wage": 1768000
+        },
+        {
+          "currency": "€",
+          "full_name": "Zach Abbott",
+          "name": "Z. Abbott",
+          "overall_score": 63,
+          "potential": 78,
+          "value": 1100000,
+          "yearly_wage": 572000
+        },
+        {
+          "currency": "€",
+          "full_name": "Willy Boly",
+          "name": "W. Boly",
+          "overall_score": 73,
+          "potential": 73,
+          "value": 1000000,
+          "yearly_wage": 2912000
+        },
+        {
+          "currency": "€",
+          "full_name": "Eric da Silva Moreira",
+          "name": "E. da Silva Moreira",
+          "overall_score": 61,
+          "potential": 77,
+          "value": 825000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "Nicolò Savona",
+          "name": "N. Savona",
+          "overall_score": 75,
+          "potential": 81,
+          "value": 8500000,
+          "yearly_wage": 2912000
+        },
+        {
+          "currency": "€",
+          "full_name": "John Victor Maciel Furtado",
+          "name": "John Victor",
+          "overall_score": 71,
+          "potential": 71,
+          "value": 1300000,
+          "yearly_wage": 1560000
+        },
+        {
+          "currency": "€",
+          "full_name": "Tyler Bindon",
+          "name": "T. Bindon",
+          "overall_score": 70,
+          "potential": 80,
+          "value": 3300000,
+          "yearly_wage": 1508000
+        },
+        {
+          "currency": "€",
+          "full_name": "João Pedro Ferreira Silva",
+          "name": "Jota Silva",
+          "overall_score": 73,
+          "potential": 74,
+          "value": 3600000,
+          "yearly_wage": 2808000
+        },
+        {
+          "currency": "€",
+          "full_name": "Detlef Esapa Osong",
+          "name": "D. Esapa Osong",
+          "overall_score": 56,
+          "potential": 69,
+          "value": 350000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "Arnaud Kalimuendo",
+          "name": "A. Kalimuendo",
+          "overall_score": 78,
+          "potential": 82,
+          "value": 20500000,
+          "yearly_wage": 4004000
+        },
+        {
+          "currency": "€",
+          "full_name": "David Mota Teixeira Carmo",
+          "name": "David Carmo",
+          "overall_score": 74,
+          "potential": 78,
+          "value": 5500000,
+          "yearly_wage": 2964000
+        },
+        {
+          "currency": "€",
+          "full_name": "Omar Richards",
+          "name": "O. Richards",
+          "overall_score": 72,
+          "potential": 72,
+          "value": 2300000,
+          "yearly_wage": 2548000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ben Hammond",
+          "name": "B. Hammond",
+          "overall_score": 59,
+          "potential": 70,
+          "value": 500000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jack Thompson",
+          "name": "J. Thompson",
+          "overall_score": 57,
+          "potential": 70,
+          "value": 375000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "Josh Powell",
+          "name": "J. Powell",
+          "overall_score": 58,
+          "potential": 71,
+          "value": 475000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "Kyle McAdam",
+          "name": "K. McAdam",
+          "overall_score": 58,
+          "potential": 67,
+          "value": 425000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "Joe Gardner",
+          "name": "J. Gardner",
+          "overall_score": 62,
+          "potential": 73,
+          "value": 875000,
+          "yearly_wage": 572000
+        }
+      ],
+      "team": "Nottingham Forest",
+      "transfer_budget": 65800000,
+      "url": "https://sofifa.com/team/14/nottingham-forest/260037/"
+    },
+    {
+      "player_count": 36,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Dean Henderson",
+          "name": "D. Henderson",
+          "overall_score": 82,
+          "potential": 83,
+          "value": 24000000,
+          "yearly_wage": 3484000
+        },
+        {
+          "currency": "€",
+          "full_name": "Daniel Muñoz",
+          "name": "D. Muñoz",
+          "overall_score": 82,
+          "potential": 82,
+          "value": 27000000,
+          "yearly_wage": 5200000
+        },
+        {
+          "currency": "€",
+          "full_name": "Chris Richards",
+          "name": "C. Richards",
+          "overall_score": 79,
+          "potential": 81,
+          "value": 19500000,
+          "yearly_wage": 3952000
+        },
+        {
+          "currency": "€",
+          "full_name": "Maxence Lacroix",
+          "name": "M. Lacroix",
+          "overall_score": 81,
+          "potential": 83,
+          "value": 28500000,
+          "yearly_wage": 4472000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jaydee Canvot",
+          "name": "J. Canvot",
+          "overall_score": 74,
+          "potential": 85,
+          "value": 8500000,
+          "yearly_wage": 1872000
+        },
+        {
+          "currency": "€",
+          "full_name": "Tyrick Mitchell",
+          "name": "T. Mitchell",
+          "overall_score": 79,
+          "potential": 81,
+          "value": 20000000,
+          "yearly_wage": 3952000
+        },
+        {
+          "currency": "€",
+          "full_name": "Adam Wharton",
+          "name": "A. Wharton",
+          "overall_score": 81,
+          "potential": 87,
+          "value": 38000000,
+          "yearly_wage": 3432000
+        },
+        {
+          "currency": "€",
+          "full_name": "Will Hughes",
+          "name": "W. Hughes",
+          "overall_score": 77,
+          "potential": 77,
+          "value": 9000000,
+          "yearly_wage": 3692000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ismaïla Sarr",
+          "name": "I. Sarr",
+          "overall_score": 81,
+          "potential": 81,
+          "value": 27500000,
+          "yearly_wage": 5200000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jørgen Strand Larsen",
+          "name": "J. Strand Larsen",
+          "overall_score": 77,
+          "potential": 80,
+          "value": 14000000,
+          "yearly_wage": 3848000
+        },
+        {
+          "currency": "€",
+          "full_name": "Yeremy Jesús Pino Santos",
+          "name": "Yeremy Pino",
+          "overall_score": 79,
+          "potential": 86,
+          "value": 35500000,
+          "yearly_wage": 4056000
+        },
+        {
+          "currency": "€",
+          "full_name": "Brennan Johnson",
+          "name": "B. Johnson",
+          "overall_score": 79,
+          "potential": 82,
+          "value": 24000000,
+          "yearly_wage": 4056000
+        },
+        {
+          "currency": "€",
+          "full_name": "Daichi Kamada",
+          "name": "D. Kamada",
+          "overall_score": 78,
+          "potential": 78,
+          "value": 14000000,
+          "yearly_wage": 4108000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jefferson Lerma",
+          "name": "J. Lerma",
+          "overall_score": 77,
+          "potential": 77,
+          "value": 9000000,
+          "yearly_wage": 3692000
+        },
+        {
+          "currency": "€",
+          "full_name": "Borna Sosa",
+          "name": "B. Sosa",
+          "overall_score": 72,
+          "potential": 72,
+          "value": 2300000,
+          "yearly_wage": 2392000
+        },
+        {
+          "currency": "€",
+          "full_name": "Chadi Riad",
+          "name": "C. Riad",
+          "overall_score": 72,
+          "potential": 81,
+          "value": 4900000,
+          "yearly_wage": 2080000
+        },
+        {
+          "currency": "€",
+          "full_name": "Nathaniel Clyne",
+          "name": "N. Clyne",
+          "overall_score": 70,
+          "potential": 70,
+          "value": 575000,
+          "yearly_wage": 2028000
+        },
+        {
+          "currency": "€",
+          "full_name": "Walter Benítez",
+          "name": "W. Benítez",
+          "overall_score": 78,
+          "potential": 78,
+          "value": 7000000,
+          "yearly_wage": 2548000
+        },
+        {
+          "currency": "€",
+          "full_name": "Evann Guessand",
+          "name": "E. Guessand",
+          "overall_score": 78,
+          "potential": 83,
+          "value": 21000000,
+          "yearly_wage": 4524000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jean-Philippe Mateta",
+          "name": "J. Mateta",
+          "overall_score": 82,
+          "potential": 82,
+          "value": 31000000,
+          "yearly_wage": 5980000
+        },
+        {
+          "currency": "€",
+          "full_name": "Justin Devenny",
+          "name": "J. Devenny",
+          "overall_score": 71,
+          "potential": 78,
+          "value": 3800000,
+          "yearly_wage": 1664000
+        },
+        {
+          "currency": "€",
+          "full_name": "Eddie Nketiah",
+          "name": "E. Nketiah",
+          "overall_score": 75,
+          "potential": 76,
+          "value": 6500000,
+          "yearly_wage": 3588000
+        },
+        {
+          "currency": "€",
+          "full_name": "Christantus Uche",
+          "name": "C. Uche",
+          "overall_score": 76,
+          "potential": 82,
+          "value": 12000000,
+          "yearly_wage": 1508000
+        },
+        {
+          "currency": "€",
+          "full_name": "Kaden Rodney",
+          "name": "K. Rodney",
+          "overall_score": 61,
+          "potential": 70,
+          "value": 675000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "Remi Matthews",
+          "name": "R. Matthews",
+          "overall_score": 63,
+          "potential": 63,
+          "value": 250000,
+          "yearly_wage": 520000
+        },
+        {
+          "currency": "€",
+          "full_name": "Rio Cardines",
+          "name": "R. Cardines",
+          "overall_score": 62,
+          "potential": 75,
+          "value": 900000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "Caleb Kporha",
+          "name": "C. Kporha",
+          "overall_score": 62,
+          "potential": 78,
+          "value": 975000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "Cheick Doucouré",
+          "name": "C. Doucouré",
+          "overall_score": 77,
+          "potential": 78,
+          "value": 11000000,
+          "yearly_wage": 3380000
+        },
+        {
+          "currency": "€",
+          "full_name": "Owen Goodman",
+          "name": "O. Goodman",
+          "overall_score": 66,
+          "potential": 78,
+          "value": 1800000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "David Ozoh",
+          "name": "D. Ozoh",
+          "overall_score": 68,
+          "potential": 78,
+          "value": 2500000,
+          "yearly_wage": 1144000
+        },
+        {
+          "currency": "€",
+          "full_name": "Romain Esse",
+          "name": "R. Esse",
+          "overall_score": 70,
+          "potential": 82,
+          "value": 3800000,
+          "yearly_wage": 1508000
+        },
+        {
+          "currency": "€",
+          "full_name": "Joe Whitworth",
+          "name": "J. Whitworth",
+          "overall_score": 66,
+          "potential": 76,
+          "value": 1700000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "Tayo Adaramola",
+          "name": "T. Adaramola",
+          "overall_score": 65,
+          "potential": 74,
+          "value": 1500000,
+          "yearly_wage": 676000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jesurun Rak-Sakyi",
+          "name": "J. Rak-Sakyi",
+          "overall_score": 72,
+          "potential": 78,
+          "value": 3800000,
+          "yearly_wage": 2184000
+        },
+        {
+          "currency": "€",
+          "full_name": "Hindolo Mustapha",
+          "name": "H. Mustapha",
+          "overall_score": 61,
+          "potential": 78,
+          "value": 825000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "Danny Imray",
+          "name": "D. Imray",
+          "overall_score": 66,
+          "potential": 73,
+          "value": 1600000,
+          "yearly_wage": 832000
+        }
+      ],
+      "team": "Crystal Palace",
+      "transfer_budget": 65100000,
+      "url": "https://sofifa.com/team/1799/crystal-palace/260037/"
+    },
+    {
+      "player_count": 36,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Đorđe Petrović",
+          "name": "Đ. Petrović",
+          "overall_score": 79,
+          "potential": 83,
+          "value": 19000000,
+          "yearly_wage": 2236000
+        },
+        {
+          "currency": "€",
+          "full_name": "Adam Smith",
+          "name": "A. Smith",
+          "overall_score": 73,
+          "potential": 73,
+          "value": 1100000,
+          "yearly_wage": 2496000
+        },
+        {
+          "currency": "€",
+          "full_name": "James Hill",
+          "name": "J. Hill",
+          "overall_score": 75,
+          "potential": 79,
+          "value": 7000000,
+          "yearly_wage": 2444000
+        },
+        {
+          "currency": "€",
+          "full_name": "Marcos Senesi",
+          "name": "M. Senesi",
+          "overall_score": 81,
+          "potential": 81,
+          "value": 22000000,
+          "yearly_wage": 4420000
+        },
+        {
+          "currency": "€",
+          "full_name": "Adrien Truffert",
+          "name": "A. Truffert",
+          "overall_score": 79,
+          "potential": 83,
+          "value": 23500000,
+          "yearly_wage": 3224000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alex Scott",
+          "name": "A. Scott",
+          "overall_score": 80,
+          "potential": 86,
+          "value": 31000000,
+          "yearly_wage": 2860000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ryan Christie",
+          "name": "R. Christie",
+          "overall_score": 78,
+          "potential": 78,
+          "value": 12000000,
+          "yearly_wage": 3536000
+        },
+        {
+          "currency": "€",
+          "full_name": "Rayan Vitor Simplício Rocha",
+          "name": "Rayan",
+          "overall_score": 78,
+          "potential": 88,
+          "value": 29500000,
+          "yearly_wage": 2340000
+        },
+        {
+          "currency": "€",
+          "full_name": "Marcus Tavernier",
+          "name": "M. Tavernier",
+          "overall_score": 78,
+          "potential": 78,
+          "value": 15500000,
+          "yearly_wage": 3536000
+        },
+        {
+          "currency": "€",
+          "full_name": "Eli Junior Kroupi",
+          "name": "E. Kroupi",
+          "overall_score": 78,
+          "potential": 86,
+          "value": 30500000,
+          "yearly_wage": 2756000
+        },
+        {
+          "currency": "€",
+          "full_name": "F. Evanilson de Lima Barbosa",
+          "name": "Evanilson",
+          "overall_score": 79,
+          "potential": 80,
+          "value": 21500000,
+          "yearly_wage": 4108000
+        },
+        {
+          "currency": "€",
+          "full_name": "Tyler Adams",
+          "name": "T. Adams",
+          "overall_score": 79,
+          "potential": 81,
+          "value": 19500000,
+          "yearly_wage": 3744000
+        },
+        {
+          "currency": "€",
+          "full_name": "Justin Kluivert",
+          "name": "J. Kluivert",
+          "overall_score": 79,
+          "potential": 80,
+          "value": 20500000,
+          "yearly_wage": 4004000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lewis Cook",
+          "name": "L. Cook",
+          "overall_score": 78,
+          "potential": 78,
+          "value": 12500000,
+          "yearly_wage": 3536000
+        },
+        {
+          "currency": "€",
+          "full_name": "David Brooks",
+          "name": "D. Brooks",
+          "overall_score": 76,
+          "potential": 76,
+          "value": 8000000,
+          "yearly_wage": 3120000
+        },
+        {
+          "currency": "€",
+          "full_name": "Bafodé Diakité",
+          "name": "B. Diakité",
+          "overall_score": 79,
+          "potential": 84,
+          "value": 24000000,
+          "yearly_wage": 3224000
+        },
+        {
+          "currency": "€",
+          "full_name": "Veljko Milosavljević",
+          "name": "V. Milosavljević",
+          "overall_score": 71,
+          "potential": 84,
+          "value": 4100000,
+          "yearly_wage": 1248000
+        },
+        {
+          "currency": "€",
+          "full_name": "Fraser Forster",
+          "name": "F. Forster",
+          "overall_score": 72,
+          "potential": 72,
+          "value": 250000,
+          "yearly_wage": 884000
+        },
+        {
+          "currency": "€",
+          "full_name": "Amine Adli",
+          "name": "A. Adli",
+          "overall_score": 77,
+          "potential": 80,
+          "value": 14000000,
+          "yearly_wage": 3484000
+        },
+        {
+          "currency": "€",
+          "full_name": "Enes Ünal",
+          "name": "E. Ünal",
+          "overall_score": 76,
+          "potential": 76,
+          "value": 7500000,
+          "yearly_wage": 3536000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alex Tóth",
+          "name": "A. Tóth",
+          "overall_score": 72,
+          "potential": 85,
+          "value": 5500000,
+          "yearly_wage": 1560000
+        },
+        {
+          "currency": "€",
+          "full_name": "Christos Mandas",
+          "name": "C. Mandas",
+          "overall_score": 74,
+          "potential": 80,
+          "value": 5500000,
+          "yearly_wage": 676000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ben Gannon-Doak",
+          "name": "B. Gannon-Doak",
+          "overall_score": 71,
+          "potential": 84,
+          "value": 4400000,
+          "yearly_wage": 1404000
+        },
+        {
+          "currency": "€",
+          "full_name": "Owen Bevan",
+          "name": "O. Bevan",
+          "overall_score": 62,
+          "potential": 72,
+          "value": 825000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "Matai Akinmboni",
+          "name": "M. Akinmboni",
+          "overall_score": 57,
+          "potential": 75,
+          "value": 400000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Remy Rees-Dottin",
+          "name": "R. Rees-Dottin",
+          "overall_score": 60,
+          "potential": 75,
+          "value": 600000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Julio Soler",
+          "name": "J. Soler",
+          "overall_score": 68,
+          "potential": 79,
+          "value": 2500000,
+          "yearly_wage": 988000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alejandro Jiménez Sánchez",
+          "name": "Álex Jiménez",
+          "overall_score": 77,
+          "potential": 84,
+          "value": 20000000,
+          "yearly_wage": 2340000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alex Paulsen",
+          "name": "A. Paulsen",
+          "overall_score": 68,
+          "potential": 77,
+          "value": 2300000,
+          "yearly_wage": 676000
+        },
+        {
+          "currency": "€",
+          "full_name": "Daniel Jebbison",
+          "name": "D. Jebbison",
+          "overall_score": 68,
+          "potential": 77,
+          "value": 2700000,
+          "yearly_wage": 1196000
+        },
+        {
+          "currency": "€",
+          "full_name": "Julian Araujo",
+          "name": "J. Araujo",
+          "overall_score": 74,
+          "potential": 81,
+          "value": 8000000,
+          "yearly_wage": 2288000
+        },
+        {
+          "currency": "€",
+          "full_name": "Will Dennis",
+          "name": "W. Dennis",
+          "overall_score": 66,
+          "potential": 71,
+          "value": 1000000,
+          "yearly_wage": 520000
+        },
+        {
+          "currency": "€",
+          "full_name": "Romain Faivre",
+          "name": "R. Faivre",
+          "overall_score": 76,
+          "potential": 76,
+          "value": 8000000,
+          "yearly_wage": 3120000
+        },
+        {
+          "currency": "€",
+          "full_name": "Hamed Junior Traoré",
+          "name": "H. Traoré",
+          "overall_score": 77,
+          "potential": 78,
+          "value": 12500000,
+          "yearly_wage": 3172000
+        },
+        {
+          "currency": "€",
+          "full_name": "Max Aarons",
+          "name": "M. Aarons",
+          "overall_score": 73,
+          "potential": 76,
+          "value": 3700000,
+          "yearly_wage": 2288000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ben Winterburn",
+          "name": "B. Winterburn",
+          "overall_score": 62,
+          "potential": 71,
+          "value": 825000,
+          "yearly_wage": 468000
+        }
+      ],
+      "team": "AFC Bournemouth",
+      "transfer_budget": 63300000,
+      "url": "https://sofifa.com/team/1943/afc-bournemouth/260037/"
+    },
+    {
+      "player_count": 39,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Caoimhin Kelleher",
+          "name": "C. Kelleher",
+          "overall_score": 79,
+          "potential": 82,
+          "value": 17500000,
+          "yearly_wage": 2392000
+        },
+        {
+          "currency": "€",
+          "full_name": "Michael Kayode",
+          "name": "M. Kayode",
+          "overall_score": 80,
+          "potential": 85,
+          "value": 29000000,
+          "yearly_wage": 2860000
+        },
+        {
+          "currency": "€",
+          "full_name": "Sepp van den Berg",
+          "name": "S. van den Berg",
+          "overall_score": 77,
+          "potential": 83,
+          "value": 15000000,
+          "yearly_wage": 2756000
+        },
+        {
+          "currency": "€",
+          "full_name": "Nathan Collins",
+          "name": "N. Collins",
+          "overall_score": 79,
+          "potential": 82,
+          "value": 21500000,
+          "yearly_wage": 3224000
+        },
+        {
+          "currency": "€",
+          "full_name": "Keane Lewis-Potter",
+          "name": "K. Lewis-Potter",
+          "overall_score": 76,
+          "potential": 79,
+          "value": 9500000,
+          "yearly_wage": 2548000
+        },
+        {
+          "currency": "€",
+          "full_name": "Yehor Yarmoliuk",
+          "name": "Y. Yarmoliuk",
+          "overall_score": 77,
+          "potential": 83,
+          "value": 15500000,
+          "yearly_wage": 2340000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mathias Jensen",
+          "name": "M. Jensen",
+          "overall_score": 79,
+          "potential": 79,
+          "value": 17000000,
+          "yearly_wage": 4108000
+        },
+        {
+          "currency": "€",
+          "full_name": "Dango Ouattara",
+          "name": "D. Ouattara",
+          "overall_score": 78,
+          "potential": 82,
+          "value": 20000000,
+          "yearly_wage": 3068000
+        },
+        {
+          "currency": "€",
+          "full_name": "Kevin Schade",
+          "name": "K. Schade",
+          "overall_score": 79,
+          "potential": 83,
+          "value": 25000000,
+          "yearly_wage": 3432000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mikkel Damsgaard",
+          "name": "M. Damsgaard",
+          "overall_score": 80,
+          "potential": 83,
+          "value": 29000000,
+          "yearly_wage": 3692000
+        },
+        {
+          "currency": "€",
+          "full_name": "Igor Thiago Rodrigues",
+          "name": "Igor Thiago",
+          "overall_score": 81,
+          "potential": 85,
+          "value": 37500000,
+          "yearly_wage": 4264000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jordan Henderson",
+          "name": "J. Henderson",
+          "overall_score": 79,
+          "potential": 79,
+          "value": 4900000,
+          "yearly_wage": 2912000
+        },
+        {
+          "currency": "€",
+          "full_name": "Vitaly Janelt",
+          "name": "V. Janelt",
+          "overall_score": 77,
+          "potential": 78,
+          "value": 11000000,
+          "yearly_wage": 3172000
+        },
+        {
+          "currency": "€",
+          "full_name": "Romelle Donovan",
+          "name": "R. Donovan",
+          "overall_score": 66,
+          "potential": 79,
+          "value": 2000000,
+          "yearly_wage": 728000
+        },
+        {
+          "currency": "€",
+          "full_name": "Kristoffer Ajer",
+          "name": "K. Ajer",
+          "overall_score": 76,
+          "potential": 77,
+          "value": 7500000,
+          "yearly_wage": 2964000
+        },
+        {
+          "currency": "€",
+          "full_name": "Rico Henry",
+          "name": "R. Henry",
+          "overall_score": 76,
+          "potential": 76,
+          "value": 7000000,
+          "yearly_wage": 2964000
+        },
+        {
+          "currency": "€",
+          "full_name": "Aaron Hickey",
+          "name": "A. Hickey",
+          "overall_score": 75,
+          "potential": 79,
+          "value": 7500000,
+          "yearly_wage": 2444000
+        },
+        {
+          "currency": "€",
+          "full_name": "Hákon Valdimarsson",
+          "name": "H. Valdimarsson",
+          "overall_score": 69,
+          "potential": 77,
+          "value": 2700000,
+          "yearly_wage": 780000
+        },
+        {
+          "currency": "€",
+          "full_name": "Reiss Nelson",
+          "name": "R. Nelson",
+          "overall_score": 75,
+          "potential": 76,
+          "value": 6500000,
+          "yearly_wage": 4368000
+        },
+        {
+          "currency": "€",
+          "full_name": "Kaye Furo",
+          "name": "K. Furo",
+          "overall_score": 63,
+          "potential": 83,
+          "value": 1300000,
+          "yearly_wage": 572000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ethan Pinnock",
+          "name": "E. Pinnock",
+          "overall_score": 75,
+          "potential": 75,
+          "value": 3600000,
+          "yearly_wage": 2964000
+        },
+        {
+          "currency": "€",
+          "full_name": "Josh Dasilva",
+          "name": "J. Dasilva",
+          "overall_score": 72,
+          "potential": 73,
+          "value": 2700000,
+          "yearly_wage": 2236000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ellery Balcombe",
+          "name": "E. Balcombe",
+          "overall_score": 63,
+          "potential": 67,
+          "value": 525000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "Julian Eyestone",
+          "name": "J. Eyestone",
+          "overall_score": 58,
+          "potential": 75,
+          "value": 475000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Fábio Leandro Carvalho",
+          "name": "Fábio Carvalho",
+          "overall_score": 74,
+          "potential": 81,
+          "value": 8500000,
+          "yearly_wage": 2444000
+        },
+        {
+          "currency": "€",
+          "full_name": "Antoni Milambo",
+          "name": "A. Milambo",
+          "overall_score": 73,
+          "potential": 85,
+          "value": 7500000,
+          "yearly_wage": 1820000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jayden Meghoma",
+          "name": "J. Meghoma",
+          "overall_score": 68,
+          "potential": 82,
+          "value": 2700000,
+          "yearly_wage": 936000
+        },
+        {
+          "currency": "€",
+          "full_name": "Iwan Morgan",
+          "name": "I. Morgan",
+          "overall_score": 60,
+          "potential": 76,
+          "value": 650000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Benjamin Arthur",
+          "name": "B. Arthur",
+          "overall_score": 65,
+          "potential": 80,
+          "value": 1600000,
+          "yearly_wage": 572000
+        },
+        {
+          "currency": "€",
+          "full_name": "Yunus Emre Konak",
+          "name": "Y. Konak",
+          "overall_score": 65,
+          "potential": 80,
+          "value": 1600000,
+          "yearly_wage": 572000
+        },
+        {
+          "currency": "€",
+          "full_name": "Tony Yogane",
+          "name": "T. Yogane",
+          "overall_score": 63,
+          "potential": 74,
+          "value": 1000000,
+          "yearly_wage": 520000
+        },
+        {
+          "currency": "€",
+          "full_name": "Michael Olakigbe",
+          "name": "M. Olakigbe",
+          "overall_score": 61,
+          "potential": 73,
+          "value": 800000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ji Soo Kim",
+          "name": "Kim Ji Soo",
+          "overall_score": 65,
+          "potential": 78,
+          "value": 1600000,
+          "yearly_wage": 624000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ryan Trevitt",
+          "name": "R. Trevitt",
+          "overall_score": 62,
+          "potential": 71,
+          "value": 900000,
+          "yearly_wage": 572000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ethan Brierley",
+          "name": "E. Brierley",
+          "overall_score": 63,
+          "potential": 74,
+          "value": 1100000,
+          "yearly_wage": 572000
+        },
+        {
+          "currency": "€",
+          "full_name": "Matthew Cox",
+          "name": "M. Cox",
+          "overall_score": 65,
+          "potential": 75,
+          "value": 1400000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "Frank Onyeka",
+          "name": "F. Onyeka",
+          "overall_score": 74,
+          "potential": 74,
+          "value": 4500000,
+          "yearly_wage": 2756000
+        },
+        {
+          "currency": "€",
+          "full_name": "Gustavo Nunes Fernandes Gomes",
+          "name": "Gustavo Nunes",
+          "overall_score": 67,
+          "potential": 82,
+          "value": 2400000,
+          "yearly_wage": 884000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ben Krauhaus",
+          "name": "B. Krauhaus",
+          "overall_score": 61,
+          "potential": 71,
+          "value": 725000,
+          "yearly_wage": 468000
+        }
+      ],
+      "team": "Brentford",
+      "transfer_budget": 53700000,
+      "url": "https://sofifa.com/team/1925/brentford/260037/"
+    },
+    {
+      "player_count": 44,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Bart Verbruggen",
+          "name": "B. Verbruggen",
+          "overall_score": 80,
+          "potential": 86,
+          "value": 27500000,
+          "yearly_wage": 2340000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mats Wieffer",
+          "name": "M. Wieffer",
+          "overall_score": 78,
+          "potential": 81,
+          "value": 17000000,
+          "yearly_wage": 3848000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jan Paul van Hecke",
+          "name": "J. van Hecke",
+          "overall_score": 80,
+          "potential": 83,
+          "value": 25000000,
+          "yearly_wage": 4472000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lewis Dunk",
+          "name": "L. Dunk",
+          "overall_score": 77,
+          "potential": 77,
+          "value": 5000000,
+          "yearly_wage": 3952000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ferdi Kadıoğlu",
+          "name": "F. Kadıoğlu",
+          "overall_score": 79,
+          "potential": 81,
+          "value": 20000000,
+          "yearly_wage": 4212000
+        },
+        {
+          "currency": "€",
+          "full_name": "Carlos Baleba",
+          "name": "C. Baleba",
+          "overall_score": 80,
+          "potential": 86,
+          "value": 31000000,
+          "yearly_wage": 3380000
+        },
+        {
+          "currency": "€",
+          "full_name": "Pascal Groß",
+          "name": "P. Groß",
+          "overall_score": 78,
+          "potential": 78,
+          "value": 4800000,
+          "yearly_wage": 4212000
+        },
+        {
+          "currency": "€",
+          "full_name": "Yankuba Minteh",
+          "name": "Y. Minteh",
+          "overall_score": 80,
+          "potential": 86,
+          "value": 33000000,
+          "yearly_wage": 3640000
+        },
+        {
+          "currency": "€",
+          "full_name": "Kaoru Mitoma",
+          "name": "K. Mitoma",
+          "overall_score": 81,
+          "potential": 81,
+          "value": 26000000,
+          "yearly_wage": 5460000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jack Hinshelwood",
+          "name": "J. Hinshelwood",
+          "overall_score": 76,
+          "potential": 84,
+          "value": 15500000,
+          "yearly_wage": 2548000
+        },
+        {
+          "currency": "€",
+          "full_name": "Danny Welbeck",
+          "name": "D. Welbeck",
+          "overall_score": 80,
+          "potential": 80,
+          "value": 10500000,
+          "yearly_wage": 5460000
+        },
+        {
+          "currency": "€",
+          "full_name": "Yasin Ayari",
+          "name": "Y. Ayari",
+          "overall_score": 79,
+          "potential": 85,
+          "value": 26000000,
+          "yearly_wage": 3224000
+        },
+        {
+          "currency": "€",
+          "full_name": "Diego Gómez",
+          "name": "D. Gómez",
+          "overall_score": 77,
+          "potential": 84,
+          "value": 20000000,
+          "yearly_wage": 3224000
+        },
+        {
+          "currency": "€",
+          "full_name": "James Milner",
+          "name": "J. Milner",
+          "overall_score": 73,
+          "potential": 73,
+          "value": 600000,
+          "yearly_wage": 1924000
+        },
+        {
+          "currency": "€",
+          "full_name": "Maxim De Cuyper",
+          "name": "M. De Cuyper",
+          "overall_score": 79,
+          "potential": 83,
+          "value": 23500000,
+          "yearly_wage": 3848000
+        },
+        {
+          "currency": "€",
+          "full_name": "Joël Veltman",
+          "name": "J. Veltman",
+          "overall_score": 78,
+          "potential": 78,
+          "value": 7500000,
+          "yearly_wage": 4212000
+        },
+        {
+          "currency": "€",
+          "full_name": "Olivier Boscagli",
+          "name": "O. Boscagli",
+          "overall_score": 78,
+          "potential": 80,
+          "value": 15000000,
+          "yearly_wage": 4004000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jason Steele",
+          "name": "J. Steele",
+          "overall_score": 73,
+          "potential": 73,
+          "value": 525000,
+          "yearly_wage": 1924000
+        },
+        {
+          "currency": "€",
+          "full_name": "Georginio Rutter",
+          "name": "G. Rutter",
+          "overall_score": 77,
+          "potential": 83,
+          "value": 16500000,
+          "yearly_wage": 3484000
+        },
+        {
+          "currency": "€",
+          "full_name": "Charalampos Kostoulas",
+          "name": "C. Kostoulas",
+          "overall_score": 73,
+          "potential": 85,
+          "value": 7000000,
+          "yearly_wage": 2184000
+        },
+        {
+          "currency": "€",
+          "full_name": "Matt O'Riley",
+          "name": "M. O'Riley",
+          "overall_score": 77,
+          "potential": 81,
+          "value": 15000000,
+          "yearly_wage": 3484000
+        },
+        {
+          "currency": "€",
+          "full_name": "Igor Julio dos Santos de Paulo",
+          "name": "Igor Julio",
+          "overall_score": 75,
+          "potential": 77,
+          "value": 6000000,
+          "yearly_wage": 3328000
+        },
+        {
+          "currency": "€",
+          "full_name": "Harry Howell",
+          "name": "H. Howell",
+          "overall_score": 64,
+          "potential": 82,
+          "value": 1500000,
+          "yearly_wage": 520000
+        },
+        {
+          "currency": "€",
+          "full_name": "Solly March",
+          "name": "S. March",
+          "overall_score": 74,
+          "potential": 74,
+          "value": 4100000,
+          "yearly_wage": 3380000
+        },
+        {
+          "currency": "€",
+          "full_name": "Nehemiah Oriola",
+          "name": "N. Oriola",
+          "overall_score": 60,
+          "potential": 78,
+          "value": 625000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Tom McGill",
+          "name": "T. McGill",
+          "overall_score": 62,
+          "potential": 67,
+          "value": 475000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "Adam Webster",
+          "name": "A. Webster",
+          "overall_score": 75,
+          "potential": 75,
+          "value": 4600000,
+          "yearly_wage": 3484000
+        },
+        {
+          "currency": "€",
+          "full_name": "Stefanos Tzimas",
+          "name": "S. Tzimas",
+          "overall_score": 72,
+          "potential": 81,
+          "value": 5000000,
+          "yearly_wage": 2080000
+        },
+        {
+          "currency": "€",
+          "full_name": "Kamari Doyle",
+          "name": "K. Doyle",
+          "overall_score": 65,
+          "potential": 77,
+          "value": 1700000,
+          "yearly_wage": 780000
+        },
+        {
+          "currency": "€",
+          "full_name": "Caylan Vickers",
+          "name": "C. Vickers",
+          "overall_score": 62,
+          "potential": 73,
+          "value": 875000,
+          "yearly_wage": 676000
+        },
+        {
+          "currency": "€",
+          "full_name": "Tom Watson",
+          "name": "T. Watson",
+          "overall_score": 68,
+          "potential": 82,
+          "value": 2900000,
+          "yearly_wage": 1196000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ibrahim Osman",
+          "name": "I. Osman",
+          "overall_score": 72,
+          "potential": 84,
+          "value": 5500000,
+          "yearly_wage": 1976000
+        },
+        {
+          "currency": "€",
+          "full_name": "James Beadle",
+          "name": "J. Beadle",
+          "overall_score": 70,
+          "potential": 82,
+          "value": 3400000,
+          "yearly_wage": 780000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mark O'Mahony",
+          "name": "M. O'Mahony",
+          "overall_score": 63,
+          "potential": 74,
+          "value": 1100000,
+          "yearly_wage": 728000
+        },
+        {
+          "currency": "€",
+          "full_name": "Brajan Gruda",
+          "name": "B. Gruda",
+          "overall_score": 75,
+          "potential": 85,
+          "value": 12500000,
+          "yearly_wage": 2652000
+        },
+        {
+          "currency": "€",
+          "full_name": "Amario Cozier-Duberry",
+          "name": "A. Cozier-Duberry",
+          "overall_score": 68,
+          "potential": 80,
+          "value": 2900000,
+          "yearly_wage": 1248000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jacob Slater",
+          "name": "J. Slater",
+          "overall_score": 58,
+          "potential": 72,
+          "value": 475000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "Facundo Buonanotte",
+          "name": "F. Buonanotte",
+          "overall_score": 74,
+          "potential": 80,
+          "value": 6500000,
+          "yearly_wage": 2444000
+        },
+        {
+          "currency": "€",
+          "full_name": "Diego Coppola",
+          "name": "D. Coppola",
+          "overall_score": 74,
+          "potential": 80,
+          "value": 6000000,
+          "yearly_wage": 2236000
+        },
+        {
+          "currency": "€",
+          "full_name": "Eíran Cashin",
+          "name": "E. Cashin",
+          "overall_score": 71,
+          "potential": 76,
+          "value": 2600000,
+          "yearly_wage": 1976000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jeremy Sarmiento",
+          "name": "J. Sarmiento",
+          "overall_score": 70,
+          "potential": 78,
+          "value": 3500000,
+          "yearly_wage": 1872000
+        },
+        {
+          "currency": "€",
+          "full_name": "Carl Rushworth",
+          "name": "C. Rushworth",
+          "overall_score": 75,
+          "potential": 83,
+          "value": 11000000,
+          "yearly_wage": 1664000
+        },
+        {
+          "currency": "€",
+          "full_name": "Evan Ferguson",
+          "name": "E. Ferguson",
+          "overall_score": 74,
+          "potential": 82,
+          "value": 9500000,
+          "yearly_wage": 2652000
+        },
+        {
+          "currency": "€",
+          "full_name": "Malick Yalcouyé",
+          "name": "M. Yalcouyé",
+          "overall_score": 70,
+          "potential": 79,
+          "value": 3400000,
+          "yearly_wage": 1508000
+        }
+      ],
+      "team": "Brighton & Hove Albion",
+      "transfer_budget": 76900000,
+      "url": "https://sofifa.com/team/1808/brighton-hove-albion/260037/"
+    },
+    {
+      "player_count": 29,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Bernd Leno",
+          "name": "B. Leno",
+          "overall_score": 79,
+          "potential": 79,
+          "value": 5500000,
+          "yearly_wage": 2860000
+        },
+        {
+          "currency": "€",
+          "full_name": "Timothy Castagne",
+          "name": "T. Castagne",
+          "overall_score": 75,
+          "potential": 75,
+          "value": 4900000,
+          "yearly_wage": 3276000
+        },
+        {
+          "currency": "€",
+          "full_name": "Joachim Andersen",
+          "name": "J. Andersen",
+          "overall_score": 79,
+          "potential": 79,
+          "value": 14500000,
+          "yearly_wage": 4316000
+        },
+        {
+          "currency": "€",
+          "full_name": "Calvin Bassey",
+          "name": "C. Bassey",
+          "overall_score": 78,
+          "potential": 81,
+          "value": 16500000,
+          "yearly_wage": 3588000
+        },
+        {
+          "currency": "€",
+          "full_name": "Antonee Robinson",
+          "name": "A. Robinson",
+          "overall_score": 81,
+          "potential": 81,
+          "value": 25000000,
+          "yearly_wage": 4680000
+        },
+        {
+          "currency": "€",
+          "full_name": "Sander Berge",
+          "name": "S. Berge",
+          "overall_score": 79,
+          "potential": 80,
+          "value": 18000000,
+          "yearly_wage": 4160000
+        },
+        {
+          "currency": "€",
+          "full_name": "Saša Lukić",
+          "name": "S. Lukić",
+          "overall_score": 78,
+          "potential": 78,
+          "value": 12500000,
+          "yearly_wage": 3952000
+        },
+        {
+          "currency": "€",
+          "full_name": "Harry Wilson",
+          "name": "H. Wilson",
+          "overall_score": 80,
+          "potential": 80,
+          "value": 21000000,
+          "yearly_wage": 4680000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alex Iwobi",
+          "name": "A. Iwobi",
+          "overall_score": 80,
+          "potential": 80,
+          "value": 20500000,
+          "yearly_wage": 4680000
+        },
+        {
+          "currency": "€",
+          "full_name": "Emile Smith Rowe",
+          "name": "E. Smith Rowe",
+          "overall_score": 77,
+          "potential": 80,
+          "value": 14500000,
+          "yearly_wage": 3276000
+        },
+        {
+          "currency": "€",
+          "full_name": "Raúl Jiménez",
+          "name": "R. Jiménez",
+          "overall_score": 78,
+          "potential": 78,
+          "value": 7000000,
+          "yearly_wage": 4420000
+        },
+        {
+          "currency": "€",
+          "full_name": "Samuel Chukwueze",
+          "name": "S. Chukwueze",
+          "overall_score": 79,
+          "potential": 79,
+          "value": 19000000,
+          "yearly_wage": 2600000
+        },
+        {
+          "currency": "€",
+          "full_name": "Oscar Bobb",
+          "name": "O. Bobb",
+          "overall_score": 76,
+          "potential": 84,
+          "value": 17000000,
+          "yearly_wage": 2548000
+        },
+        {
+          "currency": "€",
+          "full_name": "Tom Cairney",
+          "name": "T. Cairney",
+          "overall_score": 74,
+          "potential": 74,
+          "value": 1900000,
+          "yearly_wage": 3172000
+        },
+        {
+          "currency": "€",
+          "full_name": "Kenny Tete",
+          "name": "K. Tete",
+          "overall_score": 78,
+          "potential": 78,
+          "value": 12500000,
+          "yearly_wage": 3952000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ryan Sessegnon",
+          "name": "R. Sessegnon",
+          "overall_score": 77,
+          "potential": 79,
+          "value": 12000000,
+          "yearly_wage": 3380000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jorge Cuenca Barreno",
+          "name": "Jorge Cuenca",
+          "overall_score": 76,
+          "potential": 79,
+          "value": 9000000,
+          "yearly_wage": 3120000
+        },
+        {
+          "currency": "€",
+          "full_name": "Benjamin Lecomte",
+          "name": "B. Lecomte",
+          "overall_score": 74,
+          "potential": 74,
+          "value": 725000,
+          "yearly_wage": 1976000
+        },
+        {
+          "currency": "€",
+          "full_name": "Josh King",
+          "name": "J. King",
+          "overall_score": 74,
+          "potential": 84,
+          "value": 9000000,
+          "yearly_wage": 2028000
+        },
+        {
+          "currency": "€",
+          "full_name": "Rodrigo Muniz Carvalho",
+          "name": "Rodrigo Muniz",
+          "overall_score": 76,
+          "potential": 81,
+          "value": 11500000,
+          "yearly_wage": 3276000
+        },
+        {
+          "currency": "€",
+          "full_name": "Kevin Santos",
+          "name": "Kevin",
+          "overall_score": 76,
+          "potential": 81,
+          "value": 11500000,
+          "yearly_wage": 3016000
+        },
+        {
+          "currency": "€",
+          "full_name": "Issa Diop",
+          "name": "I. Diop",
+          "overall_score": 76,
+          "potential": 77,
+          "value": 7000000,
+          "yearly_wage": 3432000
+        },
+        {
+          "currency": "€",
+          "full_name": "Harrison Reed",
+          "name": "H. Reed",
+          "overall_score": 72,
+          "potential": 72,
+          "value": 2000000,
+          "yearly_wage": 2496000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jonah Kusi-Asare",
+          "name": "J. Kusi-Asare",
+          "overall_score": 62,
+          "potential": 84,
+          "value": 1300000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Luc De Fougerolles",
+          "name": "L. De Fougerolles",
+          "overall_score": 66,
+          "potential": 81,
+          "value": 1900000,
+          "yearly_wage": 780000
+        },
+        {
+          "currency": "€",
+          "full_name": "Luke Harris",
+          "name": "L. Harris",
+          "overall_score": 66,
+          "potential": 78,
+          "value": 2100000,
+          "yearly_wage": 884000
+        },
+        {
+          "currency": "€",
+          "full_name": "Steven Benda",
+          "name": "S. Benda",
+          "overall_score": 68,
+          "potential": 71,
+          "value": 1200000,
+          "yearly_wage": 988000
+        },
+        {
+          "currency": "€",
+          "full_name": "Aaron Loupalo-Bi",
+          "name": "A. Loupalo-Bi",
+          "overall_score": 59,
+          "potential": 70,
+          "value": 500000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "Harvey Araujo",
+          "name": "H. Araujo",
+          "overall_score": 63,
+          "potential": 74,
+          "value": 975000,
+          "yearly_wage": 572000
+        }
+      ],
+      "team": "Fulham FC",
+      "transfer_budget": 57100000,
+      "url": "https://sofifa.com/team/144/fulham-fc/260037/"
+    },
+    {
+      "player_count": 31,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Jordan Pickford",
+          "name": "J. Pickford",
+          "overall_score": 85,
+          "potential": 85,
+          "value": 28500000,
+          "yearly_wage": 2548000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jake O'Brien",
+          "name": "J. O'Brien",
+          "overall_score": 76,
+          "potential": 81,
+          "value": 10500000,
+          "yearly_wage": 1612000
+        },
+        {
+          "currency": "€",
+          "full_name": "James Tarkowski",
+          "name": "J. Tarkowski",
+          "overall_score": 80,
+          "potential": 80,
+          "value": 13500000,
+          "yearly_wage": 2600000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jarrad Branthwaite",
+          "name": "J. Branthwaite",
+          "overall_score": 79,
+          "potential": 85,
+          "value": 25000000,
+          "yearly_wage": 2028000
+        },
+        {
+          "currency": "€",
+          "full_name": "Vitaliy Mykolenko",
+          "name": "V. Mykolenko",
+          "overall_score": 77,
+          "potential": 78,
+          "value": 11500000,
+          "yearly_wage": 1976000
+        },
+        {
+          "currency": "€",
+          "full_name": "Idrissa Gueye",
+          "name": "I. Gueye",
+          "overall_score": 79,
+          "potential": 79,
+          "value": 4900000,
+          "yearly_wage": 1820000
+        },
+        {
+          "currency": "€",
+          "full_name": "James Garner",
+          "name": "J. Garner",
+          "overall_score": 81,
+          "potential": 84,
+          "value": 32000000,
+          "yearly_wage": 2288000
+        },
+        {
+          "currency": "€",
+          "full_name": "Dwight McNeil",
+          "name": "D. McNeil",
+          "overall_score": 77,
+          "potential": 78,
+          "value": 12500000,
+          "yearly_wage": 1976000
+        },
+        {
+          "currency": "€",
+          "full_name": "Iliman Ndiaye",
+          "name": "I. Ndiaye",
+          "overall_score": 82,
+          "potential": 83,
+          "value": 36500000,
+          "yearly_wage": 2860000
+        },
+        {
+          "currency": "€",
+          "full_name": "Kiernan Dewsbury-Hall",
+          "name": "K. Dewsbury-Hall",
+          "overall_score": 80,
+          "potential": 81,
+          "value": 25000000,
+          "yearly_wage": 2652000
+        },
+        {
+          "currency": "€",
+          "full_name": "Thierno Barry",
+          "name": "T. Barry",
+          "overall_score": 76,
+          "potential": 84,
+          "value": 17000000,
+          "yearly_wage": 1872000
+        },
+        {
+          "currency": "€",
+          "full_name": "Tim Iroegbunam",
+          "name": "T. Iroegbunam",
+          "overall_score": 76,
+          "potential": 80,
+          "value": 10000000,
+          "yearly_wage": 1612000
+        },
+        {
+          "currency": "€",
+          "full_name": "Carlos Alcaraz",
+          "name": "C. Alcaraz",
+          "overall_score": 75,
+          "potential": 82,
+          "value": 11500000,
+          "yearly_wage": 1664000
+        },
+        {
+          "currency": "€",
+          "full_name": "Merlin Röhl",
+          "name": "M. Röhl",
+          "overall_score": 74,
+          "potential": 82,
+          "value": 9500000,
+          "yearly_wage": 1092000
+        },
+        {
+          "currency": "€",
+          "full_name": "Harrison Armstrong",
+          "name": "H. Armstrong",
+          "overall_score": 73,
+          "potential": 85,
+          "value": 7000000,
+          "yearly_wage": 1040000
+        },
+        {
+          "currency": "€",
+          "full_name": "Michael Keane",
+          "name": "M. Keane",
+          "overall_score": 76,
+          "potential": 76,
+          "value": 4900000,
+          "yearly_wage": 1924000
+        },
+        {
+          "currency": "€",
+          "full_name": "Nathan Patterson",
+          "name": "N. Patterson",
+          "overall_score": 71,
+          "potential": 76,
+          "value": 2600000,
+          "yearly_wage": 1040000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mark Travers",
+          "name": "M. Travers",
+          "overall_score": 72,
+          "potential": 75,
+          "value": 2400000,
+          "yearly_wage": 884000
+        },
+        {
+          "currency": "€",
+          "full_name": "Tyler Dibling",
+          "name": "T. Dibling",
+          "overall_score": 74,
+          "potential": 84,
+          "value": 9000000,
+          "yearly_wage": 1196000
+        },
+        {
+          "currency": "€",
+          "full_name": "Norberto Gomes Betuncal",
+          "name": "Beto",
+          "overall_score": 76,
+          "potential": 76,
+          "value": 8000000,
+          "yearly_wage": 2132000
+        },
+        {
+          "currency": "€",
+          "full_name": "Tyrique George",
+          "name": "T. George",
+          "overall_score": 71,
+          "potential": 84,
+          "value": 4400000,
+          "yearly_wage": 2080000
+        },
+        {
+          "currency": "€",
+          "full_name": "Adam Aznou",
+          "name": "A. Aznou",
+          "overall_score": 66,
+          "potential": 82,
+          "value": 2100000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "Séamus Coleman",
+          "name": "S. Coleman",
+          "overall_score": 70,
+          "potential": 70,
+          "value": 350000,
+          "yearly_wage": 832000
+        },
+        {
+          "currency": "€",
+          "full_name": "Tom King",
+          "name": "T. King",
+          "overall_score": 64,
+          "potential": 64,
+          "value": 400000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jack Grealish",
+          "name": "J. Grealish",
+          "overall_score": 82,
+          "potential": 82,
+          "value": 30000000,
+          "yearly_wage": 7280000
+        },
+        {
+          "currency": "€",
+          "full_name": "Will Tamen",
+          "name": "W. Tamen",
+          "overall_score": 58,
+          "potential": 70,
+          "value": 450000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Elijah Campbell",
+          "name": "E. Campbell",
+          "overall_score": 60,
+          "potential": 75,
+          "value": 550000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Tyler Onyango",
+          "name": "T. Onyango",
+          "overall_score": 61,
+          "potential": 70,
+          "value": 725000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Isaac Heath",
+          "name": "I. Heath",
+          "overall_score": 62,
+          "potential": 71,
+          "value": 825000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Martin Sherif",
+          "name": "M. Sherif",
+          "overall_score": 60,
+          "potential": 75,
+          "value": 600000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Roman Dixon",
+          "name": "R. Dixon",
+          "overall_score": 64,
+          "potential": 76,
+          "value": 1300000,
+          "yearly_wage": 364000
+        }
+      ],
+      "team": "Everton",
+      "transfer_budget": 40300000,
+      "url": "https://sofifa.com/team/7/everton/260037/"
+    },
+    {
+      "player_count": 43,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Robin Roefs",
+          "name": "R. Roefs",
+          "overall_score": 80,
+          "potential": 86,
+          "value": 27500000,
+          "yearly_wage": 1716000
+        },
+        {
+          "currency": "€",
+          "full_name": "Nordi Mukiele",
+          "name": "N. Mukiele",
+          "overall_score": 80,
+          "potential": 80,
+          "value": 19500000,
+          "yearly_wage": 3380000
+        },
+        {
+          "currency": "€",
+          "full_name": "Daniel Ballard",
+          "name": "D. Ballard",
+          "overall_score": 78,
+          "potential": 80,
+          "value": 15500000,
+          "yearly_wage": 2756000
+        },
+        {
+          "currency": "€",
+          "full_name": "Omar Alderete",
+          "name": "O. Alderete",
+          "overall_score": 80,
+          "potential": 81,
+          "value": 20000000,
+          "yearly_wage": 3536000
+        },
+        {
+          "currency": "€",
+          "full_name": "Reinildo Isnard Mandava",
+          "name": "Reinildo",
+          "overall_score": 80,
+          "potential": 80,
+          "value": 15500000,
+          "yearly_wage": 3536000
+        },
+        {
+          "currency": "€",
+          "full_name": "Granit Xhaka",
+          "name": "G. Xhaka",
+          "overall_score": 85,
+          "potential": 85,
+          "value": 36000000,
+          "yearly_wage": 5460000
+        },
+        {
+          "currency": "€",
+          "full_name": "Noah Sadiki",
+          "name": "N. Sadiki",
+          "overall_score": 78,
+          "potential": 85,
+          "value": 27500000,
+          "yearly_wage": 2236000
+        },
+        {
+          "currency": "€",
+          "full_name": "Trai Hume",
+          "name": "T. Hume",
+          "overall_score": 78,
+          "potential": 81,
+          "value": 18000000,
+          "yearly_wage": 2496000
+        },
+        {
+          "currency": "€",
+          "full_name": "Chemsdine Talbi",
+          "name": "C. Talbi",
+          "overall_score": 76,
+          "potential": 86,
+          "value": 16500000,
+          "yearly_wage": 2132000
+        },
+        {
+          "currency": "€",
+          "full_name": "Enzo Le Fée",
+          "name": "E. Le Fée",
+          "overall_score": 78,
+          "potential": 80,
+          "value": 17500000,
+          "yearly_wage": 2912000
+        },
+        {
+          "currency": "€",
+          "full_name": "Brian Brobbey",
+          "name": "B. Brobbey",
+          "overall_score": 77,
+          "potential": 83,
+          "value": 17000000,
+          "yearly_wage": 2704000
+        },
+        {
+          "currency": "€",
+          "full_name": "Habib Diarra",
+          "name": "H. Diarra",
+          "overall_score": 77,
+          "potential": 83,
+          "value": 17000000,
+          "yearly_wage": 2080000
+        },
+        {
+          "currency": "€",
+          "full_name": "Chris Rigg",
+          "name": "C. Rigg",
+          "overall_score": 72,
+          "potential": 84,
+          "value": 5500000,
+          "yearly_wage": 1300000
+        },
+        {
+          "currency": "€",
+          "full_name": "Nilson Angulo",
+          "name": "N. Angulo",
+          "overall_score": 71,
+          "potential": 81,
+          "value": 4200000,
+          "yearly_wage": 1508000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jocelin Ta Bi",
+          "name": "J. Ta Bi",
+          "overall_score": 68,
+          "potential": 80,
+          "value": 2900000,
+          "yearly_wage": 936000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lutsharel Geertruida",
+          "name": "L. Geertruida",
+          "overall_score": 78,
+          "potential": 82,
+          "value": 18000000,
+          "yearly_wage": 2132000
+        },
+        {
+          "currency": "€",
+          "full_name": "Luke O'Nien",
+          "name": "L. O'Nien",
+          "overall_score": 72,
+          "potential": 72,
+          "value": 1900000,
+          "yearly_wage": 1924000
+        },
+        {
+          "currency": "€",
+          "full_name": "Melker Ellborg",
+          "name": "M. Ellborg",
+          "overall_score": 67,
+          "potential": 75,
+          "value": 2000000,
+          "yearly_wage": 520000
+        },
+        {
+          "currency": "€",
+          "full_name": "Wilson Isidor",
+          "name": "W. Isidor",
+          "overall_score": 75,
+          "potential": 78,
+          "value": 8000000,
+          "yearly_wage": 2392000
+        },
+        {
+          "currency": "€",
+          "full_name": "Eliezer Mayenda",
+          "name": "E. Mayenda",
+          "overall_score": 72,
+          "potential": 82,
+          "value": 5000000,
+          "yearly_wage": 1612000
+        },
+        {
+          "currency": "€",
+          "full_name": "Dennis Cirkin",
+          "name": "D. Cirkin",
+          "overall_score": 72,
+          "potential": 78,
+          "value": 3500000,
+          "yearly_wage": 1612000
+        },
+        {
+          "currency": "€",
+          "full_name": "Harrison Jones",
+          "name": "H. Jones",
+          "overall_score": 60,
+          "potential": 74,
+          "value": 600000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Simon Moore",
+          "name": "S. Moore",
+          "overall_score": 66,
+          "potential": 66,
+          "value": 90000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Milan Aleksić",
+          "name": "M. Aleksić",
+          "overall_score": 61,
+          "potential": 71,
+          "value": 700000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Abdoullah Ba",
+          "name": "A. Ba",
+          "overall_score": 65,
+          "potential": 68,
+          "value": 1000000,
+          "yearly_wage": 624000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ahmed Abdullahi",
+          "name": "A. Abdullahi",
+          "overall_score": 58,
+          "potential": 72,
+          "value": 500000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Bertrand Traoré",
+          "name": "B. Traoré",
+          "overall_score": 75,
+          "potential": 75,
+          "value": 5500000,
+          "yearly_wage": 2808000
+        },
+        {
+          "currency": "€",
+          "full_name": "Romaine Mundle",
+          "name": "R. Mundle",
+          "overall_score": 71,
+          "potential": 79,
+          "value": 4200000,
+          "yearly_wage": 1612000
+        },
+        {
+          "currency": "€",
+          "full_name": "Matt Young",
+          "name": "M. Young",
+          "overall_score": 61,
+          "potential": 79,
+          "value": 725000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Luís Hemir Silva Semedo",
+          "name": "Luís Semedo",
+          "overall_score": 59,
+          "potential": 68,
+          "value": 500000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jenson Seelt",
+          "name": "J. Seelt",
+          "overall_score": 68,
+          "potential": 77,
+          "value": 2500000,
+          "yearly_wage": 1040000
+        },
+        {
+          "currency": "€",
+          "full_name": "Simon Adingra",
+          "name": "S. Adingra",
+          "overall_score": 76,
+          "potential": 82,
+          "value": 12000000,
+          "yearly_wage": 2496000
+        },
+        {
+          "currency": "€",
+          "full_name": "Dan Neil",
+          "name": "D. Neil",
+          "overall_score": 73,
+          "potential": 81,
+          "value": 6500000,
+          "yearly_wage": 1768000
+        },
+        {
+          "currency": "€",
+          "full_name": "Timothée Pembélé",
+          "name": "T. Pembélé",
+          "overall_score": 70,
+          "potential": 78,
+          "value": 3400000,
+          "yearly_wage": 1300000
+        },
+        {
+          "currency": "€",
+          "full_name": "Leo Hjelde",
+          "name": "L. Hjelde",
+          "overall_score": 66,
+          "potential": 74,
+          "value": 1800000,
+          "yearly_wage": 624000
+        },
+        {
+          "currency": "€",
+          "full_name": "Niall Huggins",
+          "name": "N. Huggins",
+          "overall_score": 67,
+          "potential": 71,
+          "value": 1400000,
+          "yearly_wage": 884000
+        },
+        {
+          "currency": "€",
+          "full_name": "Anthony Patterson",
+          "name": "A. Patterson",
+          "overall_score": 73,
+          "potential": 78,
+          "value": 3600000,
+          "yearly_wage": 1196000
+        },
+        {
+          "currency": "€",
+          "full_name": "Nazariy Rusyn",
+          "name": "N. Rusyn",
+          "overall_score": 66,
+          "potential": 67,
+          "value": 1000000,
+          "yearly_wage": 988000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ajibola Alese",
+          "name": "A. Alese",
+          "overall_score": 66,
+          "potential": 71,
+          "value": 1200000,
+          "yearly_wage": 780000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alan Browne",
+          "name": "A. Browne",
+          "overall_score": 72,
+          "potential": 72,
+          "value": 2200000,
+          "yearly_wage": 2028000
+        },
+        {
+          "currency": "€",
+          "full_name": "Arthur Masuaku",
+          "name": "A. Masuaku",
+          "overall_score": 75,
+          "potential": 75,
+          "value": 4100000,
+          "yearly_wage": 2548000
+        },
+        {
+          "currency": "€",
+          "full_name": "Trey Samuel-Ogunsuyi",
+          "name": "T. Samuel-Ogunsuyi",
+          "overall_score": 59,
+          "potential": 74,
+          "value": 525000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Timur Tutierov",
+          "name": "T. Tutierov",
+          "overall_score": 61,
+          "potential": 77,
+          "value": 875000,
+          "yearly_wage": 416000
+        }
+      ],
+      "team": "Sunderland",
+      "transfer_budget": 41300000,
+      "url": "https://sofifa.com/team/106/sunderland/260037/"
+    },
+    {
+      "player_count": 33,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Mads Hermansen",
+          "name": "M. Hermansen",
+          "overall_score": 75,
+          "potential": 80,
+          "value": 7000000,
+          "yearly_wage": 1352000
+        },
+        {
+          "currency": "€",
+          "full_name": "Kyle Walker-Peters",
+          "name": "K. Walker-Peters",
+          "overall_score": 76,
+          "potential": 76,
+          "value": 7000000,
+          "yearly_wage": 2912000
+        },
+        {
+          "currency": "€",
+          "full_name": "Konstantinos Mavropanos",
+          "name": "K. Mavropanos",
+          "overall_score": 77,
+          "potential": 77,
+          "value": 9500000,
+          "yearly_wage": 2964000
+        },
+        {
+          "currency": "€",
+          "full_name": "Axel Disasi",
+          "name": "A. Disasi",
+          "overall_score": 77,
+          "potential": 78,
+          "value": 10500000,
+          "yearly_wage": 4628000
+        },
+        {
+          "currency": "€",
+          "full_name": "El Hadji Malick Diouf",
+          "name": "E. Diouf",
+          "overall_score": 78,
+          "potential": 84,
+          "value": 20500000,
+          "yearly_wage": 2340000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jarrod Bowen",
+          "name": "J. Bowen",
+          "overall_score": 83,
+          "potential": 83,
+          "value": 36500000,
+          "yearly_wage": 5200000
+        },
+        {
+          "currency": "€",
+          "full_name": "Tomáš Souček",
+          "name": "T. Souček",
+          "overall_score": 76,
+          "potential": 76,
+          "value": 6500000,
+          "yearly_wage": 2912000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mateus Gonçalo Espanha Fernandes",
+          "name": "Mateus Fernandes",
+          "overall_score": 79,
+          "potential": 85,
+          "value": 27000000,
+          "yearly_wage": 2704000
+        },
+        {
+          "currency": "€",
+          "full_name": "Crysencio Summerville",
+          "name": "C. Summerville",
+          "overall_score": 78,
+          "potential": 83,
+          "value": 21000000,
+          "yearly_wage": 2912000
+        },
+        {
+          "currency": "€",
+          "full_name": "Taty Castellanos",
+          "name": "T. Castellanos",
+          "overall_score": 79,
+          "potential": 80,
+          "value": 21000000,
+          "yearly_wage": 4004000
+        },
+        {
+          "currency": "€",
+          "full_name": "Pablo Felipe Pereira de Jesus",
+          "name": "Pablo",
+          "overall_score": 73,
+          "potential": 81,
+          "value": 7000000,
+          "yearly_wage": 1924000
+        },
+        {
+          "currency": "€",
+          "full_name": "Freddie Potts",
+          "name": "F. Potts",
+          "overall_score": 73,
+          "potential": 80,
+          "value": 6000000,
+          "yearly_wage": 1612000
+        },
+        {
+          "currency": "€",
+          "full_name": "Soungoutou Magassa",
+          "name": "S. Magassa",
+          "overall_score": 73,
+          "potential": 80,
+          "value": 6000000,
+          "yearly_wage": 1612000
+        },
+        {
+          "currency": "€",
+          "full_name": "Aaron Wan-Bissaka",
+          "name": "A. Wan-Bissaka",
+          "overall_score": 79,
+          "potential": 79,
+          "value": 17000000,
+          "yearly_wage": 3536000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jean-Clair Todibo",
+          "name": "J. Todibo",
+          "overall_score": 78,
+          "potential": 81,
+          "value": 16500000,
+          "yearly_wage": 3016000
+        },
+        {
+          "currency": "€",
+          "full_name": "Maximilian Kilman",
+          "name": "M. Kilman",
+          "overall_score": 75,
+          "potential": 76,
+          "value": 5500000,
+          "yearly_wage": 2756000
+        },
+        {
+          "currency": "€",
+          "full_name": "Oliver Scarles",
+          "name": "O. Scarles",
+          "overall_score": 72,
+          "potential": 80,
+          "value": 4800000,
+          "yearly_wage": 1404000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alphonse Areola",
+          "name": "A. Areola",
+          "overall_score": 76,
+          "potential": 76,
+          "value": 3700000,
+          "yearly_wage": 1924000
+        },
+        {
+          "currency": "€",
+          "full_name": "Adama Traoré Diarra",
+          "name": "Adama Traoré",
+          "overall_score": 75,
+          "potential": 75,
+          "value": 5500000,
+          "yearly_wage": 2912000
+        },
+        {
+          "currency": "€",
+          "full_name": "Callum Wilson",
+          "name": "C. Wilson",
+          "overall_score": 77,
+          "potential": 77,
+          "value": 6500000,
+          "yearly_wage": 3536000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ezra Mayers",
+          "name": "E. Mayers",
+          "overall_score": 60,
+          "potential": 78,
+          "value": 600000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mohamadou Kanté",
+          "name": "M. Kanté",
+          "overall_score": 62,
+          "potential": 76,
+          "value": 900000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "Keiber Lamadrid",
+          "name": "K. Lamadrid",
+          "overall_score": 70,
+          "potential": 79,
+          "value": 3600000,
+          "yearly_wage": 1248000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lewis Orford",
+          "name": "L. Orford",
+          "overall_score": 61,
+          "potential": 78,
+          "value": 800000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Łukasz Fabiański",
+          "name": "Ł. Fabiański",
+          "overall_score": 74,
+          "potential": 74,
+          "value": 475000,
+          "yearly_wage": 780000
+        },
+        {
+          "currency": "€",
+          "full_name": "Callum Marshall",
+          "name": "C. Marshall",
+          "overall_score": 66,
+          "potential": 75,
+          "value": 1900000,
+          "yearly_wage": 832000
+        },
+        {
+          "currency": "€",
+          "full_name": "Kaelan Casey",
+          "name": "K. Casey",
+          "overall_score": 63,
+          "potential": 76,
+          "value": 1100000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "George Earthy",
+          "name": "G. Earthy",
+          "overall_score": 67,
+          "potential": 78,
+          "value": 2200000,
+          "yearly_wage": 884000
+        },
+        {
+          "currency": "€",
+          "full_name": "Edson Álvarez",
+          "name": "E. Álvarez",
+          "overall_score": 78,
+          "potential": 79,
+          "value": 14500000,
+          "yearly_wage": 3172000
+        },
+        {
+          "currency": "€",
+          "full_name": "Maxwel Cornet",
+          "name": "M. Cornet",
+          "overall_score": 73,
+          "potential": 73,
+          "value": 3100000,
+          "yearly_wage": 2444000
+        },
+        {
+          "currency": "€",
+          "full_name": "James Ward-Prowse",
+          "name": "J. Ward-Prowse",
+          "overall_score": 74,
+          "potential": 74,
+          "value": 4000000,
+          "yearly_wage": 2704000
+        },
+        {
+          "currency": "€",
+          "full_name": "Niclas Füllkrug",
+          "name": "N. Füllkrug",
+          "overall_score": 78,
+          "potential": 78,
+          "value": 11500000,
+          "yearly_wage": 3744000
+        },
+        {
+          "currency": "€",
+          "full_name": "Michael Forbes",
+          "name": "M. Forbes",
+          "overall_score": 61,
+          "potential": 72,
+          "value": 700000,
+          "yearly_wage": 416000
+        }
+      ],
+      "team": "West Ham United",
+      "transfer_budget": 70600000,
+      "url": "https://sofifa.com/team/19/west-ham-united/260037/"
+    },
+    {
+      "player_count": 33,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Karl Darlow",
+          "name": "K. Darlow",
+          "overall_score": 74,
+          "potential": 74,
+          "value": 725000,
+          "yearly_wage": 1508000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jayden Bogle",
+          "name": "J. Bogle",
+          "overall_score": 76,
+          "potential": 79,
+          "value": 9500000,
+          "yearly_wage": 2184000
+        },
+        {
+          "currency": "€",
+          "full_name": "Joe Rodon",
+          "name": "J. Rodon",
+          "overall_score": 77,
+          "potential": 78,
+          "value": 10500000,
+          "yearly_wage": 2704000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jaka Bijol",
+          "name": "J. Bijol",
+          "overall_score": 77,
+          "potential": 79,
+          "value": 11500000,
+          "yearly_wage": 2704000
+        },
+        {
+          "currency": "€",
+          "full_name": "Pascal Struijk",
+          "name": "P. Struijk",
+          "overall_score": 76,
+          "potential": 78,
+          "value": 8500000,
+          "yearly_wage": 2444000
+        },
+        {
+          "currency": "€",
+          "full_name": "Gabriel Gudmundsson",
+          "name": "G. Gudmundsson",
+          "overall_score": 77,
+          "potential": 78,
+          "value": 11500000,
+          "yearly_wage": 2704000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ethan Ampadu",
+          "name": "E. Ampadu",
+          "overall_score": 78,
+          "potential": 81,
+          "value": 17500000,
+          "yearly_wage": 2496000
+        },
+        {
+          "currency": "€",
+          "full_name": "Anton Stach",
+          "name": "A. Stach",
+          "overall_score": 79,
+          "potential": 80,
+          "value": 20500000,
+          "yearly_wage": 3328000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ao Tanaka",
+          "name": "A. Tanaka",
+          "overall_score": 76,
+          "potential": 78,
+          "value": 8500000,
+          "yearly_wage": 2548000
+        },
+        {
+          "currency": "€",
+          "full_name": "Dominic Calvert-Lewin",
+          "name": "D. Calvert-Lewin",
+          "overall_score": 77,
+          "potential": 77,
+          "value": 11000000,
+          "yearly_wage": 3224000
+        },
+        {
+          "currency": "€",
+          "full_name": "Noah Okafor",
+          "name": "N. Okafor",
+          "overall_score": 76,
+          "potential": 79,
+          "value": 10000000,
+          "yearly_wage": 2756000
+        },
+        {
+          "currency": "€",
+          "full_name": "Daniel James",
+          "name": "D. James",
+          "overall_score": 76,
+          "potential": 76,
+          "value": 8000000,
+          "yearly_wage": 2808000
+        },
+        {
+          "currency": "€",
+          "full_name": "Brenden Aaronson",
+          "name": "B. Aaronson",
+          "overall_score": 76,
+          "potential": 79,
+          "value": 10000000,
+          "yearly_wage": 2496000
+        },
+        {
+          "currency": "€",
+          "full_name": "Sean Longstaff",
+          "name": "S. Longstaff",
+          "overall_score": 76,
+          "potential": 76,
+          "value": 8000000,
+          "yearly_wage": 2652000
+        },
+        {
+          "currency": "€",
+          "full_name": "Facundo Buonanotte",
+          "name": "F. Buonanotte",
+          "overall_score": 74,
+          "potential": 80,
+          "value": 6500000,
+          "yearly_wage": 2444000
+        },
+        {
+          "currency": "€",
+          "full_name": "James Justin",
+          "name": "J. Justin",
+          "overall_score": 76,
+          "potential": 76,
+          "value": 7000000,
+          "yearly_wage": 2548000
+        },
+        {
+          "currency": "€",
+          "full_name": "Sebastiaan Bornauw",
+          "name": "S. Bornauw",
+          "overall_score": 74,
+          "potential": 76,
+          "value": 4600000,
+          "yearly_wage": 2236000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lucas Estella Perri",
+          "name": "Lucas Perri",
+          "overall_score": 78,
+          "potential": 80,
+          "value": 13000000,
+          "yearly_wage": 1872000
+        },
+        {
+          "currency": "€",
+          "full_name": "Wilfried Gnonto",
+          "name": "W. Gnonto",
+          "overall_score": 74,
+          "potential": 81,
+          "value": 8500000,
+          "yearly_wage": 1872000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lukas Nmecha",
+          "name": "L. Nmecha",
+          "overall_score": 76,
+          "potential": 77,
+          "value": 9000000,
+          "yearly_wage": 2860000
+        },
+        {
+          "currency": "€",
+          "full_name": "Joël Piroe",
+          "name": "J. Piroe",
+          "overall_score": 75,
+          "potential": 77,
+          "value": 7000000,
+          "yearly_wage": 2652000
+        },
+        {
+          "currency": "€",
+          "full_name": "Sam Byram",
+          "name": "S. Byram",
+          "overall_score": 71,
+          "potential": 71,
+          "value": 1400000,
+          "yearly_wage": 1716000
+        },
+        {
+          "currency": "€",
+          "full_name": "Illan Meslier",
+          "name": "I. Meslier",
+          "overall_score": 71,
+          "potential": 74,
+          "value": 1900000,
+          "yearly_wage": 988000
+        },
+        {
+          "currency": "€",
+          "full_name": "Sam Chambers",
+          "name": "S. Chambers",
+          "overall_score": 63,
+          "potential": 79,
+          "value": 1200000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alex Cairns",
+          "name": "A. Cairns",
+          "overall_score": 63,
+          "potential": 63,
+          "value": 240000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ilia Gruev",
+          "name": "I. Gruev",
+          "overall_score": 75,
+          "potential": 77,
+          "value": 6500000,
+          "yearly_wage": 2288000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mateo Joseph",
+          "name": "Mateo Joseph",
+          "overall_score": 72,
+          "potential": 82,
+          "value": 5500000,
+          "yearly_wage": 1612000
+        },
+        {
+          "currency": "€",
+          "full_name": "Isaac Schmidt",
+          "name": "I. Schmidt",
+          "overall_score": 72,
+          "potential": 75,
+          "value": 2900000,
+          "yearly_wage": 1768000
+        },
+        {
+          "currency": "€",
+          "full_name": "Joe Gelhardt",
+          "name": "J. Gelhardt",
+          "overall_score": 73,
+          "potential": 79,
+          "value": 4800000,
+          "yearly_wage": 1872000
+        },
+        {
+          "currency": "€",
+          "full_name": "Largie Ramazani",
+          "name": "L. Ramazani",
+          "overall_score": 76,
+          "potential": 79,
+          "value": 10000000,
+          "yearly_wage": 2496000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jack Harrison",
+          "name": "J. Harrison",
+          "overall_score": 73,
+          "potential": 73,
+          "value": 3100000,
+          "yearly_wage": 2340000
+        },
+        {
+          "currency": "€",
+          "full_name": "Maximilian Wöber",
+          "name": "M. Wöber",
+          "overall_score": 74,
+          "potential": 75,
+          "value": 4200000,
+          "yearly_wage": 2236000
+        },
+        {
+          "currency": "€",
+          "full_name": "Harry Gray",
+          "name": "H. Gray",
+          "overall_score": 61,
+          "potential": 80,
+          "value": 825000,
+          "yearly_wage": 312000
+        }
+      ],
+      "team": "Leeds United",
+      "transfer_budget": 38900000,
+      "url": "https://sofifa.com/team/8/leeds-united/260037/"
+    },
+    {
+      "player_count": 34,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "José Pedro Malheiro de Sá",
+          "name": "José Sá",
+          "overall_score": 76,
+          "potential": 76,
+          "value": 3700000,
+          "yearly_wage": 1924000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jackson Tchatchoua",
+          "name": "J. Tchatchoua",
+          "overall_score": 74,
+          "potential": 79,
+          "value": 6000000,
+          "yearly_wage": 2132000
+        },
+        {
+          "currency": "€",
+          "full_name": "Yerson Mosquera",
+          "name": "Y. Mosquera",
+          "overall_score": 72,
+          "potential": 78,
+          "value": 3400000,
+          "yearly_wage": 1768000
+        },
+        {
+          "currency": "€",
+          "full_name": "Santiago Bueno",
+          "name": "S. Bueno",
+          "overall_score": 76,
+          "potential": 78,
+          "value": 8000000,
+          "yearly_wage": 2808000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ladislav Krejčí",
+          "name": "L. Krejčí",
+          "overall_score": 78,
+          "potential": 81,
+          "value": 16500000,
+          "yearly_wage": 1664000
+        },
+        {
+          "currency": "€",
+          "full_name": "Hugo Bueno López",
+          "name": "Hugo Bueno",
+          "overall_score": 75,
+          "potential": 80,
+          "value": 8000000,
+          "yearly_wage": 2288000
+        },
+        {
+          "currency": "€",
+          "full_name": "André Trindade",
+          "name": "André",
+          "overall_score": 78,
+          "potential": 83,
+          "value": 19500000,
+          "yearly_wage": 2756000
+        },
+        {
+          "currency": "€",
+          "full_name": "João Victor Gomes da Silva",
+          "name": "João Gomes",
+          "overall_score": 78,
+          "potential": 83,
+          "value": 19500000,
+          "yearly_wage": 2756000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mateus Bula Dami Mané",
+          "name": "Mateus Mané",
+          "overall_score": 71,
+          "potential": 84,
+          "value": 4300000,
+          "yearly_wage": 1040000
+        },
+        {
+          "currency": "€",
+          "full_name": "Tolu Arokodare",
+          "name": "T. Arokodare",
+          "overall_score": 76,
+          "potential": 79,
+          "value": 10500000,
+          "yearly_wage": 2808000
+        },
+        {
+          "currency": "€",
+          "full_name": "Adam Armstrong",
+          "name": "A. Armstrong",
+          "overall_score": 73,
+          "potential": 73,
+          "value": 3100000,
+          "yearly_wage": 2652000
+        },
+        {
+          "currency": "€",
+          "full_name": "Angel Gomes",
+          "name": "A. Gomes",
+          "overall_score": 76,
+          "potential": 81,
+          "value": 11500000,
+          "yearly_wage": 1612000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jean-Ricner Bellegarde",
+          "name": "J. Bellegarde",
+          "overall_score": 75,
+          "potential": 76,
+          "value": 6500000,
+          "yearly_wage": 2808000
+        },
+        {
+          "currency": "€",
+          "full_name": "Tote António Gomes",
+          "name": "Toti",
+          "overall_score": 75,
+          "potential": 78,
+          "value": 6500000,
+          "yearly_wage": 2652000
+        },
+        {
+          "currency": "€",
+          "full_name": "Matt Doherty",
+          "name": "M. Doherty",
+          "overall_score": 74,
+          "potential": 74,
+          "value": 2000000,
+          "yearly_wage": 2548000
+        },
+        {
+          "currency": "€",
+          "full_name": "David Møller Wolfe",
+          "name": "D. Wolfe",
+          "overall_score": 73,
+          "potential": 78,
+          "value": 4300000,
+          "yearly_wage": 1924000
+        },
+        {
+          "currency": "€",
+          "full_name": "Pedro Henrique Cardoso de Lima",
+          "name": "Pedro Lima",
+          "overall_score": 68,
+          "potential": 83,
+          "value": 2700000,
+          "yearly_wage": 884000
+        },
+        {
+          "currency": "€",
+          "full_name": "Daniel Bentley",
+          "name": "D. Bentley",
+          "overall_score": 71,
+          "potential": 71,
+          "value": 1000000,
+          "yearly_wage": 1248000
+        },
+        {
+          "currency": "€",
+          "full_name": "Rodrigo Martins Gomes",
+          "name": "Rodrigo Gomes",
+          "overall_score": 73,
+          "potential": 82,
+          "value": 7000000,
+          "yearly_wage": 1872000
+        },
+        {
+          "currency": "€",
+          "full_name": "Hee Chan Hwang",
+          "name": "Hwang Hee Chan",
+          "overall_score": 74,
+          "potential": 74,
+          "value": 4200000,
+          "yearly_wage": 2912000
+        },
+        {
+          "currency": "€",
+          "full_name": "Tom Edozie",
+          "name": "T. Edozie",
+          "overall_score": 65,
+          "potential": 78,
+          "value": 1700000,
+          "yearly_wage": 624000
+        },
+        {
+          "currency": "€",
+          "full_name": "Enso González",
+          "name": "E. González",
+          "overall_score": 63,
+          "potential": 75,
+          "value": 1200000,
+          "yearly_wage": 572000
+        },
+        {
+          "currency": "€",
+          "full_name": "Sam Johnstone",
+          "name": "S. Johnstone",
+          "overall_score": 76,
+          "potential": 76,
+          "value": 3700000,
+          "yearly_wage": 1924000
+        },
+        {
+          "currency": "€",
+          "full_name": "Tawanda Chirewa",
+          "name": "T. Chirewa",
+          "overall_score": 64,
+          "potential": 74,
+          "value": 1300000,
+          "yearly_wage": 572000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alfie Pond",
+          "name": "A. Pond",
+          "overall_score": 59,
+          "potential": 70,
+          "value": 475000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Nasser Djiga",
+          "name": "N. Djiga",
+          "overall_score": 70,
+          "potential": 78,
+          "value": 3300000,
+          "yearly_wage": 1404000
+        },
+        {
+          "currency": "€",
+          "full_name": "Nigel Lonwijk",
+          "name": "N. Lonwijk",
+          "overall_score": 67,
+          "potential": 74,
+          "value": 1900000,
+          "yearly_wage": 988000
+        },
+        {
+          "currency": "€",
+          "full_name": "Tommy Doyle",
+          "name": "T. Doyle",
+          "overall_score": 73,
+          "potential": 78,
+          "value": 4600000,
+          "yearly_wage": 2028000
+        },
+        {
+          "currency": "€",
+          "full_name": "Boubacar Traoré",
+          "name": "B. Traoré",
+          "overall_score": 71,
+          "potential": 76,
+          "value": 2600000,
+          "yearly_wage": 1560000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ki-Jana Hoever",
+          "name": "K. Hoever",
+          "overall_score": 72,
+          "potential": 76,
+          "value": 3100000,
+          "yearly_wage": 1768000
+        },
+        {
+          "currency": "€",
+          "full_name": "Saša Kalajdžić",
+          "name": "S. Kalajdžić",
+          "overall_score": 73,
+          "potential": 73,
+          "value": 3300000,
+          "yearly_wage": 2548000
+        },
+        {
+          "currency": "€",
+          "full_name": "Marshall Munetsi",
+          "name": "M. Munetsi",
+          "overall_score": 75,
+          "potential": 75,
+          "value": 5500000,
+          "yearly_wage": 2912000
+        },
+        {
+          "currency": "€",
+          "full_name": "Fernando López González",
+          "name": "Fer López",
+          "overall_score": 73,
+          "potential": 82,
+          "value": 7000000,
+          "yearly_wage": 1872000
+        },
+        {
+          "currency": "€",
+          "full_name": "Temple Ojinnaka",
+          "name": "T. Ojinnaka",
+          "overall_score": 57,
+          "potential": 72,
+          "value": 375000,
+          "yearly_wage": 312000
+        }
+      ],
+      "team": "Wolverhampton Wanderers",
+      "transfer_budget": 53500000,
+      "url": "https://sofifa.com/team/110/wolverhampton-wanderers/260037/"
+    },
+    {
+      "player_count": 40,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Martin Dúbravka",
+          "name": "M. Dúbravka",
+          "overall_score": 78,
+          "potential": 78,
+          "value": 1600000,
+          "yearly_wage": 1196000
+        },
+        {
+          "currency": "€",
+          "full_name": "Kyle Walker",
+          "name": "K. Walker",
+          "overall_score": 77,
+          "potential": 77,
+          "value": 3200000,
+          "yearly_wage": 2080000
+        },
+        {
+          "currency": "€",
+          "full_name": "Bashir Humphreys",
+          "name": "B. Humphreys",
+          "overall_score": 74,
+          "potential": 82,
+          "value": 9000000,
+          "yearly_wage": 1924000
+        },
+        {
+          "currency": "€",
+          "full_name": "Maxime Estève",
+          "name": "M. Estève",
+          "overall_score": 76,
+          "potential": 82,
+          "value": 11000000,
+          "yearly_wage": 2184000
+        },
+        {
+          "currency": "€",
+          "full_name": "Quilindschy Hartman",
+          "name": "Q. Hartman",
+          "overall_score": 76,
+          "potential": 80,
+          "value": 10000000,
+          "yearly_wage": 2184000
+        },
+        {
+          "currency": "€",
+          "full_name": "James Ward-Prowse",
+          "name": "J. Ward-Prowse",
+          "overall_score": 74,
+          "potential": 74,
+          "value": 4000000,
+          "yearly_wage": 2704000
+        },
+        {
+          "currency": "€",
+          "full_name": "Florentino Morris Luís",
+          "name": "Florentino",
+          "overall_score": 77,
+          "potential": 78,
+          "value": 11000000,
+          "yearly_wage": 936000
+        },
+        {
+          "currency": "€",
+          "full_name": "Loum Tchaouna",
+          "name": "L. Tchaouna",
+          "overall_score": 72,
+          "potential": 78,
+          "value": 3800000,
+          "yearly_wage": 1404000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jaidon Anthony",
+          "name": "J. Anthony",
+          "overall_score": 76,
+          "potential": 77,
+          "value": 9000000,
+          "yearly_wage": 2548000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lesley Ugochukwu",
+          "name": "L. Ugochukwu",
+          "overall_score": 76,
+          "potential": 82,
+          "value": 11000000,
+          "yearly_wage": 1872000
+        },
+        {
+          "currency": "€",
+          "full_name": "Zian Flemming",
+          "name": "Z. Flemming",
+          "overall_score": 75,
+          "potential": 76,
+          "value": 6500000,
+          "yearly_wage": 2756000
+        },
+        {
+          "currency": "€",
+          "full_name": "Marcus Edwards",
+          "name": "M. Edwards",
+          "overall_score": 75,
+          "potential": 75,
+          "value": 6000000,
+          "yearly_wage": 2548000
+        },
+        {
+          "currency": "€",
+          "full_name": "Hannibal Mejbri",
+          "name": "Hannibal",
+          "overall_score": 75,
+          "potential": 82,
+          "value": 11500000,
+          "yearly_wage": 2184000
+        },
+        {
+          "currency": "€",
+          "full_name": "Josh Laurent",
+          "name": "J. Laurent",
+          "overall_score": 73,
+          "potential": 73,
+          "value": 2500000,
+          "yearly_wage": 2132000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jacob Bruun Larsen",
+          "name": "J. Bruun Larsen",
+          "overall_score": 73,
+          "potential": 73,
+          "value": 3300000,
+          "yearly_wage": 2132000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lucas Pires Silva",
+          "name": "Lucas Pires",
+          "overall_score": 74,
+          "potential": 78,
+          "value": 5500000,
+          "yearly_wage": 1924000
+        },
+        {
+          "currency": "€",
+          "full_name": "Hjalmar Ekdal",
+          "name": "H. Ekdal",
+          "overall_score": 71,
+          "potential": 73,
+          "value": 2000000,
+          "yearly_wage": 1664000
+        },
+        {
+          "currency": "€",
+          "full_name": "Max Weiß",
+          "name": "M. Weiß",
+          "overall_score": 69,
+          "potential": 80,
+          "value": 2700000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "Armando Broja",
+          "name": "A. Broja",
+          "overall_score": 72,
+          "potential": 76,
+          "value": 3400000,
+          "yearly_wage": 1820000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lyle Foster",
+          "name": "L. Foster",
+          "overall_score": 73,
+          "potential": 75,
+          "value": 4000000,
+          "yearly_wage": 2028000
+        },
+        {
+          "currency": "€",
+          "full_name": "Axel Tuanzebe",
+          "name": "A. Tuanzebe",
+          "overall_score": 73,
+          "potential": 73,
+          "value": 2800000,
+          "yearly_wage": 2028000
+        },
+        {
+          "currency": "€",
+          "full_name": "Joe Worrall",
+          "name": "J. Worrall",
+          "overall_score": 73,
+          "potential": 73,
+          "value": 2600000,
+          "yearly_wage": 2132000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mike Trésor",
+          "name": "M. Trésor",
+          "overall_score": 73,
+          "potential": 73,
+          "value": 3300000,
+          "yearly_wage": 2132000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ashley Barnes",
+          "name": "A. Barnes",
+          "overall_score": 70,
+          "potential": 70,
+          "value": 675000,
+          "yearly_wage": 1352000
+        },
+        {
+          "currency": "€",
+          "full_name": "Zeki Amdouni",
+          "name": "Z. Amdouni",
+          "overall_score": 74,
+          "potential": 78,
+          "value": 6000000,
+          "yearly_wage": 2236000
+        },
+        {
+          "currency": "€",
+          "full_name": "Enock Agyei",
+          "name": "E. Agyei",
+          "overall_score": 63,
+          "potential": 75,
+          "value": 1200000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "Václav Hladký",
+          "name": "V. Hladký",
+          "overall_score": 68,
+          "potential": 68,
+          "value": 210000,
+          "yearly_wage": 832000
+        },
+        {
+          "currency": "€",
+          "full_name": "Josh Cullen",
+          "name": "J. Cullen",
+          "overall_score": 77,
+          "potential": 77,
+          "value": 9000000,
+          "yearly_wage": 2860000
+        },
+        {
+          "currency": "€",
+          "full_name": "Connor Roberts",
+          "name": "C. Roberts",
+          "overall_score": 74,
+          "potential": 74,
+          "value": 3700000,
+          "yearly_wage": 2340000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jordan Beyer",
+          "name": "J. Beyer",
+          "overall_score": 73,
+          "potential": 75,
+          "value": 3400000,
+          "yearly_wage": 1924000
+        },
+        {
+          "currency": "€",
+          "full_name": "Michael Mellon",
+          "name": "M. Mellon",
+          "overall_score": 62,
+          "potential": 71,
+          "value": 900000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jaydon Banel",
+          "name": "J. Banel",
+          "overall_score": 65,
+          "potential": 78,
+          "value": 1700000,
+          "yearly_wage": 572000
+        },
+        {
+          "currency": "€",
+          "full_name": "Tommy McDermott",
+          "name": "T. McDermott",
+          "overall_score": 58,
+          "potential": 66,
+          "value": 450000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Aaron Ramsey",
+          "name": "A. Ramsey",
+          "overall_score": 70,
+          "potential": 79,
+          "value": 3600000,
+          "yearly_wage": 1352000
+        },
+        {
+          "currency": "€",
+          "full_name": "Luca Koleosho",
+          "name": "L. Koleosho",
+          "overall_score": 72,
+          "potential": 79,
+          "value": 4600000,
+          "yearly_wage": 1560000
+        },
+        {
+          "currency": "€",
+          "full_name": "Owen Dodgson",
+          "name": "O. Dodgson",
+          "overall_score": 63,
+          "potential": 72,
+          "value": 1000000,
+          "yearly_wage": 520000
+        },
+        {
+          "currency": "€",
+          "full_name": "Andréas Hountondji",
+          "name": "A. Hountondji",
+          "overall_score": 70,
+          "potential": 77,
+          "value": 3300000,
+          "yearly_wage": 1508000
+        },
+        {
+          "currency": "€",
+          "full_name": "Shurandy Sambo",
+          "name": "S. Sambo",
+          "overall_score": 67,
+          "potential": 74,
+          "value": 1900000,
+          "yearly_wage": 884000
+        },
+        {
+          "currency": "€",
+          "full_name": "Michael Obafemi",
+          "name": "M. Obafemi",
+          "overall_score": 66,
+          "potential": 71,
+          "value": 1300000,
+          "yearly_wage": 884000
+        },
+        {
+          "currency": "€",
+          "full_name": "Oluwaseun Adewumi",
+          "name": "O. Adewumi",
+          "overall_score": 60,
+          "potential": 74,
+          "value": 600000,
+          "yearly_wage": 312000
+        }
+      ],
+      "team": "Burnley",
+      "transfer_budget": 37500000,
+      "url": "https://sofifa.com/team/1796/burnley/260037/"
+    }
+  ],
+  "total_players": 763
+}

--- a/data/2025/ENG1/teams.json
+++ b/data/2025/ENG1/teams.json
@@ -18,7 +18,11 @@
             "Belgium"
           ],
           "number": "31",
-          "position": "Goalkeeper"
+          "overall_score": 81,
+          "position": "Goalkeeper",
+          "potential": 87,
+          "value": 33500000,
+          "yearly_wage": 2340000
         },
         {
           "contract": "Jun 30, 2027",
@@ -32,7 +36,11 @@
             "Türkiye"
           ],
           "number": "1",
-          "position": "Goalkeeper"
+          "overall_score": 75,
+          "position": "Goalkeeper",
+          "potential": 77,
+          "value": 5000000,
+          "yearly_wage": 1976000
         },
         {
           "contract": "Jun 30, 2026",
@@ -46,7 +54,11 @@
             "England"
           ],
           "number": "22",
-          "position": "Goalkeeper"
+          "overall_score": 67,
+          "position": "Goalkeeper",
+          "potential": 67,
+          "value": 110000,
+          "yearly_wage": 416000
         },
         {
           "contract": "Jun 30, 2029",
@@ -61,7 +73,11 @@
             "Cote d'Ivoire"
           ],
           "number": "15",
-          "position": "Centre-Back"
+          "overall_score": 78,
+          "position": "Centre-Back",
+          "potential": 86,
+          "value": 28500000,
+          "yearly_wage": 2548000
         },
         {
           "contract": "Jun 30, 2029",
@@ -75,7 +91,11 @@
             "Netherlands"
           ],
           "number": "4",
-          "position": "Centre-Back"
+          "overall_score": 82,
+          "position": "Centre-Back",
+          "potential": 84,
+          "value": 34000000,
+          "yearly_wage": 4940000
         },
         {
           "contract": "Jun 30, 2027",
@@ -89,7 +109,11 @@
             "Argentina"
           ],
           "number": "6",
-          "position": "Centre-Back"
+          "overall_score": 81,
+          "position": "Centre-Back",
+          "potential": 82,
+          "value": 26000000,
+          "yearly_wage": 4680000
         },
         {
           "contract": "Jun 30, 2026",
@@ -103,7 +127,11 @@
             "England"
           ],
           "number": "5",
-          "position": "Centre-Back"
+          "overall_score": 81,
+          "position": "Centre-Back",
+          "potential": 81,
+          "value": 16500000,
+          "yearly_wage": 4940000
         },
         {
           "contract": "Jun 30, 2029",
@@ -118,7 +146,11 @@
             "Ghana"
           ],
           "number": "26",
-          "position": "Centre-Back"
+          "overall_score": 74,
+          "position": "Centre-Back",
+          "potential": 85,
+          "value": 8500000,
+          "yearly_wage": 1872000
         },
         {
           "contract": "-",
@@ -132,7 +164,11 @@
             "England"
           ],
           "number": "33",
-          "position": "Centre-Back"
+          "overall_score": 65,
+          "position": "Centre-Back",
+          "potential": 78,
+          "value": 1600000,
+          "yearly_wage": 676000
         },
         {
           "contract": "Jun 30, 2030",
@@ -147,7 +183,11 @@
             "Nigeria"
           ],
           "number": "13",
-          "position": "Left-Back"
+          "overall_score": 77,
+          "position": "Left-Back",
+          "potential": 84,
+          "value": 21000000,
+          "yearly_wage": 2704000
         },
         {
           "contract": "Jun 30, 2027",
@@ -161,7 +201,11 @@
             "England"
           ],
           "number": "23",
-          "position": "Left-Back"
+          "overall_score": 79,
+          "position": "Left-Back",
+          "potential": 79,
+          "value": 15500000,
+          "yearly_wage": 4316000
         },
         {
           "contract": "Jun 30, 2026",
@@ -176,7 +220,11 @@
             "Curacao"
           ],
           "number": "12",
-          "position": "Left-Back"
+          "overall_score": 75,
+          "position": "Left-Back",
+          "potential": 76,
+          "value": 6000000,
+          "yearly_wage": 3016000
         },
         {
           "contract": "Jun 30, 2029",
@@ -190,7 +238,11 @@
             "Paraguay"
           ],
           "number": "35",
-          "position": "Left-Back"
+          "overall_score": 64,
+          "position": "Left-Back",
+          "potential": 83,
+          "value": 1400000,
+          "yearly_wage": 572000
         },
         {
           "contract": "Jun 30, 2028",
@@ -204,7 +256,11 @@
             "Portugal"
           ],
           "number": "2",
-          "position": "Right-Back"
+          "overall_score": 78,
+          "position": "Right-Back",
+          "potential": 79,
+          "value": 15000000,
+          "yearly_wage": 3744000
         },
         {
           "contract": "Jun 30, 2028",
@@ -219,7 +275,11 @@
             "Netherlands"
           ],
           "number": "3",
-          "position": "Right-Back"
+          "overall_score": 80,
+          "position": "Right-Back",
+          "potential": 80,
+          "value": 20500000,
+          "yearly_wage": 4368000
         },
         {
           "contract": "Jun 30, 2029",
@@ -233,7 +293,11 @@
             "Uruguay"
           ],
           "number": "25",
-          "position": "Defensive Midfield"
+          "overall_score": 78,
+          "position": "Defensive Midfield",
+          "potential": 82,
+          "value": 18500000,
+          "yearly_wage": 3224000
         },
         {
           "contract": "Jun 30, 2026",
@@ -248,7 +312,11 @@
             "Spain"
           ],
           "number": "18",
-          "position": "Defensive Midfield"
+          "overall_score": 82,
+          "position": "Defensive Midfield",
+          "potential": 82,
+          "value": 15000000,
+          "yearly_wage": 5200000
         },
         {
           "contract": "Jun 30, 2027",
@@ -263,7 +331,11 @@
             "Ghana"
           ],
           "number": "37",
-          "position": "Central Midfield"
+          "overall_score": 79,
+          "position": "Central Midfield",
+          "potential": 85,
+          "value": 25000000,
+          "yearly_wage": 3016000
         },
         {
           "contract": "Jun 30, 2027",
@@ -277,7 +349,11 @@
             "Portugal"
           ],
           "number": "8",
-          "position": "Attacking Midfield"
+          "overall_score": 88,
+          "position": "Attacking Midfield",
+          "potential": 88,
+          "value": 88000000,
+          "yearly_wage": 9620000
         },
         {
           "contract": "Jun 30, 2028",
@@ -291,7 +367,11 @@
             "England"
           ],
           "number": "7",
-          "position": "Attacking Midfield"
+          "overall_score": 78,
+          "position": "Attacking Midfield",
+          "potential": 79,
+          "value": 16500000,
+          "yearly_wage": 4004000
         },
         {
           "contract": "Jun 30, 2030",
@@ -306,7 +386,11 @@
             "France"
           ],
           "number": "19",
-          "position": "Right Winger"
+          "overall_score": 85,
+          "position": "Right Winger",
+          "potential": 86,
+          "value": 64500000,
+          "yearly_wage": 7020000
         },
         {
           "contract": "Jun 30, 2030",
@@ -321,7 +405,11 @@
             "Italy"
           ],
           "number": "16",
-          "position": "Right Winger"
+          "overall_score": 80,
+          "position": "Right Winger",
+          "potential": 85,
+          "value": 32500000,
+          "yearly_wage": 4004000
         },
         {
           "contract": "Jun 30, 2030",
@@ -335,7 +423,11 @@
             "Brazil"
           ],
           "number": "10",
-          "position": "Centre-Forward"
+          "overall_score": 83,
+          "position": "Centre-Forward",
+          "potential": 84,
+          "value": 43000000,
+          "yearly_wage": 5980000
         },
         {
           "contract": "Jun 30, 2030",
@@ -349,7 +441,11 @@
             "Slovenia"
           ],
           "number": "30",
-          "position": "Centre-Forward"
+          "overall_score": 80,
+          "position": "Centre-Forward",
+          "potential": 87,
+          "value": 43000000,
+          "yearly_wage": 4368000
         },
         {
           "contract": "Jun 30, 2029",
@@ -364,7 +460,11 @@
             "Nigeria"
           ],
           "number": "11",
-          "position": "Centre-Forward"
+          "overall_score": 77,
+          "position": "Centre-Forward",
+          "potential": 82,
+          "value": 16000000,
+          "yearly_wage": 3536000
         },
         {
           "contract": "-",
@@ -379,7 +479,11 @@
             "Nigeria"
           ],
           "number": "32",
-          "position": "Centre-Forward"
+          "overall_score": 65,
+          "position": "Centre-Forward",
+          "potential": 84,
+          "value": 1800000,
+          "yearly_wage": 624000
         }
       ],
       "stadiumName": "Old Trafford",
@@ -402,7 +506,11 @@
             "Italy"
           ],
           "number": "1",
-          "position": "Goalkeeper"
+          "overall_score": 81,
+          "position": "Goalkeeper",
+          "potential": 82,
+          "value": 20500000,
+          "yearly_wage": 3692000
         },
         {
           "contract": "Jun 30, 2029",
@@ -416,7 +524,11 @@
             "Czech Republic"
           ],
           "number": "31",
-          "position": "Goalkeeper"
+          "overall_score": 75,
+          "position": "Goalkeeper",
+          "potential": 81,
+          "value": 7500000,
+          "yearly_wage": 1820000
         },
         {
           "contract": "Jun 30, 2029",
@@ -431,7 +543,11 @@
             "United States"
           ],
           "number": "40",
-          "position": "Goalkeeper"
+          "overall_score": 67,
+          "position": "Goalkeeper",
+          "potential": 71,
+          "value": 1100000,
+          "yearly_wage": 988000
         },
         {
           "contract": "Jun 30, 2029",
@@ -445,7 +561,11 @@
             "Netherlands"
           ],
           "number": "37",
-          "position": "Centre-Back"
+          "overall_score": 82,
+          "position": "Centre-Back",
+          "potential": 85,
+          "value": 37000000,
+          "yearly_wage": 4940000
         },
         {
           "contract": "Jun 30, 2029",
@@ -459,7 +579,11 @@
             "Argentina"
           ],
           "number": "17",
-          "position": "Centre-Back"
+          "overall_score": 82,
+          "position": "Centre-Back",
+          "potential": 84,
+          "value": 32500000,
+          "yearly_wage": 5980000
         },
         {
           "contract": "Jun 30, 2030",
@@ -473,7 +597,11 @@
             "Romania"
           ],
           "number": "3",
-          "position": "Centre-Back"
+          "overall_score": 75,
+          "position": "Centre-Back",
+          "potential": 81,
+          "value": 8000000,
+          "yearly_wage": 3120000
         },
         {
           "contract": "Jun 30, 2030",
@@ -487,7 +615,11 @@
             "Austria"
           ],
           "number": "4",
-          "position": "Centre-Back"
+          "overall_score": 79,
+          "position": "Centre-Back",
+          "potential": 82,
+          "value": 20500000,
+          "yearly_wage": 4680000
         },
         {
           "contract": "Jun 30, 2026",
@@ -501,7 +633,11 @@
             "Wales"
           ],
           "number": "33",
-          "position": "Centre-Back"
+          "overall_score": 75,
+          "position": "Centre-Back",
+          "potential": 75,
+          "value": 3600000,
+          "yearly_wage": 3796000
         },
         {
           "contract": "Jun 30, 2030",
@@ -516,7 +652,11 @@
             "Nigeria"
           ],
           "number": "13",
-          "position": "Left-Back"
+          "overall_score": 79,
+          "position": "Left-Back",
+          "potential": 83,
+          "value": 24000000,
+          "yearly_wage": 4160000
         },
         {
           "contract": "Jun 30, 2029",
@@ -531,7 +671,11 @@
             "Jamaica"
           ],
           "number": "24",
-          "position": "Left-Back"
+          "overall_score": 79,
+          "position": "Left-Back",
+          "potential": 83,
+          "value": 23500000,
+          "yearly_wage": 4160000
         },
         {
           "contract": "Jun 30, 2031",
@@ -545,7 +689,11 @@
             "Brazil"
           ],
           "number": "38",
-          "position": "Left-Back"
+          "overall_score": 70,
+          "position": "Left-Back",
+          "potential": 82,
+          "value": 3600000,
+          "yearly_wage": 1508000
         },
         {
           "contract": "Jun 30, 2028",
@@ -559,7 +707,11 @@
             "Spain"
           ],
           "number": "23",
-          "position": "Right-Back"
+          "overall_score": 82,
+          "position": "Right-Back",
+          "potential": 85,
+          "value": 37000000,
+          "yearly_wage": 5460000
         },
         {
           "contract": "-",
@@ -573,7 +725,11 @@
             "Uruguay"
           ],
           "number": "30",
-          "position": "Defensive Midfield"
+          "overall_score": 80,
+          "position": "Defensive Midfield",
+          "potential": 81,
+          "value": 20500000,
+          "yearly_wage": 5200000
         },
         {
           "contract": "Jun 30, 2026",
@@ -587,7 +743,11 @@
             "Portugal"
           ],
           "number": "6",
-          "position": "Defensive Midfield"
+          "overall_score": 82,
+          "position": "Defensive Midfield",
+          "potential": 82,
+          "value": 26000000,
+          "yearly_wage": 3900000
         },
         {
           "contract": "Jun 30, 2026",
@@ -602,7 +762,11 @@
             "Cote d'Ivoire"
           ],
           "number": "8",
-          "position": "Defensive Midfield"
+          "overall_score": 78,
+          "position": "Defensive Midfield",
+          "potential": 78,
+          "value": 12500000,
+          "yearly_wage": 4524000
         },
         {
           "contract": "Jun 30, 2031",
@@ -616,7 +780,11 @@
             "Sweden"
           ],
           "number": "15",
-          "position": "Central Midfield"
+          "overall_score": 78,
+          "position": "Central Midfield",
+          "potential": 87,
+          "value": 30000000,
+          "yearly_wage": 3172000
         },
         {
           "contract": "Jun 30, 2030",
@@ -631,7 +799,11 @@
             "Scotland"
           ],
           "number": "14",
-          "position": "Central Midfield"
+          "overall_score": 77,
+          "position": "Central Midfield",
+          "potential": 86,
+          "value": 21500000,
+          "yearly_wage": 2756000
         },
         {
           "contract": "Jun 30, 2031",
@@ -645,7 +817,11 @@
             "England"
           ],
           "number": "22",
-          "position": "Central Midfield"
+          "overall_score": 79,
+          "position": "Central Midfield",
+          "potential": 81,
+          "value": 22000000,
+          "yearly_wage": 4680000
         },
         {
           "contract": "Jun 30, 2030",
@@ -659,7 +835,11 @@
             "Senegal"
           ],
           "number": "29",
-          "position": "Central Midfield"
+          "overall_score": 80,
+          "position": "Central Midfield",
+          "potential": 85,
+          "value": 32000000,
+          "yearly_wage": 4576000
         },
         {
           "contract": "Jun 30, 2030",
@@ -674,7 +854,11 @@
             "Suriname"
           ],
           "number": "7",
-          "position": "Attacking Midfield"
+          "overall_score": 82,
+          "position": "Attacking Midfield",
+          "potential": 85,
+          "value": 42500000,
+          "yearly_wage": 5460000
         },
         {
           "contract": "Jun 30, 2028",
@@ -689,7 +873,11 @@
             "North Macedonia"
           ],
           "number": "21",
-          "position": "Attacking Midfield"
+          "overall_score": 83,
+          "position": "Attacking Midfield",
+          "potential": 86,
+          "value": 47500000,
+          "yearly_wage": 6500000
         },
         {
           "contract": "Jun 30, 2028",
@@ -703,7 +891,11 @@
             "England"
           ],
           "number": "10",
-          "position": "Attacking Midfield"
+          "overall_score": 83,
+          "position": "Attacking Midfield",
+          "potential": 83,
+          "value": 36500000,
+          "yearly_wage": 7020000
         },
         {
           "contract": "Jun 30, 2029",
@@ -718,7 +910,11 @@
             "Martinique"
           ],
           "number": "28",
-          "position": "Left Winger"
+          "overall_score": 77,
+          "position": "Left Winger",
+          "potential": 84,
+          "value": 21000000,
+          "yearly_wage": 3432000
         },
         {
           "contract": "Jun 30, 2031",
@@ -732,7 +928,11 @@
             "Ghana"
           ],
           "number": "20",
-          "position": "Right Winger"
+          "overall_score": 81,
+          "position": "Right Winger",
+          "potential": 83,
+          "value": 33500000,
+          "yearly_wage": 5200000
         },
         {
           "contract": "Jun 30, 2030",
@@ -747,7 +947,11 @@
             "Nigeria"
           ],
           "number": "19",
-          "position": "Centre-Forward"
+          "overall_score": 80,
+          "position": "Centre-Forward",
+          "potential": 80,
+          "value": 23000000,
+          "yearly_wage": 5720000
         },
         {
           "contract": "Jun 30, 2031",
@@ -762,7 +966,11 @@
             "Guadeloupe"
           ],
           "number": "11",
-          "position": "Centre-Forward"
+          "overall_score": 77,
+          "position": "Centre-Forward",
+          "potential": 85,
+          "value": 23500000,
+          "yearly_wage": 3536000
         },
         {
           "contract": "Jun 30, 2027",
@@ -776,7 +984,11 @@
             "Brazil"
           ],
           "number": "9",
-          "position": "Centre-Forward"
+          "overall_score": 79,
+          "position": "Centre-Forward",
+          "potential": 79,
+          "value": 18000000,
+          "yearly_wage": 5720000
         },
         {
           "contract": "Jun 30, 2026",
@@ -791,7 +1003,11 @@
             "DR Congo"
           ],
           "number": "39",
-          "position": "Centre-Forward"
+          "overall_score": 79,
+          "position": "Centre-Forward",
+          "potential": 80,
+          "value": 21000000,
+          "yearly_wage": 4420000
         }
       ],
       "stadiumName": "Tottenham Hotspur Stadium",
@@ -814,7 +1030,11 @@
             "Denmark"
           ],
           "number": "1",
-          "position": "Goalkeeper"
+          "overall_score": 75,
+          "position": "Goalkeeper",
+          "potential": 80,
+          "value": 7000000,
+          "yearly_wage": 1352000
         },
         {
           "contract": "Jun 30, 2027",
@@ -829,7 +1049,11 @@
             "Philippines"
           ],
           "number": "23",
-          "position": "Goalkeeper"
+          "overall_score": 76,
+          "position": "Goalkeeper",
+          "potential": 76,
+          "value": 3700000,
+          "yearly_wage": 1924000
         },
         {
           "contract": "Jun 30, 2026",
@@ -858,7 +1082,11 @@
             "French Guiana"
           ],
           "number": "25",
-          "position": "Centre-Back"
+          "overall_score": 78,
+          "position": "Centre-Back",
+          "potential": 81,
+          "value": 16500000,
+          "yearly_wage": 3016000
         },
         {
           "contract": "Jun 30, 2031",
@@ -873,7 +1101,11 @@
             "Ukraine"
           ],
           "number": "3",
-          "position": "Centre-Back"
+          "overall_score": 75,
+          "position": "Centre-Back",
+          "potential": 76,
+          "value": 5500000,
+          "yearly_wage": 2756000
         },
         {
           "contract": "Jun 30, 2026",
@@ -888,7 +1120,11 @@
             "DR Congo"
           ],
           "number": "4",
-          "position": "Centre-Back"
+          "overall_score": 77,
+          "position": "Centre-Back",
+          "potential": 78,
+          "value": 10500000,
+          "yearly_wage": 4628000
         },
         {
           "contract": "Jun 30, 2028",
@@ -902,7 +1138,11 @@
             "Greece"
           ],
           "number": "15",
-          "position": "Centre-Back"
+          "overall_score": 77,
+          "position": "Centre-Back",
+          "potential": 77,
+          "value": 9500000,
+          "yearly_wage": 2964000
         },
         {
           "contract": "Jun 30, 2028",
@@ -917,7 +1157,11 @@
             "Germany"
           ],
           "number": "63",
-          "position": "Centre-Back"
+          "overall_score": 60,
+          "position": "Centre-Back",
+          "potential": 78,
+          "value": 600000,
+          "yearly_wage": 312000
         },
         {
           "contract": "Jun 30, 2030",
@@ -931,7 +1175,11 @@
             "Senegal"
           ],
           "number": "12",
-          "position": "Left-Back"
+          "overall_score": 78,
+          "position": "Left-Back",
+          "potential": 84,
+          "value": 20500000,
+          "yearly_wage": 2340000
         },
         {
           "contract": "Jun 30, 2028",
@@ -945,7 +1193,11 @@
             "England"
           ],
           "number": "30",
-          "position": "Left-Back"
+          "overall_score": 72,
+          "position": "Left-Back",
+          "potential": 80,
+          "value": 4800000,
+          "yearly_wage": 1404000
         },
         {
           "contract": "Jun 30, 2031",
@@ -960,7 +1212,11 @@
             "England"
           ],
           "number": "29",
-          "position": "Right-Back"
+          "overall_score": 79,
+          "position": "Right-Back",
+          "potential": 79,
+          "value": 17000000,
+          "yearly_wage": 3536000
         },
         {
           "contract": "Jun 30, 2028",
@@ -975,7 +1231,11 @@
             "Jamaica"
           ],
           "number": "2",
-          "position": "Right-Back"
+          "overall_score": 76,
+          "position": "Right-Back",
+          "potential": 76,
+          "value": 7000000,
+          "yearly_wage": 2912000
         },
         {
           "contract": "Jun 30, 2031",
@@ -990,7 +1250,11 @@
             "Mali"
           ],
           "number": "27",
-          "position": "Defensive Midfield"
+          "overall_score": 73,
+          "position": "Defensive Midfield",
+          "potential": 80,
+          "value": 6000000,
+          "yearly_wage": 1612000
         },
         {
           "contract": "Jun 30, 2027",
@@ -1004,7 +1268,11 @@
             "Czech Republic"
           ],
           "number": "28",
-          "position": "Defensive Midfield"
+          "overall_score": 76,
+          "position": "Defensive Midfield",
+          "potential": 76,
+          "value": 6500000,
+          "yearly_wage": 2912000
         },
         {
           "contract": "Jun 30, 2029",
@@ -1018,7 +1286,11 @@
             "England"
           ],
           "number": "32",
-          "position": "Defensive Midfield"
+          "overall_score": 73,
+          "position": "Defensive Midfield",
+          "potential": 80,
+          "value": 6000000,
+          "yearly_wage": 1612000
         },
         {
           "contract": "Jun 30, 2030",
@@ -1032,7 +1304,11 @@
             "Portugal"
           ],
           "number": "18",
-          "position": "Central Midfield"
+          "overall_score": 79,
+          "position": "Central Midfield",
+          "potential": 85,
+          "value": 27000000,
+          "yearly_wage": 2704000
         },
         {
           "contract": "Jun 30, 2029",
@@ -1047,7 +1323,11 @@
             "Suriname"
           ],
           "number": "7",
-          "position": "Left Winger"
+          "overall_score": 78,
+          "position": "Left Winger",
+          "potential": 83,
+          "value": 21000000,
+          "yearly_wage": 2912000
         },
         {
           "contract": "Jun 30, 2026",
@@ -1061,7 +1341,11 @@
             "Venezuela",
             "Colombia"
           ],
-          "position": "Left Winger"
+          "overall_score": 70,
+          "position": "Left Winger",
+          "potential": 79,
+          "value": 3600000,
+          "yearly_wage": 1248000
         },
         {
           "contract": "Jun 30, 2030",
@@ -1075,7 +1359,11 @@
             "England"
           ],
           "number": "20",
-          "position": "Right Winger"
+          "overall_score": 83,
+          "position": "Right Winger",
+          "potential": 83,
+          "value": 36500000,
+          "yearly_wage": 5200000
         },
         {
           "contract": "Jun 30, 2026",
@@ -1090,7 +1378,11 @@
             "Mali"
           ],
           "number": "17",
-          "position": "Right Winger"
+          "overall_score": 75,
+          "position": "Right Winger",
+          "potential": 75,
+          "value": 5500000,
+          "yearly_wage": 2912000
         },
         {
           "contract": "Jun 30, 2030",
@@ -1104,7 +1396,11 @@
             "Argentina"
           ],
           "number": "11",
-          "position": "Centre-Forward"
+          "overall_score": 79,
+          "position": "Centre-Forward",
+          "potential": 80,
+          "value": 21000000,
+          "yearly_wage": 4004000
         },
         {
           "contract": "Jun 30, 2026",
@@ -1118,7 +1414,11 @@
             "England"
           ],
           "number": "9",
-          "position": "Centre-Forward"
+          "overall_score": 77,
+          "position": "Centre-Forward",
+          "potential": 77,
+          "value": 6500000,
+          "yearly_wage": 3536000
         },
         {
           "contract": "Jun 30, 2030",
@@ -1133,7 +1433,11 @@
             "Portugal"
           ],
           "number": "19",
-          "position": "Centre-Forward"
+          "overall_score": 73,
+          "position": "Centre-Forward",
+          "potential": 81,
+          "value": 7000000,
+          "yearly_wage": 1924000
         }
       ],
       "stadiumName": "London Stadium",
@@ -1156,7 +1460,11 @@
             "Georgia"
           ],
           "number": "25",
-          "position": "Goalkeeper"
+          "overall_score": 83,
+          "position": "Goalkeeper",
+          "potential": 86,
+          "value": 38500000,
+          "yearly_wage": 3172000
         },
         {
           "contract": "Jun 30, 2027",
@@ -1170,7 +1478,11 @@
             "Brazil"
           ],
           "number": "1",
-          "position": "Goalkeeper"
+          "overall_score": 88,
+          "position": "Goalkeeper",
+          "potential": 88,
+          "value": 45000000,
+          "yearly_wage": 6760000
         },
         {
           "contract": "Jun 30, 2026",
@@ -1184,7 +1496,11 @@
             "England"
           ],
           "number": "28",
-          "position": "Goalkeeper"
+          "overall_score": 71,
+          "position": "Goalkeeper",
+          "potential": 71,
+          "value": 1300000,
+          "yearly_wage": 1664000
         },
         {
           "contract": "-",
@@ -1197,7 +1513,11 @@
           "nationality": [
             "England"
           ],
-          "position": "Goalkeeper"
+          "overall_score": 61,
+          "position": "Goalkeeper",
+          "potential": 72,
+          "value": 650000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2026",
@@ -1212,7 +1532,11 @@
             "Mali"
           ],
           "number": "5",
-          "position": "Centre-Back"
+          "overall_score": 84,
+          "position": "Centre-Back",
+          "potential": 85,
+          "value": 43500000,
+          "yearly_wage": 7020000
         },
         {
           "contract": "Jun 30, 2031",
@@ -1226,7 +1550,11 @@
             "Italy"
           ],
           "number": "15",
-          "position": "Centre-Back"
+          "overall_score": 69,
+          "position": "Centre-Back",
+          "potential": 82,
+          "value": 3000000,
+          "yearly_wage": 1248000
         },
         {
           "contract": "Jun 30, 2027",
@@ -1241,7 +1569,11 @@
             "Suriname"
           ],
           "number": "4",
-          "position": "Centre-Back"
+          "overall_score": 88,
+          "position": "Centre-Back",
+          "potential": 88,
+          "value": 43500000,
+          "yearly_wage": 10140000
         },
         {
           "contract": "Jun 30, 2027",
@@ -1256,7 +1588,11 @@
             "The Gambia"
           ],
           "number": "2",
-          "position": "Centre-Back"
+          "overall_score": 79,
+          "position": "Centre-Back",
+          "potential": 79,
+          "value": 15000000,
+          "yearly_wage": 4940000
         },
         {
           "contract": "Jun 30, 2026",
@@ -1271,7 +1607,11 @@
             "Jamaica"
           ],
           "number": "46",
-          "position": "Centre-Back"
+          "overall_score": 61,
+          "position": "Centre-Back",
+          "potential": 66,
+          "value": 450000,
+          "yearly_wage": 624000
         },
         {
           "contract": "Jun 30, 2030",
@@ -1286,7 +1626,11 @@
             "Serbia"
           ],
           "number": "6",
-          "position": "Left-Back"
+          "overall_score": 81,
+          "position": "Left-Back",
+          "potential": 85,
+          "value": 35000000,
+          "yearly_wage": 3900000
         },
         {
           "contract": "Jun 30, 2026",
@@ -1300,7 +1644,11 @@
             "Scotland"
           ],
           "number": "26",
-          "position": "Left-Back"
+          "overall_score": 81,
+          "position": "Left-Back",
+          "potential": 81,
+          "value": 18500000,
+          "yearly_wage": 5460000
         },
         {
           "contract": "Jun 30, 2030",
@@ -1315,7 +1663,11 @@
             "Ghana"
           ],
           "number": "30",
-          "position": "Right-Back"
+          "overall_score": 82,
+          "position": "Right-Back",
+          "potential": 84,
+          "value": 36500000,
+          "yearly_wage": 4940000
         },
         {
           "contract": "Jun 30, 2029",
@@ -1329,7 +1681,11 @@
             "Northern Ireland"
           ],
           "number": "12",
-          "position": "Right-Back"
+          "overall_score": 79,
+          "position": "Right-Back",
+          "potential": 84,
+          "value": 25000000,
+          "yearly_wage": 3432000
         },
         {
           "contract": "Jun 30, 2028",
@@ -1344,7 +1700,11 @@
             "Suriname"
           ],
           "number": "38",
-          "position": "Defensive Midfield"
+          "overall_score": 86,
+          "position": "Defensive Midfield",
+          "potential": 89,
+          "value": 84000000,
+          "yearly_wage": 7020000
         },
         {
           "contract": "Jun 30, 2027",
@@ -1359,7 +1719,11 @@
             "Serbia"
           ],
           "number": "43",
-          "position": "Defensive Midfield"
+          "overall_score": 73,
+          "position": "Defensive Midfield",
+          "potential": 82,
+          "value": 6500000,
+          "yearly_wage": 2184000
         },
         {
           "contract": "Jun 30, 2027",
@@ -1373,7 +1737,11 @@
             "Japan"
           ],
           "number": "3",
-          "position": "Defensive Midfield"
+          "overall_score": 79,
+          "position": "Defensive Midfield",
+          "potential": 79,
+          "value": 11500000,
+          "yearly_wage": 4940000
         },
         {
           "contract": "Jun 30, 2028",
@@ -1388,7 +1756,11 @@
             "Italy"
           ],
           "number": "10",
-          "position": "Central Midfield"
+          "overall_score": 85,
+          "position": "Central Midfield",
+          "potential": 86,
+          "value": 63000000,
+          "yearly_wage": 7800000
         },
         {
           "contract": "Jun 30, 2027",
@@ -1402,7 +1774,11 @@
             "England"
           ],
           "number": "17",
-          "position": "Central Midfield"
+          "overall_score": 80,
+          "position": "Central Midfield",
+          "potential": 83,
+          "value": 28500000,
+          "yearly_wage": 4524000
         },
         {
           "contract": "Jun 30, 2026",
@@ -1417,7 +1793,11 @@
             "Zimbabwe"
           ],
           "number": "42",
-          "position": "Central Midfield"
+          "overall_score": 65,
+          "position": "Central Midfield",
+          "potential": 84,
+          "value": 1800000,
+          "yearly_wage": 728000
         },
         {
           "contract": "Jun 30, 2030",
@@ -1431,7 +1811,11 @@
             "Germany"
           ],
           "number": "7",
-          "position": "Attacking Midfield"
+          "overall_score": 87,
+          "position": "Attacking Midfield",
+          "potential": 91,
+          "value": 116500000,
+          "yearly_wage": 8320000
         },
         {
           "contract": "Jun 30, 2028",
@@ -1445,7 +1829,11 @@
             "Hungary"
           ],
           "number": "8",
-          "position": "Attacking Midfield"
+          "overall_score": 86,
+          "position": "Attacking Midfield",
+          "potential": 88,
+          "value": 88000000,
+          "yearly_wage": 7540000
         },
         {
           "contract": "Jun 30, 2030",
@@ -1460,7 +1848,11 @@
             "Togo"
           ],
           "number": "18",
-          "position": "Left Winger"
+          "overall_score": 83,
+          "position": "Left Winger",
+          "potential": 83,
+          "value": 39500000,
+          "yearly_wage": 6500000
         },
         {
           "contract": "Jun 30, 2028",
@@ -1475,7 +1867,11 @@
             "Nigeria"
           ],
           "number": "73",
-          "position": "Left Winger"
+          "overall_score": 72,
+          "position": "Left Winger",
+          "potential": 88,
+          "value": 6000000,
+          "yearly_wage": 1508000
         },
         {
           "contract": "Jun 30, 2027",
@@ -1489,7 +1885,11 @@
             "Egypt"
           ],
           "number": "11",
-          "position": "Right Winger"
+          "overall_score": 89,
+          "position": "Right Winger",
+          "potential": 89,
+          "value": 64000000,
+          "yearly_wage": 11440000
         },
         {
           "contract": "Jun 30, 2028",
@@ -1503,7 +1903,11 @@
             "Italy"
           ],
           "number": "14",
-          "position": "Right Winger"
+          "overall_score": 80,
+          "position": "Right Winger",
+          "potential": 80,
+          "value": 22500000,
+          "yearly_wage": 5200000
         },
         {
           "contract": "Jun 30, 2031",
@@ -1518,7 +1922,11 @@
             "Eritrea"
           ],
           "number": "9",
-          "position": "Centre-Forward"
+          "overall_score": 87,
+          "position": "Centre-Forward",
+          "potential": 88,
+          "value": 96500000,
+          "yearly_wage": 9620000
         },
         {
           "contract": "Jun 30, 2031",
@@ -1533,7 +1941,11 @@
             "Cameroon"
           ],
           "number": "22",
-          "position": "Centre-Forward"
+          "overall_score": 85,
+          "position": "Centre-Forward",
+          "potential": 88,
+          "value": 74500000,
+          "yearly_wage": 7540000
         }
       ],
       "stadiumName": "Anfield",
@@ -1556,7 +1968,11 @@
             "Spain"
           ],
           "number": "1",
-          "position": "Goalkeeper"
+          "overall_score": 87,
+          "position": "Goalkeeper",
+          "potential": 87,
+          "value": 54500000,
+          "yearly_wage": 7540000
         },
         {
           "contract": "Jun 30, 2028",
@@ -1570,7 +1986,11 @@
             "Spain"
           ],
           "number": "13",
-          "position": "Goalkeeper"
+          "overall_score": 79,
+          "position": "Goalkeeper",
+          "potential": 79,
+          "value": 11500000,
+          "yearly_wage": 3952000
         },
         {
           "contract": "Jun 30, 2030",
@@ -1585,7 +2005,11 @@
             "Cameroon"
           ],
           "number": "2",
-          "position": "Centre-Back"
+          "overall_score": 88,
+          "position": "Centre-Back",
+          "potential": 90,
+          "value": 105500000,
+          "yearly_wage": 10400000
         },
         {
           "contract": "Jun 30, 2029",
@@ -1599,7 +2023,11 @@
             "Brazil"
           ],
           "number": "6",
-          "position": "Centre-Back"
+          "overall_score": 89,
+          "position": "Centre-Back",
+          "potential": 90,
+          "value": 104000000,
+          "yearly_wage": 13000000
         },
         {
           "contract": "Jun 30, 2026",
@@ -1613,7 +2041,11 @@
             "Ecuador"
           ],
           "number": "5",
-          "position": "Centre-Back"
+          "overall_score": 83,
+          "position": "Centre-Back",
+          "potential": 87,
+          "value": 48500000,
+          "yearly_wage": 4212000
         },
         {
           "contract": "Jun 30, 2030",
@@ -1628,7 +2060,11 @@
             "Colombia"
           ],
           "number": "3",
-          "position": "Centre-Back"
+          "overall_score": 77,
+          "position": "Centre-Back",
+          "potential": 85,
+          "value": 22000000,
+          "yearly_wage": 3588000
         },
         {
           "contract": "Jun 30, 2029",
@@ -1642,7 +2078,11 @@
             "Italy"
           ],
           "number": "33",
-          "position": "Left-Back"
+          "overall_score": 82,
+          "position": "Left-Back",
+          "potential": 86,
+          "value": 40500000,
+          "yearly_wage": 6240000
         },
         {
           "contract": "Jun 30, 2030",
@@ -1657,7 +2097,11 @@
             "Barbados"
           ],
           "number": "49",
-          "position": "Left-Back"
+          "overall_score": 78,
+          "position": "Left-Back",
+          "potential": 87,
+          "value": 28000000,
+          "yearly_wage": 3328000
         },
         {
           "contract": "Jun 30, 2028",
@@ -1672,7 +2116,11 @@
             "Curacao"
           ],
           "number": "12",
-          "position": "Right-Back"
+          "overall_score": 84,
+          "position": "Right-Back",
+          "potential": 87,
+          "value": 53500000,
+          "yearly_wage": 7280000
         },
         {
           "contract": "Jun 30, 2028",
@@ -1686,7 +2134,11 @@
             "England"
           ],
           "number": "4",
-          "position": "Right-Back"
+          "overall_score": 82,
+          "position": "Right-Back",
+          "potential": 82,
+          "value": 29500000,
+          "yearly_wage": 7020000
         },
         {
           "contract": "Jun 30, 2030",
@@ -1700,7 +2152,11 @@
             "Spain"
           ],
           "number": "36",
-          "position": "Defensive Midfield"
+          "overall_score": 85,
+          "position": "Defensive Midfield",
+          "potential": 87,
+          "value": 60000000,
+          "yearly_wage": 9360000
         },
         {
           "contract": "Jun 30, 2027",
@@ -1714,7 +2170,11 @@
             "Denmark"
           ],
           "number": "16",
-          "position": "Defensive Midfield"
+          "overall_score": 80,
+          "position": "Defensive Midfield",
+          "potential": 80,
+          "value": 15000000,
+          "yearly_wage": 6500000
         },
         {
           "contract": "Jun 30, 2028",
@@ -1729,7 +2189,11 @@
             "Ireland"
           ],
           "number": "41",
-          "position": "Central Midfield"
+          "overall_score": 88,
+          "position": "Central Midfield",
+          "potential": 89,
+          "value": 96000000,
+          "yearly_wage": 11960000
         },
         {
           "contract": "Jun 30, 2028",
@@ -1743,7 +2207,11 @@
             "Spain"
           ],
           "number": "23",
-          "position": "Central Midfield"
+          "overall_score": 83,
+          "position": "Central Midfield",
+          "potential": 83,
+          "value": 35500000,
+          "yearly_wage": 8320000
         },
         {
           "contract": "Jun 30, 2028",
@@ -1757,7 +2225,11 @@
             "Norway"
           ],
           "number": "8",
-          "position": "Attacking Midfield"
+          "overall_score": 86,
+          "position": "Attacking Midfield",
+          "potential": 87,
+          "value": 79500000,
+          "yearly_wage": 10400000
         },
         {
           "contract": "Jun 30, 2029",
@@ -1772,7 +2244,11 @@
             "Nigeria"
           ],
           "number": "10",
-          "position": "Attacking Midfield"
+          "overall_score": 84,
+          "position": "Attacking Midfield",
+          "potential": 85,
+          "value": 48500000,
+          "yearly_wage": 9100000
         },
         {
           "contract": "Jun 30, 2027",
@@ -1787,7 +2263,11 @@
             "Italy"
           ],
           "number": "11",
-          "position": "Left Winger"
+          "overall_score": 81,
+          "position": "Left Winger",
+          "potential": 84,
+          "value": 35000000,
+          "yearly_wage": 6500000
         },
         {
           "contract": "Jun 30, 2027",
@@ -1801,7 +2281,11 @@
             "Belgium"
           ],
           "number": "19",
-          "position": "Left Winger"
+          "overall_score": 83,
+          "position": "Left Winger",
+          "potential": 83,
+          "value": 35000000,
+          "yearly_wage": 9100000
         },
         {
           "contract": "Jun 30, 2027",
@@ -1816,7 +2300,11 @@
             "Nigeria"
           ],
           "number": "7",
-          "position": "Right Winger"
+          "overall_score": 87,
+          "position": "Right Winger",
+          "potential": 89,
+          "value": 103500000,
+          "yearly_wage": 10920000
         },
         {
           "contract": "Jun 30, 2030",
@@ -1831,7 +2319,11 @@
             "Nigeria"
           ],
           "number": "20",
-          "position": "Right Winger"
+          "overall_score": 80,
+          "position": "Right Winger",
+          "potential": 84,
+          "value": 30000000,
+          "yearly_wage": 5980000
         },
         {
           "contract": "-",
@@ -1860,7 +2352,11 @@
             "Hungary"
           ],
           "number": "14",
-          "position": "Centre-Forward"
+          "overall_score": 86,
+          "position": "Centre-Forward",
+          "potential": 86,
+          "value": 73500000,
+          "yearly_wage": 11440000
         },
         {
           "contract": "Jun 30, 2028",
@@ -1874,7 +2370,11 @@
             "Germany"
           ],
           "number": "29",
-          "position": "Centre-Forward"
+          "overall_score": 82,
+          "position": "Centre-Forward",
+          "potential": 84,
+          "value": 38000000,
+          "yearly_wage": 8060000
         },
         {
           "contract": "Jun 30, 2027",
@@ -1888,7 +2388,11 @@
             "Brazil"
           ],
           "number": "9",
-          "position": "Centre-Forward"
+          "overall_score": 80,
+          "position": "Centre-Forward",
+          "potential": 80,
+          "value": 21500000,
+          "yearly_wage": 7280000
         }
       ],
       "stadiumName": "Emirates Stadium",
@@ -1911,7 +2415,11 @@
             "Italy"
           ],
           "number": "25",
-          "position": "Goalkeeper"
+          "overall_score": 89,
+          "position": "Goalkeeper",
+          "potential": 91,
+          "value": 97000000,
+          "yearly_wage": 7800000
         },
         {
           "contract": "Jun 30, 2030",
@@ -1925,7 +2433,11 @@
             "England"
           ],
           "number": "1",
-          "position": "Goalkeeper"
+          "overall_score": 77,
+          "position": "Goalkeeper",
+          "potential": 84,
+          "value": 18500000,
+          "yearly_wage": 2288000
         },
         {
           "contract": "Jun 30, 2026",
@@ -1940,7 +2452,11 @@
             "Italy"
           ],
           "number": "13",
-          "position": "Goalkeeper"
+          "overall_score": 70,
+          "position": "Goalkeeper",
+          "potential": 70,
+          "value": 525000,
+          "yearly_wage": 1716000
         },
         {
           "contract": "Jun 30, 2028",
@@ -1954,7 +2470,11 @@
             "Croatia"
           ],
           "number": "24",
-          "position": "Centre-Back"
+          "overall_score": 85,
+          "position": "Centre-Back",
+          "potential": 88,
+          "value": 66000000,
+          "yearly_wage": 7540000
         },
         {
           "contract": "Jun 30, 2029",
@@ -1968,7 +2488,11 @@
             "Portugal"
           ],
           "number": "3",
-          "position": "Centre-Back"
+          "overall_score": 87,
+          "position": "Centre-Back",
+          "potential": 87,
+          "value": 68500000,
+          "yearly_wage": 10920000
         },
         {
           "contract": "Jun 30, 2031",
@@ -1983,7 +2507,11 @@
             "Cote d'Ivoire"
           ],
           "number": "15",
-          "position": "Centre-Back"
+          "overall_score": 84,
+          "position": "Centre-Back",
+          "potential": 86,
+          "value": 48500000,
+          "yearly_wage": 6760000
         },
         {
           "contract": "Jun 30, 2029",
@@ -1997,7 +2525,11 @@
             "Uzbekistan"
           ],
           "number": "45",
-          "position": "Centre-Back"
+          "overall_score": 80,
+          "position": "Centre-Back",
+          "potential": 86,
+          "value": 31000000,
+          "yearly_wage": 4160000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2011,7 +2543,11 @@
             "England"
           ],
           "number": "5",
-          "position": "Centre-Back"
+          "overall_score": 82,
+          "position": "Centre-Back",
+          "potential": 82,
+          "value": 21000000,
+          "yearly_wage": 7020000
         },
         {
           "contract": "Jun 30, 2027",
@@ -2026,7 +2562,11 @@
             "Cote d'Ivoire"
           ],
           "number": "6",
-          "position": "Centre-Back"
+          "overall_score": 82,
+          "position": "Centre-Back",
+          "potential": 82,
+          "value": 25000000,
+          "yearly_wage": 7020000
         },
         {
           "contract": "-",
@@ -2041,7 +2581,11 @@
             "Barbados"
           ],
           "number": "68",
-          "position": "Centre-Back"
+          "overall_score": 68,
+          "position": "Centre-Back",
+          "potential": 80,
+          "value": 2700000,
+          "yearly_wage": 1352000
         },
         {
           "contract": "Jun 30, 2030",
@@ -2056,7 +2600,11 @@
             "France"
           ],
           "number": "21",
-          "position": "Left-Back"
+          "overall_score": 81,
+          "position": "Left-Back",
+          "potential": 85,
+          "value": 34500000,
+          "yearly_wage": 5200000
         },
         {
           "contract": "Jun 30, 2030",
@@ -2071,7 +2619,11 @@
             "Jamaica"
           ],
           "number": "33",
-          "position": "Left-Back"
+          "overall_score": 81,
+          "position": "Left-Back",
+          "potential": 86,
+          "value": 35500000,
+          "yearly_wage": 4472000
         },
         {
           "contract": "Jun 30, 2028",
@@ -2086,7 +2638,11 @@
             "Brazil"
           ],
           "number": "27",
-          "position": "Right-Back"
+          "overall_score": 82,
+          "position": "Right-Back",
+          "potential": 83,
+          "value": 33000000,
+          "yearly_wage": 6760000
         },
         {
           "contract": "Jun 30, 2030",
@@ -2101,7 +2657,11 @@
             "Jamaica"
           ],
           "number": "82",
-          "position": "Right-Back"
+          "overall_score": 77,
+          "position": "Right-Back",
+          "potential": 84,
+          "value": 20000000,
+          "yearly_wage": 3380000
         },
         {
           "contract": "Jun 30, 2027",
@@ -2115,7 +2675,11 @@
             "Spain"
           ],
           "number": "16",
-          "position": "Defensive Midfield"
+          "overall_score": 89,
+          "position": "Defensive Midfield",
+          "potential": 89,
+          "value": 88000000,
+          "yearly_wage": 13000000
         },
         {
           "contract": "Jun 30, 2029",
@@ -2129,7 +2693,11 @@
             "Spain"
           ],
           "number": "14",
-          "position": "Defensive Midfield"
+          "overall_score": 81,
+          "position": "Defensive Midfield",
+          "potential": 85,
+          "value": 33500000,
+          "yearly_wage": 5200000
         },
         {
           "contract": "Jun 30, 2030",
@@ -2143,7 +2711,11 @@
             "Netherlands"
           ],
           "number": "4",
-          "position": "Central Midfield"
+          "overall_score": 85,
+          "position": "Central Midfield",
+          "potential": 86,
+          "value": 63000000,
+          "yearly_wage": 9100000
         },
         {
           "contract": "Jun 30, 2027",
@@ -2157,7 +2729,11 @@
             "Croatia"
           ],
           "number": "8",
-          "position": "Central Midfield"
+          "overall_score": 82,
+          "position": "Central Midfield",
+          "potential": 82,
+          "value": 25000000,
+          "yearly_wage": 7280000
         },
         {
           "contract": "Jun 30, 2030",
@@ -2171,7 +2747,11 @@
             "Norway"
           ],
           "number": "41",
-          "position": "Central Midfield"
+          "overall_score": 70,
+          "position": "Central Midfield",
+          "potential": 86,
+          "value": 4000000,
+          "yearly_wage": 1716000
         },
         {
           "contract": "Jun 30, 2027",
@@ -2185,7 +2765,11 @@
             "England"
           ],
           "number": "47",
-          "position": "Attacking Midfield"
+          "overall_score": 85,
+          "position": "Attacking Midfield",
+          "potential": 88,
+          "value": 71500000,
+          "yearly_wage": 8840000
         },
         {
           "contract": "Jun 30, 2030",
@@ -2200,7 +2784,11 @@
             "Algeria"
           ],
           "number": "10",
-          "position": "Attacking Midfield"
+          "overall_score": 84,
+          "position": "Attacking Midfield",
+          "potential": 88,
+          "value": 61500000,
+          "yearly_wage": 6760000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2214,7 +2802,11 @@
             "Portugal"
           ],
           "number": "20",
-          "position": "Attacking Midfield"
+          "overall_score": 83,
+          "position": "Attacking Midfield",
+          "potential": 83,
+          "value": 34500000,
+          "yearly_wage": 7800000
         },
         {
           "contract": "Jun 30, 2028",
@@ -2229,7 +2821,11 @@
             "Ghana"
           ],
           "number": "11",
-          "position": "Left Winger"
+          "overall_score": 83,
+          "position": "Left Winger",
+          "potential": 86,
+          "value": 49500000,
+          "yearly_wage": 7020000
         },
         {
           "contract": "Jun 30, 2031",
@@ -2243,7 +2839,11 @@
             "Brazil"
           ],
           "number": "26",
-          "position": "Left Winger"
+          "overall_score": 81,
+          "position": "Left Winger",
+          "potential": 86,
+          "value": 39500000,
+          "yearly_wage": 5200000
         },
         {
           "contract": "Jun 30, 2031",
@@ -2258,7 +2858,11 @@
             "England"
           ],
           "number": "42",
-          "position": "Right Winger"
+          "overall_score": 84,
+          "position": "Right Winger",
+          "potential": 85,
+          "value": 50500000,
+          "yearly_wage": 8580000
         },
         {
           "contract": "Jun 30, 2034",
@@ -2272,7 +2876,11 @@
             "Norway"
           ],
           "number": "9",
-          "position": "Centre-Forward"
+          "overall_score": 91,
+          "position": "Centre-Forward",
+          "potential": 93,
+          "value": 172500000,
+          "yearly_wage": 20280000
         },
         {
           "contract": "Jun 30, 2029",
@@ -2287,7 +2895,11 @@
             "Canada"
           ],
           "number": "7",
-          "position": "Centre-Forward"
+          "overall_score": 83,
+          "position": "Centre-Forward",
+          "potential": 83,
+          "value": 39500000,
+          "yearly_wage": 8060000
         }
       ],
       "stadiumName": "Etihad Stadium",
@@ -2310,7 +2922,11 @@
             "England"
           ],
           "number": "1",
-          "position": "Goalkeeper"
+          "overall_score": 85,
+          "position": "Goalkeeper",
+          "potential": 85,
+          "value": 28500000,
+          "yearly_wage": 2548000
         },
         {
           "contract": "Jun 30, 2029",
@@ -2324,7 +2940,11 @@
             "Ireland"
           ],
           "number": "12",
-          "position": "Goalkeeper"
+          "overall_score": 72,
+          "position": "Goalkeeper",
+          "potential": 75,
+          "value": 2400000,
+          "yearly_wage": 884000
         },
         {
           "contract": "Jun 30, 2027",
@@ -2339,7 +2959,11 @@
             "England"
           ],
           "number": "31",
-          "position": "Goalkeeper"
+          "overall_score": 64,
+          "position": "Goalkeeper",
+          "potential": 64,
+          "value": 400000,
+          "yearly_wage": 364000
         },
         {
           "contract": "Jun 30, 2030",
@@ -2353,7 +2977,11 @@
             "England"
           ],
           "number": "32",
-          "position": "Centre-Back"
+          "overall_score": 79,
+          "position": "Centre-Back",
+          "potential": 85,
+          "value": 25000000,
+          "yearly_wage": 2028000
         },
         {
           "contract": "Jun 30, 2028",
@@ -2368,7 +2996,11 @@
             "Poland"
           ],
           "number": "6",
-          "position": "Centre-Back"
+          "overall_score": 80,
+          "position": "Centre-Back",
+          "potential": 80,
+          "value": 13500000,
+          "yearly_wage": 2600000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2383,7 +3015,11 @@
             "Ireland"
           ],
           "number": "5",
-          "position": "Centre-Back"
+          "overall_score": 76,
+          "position": "Centre-Back",
+          "potential": 76,
+          "value": 4900000,
+          "yearly_wage": 1924000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2397,7 +3033,11 @@
             "Ukraine"
           ],
           "number": "16",
-          "position": "Left-Back"
+          "overall_score": 77,
+          "position": "Left-Back",
+          "potential": 78,
+          "value": 11500000,
+          "yearly_wage": 1976000
         },
         {
           "contract": "Jun 30, 2029",
@@ -2412,7 +3052,11 @@
             "Spain"
           ],
           "number": "39",
-          "position": "Left-Back"
+          "overall_score": 66,
+          "position": "Left-Back",
+          "potential": 82,
+          "value": 2100000,
+          "yearly_wage": 468000
         },
         {
           "contract": "Jun 30, 2028",
@@ -2426,7 +3070,11 @@
             "Ireland"
           ],
           "number": "15",
-          "position": "Right-Back"
+          "overall_score": 76,
+          "position": "Right-Back",
+          "potential": 81,
+          "value": 10500000,
+          "yearly_wage": 1612000
         },
         {
           "contract": "Jun 30, 2027",
@@ -2440,7 +3088,11 @@
             "Scotland"
           ],
           "number": "2",
-          "position": "Right-Back"
+          "overall_score": 71,
+          "position": "Right-Back",
+          "potential": 76,
+          "value": 2600000,
+          "yearly_wage": 1040000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2454,7 +3106,11 @@
             "Ireland"
           ],
           "number": "23",
-          "position": "Right-Back"
+          "overall_score": 70,
+          "position": "Right-Back",
+          "potential": 70,
+          "value": 350000,
+          "yearly_wage": 832000
         },
         {
           "contract": "Jun 30, 2030",
@@ -2468,7 +3124,11 @@
             "England"
           ],
           "number": "37",
-          "position": "Defensive Midfield"
+          "overall_score": 81,
+          "position": "Defensive Midfield",
+          "potential": 84,
+          "value": 32000000,
+          "yearly_wage": 2288000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2482,7 +3142,11 @@
             "Senegal"
           ],
           "number": "27",
-          "position": "Defensive Midfield"
+          "overall_score": 79,
+          "position": "Defensive Midfield",
+          "potential": 79,
+          "value": 4900000,
+          "yearly_wage": 1820000
         },
         {
           "contract": "Jun 30, 2030",
@@ -2497,7 +3161,11 @@
             "Ireland"
           ],
           "number": "22",
-          "position": "Central Midfield"
+          "overall_score": 80,
+          "position": "Central Midfield",
+          "potential": 81,
+          "value": 25000000,
+          "yearly_wage": 2652000
         },
         {
           "contract": "Jun 30, 2027",
@@ -2511,7 +3179,11 @@
             "Argentina"
           ],
           "number": "24",
-          "position": "Central Midfield"
+          "overall_score": 75,
+          "position": "Central Midfield",
+          "potential": 82,
+          "value": 11500000,
+          "yearly_wage": 1664000
         },
         {
           "contract": "Jun 30, 2027",
@@ -2526,7 +3198,11 @@
             "Nigeria"
           ],
           "number": "42",
-          "position": "Central Midfield"
+          "overall_score": 76,
+          "position": "Central Midfield",
+          "potential": 80,
+          "value": 10000000,
+          "yearly_wage": 1612000
         },
         {
           "contract": "Jun 30, 2028",
@@ -2540,7 +3216,11 @@
             "England"
           ],
           "number": "45",
-          "position": "Central Midfield"
+          "overall_score": 73,
+          "position": "Central Midfield",
+          "potential": 85,
+          "value": 7000000,
+          "yearly_wage": 1040000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2554,7 +3234,11 @@
             "Germany"
           ],
           "number": "34",
-          "position": "Attacking Midfield"
+          "overall_score": 74,
+          "position": "Attacking Midfield",
+          "potential": 82,
+          "value": 9500000,
+          "yearly_wage": 1092000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2569,7 +3253,11 @@
             "Ireland"
           ],
           "number": "18",
-          "position": "Left Winger"
+          "overall_score": 82,
+          "position": "Left Winger",
+          "potential": 82,
+          "value": 30000000,
+          "yearly_wage": 7280000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2584,7 +3272,11 @@
             "Nigeria"
           ],
           "number": "19",
-          "position": "Left Winger"
+          "overall_score": 71,
+          "position": "Left Winger",
+          "potential": 84,
+          "value": 4400000,
+          "yearly_wage": 2080000
         },
         {
           "contract": "Jun 30, 2027",
@@ -2599,7 +3291,11 @@
             "Jamaica"
           ],
           "number": "7",
-          "position": "Left Winger"
+          "overall_score": 77,
+          "position": "Left Winger",
+          "potential": 78,
+          "value": 12500000,
+          "yearly_wage": 1976000
         },
         {
           "contract": "Jun 30, 2029",
@@ -2614,7 +3310,11 @@
             "France"
           ],
           "number": "10",
-          "position": "Right Winger"
+          "overall_score": 82,
+          "position": "Right Winger",
+          "potential": 83,
+          "value": 36500000,
+          "yearly_wage": 2860000
         },
         {
           "contract": "Jun 30, 2029",
@@ -2628,7 +3328,11 @@
             "England"
           ],
           "number": "20",
-          "position": "Right Winger"
+          "overall_score": 74,
+          "position": "Right Winger",
+          "potential": 84,
+          "value": 9000000,
+          "yearly_wage": 1196000
         },
         {
           "contract": "Jun 30, 2029",
@@ -2643,7 +3347,11 @@
             "Guinea"
           ],
           "number": "11",
-          "position": "Centre-Forward"
+          "overall_score": 76,
+          "position": "Centre-Forward",
+          "potential": 84,
+          "value": 17000000,
+          "yearly_wage": 1872000
         },
         {
           "contract": "Jun 30, 2027",
@@ -2658,7 +3366,11 @@
             "Portugal"
           ],
           "number": "9",
-          "position": "Centre-Forward"
+          "overall_score": 76,
+          "position": "Centre-Forward",
+          "potential": 76,
+          "value": 8000000,
+          "yearly_wage": 2132000
         }
       ],
       "stadiumName": "Hill Dickinson Stadium",
@@ -2681,7 +3393,11 @@
             "England"
           ],
           "number": "32",
-          "position": "Goalkeeper"
+          "overall_score": 77,
+          "position": "Goalkeeper",
+          "potential": 79,
+          "value": 9500000,
+          "yearly_wage": 1768000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2695,7 +3411,11 @@
             "England"
           ],
           "number": "1",
-          "position": "Goalkeeper"
+          "overall_score": 79,
+          "position": "Goalkeeper",
+          "potential": 79,
+          "value": 5500000,
+          "yearly_wage": 3692000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2709,7 +3429,11 @@
             "England"
           ],
           "number": "29",
-          "position": "Goalkeeper"
+          "overall_score": 62,
+          "position": "Goalkeeper",
+          "potential": 62,
+          "value": 130000,
+          "yearly_wage": 624000
         },
         {
           "contract": "-",
@@ -2723,7 +3447,11 @@
             "England"
           ],
           "number": "26",
-          "position": "Goalkeeper"
+          "overall_score": 68,
+          "position": "Goalkeeper",
+          "potential": 68,
+          "value": 130000,
+          "yearly_wage": 832000
         },
         {
           "contract": "-",
@@ -2738,7 +3466,11 @@
             "Finland"
           ],
           "number": "12",
-          "position": "Centre-Back"
+          "overall_score": 81,
+          "position": "Centre-Back",
+          "potential": 85,
+          "value": 33000000,
+          "yearly_wage": 5200000
         },
         {
           "contract": "Jun 30, 2030",
@@ -2752,7 +3484,11 @@
             "Netherlands"
           ],
           "number": "4",
-          "position": "Centre-Back"
+          "overall_score": 81,
+          "position": "Centre-Back",
+          "potential": 83,
+          "value": 28500000,
+          "yearly_wage": 5980000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2766,7 +3502,11 @@
             "Switzerland"
           ],
           "number": "5",
-          "position": "Centre-Back"
+          "overall_score": 82,
+          "position": "Centre-Back",
+          "potential": 82,
+          "value": 14500000,
+          "yearly_wage": 7020000
         },
         {
           "contract": "Jun 30, 2027",
@@ -2780,7 +3520,11 @@
             "England"
           ],
           "number": "33",
-          "position": "Centre-Back"
+          "overall_score": 80,
+          "position": "Centre-Back",
+          "potential": 80,
+          "value": 10000000,
+          "yearly_wage": 5980000
         },
         {
           "contract": "-",
@@ -2794,7 +3538,11 @@
             "England"
           ],
           "number": "3",
-          "position": "Left-Back"
+          "overall_score": 81,
+          "position": "Left-Back",
+          "potential": 86,
+          "value": 35500000,
+          "yearly_wage": 4472000
         },
         {
           "contract": "Jun 30, 2028",
@@ -2808,7 +3556,11 @@
             "Ireland"
           ],
           "number": "37",
-          "position": "Left-Back"
+          "overall_score": 65,
+          "position": "Left-Back",
+          "potential": 79,
+          "value": 1700000,
+          "yearly_wage": 884000
         },
         {
           "contract": "Jun 30, 2028",
@@ -2823,7 +3575,11 @@
             "Scotland"
           ],
           "number": "21",
-          "position": "Right-Back"
+          "overall_score": 80,
+          "position": "Right-Back",
+          "potential": 86,
+          "value": 31500000,
+          "yearly_wage": 4940000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2837,7 +3593,11 @@
             "England"
           ],
           "number": "2",
-          "position": "Right-Back"
+          "overall_score": 79,
+          "position": "Right-Back",
+          "potential": 79,
+          "value": 6500000,
+          "yearly_wage": 5720000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2851,7 +3611,11 @@
             "Sweden"
           ],
           "number": "17",
-          "position": "Right-Back"
+          "overall_score": 72,
+          "position": "Right-Back",
+          "potential": 72,
+          "value": 2000000,
+          "yearly_wage": 3276000
         },
         {
           "contract": "Jun 30, 2028",
@@ -2865,7 +3629,11 @@
             "Italy"
           ],
           "number": "8",
-          "position": "Defensive Midfield"
+          "overall_score": 85,
+          "position": "Defensive Midfield",
+          "potential": 87,
+          "value": 60500000,
+          "yearly_wage": 8320000
         },
         {
           "contract": "Jun 30, 2028",
@@ -2880,7 +3648,11 @@
             "Spain"
           ],
           "number": "39",
-          "position": "Central Midfield"
+          "overall_score": 86,
+          "position": "Central Midfield",
+          "potential": 86,
+          "value": 72000000,
+          "yearly_wage": 9880000
         },
         {
           "contract": "-",
@@ -2894,7 +3666,11 @@
             "England"
           ],
           "number": "41",
-          "position": "Central Midfield"
+          "overall_score": 77,
+          "position": "Central Midfield",
+          "potential": 81,
+          "value": 15000000,
+          "yearly_wage": 4212000
         },
         {
           "contract": "Jun 30, 2028",
@@ -2908,7 +3684,11 @@
             "Brazil"
           ],
           "number": "7",
-          "position": "Central Midfield"
+          "overall_score": 81,
+          "position": "Central Midfield",
+          "potential": 81,
+          "value": 25500000,
+          "yearly_wage": 6760000
         },
         {
           "contract": "Jun 30, 2029",
@@ -2922,7 +3702,11 @@
             "England"
           ],
           "number": "67",
-          "position": "Central Midfield"
+          "overall_score": 76,
+          "position": "Central Midfield",
+          "potential": 86,
+          "value": 16000000,
+          "yearly_wage": 3120000
         },
         {
           "contract": "Jun 30, 2027",
@@ -2937,7 +3721,11 @@
             "Montserrat"
           ],
           "number": "28",
-          "position": "Central Midfield"
+          "overall_score": 76,
+          "position": "Central Midfield",
+          "potential": 78,
+          "value": 9500000,
+          "yearly_wage": 4316000
         },
         {
           "contract": "-",
@@ -2951,7 +3739,11 @@
             "England"
           ],
           "number": "10",
-          "position": "Left Winger"
+          "overall_score": 82,
+          "position": "Left Winger",
+          "potential": 85,
+          "value": 41500000,
+          "yearly_wage": 6500000
         },
         {
           "contract": "Jun 30, 2028",
@@ -2966,7 +3758,11 @@
             "Scotland"
           ],
           "number": "11",
-          "position": "Left Winger"
+          "overall_score": 80,
+          "position": "Left Winger",
+          "potential": 80,
+          "value": 22500000,
+          "yearly_wage": 6500000
         },
         {
           "contract": "-",
@@ -2981,7 +3777,11 @@
             "Cameroon"
           ],
           "number": "20",
-          "position": "Right Winger"
+          "overall_score": 79,
+          "position": "Right Winger",
+          "potential": 82,
+          "value": 24000000,
+          "yearly_wage": 5460000
         },
         {
           "contract": "Jun 30, 2027",
@@ -2996,7 +3796,11 @@
             "Ireland"
           ],
           "number": "23",
-          "position": "Right Winger"
+          "overall_score": 79,
+          "position": "Right Winger",
+          "potential": 79,
+          "value": 17000000,
+          "yearly_wage": 6240000
         },
         {
           "contract": "Jul 1, 2031",
@@ -3010,7 +3814,11 @@
             "Germany"
           ],
           "number": "27",
-          "position": "Centre-Forward"
+          "overall_score": 80,
+          "position": "Centre-Forward",
+          "potential": 85,
+          "value": 32000000,
+          "yearly_wage": 5720000
         },
         {
           "contract": "-",
@@ -3025,7 +3833,11 @@
             "France"
           ],
           "number": "9",
-          "position": "Centre-Forward"
+          "overall_score": 81,
+          "position": "Centre-Forward",
+          "potential": 81,
+          "value": 26500000,
+          "yearly_wage": 7280000
         },
         {
           "contract": "Jun 30, 2029",
@@ -3040,7 +3852,11 @@
             "England"
           ],
           "number": "18",
-          "position": "Centre-Forward"
+          "overall_score": 73,
+          "position": "Centre-Forward",
+          "potential": 81,
+          "value": 7000000,
+          "yearly_wage": 2964000
         }
       ],
       "stadiumName": "St James' Park",
@@ -3063,7 +3879,11 @@
             "Netherlands"
           ],
           "number": "22",
-          "position": "Goalkeeper"
+          "overall_score": 80,
+          "position": "Goalkeeper",
+          "potential": 86,
+          "value": 27500000,
+          "yearly_wage": 1716000
         },
         {
           "contract": "Jun 30, 2030",
@@ -3076,7 +3896,11 @@
             "Sweden"
           ],
           "number": "31",
-          "position": "Goalkeeper"
+          "overall_score": 67,
+          "position": "Goalkeeper",
+          "potential": 75,
+          "value": 2000000,
+          "yearly_wage": 520000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3090,7 +3914,11 @@
             "England"
           ],
           "number": "21",
-          "position": "Goalkeeper"
+          "overall_score": 66,
+          "position": "Goalkeeper",
+          "potential": 66,
+          "value": 90000,
+          "yearly_wage": 364000
         },
         {
           "contract": "Jun 30, 2028",
@@ -3105,7 +3933,11 @@
             "England"
           ],
           "number": "5",
-          "position": "Centre-Back"
+          "overall_score": 78,
+          "position": "Centre-Back",
+          "potential": 80,
+          "value": 15500000,
+          "yearly_wage": 2756000
         },
         {
           "contract": "Jun 30, 2029",
@@ -3119,7 +3951,11 @@
             "Paraguay"
           ],
           "number": "15",
-          "position": "Centre-Back"
+          "overall_score": 80,
+          "position": "Centre-Back",
+          "potential": 81,
+          "value": 20000000,
+          "yearly_wage": 3536000
         },
         {
           "contract": "Jun 30, 2027",
@@ -3133,7 +3969,11 @@
             "England"
           ],
           "number": "13",
-          "position": "Centre-Back"
+          "overall_score": 72,
+          "position": "Centre-Back",
+          "potential": 72,
+          "value": 1900000,
+          "yearly_wage": 1924000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3148,7 +3988,11 @@
             "Ireland"
           ],
           "number": "3",
-          "position": "Left-Back"
+          "overall_score": 72,
+          "position": "Left-Back",
+          "potential": 78,
+          "value": 3500000,
+          "yearly_wage": 1612000
         },
         {
           "contract": "Jun 30, 2027",
@@ -3162,7 +4006,11 @@
             "Mozambique"
           ],
           "number": "17",
-          "position": "Left-Back"
+          "overall_score": 80,
+          "position": "Left-Back",
+          "potential": 80,
+          "value": 15500000,
+          "yearly_wage": 3536000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3177,7 +4025,11 @@
             "Curacao"
           ],
           "number": "6",
-          "position": "Right-Back"
+          "overall_score": 78,
+          "position": "Right-Back",
+          "potential": 82,
+          "value": 18000000,
+          "yearly_wage": 2132000
         },
         {
           "contract": "Jun 30, 2030",
@@ -3191,7 +4043,11 @@
             "Northern Ireland"
           ],
           "number": "32",
-          "position": "Right-Back"
+          "overall_score": 78,
+          "position": "Right-Back",
+          "potential": 81,
+          "value": 18000000,
+          "yearly_wage": 2496000
         },
         {
           "contract": "Jun 30, 2029",
@@ -3206,7 +4062,11 @@
             "DR Congo"
           ],
           "number": "20",
-          "position": "Right-Back"
+          "overall_score": 80,
+          "position": "Right-Back",
+          "potential": 80,
+          "value": 19500000,
+          "yearly_wage": 3380000
         },
         {
           "contract": "Jun 30, 2028",
@@ -3220,7 +4080,11 @@
             "Switzerland"
           ],
           "number": "34",
-          "position": "Defensive Midfield"
+          "overall_score": 85,
+          "position": "Defensive Midfield",
+          "potential": 85,
+          "value": 36000000,
+          "yearly_wage": 5460000
         },
         {
           "contract": "Jun 30, 2030",
@@ -3235,7 +4099,11 @@
             "France"
           ],
           "number": "19",
-          "position": "Central Midfield"
+          "overall_score": 77,
+          "position": "Central Midfield",
+          "potential": 83,
+          "value": 17000000,
+          "yearly_wage": 2080000
         },
         {
           "contract": "Jun 30, 2030",
@@ -3250,7 +4118,11 @@
             "Belgium"
           ],
           "number": "27",
-          "position": "Central Midfield"
+          "overall_score": 78,
+          "position": "Central Midfield",
+          "potential": 85,
+          "value": 27500000,
+          "yearly_wage": 2236000
         },
         {
           "contract": "Jun 30, 2029",
@@ -3264,7 +4136,11 @@
             "France"
           ],
           "number": "28",
-          "position": "Central Midfield"
+          "overall_score": 78,
+          "position": "Central Midfield",
+          "potential": 80,
+          "value": 17500000,
+          "yearly_wage": 2912000
         },
         {
           "contract": "Jun 30, 2027",
@@ -3279,7 +4155,11 @@
             "Mauritania"
           ],
           "number": "46",
-          "position": "Right Midfield"
+          "overall_score": 65,
+          "position": "Right Midfield",
+          "potential": 68,
+          "value": 1000000,
+          "yearly_wage": 624000
         },
         {
           "contract": "Jun 30, 2030",
@@ -3293,7 +4173,11 @@
             "England"
           ],
           "number": "11",
-          "position": "Attacking Midfield"
+          "overall_score": 72,
+          "position": "Attacking Midfield",
+          "potential": 84,
+          "value": 5500000,
+          "yearly_wage": 1300000
         },
         {
           "contract": "Jun 30, 2028",
@@ -3307,7 +4191,11 @@
             "Serbia"
           ],
           "number": "30",
-          "position": "Attacking Midfield"
+          "overall_score": 61,
+          "position": "Attacking Midfield",
+          "potential": 71,
+          "value": 700000,
+          "yearly_wage": 364000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3321,7 +4209,11 @@
             "England"
           ],
           "number": "50",
-          "position": "Attacking Midfield"
+          "overall_score": 60,
+          "position": "Attacking Midfield",
+          "potential": 74,
+          "value": 600000,
+          "yearly_wage": 312000
         },
         {
           "contract": "Jun 30, 2030",
@@ -3335,7 +4227,11 @@
             "Ecuador"
           ],
           "number": "10",
-          "position": "Left Winger"
+          "overall_score": 71,
+          "position": "Left Winger",
+          "potential": 81,
+          "value": 4200000,
+          "yearly_wage": 1508000
         },
         {
           "contract": "Jun 30, 2028",
@@ -3350,7 +4246,11 @@
             "Jamaica"
           ],
           "number": "14",
-          "position": "Left Winger"
+          "overall_score": 71,
+          "position": "Left Winger",
+          "potential": 79,
+          "value": 4200000,
+          "yearly_wage": 1612000
         },
         {
           "contract": "Jun 30, 2030",
@@ -3365,7 +4265,11 @@
             "Belgium"
           ],
           "number": "7",
-          "position": "Right Winger"
+          "overall_score": 76,
+          "position": "Right Winger",
+          "potential": 86,
+          "value": 16500000,
+          "yearly_wage": 2132000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3379,7 +4283,11 @@
             "Burkina Faso"
           ],
           "number": "25",
-          "position": "Right Winger"
+          "overall_score": 75,
+          "position": "Right Winger",
+          "potential": 75,
+          "value": 5500000,
+          "yearly_wage": 2808000
         },
         {
           "contract": "Jun 30, 2027",
@@ -3408,7 +4316,11 @@
             "Cote d'Ivoire"
           ],
           "number": "37",
-          "position": "Right Winger"
+          "overall_score": 68,
+          "position": "Right Winger",
+          "potential": 80,
+          "value": 2900000,
+          "yearly_wage": 936000
         },
         {
           "contract": "Jun 30, 2029",
@@ -3423,7 +4335,11 @@
             "Ghana"
           ],
           "number": "9",
-          "position": "Centre-Forward"
+          "overall_score": 77,
+          "position": "Centre-Forward",
+          "potential": 83,
+          "value": 17000000,
+          "yearly_wage": 2704000
         },
         {
           "contract": "Jun 30, 2030",
@@ -3438,7 +4354,11 @@
             "France"
           ],
           "number": "12",
-          "position": "Centre-Forward"
+          "overall_score": 72,
+          "position": "Centre-Forward",
+          "potential": 82,
+          "value": 5000000,
+          "yearly_wage": 1612000
         },
         {
           "contract": "Jun 30, 2028",
@@ -3453,7 +4373,11 @@
             "Haiti"
           ],
           "number": "18",
-          "position": "Centre-Forward"
+          "overall_score": 75,
+          "position": "Centre-Forward",
+          "potential": 78,
+          "value": 8000000,
+          "yearly_wage": 2392000
         },
         {
           "contract": "Jun 30, 2028",
@@ -3465,7 +4389,11 @@
             "Nigeria"
           ],
           "number": "29",
-          "position": "Centre-Forward"
+          "overall_score": 58,
+          "position": "Centre-Forward",
+          "potential": 72,
+          "value": 500000,
+          "yearly_wage": 364000
         }
       ],
       "stadiumName": "Stadium of Light",
@@ -3489,7 +4417,11 @@
             "Spain"
           ],
           "number": "23",
-          "position": "Goalkeeper"
+          "overall_score": 85,
+          "position": "Goalkeeper",
+          "potential": 85,
+          "value": 26500000,
+          "yearly_wage": 5460000
         },
         {
           "contract": "Jun 30, 2027",
@@ -3503,7 +4435,11 @@
             "Netherlands"
           ],
           "number": "40",
-          "position": "Goalkeeper"
+          "overall_score": 78,
+          "position": "Goalkeeper",
+          "potential": 78,
+          "value": 2400000,
+          "yearly_wage": 3172000
         },
         {
           "contract": "Jun 30, 2028",
@@ -3518,7 +4454,11 @@
             "DR Congo"
           ],
           "number": "4",
-          "position": "Centre-Back"
+          "overall_score": 84,
+          "position": "Centre-Back",
+          "potential": 85,
+          "value": 42500000,
+          "yearly_wage": 7540000
         },
         {
           "contract": "Jun 30, 2028",
@@ -3532,7 +4472,11 @@
             "Spain"
           ],
           "number": "14",
-          "position": "Centre-Back"
+          "overall_score": 80,
+          "position": "Centre-Back",
+          "potential": 80,
+          "value": 18000000,
+          "yearly_wage": 5720000
         },
         {
           "contract": "Jun 30, 2027",
@@ -3546,7 +4490,11 @@
             "Sweden"
           ],
           "number": "3",
-          "position": "Centre-Back"
+          "overall_score": 76,
+          "position": "Centre-Back",
+          "potential": 76,
+          "value": 6000000,
+          "yearly_wage": 4212000
         },
         {
           "contract": "Jun 30, 2027",
@@ -3560,7 +4508,11 @@
             "England"
           ],
           "number": "5",
-          "position": "Centre-Back"
+          "overall_score": 78,
+          "position": "Centre-Back",
+          "potential": 78,
+          "value": 9000000,
+          "yearly_wage": 4940000
         },
         {
           "contract": "Jun 30, 2030",
@@ -3575,7 +4527,11 @@
             "Suriname"
           ],
           "number": "22",
-          "position": "Left-Back"
+          "overall_score": 79,
+          "position": "Left-Back",
+          "potential": 84,
+          "value": 24500000,
+          "yearly_wage": 4420000
         },
         {
           "contract": "Jun 30, 2028",
@@ -3589,7 +4545,11 @@
             "France"
           ],
           "number": "12",
-          "position": "Left-Back"
+          "overall_score": 80,
+          "position": "Left-Back",
+          "potential": 80,
+          "value": 15500000,
+          "yearly_wage": 5720000
         },
         {
           "contract": "Jun 30, 2029",
@@ -3604,7 +4564,11 @@
             "England"
           ],
           "number": "2",
-          "position": "Right-Back"
+          "overall_score": 81,
+          "position": "Right-Back",
+          "potential": 81,
+          "value": 25000000,
+          "yearly_wage": 5720000
         },
         {
           "contract": "-",
@@ -3618,7 +4582,11 @@
             "Spain"
           ],
           "number": "16",
-          "position": "Right-Back"
+          "overall_score": 73,
+          "position": "Right-Back",
+          "potential": 81,
+          "value": 6500000,
+          "yearly_wage": 2808000
         },
         {
           "contract": "Jun 30, 2029",
@@ -3633,7 +4601,11 @@
             "Senegal"
           ],
           "number": "24",
-          "position": "Defensive Midfield"
+          "overall_score": 81,
+          "position": "Defensive Midfield",
+          "potential": 84,
+          "value": 32000000,
+          "yearly_wage": 4940000
         },
         {
           "contract": "Jun 30, 2030",
@@ -3648,7 +4620,11 @@
             "Senegal"
           ],
           "number": "44",
-          "position": "Defensive Midfield"
+          "overall_score": 84,
+          "position": "Defensive Midfield",
+          "potential": 86,
+          "value": 47500000,
+          "yearly_wage": 7280000
         },
         {
           "contract": "-",
@@ -3663,7 +4639,11 @@
             "Suriname"
           ],
           "number": "26",
-          "position": "Defensive Midfield"
+          "overall_score": 74,
+          "position": "Defensive Midfield",
+          "potential": 81,
+          "value": 8000000,
+          "yearly_wage": 2600000
         },
         {
           "contract": "Jun 30, 2028",
@@ -3678,7 +4658,11 @@
             "DR Congo"
           ],
           "number": "8",
-          "position": "Central Midfield"
+          "overall_score": 85,
+          "position": "Central Midfield",
+          "potential": 85,
+          "value": 54000000,
+          "yearly_wage": 8840000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3692,7 +4676,11 @@
             "Brazil"
           ],
           "number": "21",
-          "position": "Central Midfield"
+          "overall_score": 79,
+          "position": "Central Midfield",
+          "potential": 79,
+          "value": 16500000,
+          "yearly_wage": 5200000
         },
         {
           "contract": "Jun 30, 2028",
@@ -3706,7 +4694,11 @@
             "Scotland"
           ],
           "number": "7",
-          "position": "Central Midfield"
+          "overall_score": 81,
+          "position": "Central Midfield",
+          "potential": 81,
+          "value": 25000000,
+          "yearly_wage": 6240000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3720,7 +4712,11 @@
             "England"
           ],
           "number": "6",
-          "position": "Central Midfield"
+          "overall_score": 77,
+          "position": "Central Midfield",
+          "potential": 77,
+          "value": 8500000,
+          "yearly_wage": 4680000
         },
         {
           "contract": "Jun 30, 2031",
@@ -3734,7 +4730,11 @@
             "England"
           ],
           "number": "27",
-          "position": "Attacking Midfield"
+          "overall_score": 84,
+          "position": "Attacking Midfield",
+          "potential": 86,
+          "value": 56000000,
+          "yearly_wage": 7020000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3748,7 +4748,11 @@
             "England"
           ],
           "number": "9",
-          "position": "Attacking Midfield"
+          "overall_score": 78,
+          "position": "Attacking Midfield",
+          "potential": 83,
+          "value": 21500000,
+          "yearly_wage": 3952000
         },
         {
           "contract": "Jun 30, 2027",
@@ -3763,7 +4767,11 @@
             "Spain"
           ],
           "number": "10",
-          "position": "Attacking Midfield"
+          "overall_score": 78,
+          "position": "Attacking Midfield",
+          "potential": 78,
+          "value": 14000000,
+          "yearly_wage": 4940000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3778,7 +4786,11 @@
             "Jamaica"
           ],
           "number": "19",
-          "position": "Left Winger"
+          "overall_score": 79,
+          "position": "Left Winger",
+          "potential": 80,
+          "value": 21000000,
+          "yearly_wage": 4160000
         },
         {
           "contract": "Jun 30, 2027",
@@ -3792,7 +4804,11 @@
             "Jamaica"
           ],
           "number": "31",
-          "position": "Right Winger"
+          "overall_score": 78,
+          "position": "Right Winger",
+          "potential": 78,
+          "value": 15000000,
+          "yearly_wage": 4940000
         },
         {
           "contract": "-",
@@ -3806,7 +4822,11 @@
             "Brazil"
           ],
           "number": "47",
-          "position": "Right Winger"
+          "overall_score": 70,
+          "position": "Right Winger",
+          "potential": 83,
+          "value": 3800000,
+          "yearly_wage": 1716000
         },
         {
           "contract": "Jun 30, 2028",
@@ -3820,7 +4840,11 @@
             "England"
           ],
           "number": "11",
-          "position": "Centre-Forward"
+          "overall_score": 82,
+          "position": "Centre-Forward",
+          "potential": 82,
+          "value": 30500000,
+          "yearly_wage": 7280000
         },
         {
           "contract": "Jun 30, 2030",
@@ -3835,7 +4859,11 @@
             "Nigeria"
           ],
           "number": "18",
-          "position": "Centre-Forward"
+          "overall_score": 77,
+          "position": "Centre-Forward",
+          "potential": 77,
+          "value": 11500000,
+          "yearly_wage": 4940000
         }
       ],
       "stadiumName": "Villa Park",
@@ -3859,7 +4887,11 @@
             "England"
           ],
           "number": "1",
-          "position": "Goalkeeper"
+          "overall_score": 81,
+          "position": "Goalkeeper",
+          "potential": 82,
+          "value": 22000000,
+          "yearly_wage": 3952000
         },
         {
           "contract": "Jun 30, 2031",
@@ -3889,7 +4921,11 @@
             "Poland"
           ],
           "number": "44",
-          "position": "Goalkeeper"
+          "overall_score": 68,
+          "position": "Goalkeeper",
+          "potential": 80,
+          "value": 2600000,
+          "yearly_wage": 728000
         },
         {
           "contract": "Jun 30, 2028",
@@ -3903,7 +4939,11 @@
             "England"
           ],
           "number": "28",
-          "position": "Goalkeeper"
+          "overall_score": 64,
+          "position": "Goalkeeper",
+          "potential": 74,
+          "value": 1100000,
+          "yearly_wage": 572000
         },
         {
           "contract": "Jun 30, 2029",
@@ -3917,7 +4957,11 @@
             "England"
           ],
           "number": "6",
-          "position": "Centre-Back"
+          "overall_score": 80,
+          "position": "Centre-Back",
+          "potential": 84,
+          "value": 27500000,
+          "yearly_wage": 4940000
         },
         {
           "contract": "Jun 30, 2028",
@@ -3932,7 +4976,11 @@
             "Sierra Leone"
           ],
           "number": "23",
-          "position": "Centre-Back"
+          "overall_score": 80,
+          "position": "Centre-Back",
+          "potential": 82,
+          "value": 23500000,
+          "yearly_wage": 5460000
         },
         {
           "contract": "Jun 30, 2029",
@@ -3947,7 +4995,11 @@
             "Cote d'Ivoire"
           ],
           "number": "29",
-          "position": "Centre-Back"
+          "overall_score": 79,
+          "position": "Centre-Back",
+          "potential": 82,
+          "value": 21500000,
+          "yearly_wage": 4680000
         },
         {
           "contract": "Jun 30, 2033",
@@ -3962,7 +5014,11 @@
             "France"
           ],
           "number": "19",
-          "position": "Centre-Back"
+          "overall_score": 77,
+          "position": "Centre-Back",
+          "potential": 84,
+          "value": 19000000,
+          "yearly_wage": 3172000
         },
         {
           "contract": "Jun 30, 2028",
@@ -3977,7 +5033,11 @@
             "Nigeria"
           ],
           "number": "4",
-          "position": "Centre-Back"
+          "overall_score": 78,
+          "position": "Centre-Back",
+          "potential": 79,
+          "value": 14000000,
+          "yearly_wage": 4940000
         },
         {
           "contract": "Jun 30, 2030",
@@ -3992,7 +5052,11 @@
             "DR Congo"
           ],
           "number": "5",
-          "position": "Centre-Back"
+          "overall_score": 76,
+          "position": "Centre-Back",
+          "potential": 80,
+          "value": 9500000,
+          "yearly_wage": 3744000
         },
         {
           "contract": "Jun 30, 2028",
@@ -4006,7 +5070,11 @@
             "Spain"
           ],
           "number": "3",
-          "position": "Left-Back"
+          "overall_score": 85,
+          "position": "Left-Back",
+          "potential": 85,
+          "value": 53500000,
+          "yearly_wage": 8840000
         },
         {
           "contract": "Jun 30, 2032",
@@ -4021,7 +5089,11 @@
             "Curacao"
           ],
           "number": "21",
-          "position": "Left-Back"
+          "overall_score": 78,
+          "position": "Left-Back",
+          "potential": 87,
+          "value": 29000000,
+          "yearly_wage": 3380000
         },
         {
           "contract": "Jun 30, 2030",
@@ -4048,7 +5120,11 @@
             "England"
           ],
           "number": "24",
-          "position": "Right-Back"
+          "overall_score": 84,
+          "position": "Right-Back",
+          "potential": 86,
+          "value": 48500000,
+          "yearly_wage": 7540000
         },
         {
           "contract": "Jun 30, 2030",
@@ -4063,7 +5139,11 @@
             "Martinique"
           ],
           "number": "27",
-          "position": "Right-Back"
+          "overall_score": 79,
+          "position": "Right-Back",
+          "potential": 84,
+          "value": 25000000,
+          "yearly_wage": 4680000
         },
         {
           "contract": "Jun 30, 2029",
@@ -4078,7 +5158,11 @@
             "Ghana"
           ],
           "number": "34",
-          "position": "Right-Back"
+          "overall_score": 74,
+          "position": "Right-Back",
+          "potential": 85,
+          "value": 8500000,
+          "yearly_wage": 2600000
         },
         {
           "contract": "Jun 30, 2031",
@@ -4092,7 +5176,11 @@
             "Ecuador"
           ],
           "number": "25",
-          "position": "Defensive Midfield"
+          "overall_score": 88,
+          "position": "Defensive Midfield",
+          "potential": 90,
+          "value": 107000000,
+          "yearly_wage": 9620000
         },
         {
           "contract": "Jun 30, 2030",
@@ -4106,7 +5194,11 @@
             "Belgium"
           ],
           "number": "45",
-          "position": "Defensive Midfield"
+          "overall_score": 78,
+          "position": "Defensive Midfield",
+          "potential": 85,
+          "value": 27000000,
+          "yearly_wage": 3588000
         },
         {
           "contract": "Jun 30, 2033",
@@ -4121,7 +5213,11 @@
             "Angola"
           ],
           "number": "14",
-          "position": "Defensive Midfield"
+          "overall_score": 75,
+          "position": "Defensive Midfield",
+          "potential": 83,
+          "value": 11500000,
+          "yearly_wage": 3016000
         },
         {
           "contract": "Jun 30, 2032",
@@ -4135,7 +5231,11 @@
             "Argentina"
           ],
           "number": "8",
-          "position": "Central Midfield"
+          "overall_score": 85,
+          "position": "Central Midfield",
+          "potential": 88,
+          "value": 73000000,
+          "yearly_wage": 7800000
         },
         {
           "contract": "Jun 30, 2030",
@@ -4149,7 +5249,11 @@
             "Brazil"
           ],
           "number": "17",
-          "position": "Central Midfield"
+          "overall_score": 80,
+          "position": "Central Midfield",
+          "potential": 87,
+          "value": 42500000,
+          "yearly_wage": 4472000
         },
         {
           "contract": "Jun 30, 2033",
@@ -4164,7 +5268,11 @@
             "St. Kitts & Nevis"
           ],
           "number": "10",
-          "position": "Attacking Midfield"
+          "overall_score": 86,
+          "position": "Attacking Midfield",
+          "potential": 89,
+          "value": 93000000,
+          "yearly_wage": 8840000
         },
         {
           "contract": "Jun 30, 2032",
@@ -4179,7 +5287,11 @@
             "Spain"
           ],
           "number": "49",
-          "position": "Left Winger"
+          "overall_score": 78,
+          "position": "Left Winger",
+          "potential": 84,
+          "value": 22500000,
+          "yearly_wage": 3796000
         },
         {
           "contract": "Jun 30, 2032",
@@ -4194,7 +5306,11 @@
             "Barbados"
           ],
           "number": "11",
-          "position": "Left Winger"
+          "overall_score": 78,
+          "position": "Left Winger",
+          "potential": 84,
+          "value": 22000000,
+          "yearly_wage": 3796000
         },
         {
           "contract": "Jun 30, 2031",
@@ -4220,7 +5336,11 @@
             "Brazil"
           ],
           "number": "41",
-          "position": "Right Winger"
+          "overall_score": 79,
+          "position": "Right Winger",
+          "potential": 89,
+          "value": 37000000,
+          "yearly_wage": 3692000
         },
         {
           "contract": "Jun 30, 2031",
@@ -4234,7 +5354,11 @@
             "Portugal"
           ],
           "number": "7",
-          "position": "Right Winger"
+          "overall_score": 82,
+          "position": "Right Winger",
+          "potential": 83,
+          "value": 36500000,
+          "yearly_wage": 6760000
         },
         {
           "contract": "Jun 30, 2033",
@@ -4248,7 +5372,11 @@
             "Brazil"
           ],
           "number": "20",
-          "position": "Centre-Forward"
+          "overall_score": 82,
+          "position": "Centre-Forward",
+          "potential": 86,
+          "value": 44000000,
+          "yearly_wage": 6760000
         },
         {
           "contract": "Jun 30, 2031",
@@ -4263,7 +5391,11 @@
             "Ireland"
           ],
           "number": "9",
-          "position": "Centre-Forward"
+          "overall_score": 77,
+          "position": "Centre-Forward",
+          "potential": 83,
+          "value": 17000000,
+          "yearly_wage": 4628000
         },
         {
           "contract": "Jun 30, 2029",
@@ -4277,7 +5409,11 @@
             "Spain"
           ],
           "number": "38",
-          "position": "Centre-Forward"
+          "overall_score": 71,
+          "position": "Centre-Forward",
+          "potential": 84,
+          "value": 4500000,
+          "yearly_wage": 2340000
         }
       ],
       "stadiumName": "Stamford Bridge",
@@ -4301,7 +5437,11 @@
             "Italy"
           ],
           "number": "1",
-          "position": "Goalkeeper"
+          "overall_score": 78,
+          "position": "Goalkeeper",
+          "potential": 80,
+          "value": 13000000,
+          "yearly_wage": 1872000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4315,7 +5455,11 @@
             "France"
           ],
           "number": "16",
-          "position": "Goalkeeper"
+          "overall_score": 71,
+          "position": "Goalkeeper",
+          "potential": 74,
+          "value": 1900000,
+          "yearly_wage": 988000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4330,7 +5474,11 @@
             "England"
           ],
           "number": "26",
-          "position": "Goalkeeper"
+          "overall_score": 74,
+          "position": "Goalkeeper",
+          "potential": 74,
+          "value": 725000,
+          "yearly_wage": 1508000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4344,7 +5492,11 @@
             "England"
           ],
           "number": "21",
-          "position": "Goalkeeper"
+          "overall_score": 63,
+          "position": "Goalkeeper",
+          "potential": 63,
+          "value": 240000,
+          "yearly_wage": 416000
         },
         {
           "contract": "Jun 30, 2027",
@@ -4359,7 +5511,11 @@
             "Belgium"
           ],
           "number": "5",
-          "position": "Centre-Back"
+          "overall_score": 76,
+          "position": "Centre-Back",
+          "potential": 78,
+          "value": 8500000,
+          "yearly_wage": 2444000
         },
         {
           "contract": "Jun 30, 2030",
@@ -4373,7 +5529,11 @@
             "Slovenia"
           ],
           "number": "15",
-          "position": "Centre-Back"
+          "overall_score": 77,
+          "position": "Centre-Back",
+          "potential": 79,
+          "value": 11500000,
+          "yearly_wage": 2704000
         },
         {
           "contract": "Jun 30, 2028",
@@ -4387,7 +5547,11 @@
             "Wales"
           ],
           "number": "6",
-          "position": "Centre-Back"
+          "overall_score": 77,
+          "position": "Centre-Back",
+          "potential": 78,
+          "value": 10500000,
+          "yearly_wage": 2704000
         },
         {
           "contract": "Jun 30, 2029",
@@ -4401,7 +5565,11 @@
             "Belgium"
           ],
           "number": "23",
-          "position": "Centre-Back"
+          "overall_score": 74,
+          "position": "Centre-Back",
+          "potential": 76,
+          "value": 4600000,
+          "yearly_wage": 2236000
         },
         {
           "contract": "Jun 30, 2029",
@@ -4415,7 +5583,11 @@
             "Sweden"
           ],
           "number": "3",
-          "position": "Left-Back"
+          "overall_score": 77,
+          "position": "Left-Back",
+          "potential": 78,
+          "value": 11500000,
+          "yearly_wage": 2704000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4429,7 +5601,11 @@
             "England"
           ],
           "number": "25",
-          "position": "Left-Back"
+          "overall_score": 71,
+          "position": "Left-Back",
+          "potential": 71,
+          "value": 1400000,
+          "yearly_wage": 1716000
         },
         {
           "contract": "Jun 30, 2029",
@@ -4444,7 +5620,11 @@
             "St. Lucia"
           ],
           "number": "24",
-          "position": "Right-Back"
+          "overall_score": 76,
+          "position": "Right-Back",
+          "potential": 76,
+          "value": 7000000,
+          "yearly_wage": 2548000
         },
         {
           "contract": "Jun 30, 2028",
@@ -4458,7 +5638,11 @@
             "England"
           ],
           "number": "2",
-          "position": "Right-Back"
+          "overall_score": 76,
+          "position": "Right-Back",
+          "potential": 79,
+          "value": 9500000,
+          "yearly_wage": 2184000
         },
         {
           "contract": "Jun 30, 2027",
@@ -4473,7 +5657,11 @@
             "England"
           ],
           "number": "4",
-          "position": "Defensive Midfield"
+          "overall_score": 78,
+          "position": "Defensive Midfield",
+          "potential": 81,
+          "value": 17500000,
+          "yearly_wage": 2496000
         },
         {
           "contract": "Jun 30, 2029",
@@ -4487,7 +5675,11 @@
             "Germany"
           ],
           "number": "18",
-          "position": "Defensive Midfield"
+          "overall_score": 79,
+          "position": "Defensive Midfield",
+          "potential": 80,
+          "value": 20500000,
+          "yearly_wage": 3328000
         },
         {
           "contract": "Jun 30, 2027",
@@ -4502,7 +5694,11 @@
             "Germany"
           ],
           "number": "44",
-          "position": "Defensive Midfield"
+          "overall_score": 75,
+          "position": "Defensive Midfield",
+          "potential": 77,
+          "value": 6500000,
+          "yearly_wage": 2288000
         },
         {
           "contract": "Jun 30, 2028",
@@ -4530,7 +5726,11 @@
             "England"
           ],
           "number": "8",
-          "position": "Central Midfield"
+          "overall_score": 76,
+          "position": "Central Midfield",
+          "potential": 76,
+          "value": 8000000,
+          "yearly_wage": 2652000
         },
         {
           "contract": "Jun 30, 2028",
@@ -4544,7 +5744,11 @@
             "Japan"
           ],
           "number": "22",
-          "position": "Central Midfield"
+          "overall_score": 76,
+          "position": "Central Midfield",
+          "potential": 78,
+          "value": 8500000,
+          "yearly_wage": 2548000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4559,7 +5763,11 @@
             "Italy"
           ],
           "number": "40",
-          "position": "Attacking Midfield"
+          "overall_score": 74,
+          "position": "Attacking Midfield",
+          "potential": 80,
+          "value": 6500000,
+          "yearly_wage": 2444000
         },
         {
           "contract": "Jun 30, 2027",
@@ -4573,7 +5781,11 @@
             "United States"
           ],
           "number": "11",
-          "position": "Attacking Midfield"
+          "overall_score": 76,
+          "position": "Attacking Midfield",
+          "potential": 79,
+          "value": 10000000,
+          "yearly_wage": 2496000
         },
         {
           "contract": "Jun 30, 2029",
@@ -4588,7 +5800,11 @@
             "Nigeria"
           ],
           "number": "19",
-          "position": "Left Winger"
+          "overall_score": 76,
+          "position": "Left Winger",
+          "potential": 79,
+          "value": 10000000,
+          "yearly_wage": 2756000
         },
         {
           "contract": "Jun 30, 2028",
@@ -4603,7 +5819,11 @@
             "Cote d'Ivoire"
           ],
           "number": "29",
-          "position": "Right Winger"
+          "overall_score": 74,
+          "position": "Right Winger",
+          "potential": 81,
+          "value": 8500000,
+          "yearly_wage": 1872000
         },
         {
           "contract": "Jun 30, 2029",
@@ -4618,7 +5838,11 @@
             "England"
           ],
           "number": "7",
-          "position": "Right Winger"
+          "overall_score": 76,
+          "position": "Right Winger",
+          "potential": 76,
+          "value": 8000000,
+          "yearly_wage": 2808000
         },
         {
           "contract": "Jun 30, 2028",
@@ -4632,7 +5856,11 @@
             "England"
           ],
           "number": "9",
-          "position": "Centre-Forward"
+          "overall_score": 77,
+          "position": "Centre-Forward",
+          "potential": 77,
+          "value": 11000000,
+          "yearly_wage": 3224000
         },
         {
           "contract": "Jun 30, 2027",
@@ -4647,7 +5875,11 @@
             "Netherlands"
           ],
           "number": "10",
-          "position": "Centre-Forward"
+          "overall_score": 75,
+          "position": "Centre-Forward",
+          "potential": 77,
+          "value": 7000000,
+          "yearly_wage": 2652000
         },
         {
           "contract": "Jun 30, 2027",
@@ -4662,7 +5894,11 @@
             "England"
           ],
           "number": "14",
-          "position": "Centre-Forward"
+          "overall_score": 76,
+          "position": "Centre-Forward",
+          "potential": 77,
+          "value": 9000000,
+          "yearly_wage": 2860000
         }
       ],
       "stadiumName": "Elland Road",
@@ -4685,7 +5921,11 @@
             "Netherlands"
           ],
           "number": "1",
-          "position": "Goalkeeper"
+          "overall_score": 80,
+          "position": "Goalkeeper",
+          "potential": 86,
+          "value": 27500000,
+          "yearly_wage": 2340000
         },
         {
           "contract": "Jun 30, 2027",
@@ -4699,7 +5939,11 @@
             "England"
           ],
           "number": "23",
-          "position": "Goalkeeper"
+          "overall_score": 73,
+          "position": "Goalkeeper",
+          "potential": 73,
+          "value": 525000,
+          "yearly_wage": 1924000
         },
         {
           "contract": "Jun 30, 2027",
@@ -4714,7 +5958,11 @@
             "England"
           ],
           "number": "38",
-          "position": "Goalkeeper"
+          "overall_score": 62,
+          "position": "Goalkeeper",
+          "potential": 67,
+          "value": 475000,
+          "yearly_wage": 468000
         },
         {
           "contract": "Jun 30, 2027",
@@ -4728,7 +5976,11 @@
             "Netherlands"
           ],
           "number": "6",
-          "position": "Centre-Back"
+          "overall_score": 80,
+          "position": "Centre-Back",
+          "potential": 83,
+          "value": 25000000,
+          "yearly_wage": 4472000
         },
         {
           "contract": "Jun 30, 2030",
@@ -4743,7 +5995,11 @@
             "Monaco"
           ],
           "number": "21",
-          "position": "Centre-Back"
+          "overall_score": 78,
+          "position": "Centre-Back",
+          "potential": 80,
+          "value": 15000000,
+          "yearly_wage": 4004000
         },
         {
           "contract": "Jun 30, 2027",
@@ -4757,7 +6013,11 @@
             "Brazil"
           ],
           "number": "3",
-          "position": "Centre-Back"
+          "overall_score": 75,
+          "position": "Centre-Back",
+          "potential": 77,
+          "value": 6000000,
+          "yearly_wage": 3328000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4771,7 +6031,11 @@
             "England"
           ],
           "number": "4",
-          "position": "Centre-Back"
+          "overall_score": 75,
+          "position": "Centre-Back",
+          "potential": 75,
+          "value": 4600000,
+          "yearly_wage": 3484000
         },
         {
           "contract": "Jun 30, 2027",
@@ -4785,7 +6049,11 @@
             "England"
           ],
           "number": "5",
-          "position": "Centre-Back"
+          "overall_score": 77,
+          "position": "Centre-Back",
+          "potential": 77,
+          "value": 5000000,
+          "yearly_wage": 3952000
         },
         {
           "contract": "Jun 30, 2028",
@@ -4800,7 +6068,11 @@
             "Netherlands"
           ],
           "number": "24",
-          "position": "Left-Back"
+          "overall_score": 79,
+          "position": "Left-Back",
+          "potential": 81,
+          "value": 20000000,
+          "yearly_wage": 4212000
         },
         {
           "contract": "Jun 30, 2030",
@@ -4814,7 +6086,11 @@
             "Belgium"
           ],
           "number": "29",
-          "position": "Left-Back"
+          "overall_score": 79,
+          "position": "Left-Back",
+          "potential": 83,
+          "value": 23500000,
+          "yearly_wage": 3848000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4828,7 +6104,11 @@
             "Netherlands"
           ],
           "number": "34",
-          "position": "Right-Back"
+          "overall_score": 78,
+          "position": "Right-Back",
+          "potential": 78,
+          "value": 7500000,
+          "yearly_wage": 4212000
         },
         {
           "contract": "Jun 30, 2028",
@@ -4842,7 +6122,11 @@
             "Cameroon"
           ],
           "number": "17",
-          "position": "Defensive Midfield"
+          "overall_score": 80,
+          "position": "Defensive Midfield",
+          "potential": 86,
+          "value": 31000000,
+          "yearly_wage": 3380000
         },
         {
           "contract": "Jun 30, 2029",
@@ -4856,7 +6140,11 @@
             "Netherlands"
           ],
           "number": "27",
-          "position": "Defensive Midfield"
+          "overall_score": 78,
+          "position": "Defensive Midfield",
+          "potential": 81,
+          "value": 17000000,
+          "yearly_wage": 3848000
         },
         {
           "contract": "Jun 30, 2028",
@@ -4870,7 +6158,11 @@
             "England"
           ],
           "number": "13",
-          "position": "Defensive Midfield"
+          "overall_score": 76,
+          "position": "Defensive Midfield",
+          "potential": 84,
+          "value": 15500000,
+          "yearly_wage": 2548000
         },
         {
           "contract": "Jun 30, 2027",
@@ -4885,7 +6177,11 @@
             "Tunisia"
           ],
           "number": "26",
-          "position": "Central Midfield"
+          "overall_score": 79,
+          "position": "Central Midfield",
+          "potential": 85,
+          "value": 26000000,
+          "yearly_wage": 3224000
         },
         {
           "contract": "-",
@@ -4899,7 +6195,11 @@
             "Paraguay"
           ],
           "number": "25",
-          "position": "Central Midfield"
+          "overall_score": 77,
+          "position": "Central Midfield",
+          "potential": 84,
+          "value": 20000000,
+          "yearly_wage": 3224000
         },
         {
           "contract": "Jun 30, 2029",
@@ -4914,7 +6214,11 @@
             "England"
           ],
           "number": "33",
-          "position": "Central Midfield"
+          "overall_score": 77,
+          "position": "Central Midfield",
+          "potential": 81,
+          "value": 15000000,
+          "yearly_wage": 3484000
         },
         {
           "contract": "Jun 30, 2027",
@@ -4928,7 +6232,11 @@
             "Germany"
           ],
           "number": "30",
-          "position": "Central Midfield"
+          "overall_score": 78,
+          "position": "Central Midfield",
+          "potential": 78,
+          "value": 4800000,
+          "yearly_wage": 4212000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4942,7 +6250,11 @@
             "England"
           ],
           "number": "20",
-          "position": "Central Midfield"
+          "overall_score": 73,
+          "position": "Central Midfield",
+          "potential": 73,
+          "value": 600000,
+          "yearly_wage": 1924000
         },
         {
           "contract": "Jun 30, 2027",
@@ -4956,7 +6268,11 @@
             "Japan"
           ],
           "number": "22",
-          "position": "Left Winger"
+          "overall_score": 81,
+          "position": "Left Winger",
+          "potential": 81,
+          "value": 26000000,
+          "yearly_wage": 5460000
         },
         {
           "contract": "Jun 30, 2029",
@@ -4970,7 +6286,11 @@
             "The Gambia"
           ],
           "number": "11",
-          "position": "Right Winger"
+          "overall_score": 80,
+          "position": "Right Winger",
+          "potential": 86,
+          "value": 33000000,
+          "yearly_wage": 3640000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4984,7 +6304,11 @@
             "England"
           ],
           "number": "7",
-          "position": "Right Winger"
+          "overall_score": 74,
+          "position": "Right Winger",
+          "potential": 74,
+          "value": 4100000,
+          "yearly_wage": 3380000
         },
         {
           "contract": "Jun 30, 2028",
@@ -4999,7 +6323,11 @@
             "Martinique"
           ],
           "number": "10",
-          "position": "Centre-Forward"
+          "overall_score": 77,
+          "position": "Centre-Forward",
+          "potential": 83,
+          "value": 16500000,
+          "yearly_wage": 3484000
         },
         {
           "contract": "Jun 30, 2030",
@@ -5013,7 +6341,11 @@
             "Greece"
           ],
           "number": "19",
-          "position": "Centre-Forward"
+          "overall_score": 73,
+          "position": "Centre-Forward",
+          "potential": 85,
+          "value": 7000000,
+          "yearly_wage": 2184000
         },
         {
           "contract": "Jun 30, 2030",
@@ -5027,7 +6359,11 @@
             "Greece"
           ],
           "number": "9",
-          "position": "Centre-Forward"
+          "overall_score": 72,
+          "position": "Centre-Forward",
+          "potential": 81,
+          "value": 5000000,
+          "yearly_wage": 2080000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5042,7 +6378,11 @@
             "Ghana"
           ],
           "number": "18",
-          "position": "Centre-Forward"
+          "overall_score": 80,
+          "position": "Centre-Forward",
+          "potential": 80,
+          "value": 10500000,
+          "yearly_wage": 5460000
         }
       ],
       "stadiumName": "AMEX Stadium",
@@ -5065,7 +6405,11 @@
             "Portugal"
           ],
           "number": "1",
-          "position": "Goalkeeper"
+          "overall_score": 76,
+          "position": "Goalkeeper",
+          "potential": 76,
+          "value": 3700000,
+          "yearly_wage": 1924000
         },
         {
           "contract": "Jun 30, 2028",
@@ -5079,7 +6423,11 @@
             "England"
           ],
           "number": "31",
-          "position": "Goalkeeper"
+          "overall_score": 76,
+          "position": "Goalkeeper",
+          "potential": 76,
+          "value": 3700000,
+          "yearly_wage": 1924000
         },
         {
           "contract": "Jun 30, 2027",
@@ -5092,7 +6440,11 @@
             "England"
           ],
           "number": "25",
-          "position": "Goalkeeper"
+          "overall_score": 71,
+          "position": "Goalkeeper",
+          "potential": 71,
+          "value": 1000000,
+          "yearly_wage": 1248000
         },
         {
           "contract": "Jun 30, 2029",
@@ -5107,7 +6459,11 @@
             "Guinea-Bissau"
           ],
           "number": "24",
-          "position": "Centre-Back"
+          "overall_score": 75,
+          "position": "Centre-Back",
+          "potential": 78,
+          "value": 6500000,
+          "yearly_wage": 2652000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5121,7 +6477,11 @@
             "Czech Republic"
           ],
           "number": "37",
-          "position": "Centre-Back"
+          "overall_score": 78,
+          "position": "Centre-Back",
+          "potential": 81,
+          "value": 16500000,
+          "yearly_wage": 1664000
         },
         {
           "contract": "Jun 30, 2028",
@@ -5136,7 +6496,11 @@
             "Italy"
           ],
           "number": "4",
-          "position": "Centre-Back"
+          "overall_score": 76,
+          "position": "Centre-Back",
+          "potential": 78,
+          "value": 8000000,
+          "yearly_wage": 2808000
         },
         {
           "contract": "Jun 30, 2030",
@@ -5150,7 +6514,11 @@
             "Colombia"
           ],
           "number": "15",
-          "position": "Centre-Back"
+          "overall_score": 72,
+          "position": "Centre-Back",
+          "potential": 78,
+          "value": 3400000,
+          "yearly_wage": 1768000
         },
         {
           "contract": "Jun 30, 2028",
@@ -5164,7 +6532,11 @@
             "Spain"
           ],
           "number": "3",
-          "position": "Left-Back"
+          "overall_score": 75,
+          "position": "Left-Back",
+          "potential": 80,
+          "value": 8000000,
+          "yearly_wage": 2288000
         },
         {
           "contract": "Jun 30, 2030",
@@ -5178,7 +6550,11 @@
             "Norway"
           ],
           "number": "6",
-          "position": "Left-Back"
+          "overall_score": 73,
+          "position": "Left-Back",
+          "potential": 78,
+          "value": 4300000,
+          "yearly_wage": 1924000
         },
         {
           "contract": "Jun 30, 2030",
@@ -5193,7 +6569,11 @@
             "Belgium"
           ],
           "number": "38",
-          "position": "Right-Back"
+          "overall_score": 74,
+          "position": "Right-Back",
+          "potential": 79,
+          "value": 6000000,
+          "yearly_wage": 2132000
         },
         {
           "contract": "Jun 30, 2029",
@@ -5207,7 +6587,11 @@
             "Brazil"
           ],
           "number": "17",
-          "position": "Right-Back"
+          "overall_score": 68,
+          "position": "Right-Back",
+          "potential": 83,
+          "value": 2700000,
+          "yearly_wage": 884000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5221,7 +6605,11 @@
             "Ireland"
           ],
           "number": "2",
-          "position": "Right-Back"
+          "overall_score": 74,
+          "position": "Right-Back",
+          "potential": 74,
+          "value": 2000000,
+          "yearly_wage": 2548000
         },
         {
           "contract": "Jun 30, 2029",
@@ -5235,7 +6623,11 @@
             "Brazil"
           ],
           "number": "7",
-          "position": "Defensive Midfield"
+          "overall_score": 78,
+          "position": "Defensive Midfield",
+          "potential": 83,
+          "value": 19500000,
+          "yearly_wage": 2756000
         },
         {
           "contract": "Jun 30, 2030",
@@ -5249,7 +6641,11 @@
             "Brazil"
           ],
           "number": "8",
-          "position": "Central Midfield"
+          "overall_score": 78,
+          "position": "Central Midfield",
+          "potential": 83,
+          "value": 19500000,
+          "yearly_wage": 2756000
         },
         {
           "contract": "Jun 30, 2028",
@@ -5264,7 +6660,11 @@
             "France"
           ],
           "number": "27",
-          "position": "Central Midfield"
+          "overall_score": 75,
+          "position": "Central Midfield",
+          "potential": 76,
+          "value": 6500000,
+          "yearly_wage": 2808000
         },
         {
           "contract": "Jun 30, 2029",
@@ -5278,7 +6678,11 @@
             "Portugal"
           ],
           "number": "21",
-          "position": "Left Midfield"
+          "overall_score": 73,
+          "position": "Left Midfield",
+          "potential": 82,
+          "value": 7000000,
+          "yearly_wage": 1872000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5293,7 +6697,11 @@
             "Portugal"
           ],
           "number": "47",
-          "position": "Attacking Midfield"
+          "overall_score": 76,
+          "position": "Attacking Midfield",
+          "potential": 81,
+          "value": 11500000,
+          "yearly_wage": 1612000
         },
         {
           "contract": "Jun 30, 2029",
@@ -5308,7 +6716,11 @@
             "Portugal"
           ],
           "number": "36",
-          "position": "Attacking Midfield"
+          "overall_score": 71,
+          "position": "Attacking Midfield",
+          "potential": 84,
+          "value": 4300000,
+          "yearly_wage": 1040000
         },
         {
           "contract": "Jun 30, 2029",
@@ -5322,7 +6734,11 @@
             "Paraguay"
           ],
           "number": "30",
-          "position": "Left Winger"
+          "overall_score": 63,
+          "position": "Left Winger",
+          "potential": 75,
+          "value": 1200000,
+          "yearly_wage": 572000
         },
         {
           "contract": "Jun 30, 2029",
@@ -5336,7 +6752,11 @@
             "Nigeria"
           ],
           "number": "14",
-          "position": "Centre-Forward"
+          "overall_score": 76,
+          "position": "Centre-Forward",
+          "potential": 79,
+          "value": 10500000,
+          "yearly_wage": 2808000
         },
         {
           "contract": "Jun 30, 2028",
@@ -5350,7 +6770,11 @@
             "Korea, South"
           ],
           "number": "11",
-          "position": "Centre-Forward"
+          "overall_score": 74,
+          "position": "Centre-Forward",
+          "potential": 74,
+          "value": 4200000,
+          "yearly_wage": 2912000
         },
         {
           "contract": "Jun 30, 2029",
@@ -5364,7 +6788,11 @@
             "England"
           ],
           "number": "9",
-          "position": "Centre-Forward"
+          "overall_score": 73,
+          "position": "Centre-Forward",
+          "potential": 73,
+          "value": 3100000,
+          "yearly_wage": 2652000
         },
         {
           "contract": "Jun 30, 2028",
@@ -5403,7 +6831,11 @@
             "Portugal"
           ],
           "number": "13",
-          "position": "Goalkeeper"
+          "overall_score": 71,
+          "position": "Goalkeeper",
+          "potential": 71,
+          "value": 1300000,
+          "yearly_wage": 1560000
         },
         {
           "contract": "Jun 30, 2027",
@@ -5417,7 +6849,11 @@
             "Belgium"
           ],
           "number": "26",
-          "position": "Goalkeeper"
+          "overall_score": 81,
+          "position": "Goalkeeper",
+          "potential": 81,
+          "value": 8500000,
+          "yearly_wage": 3432000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5432,7 +6868,11 @@
             "Spain"
           ],
           "number": "27",
-          "position": "Goalkeeper"
+          "overall_score": 79,
+          "position": "Goalkeeper",
+          "potential": 79,
+          "value": 8500000,
+          "yearly_wage": 3016000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5447,7 +6887,11 @@
             "England"
           ],
           "number": "18",
-          "position": "Goalkeeper"
+          "overall_score": 72,
+          "position": "Goalkeeper",
+          "potential": 73,
+          "value": 1800000,
+          "yearly_wage": 1768000
         },
         {
           "contract": "Jun 30, 2029",
@@ -5461,7 +6905,11 @@
             "Brazil"
           ],
           "number": "5",
-          "position": "Centre-Back"
+          "overall_score": 82,
+          "position": "Centre-Back",
+          "potential": 86,
+          "value": 40000000,
+          "yearly_wage": 4680000
         },
         {
           "contract": "Jun 30, 2029",
@@ -5475,7 +6923,11 @@
             "Serbia"
           ],
           "number": "31",
-          "position": "Centre-Back"
+          "overall_score": 80,
+          "position": "Centre-Back",
+          "potential": 81,
+          "value": 21000000,
+          "yearly_wage": 4680000
         },
         {
           "contract": "Jun 30, 2029",
@@ -5489,7 +6941,11 @@
             "Brazil"
           ],
           "number": "4",
-          "position": "Centre-Back"
+          "overall_score": 76,
+          "position": "Centre-Back",
+          "potential": 80,
+          "value": 9500000,
+          "yearly_wage": 3016000
         },
         {
           "contract": "Jun 30, 2030",
@@ -5503,7 +6959,11 @@
             "Brazil"
           ],
           "number": "23",
-          "position": "Centre-Back"
+          "overall_score": 75,
+          "position": "Centre-Back",
+          "potential": 82,
+          "value": 10500000,
+          "yearly_wage": 2444000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5518,7 +6978,11 @@
             "France"
           ],
           "number": "30",
-          "position": "Centre-Back"
+          "overall_score": 73,
+          "position": "Centre-Back",
+          "potential": 73,
+          "value": 1000000,
+          "yearly_wage": 2912000
         },
         {
           "contract": "Jun 30, 2029",
@@ -5532,7 +6996,11 @@
             "England"
           ],
           "number": "44",
-          "position": "Centre-Back"
+          "overall_score": 63,
+          "position": "Centre-Back",
+          "potential": 78,
+          "value": 1100000,
+          "yearly_wage": 572000
         },
         {
           "contract": "Jun 30, 2029",
@@ -5546,7 +7014,11 @@
             "Wales"
           ],
           "number": "3",
-          "position": "Left-Back"
+          "overall_score": 80,
+          "position": "Left-Back",
+          "potential": 82,
+          "value": 25000000,
+          "yearly_wage": 4056000
         },
         {
           "contract": "Jun 30, 2030",
@@ -5560,7 +7032,11 @@
             "Germany"
           ],
           "number": "25",
-          "position": "Left-Back"
+          "overall_score": 73,
+          "position": "Left-Back",
+          "potential": 77,
+          "value": 4100000,
+          "yearly_wage": 2444000
         },
         {
           "contract": "Jun 30, 2028",
@@ -5575,7 +7051,11 @@
             "England"
           ],
           "number": "34",
-          "position": "Right-Back"
+          "overall_score": 80,
+          "position": "Right-Back",
+          "potential": 80,
+          "value": 19000000,
+          "yearly_wage": 4940000
         },
         {
           "contract": "Jun 30, 2030",
@@ -5589,7 +7069,11 @@
             "Italy"
           ],
           "number": "37",
-          "position": "Right-Back"
+          "overall_score": 75,
+          "position": "Right-Back",
+          "potential": 81,
+          "value": 8500000,
+          "yearly_wage": 2912000
         },
         {
           "contract": "Jun 30, 2028",
@@ -5604,7 +7088,11 @@
             "Portugal"
           ],
           "number": "17",
-          "position": "Right-Back"
+          "overall_score": 61,
+          "position": "Right-Back",
+          "potential": 77,
+          "value": 825000,
+          "yearly_wage": 468000
         },
         {
           "contract": "Jun 30, 2028",
@@ -5618,7 +7106,11 @@
             "Cote d'Ivoire"
           ],
           "number": "6",
-          "position": "Defensive Midfield"
+          "overall_score": 78,
+          "position": "Defensive Midfield",
+          "potential": 79,
+          "value": 14500000,
+          "yearly_wage": 4004000
         },
         {
           "contract": "Jun 30, 2029",
@@ -5633,7 +7125,11 @@
             "Scotland"
           ],
           "number": "8",
-          "position": "Central Midfield"
+          "overall_score": 82,
+          "position": "Central Midfield",
+          "potential": 86,
+          "value": 40500000,
+          "yearly_wage": 4680000
         },
         {
           "contract": "Jun 30, 2028",
@@ -5648,7 +7144,11 @@
             "Italy"
           ],
           "number": "16",
-          "position": "Central Midfield"
+          "overall_score": 78,
+          "position": "Central Midfield",
+          "potential": 79,
+          "value": 14500000,
+          "yearly_wage": 4004000
         },
         {
           "contract": "Jun 30, 2028",
@@ -5662,7 +7162,11 @@
             "England"
           ],
           "number": "22",
-          "position": "Central Midfield"
+          "overall_score": 76,
+          "position": "Central Midfield",
+          "potential": 77,
+          "value": 7500000,
+          "yearly_wage": 3536000
         },
         {
           "contract": "Jun 30, 2028",
@@ -5677,7 +7181,11 @@
             "Jamaica"
           ],
           "number": "10",
-          "position": "Attacking Midfield"
+          "overall_score": 81,
+          "position": "Attacking Midfield",
+          "potential": 83,
+          "value": 32500000,
+          "yearly_wage": 5200000
         },
         {
           "contract": "Jun 30, 2030",
@@ -5692,7 +7200,11 @@
             "Jamaica"
           ],
           "number": "21",
-          "position": "Attacking Midfield"
+          "overall_score": 76,
+          "position": "Attacking Midfield",
+          "potential": 84,
+          "value": 17000000,
+          "yearly_wage": 2704000
         },
         {
           "contract": "Jun 30, 2030",
@@ -5706,7 +7218,11 @@
             "England"
           ],
           "number": "24",
-          "position": "Attacking Midfield"
+          "overall_score": 73,
+          "position": "Attacking Midfield",
+          "potential": 81,
+          "value": 7000000,
+          "yearly_wage": 2548000
         },
         {
           "contract": "Jun 30, 2028",
@@ -5721,7 +7237,11 @@
             "Ghana"
           ],
           "number": "7",
-          "position": "Left Winger"
+          "overall_score": 78,
+          "position": "Left Winger",
+          "potential": 81,
+          "value": 19000000,
+          "yearly_wage": 3640000
         },
         {
           "contract": "Jun 30, 2030",
@@ -5736,7 +7256,11 @@
             "Senegal"
           ],
           "number": "14",
-          "position": "Right Winger"
+          "overall_score": 77,
+          "position": "Right Winger",
+          "potential": 80,
+          "value": 14500000,
+          "yearly_wage": 3432000
         },
         {
           "contract": "Jun 30, 2030",
@@ -5751,7 +7275,11 @@
             "DR Congo"
           ],
           "number": "29",
-          "position": "Right Winger"
+          "overall_score": 76,
+          "position": "Right Winger",
+          "potential": 82,
+          "value": 12000000,
+          "yearly_wage": 3172000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5765,7 +7293,11 @@
             "Italy"
           ],
           "number": "20",
-          "position": "Centre-Forward"
+          "overall_score": 75,
+          "position": "Centre-Forward",
+          "potential": 79,
+          "value": 8000000,
+          "yearly_wage": 884000
         },
         {
           "contract": "Jun 30, 2029",
@@ -5780,7 +7312,11 @@
             "United Arab Emirates"
           ],
           "number": "19",
-          "position": "Centre-Forward"
+          "overall_score": 77,
+          "position": "Centre-Forward",
+          "potential": 81,
+          "value": 15500000,
+          "yearly_wage": 3744000
         },
         {
           "contract": "Jun 30, 2027",
@@ -5794,7 +7330,11 @@
             "Nigeria"
           ],
           "number": "9",
-          "position": "Centre-Forward"
+          "overall_score": 74,
+          "position": "Centre-Forward",
+          "potential": 74,
+          "value": 4600000,
+          "yearly_wage": 3536000
         },
         {
           "contract": "Jun 30, 2027",
@@ -5808,7 +7348,11 @@
             "New Zealand"
           ],
           "number": "11",
-          "position": "Centre-Forward"
+          "overall_score": 81,
+          "position": "Centre-Forward",
+          "potential": 81,
+          "value": 16500000,
+          "yearly_wage": 5980000
         }
       ],
       "stadiumName": "The City Ground",
@@ -5831,7 +7375,11 @@
             "Germany"
           ],
           "number": "1",
-          "position": "Goalkeeper"
+          "overall_score": 79,
+          "position": "Goalkeeper",
+          "potential": 79,
+          "value": 5500000,
+          "yearly_wage": 2860000
         },
         {
           "contract": "Jun 30, 2027",
@@ -5845,7 +7393,11 @@
             "France"
           ],
           "number": "23",
-          "position": "Goalkeeper"
+          "overall_score": 74,
+          "position": "Goalkeeper",
+          "potential": 74,
+          "value": 725000,
+          "yearly_wage": 1976000
         },
         {
           "contract": "Jun 30, 2027",
@@ -5860,7 +7412,11 @@
             "England"
           ],
           "number": "3",
-          "position": "Centre-Back"
+          "overall_score": 78,
+          "position": "Centre-Back",
+          "potential": 81,
+          "value": 16500000,
+          "yearly_wage": 3588000
         },
         {
           "contract": "Jun 30, 2029",
@@ -5874,7 +7430,11 @@
             "Denmark"
           ],
           "number": "5",
-          "position": "Centre-Back"
+          "overall_score": 79,
+          "position": "Centre-Back",
+          "potential": 79,
+          "value": 14500000,
+          "yearly_wage": 4316000
         },
         {
           "contract": "Jun 30, 2027",
@@ -5889,7 +7449,11 @@
             "Senegal"
           ],
           "number": "31",
-          "position": "Centre-Back"
+          "overall_score": 76,
+          "position": "Centre-Back",
+          "potential": 77,
+          "value": 7000000,
+          "yearly_wage": 3432000
         },
         {
           "contract": "Jun 30, 2028",
@@ -5903,7 +7467,11 @@
             "Spain"
           ],
           "number": "15",
-          "position": "Centre-Back"
+          "overall_score": 76,
+          "position": "Centre-Back",
+          "potential": 79,
+          "value": 9000000,
+          "yearly_wage": 3120000
         },
         {
           "contract": "Jun 30, 2028",
@@ -5918,7 +7486,11 @@
             "England"
           ],
           "number": "33",
-          "position": "Left-Back"
+          "overall_score": 81,
+          "position": "Left-Back",
+          "potential": 81,
+          "value": 25000000,
+          "yearly_wage": 4680000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5932,7 +7504,11 @@
             "England"
           ],
           "number": "30",
-          "position": "Left-Back"
+          "overall_score": 77,
+          "position": "Left-Back",
+          "potential": 79,
+          "value": 12000000,
+          "yearly_wage": 3380000
         },
         {
           "contract": "Jun 30, 2028",
@@ -5947,7 +7523,11 @@
             "Mozambique"
           ],
           "number": "2",
-          "position": "Right-Back"
+          "overall_score": 78,
+          "position": "Right-Back",
+          "potential": 78,
+          "value": 12500000,
+          "yearly_wage": 3952000
         },
         {
           "contract": "Jun 30, 2027",
@@ -5961,7 +7541,11 @@
             "Belgium"
           ],
           "number": "21",
-          "position": "Right-Back"
+          "overall_score": 75,
+          "position": "Right-Back",
+          "potential": 75,
+          "value": 4900000,
+          "yearly_wage": 3276000
         },
         {
           "contract": "Jun 30, 2029",
@@ -5975,7 +7559,11 @@
             "Norway"
           ],
           "number": "16",
-          "position": "Defensive Midfield"
+          "overall_score": 79,
+          "position": "Defensive Midfield",
+          "potential": 80,
+          "value": 18000000,
+          "yearly_wage": 4160000
         },
         {
           "contract": "Jun 30, 2027",
@@ -5989,7 +7577,11 @@
             "Serbia"
           ],
           "number": "20",
-          "position": "Central Midfield"
+          "overall_score": 78,
+          "position": "Central Midfield",
+          "potential": 78,
+          "value": 12500000,
+          "yearly_wage": 3952000
         },
         {
           "contract": "Jun 30, 2027",
@@ -6003,7 +7595,11 @@
             "England"
           ],
           "number": "6",
-          "position": "Central Midfield"
+          "overall_score": 72,
+          "position": "Central Midfield",
+          "potential": 72,
+          "value": 2000000,
+          "yearly_wage": 2496000
         },
         {
           "contract": "Jun 30, 2027",
@@ -6018,7 +7614,11 @@
             "England"
           ],
           "number": "10",
-          "position": "Central Midfield"
+          "overall_score": 74,
+          "position": "Central Midfield",
+          "potential": 74,
+          "value": 1900000,
+          "yearly_wage": 3172000
         },
         {
           "contract": "Jun 30, 2029",
@@ -6032,7 +7632,11 @@
             "England"
           ],
           "number": "32",
-          "position": "Attacking Midfield"
+          "overall_score": 77,
+          "position": "Attacking Midfield",
+          "potential": 80,
+          "value": 14500000,
+          "yearly_wage": 3276000
         },
         {
           "contract": "Jun 30, 2029",
@@ -6046,7 +7650,11 @@
             "England"
           ],
           "number": "24",
-          "position": "Attacking Midfield"
+          "overall_score": 74,
+          "position": "Attacking Midfield",
+          "potential": 84,
+          "value": 9000000,
+          "yearly_wage": 2028000
         },
         {
           "contract": "Jun 30, 2030",
@@ -6060,7 +7668,11 @@
             "Brazil"
           ],
           "number": "22",
-          "position": "Left Winger"
+          "overall_score": 76,
+          "position": "Left Winger",
+          "potential": 81,
+          "value": 11500000,
+          "yearly_wage": 3016000
         },
         {
           "contract": "Jun 30, 2028",
@@ -6075,7 +7687,11 @@
             "England"
           ],
           "number": "17",
-          "position": "Left Winger"
+          "overall_score": 80,
+          "position": "Left Winger",
+          "potential": 80,
+          "value": 20500000,
+          "yearly_wage": 4680000
         },
         {
           "contract": "Jun 30, 2031",
@@ -6090,7 +7706,11 @@
             "The Gambia"
           ],
           "number": "14",
-          "position": "Right Winger"
+          "overall_score": 76,
+          "position": "Right Winger",
+          "potential": 84,
+          "value": 17000000,
+          "yearly_wage": 2548000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6105,7 +7725,11 @@
             "England"
           ],
           "number": "8",
-          "position": "Right Winger"
+          "overall_score": 80,
+          "position": "Right Winger",
+          "potential": 80,
+          "value": 21000000,
+          "yearly_wage": 4680000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6119,7 +7743,11 @@
             "Nigeria"
           ],
           "number": "19",
-          "position": "Right Winger"
+          "overall_score": 79,
+          "position": "Right Winger",
+          "potential": 79,
+          "value": 19000000,
+          "yearly_wage": 2600000
         },
         {
           "contract": "Jun 30, 2030",
@@ -6133,7 +7761,11 @@
             "Brazil"
           ],
           "number": "9",
-          "position": "Centre-Forward"
+          "overall_score": 76,
+          "position": "Centre-Forward",
+          "potential": 81,
+          "value": 11500000,
+          "yearly_wage": 3276000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6147,7 +7779,11 @@
             "Mexico"
           ],
           "number": "7",
-          "position": "Centre-Forward"
+          "overall_score": 78,
+          "position": "Centre-Forward",
+          "potential": 78,
+          "value": 7000000,
+          "yearly_wage": 4420000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6162,7 +7798,11 @@
             "Ghana"
           ],
           "number": "18",
-          "position": "Centre-Forward"
+          "overall_score": 62,
+          "position": "Centre-Forward",
+          "potential": 84,
+          "value": 1300000,
+          "yearly_wage": 364000
         }
       ],
       "stadiumName": "Craven Cottage",
@@ -6185,7 +7825,11 @@
             "England"
           ],
           "number": "1",
-          "position": "Goalkeeper"
+          "overall_score": 82,
+          "position": "Goalkeeper",
+          "potential": 83,
+          "value": 24000000,
+          "yearly_wage": 3484000
         },
         {
           "contract": "-",
@@ -6200,7 +7844,11 @@
             "France"
           ],
           "number": "44",
-          "position": "Goalkeeper"
+          "overall_score": 78,
+          "position": "Goalkeeper",
+          "potential": 78,
+          "value": 7000000,
+          "yearly_wage": 2548000
         },
         {
           "contract": "Jun 30, 2027",
@@ -6214,7 +7862,11 @@
             "England"
           ],
           "number": "31",
-          "position": "Goalkeeper"
+          "overall_score": 63,
+          "position": "Goalkeeper",
+          "potential": 63,
+          "value": 250000,
+          "yearly_wage": 520000
         },
         {
           "contract": "Jun 30, 2029",
@@ -6229,7 +7881,11 @@
             "Guadeloupe"
           ],
           "number": "5",
-          "position": "Centre-Back"
+          "overall_score": 81,
+          "position": "Centre-Back",
+          "potential": 83,
+          "value": 28500000,
+          "yearly_wage": 4472000
         },
         {
           "contract": "Jun 30, 2027",
@@ -6243,7 +7899,11 @@
             "United States"
           ],
           "number": "26",
-          "position": "Centre-Back"
+          "overall_score": 79,
+          "position": "Centre-Back",
+          "potential": 81,
+          "value": 19500000,
+          "yearly_wage": 3952000
         },
         {
           "contract": "Jun 30, 2029",
@@ -6258,7 +7918,11 @@
             "Senegal"
           ],
           "number": "23",
-          "position": "Centre-Back"
+          "overall_score": 74,
+          "position": "Centre-Back",
+          "potential": 85,
+          "value": 8500000,
+          "yearly_wage": 1872000
         },
         {
           "contract": "Jun 30, 2029",
@@ -6273,7 +7937,11 @@
             "Spain"
           ],
           "number": "34",
-          "position": "Centre-Back"
+          "overall_score": 72,
+          "position": "Centre-Back",
+          "potential": 81,
+          "value": 4900000,
+          "yearly_wage": 2080000
         },
         {
           "contract": "Jun 30, 2027",
@@ -6288,7 +7956,11 @@
             "Jamaica"
           ],
           "number": "3",
-          "position": "Left-Back"
+          "overall_score": 79,
+          "position": "Left-Back",
+          "potential": 81,
+          "value": 20000000,
+          "yearly_wage": 3952000
         },
         {
           "contract": "Jun 30, 2028",
@@ -6303,7 +7975,11 @@
             "Germany"
           ],
           "number": "24",
-          "position": "Left-Back"
+          "overall_score": 72,
+          "position": "Left-Back",
+          "potential": 72,
+          "value": 2300000,
+          "yearly_wage": 2392000
         },
         {
           "contract": "-",
@@ -6317,7 +7993,11 @@
             "England"
           ],
           "number": "59",
-          "position": "Left-Back"
+          "overall_score": 62,
+          "position": "Left-Back",
+          "potential": 75,
+          "value": 900000,
+          "yearly_wage": 468000
         },
         {
           "contract": "Jun 30, 2028",
@@ -6331,7 +8011,11 @@
             "Colombia"
           ],
           "number": "2",
-          "position": "Right-Back"
+          "overall_score": 82,
+          "position": "Right-Back",
+          "potential": 82,
+          "value": 27000000,
+          "yearly_wage": 5200000
         },
         {
           "contract": "Jun 30, 2029",
@@ -6345,7 +8029,11 @@
             "Ghana"
           ],
           "number": "58",
-          "position": "Right-Back"
+          "overall_score": 62,
+          "position": "Right-Back",
+          "potential": 78,
+          "value": 975000,
+          "yearly_wage": 468000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6360,7 +8048,11 @@
             "Grenada"
           ],
           "number": "17",
-          "position": "Right-Back"
+          "overall_score": 70,
+          "position": "Right-Back",
+          "potential": 70,
+          "value": 575000,
+          "yearly_wage": 2028000
         },
         {
           "contract": "Jun 30, 2029",
@@ -6374,7 +8066,11 @@
             "England"
           ],
           "number": "20",
-          "position": "Defensive Midfield"
+          "overall_score": 81,
+          "position": "Defensive Midfield",
+          "potential": 87,
+          "value": 38000000,
+          "yearly_wage": 3432000
         },
         {
           "contract": "Jun 30, 2029",
@@ -6388,7 +8084,11 @@
             "Mali"
           ],
           "number": "28",
-          "position": "Defensive Midfield"
+          "overall_score": 77,
+          "position": "Defensive Midfield",
+          "potential": 78,
+          "value": 11000000,
+          "yearly_wage": 3380000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6402,7 +8102,11 @@
             "Colombia"
           ],
           "number": "8",
-          "position": "Defensive Midfield"
+          "overall_score": 77,
+          "position": "Defensive Midfield",
+          "potential": 77,
+          "value": 9000000,
+          "yearly_wage": 3692000
         },
         {
           "contract": "Jun 30, 2027",
@@ -6416,7 +8120,11 @@
             "England"
           ],
           "number": "19",
-          "position": "Central Midfield"
+          "overall_score": 77,
+          "position": "Central Midfield",
+          "potential": 77,
+          "value": 9000000,
+          "yearly_wage": 3692000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6430,7 +8138,11 @@
             "Japan"
           ],
           "number": "18",
-          "position": "Attacking Midfield"
+          "overall_score": 78,
+          "position": "Attacking Midfield",
+          "potential": 78,
+          "value": 14000000,
+          "yearly_wage": 4108000
         },
         {
           "contract": "Jun 30, 2027",
@@ -6445,7 +8157,11 @@
             "Scotland"
           ],
           "number": "55",
-          "position": "Attacking Midfield"
+          "overall_score": 71,
+          "position": "Attacking Midfield",
+          "potential": 78,
+          "value": 3800000,
+          "yearly_wage": 1664000
         },
         {
           "contract": "Jun 30, 2029",
@@ -6459,7 +8175,11 @@
             "Senegal"
           ],
           "number": "7",
-          "position": "Right Winger"
+          "overall_score": 81,
+          "position": "Right Winger",
+          "potential": 81,
+          "value": 27500000,
+          "yearly_wage": 5200000
         },
         {
           "contract": "Jun 30, 2030",
@@ -6473,7 +8193,11 @@
             "Spain"
           ],
           "number": "10",
-          "position": "Right Winger"
+          "overall_score": 79,
+          "position": "Right Winger",
+          "potential": 86,
+          "value": 35500000,
+          "yearly_wage": 4056000
         },
         {
           "contract": "Jun 30, 2030",
@@ -6488,7 +8212,11 @@
             "England"
           ],
           "number": "11",
-          "position": "Right Winger"
+          "overall_score": 79,
+          "position": "Right Winger",
+          "potential": 82,
+          "value": 24000000,
+          "yearly_wage": 4056000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6503,7 +8231,11 @@
             "France"
           ],
           "number": "29",
-          "position": "Right Winger"
+          "overall_score": 78,
+          "position": "Right Winger",
+          "potential": 83,
+          "value": 21000000,
+          "yearly_wage": 4524000
         },
         {
           "contract": "Jun 30, 2027",
@@ -6518,7 +8250,11 @@
             "DR Congo"
           ],
           "number": "14",
-          "position": "Centre-Forward"
+          "overall_score": 82,
+          "position": "Centre-Forward",
+          "potential": 82,
+          "value": 31000000,
+          "yearly_wage": 5980000
         },
         {
           "contract": "Jun 30, 2030",
@@ -6532,7 +8268,11 @@
             "Norway"
           ],
           "number": "22",
-          "position": "Centre-Forward"
+          "overall_score": 77,
+          "position": "Centre-Forward",
+          "potential": 80,
+          "value": 14000000,
+          "yearly_wage": 3848000
         },
         {
           "contract": "Jun 30, 2029",
@@ -6547,7 +8287,11 @@
             "Ghana"
           ],
           "number": "9",
-          "position": "Centre-Forward"
+          "overall_score": 75,
+          "position": "Centre-Forward",
+          "potential": 76,
+          "value": 6500000,
+          "yearly_wage": 3588000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6561,7 +8305,11 @@
             "Nigeria"
           ],
           "number": "12",
-          "position": "Centre-Forward"
+          "overall_score": 76,
+          "position": "Centre-Forward",
+          "potential": 82,
+          "value": 12000000,
+          "yearly_wage": 1508000
         }
       ],
       "stadiumName": "Selhurst Park",
@@ -6584,7 +8332,11 @@
             "Germany"
           ],
           "number": "13",
-          "position": "Goalkeeper"
+          "overall_score": 69,
+          "position": "Goalkeeper",
+          "potential": 80,
+          "value": 2700000,
+          "yearly_wage": 468000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6598,7 +8350,11 @@
             "Slovakia"
           ],
           "number": "1",
-          "position": "Goalkeeper"
+          "overall_score": 78,
+          "position": "Goalkeeper",
+          "potential": 78,
+          "value": 1600000,
+          "yearly_wage": 1196000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6612,7 +8368,11 @@
             "Czech Republic"
           ],
           "number": "32",
-          "position": "Goalkeeper"
+          "overall_score": 68,
+          "position": "Goalkeeper",
+          "potential": 68,
+          "value": 210000,
+          "yearly_wage": 832000
         },
         {
           "contract": "Jun 30, 2030",
@@ -6626,7 +8386,11 @@
             "France"
           ],
           "number": "5",
-          "position": "Centre-Back"
+          "overall_score": 76,
+          "position": "Centre-Back",
+          "potential": 82,
+          "value": 11000000,
+          "yearly_wage": 2184000
         },
         {
           "contract": "-",
@@ -6641,7 +8405,11 @@
             "Uganda"
           ],
           "number": "12",
-          "position": "Centre-Back"
+          "overall_score": 74,
+          "position": "Centre-Back",
+          "potential": 82,
+          "value": 9000000,
+          "yearly_wage": 1924000
         },
         {
           "contract": "Jun 30, 2027",
@@ -6655,7 +8423,11 @@
             "Sweden"
           ],
           "number": "18",
-          "position": "Centre-Back"
+          "overall_score": 71,
+          "position": "Centre-Back",
+          "potential": 73,
+          "value": 2000000,
+          "yearly_wage": 1664000
         },
         {
           "contract": "-",
@@ -6670,7 +8442,11 @@
             "England"
           ],
           "number": "6",
-          "position": "Centre-Back"
+          "overall_score": 73,
+          "position": "Centre-Back",
+          "potential": 73,
+          "value": 2800000,
+          "yearly_wage": 2028000
         },
         {
           "contract": "Jun 30, 2028",
@@ -6684,7 +8460,11 @@
             "England"
           ],
           "number": "4",
-          "position": "Centre-Back"
+          "overall_score": 73,
+          "position": "Centre-Back",
+          "potential": 73,
+          "value": 2600000,
+          "yearly_wage": 2132000
         },
         {
           "contract": "Jun 30, 2027",
@@ -6698,7 +8478,11 @@
             "Germany"
           ],
           "number": "36",
-          "position": "Centre-Back"
+          "overall_score": 73,
+          "position": "Centre-Back",
+          "potential": 75,
+          "value": 3400000,
+          "yearly_wage": 1924000
         },
         {
           "contract": "Jun 30, 2029",
@@ -6713,7 +8497,11 @@
             "Curacao"
           ],
           "number": "3",
-          "position": "Left-Back"
+          "overall_score": 76,
+          "position": "Left-Back",
+          "potential": 80,
+          "value": 10000000,
+          "yearly_wage": 2184000
         },
         {
           "contract": "Jun 30, 2028",
@@ -6727,7 +8515,11 @@
             "Brazil"
           ],
           "number": "23",
-          "position": "Left-Back"
+          "overall_score": 74,
+          "position": "Left-Back",
+          "potential": 78,
+          "value": 5500000,
+          "yearly_wage": 1924000
         },
         {
           "contract": "Jun 30, 2027",
@@ -6741,7 +8533,11 @@
             "Wales"
           ],
           "number": "14",
-          "position": "Right-Back"
+          "overall_score": 74,
+          "position": "Right-Back",
+          "potential": 74,
+          "value": 3700000,
+          "yearly_wage": 2340000
         },
         {
           "contract": "Jun 30, 2027",
@@ -6755,7 +8551,11 @@
             "England"
           ],
           "number": "2",
-          "position": "Right-Back"
+          "overall_score": 77,
+          "position": "Right-Back",
+          "potential": 77,
+          "value": 3200000,
+          "yearly_wage": 2080000
         },
         {
           "contract": "Jun 30, 2030",
@@ -6770,7 +8570,11 @@
             "Nigeria"
           ],
           "number": "8",
-          "position": "Defensive Midfield"
+          "overall_score": 76,
+          "position": "Defensive Midfield",
+          "potential": 82,
+          "value": 11000000,
+          "yearly_wage": 1872000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6785,7 +8589,11 @@
             "Angola"
           ],
           "number": "16",
-          "position": "Defensive Midfield"
+          "overall_score": 77,
+          "position": "Defensive Midfield",
+          "potential": 78,
+          "value": 11000000,
+          "yearly_wage": 936000
         },
         {
           "contract": "Jun 30, 2027",
@@ -6800,7 +8608,11 @@
             "England"
           ],
           "number": "24",
-          "position": "Central Midfield"
+          "overall_score": 77,
+          "position": "Central Midfield",
+          "potential": 77,
+          "value": 9000000,
+          "yearly_wage": 2860000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6814,7 +8626,11 @@
             "England"
           ],
           "number": "20",
-          "position": "Central Midfield"
+          "overall_score": 74,
+          "position": "Central Midfield",
+          "potential": 74,
+          "value": 4000000,
+          "yearly_wage": 2704000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6828,7 +8644,11 @@
             "England"
           ],
           "number": "29",
-          "position": "Central Midfield"
+          "overall_score": 73,
+          "position": "Central Midfield",
+          "potential": 73,
+          "value": 2500000,
+          "yearly_wage": 2132000
         },
         {
           "contract": "Jun 30, 2028",
@@ -6843,7 +8663,11 @@
             "France"
           ],
           "number": "28",
-          "position": "Attacking Midfield"
+          "overall_score": 75,
+          "position": "Attacking Midfield",
+          "potential": 82,
+          "value": 11500000,
+          "yearly_wage": 2184000
         },
         {
           "contract": "Jun 30, 2028",
@@ -6857,7 +8681,11 @@
             "Belgium"
           ],
           "number": "31",
-          "position": "Attacking Midfield"
+          "overall_score": 73,
+          "position": "Attacking Midfield",
+          "potential": 73,
+          "value": 3300000,
+          "yearly_wage": 2132000
         },
         {
           "contract": "Jun 30, 2029",
@@ -6872,7 +8700,11 @@
             "Jamaica"
           ],
           "number": "11",
-          "position": "Left Winger"
+          "overall_score": 76,
+          "position": "Left Winger",
+          "potential": 77,
+          "value": 9000000,
+          "yearly_wage": 2548000
         },
         {
           "contract": "Jun 30, 2029",
@@ -6886,7 +8718,11 @@
             "Denmark"
           ],
           "number": "7",
-          "position": "Left Winger"
+          "overall_score": 73,
+          "position": "Left Winger",
+          "potential": 73,
+          "value": 3300000,
+          "yearly_wage": 2132000
         },
         {
           "contract": "Jun 30, 2030",
@@ -6901,7 +8737,11 @@
             "Chad"
           ],
           "number": "17",
-          "position": "Right Winger"
+          "overall_score": 72,
+          "position": "Right Winger",
+          "potential": 78,
+          "value": 3800000,
+          "yearly_wage": 1404000
         },
         {
           "contract": "Jun 30, 2029",
@@ -6916,7 +8756,11 @@
             "Cyprus"
           ],
           "number": "10",
-          "position": "Right Winger"
+          "overall_score": 75,
+          "position": "Right Winger",
+          "potential": 75,
+          "value": 6000000,
+          "yearly_wage": 2548000
         },
         {
           "contract": "Jun 30, 2028",
@@ -6930,7 +8774,11 @@
             "South Africa"
           ],
           "number": "9",
-          "position": "Centre-Forward"
+          "overall_score": 73,
+          "position": "Centre-Forward",
+          "potential": 75,
+          "value": 4000000,
+          "yearly_wage": 2028000
         },
         {
           "contract": "Jun 30, 2029",
@@ -6944,7 +8792,11 @@
             "Netherlands"
           ],
           "number": "19",
-          "position": "Centre-Forward"
+          "overall_score": 75,
+          "position": "Centre-Forward",
+          "potential": 76,
+          "value": 6500000,
+          "yearly_wage": 2756000
         },
         {
           "contract": "Jun 30, 2030",
@@ -6959,7 +8811,11 @@
             "England"
           ],
           "number": "27",
-          "position": "Centre-Forward"
+          "overall_score": 72,
+          "position": "Centre-Forward",
+          "potential": 76,
+          "value": 3400000,
+          "yearly_wage": 1820000
         },
         {
           "contract": "Jun 30, 2028",
@@ -6974,7 +8830,11 @@
             "Tunisia"
           ],
           "number": "25",
-          "position": "Centre-Forward"
+          "overall_score": 74,
+          "position": "Centre-Forward",
+          "potential": 78,
+          "value": 6000000,
+          "yearly_wage": 2236000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6988,7 +8848,11 @@
             "England"
           ],
           "number": "35",
-          "position": "Centre-Forward"
+          "overall_score": 70,
+          "position": "Centre-Forward",
+          "potential": 70,
+          "value": 675000,
+          "yearly_wage": 1352000
         }
       ],
       "stadiumName": "Turf Moor",
@@ -7011,7 +8875,11 @@
             "Ireland"
           ],
           "number": "1",
-          "position": "Goalkeeper"
+          "overall_score": 79,
+          "position": "Goalkeeper",
+          "potential": 82,
+          "value": 17500000,
+          "yearly_wage": 2392000
         },
         {
           "contract": "Jun 30, 2028",
@@ -7025,7 +8893,11 @@
             "Iceland"
           ],
           "number": "12",
-          "position": "Goalkeeper"
+          "overall_score": 69,
+          "position": "Goalkeeper",
+          "potential": 77,
+          "value": 2700000,
+          "yearly_wage": 780000
         },
         {
           "contract": "Jun 30, 2027",
@@ -7040,7 +8912,11 @@
             "St. Vincent & Grenadinen"
           ],
           "number": "31",
-          "position": "Goalkeeper"
+          "overall_score": 63,
+          "position": "Goalkeeper",
+          "potential": 67,
+          "value": 525000,
+          "yearly_wage": 416000
         },
         {
           "contract": "Jun 30, 2031",
@@ -7053,7 +8929,11 @@
             "United States"
           ],
           "number": "41",
-          "position": "Goalkeeper"
+          "overall_score": 58,
+          "position": "Goalkeeper",
+          "potential": 75,
+          "value": 475000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2029",
@@ -7067,7 +8947,11 @@
             "Ireland"
           ],
           "number": "22",
-          "position": "Centre-Back"
+          "overall_score": 79,
+          "position": "Centre-Back",
+          "potential": 82,
+          "value": 21500000,
+          "yearly_wage": 3224000
         },
         {
           "contract": "Jun 30, 2029",
@@ -7081,7 +8965,11 @@
             "Netherlands"
           ],
           "number": "4",
-          "position": "Centre-Back"
+          "overall_score": 77,
+          "position": "Centre-Back",
+          "potential": 83,
+          "value": 15000000,
+          "yearly_wage": 2756000
         },
         {
           "contract": "Jun 30, 2030",
@@ -7095,7 +8983,11 @@
             "Norway"
           ],
           "number": "20",
-          "position": "Centre-Back"
+          "overall_score": 76,
+          "position": "Centre-Back",
+          "potential": 77,
+          "value": 7500000,
+          "yearly_wage": 2964000
         },
         {
           "contract": "Jun 30, 2027",
@@ -7110,7 +9002,11 @@
             "England"
           ],
           "number": "5",
-          "position": "Centre-Back"
+          "overall_score": 75,
+          "position": "Centre-Back",
+          "potential": 75,
+          "value": 3600000,
+          "yearly_wage": 2964000
         },
         {
           "contract": "Jun 30, 2026",
@@ -7125,7 +9021,11 @@
             "England"
           ],
           "number": "3",
-          "position": "Left-Back"
+          "overall_score": 76,
+          "position": "Left-Back",
+          "potential": 76,
+          "value": 7000000,
+          "yearly_wage": 2964000
         },
         {
           "contract": "Jun 30, 2030",
@@ -7140,7 +9040,11 @@
             "Nigeria"
           ],
           "number": "33",
-          "position": "Right-Back"
+          "overall_score": 80,
+          "position": "Right-Back",
+          "potential": 85,
+          "value": 29000000,
+          "yearly_wage": 2860000
         },
         {
           "contract": "Jun 30, 2028",
@@ -7154,7 +9058,11 @@
             "Scotland"
           ],
           "number": "2",
-          "position": "Right-Back"
+          "overall_score": 75,
+          "position": "Right-Back",
+          "potential": 79,
+          "value": 7500000,
+          "yearly_wage": 2444000
         },
         {
           "contract": "Jun 30, 2030",
@@ -7169,7 +9077,11 @@
             "Bosnia-Herzegovina"
           ],
           "number": "27",
-          "position": "Defensive Midfield"
+          "overall_score": 77,
+          "position": "Defensive Midfield",
+          "potential": 78,
+          "value": 11000000,
+          "yearly_wage": 3172000
         },
         {
           "contract": "Jun 30, 2027",
@@ -7183,7 +9095,11 @@
             "England"
           ],
           "number": "6",
-          "position": "Defensive Midfield"
+          "overall_score": 79,
+          "position": "Defensive Midfield",
+          "potential": 79,
+          "value": 4900000,
+          "yearly_wage": 2912000
         },
         {
           "contract": "Jun 30, 2031",
@@ -7211,7 +9127,11 @@
             "Denmark"
           ],
           "number": "8",
-          "position": "Central Midfield"
+          "overall_score": 79,
+          "position": "Central Midfield",
+          "potential": 79,
+          "value": 17000000,
+          "yearly_wage": 4108000
         },
         {
           "contract": "Jun 30, 2026",
@@ -7226,7 +9146,11 @@
             "Angola"
           ],
           "number": "10",
-          "position": "Central Midfield"
+          "overall_score": 72,
+          "position": "Central Midfield",
+          "potential": 73,
+          "value": 2700000,
+          "yearly_wage": 2236000
         },
         {
           "contract": "Jun 30, 2031",
@@ -7240,7 +9164,11 @@
             "England"
           ],
           "number": "23",
-          "position": "Left Midfield"
+          "overall_score": 76,
+          "position": "Left Midfield",
+          "potential": 79,
+          "value": 9500000,
+          "yearly_wage": 2548000
         },
         {
           "contract": "Jun 30, 2030",
@@ -7254,7 +9182,11 @@
             "Denmark"
           ],
           "number": "24",
-          "position": "Attacking Midfield"
+          "overall_score": 80,
+          "position": "Attacking Midfield",
+          "potential": 83,
+          "value": 29000000,
+          "yearly_wage": 3692000
         },
         {
           "contract": "Jun 30, 2030",
@@ -7269,7 +9201,11 @@
             "DR Congo"
           ],
           "number": "17",
-          "position": "Attacking Midfield"
+          "overall_score": 73,
+          "position": "Attacking Midfield",
+          "potential": 85,
+          "value": 7500000,
+          "yearly_wage": 1820000
         },
         {
           "contract": "Jun 30, 2029",
@@ -7283,7 +9219,11 @@
             "Portugal"
           ],
           "number": "14",
-          "position": "Attacking Midfield"
+          "overall_score": 74,
+          "position": "Attacking Midfield",
+          "potential": 81,
+          "value": 8500000,
+          "yearly_wage": 2444000
         },
         {
           "contract": "Jun 30, 2028",
@@ -7298,7 +9238,11 @@
             "Nigeria"
           ],
           "number": "7",
-          "position": "Left Winger"
+          "overall_score": 79,
+          "position": "Left Winger",
+          "potential": 83,
+          "value": 25000000,
+          "yearly_wage": 3432000
         },
         {
           "contract": "Jun 30, 2026",
@@ -7313,7 +9257,11 @@
             "Jamaica"
           ],
           "number": "11",
-          "position": "Left Winger"
+          "overall_score": 75,
+          "position": "Left Winger",
+          "potential": 76,
+          "value": 6500000,
+          "yearly_wage": 4368000
         },
         {
           "contract": "Jun 30, 2030",
@@ -7327,7 +9275,11 @@
             "Burkina Faso"
           ],
           "number": "19",
-          "position": "Right Winger"
+          "overall_score": 78,
+          "position": "Right Winger",
+          "potential": 82,
+          "value": 20000000,
+          "yearly_wage": 3068000
         },
         {
           "contract": "Jun 30, 2030",
@@ -7342,7 +9294,11 @@
             "St. Kitts & Nevis"
           ],
           "number": "45",
-          "position": "Right Winger"
+          "overall_score": 66,
+          "position": "Right Winger",
+          "potential": 79,
+          "value": 2000000,
+          "yearly_wage": 728000
         },
         {
           "contract": "Jun 30, 2029",
@@ -7357,7 +9313,11 @@
             "Bulgaria"
           ],
           "number": "9",
-          "position": "Centre-Forward"
+          "overall_score": 81,
+          "position": "Centre-Forward",
+          "potential": 85,
+          "value": 37500000,
+          "yearly_wage": 4264000
         },
         {
           "contract": "Jun 30, 2031",
@@ -7371,7 +9331,11 @@
             "Belgium"
           ],
           "number": "47",
-          "position": "Centre-Forward"
+          "overall_score": 63,
+          "position": "Centre-Forward",
+          "potential": 83,
+          "value": 1300000,
+          "yearly_wage": 572000
         }
       ],
       "stadiumName": "Gtech Community Stadium",
@@ -7408,7 +9372,11 @@
             "Greece"
           ],
           "number": "29",
-          "position": "Goalkeeper"
+          "overall_score": 74,
+          "position": "Goalkeeper",
+          "potential": 80,
+          "value": 5500000,
+          "yearly_wage": 676000
         },
         {
           "contract": "Jun 30, 2026",
@@ -7422,7 +9390,11 @@
             "England"
           ],
           "number": "17",
-          "position": "Goalkeeper"
+          "overall_score": 72,
+          "position": "Goalkeeper",
+          "potential": 72,
+          "value": 250000,
+          "yearly_wage": 884000
         },
         {
           "contract": "-",
@@ -7437,7 +9409,11 @@
             "Guinea"
           ],
           "number": "18",
-          "position": "Centre-Back"
+          "overall_score": 79,
+          "position": "Centre-Back",
+          "potential": 84,
+          "value": 24000000,
+          "yearly_wage": 3224000
         },
         {
           "contract": "Jun 30, 2026",
@@ -7452,7 +9428,11 @@
             "Italy"
           ],
           "number": "5",
-          "position": "Centre-Back"
+          "overall_score": 81,
+          "position": "Centre-Back",
+          "potential": 81,
+          "value": 22000000,
+          "yearly_wage": 4420000
         },
         {
           "contract": "Jun 30, 2030",
@@ -7466,7 +9446,11 @@
             "Serbia"
           ],
           "number": "44",
-          "position": "Centre-Back"
+          "overall_score": 71,
+          "position": "Centre-Back",
+          "potential": 84,
+          "value": 4100000,
+          "yearly_wage": 1248000
         },
         {
           "contract": "Jun 30, 2029",
@@ -7480,7 +9464,11 @@
             "England"
           ],
           "number": "23",
-          "position": "Centre-Back"
+          "overall_score": 75,
+          "position": "Centre-Back",
+          "potential": 79,
+          "value": 7000000,
+          "yearly_wage": 2444000
         },
         {
           "contract": "Jun 30, 2026",
@@ -7495,7 +9483,11 @@
             "Nigeria"
           ],
           "number": "45",
-          "position": "Centre-Back"
+          "overall_score": 57,
+          "position": "Centre-Back",
+          "potential": 75,
+          "value": 400000,
+          "yearly_wage": 312000
         },
         {
           "contract": "Jun 30, 2030",
@@ -7509,7 +9501,11 @@
             "France"
           ],
           "number": "3",
-          "position": "Left-Back"
+          "overall_score": 79,
+          "position": "Left-Back",
+          "potential": 83,
+          "value": 23500000,
+          "yearly_wage": 3224000
         },
         {
           "contract": "Jun 30, 2029",
@@ -7524,7 +9520,11 @@
             "Paraguay"
           ],
           "number": "6",
-          "position": "Left-Back"
+          "overall_score": 68,
+          "position": "Left-Back",
+          "potential": 79,
+          "value": 2500000,
+          "yearly_wage": 988000
         },
         {
           "contract": "Jun 30, 2026",
@@ -7538,7 +9538,11 @@
             "Spain"
           ],
           "number": "20",
-          "position": "Right-Back"
+          "overall_score": 77,
+          "position": "Right-Back",
+          "potential": 84,
+          "value": 20000000,
+          "yearly_wage": 2340000
         },
         {
           "contract": "Jun 30, 2026",
@@ -7552,7 +9556,11 @@
             "England"
           ],
           "number": "15",
-          "position": "Right-Back"
+          "overall_score": 73,
+          "position": "Right-Back",
+          "potential": 73,
+          "value": 1100000,
+          "yearly_wage": 2496000
         },
         {
           "contract": "Jun 30, 2028",
@@ -7566,7 +9574,11 @@
             "United States"
           ],
           "number": "12",
-          "position": "Defensive Midfield"
+          "overall_score": 79,
+          "position": "Defensive Midfield",
+          "potential": 81,
+          "value": 19500000,
+          "yearly_wage": 3744000
         },
         {
           "contract": "Jun 30, 2028",
@@ -7581,7 +9593,11 @@
             "Guernsey"
           ],
           "number": "8",
-          "position": "Central Midfield"
+          "overall_score": 80,
+          "position": "Central Midfield",
+          "potential": 86,
+          "value": 31000000,
+          "yearly_wage": 2860000
         },
         {
           "contract": "Jun 30, 2028",
@@ -7595,7 +9611,11 @@
             "England"
           ],
           "number": "4",
-          "position": "Central Midfield"
+          "overall_score": 78,
+          "position": "Central Midfield",
+          "potential": 78,
+          "value": 12500000,
+          "yearly_wage": 3536000
         },
         {
           "contract": "Jun 30, 2027",
@@ -7609,7 +9629,11 @@
             "Scotland"
           ],
           "number": "10",
-          "position": "Central Midfield"
+          "overall_score": 78,
+          "position": "Central Midfield",
+          "potential": 78,
+          "value": 12000000,
+          "yearly_wage": 3536000
         },
         {
           "contract": "Jun 30, 2031",
@@ -7623,7 +9647,11 @@
             "Hungary"
           ],
           "number": "27",
-          "position": "Central Midfield"
+          "overall_score": 72,
+          "position": "Central Midfield",
+          "potential": 85,
+          "value": 5500000,
+          "yearly_wage": 1560000
         },
         {
           "contract": "Jun 30, 2028",
@@ -7638,7 +9666,11 @@
             "Suriname"
           ],
           "number": "19",
-          "position": "Attacking Midfield"
+          "overall_score": 79,
+          "position": "Attacking Midfield",
+          "potential": 80,
+          "value": 20500000,
+          "yearly_wage": 4004000
         },
         {
           "contract": "Jun 30, 2029",
@@ -7652,7 +9684,11 @@
             "England"
           ],
           "number": "16",
-          "position": "Attacking Midfield"
+          "overall_score": 78,
+          "position": "Attacking Midfield",
+          "potential": 78,
+          "value": 15500000,
+          "yearly_wage": 3536000
         },
         {
           "contract": "Jun 30, 2030",
@@ -7667,7 +9703,11 @@
             "France"
           ],
           "number": "21",
-          "position": "Left Winger"
+          "overall_score": 77,
+          "position": "Left Winger",
+          "potential": 80,
+          "value": 14000000,
+          "yearly_wage": 3484000
         },
         {
           "contract": "Jun 30, 2030",
@@ -7681,7 +9721,11 @@
             "Scotland"
           ],
           "number": "11",
-          "position": "Right Winger"
+          "overall_score": 71,
+          "position": "Right Winger",
+          "potential": 84,
+          "value": 4400000,
+          "yearly_wage": 1404000
         },
         {
           "contract": "Jun 30, 2029",
@@ -7696,7 +9740,11 @@
             "England"
           ],
           "number": "7",
-          "position": "Right Winger"
+          "overall_score": 76,
+          "position": "Right Winger",
+          "potential": 76,
+          "value": 8000000,
+          "yearly_wage": 3120000
         },
         {
           "contract": "Jun 30, 2029",
@@ -7710,7 +9758,11 @@
             "Brazil"
           ],
           "number": "9",
-          "position": "Centre-Forward"
+          "overall_score": 79,
+          "position": "Centre-Forward",
+          "potential": 80,
+          "value": 21500000,
+          "yearly_wage": 4108000
         },
         {
           "contract": "Jun 30, 2031",
@@ -7724,7 +9776,11 @@
             "Brazil"
           ],
           "number": "37",
-          "position": "Centre-Forward"
+          "overall_score": 78,
+          "position": "Centre-Forward",
+          "potential": 88,
+          "value": 29500000,
+          "yearly_wage": 2340000
         },
         {
           "contract": "Jun 30, 2030",
@@ -7739,7 +9795,11 @@
             "Cote d'Ivoire"
           ],
           "number": "22",
-          "position": "Centre-Forward"
+          "overall_score": 78,
+          "position": "Centre-Forward",
+          "potential": 86,
+          "value": 30500000,
+          "yearly_wage": 2756000
         },
         {
           "contract": "Jun 30, 2028",
@@ -7753,7 +9813,11 @@
             "Türkiye"
           ],
           "number": "26",
-          "position": "Centre-Forward"
+          "overall_score": 76,
+          "position": "Centre-Forward",
+          "potential": 76,
+          "value": 7500000,
+          "yearly_wage": 3536000
         }
       ],
       "stadiumName": "Vitality Stadium",

--- a/data/2025/ESP1/sofifa.json
+++ b/data/2025/ESP1/sofifa.json
@@ -1,0 +1,6468 @@
+{
+  "league": "Spain La Liga",
+  "scraped_at": "2026-06-12T09:27:53.177Z",
+  "team_count": 20,
+  "teams": [
+    {
+      "player_count": 37,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Joan García Pons",
+          "name": "Joan García",
+          "overall_score": 86,
+          "potential": 89,
+          "value": 72500000,
+          "yearly_wage": 3692000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jules Koundé",
+          "name": "J. Koundé",
+          "overall_score": 86,
+          "potential": 87,
+          "value": 73000000,
+          "yearly_wage": 7280000
+        },
+        {
+          "currency": "€",
+          "full_name": "Pau Cubarsí Paredes",
+          "name": "Pau Cubarsí",
+          "overall_score": 83,
+          "potential": 89,
+          "value": 48000000,
+          "yearly_wage": 3640000
+        },
+        {
+          "currency": "€",
+          "full_name": "Eric García Martret",
+          "name": "Eric García",
+          "overall_score": 83,
+          "potential": 86,
+          "value": 44500000,
+          "yearly_wage": 4940000
+        },
+        {
+          "currency": "€",
+          "full_name": "João Pedro Cavaco Cancelo",
+          "name": "João Cancelo",
+          "overall_score": 84,
+          "potential": 84,
+          "value": 30500000,
+          "yearly_wage": 3536000
+        },
+        {
+          "currency": "€",
+          "full_name": "Frenkie de Jong",
+          "name": "F. de Jong",
+          "overall_score": 87,
+          "potential": 87,
+          "value": 79500000,
+          "yearly_wage": 8840000
+        },
+        {
+          "currency": "€",
+          "full_name": "Pedro González López",
+          "name": "Pedri",
+          "overall_score": 90,
+          "potential": 93,
+          "value": 165000000,
+          "yearly_wage": 9360000
+        },
+        {
+          "currency": "€",
+          "full_name": "Fermín López Marín",
+          "name": "Fermín",
+          "overall_score": 83,
+          "potential": 87,
+          "value": 53000000,
+          "yearly_wage": 5200000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lamine Yamal Nasraoui Ebana",
+          "name": "Lamine Yamal",
+          "overall_score": 89,
+          "potential": 95,
+          "value": 147000000,
+          "yearly_wage": 5980000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ferran Torres García",
+          "name": "Ferran Torres",
+          "overall_score": 84,
+          "potential": 86,
+          "value": 53500000,
+          "yearly_wage": 6760000
+        },
+        {
+          "currency": "€",
+          "full_name": "Raphael Dias Belloli",
+          "name": "Raphinha",
+          "overall_score": 89,
+          "potential": 89,
+          "value": 104000000,
+          "yearly_wage": 11440000
+        },
+        {
+          "currency": "€",
+          "full_name": "Robert Lewandowski",
+          "name": "R. Lewandowski",
+          "overall_score": 86,
+          "potential": 86,
+          "value": 23000000,
+          "yearly_wage": 6760000
+        },
+        {
+          "currency": "€",
+          "full_name": "Marcus Rashford",
+          "name": "M. Rashford",
+          "overall_score": 82,
+          "potential": 82,
+          "value": 32500000,
+          "yearly_wage": 5720000
+        },
+        {
+          "currency": "€",
+          "full_name": "Daniel Olmo Carvajal",
+          "name": "Dani Olmo",
+          "overall_score": 84,
+          "potential": 84,
+          "value": 45000000,
+          "yearly_wage": 6760000
+        },
+        {
+          "currency": "€",
+          "full_name": "Pablo Martín Páez Gavira",
+          "name": "Gavi",
+          "overall_score": 83,
+          "potential": 87,
+          "value": 51000000,
+          "yearly_wage": 4420000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alejandro Balde Martínez",
+          "name": "Balde",
+          "overall_score": 83,
+          "potential": 87,
+          "value": 49500000,
+          "yearly_wage": 4160000
+        },
+        {
+          "currency": "€",
+          "full_name": "Gerard Martín Langreo",
+          "name": "Gerard Martín",
+          "overall_score": 78,
+          "potential": 82,
+          "value": 18000000,
+          "yearly_wage": 3328000
+        },
+        {
+          "currency": "€",
+          "full_name": "Wojciech Szczęsny",
+          "name": "W. Szczęsny",
+          "overall_score": 83,
+          "potential": 83,
+          "value": 4000000,
+          "yearly_wage": 2340000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ronald Araujo",
+          "name": "R. Araujo",
+          "overall_score": 81,
+          "potential": 84,
+          "value": 30000000,
+          "yearly_wage": 4680000
+        },
+        {
+          "currency": "€",
+          "full_name": "Roony Bardghji",
+          "name": "R. Bardghji",
+          "overall_score": 74,
+          "potential": 85,
+          "value": 9000000,
+          "yearly_wage": 2392000
+        },
+        {
+          "currency": "€",
+          "full_name": "Marc Casadó Torras",
+          "name": "Marc Casadó",
+          "overall_score": 78,
+          "potential": 82,
+          "value": 18500000,
+          "yearly_wage": 2808000
+        },
+        {
+          "currency": "€",
+          "full_name": "Marc Bernal Casas",
+          "name": "Marc Bernal",
+          "overall_score": 75,
+          "potential": 86,
+          "value": 11000000,
+          "yearly_wage": 2028000
+        },
+        {
+          "currency": "€",
+          "full_name": "Andreas Christensen",
+          "name": "A. Christensen",
+          "overall_score": 80,
+          "potential": 80,
+          "value": 17500000,
+          "yearly_wage": 4680000
+        },
+        {
+          "currency": "€",
+          "full_name": "Guillermo Fernández Casino",
+          "name": "Guille Fernández",
+          "overall_score": 60,
+          "potential": 80,
+          "value": 675000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Diego Kochen",
+          "name": "D. Kochen",
+          "overall_score": 62,
+          "potential": 79,
+          "value": 900000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Tomás Noël Marqués Morera",
+          "name": "Tommy Marqués",
+          "overall_score": 61,
+          "potential": 78,
+          "value": 800000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jofre Torrents Salvat",
+          "name": "Jofre Torrents",
+          "overall_score": 61,
+          "potential": 79,
+          "value": 800000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "Xavi Espart Font",
+          "name": "Xavi Espart",
+          "overall_score": 63,
+          "potential": 81,
+          "value": 1200000,
+          "yearly_wage": 520000
+        },
+        {
+          "currency": "€",
+          "full_name": "Antonio Fernández Casino",
+          "name": "Toni Fernández",
+          "overall_score": 64,
+          "potential": 83,
+          "value": 1500000,
+          "yearly_wage": 572000
+        },
+        {
+          "currency": "€",
+          "full_name": "Álvaro Cortés Moyano",
+          "name": "Álvaro Cortés",
+          "overall_score": 66,
+          "potential": 79,
+          "value": 1900000,
+          "yearly_wage": 832000
+        },
+        {
+          "currency": "€",
+          "full_name": "Héctor Fort García",
+          "name": "Héctor Fort",
+          "overall_score": 71,
+          "potential": 83,
+          "value": 4200000,
+          "yearly_wage": 1404000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ander Astralaga Aranguren",
+          "name": "Astralaga",
+          "overall_score": 64,
+          "potential": 76,
+          "value": 1300000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Áron Yaakobishvili",
+          "name": "Á. Yaakobishvili",
+          "overall_score": 70,
+          "potential": 82,
+          "value": 3300000,
+          "yearly_wage": 624000
+        },
+        {
+          "currency": "€",
+          "full_name": "Anssumane Fati",
+          "name": "Ansu Fati",
+          "overall_score": 75,
+          "potential": 81,
+          "value": 9000000,
+          "yearly_wage": 2912000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ignacio Peña Sotorres",
+          "name": "Iñaki Peña",
+          "overall_score": 76,
+          "potential": 80,
+          "value": 8000000,
+          "yearly_wage": 2132000
+        },
+        {
+          "currency": "€",
+          "full_name": "Marc-André ter Stegen",
+          "name": "M. ter Stegen",
+          "overall_score": 84,
+          "potential": 84,
+          "value": 13500000,
+          "yearly_wage": 4264000
+        },
+        {
+          "currency": "€",
+          "full_name": "Andrés Cuenca Cejudo",
+          "name": "Andrés Cuenca",
+          "overall_score": 61,
+          "potential": 82,
+          "value": 1000000,
+          "yearly_wage": 416000
+        }
+      ],
+      "team": "FC Barcelona",
+      "transfer_budget": 77500000,
+      "url": "https://sofifa.com/team/241/fc-barcelona/260037/"
+    },
+    {
+      "player_count": 38,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Thibaut Courtois",
+          "name": "T. Courtois",
+          "overall_score": 90,
+          "potential": 90,
+          "value": 39000000,
+          "yearly_wage": 12480000
+        },
+        {
+          "currency": "€",
+          "full_name": "Trent Alexander-Arnold",
+          "name": "T. Alexander-Arnold",
+          "overall_score": 85,
+          "potential": 86,
+          "value": 58000000,
+          "yearly_wage": 11960000
+        },
+        {
+          "currency": "€",
+          "full_name": "Antonio Rüdiger",
+          "name": "A. Rüdiger",
+          "overall_score": 84,
+          "potential": 84,
+          "value": 27500000,
+          "yearly_wage": 11440000
+        },
+        {
+          "currency": "€",
+          "full_name": "Dean Huijsen",
+          "name": "D. Huijsen",
+          "overall_score": 81,
+          "potential": 88,
+          "value": 47500000,
+          "yearly_wage": 6240000
+        },
+        {
+          "currency": "€",
+          "full_name": "Álvaro Fernández Carreras",
+          "name": "Álvaro Carreras",
+          "overall_score": 81,
+          "potential": 87,
+          "value": 38500000,
+          "yearly_wage": 7280000
+        },
+        {
+          "currency": "€",
+          "full_name": "Aurélien Tchouaméni",
+          "name": "A. Tchouaméni",
+          "overall_score": 84,
+          "potential": 87,
+          "value": 50500000,
+          "yearly_wage": 10400000
+        },
+        {
+          "currency": "€",
+          "full_name": "Federico Valverde",
+          "name": "F. Valverde",
+          "overall_score": 89,
+          "potential": 90,
+          "value": 120500000,
+          "yearly_wage": 17680000
+        },
+        {
+          "currency": "€",
+          "full_name": "Arda Güler",
+          "name": "A. Güler",
+          "overall_score": 83,
+          "potential": 89,
+          "value": 56500000,
+          "yearly_wage": 7800000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jude Bellingham",
+          "name": "J. Bellingham",
+          "overall_score": 89,
+          "potential": 93,
+          "value": 150500000,
+          "yearly_wage": 15600000
+        },
+        {
+          "currency": "€",
+          "full_name": "Kylian Mbappé",
+          "name": "K. Mbappé",
+          "overall_score": 91,
+          "potential": 92,
+          "value": 157000000,
+          "yearly_wage": 31720000
+        },
+        {
+          "currency": "€",
+          "full_name": "Vinícius José de Oliveira Júnior",
+          "name": "Vini Jr.",
+          "overall_score": 89,
+          "potential": 92,
+          "value": 141000000,
+          "yearly_wage": 16640000
+        },
+        {
+          "currency": "€",
+          "full_name": "Gonzalo García Torres",
+          "name": "Gonzalo",
+          "overall_score": 74,
+          "potential": 84,
+          "value": 9500000,
+          "yearly_wage": 4472000
+        },
+        {
+          "currency": "€",
+          "full_name": "Brahim Díaz",
+          "name": "Brahim",
+          "overall_score": 81,
+          "potential": 82,
+          "value": 31000000,
+          "yearly_wage": 8320000
+        },
+        {
+          "currency": "€",
+          "full_name": "Eduardo Camavinga",
+          "name": "E. Camavinga",
+          "overall_score": 81,
+          "potential": 85,
+          "value": 37500000,
+          "yearly_wage": 7540000
+        },
+        {
+          "currency": "€",
+          "full_name": "Franco Mastantuono",
+          "name": "F. Mastantuono",
+          "overall_score": 77,
+          "potential": 87,
+          "value": 22000000,
+          "yearly_wage": 3432000
+        },
+        {
+          "currency": "€",
+          "full_name": "Daniel Carvajal Ramos",
+          "name": "Carvajal",
+          "overall_score": 84,
+          "potential": 84,
+          "value": 22000000,
+          "yearly_wage": 11440000
+        },
+        {
+          "currency": "€",
+          "full_name": "Raúl Asencio del Rosario",
+          "name": "Asencio",
+          "overall_score": 78,
+          "potential": 83,
+          "value": 19500000,
+          "yearly_wage": 5720000
+        },
+        {
+          "currency": "€",
+          "full_name": "Andriy Lunin",
+          "name": "A. Lunin",
+          "overall_score": 80,
+          "potential": 83,
+          "value": 21000000,
+          "yearly_wage": 4940000
+        },
+        {
+          "currency": "€",
+          "full_name": "Thiago Pitarch Pinar",
+          "name": "Thiago Pitarch",
+          "overall_score": 68,
+          "potential": 85,
+          "value": 3000000,
+          "yearly_wage": 1508000
+        },
+        {
+          "currency": "€",
+          "full_name": "Francisco José García Torres",
+          "name": "Fran García",
+          "overall_score": 77,
+          "potential": 80,
+          "value": 13000000,
+          "yearly_wage": 5980000
+        },
+        {
+          "currency": "€",
+          "full_name": "David Alaba",
+          "name": "D. Alaba",
+          "overall_score": 80,
+          "potential": 80,
+          "value": 10000000,
+          "yearly_wage": 8320000
+        },
+        {
+          "currency": "€",
+          "full_name": "Daniel Ceballos Fernández",
+          "name": "Dani Ceballos",
+          "overall_score": 80,
+          "potential": 80,
+          "value": 21000000,
+          "yearly_wage": 8580000
+        },
+        {
+          "currency": "€",
+          "full_name": "César Palacios Pérez",
+          "name": "César Palacios",
+          "overall_score": 64,
+          "potential": 78,
+          "value": 1400000,
+          "yearly_wage": 1248000
+        },
+        {
+          "currency": "€",
+          "full_name": "Manuel Ángel Morán Ibáñez",
+          "name": "Manuel Ángel",
+          "overall_score": 64,
+          "potential": 75,
+          "value": 1300000,
+          "yearly_wage": 1196000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jorge Cestero Sancho",
+          "name": "Jorge Cestero",
+          "overall_score": 63,
+          "potential": 80,
+          "value": 1200000,
+          "yearly_wage": 1040000
+        },
+        {
+          "currency": "€",
+          "full_name": "Sergio Mestre Sánchez",
+          "name": "Sergio Mestre",
+          "overall_score": 60,
+          "potential": 74,
+          "value": 525000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jesús Fortea Tejedo",
+          "name": "Fortea",
+          "overall_score": 61,
+          "potential": 77,
+          "value": 800000,
+          "yearly_wage": 728000
+        },
+        {
+          "currency": "€",
+          "full_name": "Diego Aguado Facio",
+          "name": "Diego Aguado",
+          "overall_score": 60,
+          "potential": 76,
+          "value": 600000,
+          "yearly_wage": 572000
+        },
+        {
+          "currency": "€",
+          "full_name": "David Jiménez Corredor",
+          "name": "David Jiménez",
+          "overall_score": 63,
+          "potential": 74,
+          "value": 1000000,
+          "yearly_wage": 1040000
+        },
+        {
+          "currency": "€",
+          "full_name": "Víctor Valdepeñas Talavera",
+          "name": "Víctor Valdepeñas",
+          "overall_score": 64,
+          "potential": 81,
+          "value": 1400000,
+          "yearly_wage": 988000
+        },
+        {
+          "currency": "€",
+          "full_name": "Francisco Javie González Pérez",
+          "name": "Fran González",
+          "overall_score": 65,
+          "potential": 82,
+          "value": 1700000,
+          "yearly_wage": 624000
+        },
+        {
+          "currency": "€",
+          "full_name": "Daniel Yáñez Barla",
+          "name": "Daniel Yáñez",
+          "overall_score": 62,
+          "potential": 78,
+          "value": 1000000,
+          "yearly_wage": 988000
+        },
+        {
+          "currency": "€",
+          "full_name": "Álvaro Leiva Alemany",
+          "name": "Álvaro Leiva",
+          "overall_score": 63,
+          "potential": 72,
+          "value": 1100000,
+          "yearly_wage": 1196000
+        },
+        {
+          "currency": "€",
+          "full_name": "Manuel Serrano Salazar",
+          "name": "Manu Serrano",
+          "overall_score": 60,
+          "potential": 71,
+          "value": 525000,
+          "yearly_wage": 676000
+        },
+        {
+          "currency": "€",
+          "full_name": "Rodrygo Silva de Goes",
+          "name": "Rodrygo",
+          "overall_score": 84,
+          "potential": 87,
+          "value": 57500000,
+          "yearly_wage": 10920000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ferland Mendy",
+          "name": "F. Mendy",
+          "overall_score": 81,
+          "potential": 81,
+          "value": 22000000,
+          "yearly_wage": 8840000
+        },
+        {
+          "currency": "€",
+          "full_name": "Éder Gabriel Militão",
+          "name": "Éder Militão",
+          "overall_score": 84,
+          "potential": 86,
+          "value": 45000000,
+          "yearly_wage": 10920000
+        },
+        {
+          "currency": "€",
+          "full_name": "Endrick Felipe Moreira de Sousa",
+          "name": "Endrick",
+          "overall_score": 78,
+          "potential": 89,
+          "value": 30000000,
+          "yearly_wage": 5200000
+        }
+      ],
+      "team": "Real Madrid",
+      "transfer_budget": 146000000,
+      "url": "https://sofifa.com/team/243/real-madrid/260037/"
+    },
+    {
+      "player_count": 42,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Jan Oblak",
+          "name": "J. Oblak",
+          "overall_score": 88,
+          "potential": 88,
+          "value": 45000000,
+          "yearly_wage": 4524000
+        },
+        {
+          "currency": "€",
+          "full_name": "Marcos Llorente Moreno",
+          "name": "Marcos Llorente",
+          "overall_score": 85,
+          "potential": 85,
+          "value": 46500000,
+          "yearly_wage": 5460000
+        },
+        {
+          "currency": "€",
+          "full_name": "Marc Pubill Pagès",
+          "name": "Pubill",
+          "overall_score": 80,
+          "potential": 87,
+          "value": 40000000,
+          "yearly_wage": 2912000
+        },
+        {
+          "currency": "€",
+          "full_name": "Dávid Hancko",
+          "name": "D. Hancko",
+          "overall_score": 83,
+          "potential": 83,
+          "value": 35000000,
+          "yearly_wage": 4264000
+        },
+        {
+          "currency": "€",
+          "full_name": "Matteo Ruggeri",
+          "name": "M. Ruggeri",
+          "overall_score": 78,
+          "potential": 82,
+          "value": 19000000,
+          "yearly_wage": 2496000
+        },
+        {
+          "currency": "€",
+          "full_name": "Giuliano Simeone",
+          "name": "Giuliano",
+          "overall_score": 82,
+          "potential": 86,
+          "value": 44500000,
+          "yearly_wage": 3588000
+        },
+        {
+          "currency": "€",
+          "full_name": "Pablo Barrios Rivas",
+          "name": "Pablo Barrios",
+          "overall_score": 83,
+          "potential": 87,
+          "value": 52500000,
+          "yearly_wage": 3900000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jorge Resurrección",
+          "name": "Koke",
+          "overall_score": 81,
+          "potential": 81,
+          "value": 16000000,
+          "yearly_wage": 3952000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ademola Lookman",
+          "name": "A. Lookman",
+          "overall_score": 83,
+          "potential": 83,
+          "value": 39500000,
+          "yearly_wage": 4940000
+        },
+        {
+          "currency": "€",
+          "full_name": "Antoine Griezmann",
+          "name": "A. Griezmann",
+          "overall_score": 84,
+          "potential": 84,
+          "value": 20500000,
+          "yearly_wage": 5460000
+        },
+        {
+          "currency": "€",
+          "full_name": "Julián Alvarez",
+          "name": "J. Alvarez",
+          "overall_score": 86,
+          "potential": 89,
+          "value": 91000000,
+          "yearly_wage": 5980000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alexander Sørloth",
+          "name": "A. Sørloth",
+          "overall_score": 83,
+          "potential": 83,
+          "value": 36500000,
+          "yearly_wage": 4940000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alejandro Baena Rodríguez",
+          "name": "Álex Baena",
+          "overall_score": 82,
+          "potential": 87,
+          "value": 46000000,
+          "yearly_wage": 3588000
+        },
+        {
+          "currency": "€",
+          "full_name": "João Lucas de Souza Cardoso",
+          "name": "Johnny Cardoso",
+          "overall_score": 80,
+          "potential": 84,
+          "value": 27500000,
+          "yearly_wage": 2912000
+        },
+        {
+          "currency": "€",
+          "full_name": "Nico Gonzalez",
+          "name": "N. Gonzalez",
+          "overall_score": 79,
+          "potential": 79,
+          "value": 18500000,
+          "yearly_wage": 5460000
+        },
+        {
+          "currency": "€",
+          "full_name": "José María Giménez",
+          "name": "J. Giménez",
+          "overall_score": 83,
+          "potential": 83,
+          "value": 30000000,
+          "yearly_wage": 4472000
+        },
+        {
+          "currency": "€",
+          "full_name": "Robin Le Normand",
+          "name": "R. Le Normand",
+          "overall_score": 81,
+          "potential": 82,
+          "value": 24500000,
+          "yearly_wage": 3796000
+        },
+        {
+          "currency": "€",
+          "full_name": "Juan Musso",
+          "name": "J. Musso",
+          "overall_score": 80,
+          "potential": 80,
+          "value": 11000000,
+          "yearly_wage": 2288000
+        },
+        {
+          "currency": "€",
+          "full_name": "Thiago Almada",
+          "name": "T. Almada",
+          "overall_score": 78,
+          "potential": 83,
+          "value": 21000000,
+          "yearly_wage": 2704000
+        },
+        {
+          "currency": "€",
+          "full_name": "Nahuel Molina",
+          "name": "N. Molina",
+          "overall_score": 77,
+          "potential": 77,
+          "value": 10000000,
+          "yearly_wage": 2704000
+        },
+        {
+          "currency": "€",
+          "full_name": "Clément Lenglet",
+          "name": "C. Lenglet",
+          "overall_score": 77,
+          "potential": 77,
+          "value": 8500000,
+          "yearly_wage": 2860000
+        },
+        {
+          "currency": "€",
+          "full_name": "Obed Vargas",
+          "name": "O. Vargas",
+          "overall_score": 72,
+          "potential": 83,
+          "value": 4800000,
+          "yearly_wage": 1248000
+        },
+        {
+          "currency": "€",
+          "full_name": "Rodrigo Mendoza Martínez",
+          "name": "Rodri Mendoza",
+          "overall_score": 71,
+          "potential": 84,
+          "value": 4500000,
+          "yearly_wage": 1300000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ilias Kostis",
+          "name": "I. Kostis",
+          "overall_score": 67,
+          "potential": 77,
+          "value": 2100000,
+          "yearly_wage": 884000
+        },
+        {
+          "currency": "€",
+          "full_name": "Julio Díaz Del Romo",
+          "name": "Julio Díaz",
+          "overall_score": 64,
+          "potential": 78,
+          "value": 1300000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alejandro Monserrate Pueyo",
+          "name": "Jano Monserrate",
+          "overall_score": 60,
+          "potential": 77,
+          "value": 625000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Salvador Esquivel Gámez",
+          "name": "Salvi Esquivel",
+          "overall_score": 64,
+          "potential": 78,
+          "value": 1200000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Rayane Belaid Khelil",
+          "name": "Rayane",
+          "overall_score": 62,
+          "potential": 76,
+          "value": 950000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "Javier Morcillo",
+          "name": "Javi Morcillo",
+          "overall_score": 63,
+          "potential": 76,
+          "value": 1100000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "Taufik Seidu Zanzi Awudu",
+          "name": "Taufik Seidu",
+          "overall_score": 60,
+          "potential": 79,
+          "value": 600000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Javier Boñar Franco",
+          "name": "Javi Boñar",
+          "overall_score": 64,
+          "potential": 78,
+          "value": 1300000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "Daniel Martinez Moreno",
+          "name": "Dani Martinez",
+          "overall_score": 62,
+          "potential": 75,
+          "value": 925000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "Aleksa Purić",
+          "name": "A. Purić",
+          "overall_score": 67,
+          "potential": 78,
+          "value": 2100000,
+          "yearly_wage": 780000
+        },
+        {
+          "currency": "€",
+          "full_name": "Iker Luque Sierra",
+          "name": "Iker Luque",
+          "overall_score": 63,
+          "potential": 78,
+          "value": 1200000,
+          "yearly_wage": 520000
+        },
+        {
+          "currency": "€",
+          "full_name": "Miguel Llorente Cubo",
+          "name": "Miguel Cubo",
+          "overall_score": 63,
+          "potential": 80,
+          "value": 1200000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "Salim El Jebari",
+          "name": "S. El Jebari",
+          "overall_score": 65,
+          "potential": 73,
+          "value": 1600000,
+          "yearly_wage": 572000
+        },
+        {
+          "currency": "€",
+          "full_name": "Carlos Martín Domínguez",
+          "name": "Carlos Martín",
+          "overall_score": 70,
+          "potential": 77,
+          "value": 3200000,
+          "yearly_wage": 1508000
+        },
+        {
+          "currency": "€",
+          "full_name": "Diego Vicente Bri Carrazoni",
+          "name": "Diego Bri",
+          "overall_score": 68,
+          "potential": 73,
+          "value": 1900000,
+          "yearly_wage": 1144000
+        },
+        {
+          "currency": "€",
+          "full_name": "Pablo Pérez Rico",
+          "name": "Pablo Pérez",
+          "overall_score": 64,
+          "potential": 71,
+          "value": 1100000,
+          "yearly_wage": 572000
+        },
+        {
+          "currency": "€",
+          "full_name": "Horațiu Moldovan",
+          "name": "H. Moldovan",
+          "overall_score": 70,
+          "potential": 72,
+          "value": 1500000,
+          "yearly_wage": 936000
+        },
+        {
+          "currency": "€",
+          "full_name": "Thomas Lemar",
+          "name": "T. Lemar",
+          "overall_score": 77,
+          "potential": 77,
+          "value": 10500000,
+          "yearly_wage": 2964000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alejandro García Mestanza",
+          "name": "Mestanza",
+          "overall_score": 61,
+          "potential": 75,
+          "value": 800000,
+          "yearly_wage": 416000
+        }
+      ],
+      "team": "Atlético Madrid",
+      "transfer_budget": 75600000,
+      "url": "https://sofifa.com/team/240/atletico-madrid/260037/"
+    },
+    {
+      "player_count": 40,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Unai Simón Mendibil",
+          "name": "Unai Simón",
+          "overall_score": 84,
+          "potential": 85,
+          "value": 33500000,
+          "yearly_wage": 2288000
+        },
+        {
+          "currency": "€",
+          "full_name": "Andoni Gorosabel Espinosa",
+          "name": "Gorosabel",
+          "overall_score": 76,
+          "potential": 76,
+          "value": 7000000,
+          "yearly_wage": 1872000
+        },
+        {
+          "currency": "€",
+          "full_name": "Daniel Vivian Moreno",
+          "name": "Vivian",
+          "overall_score": 82,
+          "potential": 85,
+          "value": 36000000,
+          "yearly_wage": 2652000
+        },
+        {
+          "currency": "€",
+          "full_name": "Aymeric Laporte",
+          "name": "A. Laporte",
+          "overall_score": 82,
+          "potential": 82,
+          "value": 21000000,
+          "yearly_wage": 2912000
+        },
+        {
+          "currency": "€",
+          "full_name": "Yuri Berchiche Izeta",
+          "name": "Yuri Berchiche",
+          "overall_score": 79,
+          "potential": 79,
+          "value": 5500000,
+          "yearly_wage": 1768000
+        },
+        {
+          "currency": "€",
+          "full_name": "Iñigo Ruiz de Galarreta",
+          "name": "Ruiz de Galarreta",
+          "overall_score": 80,
+          "potential": 80,
+          "value": 15000000,
+          "yearly_wage": 2548000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mikel Jauregizar Alboniga",
+          "name": "Jauregizar",
+          "overall_score": 80,
+          "potential": 86,
+          "value": 33500000,
+          "yearly_wage": 1872000
+        },
+        {
+          "currency": "€",
+          "full_name": "Iñaki Williams Arthuer",
+          "name": "Iñaki Williams",
+          "overall_score": 81,
+          "potential": 81,
+          "value": 21500000,
+          "yearly_wage": 3016000
+        },
+        {
+          "currency": "€",
+          "full_name": "Nicholas Williams Arthuer",
+          "name": "Nico Williams",
+          "overall_score": 85,
+          "potential": 88,
+          "value": 75000000,
+          "yearly_wage": 3588000
+        },
+        {
+          "currency": "€",
+          "full_name": "Oihan Sancet Tirapu",
+          "name": "Sancet",
+          "overall_score": 82,
+          "potential": 85,
+          "value": 40500000,
+          "yearly_wage": 2860000
+        },
+        {
+          "currency": "€",
+          "full_name": "Gorka Guruzeta Rodríguez",
+          "name": "Guruzeta",
+          "overall_score": 78,
+          "potential": 78,
+          "value": 14500000,
+          "yearly_wage": 2444000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alejandro Berenguer Remiro",
+          "name": "Berenguer",
+          "overall_score": 80,
+          "potential": 80,
+          "value": 20500000,
+          "yearly_wage": 2808000
+        },
+        {
+          "currency": "€",
+          "full_name": "Robert Navarro Muñoz",
+          "name": "Robert Navarro",
+          "overall_score": 76,
+          "potential": 82,
+          "value": 12000000,
+          "yearly_wage": 1768000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mikel Vesga Arruti",
+          "name": "Vesga",
+          "overall_score": 72,
+          "potential": 72,
+          "value": 1600000,
+          "yearly_wage": 1404000
+        },
+        {
+          "currency": "€",
+          "full_name": "Unai Gómez Etxebarria",
+          "name": "Unai Gómez",
+          "overall_score": 72,
+          "potential": 78,
+          "value": 3800000,
+          "yearly_wage": 1248000
+        },
+        {
+          "currency": "€",
+          "full_name": "Yeray Álvarez López",
+          "name": "Yeray",
+          "overall_score": 80,
+          "potential": 80,
+          "value": 17500000,
+          "yearly_wage": 2548000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jesús Areso Blanco",
+          "name": "Areso",
+          "overall_score": 76,
+          "potential": 78,
+          "value": 8500000,
+          "yearly_wage": 1716000
+        },
+        {
+          "currency": "€",
+          "full_name": "Álex Padilla Pérez",
+          "name": "Álex Padilla",
+          "overall_score": 69,
+          "potential": 79,
+          "value": 2700000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Aitor Paredes Casamichana",
+          "name": "Aitor Paredes",
+          "overall_score": 78,
+          "potential": 81,
+          "value": 16500000,
+          "yearly_wage": 1976000
+        },
+        {
+          "currency": "€",
+          "full_name": "Maroan Sannadi Harrouch",
+          "name": "Maroan",
+          "overall_score": 72,
+          "potential": 77,
+          "value": 3600000,
+          "yearly_wage": 1300000
+        },
+        {
+          "currency": "€",
+          "full_name": "Nicolás Serrano Galdeano",
+          "name": "Nico Serrano",
+          "overall_score": 71,
+          "potential": 79,
+          "value": 4200000,
+          "yearly_wage": 1196000
+        },
+        {
+          "currency": "€",
+          "full_name": "Iñigo Lekue Martínez",
+          "name": "Lekue",
+          "overall_score": 72,
+          "potential": 72,
+          "value": 1600000,
+          "yearly_wage": 1404000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alejandro Rego Mora",
+          "name": "Rego",
+          "overall_score": 72,
+          "potential": 81,
+          "value": 5000000,
+          "yearly_wage": 1144000
+        },
+        {
+          "currency": "€",
+          "full_name": "Adama Boiro",
+          "name": "A. Boiro",
+          "overall_score": 73,
+          "potential": 80,
+          "value": 6000000,
+          "yearly_wage": 1248000
+        },
+        {
+          "currency": "€",
+          "full_name": "Urko Iruretagoiena",
+          "name": "Izeta",
+          "overall_score": 71,
+          "potential": 74,
+          "value": 2500000,
+          "yearly_wage": 1300000
+        },
+        {
+          "currency": "€",
+          "full_name": "Selton Sued Sánchez Camilo",
+          "name": "Selton",
+          "overall_score": 63,
+          "potential": 82,
+          "value": 1200000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Asier Hierro Campo",
+          "name": "Asier Hierro",
+          "overall_score": 60,
+          "potential": 74,
+          "value": 600000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Eder García Altuna",
+          "name": "Eder García",
+          "overall_score": 58,
+          "potential": 69,
+          "value": 450000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Iker Monreal Agundez",
+          "name": "Iker Monreal",
+          "overall_score": 59,
+          "potential": 75,
+          "value": 550000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mikel Santos Linares",
+          "name": "Mikel Santos",
+          "overall_score": 63,
+          "potential": 75,
+          "value": 1000000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Unai Egiluz Arroyo",
+          "name": "Egiluz",
+          "overall_score": 70,
+          "potential": 77,
+          "value": 3000000,
+          "yearly_wage": 936000
+        },
+        {
+          "currency": "€",
+          "full_name": "Beñat Prados Díaz",
+          "name": "Beñat Prados",
+          "overall_score": 77,
+          "potential": 82,
+          "value": 14500000,
+          "yearly_wage": 1664000
+        },
+        {
+          "currency": "€",
+          "full_name": "Aingeru Olabarrieta Capelo",
+          "name": "Olabarrieta",
+          "overall_score": 67,
+          "potential": 81,
+          "value": 2400000,
+          "yearly_wage": 572000
+        },
+        {
+          "currency": "€",
+          "full_name": "Hugo Rincón Lumbreras",
+          "name": "Hugo Rincón",
+          "overall_score": 74,
+          "potential": 82,
+          "value": 9000000,
+          "yearly_wage": 1404000
+        },
+        {
+          "currency": "€",
+          "full_name": "Julen Agirrezabala",
+          "name": "Agirrezabala",
+          "overall_score": 76,
+          "potential": 81,
+          "value": 9000000,
+          "yearly_wage": 936000
+        },
+        {
+          "currency": "€",
+          "full_name": "Unai Vencedor Paris",
+          "name": "Unai Vencedor",
+          "overall_score": 72,
+          "potential": 75,
+          "value": 2900000,
+          "yearly_wage": 1144000
+        },
+        {
+          "currency": "€",
+          "full_name": "Manex Lozano Carmona",
+          "name": "Manex Lozano",
+          "overall_score": 62,
+          "potential": 82,
+          "value": 1100000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Beñat Gerenabarrena",
+          "name": "Gerenabarrena",
+          "overall_score": 69,
+          "potential": 77,
+          "value": 3100000,
+          "yearly_wage": 832000
+        },
+        {
+          "currency": "€",
+          "full_name": "Iker Varela Parra",
+          "name": "Iker Varela",
+          "overall_score": 63,
+          "potential": 72,
+          "value": 1100000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "Peio Canales Urtasun",
+          "name": "Peio Canales",
+          "overall_score": 68,
+          "potential": 82,
+          "value": 2900000,
+          "yearly_wage": 676000
+        }
+      ],
+      "team": "Athletic Club",
+      "transfer_budget": 49700000,
+      "url": "https://sofifa.com/team/448/athletic-club/260037/"
+    },
+    {
+      "player_count": 40,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Luiz Lúcio Reis Júnior",
+          "name": "Luiz Júnior",
+          "overall_score": 78,
+          "potential": 82,
+          "value": 16000000,
+          "yearly_wage": 988000
+        },
+        {
+          "currency": "€",
+          "full_name": "Santiago Mouriño",
+          "name": "S. Mouriño",
+          "overall_score": 78,
+          "potential": 85,
+          "value": 27000000,
+          "yearly_wage": 1664000
+        },
+        {
+          "currency": "€",
+          "full_name": "Pau Navarro Badenes",
+          "name": "Pau Navarro",
+          "overall_score": 74,
+          "potential": 83,
+          "value": 8500000,
+          "yearly_wage": 1092000
+        },
+        {
+          "currency": "€",
+          "full_name": "Renato Palma Veiga",
+          "name": "Renato Veiga",
+          "overall_score": 78,
+          "potential": 83,
+          "value": 19500000,
+          "yearly_wage": 1404000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alfonso Pedraza Sag",
+          "name": "Pedraza",
+          "overall_score": 76,
+          "potential": 76,
+          "value": 6500000,
+          "yearly_wage": 1768000
+        },
+        {
+          "currency": "€",
+          "full_name": "Nicolas Pépé",
+          "name": "N. Pépé",
+          "overall_score": 81,
+          "potential": 81,
+          "value": 25000000,
+          "yearly_wage": 2808000
+        },
+        {
+          "currency": "€",
+          "full_name": "Santiago Comesaña Veiga",
+          "name": "Santi Comesaña",
+          "overall_score": 79,
+          "potential": 79,
+          "value": 17500000,
+          "yearly_wage": 2340000
+        },
+        {
+          "currency": "€",
+          "full_name": "Pape Gueye",
+          "name": "P. Gueye",
+          "overall_score": 80,
+          "potential": 81,
+          "value": 24500000,
+          "yearly_wage": 2340000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alberto Moleiro González",
+          "name": "Moleiro",
+          "overall_score": 82,
+          "potential": 87,
+          "value": 47000000,
+          "yearly_wage": 2028000
+        },
+        {
+          "currency": "€",
+          "full_name": "Gerard Moreno Balagueró",
+          "name": "Gerard Moreno",
+          "overall_score": 81,
+          "potential": 81,
+          "value": 16500000,
+          "yearly_wage": 2860000
+        },
+        {
+          "currency": "€",
+          "full_name": "Georges Mikautadze",
+          "name": "G. Mikautadze",
+          "overall_score": 79,
+          "potential": 83,
+          "value": 25500000,
+          "yearly_wage": 2132000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ayoze Pérez Gutiérrez",
+          "name": "Ayoze",
+          "overall_score": 81,
+          "potential": 81,
+          "value": 22000000,
+          "yearly_wage": 2860000
+        },
+        {
+          "currency": "€",
+          "full_name": "Daniel Parejo Muñoz",
+          "name": "Parejo",
+          "overall_score": 80,
+          "potential": 80,
+          "value": 6500000,
+          "yearly_wage": 1872000
+        },
+        {
+          "currency": "€",
+          "full_name": "Thomas Partey",
+          "name": "T. Partey",
+          "overall_score": 79,
+          "potential": 79,
+          "value": 11500000,
+          "yearly_wage": 2236000
+        },
+        {
+          "currency": "€",
+          "full_name": "Tajon Buchanan",
+          "name": "T. Buchanan",
+          "overall_score": 76,
+          "potential": 76,
+          "value": 8000000,
+          "yearly_wage": 1768000
+        },
+        {
+          "currency": "€",
+          "full_name": "Sergi Cardona Bermúdez",
+          "name": "Sergi Cardona",
+          "overall_score": 79,
+          "potential": 82,
+          "value": 21500000,
+          "yearly_wage": 2028000
+        },
+        {
+          "currency": "€",
+          "full_name": "Rafael Marín Zamora",
+          "name": "Rafa Marín",
+          "overall_score": 76,
+          "potential": 83,
+          "value": 14000000,
+          "yearly_wage": 3068000
+        },
+        {
+          "currency": "€",
+          "full_name": "Arnau Tenas Ureña",
+          "name": "Arnau Tenas",
+          "overall_score": 75,
+          "potential": 81,
+          "value": 7000000,
+          "yearly_wage": 832000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alfonso González Martínez",
+          "name": "Alfon",
+          "overall_score": 75,
+          "potential": 75,
+          "value": 6000000,
+          "yearly_wage": 1560000
+        },
+        {
+          "currency": "€",
+          "full_name": "Tani Oluwaseyi",
+          "name": "T. Oluwaseyi",
+          "overall_score": 71,
+          "potential": 74,
+          "value": 2500000,
+          "yearly_wage": 1196000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alex Freeman",
+          "name": "A. Freeman",
+          "overall_score": 73,
+          "potential": 81,
+          "value": 6500000,
+          "yearly_wage": 988000
+        },
+        {
+          "currency": "€",
+          "full_name": "Carlos Macià Coves",
+          "name": "Carlos Macià",
+          "overall_score": 62,
+          "potential": 81,
+          "value": 1000000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Willy Kambwala",
+          "name": "W. Kambwala",
+          "overall_score": 72,
+          "potential": 81,
+          "value": 4800000,
+          "yearly_wage": 884000
+        },
+        {
+          "currency": "€",
+          "full_name": "Diego José Conde Alcolado",
+          "name": "Diego Conde",
+          "overall_score": 76,
+          "potential": 79,
+          "value": 7500000,
+          "yearly_wage": 1092000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jean Yves Valou",
+          "name": "J. Valou",
+          "overall_score": 62,
+          "potential": 78,
+          "value": 975000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Hugo López Cortés",
+          "name": "Hugo López",
+          "overall_score": 60,
+          "potential": 79,
+          "value": 625000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alassane Diatta",
+          "name": "A. Diatta",
+          "overall_score": 63,
+          "potential": 75,
+          "value": 1100000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Rubén Gómez Peris",
+          "name": "Rubén Gómez",
+          "overall_score": 63,
+          "potential": 71,
+          "value": 925000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Juan Foyth",
+          "name": "J. Foyth",
+          "overall_score": 79,
+          "potential": 79,
+          "value": 16000000,
+          "yearly_wage": 2132000
+        },
+        {
+          "currency": "€",
+          "full_name": "Logan Costa",
+          "name": "L. Costa",
+          "overall_score": 77,
+          "potential": 83,
+          "value": 15000000,
+          "yearly_wage": 1560000
+        },
+        {
+          "currency": "€",
+          "full_name": "Pau Cabanes de la Torre",
+          "name": "Pau Cabanes",
+          "overall_score": 65,
+          "potential": 78,
+          "value": 1700000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "Daniel Requena Sánchez",
+          "name": "Dani Requena",
+          "overall_score": 70,
+          "potential": 78,
+          "value": 3600000,
+          "yearly_wage": 780000
+        },
+        {
+          "currency": "€",
+          "full_name": "Víctor Moreno Alcalá",
+          "name": "Víctor Moreno",
+          "overall_score": 66,
+          "potential": 78,
+          "value": 2000000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "Thiago Fernández",
+          "name": "T. Fernández",
+          "overall_score": 74,
+          "potential": 81,
+          "value": 8500000,
+          "yearly_wage": 1248000
+        },
+        {
+          "currency": "€",
+          "full_name": "Thiago Ojeda",
+          "name": "T. Ojeda",
+          "overall_score": 67,
+          "potential": 76,
+          "value": 2200000,
+          "yearly_wage": 624000
+        },
+        {
+          "currency": "€",
+          "full_name": "Carlos Romero Serrano",
+          "name": "Carlos Romero",
+          "overall_score": 79,
+          "potential": 83,
+          "value": 23500000,
+          "yearly_wage": 1820000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alex Forés Mendoza",
+          "name": "Alex Forés",
+          "overall_score": 70,
+          "potential": 75,
+          "value": 2400000,
+          "yearly_wage": 988000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ilias Akhomach",
+          "name": "I. Akhomach",
+          "overall_score": 75,
+          "potential": 83,
+          "value": 12500000,
+          "yearly_wage": 1352000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ramón Terrats Espacio",
+          "name": "Terrats",
+          "overall_score": 74,
+          "potential": 77,
+          "value": 6000000,
+          "yearly_wage": 1352000
+        },
+        {
+          "currency": "€",
+          "full_name": "Toni Tamarit Tamarit",
+          "name": "Toni Tamarit",
+          "overall_score": 62,
+          "potential": 77,
+          "value": 900000,
+          "yearly_wage": 260000
+        }
+      ],
+      "team": "Villarreal CF",
+      "transfer_budget": 35000000,
+      "url": "https://sofifa.com/team/483/villarreal-cf/260037/"
+    },
+    {
+      "player_count": 35,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Álvaro Valles Rosa",
+          "name": "Álvaro Valles",
+          "overall_score": 77,
+          "potential": 79,
+          "value": 9500000,
+          "yearly_wage": 884000
+        },
+        {
+          "currency": "€",
+          "full_name": "Héctor Bellerín Moruno",
+          "name": "Héctor Bellerín",
+          "overall_score": 76,
+          "potential": 76,
+          "value": 6500000,
+          "yearly_wage": 1352000
+        },
+        {
+          "currency": "€",
+          "full_name": "Diego Javier Llorente Ríos",
+          "name": "Diego Llorente",
+          "overall_score": 80,
+          "potential": 80,
+          "value": 14500000,
+          "yearly_wage": 1820000
+        },
+        {
+          "currency": "€",
+          "full_name": "Natan Bernardo de Souza",
+          "name": "Natan",
+          "overall_score": 78,
+          "potential": 83,
+          "value": 19000000,
+          "yearly_wage": 1300000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ricardo Rodríguez",
+          "name": "R. Rodríguez",
+          "overall_score": 73,
+          "potential": 73,
+          "value": 2100000,
+          "yearly_wage": 1092000
+        },
+        {
+          "currency": "€",
+          "full_name": "Marc Roca Junqué",
+          "name": "Marc Roca",
+          "overall_score": 78,
+          "potential": 78,
+          "value": 12500000,
+          "yearly_wage": 1560000
+        },
+        {
+          "currency": "€",
+          "full_name": "Pablo Fornals Malla",
+          "name": "Fornals",
+          "overall_score": 81,
+          "potential": 81,
+          "value": 25000000,
+          "yearly_wage": 2028000
+        },
+        {
+          "currency": "€",
+          "full_name": "Sofyan Amrabat",
+          "name": "S. Amrabat",
+          "overall_score": 79,
+          "potential": 79,
+          "value": 15500000,
+          "yearly_wage": 2860000
+        },
+        {
+          "currency": "€",
+          "full_name": "Antony Matheus dos Santos",
+          "name": "Antony",
+          "overall_score": 81,
+          "potential": 82,
+          "value": 31000000,
+          "yearly_wage": 1976000
+        },
+        {
+          "currency": "€",
+          "full_name": "Juan Camilo Hernández Suárez",
+          "name": "Cucho Hernández",
+          "overall_score": 79,
+          "potential": 80,
+          "value": 21000000,
+          "yearly_wage": 1872000
+        },
+        {
+          "currency": "€",
+          "full_name": "Abdessamad Ezzalzouli",
+          "name": "Abde",
+          "overall_score": 80,
+          "potential": 84,
+          "value": 30000000,
+          "yearly_wage": 1716000
+        },
+        {
+          "currency": "€",
+          "full_name": "Cédric Bakambu",
+          "name": "C. Bakambu",
+          "overall_score": 75,
+          "potential": 75,
+          "value": 2700000,
+          "yearly_wage": 1456000
+        },
+        {
+          "currency": "€",
+          "full_name": "Francisco Román Alarcón Suárez",
+          "name": "Isco",
+          "overall_score": 84,
+          "potential": 84,
+          "value": 26500000,
+          "yearly_wage": 2704000
+        },
+        {
+          "currency": "€",
+          "full_name": "Aitor Ruibal García",
+          "name": "Aitor Ruibal",
+          "overall_score": 77,
+          "potential": 77,
+          "value": 10500000,
+          "yearly_wage": 1508000
+        },
+        {
+          "currency": "€",
+          "full_name": "Sergio Altimira Clavell",
+          "name": "Altimira",
+          "overall_score": 77,
+          "potential": 83,
+          "value": 15500000,
+          "yearly_wage": 1196000
+        },
+        {
+          "currency": "€",
+          "full_name": "Rodrigo Riquelme Reche",
+          "name": "Riquelme",
+          "overall_score": 76,
+          "potential": 77,
+          "value": 9000000,
+          "yearly_wage": 1300000
+        },
+        {
+          "currency": "€",
+          "full_name": "Marc Bartra Aregall",
+          "name": "Bartra",
+          "overall_score": 79,
+          "potential": 79,
+          "value": 5500000,
+          "yearly_wage": 1716000
+        },
+        {
+          "currency": "€",
+          "full_name": "Pau López Sabata",
+          "name": "Pau López",
+          "overall_score": 77,
+          "potential": 77,
+          "value": 7000000,
+          "yearly_wage": 936000
+        },
+        {
+          "currency": "€",
+          "full_name": "Álvaro Fidalgo Fernández",
+          "name": "Fidalgo",
+          "overall_score": 77,
+          "potential": 77,
+          "value": 10500000,
+          "yearly_wage": 1508000
+        },
+        {
+          "currency": "€",
+          "full_name": "Giovani Lo Celso",
+          "name": "G. Lo Celso",
+          "overall_score": 81,
+          "potential": 81,
+          "value": 25500000,
+          "yearly_wage": 2080000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ángel Ortiz Monterrey",
+          "name": "Ángel Ortiz",
+          "overall_score": 70,
+          "potential": 81,
+          "value": 3300000,
+          "yearly_wage": 572000
+        },
+        {
+          "currency": "€",
+          "full_name": "Nelson Deossa",
+          "name": "N. Deossa",
+          "overall_score": 75,
+          "potential": 80,
+          "value": 7500000,
+          "yearly_wage": 1196000
+        },
+        {
+          "currency": "€",
+          "full_name": "Valentín Gómez",
+          "name": "V. Gómez",
+          "overall_score": 76,
+          "potential": 84,
+          "value": 15500000,
+          "yearly_wage": 1144000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ezequiel Ávila",
+          "name": "Chimy Ávila",
+          "overall_score": 73,
+          "potential": 73,
+          "value": 2600000,
+          "yearly_wage": 1248000
+        },
+        {
+          "currency": "€",
+          "full_name": "Adrián San Miguel Castillo",
+          "name": "Adrián",
+          "overall_score": 71,
+          "potential": 71,
+          "value": 210000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Germán García Fernández",
+          "name": "Germán García",
+          "overall_score": 57,
+          "potential": 64,
+          "value": 275000,
+          "yearly_wage": 52000
+        },
+        {
+          "currency": "€",
+          "full_name": "Iván Corralejo Mantero",
+          "name": "Iván Corralejo",
+          "overall_score": 59,
+          "potential": 76,
+          "value": 575000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Daniel Pérez Guerrero",
+          "name": "Dani Pérez",
+          "overall_score": 63,
+          "potential": 76,
+          "value": 1100000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Pablo García Fernández",
+          "name": "Pablo García",
+          "overall_score": 70,
+          "potential": 83,
+          "value": 3800000,
+          "yearly_wage": 624000
+        },
+        {
+          "currency": "€",
+          "full_name": "Manuel González Pallarés",
+          "name": "Manu González",
+          "overall_score": 62,
+          "potential": 79,
+          "value": 900000,
+          "yearly_wage": 52000
+        },
+        {
+          "currency": "€",
+          "full_name": "Héctor Junior Firpo Adamés",
+          "name": "Junior Firpo",
+          "overall_score": 74,
+          "potential": 74,
+          "value": 3800000,
+          "yearly_wage": 1196000
+        },
+        {
+          "currency": "€",
+          "full_name": "Guilherme Sousa Carvalho Fernandes",
+          "name": "Guilherme Fernandes",
+          "overall_score": 69,
+          "potential": 75,
+          "value": 1800000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Iker Losada Aragunde",
+          "name": "Iker Losada",
+          "overall_score": 72,
+          "potential": 77,
+          "value": 3500000,
+          "yearly_wage": 884000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mateo Flores Lozano",
+          "name": "Mateo Flores",
+          "overall_score": 66,
+          "potential": 79,
+          "value": 2000000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Gonzalo Petit",
+          "name": "G. Petit",
+          "overall_score": 68,
+          "potential": 77,
+          "value": 2600000,
+          "yearly_wage": 468000
+        }
+      ],
+      "team": "Real Betis Balompié",
+      "transfer_budget": 16400000,
+      "url": "https://sofifa.com/team/449/real-betis-balompie/260037/"
+    },
+    {
+      "player_count": 29,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Alejandro Remiro Gargallo",
+          "name": "Álex Remiro",
+          "overall_score": 82,
+          "potential": 82,
+          "value": 20500000,
+          "yearly_wage": 1768000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jon Mikel Aramburu",
+          "name": "J. Aramburu",
+          "overall_score": 77,
+          "potential": 83,
+          "value": 16000000,
+          "yearly_wage": 1560000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jon Martín Vicente",
+          "name": "Jon Martín",
+          "overall_score": 77,
+          "potential": 86,
+          "value": 21000000,
+          "yearly_wage": 1248000
+        },
+        {
+          "currency": "€",
+          "full_name": "Duje Ćaleta-Car",
+          "name": "D. Ćaleta-Car",
+          "overall_score": 74,
+          "potential": 74,
+          "value": 3600000,
+          "yearly_wage": 936000
+        },
+        {
+          "currency": "€",
+          "full_name": "Sergio Gómez Martín",
+          "name": "Sergio Gómez",
+          "overall_score": 78,
+          "potential": 81,
+          "value": 18000000,
+          "yearly_wage": 1664000
+        },
+        {
+          "currency": "€",
+          "full_name": "Beñat Turrientes Imaz",
+          "name": "Turrientes",
+          "overall_score": 76,
+          "potential": 82,
+          "value": 12000000,
+          "yearly_wage": 1560000
+        },
+        {
+          "currency": "€",
+          "full_name": "Gonçalo Manuel Ganchinho Guedes",
+          "name": "Guedes",
+          "overall_score": 78,
+          "potential": 78,
+          "value": 14000000,
+          "yearly_wage": 2236000
+        },
+        {
+          "currency": "€",
+          "full_name": "Brais Méndez Portela",
+          "name": "Brais Méndez",
+          "overall_score": 78,
+          "potential": 78,
+          "value": 14000000,
+          "yearly_wage": 2132000
+        },
+        {
+          "currency": "€",
+          "full_name": "Carlos Soler Barragán",
+          "name": "Carlos Soler",
+          "overall_score": 78,
+          "potential": 78,
+          "value": 14000000,
+          "yearly_wage": 2132000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ander Barrenetxea",
+          "name": "Barrenetxea",
+          "overall_score": 78,
+          "potential": 83,
+          "value": 21000000,
+          "yearly_wage": 1924000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mikel Oyarzabal Ugarte",
+          "name": "Oyarzabal",
+          "overall_score": 83,
+          "potential": 83,
+          "value": 37000000,
+          "yearly_wage": 3380000
+        },
+        {
+          "currency": "€",
+          "full_name": "Orri Óskarsson",
+          "name": "O. Óskarsson",
+          "overall_score": 74,
+          "potential": 80,
+          "value": 6500000,
+          "yearly_wage": 1300000
+        },
+        {
+          "currency": "€",
+          "full_name": "Takefusa Kubo",
+          "name": "T. Kubo",
+          "overall_score": 81,
+          "potential": 84,
+          "value": 35000000,
+          "yearly_wage": 2184000
+        },
+        {
+          "currency": "€",
+          "full_name": "Yangel Herrera",
+          "name": "Y. Herrera",
+          "overall_score": 79,
+          "potential": 79,
+          "value": 18500000,
+          "yearly_wage": 2236000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jon Gorrotxategi",
+          "name": "Gorrotxa",
+          "overall_score": 77,
+          "potential": 85,
+          "value": 22500000,
+          "yearly_wage": 1560000
+        },
+        {
+          "currency": "€",
+          "full_name": "Igor Zubeldia Elorza",
+          "name": "Zubeldia",
+          "overall_score": 77,
+          "potential": 78,
+          "value": 10000000,
+          "yearly_wage": 1872000
+        },
+        {
+          "currency": "€",
+          "full_name": "Aihen Muñoz Capellán",
+          "name": "Aihen Muñoz",
+          "overall_score": 74,
+          "potential": 74,
+          "value": 4100000,
+          "yearly_wage": 1508000
+        },
+        {
+          "currency": "€",
+          "full_name": "Unai Marrero Larrañaga",
+          "name": "Unai Marrero",
+          "overall_score": 72,
+          "potential": 79,
+          "value": 4000000,
+          "yearly_wage": 624000
+        },
+        {
+          "currency": "€",
+          "full_name": "Luka Sučić",
+          "name": "L. Sučić",
+          "overall_score": 76,
+          "potential": 81,
+          "value": 11500000,
+          "yearly_wage": 1560000
+        },
+        {
+          "currency": "€",
+          "full_name": "Pablo Marín Tejada",
+          "name": "Pablo Marín",
+          "overall_score": 73,
+          "potential": 82,
+          "value": 7000000,
+          "yearly_wage": 1040000
+        },
+        {
+          "currency": "€",
+          "full_name": "Aritz Elustondo",
+          "name": "Aritz Elustondo",
+          "overall_score": 74,
+          "potential": 74,
+          "value": 2900000,
+          "yearly_wage": 1560000
+        },
+        {
+          "currency": "€",
+          "full_name": "Arsen Zakharyan",
+          "name": "A. Zakharyan",
+          "overall_score": 73,
+          "potential": 81,
+          "value": 7000000,
+          "yearly_wage": 1248000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jon Karrikaburu",
+          "name": "Karrikaburu",
+          "overall_score": 67,
+          "potential": 76,
+          "value": 2300000,
+          "yearly_wage": 676000
+        },
+        {
+          "currency": "€",
+          "full_name": "Wesley Gassova Ribeiro Teixeira",
+          "name": "Wesley",
+          "overall_score": 69,
+          "potential": 80,
+          "value": 3100000,
+          "yearly_wage": 780000
+        },
+        {
+          "currency": "€",
+          "full_name": "Álvaro Odriozola Arzalluz",
+          "name": "Odriozola",
+          "overall_score": 73,
+          "potential": 73,
+          "value": 2700000,
+          "yearly_wage": 1404000
+        },
+        {
+          "currency": "€",
+          "full_name": "Javier López Carballo",
+          "name": "Javi López",
+          "overall_score": 73,
+          "potential": 79,
+          "value": 4500000,
+          "yearly_wage": 1196000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jon Pacheco Dozagarat",
+          "name": "Pacheco",
+          "overall_score": 74,
+          "potential": 81,
+          "value": 8000000,
+          "yearly_wage": 1300000
+        },
+        {
+          "currency": "€",
+          "full_name": "Carlos Fernández Luna",
+          "name": "Carlos Fernández",
+          "overall_score": 71,
+          "potential": 71,
+          "value": 1900000,
+          "yearly_wage": 1300000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mikel Goti López",
+          "name": "Mikel Goti",
+          "overall_score": 69,
+          "potential": 76,
+          "value": 2800000,
+          "yearly_wage": 832000
+        }
+      ],
+      "team": "Real Sociedad",
+      "transfer_budget": 16200000,
+      "url": "https://sofifa.com/team/457/real-sociedad/260037/"
+    },
+    {
+      "player_count": 32,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Augusto Batalla",
+          "name": "A. Batalla",
+          "overall_score": 79,
+          "potential": 80,
+          "value": 13500000,
+          "yearly_wage": 988000
+        },
+        {
+          "currency": "€",
+          "full_name": "Andrei Rațiu",
+          "name": "A. Rațiu",
+          "overall_score": 80,
+          "potential": 81,
+          "value": 22000000,
+          "yearly_wage": 1560000
+        },
+        {
+          "currency": "€",
+          "full_name": "Florian Lejeune",
+          "name": "F. Lejeune",
+          "overall_score": 79,
+          "potential": 79,
+          "value": 5500000,
+          "yearly_wage": 1560000
+        },
+        {
+          "currency": "€",
+          "full_name": "Nobel Mendy",
+          "name": "N. Mendy",
+          "overall_score": 75,
+          "potential": 85,
+          "value": 11500000,
+          "yearly_wage": 832000
+        },
+        {
+          "currency": "€",
+          "full_name": "Josep María Chavarría Pérez",
+          "name": "Pep Chavarría",
+          "overall_score": 78,
+          "potential": 78,
+          "value": 13500000,
+          "yearly_wage": 1352000
+        },
+        {
+          "currency": "€",
+          "full_name": "Pathé Ciss",
+          "name": "P. Ciss",
+          "overall_score": 77,
+          "potential": 77,
+          "value": 7500000,
+          "yearly_wage": 1300000
+        },
+        {
+          "currency": "€",
+          "full_name": "Unai López Cabrera",
+          "name": "Unai López",
+          "overall_score": 76,
+          "potential": 76,
+          "value": 7500000,
+          "yearly_wage": 1248000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ilias Akhomach",
+          "name": "I. Akhomach",
+          "overall_score": 75,
+          "potential": 83,
+          "value": 12500000,
+          "yearly_wage": 1352000
+        },
+        {
+          "currency": "€",
+          "full_name": "Álvaro García Rivera",
+          "name": "Álvaro García",
+          "overall_score": 81,
+          "potential": 81,
+          "value": 20500000,
+          "yearly_wage": 1924000
+        },
+        {
+          "currency": "€",
+          "full_name": "Isaac Palazón Camacho",
+          "name": "Isi",
+          "overall_score": 80,
+          "potential": 80,
+          "value": 20500000,
+          "yearly_wage": 1716000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jorge de Frutos Sebastián",
+          "name": "De Frutos",
+          "overall_score": 81,
+          "potential": 81,
+          "value": 26000000,
+          "yearly_wage": 1924000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alexandre Zurawski",
+          "name": "Alemão",
+          "overall_score": 74,
+          "potential": 74,
+          "value": 4600000,
+          "yearly_wage": 1144000
+        },
+        {
+          "currency": "€",
+          "full_name": "Carlos Martín Domínguez",
+          "name": "Carlos Martín",
+          "overall_score": 70,
+          "potential": 77,
+          "value": 3200000,
+          "yearly_wage": 1508000
+        },
+        {
+          "currency": "€",
+          "full_name": "Óscar Valentín Martín Luengo",
+          "name": "Óscar Valentín",
+          "overall_score": 77,
+          "potential": 77,
+          "value": 9000000,
+          "yearly_wage": 1300000
+        },
+        {
+          "currency": "€",
+          "full_name": "Gerard Gumbau Garriga",
+          "name": "Gumbau",
+          "overall_score": 72,
+          "potential": 72,
+          "value": 2200000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Abdul Mumin",
+          "name": "A. Mumin",
+          "overall_score": 77,
+          "potential": 79,
+          "value": 11000000,
+          "yearly_wage": 1248000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alfonso Espino",
+          "name": "Pacha Espino",
+          "overall_score": 72,
+          "potential": 72,
+          "value": 1200000,
+          "yearly_wage": 884000
+        },
+        {
+          "currency": "€",
+          "full_name": "Daniel Cárdenas Líndez",
+          "name": "Dani Cárdenas",
+          "overall_score": 73,
+          "potential": 75,
+          "value": 2600000,
+          "yearly_wage": 624000
+        },
+        {
+          "currency": "€",
+          "full_name": "Iván Balliu",
+          "name": "I. Balliu",
+          "overall_score": 75,
+          "potential": 75,
+          "value": 2900000,
+          "yearly_wage": 1144000
+        },
+        {
+          "currency": "€",
+          "full_name": "Pedro Díaz Fanjul",
+          "name": "Pedro Díaz",
+          "overall_score": 75,
+          "potential": 75,
+          "value": 6000000,
+          "yearly_wage": 1144000
+        },
+        {
+          "currency": "€",
+          "full_name": "Luiz Felipe Ramos Marchi",
+          "name": "Luiz Felipe",
+          "overall_score": 75,
+          "potential": 76,
+          "value": 5500000,
+          "yearly_wage": 1144000
+        },
+        {
+          "currency": "€",
+          "full_name": "Sergio Camello Pérez",
+          "name": "Sergio Camello",
+          "overall_score": 73,
+          "potential": 78,
+          "value": 4700000,
+          "yearly_wage": 936000
+        },
+        {
+          "currency": "€",
+          "full_name": "Francisco Pérez Martínez",
+          "name": "Fran Pérez",
+          "overall_score": 74,
+          "potential": 79,
+          "value": 6500000,
+          "yearly_wage": 936000
+        },
+        {
+          "currency": "€",
+          "full_name": "Randy Nteka",
+          "name": "R. Nteka",
+          "overall_score": 70,
+          "potential": 70,
+          "value": 1700000,
+          "yearly_wage": 780000
+        },
+        {
+          "currency": "€",
+          "full_name": "Óscar Trejo",
+          "name": "Ó. Trejo",
+          "overall_score": 70,
+          "potential": 70,
+          "value": 525000,
+          "yearly_wage": 572000
+        },
+        {
+          "currency": "€",
+          "full_name": "Samuel Becerra Gómez",
+          "name": "Samu Becerra",
+          "overall_score": 60,
+          "potential": 73,
+          "value": 575000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Marco de las Sías López",
+          "name": "De las Sías",
+          "overall_score": 59,
+          "potential": 69,
+          "value": 450000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Juan Pedro Gil Bueno",
+          "name": "Juanpe Gil",
+          "overall_score": 58,
+          "potential": 64,
+          "value": 250000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Adrián Molina Colorado",
+          "name": "Adrián Molina",
+          "overall_score": 54,
+          "potential": 64,
+          "value": 200000,
+          "yearly_wage": 44200
+        },
+        {
+          "currency": "€",
+          "full_name": "Jozhua Vertrouwd",
+          "name": "J. Vertrouwd",
+          "overall_score": 68,
+          "potential": 78,
+          "value": 2500000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "Diego Méndez Molero",
+          "name": "Diego Méndez",
+          "overall_score": 64,
+          "potential": 72,
+          "value": 1200000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Pelayo Fernández Balboa",
+          "name": "Pelayo",
+          "overall_score": 64,
+          "potential": 71,
+          "value": 1100000,
+          "yearly_wage": 260000
+        }
+      ],
+      "team": "Rayo Vallecano",
+      "transfer_budget": 3300000,
+      "url": "https://sofifa.com/team/480/rayo-vallecano/260037/"
+    },
+    {
+      "player_count": 26,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Sergio Herrera Pirón",
+          "name": "Sergio Herrera",
+          "overall_score": 79,
+          "potential": 79,
+          "value": 8500000,
+          "yearly_wage": 1300000
+        },
+        {
+          "currency": "€",
+          "full_name": "Valentin Rosier",
+          "name": "V. Rosier",
+          "overall_score": 78,
+          "potential": 78,
+          "value": 12500000,
+          "yearly_wage": 1820000
+        },
+        {
+          "currency": "€",
+          "full_name": "Flavien-Enzo Boyomo",
+          "name": "F. Boyomo",
+          "overall_score": 79,
+          "potential": 85,
+          "value": 25000000,
+          "yearly_wage": 1664000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alejandro Catena Marugán",
+          "name": "Catena",
+          "overall_score": 78,
+          "potential": 78,
+          "value": 11500000,
+          "yearly_wage": 1820000
+        },
+        {
+          "currency": "€",
+          "full_name": "Javier Galán Gil",
+          "name": "Javi Galán",
+          "overall_score": 78,
+          "potential": 78,
+          "value": 12000000,
+          "yearly_wage": 1820000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jon Moncayola Tollar",
+          "name": "Moncayola",
+          "overall_score": 77,
+          "potential": 77,
+          "value": 11000000,
+          "yearly_wage": 1716000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lucas Torró Marset",
+          "name": "Lucas Torró",
+          "overall_score": 77,
+          "potential": 77,
+          "value": 9000000,
+          "yearly_wage": 1716000
+        },
+        {
+          "currency": "€",
+          "full_name": "Rubén García Santos",
+          "name": "Rubén García",
+          "overall_score": 78,
+          "potential": 78,
+          "value": 11500000,
+          "yearly_wage": 1924000
+        },
+        {
+          "currency": "€",
+          "full_name": "Víctor Muñoz Villanueva",
+          "name": "Víctor Muñoz",
+          "overall_score": 78,
+          "potential": 86,
+          "value": 31500000,
+          "yearly_wage": 1456000
+        },
+        {
+          "currency": "€",
+          "full_name": "Aimar Oroz Huarte",
+          "name": "Aimar Oroz",
+          "overall_score": 77,
+          "potential": 82,
+          "value": 16000000,
+          "yearly_wage": 1508000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ante Budimir",
+          "name": "A. Budimir",
+          "overall_score": 82,
+          "potential": 82,
+          "value": 19500000,
+          "yearly_wage": 2756000
+        },
+        {
+          "currency": "€",
+          "full_name": "Raúl Moro Prescoli",
+          "name": "Raúl Moro",
+          "overall_score": 75,
+          "potential": 82,
+          "value": 11500000,
+          "yearly_wage": 1404000
+        },
+        {
+          "currency": "€",
+          "full_name": "Raúl García de Haro",
+          "name": "Raúl García",
+          "overall_score": 74,
+          "potential": 79,
+          "value": 6500000,
+          "yearly_wage": 1352000
+        },
+        {
+          "currency": "€",
+          "full_name": "Enrique Barja Afonso",
+          "name": "Kike Barja",
+          "overall_score": 73,
+          "potential": 73,
+          "value": 3100000,
+          "yearly_wage": 1404000
+        },
+        {
+          "currency": "€",
+          "full_name": "Moisés Gómez Bordonado",
+          "name": "Moi Gómez",
+          "overall_score": 76,
+          "potential": 76,
+          "value": 6000000,
+          "yearly_wage": 1664000
+        },
+        {
+          "currency": "€",
+          "full_name": "Abel Bretones Cruz",
+          "name": "Abel Bretones",
+          "overall_score": 75,
+          "potential": 80,
+          "value": 8000000,
+          "yearly_wage": 1248000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jorge Herrando Oroz",
+          "name": "Herrando",
+          "overall_score": 75,
+          "potential": 78,
+          "value": 7000000,
+          "yearly_wage": 1248000
+        },
+        {
+          "currency": "€",
+          "full_name": "Aitor Fernández",
+          "name": "Aitor Fernández",
+          "overall_score": 77,
+          "potential": 77,
+          "value": 1800000,
+          "yearly_wage": 1144000
+        },
+        {
+          "currency": "€",
+          "full_name": "Iker Muñoz Cameros",
+          "name": "Iker Muñoz",
+          "overall_score": 71,
+          "potential": 79,
+          "value": 4200000,
+          "yearly_wage": 936000
+        },
+        {
+          "currency": "€",
+          "full_name": "Asier Osambela Larraya",
+          "name": "Osambela",
+          "overall_score": 66,
+          "potential": 77,
+          "value": 1800000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "Juan Cruz Álvaro Armada",
+          "name": "Juan Cruz",
+          "overall_score": 73,
+          "potential": 73,
+          "value": 2100000,
+          "yearly_wage": 1300000
+        },
+        {
+          "currency": "€",
+          "full_name": "Iñigo Arguibide Goñi",
+          "name": "Arguibide",
+          "overall_score": 63,
+          "potential": 77,
+          "value": 1100000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Raúl Chasco Ruiz",
+          "name": "Raúl Chasco",
+          "overall_score": 63,
+          "potential": 73,
+          "value": 1000000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mauro Echegoyen Berrozpe",
+          "name": "Mauro",
+          "overall_score": 64,
+          "potential": 73,
+          "value": 1200000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Dimitrios Stamatakis",
+          "name": "D. Stamatakis",
+          "overall_score": 63,
+          "potential": 73,
+          "value": 925000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Iker Benito Sánchez",
+          "name": "Iker Benito",
+          "overall_score": 71,
+          "potential": 78,
+          "value": 3800000,
+          "yearly_wage": 988000
+        }
+      ],
+      "team": "CA Osasuna",
+      "transfer_budget": 4800000,
+      "url": "https://sofifa.com/team/479/ca-osasuna/260037/"
+    },
+    {
+      "player_count": 36,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Paulo Gazzaniga",
+          "name": "P. Gazzaniga",
+          "overall_score": 78,
+          "potential": 78,
+          "value": 4600000,
+          "yearly_wage": 1144000
+        },
+        {
+          "currency": "€",
+          "full_name": "Arnau Martínez López",
+          "name": "Arnau Martínez",
+          "overall_score": 78,
+          "potential": 83,
+          "value": 20000000,
+          "yearly_wage": 1456000
+        },
+        {
+          "currency": "€",
+          "full_name": "Vitor Reis",
+          "name": "Vitor Reis",
+          "overall_score": 76,
+          "potential": 86,
+          "value": 15000000,
+          "yearly_wage": 2912000
+        },
+        {
+          "currency": "€",
+          "full_name": "Daley Blind",
+          "name": "D. Blind",
+          "overall_score": 76,
+          "potential": 76,
+          "value": 2000000,
+          "yearly_wage": 1144000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alexandre Moreno Lopera",
+          "name": "Álex Moreno",
+          "overall_score": 77,
+          "potential": 77,
+          "value": 7500000,
+          "yearly_wage": 1612000
+        },
+        {
+          "currency": "€",
+          "full_name": "Francisco José Beltrán Peinado",
+          "name": "Fran Beltrán",
+          "overall_score": 77,
+          "potential": 78,
+          "value": 12500000,
+          "yearly_wage": 1612000
+        },
+        {
+          "currency": "€",
+          "full_name": "Axel Witsel",
+          "name": "A. Witsel",
+          "overall_score": 76,
+          "potential": 76,
+          "value": 1500000,
+          "yearly_wage": 1144000
+        },
+        {
+          "currency": "€",
+          "full_name": "Viktor Tsygankov",
+          "name": "V. Tsygankov",
+          "overall_score": 78,
+          "potential": 78,
+          "value": 15000000,
+          "yearly_wage": 1872000
+        },
+        {
+          "currency": "€",
+          "full_name": "Bryan Gil Salvatierra",
+          "name": "Bryan Gil",
+          "overall_score": 76,
+          "potential": 79,
+          "value": 10000000,
+          "yearly_wage": 1404000
+        },
+        {
+          "currency": "€",
+          "full_name": "Azzedine Ounahi",
+          "name": "A. Ounahi",
+          "overall_score": 79,
+          "potential": 82,
+          "value": 23000000,
+          "yearly_wage": 1820000
+        },
+        {
+          "currency": "€",
+          "full_name": "Vladyslav Vanat",
+          "name": "V. Vanat",
+          "overall_score": 77,
+          "potential": 82,
+          "value": 16000000,
+          "yearly_wage": 1560000
+        },
+        {
+          "currency": "€",
+          "full_name": "Cristhian Stuani",
+          "name": "C. Stuani",
+          "overall_score": 75,
+          "potential": 75,
+          "value": 1900000,
+          "yearly_wage": 1248000
+        },
+        {
+          "currency": "€",
+          "full_name": "Joel Roca Casals",
+          "name": "Joel Roca",
+          "overall_score": 73,
+          "potential": 82,
+          "value": 6500000,
+          "yearly_wage": 988000
+        },
+        {
+          "currency": "€",
+          "full_name": "Thomas Lemar",
+          "name": "T. Lemar",
+          "overall_score": 77,
+          "potential": 77,
+          "value": 10500000,
+          "yearly_wage": 2964000
+        },
+        {
+          "currency": "€",
+          "full_name": "Iván Martín Núñez",
+          "name": "Iván Martín",
+          "overall_score": 77,
+          "potential": 78,
+          "value": 12500000,
+          "yearly_wage": 1612000
+        },
+        {
+          "currency": "€",
+          "full_name": "Claudio Echeverri",
+          "name": "C. Echeverri",
+          "overall_score": 73,
+          "potential": 85,
+          "value": 7000000,
+          "yearly_wage": 2548000
+        },
+        {
+          "currency": "€",
+          "full_name": "Hugo Rincón Lumbreras",
+          "name": "Hugo Rincón",
+          "overall_score": 74,
+          "potential": 82,
+          "value": 9000000,
+          "yearly_wage": 1404000
+        },
+        {
+          "currency": "€",
+          "full_name": "Rubén Blanco Veiga",
+          "name": "Rubén Blanco",
+          "overall_score": 73,
+          "potential": 74,
+          "value": 2300000,
+          "yearly_wage": 780000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alejandro Francés Torrijo",
+          "name": "Francés",
+          "overall_score": 75,
+          "potential": 80,
+          "value": 8000000,
+          "yearly_wage": 1196000
+        },
+        {
+          "currency": "€",
+          "full_name": "Abel Ruiz Ortega",
+          "name": "Abel Ruiz",
+          "overall_score": 72,
+          "potential": 75,
+          "value": 3100000,
+          "yearly_wage": 1144000
+        },
+        {
+          "currency": "€",
+          "full_name": "David López Silva",
+          "name": "David López",
+          "overall_score": 76,
+          "potential": 76,
+          "value": 2000000,
+          "yearly_wage": 1144000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lancinet Kourouma",
+          "name": "Lass Kourouma",
+          "overall_score": 65,
+          "potential": 74,
+          "value": 1600000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Vladyslav Krapyvtsov",
+          "name": "V. Krapyvtsov",
+          "overall_score": 64,
+          "potential": 78,
+          "value": 1200000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Papa Dame Ba",
+          "name": "P. Ba",
+          "overall_score": 63,
+          "potential": 71,
+          "value": 1100000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Gibert Jordana Cámara",
+          "name": "Gibi",
+          "overall_score": 61,
+          "potential": 78,
+          "value": 800000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Juan Arango",
+          "name": "J. Arango",
+          "overall_score": 61,
+          "potential": 75,
+          "value": 775000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Donny van de Beek",
+          "name": "D. van de Beek",
+          "overall_score": 75,
+          "potential": 75,
+          "value": 5500000,
+          "yearly_wage": 1560000
+        },
+        {
+          "currency": "€",
+          "full_name": "Marc-André ter Stegen",
+          "name": "M. ter Stegen",
+          "overall_score": 84,
+          "potential": 84,
+          "value": 13500000,
+          "yearly_wage": 4264000
+        },
+        {
+          "currency": "€",
+          "full_name": "Juan Carlos Martín Corral",
+          "name": "Juan Carlos",
+          "overall_score": 70,
+          "potential": 70,
+          "value": 180000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Cristian Portugues Manzanera",
+          "name": "Portu",
+          "overall_score": 75,
+          "potential": 75,
+          "value": 3500000,
+          "yearly_wage": 1612000
+        },
+        {
+          "currency": "€",
+          "full_name": "Antonino Jastin García López",
+          "name": "Jastin",
+          "overall_score": 68,
+          "potential": 80,
+          "value": 3000000,
+          "yearly_wage": 520000
+        },
+        {
+          "currency": "€",
+          "full_name": "Yáser Asprilla",
+          "name": "Y. Asprilla",
+          "overall_score": 74,
+          "potential": 80,
+          "value": 7000000,
+          "yearly_wage": 988000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jhon Solís",
+          "name": "J. Solís",
+          "overall_score": 71,
+          "potential": 80,
+          "value": 3900000,
+          "yearly_wage": 676000
+        },
+        {
+          "currency": "€",
+          "full_name": "Dawda Camara",
+          "name": "D. Camara",
+          "overall_score": 68,
+          "potential": 74,
+          "value": 2000000,
+          "yearly_wage": 676000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ladislav Krejčí",
+          "name": "L. Krejčí",
+          "overall_score": 78,
+          "potential": 81,
+          "value": 16500000,
+          "yearly_wage": 1664000
+        },
+        {
+          "currency": "€",
+          "full_name": "Min Su Kim",
+          "name": "Kim Min Su",
+          "overall_score": 70,
+          "potential": 82,
+          "value": 3800000,
+          "yearly_wage": 676000
+        }
+      ],
+      "team": "Girona FC",
+      "transfer_budget": 3600000,
+      "url": "https://sofifa.com/team/110062/girona-fc/260037/"
+    },
+    {
+      "player_count": 36,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Stole Dimitrievski",
+          "name": "S. Dimitrievski",
+          "overall_score": 77,
+          "potential": 77,
+          "value": 5500000,
+          "yearly_wage": 1248000
+        },
+        {
+          "currency": "€",
+          "full_name": "Thierry Rendall Correia",
+          "name": "Thierry Correia",
+          "overall_score": 74,
+          "potential": 74,
+          "value": 4200000,
+          "yearly_wage": 1508000
+        },
+        {
+          "currency": "€",
+          "full_name": "César Tárrega Requeni",
+          "name": "César Tárrega",
+          "overall_score": 75,
+          "potential": 82,
+          "value": 10500000,
+          "yearly_wage": 1404000
+        },
+        {
+          "currency": "€",
+          "full_name": "Eray Cömert",
+          "name": "E. Cömert",
+          "overall_score": 73,
+          "potential": 74,
+          "value": 3100000,
+          "yearly_wage": 1352000
+        },
+        {
+          "currency": "€",
+          "full_name": "José Luís Gayà Peña",
+          "name": "Gayà",
+          "overall_score": 77,
+          "potential": 77,
+          "value": 9000000,
+          "yearly_wage": 1872000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jose Luís García Vayá",
+          "name": "Pepelu",
+          "overall_score": 76,
+          "potential": 77,
+          "value": 9000000,
+          "yearly_wage": 1768000
+        },
+        {
+          "currency": "€",
+          "full_name": "Guido Rodríguez",
+          "name": "G. Rodríguez",
+          "overall_score": 76,
+          "potential": 76,
+          "value": 5000000,
+          "yearly_wage": 1768000
+        },
+        {
+          "currency": "€",
+          "full_name": "Largie Ramazani",
+          "name": "L. Ramazani",
+          "overall_score": 76,
+          "potential": 79,
+          "value": 10000000,
+          "yearly_wage": 2496000
+        },
+        {
+          "currency": "€",
+          "full_name": "Luis Rioja González",
+          "name": "Luis Rioja",
+          "overall_score": 77,
+          "potential": 77,
+          "value": 8500000,
+          "yearly_wage": 1976000
+        },
+        {
+          "currency": "€",
+          "full_name": "Javier Guerra Moreno",
+          "name": "Javi Guerra",
+          "overall_score": 76,
+          "potential": 84,
+          "value": 17000000,
+          "yearly_wage": 1560000
+        },
+        {
+          "currency": "€",
+          "full_name": "Umar Sadiq",
+          "name": "U. Sadiq",
+          "overall_score": 76,
+          "potential": 76,
+          "value": 7500000,
+          "yearly_wage": 1976000
+        },
+        {
+          "currency": "€",
+          "full_name": "Hugo Duro Perales",
+          "name": "Hugo Duro",
+          "overall_score": 77,
+          "potential": 79,
+          "value": 13500000,
+          "yearly_wage": 1976000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lucas Beltrán",
+          "name": "L. Beltrán",
+          "overall_score": 75,
+          "potential": 79,
+          "value": 8000000,
+          "yearly_wage": 1976000
+        },
+        {
+          "currency": "€",
+          "full_name": "Filip Ugrinić",
+          "name": "F. Ugrinić",
+          "overall_score": 75,
+          "potential": 76,
+          "value": 6500000,
+          "yearly_wage": 1664000
+        },
+        {
+          "currency": "€",
+          "full_name": "Domingos André Ribeiro Almeida",
+          "name": "André Almeida",
+          "overall_score": 74,
+          "potential": 77,
+          "value": 5500000,
+          "yearly_wage": 1508000
+        },
+        {
+          "currency": "€",
+          "full_name": "Unai Núñez Gestoso",
+          "name": "Unai Núñez",
+          "overall_score": 75,
+          "potential": 76,
+          "value": 5500000,
+          "yearly_wage": 1300000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jesús Vázquez Alcalde",
+          "name": "Jesús Vázquez",
+          "overall_score": 71,
+          "potential": 77,
+          "value": 2800000,
+          "yearly_wage": 988000
+        },
+        {
+          "currency": "€",
+          "full_name": "Cristian Rivero Sabater",
+          "name": "Cristian Rivero",
+          "overall_score": 65,
+          "potential": 67,
+          "value": 650000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Arnaut Danjuma",
+          "name": "A. Danjuma",
+          "overall_score": 75,
+          "potential": 75,
+          "value": 5500000,
+          "yearly_wage": 1872000
+        },
+        {
+          "currency": "€",
+          "full_name": "Baptiste Santamaria",
+          "name": "B. Santamaria",
+          "overall_score": 75,
+          "potential": 75,
+          "value": 5500000,
+          "yearly_wage": 1768000
+        },
+        {
+          "currency": "€",
+          "full_name": "Rubén Iranzo Lendínez",
+          "name": "Rubén Iranzo",
+          "overall_score": 64,
+          "potential": 73,
+          "value": 1200000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "Daniel Raba Antolin",
+          "name": "Dani Raba",
+          "overall_score": 74,
+          "potential": 74,
+          "value": 4100000,
+          "yearly_wage": 1716000
+        },
+        {
+          "currency": "€",
+          "full_name": "Renzo Saravia",
+          "name": "R. Saravia",
+          "overall_score": 72,
+          "potential": 72,
+          "value": 1600000,
+          "yearly_wage": 1300000
+        },
+        {
+          "currency": "€",
+          "full_name": "David Otorbi Ejededawe",
+          "name": "David Otorbi",
+          "overall_score": 63,
+          "potential": 78,
+          "value": 1100000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Aimar Blázquez Labraca",
+          "name": "Aimar Blázquez",
+          "overall_score": 62,
+          "potential": 77,
+          "value": 950000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lucas Núñez Ramírez",
+          "name": "Lucas Núñez",
+          "overall_score": 61,
+          "potential": 74,
+          "value": 775000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Diego López Noguerol",
+          "name": "Diego López",
+          "overall_score": 77,
+          "potential": 82,
+          "value": 16000000,
+          "yearly_wage": 1768000
+        },
+        {
+          "currency": "€",
+          "full_name": "José Manuel Arias Copete",
+          "name": "Copete",
+          "overall_score": 74,
+          "potential": 78,
+          "value": 5500000,
+          "yearly_wage": 1404000
+        },
+        {
+          "currency": "€",
+          "full_name": "Julen Agirrezabala",
+          "name": "Agirrezabala",
+          "overall_score": 76,
+          "potential": 81,
+          "value": 9000000,
+          "yearly_wage": 936000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mouctar Diakhaby",
+          "name": "M. Diakhaby",
+          "overall_score": 76,
+          "potential": 76,
+          "value": 6500000,
+          "yearly_wage": 1768000
+        },
+        {
+          "currency": "€",
+          "full_name": "Dimitri Foulquier",
+          "name": "D. Foulquier",
+          "overall_score": 72,
+          "potential": 72,
+          "value": 1600000,
+          "yearly_wage": 1300000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alberto Marí Sánchez",
+          "name": "Alberto Marí",
+          "overall_score": 64,
+          "potential": 68,
+          "value": 850000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "Cenk Özkacar",
+          "name": "C. Özkacar",
+          "overall_score": 71,
+          "potential": 76,
+          "value": 2600000,
+          "yearly_wage": 988000
+        },
+        {
+          "currency": "€",
+          "full_name": "Sergi Canós Tenés",
+          "name": "Sergi Canós",
+          "overall_score": 69,
+          "potential": 69,
+          "value": 1400000,
+          "yearly_wage": 936000
+        },
+        {
+          "currency": "€",
+          "full_name": "Pablo López Gómez",
+          "name": "Pablo López",
+          "overall_score": 63,
+          "potential": 81,
+          "value": 1200000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Iker Córdoba Sánchez",
+          "name": "Iker Córdoba",
+          "overall_score": 64,
+          "potential": 77,
+          "value": 1300000,
+          "yearly_wage": 312000
+        }
+      ],
+      "team": "Valencia CF",
+      "transfer_budget": 38300000,
+      "url": "https://sofifa.com/team/461/valencia-cf/260037/"
+    },
+    {
+      "player_count": 38,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "David Soria Solís",
+          "name": "David Soria",
+          "overall_score": 80,
+          "potential": 80,
+          "value": 10500000,
+          "yearly_wage": 1404000
+        },
+        {
+          "currency": "€",
+          "full_name": "Francisco Femenía Far",
+          "name": "Kiko Femenía",
+          "overall_score": 74,
+          "potential": 74,
+          "value": 1500000,
+          "yearly_wage": 1404000
+        },
+        {
+          "currency": "€",
+          "full_name": "Dakonam Djené",
+          "name": "D. Djené",
+          "overall_score": 77,
+          "potential": 77,
+          "value": 5000000,
+          "yearly_wage": 1716000
+        },
+        {
+          "currency": "€",
+          "full_name": "Domingos Sousa Menezes Duarte",
+          "name": "Domingos Duarte",
+          "overall_score": 74,
+          "potential": 74,
+          "value": 3500000,
+          "yearly_wage": 1404000
+        },
+        {
+          "currency": "€",
+          "full_name": "Zaid Romero",
+          "name": "Z. Romero",
+          "overall_score": 76,
+          "potential": 79,
+          "value": 9000000,
+          "yearly_wage": 1352000
+        },
+        {
+          "currency": "€",
+          "full_name": "Juan Antonio Iglesias Sánchez",
+          "name": "Juan Iglesias",
+          "overall_score": 76,
+          "potential": 77,
+          "value": 8000000,
+          "yearly_wage": 1508000
+        },
+        {
+          "currency": "€",
+          "full_name": "Luis Milla Manzanares",
+          "name": "Luis Milla",
+          "overall_score": 81,
+          "potential": 81,
+          "value": 24500000,
+          "yearly_wage": 2392000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mauro Arambarri",
+          "name": "M. Arambarri",
+          "overall_score": 80,
+          "potential": 80,
+          "value": 20500000,
+          "yearly_wage": 2236000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mario Martín Rielves",
+          "name": "Mario Martín",
+          "overall_score": 74,
+          "potential": 82,
+          "value": 9500000,
+          "yearly_wage": 1040000
+        },
+        {
+          "currency": "€",
+          "full_name": "Luis Vázquez",
+          "name": "L. Vázquez",
+          "overall_score": 72,
+          "potential": 76,
+          "value": 3400000,
+          "yearly_wage": 1040000
+        },
+        {
+          "currency": "€",
+          "full_name": "Martín Satriano",
+          "name": "M. Satriano",
+          "overall_score": 75,
+          "potential": 79,
+          "value": 8000000,
+          "yearly_wage": 1456000
+        },
+        {
+          "currency": "€",
+          "full_name": "Borja Mayoral Moya",
+          "name": "Borja Mayoral",
+          "overall_score": 77,
+          "potential": 77,
+          "value": 11000000,
+          "yearly_wage": 1924000
+        },
+        {
+          "currency": "€",
+          "full_name": "Adrián Liso Lahoz",
+          "name": "Adrián Liso",
+          "overall_score": 72,
+          "potential": 83,
+          "value": 5000000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Javier Muñoz Jiménez",
+          "name": "Javi Muñoz",
+          "overall_score": 74,
+          "potential": 74,
+          "value": 4000000,
+          "yearly_wage": 1456000
+        },
+        {
+          "currency": "€",
+          "full_name": "Diego Rico Salguero",
+          "name": "Diego Rico",
+          "overall_score": 76,
+          "potential": 76,
+          "value": 5000000,
+          "yearly_wage": 1612000
+        },
+        {
+          "currency": "€",
+          "full_name": "Abdelkabir Abqar",
+          "name": "A. Abqar",
+          "overall_score": 74,
+          "potential": 77,
+          "value": 4900000,
+          "yearly_wage": 1352000
+        },
+        {
+          "currency": "€",
+          "full_name": "Sebastián Boselli",
+          "name": "S. Boselli",
+          "overall_score": 72,
+          "potential": 77,
+          "value": 3300000,
+          "yearly_wage": 832000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jiří Letáček",
+          "name": "J. Letáček",
+          "overall_score": 69,
+          "potential": 73,
+          "value": 1500000,
+          "yearly_wage": 520000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alejandro San Cristóbal",
+          "name": "Álex Sancris",
+          "overall_score": 73,
+          "potential": 73,
+          "value": 3100000,
+          "yearly_wage": 1352000
+        },
+        {
+          "currency": "€",
+          "full_name": "Veljko Birmančević",
+          "name": "V. Birmančević",
+          "overall_score": 76,
+          "potential": 76,
+          "value": 8000000,
+          "yearly_wage": 1300000
+        },
+        {
+          "currency": "€",
+          "full_name": "David Cordón Mancha",
+          "name": "Davinchi",
+          "overall_score": 67,
+          "potential": 81,
+          "value": 2200000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Damián Cáceres Rodríguez",
+          "name": "Damián",
+          "overall_score": 61,
+          "potential": 70,
+          "value": 725000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Allan-Roméo Nyom",
+          "name": "A. Nyom",
+          "overall_score": 71,
+          "potential": 71,
+          "value": 425000,
+          "yearly_wage": 780000
+        },
+        {
+          "currency": "€",
+          "full_name": "Abu Kamara",
+          "name": "A. Kamara",
+          "overall_score": 68,
+          "potential": 76,
+          "value": 2700000,
+          "yearly_wage": 624000
+        },
+        {
+          "currency": "€",
+          "full_name": "Hugo Solozábal Granados",
+          "name": "Hugo Solozábal",
+          "overall_score": 59,
+          "potential": 68,
+          "value": 500000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alberto Risco Alcántara",
+          "name": "Alberto Risco",
+          "overall_score": 62,
+          "potential": 75,
+          "value": 950000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jorge Montes García",
+          "name": "Jorge Montes",
+          "overall_score": 57,
+          "potential": 67,
+          "value": 350000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lucas Laso Gutiérrez",
+          "name": "Lucas Laso",
+          "overall_score": 61,
+          "potential": 72,
+          "value": 700000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jorge Benito de Valle",
+          "name": "Jorge Benito",
+          "overall_score": 58,
+          "potential": 73,
+          "value": 425000,
+          "yearly_wage": 52000
+        },
+        {
+          "currency": "€",
+          "full_name": "José Luis Pérez del Amo",
+          "name": "Joselu Pérez",
+          "overall_score": 56,
+          "potential": 67,
+          "value": 325000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Juan Miguel Jiménez López",
+          "name": "Juanmi",
+          "overall_score": 72,
+          "potential": 72,
+          "value": 1900000,
+          "yearly_wage": 1300000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alejandro García Mestanza",
+          "name": "Mestanza",
+          "overall_score": 61,
+          "potential": 75,
+          "value": 800000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ismael Bekhoucha",
+          "name": "I. Bekhoucha",
+          "overall_score": 64,
+          "potential": 75,
+          "value": 1200000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Peter Federico González Carmona",
+          "name": "Peter",
+          "overall_score": 69,
+          "potential": 76,
+          "value": 2800000,
+          "yearly_wage": 728000
+        },
+        {
+          "currency": "€",
+          "full_name": "Juan Berrocal González",
+          "name": "Berrocal",
+          "overall_score": 71,
+          "potential": 74,
+          "value": 2200000,
+          "yearly_wage": 988000
+        },
+        {
+          "currency": "€",
+          "full_name": "Yvan Neyou",
+          "name": "Y. Neyou",
+          "overall_score": 74,
+          "potential": 74,
+          "value": 4200000,
+          "yearly_wage": 1456000
+        },
+        {
+          "currency": "€",
+          "full_name": "Coba Gomes da Costa",
+          "name": "Coba da Costa",
+          "overall_score": 70,
+          "potential": 77,
+          "value": 3200000,
+          "yearly_wage": 832000
+        },
+        {
+          "currency": "€",
+          "full_name": "Christantus Uche",
+          "name": "C. Uche",
+          "overall_score": 76,
+          "potential": 82,
+          "value": 12000000,
+          "yearly_wage": 1508000
+        }
+      ],
+      "team": "Getafe CF",
+      "transfer_budget": 8300000,
+      "url": "https://sofifa.com/team/1860/getafe-cf/260037/"
+    },
+    {
+      "player_count": 33,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Leo Román Riquelme",
+          "name": "Leo Román",
+          "overall_score": 77,
+          "potential": 83,
+          "value": 13500000,
+          "yearly_wage": 780000
+        },
+        {
+          "currency": "€",
+          "full_name": "Pablo Maffeo Becerra",
+          "name": "Maffeo",
+          "overall_score": 78,
+          "potential": 78,
+          "value": 13500000,
+          "yearly_wage": 1664000
+        },
+        {
+          "currency": "€",
+          "full_name": "Martin Valjent",
+          "name": "M. Valjent",
+          "overall_score": 77,
+          "potential": 77,
+          "value": 9000000,
+          "yearly_wage": 1612000
+        },
+        {
+          "currency": "€",
+          "full_name": "Antonio José Raíllo Arenas",
+          "name": "Raíllo",
+          "overall_score": 79,
+          "potential": 79,
+          "value": 8500000,
+          "yearly_wage": 1924000
+        },
+        {
+          "currency": "€",
+          "full_name": "Johan Mojica",
+          "name": "J. Mojica",
+          "overall_score": 77,
+          "potential": 77,
+          "value": 7500000,
+          "yearly_wage": 1612000
+        },
+        {
+          "currency": "€",
+          "full_name": "Manuel Morlanes Ariño",
+          "name": "Manu Morlanes",
+          "overall_score": 76,
+          "potential": 78,
+          "value": 8500000,
+          "yearly_wage": 1456000
+        },
+        {
+          "currency": "€",
+          "full_name": "Sergi Darder Moll",
+          "name": "Sergi Darder",
+          "overall_score": 79,
+          "potential": 79,
+          "value": 14500000,
+          "yearly_wage": 1976000
+        },
+        {
+          "currency": "€",
+          "full_name": "Samuel Almeida Costa",
+          "name": "Samú Costa",
+          "overall_score": 78,
+          "potential": 82,
+          "value": 18500000,
+          "yearly_wage": 1456000
+        },
+        {
+          "currency": "€",
+          "full_name": "Pablo Torre Carral",
+          "name": "Pablo Torre",
+          "overall_score": 74,
+          "potential": 82,
+          "value": 9500000,
+          "yearly_wage": 1196000
+        },
+        {
+          "currency": "€",
+          "full_name": "Zito André Sebastião Luvumbo",
+          "name": "Zito Luvumbo",
+          "overall_score": 71,
+          "potential": 78,
+          "value": 3800000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "Vedat Muriqi",
+          "name": "V. Muriqi",
+          "overall_score": 81,
+          "potential": 81,
+          "value": 22000000,
+          "yearly_wage": 2444000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jan Virgili Tenas",
+          "name": "Jan Virgili",
+          "overall_score": 75,
+          "potential": 86,
+          "value": 12000000,
+          "yearly_wage": 1040000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mateo Joseph",
+          "name": "Mateo Joseph",
+          "overall_score": 72,
+          "potential": 82,
+          "value": 5500000,
+          "yearly_wage": 1612000
+        },
+        {
+          "currency": "€",
+          "full_name": "Omar Mascarell González",
+          "name": "Omar Mascarell",
+          "overall_score": 75,
+          "potential": 75,
+          "value": 3700000,
+          "yearly_wage": 1456000
+        },
+        {
+          "currency": "€",
+          "full_name": "Antonio Sánchez Navarro",
+          "name": "Antonio Sánchez",
+          "overall_score": 73,
+          "potential": 73,
+          "value": 3100000,
+          "yearly_wage": 1248000
+        },
+        {
+          "currency": "€",
+          "full_name": "Marash Kumbulla",
+          "name": "M. Kumbulla",
+          "overall_score": 76,
+          "potential": 79,
+          "value": 9000000,
+          "yearly_wage": 2132000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mateu Jaume Morey Bauzá",
+          "name": "Mateu Morey",
+          "overall_score": 73,
+          "potential": 76,
+          "value": 3700000,
+          "yearly_wage": 1092000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lucas Bergström",
+          "name": "L. Bergström",
+          "overall_score": 68,
+          "potential": 75,
+          "value": 2100000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Antonio Latorre Grueso",
+          "name": "Toni Lato",
+          "overall_score": 73,
+          "potential": 73,
+          "value": 2900000,
+          "yearly_wage": 1144000
+        },
+        {
+          "currency": "€",
+          "full_name": "Takuma Asano",
+          "name": "T. Asano",
+          "overall_score": 74,
+          "potential": 74,
+          "value": 4100000,
+          "yearly_wage": 1508000
+        },
+        {
+          "currency": "€",
+          "full_name": "Abdón Prats Bastidas",
+          "name": "Abdón Prats",
+          "overall_score": 72,
+          "potential": 72,
+          "value": 1900000,
+          "yearly_wage": 1248000
+        },
+        {
+          "currency": "€",
+          "full_name": "Javier Llabrés Exposito",
+          "name": "Javi Llabrés",
+          "overall_score": 69,
+          "potential": 76,
+          "value": 2800000,
+          "yearly_wage": 728000
+        },
+        {
+          "currency": "€",
+          "full_name": "David López Guijarro",
+          "name": "David López",
+          "overall_score": 69,
+          "potential": 78,
+          "value": 2900000,
+          "yearly_wage": 676000
+        },
+        {
+          "currency": "€",
+          "full_name": "Iliesse Salhi",
+          "name": "I. Salhi",
+          "overall_score": 60,
+          "potential": 77,
+          "value": 600000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Iván Cuéllar Sacristán",
+          "name": "Pichu Cuéllar",
+          "overall_score": 67,
+          "potential": 67,
+          "value": 110000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Miguel Calatayud García",
+          "name": "Miguel Calatayud",
+          "overall_score": 60,
+          "potential": 75,
+          "value": 550000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Miguel Jan Salas Franch",
+          "name": "Jan Salas",
+          "overall_score": 62,
+          "potential": 76,
+          "value": 950000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Justin Kalumba",
+          "name": "J. Kalumba",
+          "overall_score": 65,
+          "potential": 75,
+          "value": 1600000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Luis Orejuela de la Rosa",
+          "name": "Orejuela",
+          "overall_score": 61,
+          "potential": 78,
+          "value": 775000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Javier Olaizola Jiménez",
+          "name": "Javier Olaizola",
+          "overall_score": 59,
+          "potential": 76,
+          "value": 550000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Daniel Luna",
+          "name": "D. Luna",
+          "overall_score": 65,
+          "potential": 73,
+          "value": 1600000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "Cyle Larin",
+          "name": "C. Larin",
+          "overall_score": 74,
+          "potential": 74,
+          "value": 4100000,
+          "yearly_wage": 1508000
+        },
+        {
+          "currency": "€",
+          "full_name": "Marc Domènech González",
+          "name": "Marc Domènech",
+          "overall_score": 64,
+          "potential": 81,
+          "value": 1500000,
+          "yearly_wage": 260000
+        }
+      ],
+      "team": "RCD Mallorca",
+      "transfer_budget": 3300000,
+      "url": "https://sofifa.com/team/453/rcd-mallorca/260037/"
+    },
+    {
+      "player_count": 35,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Ionuț Andrei Radu",
+          "name": "I. Radu",
+          "overall_score": 78,
+          "potential": 78,
+          "value": 10000000,
+          "yearly_wage": 1040000
+        },
+        {
+          "currency": "€",
+          "full_name": "Javier Rodríguez Galiano",
+          "name": "Javi Rodríguez",
+          "overall_score": 76,
+          "potential": 82,
+          "value": 11000000,
+          "yearly_wage": 1144000
+        },
+        {
+          "currency": "€",
+          "full_name": "Carl Starfelt",
+          "name": "C. Starfelt",
+          "overall_score": 78,
+          "potential": 78,
+          "value": 11500000,
+          "yearly_wage": 1560000
+        },
+        {
+          "currency": "€",
+          "full_name": "Marcos Alonso Mendoza",
+          "name": "Marcos Alonso",
+          "overall_score": 79,
+          "potential": 79,
+          "value": 5500000,
+          "yearly_wage": 1716000
+        },
+        {
+          "currency": "€",
+          "full_name": "Sergio Carreira Vilariño",
+          "name": "Carreira",
+          "overall_score": 75,
+          "potential": 78,
+          "value": 7000000,
+          "yearly_wage": 1092000
+        },
+        {
+          "currency": "€",
+          "full_name": "Hugo Sotelo Gómez",
+          "name": "Hugo Sotelo",
+          "overall_score": 74,
+          "potential": 81,
+          "value": 8500000,
+          "yearly_wage": 884000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ilaix Moriba",
+          "name": "I. Moriba",
+          "overall_score": 78,
+          "potential": 83,
+          "value": 21500000,
+          "yearly_wage": 1352000
+        },
+        {
+          "currency": "€",
+          "full_name": "Óscar Mingueza García",
+          "name": "Mingueza",
+          "overall_score": 80,
+          "potential": 81,
+          "value": 22500000,
+          "yearly_wage": 1768000
+        },
+        {
+          "currency": "€",
+          "full_name": "Fernando López González",
+          "name": "Fer López",
+          "overall_score": 73,
+          "potential": 82,
+          "value": 7000000,
+          "yearly_wage": 1872000
+        },
+        {
+          "currency": "€",
+          "full_name": "Williot Swedberg",
+          "name": "W. Swedberg",
+          "overall_score": 75,
+          "potential": 82,
+          "value": 11500000,
+          "yearly_wage": 1040000
+        },
+        {
+          "currency": "€",
+          "full_name": "Borja Iglesias Quintás",
+          "name": "Borja Iglesias",
+          "overall_score": 80,
+          "potential": 80,
+          "value": 17000000,
+          "yearly_wage": 2080000
+        },
+        {
+          "currency": "€",
+          "full_name": "Iago Aspas Juncal",
+          "name": "Iago Aspas",
+          "overall_score": 82,
+          "potential": 82,
+          "value": 10000000,
+          "yearly_wage": 1820000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ferran Jutglà Blanch",
+          "name": "Ferran Jutglà",
+          "overall_score": 75,
+          "potential": 75,
+          "value": 6000000,
+          "yearly_wage": 1404000
+        },
+        {
+          "currency": "€",
+          "full_name": "Hugo Álvarez Antúnez",
+          "name": "Hugo Álvarez",
+          "overall_score": 75,
+          "potential": 81,
+          "value": 9000000,
+          "yearly_wage": 988000
+        },
+        {
+          "currency": "€",
+          "full_name": "Álvaro Núñez Cobo",
+          "name": "Álvaro Núñez",
+          "overall_score": 76,
+          "potential": 80,
+          "value": 10000000,
+          "yearly_wage": 1144000
+        },
+        {
+          "currency": "€",
+          "full_name": "Javier Rueda García",
+          "name": "Javi Rueda",
+          "overall_score": 74,
+          "potential": 81,
+          "value": 8000000,
+          "yearly_wage": 988000
+        },
+        {
+          "currency": "€",
+          "full_name": "Joseph Aidoo",
+          "name": "J. Aidoo",
+          "overall_score": 73,
+          "potential": 73,
+          "value": 2500000,
+          "yearly_wage": 1092000
+        },
+        {
+          "currency": "€",
+          "full_name": "Iván Villar Martínez",
+          "name": "Iván Villar",
+          "overall_score": 72,
+          "potential": 75,
+          "value": 2300000,
+          "yearly_wage": 624000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jones El-Abdellaoui",
+          "name": "J. El-Abdellaoui",
+          "overall_score": 70,
+          "potential": 81,
+          "value": 3400000,
+          "yearly_wage": 624000
+        },
+        {
+          "currency": "€",
+          "full_name": "Matías Vecino",
+          "name": "M. Vecino",
+          "overall_score": 76,
+          "potential": 76,
+          "value": 4600000,
+          "yearly_wage": 1404000
+        },
+        {
+          "currency": "€",
+          "full_name": "Pablo Durán Fernández",
+          "name": "Pablo Durán",
+          "overall_score": 74,
+          "potential": 78,
+          "value": 6000000,
+          "yearly_wage": 1144000
+        },
+        {
+          "currency": "€",
+          "full_name": "Manuel Fernández Arroyo",
+          "name": "Manu Fernández",
+          "overall_score": 70,
+          "potential": 75,
+          "value": 2200000,
+          "yearly_wage": 676000
+        },
+        {
+          "currency": "€",
+          "full_name": "Hugo Burcio García",
+          "name": "Hugo Burcio",
+          "overall_score": 63,
+          "potential": 77,
+          "value": 1100000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Andrés Antañón Vieites",
+          "name": "Andrés Antañón",
+          "overall_score": 61,
+          "potential": 78,
+          "value": 825000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Carlos Dominguez Cáceres",
+          "name": "Carlos Domínguez",
+          "overall_score": 73,
+          "potential": 78,
+          "value": 4200000,
+          "yearly_wage": 884000
+        },
+        {
+          "currency": "€",
+          "full_name": "Franco Cervi",
+          "name": "F. Cervi",
+          "overall_score": 71,
+          "potential": 71,
+          "value": 1600000,
+          "yearly_wage": 936000
+        },
+        {
+          "currency": "€",
+          "full_name": "Marc Vidal Girona",
+          "name": "Marc Vidal",
+          "overall_score": 64,
+          "potential": 68,
+          "value": 650000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Yoel Lago Amil",
+          "name": "Yoel Lago",
+          "overall_score": 71,
+          "potential": 78,
+          "value": 3500000,
+          "yearly_wage": 624000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mihailo Ristić",
+          "name": "M. Ristić",
+          "overall_score": 72,
+          "potential": 72,
+          "value": 2100000,
+          "yearly_wage": 988000
+        },
+        {
+          "currency": "€",
+          "full_name": "Hugo González Sotos",
+          "name": "Hugo González",
+          "overall_score": 65,
+          "potential": 74,
+          "value": 1600000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Miguel Román González",
+          "name": "Miguel Román",
+          "overall_score": 74,
+          "potential": 80,
+          "value": 6500000,
+          "yearly_wage": 1040000
+        },
+        {
+          "currency": "€",
+          "full_name": "Damián Rodríguez Sousa",
+          "name": "Damián Rodríguez",
+          "overall_score": 72,
+          "potential": 76,
+          "value": 3400000,
+          "yearly_wage": 884000
+        },
+        {
+          "currency": "€",
+          "full_name": "Carlos Dotor Gonzalez",
+          "name": "Dotor",
+          "overall_score": 68,
+          "potential": 73,
+          "value": 1800000,
+          "yearly_wage": 572000
+        },
+        {
+          "currency": "€",
+          "full_name": "Manuel Sánchez de la Peña",
+          "name": "Manu Sánchez",
+          "overall_score": 76,
+          "potential": 80,
+          "value": 10000000,
+          "yearly_wage": 1144000
+        },
+        {
+          "currency": "€",
+          "full_name": "Unai Núñez Gestoso",
+          "name": "Unai Núñez",
+          "overall_score": 75,
+          "potential": 76,
+          "value": 5500000,
+          "yearly_wage": 1300000
+        }
+      ],
+      "team": "RC Celta",
+      "transfer_budget": 11800000,
+      "url": "https://sofifa.com/team/450/rc-celta/260037/"
+    },
+    {
+      "player_count": 33,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Marko Dmitrović",
+          "name": "M. Dmitrović",
+          "overall_score": 79,
+          "potential": 79,
+          "value": 5500000,
+          "yearly_wage": 936000
+        },
+        {
+          "currency": "€",
+          "full_name": "Omar El Hilali",
+          "name": "Omar El Hilali",
+          "overall_score": 75,
+          "potential": 81,
+          "value": 8500000,
+          "yearly_wage": 780000
+        },
+        {
+          "currency": "€",
+          "full_name": "Fernando Calero Villa",
+          "name": "Calero",
+          "overall_score": 75,
+          "potential": 75,
+          "value": 4700000,
+          "yearly_wage": 1092000
+        },
+        {
+          "currency": "€",
+          "full_name": "Leandro Cabrera",
+          "name": "L. Cabrera",
+          "overall_score": 76,
+          "potential": 76,
+          "value": 2400000,
+          "yearly_wage": 1144000
+        },
+        {
+          "currency": "€",
+          "full_name": "Carlos Romero Serrano",
+          "name": "Carlos Romero",
+          "overall_score": 79,
+          "potential": 83,
+          "value": 23500000,
+          "yearly_wage": 1820000
+        },
+        {
+          "currency": "€",
+          "full_name": "Urko González de Zárate",
+          "name": "Urko González",
+          "overall_score": 76,
+          "potential": 82,
+          "value": 11000000,
+          "yearly_wage": 936000
+        },
+        {
+          "currency": "€",
+          "full_name": "Pol Lozano Vizuete",
+          "name": "Pol Lozano",
+          "overall_score": 75,
+          "potential": 77,
+          "value": 6500000,
+          "yearly_wage": 988000
+        },
+        {
+          "currency": "€",
+          "full_name": "Tyrhys Dolan",
+          "name": "T. Dolan",
+          "overall_score": 74,
+          "potential": 79,
+          "value": 6500000,
+          "yearly_wage": 936000
+        },
+        {
+          "currency": "€",
+          "full_name": "Pere Milla Peña",
+          "name": "Pere Milla",
+          "overall_score": 75,
+          "potential": 75,
+          "value": 4500000,
+          "yearly_wage": 1144000
+        },
+        {
+          "currency": "€",
+          "full_name": "Eduardo Expósito Jaén",
+          "name": "Edu Expósito",
+          "overall_score": 77,
+          "potential": 77,
+          "value": 10500000,
+          "yearly_wage": 1300000
+        },
+        {
+          "currency": "€",
+          "full_name": "Enrique García Martínez",
+          "name": "Kike García",
+          "overall_score": 74,
+          "potential": 74,
+          "value": 1800000,
+          "yearly_wage": 884000
+        },
+        {
+          "currency": "€",
+          "full_name": "Roberto Fernández Jaén",
+          "name": "Roberto Fernández",
+          "overall_score": 74,
+          "potential": 80,
+          "value": 7000000,
+          "yearly_wage": 988000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jofre Carreras Pagès",
+          "name": "Jofre",
+          "overall_score": 73,
+          "potential": 75,
+          "value": 4000000,
+          "yearly_wage": 884000
+        },
+        {
+          "currency": "€",
+          "full_name": "Cyril Ngonge",
+          "name": "C. Ngonge",
+          "overall_score": 72,
+          "potential": 73,
+          "value": 2800000,
+          "yearly_wage": 2756000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ramón Terrats Espacio",
+          "name": "Terrats",
+          "overall_score": 74,
+          "potential": 77,
+          "value": 6000000,
+          "yearly_wage": 1352000
+        },
+        {
+          "currency": "€",
+          "full_name": "Charles Pickel",
+          "name": "C. Pickel",
+          "overall_score": 70,
+          "potential": 70,
+          "value": 1600000,
+          "yearly_wage": 676000
+        },
+        {
+          "currency": "€",
+          "full_name": "Clemens Riedel",
+          "name": "C. Riedel",
+          "overall_score": 71,
+          "potential": 81,
+          "value": 3900000,
+          "yearly_wage": 520000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ángel Fortuño Viñas",
+          "name": "Fortuño",
+          "overall_score": 65,
+          "potential": 73,
+          "value": 1400000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Rubén Sánchez Sáez",
+          "name": "Rubén Sánchez",
+          "overall_score": 71,
+          "potential": 76,
+          "value": 2600000,
+          "yearly_wage": 624000
+        },
+        {
+          "currency": "€",
+          "full_name": "Antoniu Roca Vives",
+          "name": "Antoniu Roca",
+          "overall_score": 73,
+          "potential": 76,
+          "value": 4200000,
+          "yearly_wage": 780000
+        },
+        {
+          "currency": "€",
+          "full_name": "José Salinas Morán",
+          "name": "Salinas",
+          "overall_score": 72,
+          "potential": 76,
+          "value": 3100000,
+          "yearly_wage": 676000
+        },
+        {
+          "currency": "€",
+          "full_name": "Miguel Ángel Rubio Lestán",
+          "name": "Miguel Rubio",
+          "overall_score": 70,
+          "potential": 72,
+          "value": 1700000,
+          "yearly_wage": 624000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lluc Castell Solé",
+          "name": "Lluc Castell",
+          "overall_score": 60,
+          "potential": 76,
+          "value": 625000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Javier Puado Díaz",
+          "name": "Puado",
+          "overall_score": 77,
+          "potential": 77,
+          "value": 11000000,
+          "yearly_wage": 1300000
+        },
+        {
+          "currency": "€",
+          "full_name": "Pol Tristán Jiménez",
+          "name": "Tristán",
+          "overall_score": 64,
+          "potential": 72,
+          "value": 1100000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Omar Sadik",
+          "name": "O. Sadik",
+          "overall_score": 64,
+          "potential": 73,
+          "value": 1300000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Javier Hernández Coarasa",
+          "name": "Javi Hernández",
+          "overall_score": 68,
+          "potential": 79,
+          "value": 2700000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "Justin Smith",
+          "name": "J. Smith",
+          "overall_score": 68,
+          "potential": 79,
+          "value": 2600000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "José Gragera Amado",
+          "name": "José Gragera",
+          "overall_score": 71,
+          "potential": 74,
+          "value": 2200000,
+          "yearly_wage": 676000
+        },
+        {
+          "currency": "€",
+          "full_name": "Pablo Ramón Parra",
+          "name": "Pablo Ramón",
+          "overall_score": 68,
+          "potential": 77,
+          "value": 2500000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "Marcos Fernández Sánchez",
+          "name": "Marcos Fernández",
+          "overall_score": 68,
+          "potential": 77,
+          "value": 2700000,
+          "yearly_wage": 520000
+        },
+        {
+          "currency": "€",
+          "full_name": "Roger Hinojo Estrada",
+          "name": "Roger Hinojo",
+          "overall_score": 67,
+          "potential": 78,
+          "value": 2100000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Rafel Bauzà Sureda",
+          "name": "Rafa Bauza",
+          "overall_score": 66,
+          "potential": 79,
+          "value": 1900000,
+          "yearly_wage": 260000
+        }
+      ],
+      "team": "RCD Espanyol",
+      "transfer_budget": 6500000,
+      "url": "https://sofifa.com/team/452/rcd-espanyol/260037/"
+    },
+    {
+      "player_count": 34,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Odysseas Vlachodimos",
+          "name": "O. Vlachodimos",
+          "overall_score": 79,
+          "potential": 79,
+          "value": 9500000,
+          "yearly_wage": 3692000
+        },
+        {
+          "currency": "€",
+          "full_name": "César Azpilicueta Tanco",
+          "name": "Azpilicueta",
+          "overall_score": 77,
+          "potential": 77,
+          "value": 2800000,
+          "yearly_wage": 1196000
+        },
+        {
+          "currency": "€",
+          "full_name": "Andrés López Gallo",
+          "name": "Andrés Castrín",
+          "overall_score": 72,
+          "potential": 81,
+          "value": 4900000,
+          "yearly_wage": 936000
+        },
+        {
+          "currency": "€",
+          "full_name": "Enrique Jesús Salas Valiente",
+          "name": "Kike Salas",
+          "overall_score": 76,
+          "potential": 82,
+          "value": 11000000,
+          "yearly_wage": 1248000
+        },
+        {
+          "currency": "€",
+          "full_name": "Juan Luis Sánchez Velasco",
+          "name": "Juanlu Sánchez",
+          "overall_score": 75,
+          "potential": 81,
+          "value": 8500000,
+          "yearly_wage": 988000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lucien Agoumé",
+          "name": "L. Agoumé",
+          "overall_score": 76,
+          "potential": 82,
+          "value": 11000000,
+          "yearly_wage": 1248000
+        },
+        {
+          "currency": "€",
+          "full_name": "Nemanja Gudelj",
+          "name": "N. Gudelj",
+          "overall_score": 75,
+          "potential": 75,
+          "value": 2700000,
+          "yearly_wage": 1456000
+        },
+        {
+          "currency": "€",
+          "full_name": "Gabriel Suazo",
+          "name": "G. Suazo",
+          "overall_score": 74,
+          "potential": 74,
+          "value": 4100000,
+          "yearly_wage": 1300000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alexis Sánchez",
+          "name": "A. Sánchez",
+          "overall_score": 75,
+          "potential": 75,
+          "value": 1900000,
+          "yearly_wage": 1248000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ruben Vargas",
+          "name": "R. Vargas",
+          "overall_score": 78,
+          "potential": 78,
+          "value": 15500000,
+          "yearly_wage": 1872000
+        },
+        {
+          "currency": "€",
+          "full_name": "Akor Jerome Adams",
+          "name": "A. Adams",
+          "overall_score": 75,
+          "potential": 78,
+          "value": 7500000,
+          "yearly_wage": 1508000
+        },
+        {
+          "currency": "€",
+          "full_name": "Neal Maupay",
+          "name": "N. Maupay",
+          "overall_score": 74,
+          "potential": 74,
+          "value": 4300000,
+          "yearly_wage": 1820000
+        },
+        {
+          "currency": "€",
+          "full_name": "Djibril Sow",
+          "name": "D. Sow",
+          "overall_score": 75,
+          "potential": 75,
+          "value": 5500000,
+          "yearly_wage": 1508000
+        },
+        {
+          "currency": "€",
+          "full_name": "Batista Mendy",
+          "name": "B. Mendy",
+          "overall_score": 75,
+          "potential": 80,
+          "value": 7500000,
+          "yearly_wage": 2028000
+        },
+        {
+          "currency": "€",
+          "full_name": "José Ángel Carmona Navarro",
+          "name": "Carmona",
+          "overall_score": 77,
+          "potential": 83,
+          "value": 15500000,
+          "yearly_wage": 1352000
+        },
+        {
+          "currency": "€",
+          "full_name": "Joaquín Martínez Gauna",
+          "name": "Oso",
+          "overall_score": 72,
+          "potential": 80,
+          "value": 5000000,
+          "yearly_wage": 780000
+        },
+        {
+          "currency": "€",
+          "full_name": "Tanguy Nianzou",
+          "name": "T. Nianzou",
+          "overall_score": 71,
+          "potential": 76,
+          "value": 2600000,
+          "yearly_wage": 832000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ørjan Nyland",
+          "name": "Ø. Nyland",
+          "overall_score": 74,
+          "potential": 74,
+          "value": 725000,
+          "yearly_wage": 884000
+        },
+        {
+          "currency": "€",
+          "full_name": "Isaac Romero Bernal",
+          "name": "Isaac Romero",
+          "overall_score": 74,
+          "potential": 77,
+          "value": 5500000,
+          "yearly_wage": 1404000
+        },
+        {
+          "currency": "€",
+          "full_name": "Chidera Ejuke",
+          "name": "C. Ejuke",
+          "overall_score": 76,
+          "potential": 76,
+          "value": 8000000,
+          "yearly_wage": 1612000
+        },
+        {
+          "currency": "€",
+          "full_name": "Gerard Fdez. Castellano",
+          "name": "Peque",
+          "overall_score": 74,
+          "potential": 81,
+          "value": 8500000,
+          "yearly_wage": 1196000
+        },
+        {
+          "currency": "€",
+          "full_name": "Fábio Rafael Rodrigues Cardoso",
+          "name": "Fábio Cardoso",
+          "overall_score": 74,
+          "potential": 74,
+          "value": 2900000,
+          "yearly_wage": 1352000
+        },
+        {
+          "currency": "€",
+          "full_name": "Adnan Januzaj",
+          "name": "A. Januzaj",
+          "overall_score": 73,
+          "potential": 73,
+          "value": 2900000,
+          "yearly_wage": 1352000
+        },
+        {
+          "currency": "€",
+          "full_name": "Federico Gattoni",
+          "name": "F. Gattoni",
+          "overall_score": 71,
+          "potential": 71,
+          "value": 1800000,
+          "yearly_wage": 936000
+        },
+        {
+          "currency": "€",
+          "full_name": "Miguel Ángel Sierra Ortega",
+          "name": "Miguel Sierra",
+          "overall_score": 64,
+          "potential": 74,
+          "value": 1300000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alberto Flores López",
+          "name": "Alberto Flores",
+          "overall_score": 65,
+          "potential": 77,
+          "value": 1500000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Manuel Bueno Sebastián",
+          "name": "Manu Bueno",
+          "overall_score": 67,
+          "potential": 78,
+          "value": 2200000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "Eduardo Altozano Agudo",
+          "name": "Edu Altozano",
+          "overall_score": 58,
+          "potential": 78,
+          "value": 550000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Rafael Romero Morilla",
+          "name": "Rafa Romero",
+          "overall_score": 62,
+          "potential": 72,
+          "value": 775000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Joan Jordán Moreno",
+          "name": "Joan Jordán",
+          "overall_score": 74,
+          "potential": 74,
+          "value": 4000000,
+          "yearly_wage": 1404000
+        },
+        {
+          "currency": "€",
+          "full_name": "Marcos Nascimento Teixeira",
+          "name": "Marcão",
+          "overall_score": 74,
+          "potential": 74,
+          "value": 3500000,
+          "yearly_wage": 1352000
+        },
+        {
+          "currency": "€",
+          "full_name": "Adrià Giner Pedrosa",
+          "name": "Adrià Pedrosa",
+          "overall_score": 74,
+          "potential": 74,
+          "value": 4100000,
+          "yearly_wage": 1300000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alfonso González Martínez",
+          "name": "Alfon",
+          "overall_score": 75,
+          "potential": 75,
+          "value": 6000000,
+          "yearly_wage": 1560000
+        },
+        {
+          "currency": "€",
+          "full_name": "Rafael Mir Vicente",
+          "name": "Rafa Mir",
+          "overall_score": 75,
+          "potential": 75,
+          "value": 6000000,
+          "yearly_wage": 1612000
+        }
+      ],
+      "team": "Sevilla FC",
+      "transfer_budget": 32000000,
+      "url": "https://sofifa.com/team/481/sevilla-fc/260037/"
+    },
+    {
+      "player_count": 31,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Mathew Ryan",
+          "name": "M. Ryan",
+          "overall_score": 79,
+          "potential": 79,
+          "value": 5500000,
+          "yearly_wage": 1196000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jeremy Toljan",
+          "name": "J. Toljan",
+          "overall_score": 74,
+          "potential": 74,
+          "value": 3600000,
+          "yearly_wage": 1248000
+        },
+        {
+          "currency": "€",
+          "full_name": "Adrián De La Fuente",
+          "name": "Dela",
+          "overall_score": 74,
+          "potential": 77,
+          "value": 4900000,
+          "yearly_wage": 1196000
+        },
+        {
+          "currency": "€",
+          "full_name": "Matías Moreno",
+          "name": "M. Moreno",
+          "overall_score": 73,
+          "potential": 79,
+          "value": 4400000,
+          "yearly_wage": 1196000
+        },
+        {
+          "currency": "€",
+          "full_name": "Manuel Sánchez de la Peña",
+          "name": "Manu Sánchez",
+          "overall_score": 76,
+          "potential": 80,
+          "value": 10000000,
+          "yearly_wage": 1144000
+        },
+        {
+          "currency": "€",
+          "full_name": "Oriol Rey Erenas",
+          "name": "Oriol Rey",
+          "overall_score": 73,
+          "potential": 73,
+          "value": 3200000,
+          "yearly_wage": 1144000
+        },
+        {
+          "currency": "€",
+          "full_name": "Pablo Martínez Andrés",
+          "name": "Pablo Martínez",
+          "overall_score": 76,
+          "potential": 76,
+          "value": 8000000,
+          "yearly_wage": 1404000
+        },
+        {
+          "currency": "€",
+          "full_name": "Kareem Tunde Ruiz",
+          "name": "Kareem Tunde",
+          "overall_score": 68,
+          "potential": 79,
+          "value": 2600000,
+          "yearly_wage": 520000
+        },
+        {
+          "currency": "€",
+          "full_name": "Iván Romero de Ávila",
+          "name": "Iván Romero",
+          "overall_score": 75,
+          "potential": 80,
+          "value": 8500000,
+          "yearly_wage": 1300000
+        },
+        {
+          "currency": "€",
+          "full_name": "Carlos Álvarez Rivera",
+          "name": "Carlos Álvarez",
+          "overall_score": 77,
+          "potential": 83,
+          "value": 17000000,
+          "yearly_wage": 1144000
+        },
+        {
+          "currency": "€",
+          "full_name": "Carlos Espí Escrihuela",
+          "name": "Carlos Espí",
+          "overall_score": 75,
+          "potential": 84,
+          "value": 12000000,
+          "yearly_wage": 1040000
+        },
+        {
+          "currency": "€",
+          "full_name": "Karl Edouard Etta Eyong",
+          "name": "K. Etta Eyong",
+          "overall_score": 75,
+          "potential": 84,
+          "value": 12500000,
+          "yearly_wage": 1144000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jon Ander Olasagasti Imizcoz",
+          "name": "Olasagasti",
+          "overall_score": 74,
+          "potential": 77,
+          "value": 5500000,
+          "yearly_wage": 1092000
+        },
+        {
+          "currency": "€",
+          "full_name": "Kervin Arriaga",
+          "name": "K. Arriaga",
+          "overall_score": 74,
+          "potential": 75,
+          "value": 4300000,
+          "yearly_wage": 1196000
+        },
+        {
+          "currency": "€",
+          "full_name": "Iker Losada Aragunde",
+          "name": "Iker Losada",
+          "overall_score": 72,
+          "potential": 77,
+          "value": 3500000,
+          "yearly_wage": 884000
+        },
+        {
+          "currency": "€",
+          "full_name": "Víctor García Raja",
+          "name": "Víctor García",
+          "overall_score": 71,
+          "potential": 71,
+          "value": 2000000,
+          "yearly_wage": 936000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alan Matturro",
+          "name": "A. Matturro",
+          "overall_score": 70,
+          "potential": 80,
+          "value": 3300000,
+          "yearly_wage": 520000
+        },
+        {
+          "currency": "€",
+          "full_name": "Pablo Cuñat Campos",
+          "name": "Pablo Campos",
+          "overall_score": 69,
+          "potential": 77,
+          "value": 2700000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ugo Raghouber",
+          "name": "U. Raghouber",
+          "overall_score": 71,
+          "potential": 81,
+          "value": 4000000,
+          "yearly_wage": 676000
+        },
+        {
+          "currency": "€",
+          "full_name": "Unai Vencedor Paris",
+          "name": "Unai Vencedor",
+          "overall_score": 72,
+          "potential": 75,
+          "value": 2900000,
+          "yearly_wage": 1144000
+        },
+        {
+          "currency": "€",
+          "full_name": "Unai Elgezabal Udondo",
+          "name": "Elgezabal",
+          "overall_score": 71,
+          "potential": 71,
+          "value": 1200000,
+          "yearly_wage": 936000
+        },
+        {
+          "currency": "€",
+          "full_name": "José Luis Morales Nogales",
+          "name": "Morales",
+          "overall_score": 73,
+          "potential": 73,
+          "value": 1000000,
+          "yearly_wage": 988000
+        },
+        {
+          "currency": "€",
+          "full_name": "Diego Varela Pampín",
+          "name": "Diego Pampín",
+          "overall_score": 69,
+          "potential": 71,
+          "value": 1600000,
+          "yearly_wage": 676000
+        },
+        {
+          "currency": "€",
+          "full_name": "Francisco Cortés Gracia",
+          "name": "Paco Cortés",
+          "overall_score": 68,
+          "potential": 81,
+          "value": 2800000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "Martín Wilhelm Krug",
+          "name": "M. Krug",
+          "overall_score": 62,
+          "potential": 76,
+          "value": 875000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alejandro Primo Hernández",
+          "name": "Álex Primo",
+          "overall_score": 60,
+          "potential": 72,
+          "value": 525000,
+          "yearly_wage": 52000
+        },
+        {
+          "currency": "€",
+          "full_name": "Nacho Pérez Gómez",
+          "name": "Nacho Pérez",
+          "overall_score": 67,
+          "potential": 81,
+          "value": 2200000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Tay Abed",
+          "name": "T. Abed",
+          "overall_score": 66,
+          "potential": 78,
+          "value": 2100000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "Roger Brugué Ayguade",
+          "name": "Brugui",
+          "overall_score": 73,
+          "potential": 73,
+          "value": 3100000,
+          "yearly_wage": 1300000
+        },
+        {
+          "currency": "€",
+          "full_name": "Daniel Martín Rodríguez",
+          "name": "Dani Martín",
+          "overall_score": 62,
+          "potential": 79,
+          "value": 900000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jorge Cabello Trujillo",
+          "name": "Cabello",
+          "overall_score": 66,
+          "potential": 77,
+          "value": 1800000,
+          "yearly_wage": 364000
+        }
+      ],
+      "team": "Levante UD",
+      "transfer_budget": 9300000,
+      "url": "https://sofifa.com/team/1853/levante-ud/260037/"
+    },
+    {
+      "player_count": 33,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Matías Dituro",
+          "name": "M. Dituro",
+          "overall_score": 76,
+          "potential": 76,
+          "value": 825000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "Víctor Chust García",
+          "name": "Víctor Chust",
+          "overall_score": 73,
+          "potential": 78,
+          "value": 4000000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "David Affengruber",
+          "name": "D. Affengruber",
+          "overall_score": 75,
+          "potential": 82,
+          "value": 10500000,
+          "yearly_wage": 936000
+        },
+        {
+          "currency": "€",
+          "full_name": "Pedro Bigas Rigo",
+          "name": "Bigas",
+          "overall_score": 76,
+          "potential": 76,
+          "value": 2000000,
+          "yearly_wage": 884000
+        },
+        {
+          "currency": "€",
+          "full_name": "Marc Aguado Pallarés",
+          "name": "Marc Aguado",
+          "overall_score": 73,
+          "potential": 78,
+          "value": 4100000,
+          "yearly_wage": 884000
+        },
+        {
+          "currency": "€",
+          "full_name": "José Antonio Morente Oliva",
+          "name": "Tete Morente",
+          "overall_score": 71,
+          "potential": 71,
+          "value": 1900000,
+          "yearly_wage": 832000
+        },
+        {
+          "currency": "€",
+          "full_name": "Gonzalo Villar del Fraile",
+          "name": "Gonzalo Villar",
+          "overall_score": 72,
+          "potential": 72,
+          "value": 2500000,
+          "yearly_wage": 884000
+        },
+        {
+          "currency": "€",
+          "full_name": "Aleix Febas Pérez",
+          "name": "Aleix Febas",
+          "overall_score": 78,
+          "potential": 78,
+          "value": 13500000,
+          "yearly_wage": 1456000
+        },
+        {
+          "currency": "€",
+          "full_name": "Germán Valera Karabinaite",
+          "name": "Valera",
+          "overall_score": 76,
+          "potential": 80,
+          "value": 11000000,
+          "yearly_wage": 1040000
+        },
+        {
+          "currency": "€",
+          "full_name": "André Miguel Valente da Silva",
+          "name": "André da Silva",
+          "overall_score": 76,
+          "potential": 76,
+          "value": 7500000,
+          "yearly_wage": 1352000
+        },
+        {
+          "currency": "€",
+          "full_name": "Rafael Mir Vicente",
+          "name": "Rafa Mir",
+          "overall_score": 75,
+          "potential": 75,
+          "value": 6000000,
+          "yearly_wage": 1612000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lucas Cepeda",
+          "name": "L. Cepeda",
+          "overall_score": 72,
+          "potential": 81,
+          "value": 5500000,
+          "yearly_wage": 832000
+        },
+        {
+          "currency": "€",
+          "full_name": "Álvaro Daniel Rodríguez Muñoz",
+          "name": "Álvaro Rodríguez",
+          "overall_score": 72,
+          "potential": 83,
+          "value": 5000000,
+          "yearly_wage": 728000
+        },
+        {
+          "currency": "€",
+          "full_name": "Grady Diangana",
+          "name": "G. Diangana",
+          "overall_score": 70,
+          "potential": 70,
+          "value": 1700000,
+          "yearly_wage": 728000
+        },
+        {
+          "currency": "€",
+          "full_name": "Léo Pétrot",
+          "name": "L. Pétrot",
+          "overall_score": 71,
+          "potential": 71,
+          "value": 1600000,
+          "yearly_wage": 780000
+        },
+        {
+          "currency": "€",
+          "full_name": "Héctor Fort García",
+          "name": "Héctor Fort",
+          "overall_score": 71,
+          "potential": 83,
+          "value": 4200000,
+          "yearly_wage": 1404000
+        },
+        {
+          "currency": "€",
+          "full_name": "John Chetauya Donald",
+          "name": "John Donald",
+          "overall_score": 69,
+          "potential": 76,
+          "value": 2600000,
+          "yearly_wage": 520000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ignacio Peña Sotorres",
+          "name": "Iñaki Peña",
+          "overall_score": 76,
+          "potential": 80,
+          "value": 8000000,
+          "yearly_wage": 2132000
+        },
+        {
+          "currency": "€",
+          "full_name": "Adrià Giner Pedrosa",
+          "name": "Adrià Pedrosa",
+          "overall_score": 74,
+          "potential": 74,
+          "value": 4100000,
+          "yearly_wage": 1300000
+        },
+        {
+          "currency": "€",
+          "full_name": "Martim Carvalho Neto",
+          "name": "Martim Neto",
+          "overall_score": 72,
+          "potential": 81,
+          "value": 5000000,
+          "yearly_wage": 780000
+        },
+        {
+          "currency": "€",
+          "full_name": "Federico Redondo",
+          "name": "F. Redondo",
+          "overall_score": 70,
+          "potential": 77,
+          "value": 3200000,
+          "yearly_wage": 624000
+        },
+        {
+          "currency": "€",
+          "full_name": "José Antonio Ferrández Pomares",
+          "name": "Josan",
+          "overall_score": 72,
+          "potential": 72,
+          "value": 950000,
+          "yearly_wage": 676000
+        },
+        {
+          "currency": "€",
+          "full_name": "Yago de Santiago Alonso",
+          "name": "Yago Santiago",
+          "overall_score": 70,
+          "potential": 79,
+          "value": 3600000,
+          "yearly_wage": 676000
+        },
+        {
+          "currency": "€",
+          "full_name": "Adam Boayar",
+          "name": "A. Boayar",
+          "overall_score": 62,
+          "potential": 78,
+          "value": 1000000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alejandro Iturbe Encabo",
+          "name": "Iturbe",
+          "overall_score": 66,
+          "potential": 76,
+          "value": 1700000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Antonio Martínez Bastida",
+          "name": "Antonio Martínez",
+          "overall_score": 59,
+          "potential": 71,
+          "value": 525000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Albert Niculăesei Plesca",
+          "name": "Albert",
+          "overall_score": 58,
+          "potential": 75,
+          "value": 475000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Aboubacar Sangaré Traoré",
+          "name": "Buba Sangaré",
+          "overall_score": 65,
+          "potential": 79,
+          "value": 1600000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alejandro Sánchez Mantecón",
+          "name": "Álex Sánchez",
+          "overall_score": 62,
+          "potential": 76,
+          "value": 950000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Abiel Osorio",
+          "name": "A. Osorio",
+          "overall_score": 69,
+          "potential": 76,
+          "value": 2800000,
+          "yearly_wage": 624000
+        },
+        {
+          "currency": "€",
+          "full_name": "Bambo Diaby",
+          "name": "B. Diaby",
+          "overall_score": 67,
+          "potential": 69,
+          "value": 1100000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "Matia Barzić Gutiérrez",
+          "name": "Matia Barzić",
+          "overall_score": 67,
+          "potential": 80,
+          "value": 2400000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ali Houary Jeddoub",
+          "name": "Ali Houary",
+          "overall_score": 65,
+          "potential": 80,
+          "value": 1700000,
+          "yearly_wage": 260000
+        }
+      ],
+      "team": "Elche CF",
+      "transfer_budget": 1800000,
+      "url": "https://sofifa.com/team/468/elche-cf/260037/"
+    },
+    {
+      "player_count": 35,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Antonio Sivera Salvá",
+          "name": "Sivera",
+          "overall_score": 77,
+          "potential": 79,
+          "value": 9000000,
+          "yearly_wage": 988000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jonathan Castro Otto",
+          "name": "Jonny",
+          "overall_score": 75,
+          "potential": 75,
+          "value": 4100000,
+          "yearly_wage": 1352000
+        },
+        {
+          "currency": "€",
+          "full_name": "Nahuel Tenaglia",
+          "name": "N. Tenaglia",
+          "overall_score": 77,
+          "potential": 77,
+          "value": 9000000,
+          "yearly_wage": 1508000
+        },
+        {
+          "currency": "€",
+          "full_name": "Víctor Parada González",
+          "name": "Víctor Parada",
+          "overall_score": 70,
+          "potential": 74,
+          "value": 2100000,
+          "yearly_wage": 676000
+        },
+        {
+          "currency": "€",
+          "full_name": "Antonio Blanco Conde",
+          "name": "Antonio Blanco",
+          "overall_score": 76,
+          "potential": 81,
+          "value": 10500000,
+          "yearly_wage": 1196000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ángel Pérez Hidalgo",
+          "name": "Ángel Pérez",
+          "overall_score": 70,
+          "potential": 79,
+          "value": 3600000,
+          "yearly_wage": 728000
+        },
+        {
+          "currency": "€",
+          "full_name": "Pablo Ibáñez Lumbreras",
+          "name": "Pablo Ibáñez",
+          "overall_score": 73,
+          "potential": 74,
+          "value": 3600000,
+          "yearly_wage": 1144000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jon Guridi Aldalur",
+          "name": "Guridi",
+          "overall_score": 73,
+          "potential": 73,
+          "value": 2900000,
+          "yearly_wage": 1196000
+        },
+        {
+          "currency": "€",
+          "full_name": "Abderrahman Rebbach",
+          "name": "A. Rebbach",
+          "overall_score": 72,
+          "potential": 72,
+          "value": 2600000,
+          "yearly_wage": 1092000
+        },
+        {
+          "currency": "€",
+          "full_name": "Antonio Martínez López",
+          "name": "Toni Martínez",
+          "overall_score": 77,
+          "potential": 77,
+          "value": 11000000,
+          "yearly_wage": 1716000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lucas Boyé",
+          "name": "L. Boyé",
+          "overall_score": 77,
+          "potential": 77,
+          "value": 10500000,
+          "yearly_wage": 1716000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ibrahim Diabate",
+          "name": "I. Diabate",
+          "overall_score": 72,
+          "potential": 74,
+          "value": 3000000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Denis Suárez Fernández",
+          "name": "Denis Suárez",
+          "overall_score": 74,
+          "potential": 74,
+          "value": 3500000,
+          "yearly_wage": 1300000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ander Guevara Lajo",
+          "name": "Ander Guevara",
+          "overall_score": 74,
+          "potential": 75,
+          "value": 4300000,
+          "yearly_wage": 1196000
+        },
+        {
+          "currency": "€",
+          "full_name": "Calebe Ferreira da Silva",
+          "name": "Calebe",
+          "overall_score": 71,
+          "potential": 72,
+          "value": 2200000,
+          "yearly_wage": 884000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jon Pacheco Dozagarat",
+          "name": "Pacheco",
+          "overall_score": 74,
+          "potential": 81,
+          "value": 8000000,
+          "yearly_wage": 1300000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ville Koski",
+          "name": "V. Koski",
+          "overall_score": 66,
+          "potential": 72,
+          "value": 1200000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "Raúl Fdez-Cavada Mateos",
+          "name": "Raúl Fernández",
+          "overall_score": 72,
+          "potential": 72,
+          "value": 250000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "Carles Aleñá Castillo",
+          "name": "Aleñá",
+          "overall_score": 74,
+          "potential": 74,
+          "value": 4500000,
+          "yearly_wage": 1248000
+        },
+        {
+          "currency": "€",
+          "full_name": "Carlos Protesoni",
+          "name": "C. Protesoni",
+          "overall_score": 73,
+          "potential": 74,
+          "value": 3100000,
+          "yearly_wage": 1092000
+        },
+        {
+          "currency": "€",
+          "full_name": "Youssef Enríquez Lekhedim",
+          "name": "Yusi",
+          "overall_score": 70,
+          "potential": 81,
+          "value": 3300000,
+          "yearly_wage": 572000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mariano Díaz Mejía",
+          "name": "Mariano",
+          "overall_score": 67,
+          "potential": 67,
+          "value": 850000,
+          "yearly_wage": 676000
+        },
+        {
+          "currency": "€",
+          "full_name": "Aitor Mañas Buenadicha",
+          "name": "Aitor Mañas",
+          "overall_score": 63,
+          "potential": 71,
+          "value": 1100000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Grégoire Swiderski",
+          "name": "G. Swiderski",
+          "overall_score": 61,
+          "potential": 77,
+          "value": 750000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Diego Morcillo Muñoz",
+          "name": "Diego Morcillo",
+          "overall_score": 59,
+          "potential": 66,
+          "value": 450000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lander Pinillos Wilson",
+          "name": "Lander Pinillos",
+          "overall_score": 62,
+          "potential": 73,
+          "value": 900000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Carlos Ballestero García",
+          "name": "Carlos Ballestero",
+          "overall_score": 61,
+          "potential": 72,
+          "value": 700000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mamadou Selu Diallo Diallo",
+          "name": "Selu Diallo",
+          "overall_score": 64,
+          "potential": 73,
+          "value": 1300000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jesús Lázaro Owono Ngua Akeng",
+          "name": "Owono",
+          "overall_score": 67,
+          "potential": 73,
+          "value": 1300000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Hugo Novoa Ramos",
+          "name": "Hugo Novoa",
+          "overall_score": 66,
+          "potential": 73,
+          "value": 1700000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "Adrián Rodríguez Giménez",
+          "name": "Adrián",
+          "overall_score": 68,
+          "potential": 74,
+          "value": 1500000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Moussa Diarra",
+          "name": "M. Diarra",
+          "overall_score": 71,
+          "potential": 77,
+          "value": 2700000,
+          "yearly_wage": 780000
+        },
+        {
+          "currency": "€",
+          "full_name": "Nikola Maraš",
+          "name": "N. Maraš",
+          "overall_score": 68,
+          "potential": 68,
+          "value": 1000000,
+          "yearly_wage": 676000
+        },
+        {
+          "currency": "€",
+          "full_name": "Asier Villalibre Molina",
+          "name": "Villalibre",
+          "overall_score": 74,
+          "potential": 74,
+          "value": 4600000,
+          "yearly_wage": 1352000
+        },
+        {
+          "currency": "€",
+          "full_name": "Adrián Hernández Hernández",
+          "name": "Pica",
+          "overall_score": 67,
+          "potential": 76,
+          "value": 2100000,
+          "yearly_wage": 468000
+        }
+      ],
+      "team": "Deportivo Alavés",
+      "transfer_budget": 4400000,
+      "url": "https://sofifa.com/team/463/deportivo-alaves/260037/"
+    },
+    {
+      "player_count": 37,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Aarón Escandell",
+          "name": "Aarón Escandell",
+          "overall_score": 78,
+          "potential": 79,
+          "value": 11000000,
+          "yearly_wage": 1196000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ignacio Vidal Miralles",
+          "name": "Nacho Vidal",
+          "overall_score": 71,
+          "potential": 71,
+          "value": 1600000,
+          "yearly_wage": 1040000
+        },
+        {
+          "currency": "€",
+          "full_name": "David Costas Cordal",
+          "name": "David Costas",
+          "overall_score": 75,
+          "potential": 75,
+          "value": 4600000,
+          "yearly_wage": 1508000
+        },
+        {
+          "currency": "€",
+          "full_name": "Eric Bailly",
+          "name": "E. Bailly",
+          "overall_score": 73,
+          "potential": 73,
+          "value": 2100000,
+          "yearly_wage": 1300000
+        },
+        {
+          "currency": "€",
+          "full_name": "Javier López Carballo",
+          "name": "Javi López",
+          "overall_score": 73,
+          "potential": 79,
+          "value": 4500000,
+          "yearly_wage": 1196000
+        },
+        {
+          "currency": "€",
+          "full_name": "Kwasi Sibo",
+          "name": "K. Sibo",
+          "overall_score": 70,
+          "potential": 72,
+          "value": 1700000,
+          "yearly_wage": 884000
+        },
+        {
+          "currency": "€",
+          "full_name": "Nicolás Fonseca",
+          "name": "N. Fonseca",
+          "overall_score": 72,
+          "potential": 72,
+          "value": 2300000,
+          "yearly_wage": 1092000
+        },
+        {
+          "currency": "€",
+          "full_name": "Haissem Hassan",
+          "name": "H. Hassan",
+          "overall_score": 73,
+          "potential": 79,
+          "value": 4800000,
+          "yearly_wage": 1196000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ilyas Chaira",
+          "name": "I. Chaira",
+          "overall_score": 73,
+          "potential": 76,
+          "value": 4200000,
+          "yearly_wage": 1196000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alberto Reina Campos",
+          "name": "Alberto Reina",
+          "overall_score": 74,
+          "potential": 74,
+          "value": 4500000,
+          "yearly_wage": 1404000
+        },
+        {
+          "currency": "€",
+          "full_name": "Federico Viñas",
+          "name": "F. Viñas",
+          "overall_score": 75,
+          "potential": 76,
+          "value": 6500000,
+          "yearly_wage": 1664000
+        },
+        {
+          "currency": "€",
+          "full_name": "Thiago Fernández",
+          "name": "T. Fernández",
+          "overall_score": 74,
+          "potential": 81,
+          "value": 8500000,
+          "yearly_wage": 1248000
+        },
+        {
+          "currency": "€",
+          "full_name": "Thiago Borbas",
+          "name": "T. Borbas",
+          "overall_score": 70,
+          "potential": 76,
+          "value": 2500000,
+          "yearly_wage": 884000
+        },
+        {
+          "currency": "€",
+          "full_name": "Santiago Cazorla González",
+          "name": "Santi Cazorla",
+          "overall_score": 75,
+          "potential": 75,
+          "value": 0,
+          "yearly_wage": 1092000
+        },
+        {
+          "currency": "€",
+          "full_name": "David Mota Teixeira Carmo",
+          "name": "David Carmo",
+          "overall_score": 74,
+          "potential": 78,
+          "value": 5500000,
+          "yearly_wage": 2964000
+        },
+        {
+          "currency": "€",
+          "full_name": "Daniel Pedro Calvo Sanromán",
+          "name": "Dani Calvo",
+          "overall_score": 72,
+          "potential": 72,
+          "value": 1600000,
+          "yearly_wage": 1144000
+        },
+        {
+          "currency": "€",
+          "full_name": "Rahim Alhassane",
+          "name": "R. Alhassane",
+          "overall_score": 71,
+          "potential": 77,
+          "value": 2800000,
+          "yearly_wage": 884000
+        },
+        {
+          "currency": "€",
+          "full_name": "Horațiu Moldovan",
+          "name": "H. Moldovan",
+          "overall_score": 70,
+          "potential": 72,
+          "value": 1500000,
+          "yearly_wage": 936000
+        },
+        {
+          "currency": "€",
+          "full_name": "Santiago Colombatto",
+          "name": "S. Colombatto",
+          "overall_score": 72,
+          "potential": 72,
+          "value": 2100000,
+          "yearly_wage": 1144000
+        },
+        {
+          "currency": "€",
+          "full_name": "Leander Dendoncker",
+          "name": "L. Dendoncker",
+          "overall_score": 72,
+          "potential": 72,
+          "value": 2200000,
+          "yearly_wage": 1196000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lucas Ahijado Quintana",
+          "name": "Lucas Ahijado",
+          "overall_score": 69,
+          "potential": 69,
+          "value": 1200000,
+          "yearly_wage": 832000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alex Forés Mendoza",
+          "name": "Alex Forés",
+          "overall_score": 70,
+          "potential": 75,
+          "value": 2400000,
+          "yearly_wage": 988000
+        },
+        {
+          "currency": "€",
+          "full_name": "Luka Ilić",
+          "name": "L. Ilić",
+          "overall_score": 69,
+          "potential": 72,
+          "value": 1800000,
+          "yearly_wage": 780000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ovie Ejaria",
+          "name": "O. Ejaria",
+          "overall_score": 66,
+          "potential": 66,
+          "value": 900000,
+          "yearly_wage": 572000
+        },
+        {
+          "currency": "€",
+          "full_name": "Omar Falah Ruiz",
+          "name": "Omar Falah",
+          "overall_score": 61,
+          "potential": 72,
+          "value": 700000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Pablo Menéndez Agudín",
+          "name": "Pablo Agudín",
+          "overall_score": 63,
+          "potential": 81,
+          "value": 1200000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Marco Esteban Fernández",
+          "name": "Marco Esteban",
+          "overall_score": 64,
+          "potential": 75,
+          "value": 1200000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Miguel de Jesús Narváez López",
+          "name": "Miguel Narváez",
+          "overall_score": 63,
+          "potential": 70,
+          "value": 825000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mouhamed Lamine Gueye",
+          "name": "M. Gueye",
+          "overall_score": 61,
+          "potential": 74,
+          "value": 800000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "José Luis Pereda López",
+          "name": "Cheli",
+          "overall_score": 61,
+          "potential": 74,
+          "value": 775000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Diego Menéndez Secades",
+          "name": "Dieguito",
+          "overall_score": 62,
+          "potential": 76,
+          "value": 950000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Adrián Fernández García",
+          "name": "Adri Fernández",
+          "overall_score": 60,
+          "potential": 74,
+          "value": 550000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Brandon Domingues",
+          "name": "B. Domingues",
+          "overall_score": 68,
+          "potential": 69,
+          "value": 1400000,
+          "yearly_wage": 728000
+        },
+        {
+          "currency": "€",
+          "full_name": "Diego Espinosa García",
+          "name": "Diego Espinosa",
+          "overall_score": 62,
+          "potential": 75,
+          "value": 900000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alberto del Moral Saelices",
+          "name": "Alberto del Moral",
+          "overall_score": 66,
+          "potential": 71,
+          "value": 1200000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "Oier Luengo Redondo",
+          "name": "Oier Luengo",
+          "overall_score": 69,
+          "potential": 71,
+          "value": 1500000,
+          "yearly_wage": 780000
+        },
+        {
+          "currency": "€",
+          "full_name": "Daniel Paraschiv",
+          "name": "D. Paraschiv",
+          "overall_score": 66,
+          "potential": 67,
+          "value": 1000000,
+          "yearly_wage": 624000
+        }
+      ],
+      "team": "Real Oviedo",
+      "transfer_budget": 2100000,
+      "url": "https://sofifa.com/team/110827/real-oviedo/260037/"
+    }
+  ],
+  "total_players": 700
+}

--- a/data/2025/ESP1/teams.json
+++ b/data/2025/ESP1/teams.json
@@ -18,7 +18,11 @@
             "Belgium"
           ],
           "number": "1",
-          "position": "Goalkeeper"
+          "overall_score": 90,
+          "position": "Goalkeeper",
+          "potential": 90,
+          "value": 39000000,
+          "yearly_wage": 12480000
         },
         {
           "contract": "Jun 30, 2030",
@@ -32,7 +36,11 @@
             "Ukraine"
           ],
           "number": "13",
-          "position": "Goalkeeper"
+          "overall_score": 80,
+          "position": "Goalkeeper",
+          "potential": 83,
+          "value": 21000000,
+          "yearly_wage": 4940000
         },
         {
           "contract": "Jun 30, 2026",
@@ -46,7 +54,11 @@
             "Spain"
           ],
           "number": "26",
-          "position": "Goalkeeper"
+          "overall_score": 65,
+          "position": "Goalkeeper",
+          "potential": 82,
+          "value": 1700000,
+          "yearly_wage": 624000
         },
         {
           "contract": "Jun 30, 2030",
@@ -61,7 +73,11 @@
             "Netherlands"
           ],
           "number": "24",
-          "position": "Centre-Back"
+          "overall_score": 81,
+          "position": "Centre-Back",
+          "potential": 88,
+          "value": 47500000,
+          "yearly_wage": 6240000
         },
         {
           "contract": "Jun 30, 2028",
@@ -76,7 +92,11 @@
             "Spain"
           ],
           "number": "3",
-          "position": "Centre-Back"
+          "overall_score": 84,
+          "position": "Centre-Back",
+          "potential": 86,
+          "value": 45000000,
+          "yearly_wage": 10920000
         },
         {
           "contract": "Jun 30, 2031",
@@ -90,7 +110,11 @@
             "Spain"
           ],
           "number": "17",
-          "position": "Centre-Back"
+          "overall_score": 78,
+          "position": "Centre-Back",
+          "potential": 83,
+          "value": 19500000,
+          "yearly_wage": 5720000
         },
         {
           "contract": "Jun 30, 2026",
@@ -105,7 +129,11 @@
             "Sierra Leone"
           ],
           "number": "22",
-          "position": "Centre-Back"
+          "overall_score": 84,
+          "position": "Centre-Back",
+          "potential": 84,
+          "value": 27500000,
+          "yearly_wage": 11440000
         },
         {
           "contract": "Jun 30, 2026",
@@ -119,7 +147,11 @@
             "Austria"
           ],
           "number": "4",
-          "position": "Centre-Back"
+          "overall_score": 80,
+          "position": "Centre-Back",
+          "potential": 80,
+          "value": 10000000,
+          "yearly_wage": 8320000
         },
         {
           "contract": "Jun 30, 2031",
@@ -133,7 +165,11 @@
             "Spain"
           ],
           "number": "18",
-          "position": "Left-Back"
+          "overall_score": 81,
+          "position": "Left-Back",
+          "potential": 87,
+          "value": 38500000,
+          "yearly_wage": 7280000
         },
         {
           "contract": "Jun 30, 2027",
@@ -147,7 +183,11 @@
             "Spain"
           ],
           "number": "20",
-          "position": "Left-Back"
+          "overall_score": 77,
+          "position": "Left-Back",
+          "potential": 80,
+          "value": 13000000,
+          "yearly_wage": 5980000
         },
         {
           "contract": "Jun 30, 2028",
@@ -162,7 +202,11 @@
             "Senegal"
           ],
           "number": "23",
-          "position": "Left-Back"
+          "overall_score": 81,
+          "position": "Left-Back",
+          "potential": 81,
+          "value": 22000000,
+          "yearly_wage": 8840000
         },
         {
           "contract": "Jun 30, 2031",
@@ -176,7 +220,11 @@
             "England"
           ],
           "number": "12",
-          "position": "Right-Back"
+          "overall_score": 85,
+          "position": "Right-Back",
+          "potential": 86,
+          "value": 58000000,
+          "yearly_wage": 11960000
         },
         {
           "contract": "Jun 30, 2026",
@@ -190,7 +238,11 @@
             "Spain"
           ],
           "number": "2",
-          "position": "Right-Back"
+          "overall_score": 84,
+          "position": "Right-Back",
+          "potential": 84,
+          "value": 22000000,
+          "yearly_wage": 11440000
         },
         {
           "contract": "Jun 30, 2028",
@@ -205,7 +257,11 @@
             "Cameroon"
           ],
           "number": "14",
-          "position": "Defensive Midfield"
+          "overall_score": 84,
+          "position": "Defensive Midfield",
+          "potential": 87,
+          "value": 50500000,
+          "yearly_wage": 10400000
         },
         {
           "contract": "Jun 30, 2029",
@@ -220,7 +276,11 @@
             "Spain"
           ],
           "number": "8",
-          "position": "Central Midfield"
+          "overall_score": 89,
+          "position": "Central Midfield",
+          "potential": 90,
+          "value": 120500000,
+          "yearly_wage": 17680000
         },
         {
           "contract": "Jun 30, 2029",
@@ -235,7 +295,11 @@
             "Congo"
           ],
           "number": "6",
-          "position": "Central Midfield"
+          "overall_score": 81,
+          "position": "Central Midfield",
+          "potential": 85,
+          "value": 37500000,
+          "yearly_wage": 7540000
         },
         {
           "contract": "Jun 30, 2027",
@@ -250,7 +314,11 @@
             "Morocco"
           ],
           "number": "45",
-          "position": "Central Midfield"
+          "overall_score": 68,
+          "position": "Central Midfield",
+          "potential": 85,
+          "value": 3000000,
+          "yearly_wage": 1508000
         },
         {
           "contract": "Jun 30, 2027",
@@ -264,7 +332,11 @@
             "Spain"
           ],
           "number": "19",
-          "position": "Central Midfield"
+          "overall_score": 80,
+          "position": "Central Midfield",
+          "potential": 80,
+          "value": 21000000,
+          "yearly_wage": 8580000
         },
         {
           "contract": "Jun 30, 2028",
@@ -278,7 +350,11 @@
             "Spain"
           ],
           "number": "28",
-          "position": "Central Midfield"
+          "overall_score": 63,
+          "position": "Central Midfield",
+          "potential": 80,
+          "value": 1200000,
+          "yearly_wage": 1040000
         },
         {
           "contract": "Jun 30, 2027",
@@ -292,7 +368,11 @@
             "Spain"
           ],
           "number": "37",
-          "position": "Central Midfield"
+          "overall_score": 64,
+          "position": "Central Midfield",
+          "potential": 75,
+          "value": 1300000,
+          "yearly_wage": 1196000
         },
         {
           "contract": "Jun 30, 2029",
@@ -307,7 +387,11 @@
             "Ireland"
           ],
           "number": "5",
-          "position": "Attacking Midfield"
+          "overall_score": 89,
+          "position": "Attacking Midfield",
+          "potential": 93,
+          "value": 150500000,
+          "yearly_wage": 15600000
         },
         {
           "contract": "Jun 30, 2029",
@@ -321,7 +405,11 @@
             "Türkiye"
           ],
           "number": "15",
-          "position": "Attacking Midfield"
+          "overall_score": 83,
+          "position": "Attacking Midfield",
+          "potential": 89,
+          "value": 56500000,
+          "yearly_wage": 7800000
         },
         {
           "contract": "Jun 30, 2027",
@@ -336,7 +424,11 @@
             "Spain"
           ],
           "number": "7",
-          "position": "Left Winger"
+          "overall_score": 89,
+          "position": "Left Winger",
+          "potential": 92,
+          "value": 141000000,
+          "yearly_wage": 16640000
         },
         {
           "contract": "Jun 30, 2028",
@@ -351,7 +443,11 @@
             "Spain"
           ],
           "number": "11",
-          "position": "Right Winger"
+          "overall_score": 84,
+          "position": "Right Winger",
+          "potential": 87,
+          "value": 57500000,
+          "yearly_wage": 10920000
         },
         {
           "contract": "Jun 30, 2031",
@@ -366,7 +462,11 @@
             "Italy"
           ],
           "number": "30",
-          "position": "Right Winger"
+          "overall_score": 77,
+          "position": "Right Winger",
+          "potential": 87,
+          "value": 22000000,
+          "yearly_wage": 3432000
         },
         {
           "contract": "Jun 30, 2027",
@@ -381,7 +481,11 @@
             "Spain"
           ],
           "number": "21",
-          "position": "Right Winger"
+          "overall_score": 81,
+          "position": "Right Winger",
+          "potential": 82,
+          "value": 31000000,
+          "yearly_wage": 8320000
         },
         {
           "contract": "Jun 30, 2029",
@@ -396,7 +500,11 @@
             "Cameroon"
           ],
           "number": "10",
-          "position": "Centre-Forward"
+          "overall_score": 91,
+          "position": "Centre-Forward",
+          "potential": 92,
+          "value": 157000000,
+          "yearly_wage": 31720000
         },
         {
           "contract": "Jun 30, 2030",
@@ -410,7 +518,11 @@
             "Spain"
           ],
           "number": "16",
-          "position": "Centre-Forward"
+          "overall_score": 74,
+          "position": "Centre-Forward",
+          "potential": 84,
+          "value": 9500000,
+          "yearly_wage": 4472000
         }
       ],
       "stadiumName": "Santiago Bernabéu",
@@ -433,7 +545,11 @@
             "Slovenia"
           ],
           "number": "13",
-          "position": "Goalkeeper"
+          "overall_score": 88,
+          "position": "Goalkeeper",
+          "potential": 88,
+          "value": 45000000,
+          "yearly_wage": 4524000
         },
         {
           "contract": "Jun 30, 2028",
@@ -448,7 +564,11 @@
             "Italy"
           ],
           "number": "1",
-          "position": "Goalkeeper"
+          "overall_score": 80,
+          "position": "Goalkeeper",
+          "potential": 80,
+          "value": 11000000,
+          "yearly_wage": 2288000
         },
         {
           "contract": "Jun 30, 2030",
@@ -462,7 +582,11 @@
             "Slovakia"
           ],
           "number": "17",
-          "position": "Centre-Back"
+          "overall_score": 83,
+          "position": "Centre-Back",
+          "potential": 83,
+          "value": 35000000,
+          "yearly_wage": 4264000
         },
         {
           "contract": "Jun 30, 2030",
@@ -476,7 +600,11 @@
             "Spain"
           ],
           "number": "18",
-          "position": "Centre-Back"
+          "overall_score": 80,
+          "position": "Centre-Back",
+          "potential": 87,
+          "value": 40000000,
+          "yearly_wage": 2912000
         },
         {
           "contract": "Jun 30, 2029",
@@ -491,7 +619,11 @@
             "France"
           ],
           "number": "24",
-          "position": "Centre-Back"
+          "overall_score": 81,
+          "position": "Centre-Back",
+          "potential": 82,
+          "value": 24500000,
+          "yearly_wage": 3796000
         },
         {
           "contract": "Jun 30, 2028",
@@ -506,7 +638,11 @@
             "Spain"
           ],
           "number": "2",
-          "position": "Centre-Back"
+          "overall_score": 83,
+          "position": "Centre-Back",
+          "potential": 83,
+          "value": 30000000,
+          "yearly_wage": 4472000
         },
         {
           "contract": "Jun 30, 2028",
@@ -520,7 +656,11 @@
             "France"
           ],
           "number": "15",
-          "position": "Centre-Back"
+          "overall_score": 77,
+          "position": "Centre-Back",
+          "potential": 77,
+          "value": 8500000,
+          "yearly_wage": 2860000
         },
         {
           "contract": "Jun 30, 2030",
@@ -534,7 +674,11 @@
             "Italy"
           ],
           "number": "3",
-          "position": "Left-Back"
+          "overall_score": 78,
+          "position": "Left-Back",
+          "potential": 82,
+          "value": 19000000,
+          "yearly_wage": 2496000
         },
         {
           "contract": "Jun 30, 2027",
@@ -548,7 +692,11 @@
             "Spain"
           ],
           "number": "14",
-          "position": "Right-Back"
+          "overall_score": 85,
+          "position": "Right-Back",
+          "potential": 85,
+          "value": 46500000,
+          "yearly_wage": 5460000
         },
         {
           "contract": "Jun 30, 2027",
@@ -562,7 +710,11 @@
             "Argentina"
           ],
           "number": "16",
-          "position": "Right-Back"
+          "overall_score": 77,
+          "position": "Right-Back",
+          "potential": 77,
+          "value": 10000000,
+          "yearly_wage": 2704000
         },
         {
           "contract": "Jun 30, 2030",
@@ -576,7 +728,11 @@
             "Spain"
           ],
           "number": "8",
-          "position": "Central Midfield"
+          "overall_score": 83,
+          "position": "Central Midfield",
+          "potential": 87,
+          "value": 52500000,
+          "yearly_wage": 3900000
         },
         {
           "contract": "Jun 30, 2030",
@@ -591,7 +747,11 @@
             "Italy"
           ],
           "number": "5",
-          "position": "Central Midfield"
+          "overall_score": 80,
+          "position": "Central Midfield",
+          "potential": 84,
+          "value": 27500000,
+          "yearly_wage": 2912000
         },
         {
           "contract": "Jun 30, 2031",
@@ -605,7 +765,11 @@
             "Spain"
           ],
           "number": "4",
-          "position": "Central Midfield"
+          "overall_score": 71,
+          "position": "Central Midfield",
+          "potential": 84,
+          "value": 4500000,
+          "yearly_wage": 1300000
         },
         {
           "contract": "Jun 30, 2030",
@@ -620,7 +784,11 @@
             "United States"
           ],
           "number": "21",
-          "position": "Central Midfield"
+          "overall_score": 72,
+          "position": "Central Midfield",
+          "potential": 83,
+          "value": 4800000,
+          "yearly_wage": 1248000
         },
         {
           "contract": "Jun 30, 2026",
@@ -634,7 +802,11 @@
             "Spain"
           ],
           "number": "6",
-          "position": "Central Midfield"
+          "overall_score": 81,
+          "position": "Central Midfield",
+          "potential": 81,
+          "value": 16000000,
+          "yearly_wage": 3952000
         },
         {
           "contract": "Jun 30, 2030",
@@ -648,7 +820,11 @@
             "Spain"
           ],
           "number": "10",
-          "position": "Left Winger"
+          "overall_score": 82,
+          "position": "Left Winger",
+          "potential": 87,
+          "value": 46000000,
+          "yearly_wage": 3588000
         },
         {
           "contract": "Jun 30, 2026",
@@ -663,7 +839,11 @@
             "Italy"
           ],
           "number": "23",
-          "position": "Left Winger"
+          "overall_score": 79,
+          "position": "Left Winger",
+          "potential": 79,
+          "value": 18500000,
+          "yearly_wage": 5460000
         },
         {
           "contract": "Jun 30, 2030",
@@ -678,7 +858,11 @@
             "Italy"
           ],
           "number": "11",
-          "position": "Left Winger"
+          "overall_score": 78,
+          "position": "Left Winger",
+          "potential": 83,
+          "value": 21000000,
+          "yearly_wage": 2704000
         },
         {
           "contract": "Jun 30, 2030",
@@ -693,7 +877,11 @@
             "Italy"
           ],
           "number": "20",
-          "position": "Right Winger"
+          "overall_score": 82,
+          "position": "Right Winger",
+          "potential": 86,
+          "value": 44500000,
+          "yearly_wage": 3588000
         },
         {
           "contract": "Jun 30, 2030",
@@ -708,7 +896,11 @@
             "England"
           ],
           "number": "22",
-          "position": "Second Striker"
+          "overall_score": 83,
+          "position": "Second Striker",
+          "potential": 83,
+          "value": 39500000,
+          "yearly_wage": 4940000
         },
         {
           "contract": "Jun 30, 2027",
@@ -722,7 +914,11 @@
             "France"
           ],
           "number": "7",
-          "position": "Second Striker"
+          "overall_score": 84,
+          "position": "Second Striker",
+          "potential": 84,
+          "value": 20500000,
+          "yearly_wage": 5460000
         },
         {
           "contract": "Jun 30, 2030",
@@ -737,7 +933,11 @@
             "Italy"
           ],
           "number": "19",
-          "position": "Centre-Forward"
+          "overall_score": 86,
+          "position": "Centre-Forward",
+          "potential": 89,
+          "value": 91000000,
+          "yearly_wage": 5980000
         },
         {
           "contract": "Jun 30, 2028",
@@ -751,7 +951,11 @@
             "Norway"
           ],
           "number": "9",
-          "position": "Centre-Forward"
+          "overall_score": 83,
+          "position": "Centre-Forward",
+          "potential": 83,
+          "value": 36500000,
+          "yearly_wage": 4940000
         }
       ],
       "stadiumName": "Riyadh Air Metropolitano",
@@ -774,7 +978,11 @@
             "Spain"
           ],
           "number": "1",
-          "position": "Goalkeeper"
+          "overall_score": 77,
+          "position": "Goalkeeper",
+          "potential": 79,
+          "value": 9500000,
+          "yearly_wage": 884000
         },
         {
           "contract": "Jun 30, 2028",
@@ -788,7 +996,11 @@
             "Spain"
           ],
           "number": "25",
-          "position": "Goalkeeper"
+          "overall_score": 77,
+          "position": "Goalkeeper",
+          "potential": 77,
+          "value": 7000000,
+          "yearly_wage": 936000
         },
         {
           "contract": "Jun 30, 2026",
@@ -802,7 +1014,11 @@
             "Spain"
           ],
           "number": "13",
-          "position": "Goalkeeper"
+          "overall_score": 71,
+          "position": "Goalkeeper",
+          "potential": 71,
+          "value": 210000,
+          "yearly_wage": 364000
         },
         {
           "contract": "Jun 30, 2030",
@@ -816,7 +1032,11 @@
             "Brazil"
           ],
           "number": "4",
-          "position": "Centre-Back"
+          "overall_score": 78,
+          "position": "Centre-Back",
+          "potential": 83,
+          "value": 19000000,
+          "yearly_wage": 1300000
         },
         {
           "contract": "Jun 30, 2030",
@@ -831,7 +1051,11 @@
             "Spain"
           ],
           "number": "16",
-          "position": "Centre-Back"
+          "overall_score": 76,
+          "position": "Centre-Back",
+          "potential": 84,
+          "value": 15500000,
+          "yearly_wage": 1144000
         },
         {
           "contract": "Jun 30, 2028",
@@ -845,7 +1069,11 @@
             "Spain"
           ],
           "number": "3",
-          "position": "Centre-Back"
+          "overall_score": 80,
+          "position": "Centre-Back",
+          "potential": 80,
+          "value": 14500000,
+          "yearly_wage": 1820000
         },
         {
           "contract": "Jun 30, 2027",
@@ -859,7 +1087,11 @@
             "Spain"
           ],
           "number": "5",
-          "position": "Centre-Back"
+          "overall_score": 79,
+          "position": "Centre-Back",
+          "potential": 79,
+          "value": 5500000,
+          "yearly_wage": 1716000
         },
         {
           "contract": "Jun 30, 2028",
@@ -874,7 +1106,11 @@
             "Spain"
           ],
           "number": "23",
-          "position": "Left-Back"
+          "overall_score": 74,
+          "position": "Left-Back",
+          "potential": 74,
+          "value": 3800000,
+          "yearly_wage": 1196000
         },
         {
           "contract": "Jun 30, 2026",
@@ -889,7 +1125,11 @@
             "Chile"
           ],
           "number": "12",
-          "position": "Left-Back"
+          "overall_score": 73,
+          "position": "Left-Back",
+          "potential": 73,
+          "value": 2100000,
+          "yearly_wage": 1092000
         },
         {
           "contract": "Jun 30, 2029",
@@ -903,7 +1143,11 @@
             "Spain"
           ],
           "number": "40",
-          "position": "Right-Back"
+          "overall_score": 70,
+          "position": "Right-Back",
+          "potential": 81,
+          "value": 3300000,
+          "yearly_wage": 572000
         },
         {
           "contract": "Jun 30, 2028",
@@ -917,7 +1161,11 @@
             "Spain"
           ],
           "number": "2",
-          "position": "Right-Back"
+          "overall_score": 76,
+          "position": "Right-Back",
+          "potential": 76,
+          "value": 6500000,
+          "yearly_wage": 1352000
         },
         {
           "contract": "Jun 30, 2026",
@@ -932,7 +1180,11 @@
             "Netherlands"
           ],
           "number": "14",
-          "position": "Defensive Midfield"
+          "overall_score": 79,
+          "position": "Defensive Midfield",
+          "potential": 79,
+          "value": 15500000,
+          "yearly_wage": 2860000
         },
         {
           "contract": "Jun 30, 2029",
@@ -946,7 +1198,11 @@
             "Spain"
           ],
           "number": "21",
-          "position": "Defensive Midfield"
+          "overall_score": 78,
+          "position": "Defensive Midfield",
+          "potential": 78,
+          "value": 12500000,
+          "yearly_wage": 1560000
         },
         {
           "contract": "Jun 30, 2029",
@@ -960,7 +1216,11 @@
             "Spain"
           ],
           "number": "6",
-          "position": "Central Midfield"
+          "overall_score": 77,
+          "position": "Central Midfield",
+          "potential": 83,
+          "value": 15500000,
+          "yearly_wage": 1196000
         },
         {
           "contract": "Jun 30, 2030",
@@ -975,7 +1235,11 @@
             "Spain"
           ],
           "number": "15",
-          "position": "Central Midfield"
+          "overall_score": 77,
+          "position": "Central Midfield",
+          "potential": 77,
+          "value": 10500000,
+          "yearly_wage": 1508000
         },
         {
           "contract": "Jun 30, 2030",
@@ -989,7 +1253,11 @@
             "Colombia"
           ],
           "number": "18",
-          "position": "Central Midfield"
+          "overall_score": 75,
+          "position": "Central Midfield",
+          "potential": 80,
+          "value": 7500000,
+          "yearly_wage": 1196000
         },
         {
           "contract": "Jun 30, 2029",
@@ -1003,7 +1271,11 @@
             "Spain"
           ],
           "number": "8",
-          "position": "Central Midfield"
+          "overall_score": 81,
+          "position": "Central Midfield",
+          "potential": 81,
+          "value": 25000000,
+          "yearly_wage": 2028000
         },
         {
           "contract": "Jun 30, 2028",
@@ -1018,7 +1290,11 @@
             "Italy"
           ],
           "number": "20",
-          "position": "Attacking Midfield"
+          "overall_score": 81,
+          "position": "Attacking Midfield",
+          "potential": 81,
+          "value": 25500000,
+          "yearly_wage": 2080000
         },
         {
           "contract": "Jun 30, 2028",
@@ -1032,7 +1308,11 @@
             "Spain"
           ],
           "number": "22",
-          "position": "Attacking Midfield"
+          "overall_score": 84,
+          "position": "Attacking Midfield",
+          "potential": 84,
+          "value": 26500000,
+          "yearly_wage": 2704000
         },
         {
           "contract": "Jun 30, 2029",
@@ -1047,7 +1327,11 @@
             "Spain"
           ],
           "number": "10",
-          "position": "Left Winger"
+          "overall_score": 80,
+          "position": "Left Winger",
+          "potential": 84,
+          "value": 30000000,
+          "yearly_wage": 1716000
         },
         {
           "contract": "Jun 30, 2030",
@@ -1061,7 +1345,11 @@
             "Spain"
           ],
           "number": "17",
-          "position": "Left Winger"
+          "overall_score": 76,
+          "position": "Left Winger",
+          "potential": 77,
+          "value": 9000000,
+          "yearly_wage": 1300000
         },
         {
           "contract": "Jun 30, 2030",
@@ -1075,7 +1363,11 @@
             "Brazil"
           ],
           "number": "7",
-          "position": "Right Winger"
+          "overall_score": 81,
+          "position": "Right Winger",
+          "potential": 82,
+          "value": 31000000,
+          "yearly_wage": 1976000
         },
         {
           "contract": "Jun 30, 2029",
@@ -1089,7 +1381,11 @@
             "Spain"
           ],
           "number": "52",
-          "position": "Right Winger"
+          "overall_score": 70,
+          "position": "Right Winger",
+          "potential": 83,
+          "value": 3800000,
+          "yearly_wage": 624000
         },
         {
           "contract": "Jun 30, 2028",
@@ -1103,7 +1399,11 @@
             "Spain"
           ],
           "number": "24",
-          "position": "Right Winger"
+          "overall_score": 77,
+          "position": "Right Winger",
+          "potential": 77,
+          "value": 10500000,
+          "yearly_wage": 1508000
         },
         {
           "contract": "Jun 30, 2030",
@@ -1118,7 +1418,11 @@
             "Spain"
           ],
           "number": "19",
-          "position": "Centre-Forward"
+          "overall_score": 79,
+          "position": "Centre-Forward",
+          "potential": 80,
+          "value": 21000000,
+          "yearly_wage": 1872000
         },
         {
           "contract": "Jun 30, 2027",
@@ -1133,7 +1437,11 @@
             "Spain"
           ],
           "number": "9",
-          "position": "Centre-Forward"
+          "overall_score": 73,
+          "position": "Centre-Forward",
+          "potential": 73,
+          "value": 2600000,
+          "yearly_wage": 1248000
         },
         {
           "contract": "Jun 30, 2026",
@@ -1148,7 +1456,11 @@
             "France"
           ],
           "number": "11",
-          "position": "Centre-Forward"
+          "overall_score": 75,
+          "position": "Centre-Forward",
+          "potential": 75,
+          "value": 2700000,
+          "yearly_wage": 1456000
         }
       ],
       "stadiumName": "La Cartuja",
@@ -1171,7 +1483,11 @@
             "Spain"
           ],
           "number": "13",
-          "position": "Goalkeeper"
+          "overall_score": 86,
+          "position": "Goalkeeper",
+          "potential": 89,
+          "value": 72500000,
+          "yearly_wage": 3692000
         },
         {
           "contract": "Jun 30, 2027",
@@ -1185,7 +1501,11 @@
             "Poland"
           ],
           "number": "25",
-          "position": "Goalkeeper"
+          "overall_score": 83,
+          "position": "Goalkeeper",
+          "potential": 83,
+          "value": 4000000,
+          "yearly_wage": 2340000
         },
         {
           "contract": "Jun 30, 2028",
@@ -1200,7 +1520,11 @@
             "Peru"
           ],
           "number": "31",
-          "position": "Goalkeeper"
+          "overall_score": 62,
+          "position": "Goalkeeper",
+          "potential": 79,
+          "value": 900000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2029",
@@ -1214,7 +1538,11 @@
             "Spain"
           ],
           "number": "5",
-          "position": "Centre-Back"
+          "overall_score": 83,
+          "position": "Centre-Back",
+          "potential": 89,
+          "value": 48000000,
+          "yearly_wage": 3640000
         },
         {
           "contract": "Jun 30, 2031",
@@ -1228,7 +1556,11 @@
             "Spain"
           ],
           "number": "24",
-          "position": "Centre-Back"
+          "overall_score": 83,
+          "position": "Centre-Back",
+          "potential": 86,
+          "value": 44500000,
+          "yearly_wage": 4940000
         },
         {
           "contract": "Jun 30, 2031",
@@ -1243,7 +1575,11 @@
             "Spain"
           ],
           "number": "4",
-          "position": "Centre-Back"
+          "overall_score": 81,
+          "position": "Centre-Back",
+          "potential": 84,
+          "value": 30000000,
+          "yearly_wage": 4680000
         },
         {
           "contract": "Jun 30, 2026",
@@ -1257,7 +1593,11 @@
             "Denmark"
           ],
           "number": "15",
-          "position": "Centre-Back"
+          "overall_score": 80,
+          "position": "Centre-Back",
+          "potential": 80,
+          "value": 17500000,
+          "yearly_wage": 4680000
         },
         {
           "contract": "Jun 30, 2028",
@@ -1271,7 +1611,11 @@
             "Spain"
           ],
           "number": "3",
-          "position": "Left-Back"
+          "overall_score": 83,
+          "position": "Left-Back",
+          "potential": 87,
+          "value": 49500000,
+          "yearly_wage": 4160000
         },
         {
           "contract": "Jun 30, 2028",
@@ -1285,7 +1629,11 @@
             "Spain"
           ],
           "number": "18",
-          "position": "Left-Back"
+          "overall_score": 78,
+          "position": "Left-Back",
+          "potential": 82,
+          "value": 18000000,
+          "yearly_wage": 3328000
         },
         {
           "contract": "Jun 30, 2030",
@@ -1300,7 +1648,11 @@
             "Benin"
           ],
           "number": "23",
-          "position": "Right-Back"
+          "overall_score": 86,
+          "position": "Right-Back",
+          "potential": 87,
+          "value": 73000000,
+          "yearly_wage": 7280000
         },
         {
           "contract": "Jun 30, 2026",
@@ -1314,7 +1666,11 @@
             "Portugal"
           ],
           "number": "2",
-          "position": "Right-Back"
+          "overall_score": 84,
+          "position": "Right-Back",
+          "potential": 84,
+          "value": 30500000,
+          "yearly_wage": 3536000
         },
         {
           "contract": "Jun 30, 2029",
@@ -1328,7 +1684,11 @@
             "Spain"
           ],
           "number": "22",
-          "position": "Defensive Midfield"
+          "overall_score": 75,
+          "position": "Defensive Midfield",
+          "potential": 86,
+          "value": 11000000,
+          "yearly_wage": 2028000
         },
         {
           "contract": "Jun 30, 2028",
@@ -1342,7 +1702,11 @@
             "Spain"
           ],
           "number": "17",
-          "position": "Defensive Midfield"
+          "overall_score": 78,
+          "position": "Defensive Midfield",
+          "potential": 82,
+          "value": 18500000,
+          "yearly_wage": 2808000
         },
         {
           "contract": "Jun 30, 2030",
@@ -1356,7 +1720,11 @@
             "Spain"
           ],
           "number": "8",
-          "position": "Central Midfield"
+          "overall_score": 90,
+          "position": "Central Midfield",
+          "potential": 93,
+          "value": 165000000,
+          "yearly_wage": 9360000
         },
         {
           "contract": "Jun 30, 2029",
@@ -1370,7 +1738,11 @@
             "Netherlands"
           ],
           "number": "21",
-          "position": "Central Midfield"
+          "overall_score": 87,
+          "position": "Central Midfield",
+          "potential": 87,
+          "value": 79500000,
+          "yearly_wage": 8840000
         },
         {
           "contract": "Jun 30, 2030",
@@ -1384,7 +1756,11 @@
             "Spain"
           ],
           "number": "6",
-          "position": "Central Midfield"
+          "overall_score": 83,
+          "position": "Central Midfield",
+          "potential": 87,
+          "value": 51000000,
+          "yearly_wage": 4420000
         },
         {
           "contract": "Jun 30, 2031",
@@ -1398,7 +1774,11 @@
             "Spain"
           ],
           "number": "16",
-          "position": "Attacking Midfield"
+          "overall_score": 83,
+          "position": "Attacking Midfield",
+          "potential": 87,
+          "value": 53000000,
+          "yearly_wage": 5200000
         },
         {
           "contract": "Jun 30, 2030",
@@ -1412,7 +1792,11 @@
             "Spain"
           ],
           "number": "20",
-          "position": "Attacking Midfield"
+          "overall_score": 84,
+          "position": "Attacking Midfield",
+          "potential": 84,
+          "value": 45000000,
+          "yearly_wage": 6760000
         },
         {
           "contract": "Jun 30, 2028",
@@ -1427,7 +1811,11 @@
             "Italy"
           ],
           "number": "11",
-          "position": "Left Winger"
+          "overall_score": 89,
+          "position": "Left Winger",
+          "potential": 89,
+          "value": 104000000,
+          "yearly_wage": 11440000
         },
         {
           "contract": "Jun 30, 2026",
@@ -1442,7 +1830,11 @@
             "St. Kitts & Nevis"
           ],
           "number": "14",
-          "position": "Left Winger"
+          "overall_score": 82,
+          "position": "Left Winger",
+          "potential": 82,
+          "value": 32500000,
+          "yearly_wage": 5720000
         },
         {
           "contract": "Jun 30, 2031",
@@ -1456,7 +1848,11 @@
             "Spain"
           ],
           "number": "10",
-          "position": "Right Winger"
+          "overall_score": 89,
+          "position": "Right Winger",
+          "potential": 95,
+          "value": 147000000,
+          "yearly_wage": 5980000
         },
         {
           "contract": "Jun 30, 2029",
@@ -1471,7 +1867,11 @@
             "Syria"
           ],
           "number": "19",
-          "position": "Right Winger"
+          "overall_score": 74,
+          "position": "Right Winger",
+          "potential": 85,
+          "value": 9000000,
+          "yearly_wage": 2392000
         },
         {
           "contract": "Jun 30, 2027",
@@ -1485,7 +1885,11 @@
             "Spain"
           ],
           "number": "7",
-          "position": "Centre-Forward"
+          "overall_score": 84,
+          "position": "Centre-Forward",
+          "potential": 86,
+          "value": 53500000,
+          "yearly_wage": 6760000
         },
         {
           "contract": "Jun 30, 2026",
@@ -1499,7 +1903,11 @@
             "Poland"
           ],
           "number": "9",
-          "position": "Centre-Forward"
+          "overall_score": 86,
+          "position": "Centre-Forward",
+          "potential": 86,
+          "value": 23000000,
+          "yearly_wage": 6760000
         }
       ],
       "stadiumName": "Spotify Camp Nou",
@@ -1522,7 +1930,11 @@
             "Spain"
           ],
           "number": "1",
-          "position": "Goalkeeper"
+          "overall_score": 84,
+          "position": "Goalkeeper",
+          "potential": 85,
+          "value": 33500000,
+          "yearly_wage": 2288000
         },
         {
           "contract": "Jun 30, 2029",
@@ -1537,7 +1949,11 @@
             "Spain"
           ],
           "number": "27",
-          "position": "Goalkeeper"
+          "overall_score": 69,
+          "position": "Goalkeeper",
+          "potential": 79,
+          "value": 2700000,
+          "yearly_wage": 364000
         },
         {
           "contract": "Jun 30, 2032",
@@ -1551,7 +1967,11 @@
             "Spain"
           ],
           "number": "3",
-          "position": "Centre-Back"
+          "overall_score": 82,
+          "position": "Centre-Back",
+          "potential": 85,
+          "value": 36000000,
+          "yearly_wage": 2652000
         },
         {
           "contract": "Jun 30, 2029",
@@ -1565,7 +1985,11 @@
             "Spain"
           ],
           "number": "4",
-          "position": "Centre-Back"
+          "overall_score": 78,
+          "position": "Centre-Back",
+          "potential": 81,
+          "value": 16500000,
+          "yearly_wage": 1976000
         },
         {
           "contract": "Jun 30, 2028",
@@ -1580,7 +2004,11 @@
             "France"
           ],
           "number": "14",
-          "position": "Centre-Back"
+          "overall_score": 82,
+          "position": "Centre-Back",
+          "potential": 82,
+          "value": 21000000,
+          "yearly_wage": 2912000
         },
         {
           "contract": "Jun 30, 2026",
@@ -1594,7 +2022,11 @@
             "Spain"
           ],
           "number": "5",
-          "position": "Centre-Back"
+          "overall_score": 80,
+          "position": "Centre-Back",
+          "potential": 80,
+          "value": 17500000,
+          "yearly_wage": 2548000
         },
         {
           "contract": "Jun 30, 2028",
@@ -1608,7 +2040,11 @@
             "Spain"
           ],
           "number": "13",
-          "position": "Centre-Back"
+          "overall_score": 70,
+          "position": "Centre-Back",
+          "potential": 77,
+          "value": 3000000,
+          "yearly_wage": 936000
         },
         {
           "contract": "Jun 30, 2029",
@@ -1623,7 +2059,11 @@
             "Senegal"
           ],
           "number": "19",
-          "position": "Left-Back"
+          "overall_score": 73,
+          "position": "Left-Back",
+          "potential": 80,
+          "value": 6000000,
+          "yearly_wage": 1248000
         },
         {
           "contract": "Jun 30, 2026",
@@ -1638,7 +2078,11 @@
             "Algeria"
           ],
           "number": "17",
-          "position": "Left-Back"
+          "overall_score": 79,
+          "position": "Left-Back",
+          "potential": 79,
+          "value": 5500000,
+          "yearly_wage": 1768000
         },
         {
           "contract": "Jun 30, 2031",
@@ -1652,7 +2096,11 @@
             "Spain"
           ],
           "number": "12",
-          "position": "Right-Back"
+          "overall_score": 76,
+          "position": "Right-Back",
+          "potential": 78,
+          "value": 8500000,
+          "yearly_wage": 1716000
         },
         {
           "contract": "Jun 30, 2028",
@@ -1666,7 +2114,11 @@
             "Spain"
           ],
           "number": "2",
-          "position": "Right-Back"
+          "overall_score": 76,
+          "position": "Right-Back",
+          "potential": 76,
+          "value": 7000000,
+          "yearly_wage": 1872000
         },
         {
           "contract": "Jun 30, 2026",
@@ -1680,7 +2132,11 @@
             "Spain"
           ],
           "number": "15",
-          "position": "Right-Back"
+          "overall_score": 72,
+          "position": "Right-Back",
+          "potential": 72,
+          "value": 1600000,
+          "yearly_wage": 1404000
         },
         {
           "contract": "Jun 30, 2027",
@@ -1694,7 +2150,11 @@
             "Spain"
           ],
           "number": "6",
-          "position": "Defensive Midfield"
+          "overall_score": 72,
+          "position": "Defensive Midfield",
+          "potential": 72,
+          "value": 1600000,
+          "yearly_wage": 1404000
         },
         {
           "contract": "Jun 30, 2031",
@@ -1708,7 +2168,11 @@
             "Spain"
           ],
           "number": "18",
-          "position": "Central Midfield"
+          "overall_score": 80,
+          "position": "Central Midfield",
+          "potential": 86,
+          "value": 33500000,
+          "yearly_wage": 1872000
         },
         {
           "contract": "Jun 30, 2031",
@@ -1722,7 +2186,11 @@
             "Spain"
           ],
           "number": "24",
-          "position": "Central Midfield"
+          "overall_score": 77,
+          "position": "Central Midfield",
+          "potential": 82,
+          "value": 14500000,
+          "yearly_wage": 1664000
         },
         {
           "contract": "Jun 30, 2026",
@@ -1736,7 +2204,11 @@
             "Spain"
           ],
           "number": "30",
-          "position": "Central Midfield"
+          "overall_score": 72,
+          "position": "Central Midfield",
+          "potential": 81,
+          "value": 5000000,
+          "yearly_wage": 1144000
         },
         {
           "contract": "Jun 30, 2029",
@@ -1751,7 +2223,11 @@
             "Brazil"
           ],
           "number": "44",
-          "position": "Central Midfield"
+          "overall_score": 63,
+          "position": "Central Midfield",
+          "potential": 82,
+          "value": 1200000,
+          "yearly_wage": 312000
         },
         {
           "contract": "Jun 30, 2027",
@@ -1765,7 +2241,11 @@
             "Spain"
           ],
           "number": "16",
-          "position": "Central Midfield"
+          "overall_score": 80,
+          "position": "Central Midfield",
+          "potential": 80,
+          "value": 15000000,
+          "yearly_wage": 2548000
         },
         {
           "contract": "Jun 30, 2032",
@@ -1779,7 +2259,11 @@
             "Spain"
           ],
           "number": "8",
-          "position": "Attacking Midfield"
+          "overall_score": 82,
+          "position": "Attacking Midfield",
+          "potential": 85,
+          "value": 40500000,
+          "yearly_wage": 2860000
         },
         {
           "contract": "Jun 30, 2028",
@@ -1793,7 +2277,11 @@
             "Spain"
           ],
           "number": "20",
-          "position": "Attacking Midfield"
+          "overall_score": 72,
+          "position": "Attacking Midfield",
+          "potential": 78,
+          "value": 3800000,
+          "yearly_wage": 1248000
         },
         {
           "contract": "Jun 30, 2035",
@@ -1808,7 +2296,11 @@
             "Ghana"
           ],
           "number": "10",
-          "position": "Left Winger"
+          "overall_score": 85,
+          "position": "Left Winger",
+          "potential": 88,
+          "value": 75000000,
+          "yearly_wage": 3588000
         },
         {
           "contract": "Jun 30, 2027",
@@ -1822,7 +2314,11 @@
             "Spain"
           ],
           "number": "7",
-          "position": "Left Winger"
+          "overall_score": 80,
+          "position": "Left Winger",
+          "potential": 80,
+          "value": 20500000,
+          "yearly_wage": 2808000
         },
         {
           "contract": "Jun 30, 2028",
@@ -1836,7 +2332,11 @@
             "Spain"
           ],
           "number": "22",
-          "position": "Left Winger"
+          "overall_score": 71,
+          "position": "Left Winger",
+          "potential": 79,
+          "value": 4200000,
+          "yearly_wage": 1196000
         },
         {
           "contract": "Jun 30, 2028",
@@ -1851,7 +2351,11 @@
             "Spain"
           ],
           "number": "9",
-          "position": "Right Winger"
+          "overall_score": 81,
+          "position": "Right Winger",
+          "potential": 81,
+          "value": 21500000,
+          "yearly_wage": 3016000
         },
         {
           "contract": "Jun 30, 2030",
@@ -1865,7 +2369,11 @@
             "Spain"
           ],
           "number": "23",
-          "position": "Right Winger"
+          "overall_score": 76,
+          "position": "Right Winger",
+          "potential": 82,
+          "value": 12000000,
+          "yearly_wage": 1768000
         },
         {
           "contract": "Jun 30, 2028",
@@ -1879,7 +2387,11 @@
             "Spain"
           ],
           "number": "11",
-          "position": "Centre-Forward"
+          "overall_score": 78,
+          "position": "Centre-Forward",
+          "potential": 78,
+          "value": 14500000,
+          "yearly_wage": 2444000
         },
         {
           "contract": "Jun 30, 2029",
@@ -1894,7 +2406,11 @@
             "Spain"
           ],
           "number": "21",
-          "position": "Centre-Forward"
+          "overall_score": 72,
+          "position": "Centre-Forward",
+          "potential": 77,
+          "value": 3600000,
+          "yearly_wage": 1300000
         },
         {
           "contract": "Jun 30, 2027",
@@ -1908,7 +2424,11 @@
             "Spain"
           ],
           "number": "25",
-          "position": "Centre-Forward"
+          "overall_score": 71,
+          "position": "Centre-Forward",
+          "potential": 74,
+          "value": 2500000,
+          "yearly_wage": 1300000
         }
       ],
       "stadiumName": "San Mamés",
@@ -1931,7 +2451,11 @@
             "Spain"
           ],
           "number": "25",
-          "position": "Goalkeeper"
+          "overall_score": 76,
+          "position": "Goalkeeper",
+          "potential": 81,
+          "value": 9000000,
+          "yearly_wage": 936000
         },
         {
           "contract": "Jun 30, 2026",
@@ -1946,7 +2470,11 @@
             "Spain"
           ],
           "number": "1",
-          "position": "Goalkeeper"
+          "overall_score": 77,
+          "position": "Goalkeeper",
+          "potential": 77,
+          "value": 5500000,
+          "yearly_wage": 1248000
         },
         {
           "contract": "Jun 30, 2027",
@@ -1960,7 +2488,11 @@
             "Spain"
           ],
           "number": "13",
-          "position": "Goalkeeper"
+          "overall_score": 65,
+          "position": "Goalkeeper",
+          "potential": 67,
+          "value": 650000,
+          "yearly_wage": 312000
         },
         {
           "contract": "Jun 30, 2030",
@@ -1974,7 +2506,11 @@
             "Spain"
           ],
           "number": "5",
-          "position": "Centre-Back"
+          "overall_score": 75,
+          "position": "Centre-Back",
+          "potential": 82,
+          "value": 10500000,
+          "yearly_wage": 1404000
         },
         {
           "contract": "Jun 30, 2029",
@@ -1988,7 +2524,11 @@
             "Spain"
           ],
           "number": "3",
-          "position": "Centre-Back"
+          "overall_score": 74,
+          "position": "Centre-Back",
+          "potential": 78,
+          "value": 5500000,
+          "yearly_wage": 1404000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2002,7 +2542,11 @@
             "Spain"
           ],
           "number": "4",
-          "position": "Centre-Back"
+          "overall_score": 75,
+          "position": "Centre-Back",
+          "potential": 76,
+          "value": 5500000,
+          "yearly_wage": 1300000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2017,7 +2561,11 @@
             "Türkiye"
           ],
           "number": "24",
-          "position": "Centre-Back"
+          "overall_score": 73,
+          "position": "Centre-Back",
+          "potential": 74,
+          "value": 3100000,
+          "yearly_wage": 1352000
         },
         {
           "contract": "Jun 30, 2027",
@@ -2031,7 +2579,11 @@
             "Guinea",
             "France"
           ],
-          "position": "Centre-Back"
+          "overall_score": 76,
+          "position": "Centre-Back",
+          "potential": 76,
+          "value": 6500000,
+          "yearly_wage": 1768000
         },
         {
           "contract": "Jun 30, 2027",
@@ -2045,7 +2597,11 @@
             "Spain"
           ],
           "number": "14",
-          "position": "Left-Back"
+          "overall_score": 77,
+          "position": "Left-Back",
+          "potential": 77,
+          "value": 9000000,
+          "yearly_wage": 1872000
         },
         {
           "contract": "Jun 30, 2028",
@@ -2059,7 +2615,11 @@
             "Spain"
           ],
           "number": "21",
-          "position": "Left-Back"
+          "overall_score": 71,
+          "position": "Left-Back",
+          "potential": 77,
+          "value": 2800000,
+          "yearly_wage": 988000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2074,7 +2634,11 @@
             "Cape Verde"
           ],
           "number": "12",
-          "position": "Right-Back"
+          "overall_score": 74,
+          "position": "Right-Back",
+          "potential": 74,
+          "value": 4200000,
+          "yearly_wage": 1508000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2088,7 +2652,11 @@
             "Argentina"
           ],
           "number": "20",
-          "position": "Right-Back"
+          "overall_score": 72,
+          "position": "Right-Back",
+          "potential": 72,
+          "value": 1600000,
+          "yearly_wage": 1300000
         },
         {
           "contract": "Jun 30, 2027",
@@ -2102,7 +2670,11 @@
             "Guadeloupe",
             "France"
           ],
-          "position": "Right-Back"
+          "overall_score": 72,
+          "position": "Right-Back",
+          "potential": 72,
+          "value": 1600000,
+          "yearly_wage": 1300000
         },
         {
           "contract": "Jun 30, 2028",
@@ -2116,7 +2688,11 @@
             "Spain"
           ],
           "number": "18",
-          "position": "Defensive Midfield"
+          "overall_score": 76,
+          "position": "Defensive Midfield",
+          "potential": 77,
+          "value": 9000000,
+          "yearly_wage": 1768000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2131,7 +2707,11 @@
             "Italy"
           ],
           "number": "2",
-          "position": "Defensive Midfield"
+          "overall_score": 76,
+          "position": "Defensive Midfield",
+          "potential": 76,
+          "value": 5000000,
+          "yearly_wage": 1768000
         },
         {
           "contract": "Jun 30, 2027",
@@ -2145,7 +2725,11 @@
             "France"
           ],
           "number": "22",
-          "position": "Defensive Midfield"
+          "overall_score": 75,
+          "position": "Defensive Midfield",
+          "potential": 75,
+          "value": 5500000,
+          "yearly_wage": 1768000
         },
         {
           "contract": "Jun 30, 2029",
@@ -2159,7 +2743,11 @@
             "Spain"
           ],
           "number": "8",
-          "position": "Central Midfield"
+          "overall_score": 76,
+          "position": "Central Midfield",
+          "potential": 84,
+          "value": 17000000,
+          "yearly_wage": 1560000
         },
         {
           "contract": "Jun 30, 2029",
@@ -2173,7 +2761,11 @@
             "Switzerland"
           ],
           "number": "23",
-          "position": "Central Midfield"
+          "overall_score": 75,
+          "position": "Central Midfield",
+          "potential": 76,
+          "value": 6500000,
+          "yearly_wage": 1664000
         },
         {
           "contract": "Jun 30, 2029",
@@ -2187,7 +2779,11 @@
             "Portugal"
           ],
           "number": "10",
-          "position": "Attacking Midfield"
+          "overall_score": 74,
+          "position": "Attacking Midfield",
+          "potential": 77,
+          "value": 5500000,
+          "yearly_wage": 1508000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2202,7 +2798,11 @@
             "Burundi"
           ],
           "number": "17",
-          "position": "Left Winger"
+          "overall_score": 76,
+          "position": "Left Winger",
+          "potential": 79,
+          "value": 10000000,
+          "yearly_wage": 2496000
         },
         {
           "contract": "Jun 30, 2028",
@@ -2217,7 +2817,11 @@
             "Nigeria"
           ],
           "number": "7",
-          "position": "Left Winger"
+          "overall_score": 75,
+          "position": "Left Winger",
+          "potential": 75,
+          "value": 5500000,
+          "yearly_wage": 1872000
         },
         {
           "contract": "Jun 30, 2029",
@@ -2231,7 +2835,11 @@
             "Spain"
           ],
           "number": "16",
-          "position": "Right Winger"
+          "overall_score": 77,
+          "position": "Right Winger",
+          "potential": 82,
+          "value": 16000000,
+          "yearly_wage": 1768000
         },
         {
           "contract": "Jun 30, 2027",
@@ -2245,7 +2853,11 @@
             "Spain"
           ],
           "number": "11",
-          "position": "Right Winger"
+          "overall_score": 77,
+          "position": "Right Winger",
+          "potential": 77,
+          "value": 8500000,
+          "yearly_wage": 1976000
         },
         {
           "contract": "Jun 30, 2027",
@@ -2259,7 +2871,11 @@
             "Spain"
           ],
           "number": "19",
-          "position": "Second Striker"
+          "overall_score": 74,
+          "position": "Second Striker",
+          "potential": 74,
+          "value": 4100000,
+          "yearly_wage": 1716000
         },
         {
           "contract": "Jun 30, 2028",
@@ -2273,7 +2889,11 @@
             "Spain"
           ],
           "number": "9",
-          "position": "Centre-Forward"
+          "overall_score": 77,
+          "position": "Centre-Forward",
+          "potential": 79,
+          "value": 13500000,
+          "yearly_wage": 1976000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2288,7 +2908,11 @@
             "Italy"
           ],
           "number": "15",
-          "position": "Centre-Forward"
+          "overall_score": 75,
+          "position": "Centre-Forward",
+          "potential": 79,
+          "value": 8000000,
+          "yearly_wage": 1976000
         },
         {
           "contract": "Jun 30, 2028",
@@ -2302,7 +2926,11 @@
             "Nigeria"
           ],
           "number": "6",
-          "position": "Centre-Forward"
+          "overall_score": 76,
+          "position": "Centre-Forward",
+          "potential": 76,
+          "value": 7500000,
+          "yearly_wage": 1976000
         }
       ],
       "stadiumName": "Mestalla",
@@ -2326,7 +2954,11 @@
             "Germany"
           ],
           "number": "1",
-          "position": "Goalkeeper"
+          "overall_score": 79,
+          "position": "Goalkeeper",
+          "potential": 79,
+          "value": 9500000,
+          "yearly_wage": 3692000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2340,7 +2972,11 @@
             "Norway"
           ],
           "number": "13",
-          "position": "Goalkeeper"
+          "overall_score": 74,
+          "position": "Goalkeeper",
+          "potential": 74,
+          "value": 725000,
+          "yearly_wage": 884000
         },
         {
           "contract": "Jun 30, 2029",
@@ -2354,7 +2990,11 @@
             "Spain"
           ],
           "number": "4",
-          "position": "Centre-Back"
+          "overall_score": 76,
+          "position": "Centre-Back",
+          "potential": 82,
+          "value": 11000000,
+          "yearly_wage": 1248000
         },
         {
           "contract": "Jun 30, 2028",
@@ -2368,7 +3008,11 @@
             "Brazil"
           ],
           "number": "23",
-          "position": "Centre-Back"
+          "overall_score": 74,
+          "position": "Centre-Back",
+          "potential": 74,
+          "value": 3500000,
+          "yearly_wage": 1352000
         },
         {
           "contract": "Jun 30, 2028",
@@ -2382,7 +3026,11 @@
             "Portugal"
           ],
           "number": "15",
-          "position": "Centre-Back"
+          "overall_score": 74,
+          "position": "Centre-Back",
+          "potential": 74,
+          "value": 2900000,
+          "yearly_wage": 1352000
         },
         {
           "contract": "Jun 30, 2027",
@@ -2396,7 +3044,11 @@
             "Spain"
           ],
           "number": "32",
-          "position": "Centre-Back"
+          "overall_score": 72,
+          "position": "Centre-Back",
+          "potential": 81,
+          "value": 4900000,
+          "yearly_wage": 936000
         },
         {
           "contract": "Jun 30, 2027",
@@ -2411,7 +3063,11 @@
             "Cote d'Ivoire"
           ],
           "number": "5",
-          "position": "Centre-Back"
+          "overall_score": 71,
+          "position": "Centre-Back",
+          "potential": 76,
+          "value": 2600000,
+          "yearly_wage": 832000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2425,7 +3081,11 @@
             "Spain"
           ],
           "number": "3",
-          "position": "Centre-Back"
+          "overall_score": 77,
+          "position": "Centre-Back",
+          "potential": 77,
+          "value": 2800000,
+          "yearly_wage": 1196000
         },
         {
           "contract": "Jun 30, 2027",
@@ -2440,7 +3100,11 @@
             "Italy"
           ],
           "number": "22",
-          "position": "Centre-Back"
+          "overall_score": 71,
+          "position": "Centre-Back",
+          "potential": 71,
+          "value": 1800000,
+          "yearly_wage": 936000
         },
         {
           "contract": "Jun 30, 2028",
@@ -2454,7 +3118,11 @@
             "Chile"
           ],
           "number": "12",
-          "position": "Left-Back"
+          "overall_score": 74,
+          "position": "Left-Back",
+          "potential": 74,
+          "value": 4100000,
+          "yearly_wage": 1300000
         },
         {
           "contract": "Jun 30, 2027",
@@ -2469,7 +3137,11 @@
             "Argentina"
           ],
           "number": "36",
-          "position": "Left-Back"
+          "overall_score": 72,
+          "position": "Left-Back",
+          "potential": 80,
+          "value": 5000000,
+          "yearly_wage": 780000
         },
         {
           "contract": "Jun 30, 2029",
@@ -2483,7 +3155,11 @@
             "Spain"
           ],
           "number": "16",
-          "position": "Right-Back"
+          "overall_score": 75,
+          "position": "Right-Back",
+          "potential": 81,
+          "value": 8500000,
+          "yearly_wage": 988000
         },
         {
           "contract": "Jun 30, 2028",
@@ -2497,7 +3173,11 @@
             "Spain"
           ],
           "number": "2",
-          "position": "Right-Back"
+          "overall_score": 77,
+          "position": "Right-Back",
+          "potential": 83,
+          "value": 15500000,
+          "yearly_wage": 1352000
         },
         {
           "contract": "Jun 30, 2028",
@@ -2512,7 +3192,11 @@
             "Cameroon"
           ],
           "number": "18",
-          "position": "Defensive Midfield"
+          "overall_score": 76,
+          "position": "Defensive Midfield",
+          "potential": 82,
+          "value": 11000000,
+          "yearly_wage": 1248000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2527,7 +3211,11 @@
             "Guinea-Bissau"
           ],
           "number": "19",
-          "position": "Defensive Midfield"
+          "overall_score": 75,
+          "position": "Defensive Midfield",
+          "potential": 80,
+          "value": 7500000,
+          "yearly_wage": 2028000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2542,7 +3230,11 @@
             "Netherlands"
           ],
           "number": "6",
-          "position": "Defensive Midfield"
+          "overall_score": 75,
+          "position": "Defensive Midfield",
+          "potential": 75,
+          "value": 2700000,
+          "yearly_wage": 1456000
         },
         {
           "contract": "Jun 30, 2029",
@@ -2557,7 +3249,11 @@
             "Senegal"
           ],
           "number": "20",
-          "position": "Central Midfield"
+          "overall_score": 75,
+          "position": "Central Midfield",
+          "potential": 75,
+          "value": 5500000,
+          "yearly_wage": 1508000
         },
         {
           "contract": "Jun 30, 2027",
@@ -2571,7 +3267,11 @@
             "Spain"
           ],
           "number": "8",
-          "position": "Central Midfield"
+          "overall_score": 74,
+          "position": "Central Midfield",
+          "potential": 74,
+          "value": 4000000,
+          "yearly_wage": 1404000
         },
         {
           "contract": "Jun 30, 2027",
@@ -2585,7 +3285,11 @@
             "Spain"
           ],
           "number": "28",
-          "position": "Central Midfield"
+          "overall_score": 67,
+          "position": "Central Midfield",
+          "potential": 78,
+          "value": 2200000,
+          "yearly_wage": 468000
         },
         {
           "contract": "Jun 30, 2029",
@@ -2600,7 +3304,11 @@
             "Dominican Republic"
           ],
           "number": "11",
-          "position": "Left Winger"
+          "overall_score": 78,
+          "position": "Left Winger",
+          "potential": 78,
+          "value": 15500000,
+          "yearly_wage": 1872000
         },
         {
           "contract": "Jun 30, 2027",
@@ -2614,7 +3322,11 @@
             "Nigeria"
           ],
           "number": "21",
-          "position": "Left Winger"
+          "overall_score": 76,
+          "position": "Left Winger",
+          "potential": 76,
+          "value": 8000000,
+          "yearly_wage": 1612000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2629,7 +3341,11 @@
             "Kosovo"
           ],
           "number": "24",
-          "position": "Right Winger"
+          "overall_score": 73,
+          "position": "Right Winger",
+          "potential": 73,
+          "value": 2900000,
+          "yearly_wage": 1352000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2643,7 +3359,11 @@
             "Spain"
           ],
           "number": "29",
-          "position": "Right Winger"
+          "overall_score": 64,
+          "position": "Right Winger",
+          "potential": 74,
+          "value": 1300000,
+          "yearly_wage": 312000
         },
         {
           "contract": "Jun 30, 2028",
@@ -2657,7 +3377,11 @@
             "Spain"
           ],
           "number": "14",
-          "position": "Second Striker"
+          "overall_score": 74,
+          "position": "Second Striker",
+          "potential": 81,
+          "value": 8500000,
+          "yearly_wage": 1196000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2671,7 +3395,11 @@
             "Chile"
           ],
           "number": "10",
-          "position": "Second Striker"
+          "overall_score": 75,
+          "position": "Second Striker",
+          "potential": 75,
+          "value": 1900000,
+          "yearly_wage": 1248000
         },
         {
           "contract": "Jun 30, 2029",
@@ -2685,7 +3413,11 @@
             "Nigeria"
           ],
           "number": "9",
-          "position": "Centre-Forward"
+          "overall_score": 75,
+          "position": "Centre-Forward",
+          "potential": 78,
+          "value": 7500000,
+          "yearly_wage": 1508000
         },
         {
           "contract": "Jun 30, 2028",
@@ -2699,7 +3431,11 @@
             "Spain"
           ],
           "number": "7",
-          "position": "Centre-Forward"
+          "overall_score": 74,
+          "position": "Centre-Forward",
+          "potential": 77,
+          "value": 5500000,
+          "yearly_wage": 1404000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2714,7 +3450,11 @@
             "Argentina"
           ],
           "number": "17",
-          "position": "Centre-Forward"
+          "overall_score": 74,
+          "position": "Centre-Forward",
+          "potential": 74,
+          "value": 4300000,
+          "yearly_wage": 1820000
         }
       ],
       "stadiumName": "Ramón Sánchez-Pizjuán",
@@ -2737,7 +3477,11 @@
             "Spain"
           ],
           "number": "1",
-          "position": "Goalkeeper"
+          "overall_score": 82,
+          "position": "Goalkeeper",
+          "potential": 82,
+          "value": 20500000,
+          "yearly_wage": 1768000
         },
         {
           "contract": "Jun 30, 2030",
@@ -2751,7 +3495,11 @@
             "Spain"
           ],
           "number": "13",
-          "position": "Goalkeeper"
+          "overall_score": 72,
+          "position": "Goalkeeper",
+          "potential": 79,
+          "value": 4000000,
+          "yearly_wage": 624000
         },
         {
           "contract": "Jun 30, 2031",
@@ -2765,7 +3513,11 @@
             "Spain"
           ],
           "number": "31",
-          "position": "Centre-Back"
+          "overall_score": 77,
+          "position": "Centre-Back",
+          "potential": 86,
+          "value": 21000000,
+          "yearly_wage": 1248000
         },
         {
           "contract": "Jun 30, 2029",
@@ -2779,7 +3531,11 @@
             "Spain"
           ],
           "number": "5",
-          "position": "Centre-Back"
+          "overall_score": 77,
+          "position": "Centre-Back",
+          "potential": 78,
+          "value": 10000000,
+          "yearly_wage": 1872000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2793,7 +3549,11 @@
             "Croatia"
           ],
           "number": "16",
-          "position": "Centre-Back"
+          "overall_score": 74,
+          "position": "Centre-Back",
+          "potential": 74,
+          "value": 3600000,
+          "yearly_wage": 936000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2807,7 +3567,11 @@
             "Spain"
           ],
           "number": "6",
-          "position": "Centre-Back"
+          "overall_score": 74,
+          "position": "Centre-Back",
+          "potential": 74,
+          "value": 2900000,
+          "yearly_wage": 1560000
         },
         {
           "contract": "Jun 30, 2030",
@@ -2821,7 +3585,11 @@
             "Spain"
           ],
           "number": "17",
-          "position": "Left-Back"
+          "overall_score": 78,
+          "position": "Left-Back",
+          "potential": 81,
+          "value": 18000000,
+          "yearly_wage": 1664000
         },
         {
           "contract": "Jun 30, 2027",
@@ -2835,7 +3603,11 @@
             "Spain"
           ],
           "number": "3",
-          "position": "Left-Back"
+          "overall_score": 74,
+          "position": "Left-Back",
+          "potential": 74,
+          "value": 4100000,
+          "yearly_wage": 1508000
         },
         {
           "contract": "Jun 30, 2030",
@@ -2850,7 +3622,11 @@
             "Spain"
           ],
           "number": "2",
-          "position": "Right-Back"
+          "overall_score": 77,
+          "position": "Right-Back",
+          "potential": 83,
+          "value": 16000000,
+          "yearly_wage": 1560000
         },
         {
           "contract": "Jun 30, 2029",
@@ -2864,7 +3640,11 @@
             "Spain"
           ],
           "number": "20",
-          "position": "Right-Back"
+          "overall_score": 73,
+          "position": "Right-Back",
+          "potential": 73,
+          "value": 2700000,
+          "yearly_wage": 1404000
         },
         {
           "contract": "Jun 30, 2030",
@@ -2878,7 +3658,11 @@
             "Spain"
           ],
           "number": "4",
-          "position": "Defensive Midfield"
+          "overall_score": 77,
+          "position": "Defensive Midfield",
+          "potential": 85,
+          "value": 22500000,
+          "yearly_wage": 1560000
         },
         {
           "contract": "Jun 30, 2030",
@@ -2892,7 +3676,11 @@
             "Spain"
           ],
           "number": "8",
-          "position": "Central Midfield"
+          "overall_score": 76,
+          "position": "Central Midfield",
+          "potential": 82,
+          "value": 12000000,
+          "yearly_wage": 1560000
         },
         {
           "contract": "Jun 30, 2029",
@@ -2906,7 +3694,11 @@
             "Croatia"
           ],
           "number": "24",
-          "position": "Central Midfield"
+          "overall_score": 76,
+          "position": "Central Midfield",
+          "potential": 81,
+          "value": 11500000,
+          "yearly_wage": 1560000
         },
         {
           "contract": "Jun 30, 2030",
@@ -2921,7 +3713,11 @@
             "Spain"
           ],
           "number": "12",
-          "position": "Central Midfield"
+          "overall_score": 79,
+          "position": "Central Midfield",
+          "potential": 79,
+          "value": 18500000,
+          "yearly_wage": 2236000
         },
         {
           "contract": "Jun 30, 2029",
@@ -2935,7 +3731,11 @@
             "Spain"
           ],
           "number": "18",
-          "position": "Central Midfield"
+          "overall_score": 78,
+          "position": "Central Midfield",
+          "potential": 78,
+          "value": 14000000,
+          "yearly_wage": 2132000
         },
         {
           "contract": "Jun 30, 2028",
@@ -2949,7 +3749,11 @@
             "Spain"
           ],
           "number": "23",
-          "position": "Attacking Midfield"
+          "overall_score": 78,
+          "position": "Attacking Midfield",
+          "potential": 78,
+          "value": 14000000,
+          "yearly_wage": 2132000
         },
         {
           "contract": "Jun 30, 2029",
@@ -2963,7 +3767,11 @@
             "Russia"
           ],
           "number": "21",
-          "position": "Attacking Midfield"
+          "overall_score": 73,
+          "position": "Attacking Midfield",
+          "potential": 81,
+          "value": 7000000,
+          "yearly_wage": 1248000
         },
         {
           "contract": "Jun 30, 2029",
@@ -2977,7 +3785,11 @@
             "Spain"
           ],
           "number": "15",
-          "position": "Attacking Midfield"
+          "overall_score": 73,
+          "position": "Attacking Midfield",
+          "potential": 82,
+          "value": 7000000,
+          "yearly_wage": 1040000
         },
         {
           "contract": "Jun 30, 2030",
@@ -2991,7 +3803,11 @@
             "Spain"
           ],
           "number": "7",
-          "position": "Left Winger"
+          "overall_score": 78,
+          "position": "Left Winger",
+          "potential": 83,
+          "value": 21000000,
+          "yearly_wage": 1924000
         },
         {
           "contract": "Jun 30, 2028",
@@ -3005,7 +3821,11 @@
             "Portugal"
           ],
           "number": "11",
-          "position": "Left Winger"
+          "overall_score": 78,
+          "position": "Left Winger",
+          "potential": 78,
+          "value": 14000000,
+          "yearly_wage": 2236000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3019,7 +3839,11 @@
             "Brazil"
           ],
           "number": "22",
-          "position": "Left Winger"
+          "overall_score": 69,
+          "position": "Left Winger",
+          "potential": 80,
+          "value": 3100000,
+          "yearly_wage": 780000
         },
         {
           "contract": "Jun 30, 2029",
@@ -3033,7 +3857,11 @@
             "Japan"
           ],
           "number": "14",
-          "position": "Right Winger"
+          "overall_score": 81,
+          "position": "Right Winger",
+          "potential": 84,
+          "value": 35000000,
+          "yearly_wage": 2184000
         },
         {
           "contract": "Jun 30, 2028",
@@ -3047,7 +3875,11 @@
             "Spain"
           ],
           "number": "10",
-          "position": "Centre-Forward"
+          "overall_score": 83,
+          "position": "Centre-Forward",
+          "potential": 83,
+          "value": 37000000,
+          "yearly_wage": 3380000
         },
         {
           "contract": "Jun 30, 2030",
@@ -3061,7 +3893,11 @@
             "Iceland"
           ],
           "number": "9",
-          "position": "Centre-Forward"
+          "overall_score": 74,
+          "position": "Centre-Forward",
+          "potential": 80,
+          "value": 6500000,
+          "yearly_wage": 1300000
         },
         {
           "contract": "Jun 30, 2027",
@@ -3075,7 +3911,11 @@
             "Spain"
           ],
           "number": "19",
-          "position": "Centre-Forward"
+          "overall_score": 67,
+          "position": "Centre-Forward",
+          "potential": 76,
+          "value": 2300000,
+          "yearly_wage": 676000
         }
       ],
       "stadiumName": "Reale Arena",
@@ -3098,7 +3938,11 @@
             "Serbia"
           ],
           "number": "13",
-          "position": "Goalkeeper"
+          "overall_score": 79,
+          "position": "Goalkeeper",
+          "potential": 79,
+          "value": 5500000,
+          "yearly_wage": 936000
         },
         {
           "contract": "Jun 30, 2027",
@@ -3112,7 +3956,11 @@
             "Spain"
           ],
           "number": "1",
-          "position": "Goalkeeper"
+          "overall_score": 65,
+          "position": "Goalkeeper",
+          "potential": 73,
+          "value": 1400000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2029",
@@ -3126,7 +3974,11 @@
             "Germany"
           ],
           "number": "38",
-          "position": "Centre-Back"
+          "overall_score": 71,
+          "position": "Centre-Back",
+          "potential": 81,
+          "value": 3900000,
+          "yearly_wage": 520000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3140,7 +3992,11 @@
             "Spain"
           ],
           "number": "5",
-          "position": "Centre-Back"
+          "overall_score": 75,
+          "position": "Centre-Back",
+          "potential": 75,
+          "value": 4700000,
+          "yearly_wage": 1092000
         },
         {
           "contract": "Jun 30, 2028",
@@ -3154,7 +4010,11 @@
             "Spain"
           ],
           "number": "15",
-          "position": "Centre-Back"
+          "overall_score": 70,
+          "position": "Centre-Back",
+          "potential": 72,
+          "value": 1700000,
+          "yearly_wage": 624000
         },
         {
           "contract": "Jun 30, 2027",
@@ -3169,7 +4029,11 @@
             "Spain"
           ],
           "number": "6",
-          "position": "Centre-Back"
+          "overall_score": 76,
+          "position": "Centre-Back",
+          "potential": 76,
+          "value": 2400000,
+          "yearly_wage": 1144000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3183,7 +4047,11 @@
             "Spain"
           ],
           "number": "22",
-          "position": "Left-Back"
+          "overall_score": 79,
+          "position": "Left-Back",
+          "potential": 83,
+          "value": 23500000,
+          "yearly_wage": 1820000
         },
         {
           "contract": "Jun 30, 2028",
@@ -3197,7 +4065,11 @@
             "Spain"
           ],
           "number": "12",
-          "position": "Left-Back"
+          "overall_score": 72,
+          "position": "Left-Back",
+          "potential": 76,
+          "value": 3100000,
+          "yearly_wage": 676000
         },
         {
           "contract": "Jun 30, 2027",
@@ -3212,7 +4084,11 @@
             "Spain"
           ],
           "number": "23",
-          "position": "Right-Back"
+          "overall_score": 75,
+          "position": "Right-Back",
+          "potential": 81,
+          "value": 8500000,
+          "yearly_wage": 780000
         },
         {
           "contract": "Jun 30, 2027",
@@ -3226,7 +4102,11 @@
             "Spain"
           ],
           "number": "2",
-          "position": "Right-Back"
+          "overall_score": 71,
+          "position": "Right-Back",
+          "potential": 76,
+          "value": 2600000,
+          "yearly_wage": 624000
         },
         {
           "contract": "Jun 30, 2030",
@@ -3240,7 +4120,11 @@
             "Spain"
           ],
           "number": "4",
-          "position": "Defensive Midfield"
+          "overall_score": 76,
+          "position": "Defensive Midfield",
+          "potential": 82,
+          "value": 11000000,
+          "yearly_wage": 936000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3255,7 +4139,11 @@
             "Switzerland"
           ],
           "number": "18",
-          "position": "Defensive Midfield"
+          "overall_score": 70,
+          "position": "Defensive Midfield",
+          "potential": 70,
+          "value": 1600000,
+          "yearly_wage": 676000
         },
         {
           "contract": "Jun 30, 2027",
@@ -3269,7 +4157,11 @@
             "Spain"
           ],
           "number": "10",
-          "position": "Central Midfield"
+          "overall_score": 75,
+          "position": "Central Midfield",
+          "potential": 77,
+          "value": 6500000,
+          "yearly_wage": 988000
         },
         {
           "contract": "Jun 30, 2027",
@@ -3283,7 +4175,11 @@
             "Spain"
           ],
           "number": "8",
-          "position": "Central Midfield"
+          "overall_score": 77,
+          "position": "Central Midfield",
+          "potential": 77,
+          "value": 10500000,
+          "yearly_wage": 1300000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3297,7 +4193,11 @@
             "Spain"
           ],
           "number": "14",
-          "position": "Central Midfield"
+          "overall_score": 74,
+          "position": "Central Midfield",
+          "potential": 77,
+          "value": 6000000,
+          "yearly_wage": 1352000
         },
         {
           "contract": "Jun 30, 2030",
@@ -3311,7 +4211,11 @@
             "Spain"
           ],
           "number": "7",
-          "position": "Left Winger"
+          "overall_score": 77,
+          "position": "Left Winger",
+          "potential": 77,
+          "value": 11000000,
+          "yearly_wage": 1300000
         },
         {
           "contract": "Jun 30, 2027",
@@ -3325,7 +4229,11 @@
             "Spain"
           ],
           "number": "11",
-          "position": "Left Winger"
+          "overall_score": 75,
+          "position": "Left Winger",
+          "potential": 75,
+          "value": 4500000,
+          "yearly_wage": 1144000
         },
         {
           "contract": "Jun 30, 2028",
@@ -3339,7 +4247,11 @@
             "England"
           ],
           "number": "24",
-          "position": "Right Winger"
+          "overall_score": 74,
+          "position": "Right Winger",
+          "potential": 79,
+          "value": 6500000,
+          "yearly_wage": 936000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3354,7 +4266,11 @@
             "DR Congo"
           ],
           "number": "16",
-          "position": "Right Winger"
+          "overall_score": 72,
+          "position": "Right Winger",
+          "potential": 73,
+          "value": 2800000,
+          "yearly_wage": 2756000
         },
         {
           "contract": "Jun 30, 2029",
@@ -3368,7 +4284,11 @@
             "Spain"
           ],
           "number": "17",
-          "position": "Right Winger"
+          "overall_score": 73,
+          "position": "Right Winger",
+          "potential": 75,
+          "value": 4000000,
+          "yearly_wage": 884000
         },
         {
           "contract": "Jun 30, 2028",
@@ -3382,7 +4302,11 @@
             "Spain"
           ],
           "number": "20",
-          "position": "Right Winger"
+          "overall_score": 73,
+          "position": "Right Winger",
+          "potential": 76,
+          "value": 4200000,
+          "yearly_wage": 780000
         },
         {
           "contract": "Jun 30, 2031",
@@ -3396,7 +4320,11 @@
             "Spain"
           ],
           "number": "9",
-          "position": "Centre-Forward"
+          "overall_score": 74,
+          "position": "Centre-Forward",
+          "potential": 80,
+          "value": 7000000,
+          "yearly_wage": 988000
         },
         {
           "contract": "Jun 30, 2027",
@@ -3410,7 +4338,11 @@
             "Spain"
           ],
           "number": "19",
-          "position": "Centre-Forward"
+          "overall_score": 74,
+          "position": "Centre-Forward",
+          "potential": 74,
+          "value": 1800000,
+          "yearly_wage": 884000
         }
       ],
       "stadiumName": "RCDE Stadium",
@@ -3433,7 +4365,11 @@
             "Spain"
           ],
           "number": "13",
-          "position": "Goalkeeper"
+          "overall_score": 76,
+          "position": "Goalkeeper",
+          "potential": 80,
+          "value": 8000000,
+          "yearly_wage": 2132000
         },
         {
           "contract": "Jun 30, 2029",
@@ -3447,7 +4383,11 @@
             "Spain"
           ],
           "number": "45",
-          "position": "Goalkeeper"
+          "overall_score": 66,
+          "position": "Goalkeeper",
+          "potential": 76,
+          "value": 1700000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2027",
@@ -3462,7 +4402,11 @@
             "Chile"
           ],
           "number": "1",
-          "position": "Goalkeeper"
+          "overall_score": 76,
+          "position": "Goalkeeper",
+          "potential": 76,
+          "value": 825000,
+          "yearly_wage": 468000
         },
         {
           "contract": "Jun 30, 2027",
@@ -3476,7 +4420,11 @@
             "Austria"
           ],
           "number": "22",
-          "position": "Centre-Back"
+          "overall_score": 75,
+          "position": "Centre-Back",
+          "potential": 82,
+          "value": 10500000,
+          "yearly_wage": 936000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3490,7 +4438,11 @@
             "Spain"
           ],
           "number": "23",
-          "position": "Centre-Back"
+          "overall_score": 73,
+          "position": "Centre-Back",
+          "potential": 78,
+          "value": 4000000,
+          "yearly_wage": 416000
         },
         {
           "contract": "Jun 30, 2028",
@@ -3505,7 +4457,11 @@
             "Nigeria"
           ],
           "number": "18",
-          "position": "Centre-Back"
+          "overall_score": 69,
+          "position": "Centre-Back",
+          "potential": 76,
+          "value": 2600000,
+          "yearly_wage": 520000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3519,7 +4475,11 @@
             "Spain"
           ],
           "number": "6",
-          "position": "Centre-Back"
+          "overall_score": 76,
+          "position": "Centre-Back",
+          "potential": 76,
+          "value": 2000000,
+          "yearly_wage": 884000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3533,7 +4493,11 @@
             "Spain"
           ],
           "number": "3",
-          "position": "Left-Back"
+          "overall_score": 74,
+          "position": "Left-Back",
+          "potential": 74,
+          "value": 4100000,
+          "yearly_wage": 1300000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3547,7 +4511,11 @@
             "France"
           ],
           "number": "21",
-          "position": "Left-Back"
+          "overall_score": 71,
+          "position": "Left-Back",
+          "potential": 71,
+          "value": 1600000,
+          "yearly_wage": 780000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3561,7 +4529,11 @@
             "Spain"
           ],
           "number": "39",
-          "position": "Right-Back"
+          "overall_score": 71,
+          "position": "Right-Back",
+          "potential": 83,
+          "value": 4200000,
+          "yearly_wage": 1404000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3576,7 +4548,11 @@
             "Mali"
           ],
           "number": "42",
-          "position": "Right-Back"
+          "overall_score": 65,
+          "position": "Right-Back",
+          "potential": 79,
+          "value": 1600000,
+          "yearly_wage": 312000
         },
         {
           "contract": "Jun 30, 2030",
@@ -3591,7 +4567,11 @@
             "Spain"
           ],
           "number": "5",
-          "position": "Defensive Midfield"
+          "overall_score": 70,
+          "position": "Defensive Midfield",
+          "potential": 77,
+          "value": 3200000,
+          "yearly_wage": 624000
         },
         {
           "contract": "Jun 30, 2027",
@@ -3605,7 +4585,11 @@
             "Spain"
           ],
           "number": "8",
-          "position": "Defensive Midfield"
+          "overall_score": 73,
+          "position": "Defensive Midfield",
+          "potential": 78,
+          "value": 4100000,
+          "yearly_wage": 884000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3619,7 +4603,11 @@
             "Spain"
           ],
           "number": "14",
-          "position": "Central Midfield"
+          "overall_score": 78,
+          "position": "Central Midfield",
+          "potential": 78,
+          "value": 13500000,
+          "yearly_wage": 1456000
         },
         {
           "contract": "Jun 30, 2028",
@@ -3633,7 +4621,11 @@
             "Portugal"
           ],
           "number": "16",
-          "position": "Central Midfield"
+          "overall_score": 72,
+          "position": "Central Midfield",
+          "potential": 81,
+          "value": 5000000,
+          "yearly_wage": 780000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3647,7 +4639,11 @@
             "Spain"
           ],
           "number": "12",
-          "position": "Central Midfield"
+          "overall_score": 72,
+          "position": "Central Midfield",
+          "potential": 72,
+          "value": 2500000,
+          "yearly_wage": 884000
         },
         {
           "contract": "Jun 30, 2027",
@@ -3662,7 +4658,11 @@
             "Lithuania"
           ],
           "number": "11",
-          "position": "Left Winger"
+          "overall_score": 76,
+          "position": "Left Winger",
+          "potential": 80,
+          "value": 11000000,
+          "yearly_wage": 1040000
         },
         {
           "contract": "Jun 30, 2030",
@@ -3676,7 +4676,11 @@
             "Chile"
           ],
           "number": "24",
-          "position": "Left Winger"
+          "overall_score": 72,
+          "position": "Left Winger",
+          "potential": 81,
+          "value": 5500000,
+          "yearly_wage": 832000
         },
         {
           "contract": "Jun 30, 2028",
@@ -3690,7 +4694,11 @@
             "Spain"
           ],
           "number": "15",
-          "position": "Left Winger"
+          "overall_score": 71,
+          "position": "Left Winger",
+          "potential": 71,
+          "value": 1900000,
+          "yearly_wage": 832000
         },
         {
           "contract": "Jun 30, 2027",
@@ -3704,7 +4712,11 @@
             "Spain"
           ],
           "number": "7",
-          "position": "Left Winger"
+          "overall_score": 70,
+          "position": "Left Winger",
+          "potential": 79,
+          "value": 3600000,
+          "yearly_wage": 676000
         },
         {
           "contract": "Jun 30, 2027",
@@ -3719,7 +4731,11 @@
             "England"
           ],
           "number": "19",
-          "position": "Right Winger"
+          "overall_score": 70,
+          "position": "Right Winger",
+          "potential": 70,
+          "value": 1700000,
+          "yearly_wage": 728000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3733,7 +4749,11 @@
             "Spain"
           ],
           "number": "17",
-          "position": "Right Winger"
+          "overall_score": 72,
+          "position": "Right Winger",
+          "potential": 72,
+          "value": 950000,
+          "yearly_wage": 676000
         },
         {
           "contract": "Jun 30, 2027",
@@ -3748,7 +4768,11 @@
             "Spain"
           ],
           "number": "32",
-          "position": "Second Striker"
+          "overall_score": 62,
+          "position": "Second Striker",
+          "potential": 78,
+          "value": 1000000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2029",
@@ -3763,7 +4787,11 @@
             "Spain"
           ],
           "number": "20",
-          "position": "Centre-Forward"
+          "overall_score": 72,
+          "position": "Centre-Forward",
+          "potential": 83,
+          "value": 5000000,
+          "yearly_wage": 728000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3777,7 +4805,11 @@
             "Spain"
           ],
           "number": "10",
-          "position": "Centre-Forward"
+          "overall_score": 75,
+          "position": "Centre-Forward",
+          "potential": 75,
+          "value": 6000000,
+          "yearly_wage": 1612000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3791,7 +4823,11 @@
             "Portugal"
           ],
           "number": "9",
-          "position": "Centre-Forward"
+          "overall_score": 76,
+          "position": "Centre-Forward",
+          "potential": 76,
+          "value": 7500000,
+          "yearly_wage": 1352000
         }
       ],
       "stadiumName": "Manuel Martínez Valero",
@@ -3814,7 +4850,11 @@
             "Spain"
           ],
           "number": "13",
-          "position": "Goalkeeper"
+          "overall_score": 78,
+          "position": "Goalkeeper",
+          "potential": 79,
+          "value": 11000000,
+          "yearly_wage": 1196000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3828,7 +4868,11 @@
             "Romania"
           ],
           "number": "1",
-          "position": "Goalkeeper"
+          "overall_score": 70,
+          "position": "Goalkeeper",
+          "potential": 72,
+          "value": 1500000,
+          "yearly_wage": 936000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3843,7 +4887,11 @@
             "Portugal"
           ],
           "number": "16",
-          "position": "Centre-Back"
+          "overall_score": 74,
+          "position": "Centre-Back",
+          "potential": 78,
+          "value": 5500000,
+          "yearly_wage": 2964000
         },
         {
           "contract": "Jun 30, 2027",
@@ -3857,7 +4905,11 @@
             "Cote d'Ivoire"
           ],
           "number": "2",
-          "position": "Centre-Back"
+          "overall_score": 73,
+          "position": "Centre-Back",
+          "potential": 73,
+          "value": 2100000,
+          "yearly_wage": 1300000
         },
         {
           "contract": "Jun 30, 2028",
@@ -3871,7 +4923,11 @@
             "Spain"
           ],
           "number": "4",
-          "position": "Centre-Back"
+          "overall_score": 75,
+          "position": "Centre-Back",
+          "potential": 75,
+          "value": 4600000,
+          "yearly_wage": 1508000
         },
         {
           "contract": "Jun 30, 2027",
@@ -3885,7 +4941,11 @@
             "Spain"
           ],
           "number": "12",
-          "position": "Centre-Back"
+          "overall_score": 72,
+          "position": "Centre-Back",
+          "potential": 72,
+          "value": 1600000,
+          "yearly_wage": 1144000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3899,7 +4959,11 @@
             "Spain"
           ],
           "number": "25",
-          "position": "Left-Back"
+          "overall_score": 73,
+          "position": "Left-Back",
+          "potential": 79,
+          "value": 4500000,
+          "yearly_wage": 1196000
         },
         {
           "contract": "Jun 30, 2028",
@@ -3914,7 +4978,11 @@
             "Spain"
           ],
           "number": "3",
-          "position": "Left-Back"
+          "overall_score": 71,
+          "position": "Left-Back",
+          "potential": 77,
+          "value": 2800000,
+          "yearly_wage": 884000
         },
         {
           "contract": "Jun 30, 2027",
@@ -3928,7 +4996,11 @@
             "Spain"
           ],
           "number": "22",
-          "position": "Right-Back"
+          "overall_score": 71,
+          "position": "Right-Back",
+          "potential": 71,
+          "value": 1600000,
+          "yearly_wage": 1040000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3942,7 +5014,11 @@
             "Spain"
           ],
           "number": "24",
-          "position": "Right-Back"
+          "overall_score": 69,
+          "position": "Right-Back",
+          "potential": 69,
+          "value": 1200000,
+          "yearly_wage": 832000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3957,7 +5033,11 @@
             "Italy"
           ],
           "number": "11",
-          "position": "Defensive Midfield"
+          "overall_score": 72,
+          "position": "Defensive Midfield",
+          "potential": 72,
+          "value": 2100000,
+          "yearly_wage": 1144000
         },
         {
           "contract": "Jun 30, 2027",
@@ -3971,7 +5051,11 @@
             "Belgium"
           ],
           "number": "20",
-          "position": "Defensive Midfield"
+          "overall_score": 72,
+          "position": "Defensive Midfield",
+          "potential": 72,
+          "value": 2200000,
+          "yearly_wage": 1196000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3986,7 +5070,11 @@
             "Italy"
           ],
           "number": "23",
-          "position": "Defensive Midfield"
+          "overall_score": 72,
+          "position": "Defensive Midfield",
+          "potential": 72,
+          "value": 2300000,
+          "yearly_wage": 1092000
         },
         {
           "contract": "Jun 30, 2027",
@@ -4000,7 +5088,11 @@
             "Spain"
           ],
           "number": "5",
-          "position": "Central Midfield"
+          "overall_score": 74,
+          "position": "Central Midfield",
+          "potential": 74,
+          "value": 4500000,
+          "yearly_wage": 1404000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4014,7 +5106,11 @@
             "Ghana"
           ],
           "number": "6",
-          "position": "Central Midfield"
+          "overall_score": 70,
+          "position": "Central Midfield",
+          "potential": 72,
+          "value": 1700000,
+          "yearly_wage": 884000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4028,7 +5124,11 @@
             "Spain"
           ],
           "number": "8",
-          "position": "Central Midfield"
+          "overall_score": 75,
+          "position": "Central Midfield",
+          "potential": 75,
+          "value": 0,
+          "yearly_wage": 1092000
         },
         {
           "contract": "Jun 30, 2028",
@@ -4042,7 +5142,11 @@
             "Serbia"
           ],
           "number": "21",
-          "position": "Attacking Midfield"
+          "overall_score": 69,
+          "position": "Attacking Midfield",
+          "potential": 72,
+          "value": 1800000,
+          "yearly_wage": 780000
         },
         {
           "contract": "Jun 30, 2029",
@@ -4056,7 +5160,11 @@
             "Spain"
           ],
           "number": "27",
-          "position": "Attacking Midfield"
+          "overall_score": 63,
+          "position": "Attacking Midfield",
+          "potential": 81,
+          "value": 1200000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4070,7 +5178,11 @@
             "Argentina"
           ],
           "number": "15",
-          "position": "Left Winger"
+          "overall_score": 74,
+          "position": "Left Winger",
+          "potential": 81,
+          "value": 8500000,
+          "yearly_wage": 1248000
         },
         {
           "contract": "Jun 30, 2028",
@@ -4085,7 +5197,11 @@
             "Spain"
           ],
           "number": "7",
-          "position": "Left Winger"
+          "overall_score": 73,
+          "position": "Left Winger",
+          "potential": 76,
+          "value": 4200000,
+          "yearly_wage": 1196000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4100,7 +5216,11 @@
             "Nigeria"
           ],
           "number": "14",
-          "position": "Left Winger"
+          "overall_score": 66,
+          "position": "Left Winger",
+          "potential": 66,
+          "value": 900000,
+          "yearly_wage": 572000
         },
         {
           "contract": "Jun 30, 2027",
@@ -4115,7 +5235,11 @@
             "France"
           ],
           "number": "10",
-          "position": "Right Winger"
+          "overall_score": 73,
+          "position": "Right Winger",
+          "potential": 79,
+          "value": 4800000,
+          "yearly_wage": 1196000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4129,7 +5253,11 @@
             "Uruguay"
           ],
           "number": "9",
-          "position": "Centre-Forward"
+          "overall_score": 75,
+          "position": "Centre-Forward",
+          "potential": 76,
+          "value": 6500000,
+          "yearly_wage": 1664000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4143,7 +5271,11 @@
             "Uruguay"
           ],
           "number": "17",
-          "position": "Centre-Forward"
+          "overall_score": 70,
+          "position": "Centre-Forward",
+          "potential": 76,
+          "value": 2500000,
+          "yearly_wage": 884000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4157,7 +5289,11 @@
             "Spain"
           ],
           "number": "19",
-          "position": "Centre-Forward"
+          "overall_score": 70,
+          "position": "Centre-Forward",
+          "potential": 75,
+          "value": 2400000,
+          "yearly_wage": 988000
         }
       ],
       "stadiumName": "Carlos Tartiere",
@@ -4181,7 +5317,11 @@
             "Scotland"
           ],
           "number": "13",
-          "position": "Goalkeeper"
+          "overall_score": 79,
+          "position": "Goalkeeper",
+          "potential": 79,
+          "value": 5500000,
+          "yearly_wage": 1196000
         },
         {
           "contract": "Jun 30, 2027",
@@ -4195,7 +5335,11 @@
             "Spain"
           ],
           "number": "1",
-          "position": "Goalkeeper"
+          "overall_score": 69,
+          "position": "Goalkeeper",
+          "potential": 77,
+          "value": 2700000,
+          "yearly_wage": 364000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4209,7 +5353,11 @@
             "Argentina"
           ],
           "number": "2",
-          "position": "Centre-Back"
+          "overall_score": 73,
+          "position": "Centre-Back",
+          "potential": 79,
+          "value": 4400000,
+          "yearly_wage": 1196000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4224,7 +5372,11 @@
             "Italy"
           ],
           "number": "3",
-          "position": "Centre-Back"
+          "overall_score": 70,
+          "position": "Centre-Back",
+          "potential": 80,
+          "value": 3300000,
+          "yearly_wage": 520000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4238,7 +5390,11 @@
             "Spain"
           ],
           "number": "4",
-          "position": "Centre-Back"
+          "overall_score": 74,
+          "position": "Centre-Back",
+          "potential": 77,
+          "value": 4900000,
+          "yearly_wage": 1196000
         },
         {
           "contract": "Jun 30, 2027",
@@ -4252,7 +5408,11 @@
             "Spain"
           ],
           "number": "5",
-          "position": "Centre-Back"
+          "overall_score": 71,
+          "position": "Centre-Back",
+          "potential": 71,
+          "value": 1200000,
+          "yearly_wage": 936000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4266,7 +5426,11 @@
             "Spain"
           ],
           "number": "23",
-          "position": "Left-Back"
+          "overall_score": 76,
+          "position": "Left-Back",
+          "potential": 80,
+          "value": 10000000,
+          "yearly_wage": 1144000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4280,7 +5444,11 @@
             "Spain"
           ],
           "number": "6",
-          "position": "Left-Back"
+          "overall_score": 69,
+          "position": "Left-Back",
+          "potential": 71,
+          "value": 1600000,
+          "yearly_wage": 676000
         },
         {
           "contract": "Jun 30, 2027",
@@ -4295,7 +5463,11 @@
             "United States"
           ],
           "number": "22",
-          "position": "Right-Back"
+          "overall_score": 74,
+          "position": "Right-Back",
+          "potential": 74,
+          "value": 3600000,
+          "yearly_wage": 1248000
         },
         {
           "contract": "Jun 30, 2027",
@@ -4309,7 +5481,11 @@
             "Spain"
           ],
           "number": "17",
-          "position": "Right-Back"
+          "overall_score": 71,
+          "position": "Right-Back",
+          "potential": 71,
+          "value": 2000000,
+          "yearly_wage": 936000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4323,7 +5499,11 @@
             "France"
           ],
           "number": "14",
-          "position": "Defensive Midfield"
+          "overall_score": 71,
+          "position": "Defensive Midfield",
+          "potential": 81,
+          "value": 4000000,
+          "yearly_wage": 676000
         },
         {
           "contract": "Jun 30, 2027",
@@ -4337,7 +5517,11 @@
             "Spain"
           ],
           "number": "20",
-          "position": "Defensive Midfield"
+          "overall_score": 73,
+          "position": "Defensive Midfield",
+          "potential": 73,
+          "value": 3200000,
+          "yearly_wage": 1144000
         },
         {
           "contract": "Jun 30, 2028",
@@ -4351,7 +5535,11 @@
             "Honduras"
           ],
           "number": "16",
-          "position": "Defensive Midfield"
+          "overall_score": 74,
+          "position": "Defensive Midfield",
+          "potential": 75,
+          "value": 4300000,
+          "yearly_wage": 1196000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4365,7 +5553,11 @@
             "Spain"
           ],
           "number": "10",
-          "position": "Central Midfield"
+          "overall_score": 76,
+          "position": "Central Midfield",
+          "potential": 76,
+          "value": 8000000,
+          "yearly_wage": 1404000
         },
         {
           "contract": "Jun 30, 2028",
@@ -4379,7 +5571,11 @@
             "Spain"
           ],
           "number": "8",
-          "position": "Central Midfield"
+          "overall_score": 74,
+          "position": "Central Midfield",
+          "potential": 77,
+          "value": 5500000,
+          "yearly_wage": 1092000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4393,7 +5589,11 @@
             "Spain"
           ],
           "number": "12",
-          "position": "Central Midfield"
+          "overall_score": 72,
+          "position": "Central Midfield",
+          "potential": 75,
+          "value": 2900000,
+          "yearly_wage": 1144000
         },
         {
           "contract": "Jun 30, 2027",
@@ -4407,7 +5607,11 @@
             "Spain"
           ],
           "number": "24",
-          "position": "Attacking Midfield"
+          "overall_score": 77,
+          "position": "Attacking Midfield",
+          "potential": 83,
+          "value": 17000000,
+          "yearly_wage": 1144000
         },
         {
           "contract": "Jun 30, 2028",
@@ -4421,7 +5625,11 @@
             "Spain"
           ],
           "number": "7",
-          "position": "Left Winger"
+          "overall_score": 73,
+          "position": "Left Winger",
+          "potential": 73,
+          "value": 3100000,
+          "yearly_wage": 1300000
         },
         {
           "contract": "Jun 30, 2028",
@@ -4435,7 +5643,11 @@
             "Spain"
           ],
           "number": "27",
-          "position": "Left Winger"
+          "overall_score": 68,
+          "position": "Left Winger",
+          "potential": 81,
+          "value": 2800000,
+          "yearly_wage": 416000
         },
         {
           "contract": "Jun 30, 2029",
@@ -4450,7 +5662,11 @@
             "Nigeria"
           ],
           "number": "26",
-          "position": "Right Winger"
+          "overall_score": 68,
+          "position": "Right Winger",
+          "potential": 79,
+          "value": 2600000,
+          "yearly_wage": 520000
         },
         {
           "contract": "Jun 30, 2029",
@@ -4465,7 +5681,11 @@
             "Spain"
           ],
           "number": "55",
-          "position": "Right Winger"
+          "overall_score": 66,
+          "position": "Right Winger",
+          "potential": 78,
+          "value": 2100000,
+          "yearly_wage": 416000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4479,7 +5699,11 @@
             "Spain"
           ],
           "number": "18",
-          "position": "Second Striker"
+          "overall_score": 72,
+          "position": "Second Striker",
+          "potential": 77,
+          "value": 3500000,
+          "yearly_wage": 884000
         },
         {
           "contract": "Jun 30, 2029",
@@ -4493,7 +5717,11 @@
             "Cameroon"
           ],
           "number": "21",
-          "position": "Centre-Forward"
+          "overall_score": 75,
+          "position": "Centre-Forward",
+          "potential": 84,
+          "value": 12500000,
+          "yearly_wage": 1144000
         },
         {
           "contract": "Jun 30, 2028",
@@ -4507,7 +5735,11 @@
             "Spain"
           ],
           "number": "9",
-          "position": "Centre-Forward"
+          "overall_score": 75,
+          "position": "Centre-Forward",
+          "potential": 80,
+          "value": 8500000,
+          "yearly_wage": 1300000
         },
         {
           "contract": "Jun 30, 2028",
@@ -4521,7 +5753,11 @@
             "Spain"
           ],
           "number": "19",
-          "position": "Centre-Forward"
+          "overall_score": 75,
+          "position": "Centre-Forward",
+          "potential": 84,
+          "value": 12000000,
+          "yearly_wage": 1040000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4535,7 +5771,11 @@
             "Spain"
           ],
           "number": "11",
-          "position": "Centre-Forward"
+          "overall_score": 73,
+          "position": "Centre-Forward",
+          "potential": 73,
+          "value": 1000000,
+          "yearly_wage": 988000
         }
       ],
       "stadiumName": "Ciutat de València",
@@ -4558,7 +5798,11 @@
             "Spain"
           ],
           "number": "1",
-          "position": "Goalkeeper"
+          "overall_score": 77,
+          "position": "Goalkeeper",
+          "potential": 83,
+          "value": 13500000,
+          "yearly_wage": 780000
         },
         {
           "contract": "Jun 30, 2027",
@@ -4572,7 +5816,11 @@
             "Finland"
           ],
           "number": "13",
-          "position": "Goalkeeper"
+          "overall_score": 68,
+          "position": "Goalkeeper",
+          "potential": 75,
+          "value": 2100000,
+          "yearly_wage": 364000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4586,7 +5834,11 @@
             "Spain"
           ],
           "number": "25",
-          "position": "Goalkeeper"
+          "overall_score": 67,
+          "position": "Goalkeeper",
+          "potential": 67,
+          "value": 110000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2029",
@@ -4600,7 +5852,11 @@
             "Slovakia"
           ],
           "number": "24",
-          "position": "Centre-Back"
+          "overall_score": 77,
+          "position": "Centre-Back",
+          "potential": 77,
+          "value": 9000000,
+          "yearly_wage": 1612000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4615,7 +5871,11 @@
             "Italy"
           ],
           "number": "4",
-          "position": "Centre-Back"
+          "overall_score": 76,
+          "position": "Centre-Back",
+          "potential": 79,
+          "value": 9000000,
+          "yearly_wage": 2132000
         },
         {
           "contract": "Jun 30, 2027",
@@ -4629,7 +5889,11 @@
             "Spain"
           ],
           "number": "21",
-          "position": "Centre-Back"
+          "overall_score": 79,
+          "position": "Centre-Back",
+          "potential": 79,
+          "value": 8500000,
+          "yearly_wage": 1924000
         },
         {
           "contract": "Jun 30, 2027",
@@ -4643,7 +5907,11 @@
             "Spain"
           ],
           "number": "27",
-          "position": "Centre-Back"
+          "overall_score": 69,
+          "position": "Centre-Back",
+          "potential": 78,
+          "value": 2900000,
+          "yearly_wage": 676000
         },
         {
           "contract": "Jun 30, 2027",
@@ -4658,7 +5926,11 @@
             "Spain"
           ],
           "number": "22",
-          "position": "Left-Back"
+          "overall_score": 77,
+          "position": "Left-Back",
+          "potential": 77,
+          "value": 7500000,
+          "yearly_wage": 1612000
         },
         {
           "contract": "Jun 30, 2027",
@@ -4672,7 +5944,11 @@
             "Spain"
           ],
           "number": "3",
-          "position": "Left-Back"
+          "overall_score": 73,
+          "position": "Left-Back",
+          "potential": 73,
+          "value": 2900000,
+          "yearly_wage": 1144000
         },
         {
           "contract": "Jun 30, 2027",
@@ -4687,7 +5963,11 @@
             "Spain"
           ],
           "number": "23",
-          "position": "Right-Back"
+          "overall_score": 78,
+          "position": "Right-Back",
+          "potential": 78,
+          "value": 13500000,
+          "yearly_wage": 1664000
         },
         {
           "contract": "Jun 30, 2027",
@@ -4701,7 +5981,11 @@
             "Spain"
           ],
           "number": "2",
-          "position": "Right-Back"
+          "overall_score": 73,
+          "position": "Right-Back",
+          "potential": 76,
+          "value": 3700000,
+          "yearly_wage": 1092000
         },
         {
           "contract": "Jun 30, 2028",
@@ -4715,7 +5999,11 @@
             "Portugal"
           ],
           "number": "12",
-          "position": "Defensive Midfield"
+          "overall_score": 78,
+          "position": "Defensive Midfield",
+          "potential": 82,
+          "value": 18500000,
+          "yearly_wage": 1456000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4730,7 +6018,11 @@
             "Spain"
           ],
           "number": "5",
-          "position": "Defensive Midfield"
+          "overall_score": 75,
+          "position": "Defensive Midfield",
+          "potential": 75,
+          "value": 3700000,
+          "yearly_wage": 1456000
         },
         {
           "contract": "Jun 30, 2028",
@@ -4744,7 +6036,11 @@
             "Spain"
           ],
           "number": "10",
-          "position": "Central Midfield"
+          "overall_score": 79,
+          "position": "Central Midfield",
+          "potential": 79,
+          "value": 14500000,
+          "yearly_wage": 1976000
         },
         {
           "contract": "Jun 30, 2027",
@@ -4758,7 +6054,11 @@
             "Spain"
           ],
           "number": "6",
-          "position": "Central Midfield"
+          "overall_score": 73,
+          "position": "Central Midfield",
+          "potential": 73,
+          "value": 3100000,
+          "yearly_wage": 1248000
         },
         {
           "contract": "Jun 30, 2028",
@@ -4772,7 +6072,11 @@
             "Spain"
           ],
           "number": "8",
-          "position": "Central Midfield"
+          "overall_score": 76,
+          "position": "Central Midfield",
+          "potential": 78,
+          "value": 8500000,
+          "yearly_wage": 1456000
         },
         {
           "contract": "Jun 30, 2028",
@@ -4786,7 +6090,11 @@
             "Spain"
           ],
           "number": "41",
-          "position": "Central Midfield"
+          "overall_score": 62,
+          "position": "Central Midfield",
+          "potential": 76,
+          "value": 950000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2029",
@@ -4800,7 +6108,11 @@
             "Spain"
           ],
           "number": "20",
-          "position": "Attacking Midfield"
+          "overall_score": 74,
+          "position": "Attacking Midfield",
+          "potential": 82,
+          "value": 9500000,
+          "yearly_wage": 1196000
         },
         {
           "contract": "Jun 30, 2030",
@@ -4814,7 +6126,11 @@
             "Spain"
           ],
           "number": "17",
-          "position": "Left Winger"
+          "overall_score": 75,
+          "position": "Left Winger",
+          "potential": 86,
+          "value": 12000000,
+          "yearly_wage": 1040000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4828,7 +6144,11 @@
             "Spain"
           ],
           "number": "19",
-          "position": "Left Winger"
+          "overall_score": 69,
+          "position": "Left Winger",
+          "potential": 76,
+          "value": 2800000,
+          "yearly_wage": 728000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4842,7 +6162,11 @@
             "Angola"
           ],
           "number": "15",
-          "position": "Right Winger"
+          "overall_score": 71,
+          "position": "Right Winger",
+          "potential": 78,
+          "value": 3800000,
+          "yearly_wage": 416000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4856,7 +6180,11 @@
             "Japan"
           ],
           "number": "11",
-          "position": "Right Winger"
+          "overall_score": 74,
+          "position": "Right Winger",
+          "potential": 74,
+          "value": 4100000,
+          "yearly_wage": 1508000
         },
         {
           "contract": "Jun 30, 2029",
@@ -4871,7 +6199,11 @@
             "DR Congo"
           ],
           "number": "30",
-          "position": "Right Winger"
+          "overall_score": 65,
+          "position": "Right Winger",
+          "potential": 75,
+          "value": 1600000,
+          "yearly_wage": 312000
         },
         {
           "contract": "Jun 30, 2029",
@@ -4886,7 +6218,11 @@
             "Albania"
           ],
           "number": "7",
-          "position": "Centre-Forward"
+          "overall_score": 81,
+          "position": "Centre-Forward",
+          "potential": 81,
+          "value": 22000000,
+          "yearly_wage": 2444000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4901,7 +6237,11 @@
             "England"
           ],
           "number": "18",
-          "position": "Centre-Forward"
+          "overall_score": 72,
+          "position": "Centre-Forward",
+          "potential": 82,
+          "value": 5500000,
+          "yearly_wage": 1612000
         },
         {
           "contract": "Jun 30, 2028",
@@ -4915,7 +6255,11 @@
             "Spain"
           ],
           "number": "9",
-          "position": "Centre-Forward"
+          "overall_score": 72,
+          "position": "Centre-Forward",
+          "potential": 72,
+          "value": 1900000,
+          "yearly_wage": 1248000
         }
       ],
       "stadiumName": "Mallorca Son Moix",
@@ -4938,7 +6282,11 @@
             "Romania"
           ],
           "number": "13",
-          "position": "Goalkeeper"
+          "overall_score": 78,
+          "position": "Goalkeeper",
+          "potential": 78,
+          "value": 10000000,
+          "yearly_wage": 1040000
         },
         {
           "contract": "Jun 30, 2027",
@@ -4952,7 +6300,11 @@
             "Spain"
           ],
           "number": "1",
-          "position": "Goalkeeper"
+          "overall_score": 72,
+          "position": "Goalkeeper",
+          "potential": 75,
+          "value": 2300000,
+          "yearly_wage": 624000
         },
         {
           "contract": "Jun 30, 2028",
@@ -4966,7 +6318,11 @@
             "Spain"
           ],
           "number": "25",
-          "position": "Goalkeeper"
+          "overall_score": 64,
+          "position": "Goalkeeper",
+          "potential": 68,
+          "value": 650000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2028",
@@ -4980,7 +6336,11 @@
             "Spain"
           ],
           "number": "32",
-          "position": "Centre-Back"
+          "overall_score": 76,
+          "position": "Centre-Back",
+          "potential": 82,
+          "value": 11000000,
+          "yearly_wage": 1144000
         },
         {
           "contract": "Jun 30, 2027",
@@ -4994,7 +6354,11 @@
             "Sweden"
           ],
           "number": "2",
-          "position": "Centre-Back"
+          "overall_score": 78,
+          "position": "Centre-Back",
+          "potential": 78,
+          "value": 11500000,
+          "yearly_wage": 1560000
         },
         {
           "contract": "Jun 30, 2028",
@@ -5008,7 +6372,11 @@
             "Spain"
           ],
           "number": "24",
-          "position": "Centre-Back"
+          "overall_score": 73,
+          "position": "Centre-Back",
+          "potential": 78,
+          "value": 4200000,
+          "yearly_wage": 884000
         },
         {
           "contract": "Jun 30, 2029",
@@ -5022,7 +6390,11 @@
             "Spain"
           ],
           "number": "29",
-          "position": "Centre-Back"
+          "overall_score": 71,
+          "position": "Centre-Back",
+          "potential": 78,
+          "value": 3500000,
+          "yearly_wage": 624000
         },
         {
           "contract": "Jun 30, 2028",
@@ -5036,7 +6408,11 @@
             "Spain"
           ],
           "number": "12",
-          "position": "Centre-Back"
+          "overall_score": 70,
+          "position": "Centre-Back",
+          "potential": 75,
+          "value": 2200000,
+          "yearly_wage": 676000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5050,7 +6426,11 @@
             "Spain"
           ],
           "number": "20",
-          "position": "Centre-Back"
+          "overall_score": 79,
+          "position": "Centre-Back",
+          "potential": 79,
+          "value": 5500000,
+          "yearly_wage": 1716000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5064,7 +6444,11 @@
             "Ghana"
           ],
           "number": "4",
-          "position": "Centre-Back"
+          "overall_score": 73,
+          "position": "Centre-Back",
+          "potential": 73,
+          "value": 2500000,
+          "yearly_wage": 1092000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5079,7 +6463,11 @@
             "Bosnia-Herzegovina"
           ],
           "number": "21",
-          "position": "Left-Back"
+          "overall_score": 72,
+          "position": "Left-Back",
+          "potential": 72,
+          "value": 2100000,
+          "yearly_wage": 988000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5093,7 +6481,11 @@
             "Spain"
           ],
           "number": "3",
-          "position": "Right-Back"
+          "overall_score": 80,
+          "position": "Right-Back",
+          "potential": 81,
+          "value": 22500000,
+          "yearly_wage": 1768000
         },
         {
           "contract": "Jun 30, 2029",
@@ -5107,7 +6499,11 @@
             "Spain"
           ],
           "number": "5",
-          "position": "Right-Back"
+          "overall_score": 75,
+          "position": "Right-Back",
+          "potential": 78,
+          "value": 7000000,
+          "yearly_wage": 1092000
         },
         {
           "contract": "Jun 30, 2030",
@@ -5121,7 +6517,11 @@
             "Spain"
           ],
           "number": "14",
-          "position": "Right-Back"
+          "overall_score": 76,
+          "position": "Right-Back",
+          "potential": 80,
+          "value": 10000000,
+          "yearly_wage": 1144000
         },
         {
           "contract": "Jun 30, 2029",
@@ -5135,7 +6535,11 @@
             "Spain"
           ],
           "number": "17",
-          "position": "Right-Back"
+          "overall_score": 74,
+          "position": "Right-Back",
+          "potential": 81,
+          "value": 8000000,
+          "yearly_wage": 988000
         },
         {
           "contract": "Jun 30, 2028",
@@ -5149,7 +6553,11 @@
             "Spain"
           ],
           "number": "16",
-          "position": "Central Midfield"
+          "overall_score": 74,
+          "position": "Central Midfield",
+          "potential": 80,
+          "value": 6500000,
+          "yearly_wage": 1040000
         },
         {
           "contract": "Jun 30, 2029",
@@ -5164,7 +6572,11 @@
             "Spain"
           ],
           "number": "6",
-          "position": "Central Midfield"
+          "overall_score": 78,
+          "position": "Central Midfield",
+          "potential": 83,
+          "value": 21500000,
+          "yearly_wage": 1352000
         },
         {
           "contract": "Jun 30, 2028",
@@ -5178,7 +6590,11 @@
             "Spain"
           ],
           "number": "22",
-          "position": "Central Midfield"
+          "overall_score": 74,
+          "position": "Central Midfield",
+          "potential": 81,
+          "value": 8500000,
+          "yearly_wage": 884000
         },
         {
           "contract": "Jun 30, 2027",
@@ -5193,7 +6609,11 @@
             "Italy"
           ],
           "number": "15",
-          "position": "Central Midfield"
+          "overall_score": 76,
+          "position": "Central Midfield",
+          "potential": 76,
+          "value": 4600000,
+          "yearly_wage": 1404000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5207,7 +6627,11 @@
             "Spain"
           ],
           "number": "8",
-          "position": "Attacking Midfield"
+          "overall_score": 73,
+          "position": "Attacking Midfield",
+          "potential": 82,
+          "value": 7000000,
+          "yearly_wage": 1872000
         },
         {
           "contract": "Jun 30, 2029",
@@ -5221,7 +6645,11 @@
             "Sweden"
           ],
           "number": "19",
-          "position": "Left Winger"
+          "overall_score": 75,
+          "position": "Left Winger",
+          "potential": 82,
+          "value": 11500000,
+          "yearly_wage": 1040000
         },
         {
           "contract": "Jun 30, 2028",
@@ -5235,7 +6663,11 @@
             "Spain"
           ],
           "number": "23",
-          "position": "Left Winger"
+          "overall_score": 75,
+          "position": "Left Winger",
+          "potential": 81,
+          "value": 9000000,
+          "yearly_wage": 988000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5250,7 +6682,11 @@
             "Italy"
           ],
           "number": "11",
-          "position": "Left Winger"
+          "overall_score": 71,
+          "position": "Left Winger",
+          "potential": 71,
+          "value": 1600000,
+          "yearly_wage": 936000
         },
         {
           "contract": "Jun 30, 2029",
@@ -5265,7 +6701,11 @@
             "Norway"
           ],
           "number": "39",
-          "position": "Right Winger"
+          "overall_score": 70,
+          "position": "Right Winger",
+          "potential": 81,
+          "value": 3400000,
+          "yearly_wage": 624000
         },
         {
           "contract": "Jun 30, 2029",
@@ -5279,7 +6719,11 @@
             "Spain"
           ],
           "number": "9",
-          "position": "Centre-Forward"
+          "overall_score": 75,
+          "position": "Centre-Forward",
+          "potential": 75,
+          "value": 6000000,
+          "yearly_wage": 1404000
         },
         {
           "contract": "Jun 30, 2027",
@@ -5293,7 +6737,11 @@
             "Spain"
           ],
           "number": "18",
-          "position": "Centre-Forward"
+          "overall_score": 74,
+          "position": "Centre-Forward",
+          "potential": 78,
+          "value": 6000000,
+          "yearly_wage": 1144000
         },
         {
           "contract": "Jun 30, 2027",
@@ -5307,7 +6755,11 @@
             "Spain"
           ],
           "number": "7",
-          "position": "Centre-Forward"
+          "overall_score": 80,
+          "position": "Centre-Forward",
+          "potential": 80,
+          "value": 17000000,
+          "yearly_wage": 2080000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5321,7 +6773,11 @@
             "Spain"
           ],
           "number": "10",
-          "position": "Centre-Forward"
+          "overall_score": 82,
+          "position": "Centre-Forward",
+          "potential": 82,
+          "value": 10000000,
+          "yearly_wage": 1820000
         }
       ],
       "stadiumName": "Abanca Balaídos",
@@ -5344,7 +6800,11 @@
             "Spain"
           ],
           "number": "1",
-          "position": "Goalkeeper"
+          "overall_score": 79,
+          "position": "Goalkeeper",
+          "potential": 79,
+          "value": 8500000,
+          "yearly_wage": 1300000
         },
         {
           "contract": "Jun 30, 2027",
@@ -5358,7 +6818,11 @@
             "Spain"
           ],
           "number": "13",
-          "position": "Goalkeeper"
+          "overall_score": 77,
+          "position": "Goalkeeper",
+          "potential": 77,
+          "value": 1800000,
+          "yearly_wage": 1144000
         },
         {
           "contract": "Jun 30, 2029",
@@ -5373,7 +6837,11 @@
             "France"
           ],
           "number": "22",
-          "position": "Centre-Back"
+          "overall_score": 79,
+          "position": "Centre-Back",
+          "potential": 85,
+          "value": 25000000,
+          "yearly_wage": 1664000
         },
         {
           "contract": "Jun 30, 2030",
@@ -5387,7 +6855,11 @@
             "Spain"
           ],
           "number": "5",
-          "position": "Centre-Back"
+          "overall_score": 75,
+          "position": "Centre-Back",
+          "potential": 78,
+          "value": 7000000,
+          "yearly_wage": 1248000
         },
         {
           "contract": "Jun 30, 2028",
@@ -5401,7 +6873,11 @@
             "Spain"
           ],
           "number": "24",
-          "position": "Centre-Back"
+          "overall_score": 78,
+          "position": "Centre-Back",
+          "potential": 78,
+          "value": 11500000,
+          "yearly_wage": 1820000
         },
         {
           "contract": "Jun 30, 2029",
@@ -5415,7 +6891,11 @@
             "Spain"
           ],
           "number": "23",
-          "position": "Left-Back"
+          "overall_score": 75,
+          "position": "Left-Back",
+          "potential": 80,
+          "value": 8000000,
+          "yearly_wage": 1248000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5429,7 +6909,11 @@
             "Spain"
           ],
           "number": "20",
-          "position": "Left-Back"
+          "overall_score": 78,
+          "position": "Left-Back",
+          "potential": 78,
+          "value": 12000000,
+          "yearly_wage": 1820000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5443,7 +6927,11 @@
             "Spain"
           ],
           "number": "3",
-          "position": "Left-Back"
+          "overall_score": 73,
+          "position": "Left-Back",
+          "potential": 73,
+          "value": 2100000,
+          "yearly_wage": 1300000
         },
         {
           "contract": "Jun 30, 2028",
@@ -5458,7 +6946,11 @@
             "Guadeloupe"
           ],
           "number": "19",
-          "position": "Right-Back"
+          "overall_score": 78,
+          "position": "Right-Back",
+          "potential": 78,
+          "value": 12500000,
+          "yearly_wage": 1820000
         },
         {
           "contract": "Jun 30, 2027",
@@ -5472,7 +6964,11 @@
             "Spain"
           ],
           "number": "41",
-          "position": "Right-Back"
+          "overall_score": 63,
+          "position": "Right-Back",
+          "potential": 77,
+          "value": 1100000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2027",
@@ -5486,7 +6982,11 @@
             "Spain"
           ],
           "number": "6",
-          "position": "Defensive Midfield"
+          "overall_score": 77,
+          "position": "Defensive Midfield",
+          "potential": 77,
+          "value": 9000000,
+          "yearly_wage": 1716000
         },
         {
           "contract": "Jun 30, 2027",
@@ -5500,7 +7000,11 @@
             "Spain"
           ],
           "number": "8",
-          "position": "Defensive Midfield"
+          "overall_score": 71,
+          "position": "Defensive Midfield",
+          "potential": 79,
+          "value": 4200000,
+          "yearly_wage": 936000
         },
         {
           "contract": "Jun 30, 2031",
@@ -5514,7 +7018,11 @@
             "Spain"
           ],
           "number": "7",
-          "position": "Central Midfield"
+          "overall_score": 77,
+          "position": "Central Midfield",
+          "potential": 77,
+          "value": 11000000,
+          "yearly_wage": 1716000
         },
         {
           "contract": "Jun 30, 2029",
@@ -5528,7 +7036,11 @@
             "Spain"
           ],
           "number": "29",
-          "position": "Central Midfield"
+          "overall_score": 66,
+          "position": "Central Midfield",
+          "potential": 77,
+          "value": 1800000,
+          "yearly_wage": 416000
         },
         {
           "contract": "Jun 30, 2029",
@@ -5542,7 +7054,11 @@
             "Spain"
           ],
           "number": "10",
-          "position": "Attacking Midfield"
+          "overall_score": 77,
+          "position": "Attacking Midfield",
+          "potential": 82,
+          "value": 16000000,
+          "yearly_wage": 1508000
         },
         {
           "contract": "Jun 30, 2027",
@@ -5556,7 +7072,11 @@
             "Spain"
           ],
           "number": "16",
-          "position": "Attacking Midfield"
+          "overall_score": 76,
+          "position": "Attacking Midfield",
+          "potential": 76,
+          "value": 6000000,
+          "yearly_wage": 1664000
         },
         {
           "contract": "Jun 30, 2030",
@@ -5570,7 +7090,11 @@
             "Spain"
           ],
           "number": "21",
-          "position": "Left Winger"
+          "overall_score": 78,
+          "position": "Left Winger",
+          "potential": 86,
+          "value": 31500000,
+          "yearly_wage": 1456000
         },
         {
           "contract": "Jun 30, 2031",
@@ -5584,7 +7108,11 @@
             "Spain"
           ],
           "number": "15",
-          "position": "Left Winger"
+          "overall_score": 75,
+          "position": "Left Winger",
+          "potential": 82,
+          "value": 11500000,
+          "yearly_wage": 1404000
         },
         {
           "contract": "Jun 30, 2027",
@@ -5598,7 +7126,11 @@
             "Spain"
           ],
           "number": "14",
-          "position": "Right Winger"
+          "overall_score": 78,
+          "position": "Right Winger",
+          "potential": 78,
+          "value": 11500000,
+          "yearly_wage": 1924000
         },
         {
           "contract": "Jun 30, 2027",
@@ -5612,7 +7144,11 @@
             "Spain"
           ],
           "number": "2",
-          "position": "Right Winger"
+          "overall_score": 71,
+          "position": "Right Winger",
+          "potential": 78,
+          "value": 3800000,
+          "yearly_wage": 988000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5626,7 +7162,11 @@
             "Spain"
           ],
           "number": "11",
-          "position": "Right Winger"
+          "overall_score": 73,
+          "position": "Right Winger",
+          "potential": 73,
+          "value": 3100000,
+          "yearly_wage": 1404000
         },
         {
           "contract": "Jun 30, 2028",
@@ -5640,7 +7180,11 @@
             "Spain"
           ],
           "number": "9",
-          "position": "Centre-Forward"
+          "overall_score": 74,
+          "position": "Centre-Forward",
+          "potential": 79,
+          "value": 6500000,
+          "yearly_wage": 1352000
         },
         {
           "contract": "Jun 30, 2027",
@@ -5654,7 +7198,11 @@
             "Croatia"
           ],
           "number": "17",
-          "position": "Centre-Forward"
+          "overall_score": 82,
+          "position": "Centre-Forward",
+          "potential": 82,
+          "value": 19500000,
+          "yearly_wage": 2756000
         }
       ],
       "stadiumName": "El Sadar",
@@ -5678,7 +7226,11 @@
             "Portugal"
           ],
           "number": "1",
-          "position": "Goalkeeper"
+          "overall_score": 78,
+          "position": "Goalkeeper",
+          "potential": 82,
+          "value": 16000000,
+          "yearly_wage": 988000
         },
         {
           "contract": "Jun 30, 2029",
@@ -5692,7 +7244,11 @@
             "Spain"
           ],
           "number": "13",
-          "position": "Goalkeeper"
+          "overall_score": 76,
+          "position": "Goalkeeper",
+          "potential": 79,
+          "value": 7500000,
+          "yearly_wage": 1092000
         },
         {
           "contract": "Jun 30, 2029",
@@ -5706,7 +7262,11 @@
             "Spain"
           ],
           "number": "25",
-          "position": "Goalkeeper"
+          "overall_score": 75,
+          "position": "Goalkeeper",
+          "potential": 81,
+          "value": 7000000,
+          "yearly_wage": 832000
         },
         {
           "contract": "Jun 30, 2032",
@@ -5721,7 +7281,11 @@
             "Cape Verde"
           ],
           "number": "12",
-          "position": "Centre-Back"
+          "overall_score": 78,
+          "position": "Centre-Back",
+          "potential": 83,
+          "value": 19500000,
+          "yearly_wage": 1404000
         },
         {
           "contract": "Jun 30, 2030",
@@ -5736,7 +7300,11 @@
             "France"
           ],
           "number": "2",
-          "position": "Centre-Back"
+          "overall_score": 77,
+          "position": "Centre-Back",
+          "potential": 83,
+          "value": 15000000,
+          "yearly_wage": 1560000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5750,7 +7318,11 @@
             "Spain"
           ],
           "number": "4",
-          "position": "Centre-Back"
+          "overall_score": 76,
+          "position": "Centre-Back",
+          "potential": 83,
+          "value": 14000000,
+          "yearly_wage": 3068000
         },
         {
           "contract": "Jun 30, 2029",
@@ -5765,7 +7337,11 @@
             "Spain"
           ],
           "number": "8",
-          "position": "Centre-Back"
+          "overall_score": 79,
+          "position": "Centre-Back",
+          "potential": 79,
+          "value": 16000000,
+          "yearly_wage": 2132000
         },
         {
           "contract": "Jun 30, 2029",
@@ -5780,7 +7356,11 @@
             "DR Congo"
           ],
           "number": "5",
-          "position": "Centre-Back"
+          "overall_score": 72,
+          "position": "Centre-Back",
+          "potential": 81,
+          "value": 4800000,
+          "yearly_wage": 884000
         },
         {
           "contract": "Jun 30, 2027",
@@ -5794,7 +7374,11 @@
             "Spain"
           ],
           "number": "23",
-          "position": "Left-Back"
+          "overall_score": 79,
+          "position": "Left-Back",
+          "potential": 82,
+          "value": 21500000,
+          "yearly_wage": 2028000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5808,7 +7392,11 @@
             "Spain"
           ],
           "number": "24",
-          "position": "Left-Back"
+          "overall_score": 76,
+          "position": "Left-Back",
+          "potential": 76,
+          "value": 6500000,
+          "yearly_wage": 1768000
         },
         {
           "contract": "Jun 30, 2030",
@@ -5822,7 +7410,11 @@
             "Spain"
           ],
           "number": "6",
-          "position": "Right-Back"
+          "overall_score": 74,
+          "position": "Right-Back",
+          "potential": 83,
+          "value": 8500000,
+          "yearly_wage": 1092000
         },
         {
           "contract": "Jun 30, 2030",
@@ -5837,7 +7429,11 @@
             "Spain"
           ],
           "number": "15",
-          "position": "Right-Back"
+          "overall_score": 78,
+          "position": "Right-Back",
+          "potential": 85,
+          "value": 27000000,
+          "yearly_wage": 1664000
         },
         {
           "contract": "Jun 30, 2032",
@@ -5850,7 +7446,11 @@
             "United States"
           ],
           "number": "3",
-          "position": "Right-Back"
+          "overall_score": 73,
+          "position": "Right-Back",
+          "potential": 81,
+          "value": 6500000,
+          "yearly_wage": 988000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5864,7 +7464,11 @@
             "Ghana"
           ],
           "number": "16",
-          "position": "Defensive Midfield"
+          "overall_score": 79,
+          "position": "Defensive Midfield",
+          "potential": 79,
+          "value": 11500000,
+          "yearly_wage": 2236000
         },
         {
           "contract": "Jun 30, 2028",
@@ -5879,7 +7483,11 @@
             "France"
           ],
           "number": "18",
-          "position": "Central Midfield"
+          "overall_score": 80,
+          "position": "Central Midfield",
+          "potential": 81,
+          "value": 24500000,
+          "yearly_wage": 2340000
         },
         {
           "contract": "Jun 30, 2028",
@@ -5893,7 +7501,11 @@
             "Spain"
           ],
           "number": "14",
-          "position": "Central Midfield"
+          "overall_score": 79,
+          "position": "Central Midfield",
+          "potential": 79,
+          "value": 17500000,
+          "yearly_wage": 2340000
         },
         {
           "contract": "Jun 30, 2029",
@@ -5907,7 +7519,11 @@
             "Spain"
           ],
           "number": "37",
-          "position": "Central Midfield"
+          "overall_score": 62,
+          "position": "Central Midfield",
+          "potential": 81,
+          "value": 1000000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5921,7 +7537,11 @@
             "Spain"
           ],
           "number": "10",
-          "position": "Central Midfield"
+          "overall_score": 80,
+          "position": "Central Midfield",
+          "potential": 80,
+          "value": 6500000,
+          "yearly_wage": 1872000
         },
         {
           "contract": "Jun 30, 2030",
@@ -5936,7 +7556,11 @@
             "Cuba"
           ],
           "number": "20",
-          "position": "Left Winger"
+          "overall_score": 82,
+          "position": "Left Winger",
+          "potential": 87,
+          "value": 47000000,
+          "yearly_wage": 2028000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5949,7 +7573,11 @@
             "Spain"
           ],
           "number": "11",
-          "position": "Left Winger"
+          "overall_score": 75,
+          "position": "Left Winger",
+          "potential": 75,
+          "value": 6000000,
+          "yearly_wage": 1560000
         },
         {
           "contract": "Jun 30, 2027",
@@ -5961,7 +7589,11 @@
             "Spain"
           ],
           "number": "32",
-          "position": "Left Winger"
+          "overall_score": 60,
+          "position": "Left Winger",
+          "potential": 79,
+          "value": 625000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2030",
@@ -5976,7 +7608,11 @@
             "Jamaica"
           ],
           "number": "17",
-          "position": "Right Winger"
+          "overall_score": 76,
+          "position": "Right Winger",
+          "potential": 76,
+          "value": 8000000,
+          "yearly_wage": 1768000
         },
         {
           "contract": "Jun 30, 2028",
@@ -5991,7 +7627,11 @@
             "France"
           ],
           "number": "19",
-          "position": "Right Winger"
+          "overall_score": 81,
+          "position": "Right Winger",
+          "potential": 81,
+          "value": 25000000,
+          "yearly_wage": 2808000
         },
         {
           "contract": "Jun 30, 2031",
@@ -6006,7 +7646,11 @@
             "France"
           ],
           "number": "9",
-          "position": "Centre-Forward"
+          "overall_score": 79,
+          "position": "Centre-Forward",
+          "potential": 83,
+          "value": 25500000,
+          "yearly_wage": 2132000
         },
         {
           "contract": "Jun 30, 2030",
@@ -6021,7 +7665,11 @@
             "Nigeria"
           ],
           "number": "21",
-          "position": "Centre-Forward"
+          "overall_score": 71,
+          "position": "Centre-Forward",
+          "potential": 74,
+          "value": 2500000,
+          "yearly_wage": 1196000
         },
         {
           "contract": "Jun 30, 2028",
@@ -6035,7 +7683,11 @@
             "Spain"
           ],
           "number": "22",
-          "position": "Centre-Forward"
+          "overall_score": 81,
+          "position": "Centre-Forward",
+          "potential": 81,
+          "value": 22000000,
+          "yearly_wage": 2860000
         },
         {
           "contract": "Jun 30, 2027",
@@ -6049,7 +7701,11 @@
             "Spain"
           ],
           "number": "7",
-          "position": "Centre-Forward"
+          "overall_score": 81,
+          "position": "Centre-Forward",
+          "potential": 81,
+          "value": 16500000,
+          "yearly_wage": 2860000
         },
         {
           "contract": "Jun 30, 2028",
@@ -6063,7 +7719,11 @@
             "Spain"
           ],
           "number": "33",
-          "position": "Centre-Forward"
+          "overall_score": 65,
+          "position": "Centre-Forward",
+          "potential": 78,
+          "value": 1700000,
+          "yearly_wage": 416000
         }
       ],
       "stadiumName": "La Cerámica",
@@ -6086,7 +7746,11 @@
             "Spain"
           ],
           "number": "1",
-          "position": "Goalkeeper"
+          "overall_score": 77,
+          "position": "Goalkeeper",
+          "potential": 79,
+          "value": 9000000,
+          "yearly_wage": 988000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6100,7 +7764,11 @@
             "Spain"
           ],
           "number": "13",
-          "position": "Goalkeeper"
+          "overall_score": 72,
+          "position": "Goalkeeper",
+          "potential": 72,
+          "value": 250000,
+          "yearly_wage": 416000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6114,7 +7782,11 @@
             "Spain"
           ],
           "number": "5",
-          "position": "Centre-Back"
+          "overall_score": 74,
+          "position": "Centre-Back",
+          "potential": 81,
+          "value": 8000000,
+          "yearly_wage": 1300000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6128,7 +7800,11 @@
             "Finland"
           ],
           "number": "16",
-          "position": "Centre-Back"
+          "overall_score": 66,
+          "position": "Centre-Back",
+          "potential": 72,
+          "value": 1200000,
+          "yearly_wage": 416000
         },
         {
           "contract": "Jun 30, 2028",
@@ -6157,7 +7833,11 @@
             "Spain"
           ],
           "number": "3",
-          "position": "Left-Back"
+          "overall_score": 70,
+          "position": "Left-Back",
+          "potential": 81,
+          "value": 3300000,
+          "yearly_wage": 572000
         },
         {
           "contract": "Jun 30, 2029",
@@ -6171,7 +7851,11 @@
             "Spain"
           ],
           "number": "24",
-          "position": "Left-Back"
+          "overall_score": 70,
+          "position": "Left-Back",
+          "potential": 74,
+          "value": 2100000,
+          "yearly_wage": 676000
         },
         {
           "contract": "Jun 30, 2029",
@@ -6186,7 +7870,11 @@
             "Italy"
           ],
           "number": "14",
-          "position": "Right-Back"
+          "overall_score": 77,
+          "position": "Right-Back",
+          "potential": 77,
+          "value": 9000000,
+          "yearly_wage": 1508000
         },
         {
           "contract": "Jun 30, 2027",
@@ -6200,7 +7888,11 @@
             "Spain"
           ],
           "number": "17",
-          "position": "Right-Back"
+          "overall_score": 75,
+          "position": "Right-Back",
+          "potential": 75,
+          "value": 4100000,
+          "yearly_wage": 1352000
         },
         {
           "contract": "Jun 30, 2027",
@@ -6214,7 +7906,11 @@
             "Spain"
           ],
           "number": "8",
-          "position": "Defensive Midfield"
+          "overall_score": 76,
+          "position": "Defensive Midfield",
+          "potential": 81,
+          "value": 10500000,
+          "yearly_wage": 1196000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6229,7 +7925,11 @@
             "Italy"
           ],
           "number": "23",
-          "position": "Defensive Midfield"
+          "overall_score": 73,
+          "position": "Defensive Midfield",
+          "potential": 74,
+          "value": 3100000,
+          "yearly_wage": 1092000
         },
         {
           "contract": "Jun 30, 2030",
@@ -6243,7 +7943,11 @@
             "Spain"
           ],
           "number": "19",
-          "position": "Central Midfield"
+          "overall_score": 73,
+          "position": "Central Midfield",
+          "potential": 74,
+          "value": 3600000,
+          "yearly_wage": 1144000
         },
         {
           "contract": "Jun 30, 2029",
@@ -6257,7 +7961,11 @@
             "Spain"
           ],
           "number": "10",
-          "position": "Central Midfield"
+          "overall_score": 74,
+          "position": "Central Midfield",
+          "potential": 74,
+          "value": 4500000,
+          "yearly_wage": 1248000
         },
         {
           "contract": "Jun 30, 2027",
@@ -6271,7 +7979,11 @@
             "Spain"
           ],
           "number": "6",
-          "position": "Central Midfield"
+          "overall_score": 74,
+          "position": "Central Midfield",
+          "potential": 75,
+          "value": 4300000,
+          "yearly_wage": 1196000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6285,7 +7997,11 @@
             "Spain"
           ],
           "number": "18",
-          "position": "Central Midfield"
+          "overall_score": 73,
+          "position": "Central Midfield",
+          "potential": 73,
+          "value": 2900000,
+          "yearly_wage": 1196000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6299,7 +8015,11 @@
             "Brazil"
           ],
           "number": "20",
-          "position": "Attacking Midfield"
+          "overall_score": 71,
+          "position": "Attacking Midfield",
+          "potential": 72,
+          "value": 2200000,
+          "yearly_wage": 884000
         },
         {
           "contract": "Jun 30, 2027",
@@ -6313,7 +8033,11 @@
             "Spain"
           ],
           "number": "4",
-          "position": "Attacking Midfield"
+          "overall_score": 74,
+          "position": "Attacking Midfield",
+          "potential": 74,
+          "value": 3500000,
+          "yearly_wage": 1300000
         },
         {
           "contract": "Jun 30, 2028",
@@ -6328,7 +8052,11 @@
             "Spain"
           ],
           "number": "21",
-          "position": "Left Winger"
+          "overall_score": 72,
+          "position": "Left Winger",
+          "potential": 72,
+          "value": 2600000,
+          "yearly_wage": 1092000
         },
         {
           "contract": "Jun 30, 2030",
@@ -6342,7 +8070,11 @@
             "Spain"
           ],
           "number": "7",
-          "position": "Right Winger"
+          "overall_score": 70,
+          "position": "Right Winger",
+          "potential": 79,
+          "value": 3600000,
+          "yearly_wage": 728000
         },
         {
           "contract": "Jun 30, 2029",
@@ -6357,7 +8089,11 @@
             "Italy"
           ],
           "number": "15",
-          "position": "Centre-Forward"
+          "overall_score": 77,
+          "position": "Centre-Forward",
+          "potential": 77,
+          "value": 10500000,
+          "yearly_wage": 1716000
         },
         {
           "contract": "Jun 30, 2028",
@@ -6371,7 +8107,11 @@
             "Spain"
           ],
           "number": "11",
-          "position": "Centre-Forward"
+          "overall_score": 77,
+          "position": "Centre-Forward",
+          "potential": 77,
+          "value": 11000000,
+          "yearly_wage": 1716000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6385,7 +8125,11 @@
             "Cote d'Ivoire"
           ],
           "number": "22",
-          "position": "Centre-Forward"
+          "overall_score": 72,
+          "position": "Centre-Forward",
+          "potential": 74,
+          "value": 3000000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2028",
@@ -6399,7 +8143,11 @@
             "Spain"
           ],
           "number": "34",
-          "position": "Centre-Forward"
+          "overall_score": 63,
+          "position": "Centre-Forward",
+          "potential": 71,
+          "value": 1100000,
+          "yearly_wage": 312000
         },
         {
           "contract": "Jun 30, 2027",
@@ -6414,7 +8162,11 @@
             "Spain"
           ],
           "number": "9",
-          "position": "Centre-Forward"
+          "overall_score": 67,
+          "position": "Centre-Forward",
+          "potential": 67,
+          "value": 850000,
+          "yearly_wage": 676000
         }
       ],
       "stadiumName": "Mendizorroza",
@@ -6437,7 +8189,11 @@
             "Spain"
           ],
           "number": "13",
-          "position": "Goalkeeper"
+          "overall_score": 80,
+          "position": "Goalkeeper",
+          "potential": 80,
+          "value": 10500000,
+          "yearly_wage": 1404000
         },
         {
           "contract": "Jun 30, 2028",
@@ -6451,7 +8207,11 @@
             "Czech Republic"
           ],
           "number": "1",
-          "position": "Goalkeeper"
+          "overall_score": 69,
+          "position": "Goalkeeper",
+          "potential": 73,
+          "value": 1500000,
+          "yearly_wage": 520000
         },
         {
           "contract": "Jun 30, 2028",
@@ -6465,7 +8225,11 @@
             "Morocco"
           ],
           "number": "3",
-          "position": "Centre-Back"
+          "overall_score": 74,
+          "position": "Centre-Back",
+          "potential": 77,
+          "value": 4900000,
+          "yearly_wage": 1352000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6480,7 +8244,11 @@
             "Italy"
           ],
           "number": "15",
-          "position": "Centre-Back"
+          "overall_score": 72,
+          "position": "Centre-Back",
+          "potential": 77,
+          "value": 3300000,
+          "yearly_wage": 832000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6495,7 +8263,11 @@
             "Syria"
           ],
           "number": "24",
-          "position": "Centre-Back"
+          "overall_score": 76,
+          "position": "Centre-Back",
+          "potential": 79,
+          "value": 9000000,
+          "yearly_wage": 1352000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6509,7 +8281,11 @@
             "Togo"
           ],
           "number": "2",
-          "position": "Centre-Back"
+          "overall_score": 77,
+          "position": "Centre-Back",
+          "potential": 77,
+          "value": 5000000,
+          "yearly_wage": 1716000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6523,7 +8299,11 @@
             "Portugal"
           ],
           "number": "22",
-          "position": "Centre-Back"
+          "overall_score": 74,
+          "position": "Centre-Back",
+          "potential": 74,
+          "value": 3500000,
+          "yearly_wage": 1404000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6537,7 +8317,11 @@
             "Spain"
           ],
           "number": "16",
-          "position": "Left-Back"
+          "overall_score": 76,
+          "position": "Left-Back",
+          "potential": 76,
+          "value": 5000000,
+          "yearly_wage": 1612000
         },
         {
           "contract": "Jun 30, 2028",
@@ -6551,7 +8335,11 @@
             "Spain"
           ],
           "number": "26",
-          "position": "Left-Back"
+          "overall_score": 67,
+          "position": "Left-Back",
+          "potential": 81,
+          "value": 2200000,
+          "yearly_wage": 312000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6565,7 +8353,11 @@
             "Spain"
           ],
           "number": "21",
-          "position": "Right-Back"
+          "overall_score": 76,
+          "position": "Right-Back",
+          "potential": 77,
+          "value": 8000000,
+          "yearly_wage": 1508000
         },
         {
           "contract": "Jun 30, 2027",
@@ -6579,7 +8371,11 @@
             "Spain"
           ],
           "number": "17",
-          "position": "Right-Back"
+          "overall_score": 74,
+          "position": "Right-Back",
+          "potential": 74,
+          "value": 1500000,
+          "yearly_wage": 1404000
         },
         {
           "contract": "Jun 30, 2028",
@@ -6594,7 +8390,11 @@
             "Spain"
           ],
           "number": "31",
-          "position": "Right-Back"
+          "overall_score": 64,
+          "position": "Right-Back",
+          "potential": 75,
+          "value": 1200000,
+          "yearly_wage": 312000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6609,7 +8409,11 @@
             "France"
           ],
           "number": "12",
-          "position": "Right-Back"
+          "overall_score": 71,
+          "position": "Right-Back",
+          "potential": 71,
+          "value": 425000,
+          "yearly_wage": 780000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6623,7 +8427,11 @@
             "Spain"
           ],
           "number": "6",
-          "position": "Defensive Midfield"
+          "overall_score": 74,
+          "position": "Defensive Midfield",
+          "potential": 82,
+          "value": 9500000,
+          "yearly_wage": 1040000
         },
         {
           "contract": "Jun 30, 2028",
@@ -6638,7 +8446,11 @@
             "Spain"
           ],
           "number": "8",
-          "position": "Central Midfield"
+          "overall_score": 80,
+          "position": "Central Midfield",
+          "potential": 80,
+          "value": 20500000,
+          "yearly_wage": 2236000
         },
         {
           "contract": "Jun 30, 2027",
@@ -6652,7 +8464,11 @@
             "Spain"
           ],
           "number": "5",
-          "position": "Central Midfield"
+          "overall_score": 81,
+          "position": "Central Midfield",
+          "potential": 81,
+          "value": 24500000,
+          "yearly_wage": 2392000
         },
         {
           "contract": "Jun 30, 2028",
@@ -6666,7 +8482,11 @@
             "Spain"
           ],
           "number": "14",
-          "position": "Central Midfield"
+          "overall_score": 74,
+          "position": "Central Midfield",
+          "potential": 74,
+          "value": 4000000,
+          "yearly_wage": 1456000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6680,7 +8500,11 @@
             "Spain"
           ],
           "number": "23",
-          "position": "Left Winger"
+          "overall_score": 72,
+          "position": "Left Winger",
+          "potential": 83,
+          "value": 5000000,
+          "yearly_wage": 364000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6694,7 +8518,11 @@
             "Serbia"
           ],
           "number": "20",
-          "position": "Left Winger"
+          "overall_score": 76,
+          "position": "Left Winger",
+          "potential": 76,
+          "value": 8000000,
+          "yearly_wage": 1300000
         },
         {
           "contract": "Jun 30, 2027",
@@ -6708,7 +8536,11 @@
             "Spain"
           ],
           "number": "7",
-          "position": "Left Winger"
+          "overall_score": 72,
+          "position": "Left Winger",
+          "potential": 72,
+          "value": 1900000,
+          "yearly_wage": 1300000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6723,7 +8555,11 @@
             "Sierra Leone"
           ],
           "number": "11",
-          "position": "Right Winger"
+          "overall_score": 68,
+          "position": "Right Winger",
+          "potential": 76,
+          "value": 2700000,
+          "yearly_wage": 624000
         },
         {
           "contract": "Jun 30, 2028",
@@ -6737,7 +8573,11 @@
             "Spain"
           ],
           "number": "18",
-          "position": "Right Winger"
+          "overall_score": 73,
+          "position": "Right Winger",
+          "potential": 73,
+          "value": 3100000,
+          "yearly_wage": 1352000
         },
         {
           "contract": "Jun 30, 2027",
@@ -6751,7 +8591,11 @@
             "Spain"
           ],
           "number": "9",
-          "position": "Centre-Forward"
+          "overall_score": 77,
+          "position": "Centre-Forward",
+          "potential": 77,
+          "value": 11000000,
+          "yearly_wage": 1924000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6766,7 +8610,11 @@
             "Italy"
           ],
           "number": "10",
-          "position": "Centre-Forward"
+          "overall_score": 75,
+          "position": "Centre-Forward",
+          "potential": 79,
+          "value": 8000000,
+          "yearly_wage": 1456000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6780,7 +8628,11 @@
             "Argentina"
           ],
           "number": "19",
-          "position": "Centre-Forward"
+          "overall_score": 72,
+          "position": "Centre-Forward",
+          "potential": 76,
+          "value": 3400000,
+          "yearly_wage": 1040000
         }
       ],
       "stadiumName": "Coliseum",
@@ -6804,7 +8656,11 @@
             "Italy"
           ],
           "number": "13",
-          "position": "Goalkeeper"
+          "overall_score": 79,
+          "position": "Goalkeeper",
+          "potential": 80,
+          "value": 13500000,
+          "yearly_wage": 988000
         },
         {
           "contract": "Jun 30, 2027",
@@ -6818,7 +8674,11 @@
             "Spain"
           ],
           "number": "1",
-          "position": "Goalkeeper"
+          "overall_score": 73,
+          "position": "Goalkeeper",
+          "potential": 75,
+          "value": 2600000,
+          "yearly_wage": 624000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6833,7 +8693,11 @@
             "Guinea-Bissau"
           ],
           "number": "32",
-          "position": "Centre-Back"
+          "overall_score": 75,
+          "position": "Centre-Back",
+          "potential": 85,
+          "value": 11500000,
+          "yearly_wage": 832000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6848,7 +8712,11 @@
             "Nigeria"
           ],
           "number": "16",
-          "position": "Centre-Back"
+          "overall_score": 77,
+          "position": "Centre-Back",
+          "potential": 79,
+          "value": 11000000,
+          "yearly_wage": 1248000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6863,7 +8731,11 @@
             "Brazil"
           ],
           "number": "5",
-          "position": "Centre-Back"
+          "overall_score": 75,
+          "position": "Centre-Back",
+          "potential": 76,
+          "value": 5500000,
+          "yearly_wage": 1144000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6877,7 +8749,11 @@
             "Netherlands"
           ],
           "number": "33",
-          "position": "Centre-Back"
+          "overall_score": 68,
+          "position": "Centre-Back",
+          "potential": 78,
+          "value": 2500000,
+          "yearly_wage": 416000
         },
         {
           "contract": "Jun 30, 2027",
@@ -6891,7 +8767,11 @@
             "France"
           ],
           "number": "24",
-          "position": "Centre-Back"
+          "overall_score": 79,
+          "position": "Centre-Back",
+          "potential": 79,
+          "value": 5500000,
+          "yearly_wage": 1560000
         },
         {
           "contract": "Jun 30, 2030",
@@ -6905,7 +8785,11 @@
             "Spain"
           ],
           "number": "3",
-          "position": "Left-Back"
+          "overall_score": 78,
+          "position": "Left-Back",
+          "potential": 78,
+          "value": 13500000,
+          "yearly_wage": 1352000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6920,7 +8804,11 @@
             "Spain"
           ],
           "number": "22",
-          "position": "Left-Back"
+          "overall_score": 72,
+          "position": "Left-Back",
+          "potential": 72,
+          "value": 1200000,
+          "yearly_wage": 884000
         },
         {
           "contract": "Jun 30, 2030",
@@ -6935,7 +8823,11 @@
             "Spain"
           ],
           "number": "2",
-          "position": "Right-Back"
+          "overall_score": 80,
+          "position": "Right-Back",
+          "potential": 81,
+          "value": 22000000,
+          "yearly_wage": 1560000
         },
         {
           "contract": "Jun 30, 2027",
@@ -6950,7 +8842,11 @@
             "Spain"
           ],
           "number": "20",
-          "position": "Right-Back"
+          "overall_score": 75,
+          "position": "Right-Back",
+          "potential": 75,
+          "value": 2900000,
+          "yearly_wage": 1144000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6964,7 +8860,11 @@
             "Spain"
           ],
           "number": "15",
-          "position": "Defensive Midfield"
+          "overall_score": 72,
+          "position": "Defensive Midfield",
+          "potential": 72,
+          "value": 2200000,
+          "yearly_wage": 364000
         },
         {
           "contract": "Jun 30, 2028",
@@ -6978,7 +8878,11 @@
             "Spain"
           ],
           "number": "4",
-          "position": "Central Midfield"
+          "overall_score": 75,
+          "position": "Central Midfield",
+          "potential": 75,
+          "value": 6000000,
+          "yearly_wage": 1144000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6992,7 +8896,11 @@
             "Spain"
           ],
           "number": "17",
-          "position": "Central Midfield"
+          "overall_score": 76,
+          "position": "Central Midfield",
+          "potential": 76,
+          "value": 7500000,
+          "yearly_wage": 1248000
         },
         {
           "contract": "Jun 30, 2027",
@@ -7006,7 +8914,11 @@
             "Spain"
           ],
           "number": "23",
-          "position": "Central Midfield"
+          "overall_score": 77,
+          "position": "Central Midfield",
+          "potential": 77,
+          "value": 9000000,
+          "yearly_wage": 1300000
         },
         {
           "contract": "Jun 30, 2027",
@@ -7020,7 +8932,11 @@
             "Senegal"
           ],
           "number": "6",
-          "position": "Central Midfield"
+          "overall_score": 77,
+          "position": "Central Midfield",
+          "potential": 77,
+          "value": 7500000,
+          "yearly_wage": 1300000
         },
         {
           "contract": "Jun 30, 2027",
@@ -7033,7 +8949,11 @@
             "Spain"
           ],
           "number": "28",
-          "position": "Central Midfield"
+          "overall_score": 60,
+          "position": "Central Midfield",
+          "potential": 73,
+          "value": 575000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2028",
@@ -7048,7 +8968,11 @@
             "France"
           ],
           "number": "11",
-          "position": "Attacking Midfield"
+          "overall_score": 70,
+          "position": "Attacking Midfield",
+          "potential": 70,
+          "value": 1700000,
+          "yearly_wage": 780000
         },
         {
           "contract": "Jun 30, 2026",
@@ -7063,7 +8987,11 @@
             "Italy"
           ],
           "number": "8",
-          "position": "Attacking Midfield"
+          "overall_score": 70,
+          "position": "Attacking Midfield",
+          "potential": 70,
+          "value": 525000,
+          "yearly_wage": 572000
         },
         {
           "contract": "Jun 30, 2026",
@@ -7077,7 +9005,11 @@
             "Spain"
           ],
           "number": "14",
-          "position": "Left Winger"
+          "overall_score": 70,
+          "position": "Left Winger",
+          "potential": 77,
+          "value": 3200000,
+          "yearly_wage": 1508000
         },
         {
           "contract": "Jun 30, 2028",
@@ -7091,7 +9023,11 @@
             "Spain"
           ],
           "number": "18",
-          "position": "Left Winger"
+          "overall_score": 81,
+          "position": "Left Winger",
+          "potential": 81,
+          "value": 20500000,
+          "yearly_wage": 1924000
         },
         {
           "contract": "Jun 30, 2026",
@@ -7106,7 +9042,11 @@
             "Spain"
           ],
           "number": "12",
-          "position": "Right Winger"
+          "overall_score": 75,
+          "position": "Right Winger",
+          "potential": 83,
+          "value": 12500000,
+          "yearly_wage": 1352000
         },
         {
           "contract": "Jun 30, 2028",
@@ -7120,7 +9060,11 @@
             "Spain"
           ],
           "number": "19",
-          "position": "Right Winger"
+          "overall_score": 81,
+          "position": "Right Winger",
+          "potential": 81,
+          "value": 26000000,
+          "yearly_wage": 1924000
         },
         {
           "contract": "Jun 30, 2029",
@@ -7134,7 +9078,11 @@
             "Spain"
           ],
           "number": "21",
-          "position": "Right Winger"
+          "overall_score": 74,
+          "position": "Right Winger",
+          "potential": 79,
+          "value": 6500000,
+          "yearly_wage": 936000
         },
         {
           "contract": "Jun 30, 2028",
@@ -7148,7 +9096,11 @@
             "Spain"
           ],
           "number": "7",
-          "position": "Second Striker"
+          "overall_score": 80,
+          "position": "Second Striker",
+          "potential": 80,
+          "value": 20500000,
+          "yearly_wage": 1716000
         },
         {
           "contract": "Jun 30, 2030",
@@ -7163,7 +9115,11 @@
             "Poland"
           ],
           "number": "9",
-          "position": "Centre-Forward"
+          "overall_score": 74,
+          "position": "Centre-Forward",
+          "potential": 74,
+          "value": 4600000,
+          "yearly_wage": 1144000
         },
         {
           "contract": "Jun 30, 2027",
@@ -7177,7 +9133,11 @@
             "Spain"
           ],
           "number": "10",
-          "position": "Centre-Forward"
+          "overall_score": 73,
+          "position": "Centre-Forward",
+          "potential": 78,
+          "value": 4700000,
+          "yearly_wage": 936000
         }
       ],
       "stadiumName": "Estadio de Vallecas",
@@ -7200,7 +9160,11 @@
             "Germany"
           ],
           "number": "22",
-          "position": "Goalkeeper"
+          "overall_score": 84,
+          "position": "Goalkeeper",
+          "potential": 84,
+          "value": 13500000,
+          "yearly_wage": 4264000
         },
         {
           "contract": "Jun 30, 2027",
@@ -7215,7 +9179,11 @@
             "Italy"
           ],
           "number": "13",
-          "position": "Goalkeeper"
+          "overall_score": 78,
+          "position": "Goalkeeper",
+          "potential": 78,
+          "value": 4600000,
+          "yearly_wage": 1144000
         },
         {
           "contract": "Jun 30, 2026",
@@ -7229,7 +9197,11 @@
             "Spain"
           ],
           "number": "1",
-          "position": "Goalkeeper"
+          "overall_score": 73,
+          "position": "Goalkeeper",
+          "potential": 74,
+          "value": 2300000,
+          "yearly_wage": 780000
         },
         {
           "contract": "Jun 30, 2029",
@@ -7243,7 +9215,11 @@
             "Ukraine"
           ],
           "number": "25",
-          "position": "Goalkeeper"
+          "overall_score": 64,
+          "position": "Goalkeeper",
+          "potential": 78,
+          "value": 1200000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2026",
@@ -7256,7 +9232,11 @@
           "nationality": [
             "Spain"
           ],
-          "position": "Goalkeeper"
+          "overall_score": 70,
+          "position": "Goalkeeper",
+          "potential": 70,
+          "value": 180000,
+          "yearly_wage": 364000
         },
         {
           "contract": "Jun 30, 2026",
@@ -7270,7 +9250,11 @@
             "Brazil"
           ],
           "number": "12",
-          "position": "Centre-Back"
+          "overall_score": 76,
+          "position": "Centre-Back",
+          "potential": 86,
+          "value": 15000000,
+          "yearly_wage": 2912000
         },
         {
           "contract": "Jun 30, 2029",
@@ -7284,7 +9268,11 @@
             "Spain"
           ],
           "number": "16",
-          "position": "Centre-Back"
+          "overall_score": 75,
+          "position": "Centre-Back",
+          "potential": 80,
+          "value": 8000000,
+          "yearly_wage": 1196000
         },
         {
           "contract": "Jun 30, 2026",
@@ -7298,7 +9286,11 @@
             "Netherlands"
           ],
           "number": "17",
-          "position": "Centre-Back"
+          "overall_score": 76,
+          "position": "Centre-Back",
+          "potential": 76,
+          "value": 2000000,
+          "yearly_wage": 1144000
         },
         {
           "contract": "Jun 30, 2026",
@@ -7312,7 +9304,11 @@
             "Spain"
           ],
           "number": "5",
-          "position": "Centre-Back"
+          "overall_score": 76,
+          "position": "Centre-Back",
+          "potential": 76,
+          "value": 2000000,
+          "yearly_wage": 1144000
         },
         {
           "contract": "Jun 30, 2027",
@@ -7326,7 +9322,11 @@
             "Spain"
           ],
           "number": "24",
-          "position": "Left-Back"
+          "overall_score": 77,
+          "position": "Left-Back",
+          "potential": 77,
+          "value": 7500000,
+          "yearly_wage": 1612000
         },
         {
           "contract": "Jun 30, 2027",
@@ -7340,7 +9340,11 @@
             "Spain"
           ],
           "number": "4",
-          "position": "Right-Back"
+          "overall_score": 78,
+          "position": "Right-Back",
+          "potential": 83,
+          "value": 20000000,
+          "yearly_wage": 1456000
         },
         {
           "contract": "Jun 30, 2026",
@@ -7354,7 +9358,11 @@
             "Spain"
           ],
           "number": "2",
-          "position": "Right-Back"
+          "overall_score": 74,
+          "position": "Right-Back",
+          "potential": 82,
+          "value": 9000000,
+          "yearly_wage": 1404000
         },
         {
           "contract": "Jun 30, 2026",
@@ -7369,7 +9377,11 @@
             "Martinique"
           ],
           "number": "20",
-          "position": "Defensive Midfield"
+          "overall_score": 76,
+          "position": "Defensive Midfield",
+          "potential": 76,
+          "value": 1500000,
+          "yearly_wage": 1144000
         },
         {
           "contract": "Jun 30, 2030",
@@ -7383,7 +9395,11 @@
             "Morocco"
           ],
           "number": "18",
-          "position": "Central Midfield"
+          "overall_score": 79,
+          "position": "Central Midfield",
+          "potential": 82,
+          "value": 23000000,
+          "yearly_wage": 1820000
         },
         {
           "contract": "Jun 30, 2028",
@@ -7397,7 +9413,11 @@
             "Spain"
           ],
           "number": "23",
-          "position": "Central Midfield"
+          "overall_score": 77,
+          "position": "Central Midfield",
+          "potential": 78,
+          "value": 12500000,
+          "yearly_wage": 1612000
         },
         {
           "contract": "Jun 30, 2030",
@@ -7411,7 +9431,11 @@
             "Spain"
           ],
           "number": "8",
-          "position": "Central Midfield"
+          "overall_score": 77,
+          "position": "Central Midfield",
+          "potential": 78,
+          "value": 12500000,
+          "yearly_wage": 1612000
         },
         {
           "contract": "Jun 30, 2028",
@@ -7425,7 +9449,11 @@
             "Netherlands"
           ],
           "number": "6",
-          "position": "Central Midfield"
+          "overall_score": 75,
+          "position": "Central Midfield",
+          "potential": 75,
+          "value": 5500000,
+          "yearly_wage": 1560000
         },
         {
           "contract": "Jun 30, 2028",
@@ -7440,7 +9468,11 @@
             "Spain"
           ],
           "number": "29",
-          "position": "Central Midfield"
+          "overall_score": 65,
+          "position": "Central Midfield",
+          "potential": 74,
+          "value": 1600000,
+          "yearly_wage": 312000
         },
         {
           "contract": "Jun 30, 2026",
@@ -7454,7 +9486,11 @@
             "Argentina"
           ],
           "number": "14",
-          "position": "Attacking Midfield"
+          "overall_score": 73,
+          "position": "Attacking Midfield",
+          "potential": 85,
+          "value": 7000000,
+          "yearly_wage": 2548000
         },
         {
           "contract": "Jun 30, 2026",
@@ -7469,7 +9505,11 @@
             "Guadeloupe"
           ],
           "number": "11",
-          "position": "Attacking Midfield"
+          "overall_score": 77,
+          "position": "Attacking Midfield",
+          "potential": 77,
+          "value": 10500000,
+          "yearly_wage": 2964000
         },
         {
           "contract": "Jun 30, 2030",
@@ -7483,7 +9523,11 @@
             "Spain"
           ],
           "number": "21",
-          "position": "Left Winger"
+          "overall_score": 76,
+          "position": "Left Winger",
+          "potential": 79,
+          "value": 10000000,
+          "yearly_wage": 1404000
         },
         {
           "contract": "Jun 30, 2029",
@@ -7497,7 +9541,11 @@
             "Spain"
           ],
           "number": "3",
-          "position": "Left Winger"
+          "overall_score": 73,
+          "position": "Left Winger",
+          "potential": 82,
+          "value": 6500000,
+          "yearly_wage": 988000
         },
         {
           "contract": "Jun 30, 2027",
@@ -7511,7 +9559,11 @@
             "Ukraine"
           ],
           "number": "15",
-          "position": "Right Winger"
+          "overall_score": 78,
+          "position": "Right Winger",
+          "potential": 78,
+          "value": 15000000,
+          "yearly_wage": 1872000
         },
         {
           "contract": "Jun 30, 2027",
@@ -7524,7 +9576,11 @@
           "nationality": [
             "Spain"
           ],
-          "position": "Right Winger"
+          "overall_score": 75,
+          "position": "Right Winger",
+          "potential": 75,
+          "value": 3500000,
+          "yearly_wage": 1612000
         },
         {
           "contract": "Jun 30, 2030",
@@ -7538,7 +9594,11 @@
             "Ukraine"
           ],
           "number": "19",
-          "position": "Centre-Forward"
+          "overall_score": 77,
+          "position": "Centre-Forward",
+          "potential": 82,
+          "value": 16000000,
+          "yearly_wage": 1560000
         },
         {
           "contract": "Jun 30, 2029",
@@ -7552,7 +9612,11 @@
             "Spain"
           ],
           "number": "9",
-          "position": "Centre-Forward"
+          "overall_score": 72,
+          "position": "Centre-Forward",
+          "potential": 75,
+          "value": 3100000,
+          "yearly_wage": 1144000
         },
         {
           "contract": "Jun 30, 2026",
@@ -7567,7 +9631,11 @@
             "Italy"
           ],
           "number": "7",
-          "position": "Centre-Forward"
+          "overall_score": 75,
+          "position": "Centre-Forward",
+          "potential": 75,
+          "value": 1900000,
+          "yearly_wage": 1248000
         }
       ],
       "stadiumName": "Montilivi",

--- a/data/2025/ESP2/sofifa.json
+++ b/data/2025/ESP2/sofifa.json
@@ -1,0 +1,6520 @@
+{
+  "league": "Spain La Liga 2",
+  "scraped_at": "2026-06-12T09:35:59.480Z",
+  "team_count": 22,
+  "teams": [
+    {
+      "player_count": 36,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Andrés Eduardo Fernández Moreno",
+          "name": "Andrés Fernández",
+          "overall_score": 72,
+          "potential": 72,
+          "value": 250000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Daijiro Chirino",
+          "name": "D. Chirino",
+          "overall_score": 71,
+          "potential": 78,
+          "value": 3600000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Nélson Macedo Monte",
+          "name": "Nélson Monte",
+          "overall_score": 71,
+          "potential": 71,
+          "value": 1600000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Federico Bonini",
+          "name": "F. Bonini",
+          "overall_score": 73,
+          "potential": 82,
+          "value": 6500000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alejandro José Muñoz Miguel",
+          "name": "Álex Muñoz",
+          "overall_score": 74,
+          "potential": 74,
+          "value": 3600000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "Guilherme Borges Guedes",
+          "name": "Gui Guedes",
+          "overall_score": 68,
+          "potential": 74,
+          "value": 1800000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Dion Lopy",
+          "name": "D. Lopy",
+          "overall_score": 73,
+          "potential": 82,
+          "value": 6500000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Leonardo Carrilho Baptistão",
+          "name": "Léo Baptistão",
+          "overall_score": 71,
+          "potential": 71,
+          "value": 1500000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Adrián Embarba Blázquez",
+          "name": "Embarba",
+          "overall_score": 75,
+          "potential": 75,
+          "value": 3500000,
+          "yearly_wage": 520000
+        },
+        {
+          "currency": "€",
+          "full_name": "Sergio Arribas Calvo",
+          "name": "Arribas",
+          "overall_score": 77,
+          "potential": 83,
+          "value": 16500000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "Miguel de la Fuente",
+          "name": "Miguel de la Fuente",
+          "overall_score": 71,
+          "potential": 74,
+          "value": 2500000,
+          "yearly_wage": 520000
+        },
+        {
+          "currency": "€",
+          "full_name": "Thalys Henrique Gomes de Araújo",
+          "name": "Thalys",
+          "overall_score": 66,
+          "potential": 79,
+          "value": 2100000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Arnau Puigmal Martínez",
+          "name": "Puigmal",
+          "overall_score": 71,
+          "potential": 74,
+          "value": 2600000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Iddrisu Baba",
+          "name": "I. Baba",
+          "overall_score": 71,
+          "potential": 71,
+          "value": 1600000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "André Filipe Luz Horta",
+          "name": "André Horta",
+          "overall_score": 70,
+          "potential": 70,
+          "value": 1600000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "Marcos Luna Ruiz",
+          "name": "Luna",
+          "overall_score": 71,
+          "potential": 80,
+          "value": 4000000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Juan Brandáriz Movilla",
+          "name": "Chumi",
+          "overall_score": 65,
+          "potential": 68,
+          "value": 825000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Fernando Martínez Rubio",
+          "name": "Fernando",
+          "overall_score": 69,
+          "potential": 69,
+          "value": 150000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Nicolás Melamed Ribaudo",
+          "name": "Nico Melamed",
+          "overall_score": 69,
+          "potential": 72,
+          "value": 1900000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Patrick Soko",
+          "name": "P. Soko",
+          "overall_score": 68,
+          "potential": 68,
+          "value": 1300000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Stefan Džodić",
+          "name": "S. Džodić",
+          "overall_score": 69,
+          "potential": 80,
+          "value": 2900000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jon Morcillo Conesa",
+          "name": "Morci",
+          "overall_score": 73,
+          "potential": 73,
+          "value": 3300000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alejandro Centelles Plaza",
+          "name": "Álex Centelles",
+          "overall_score": 68,
+          "potential": 71,
+          "value": 1500000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Pedro Fidel Cedillo Segura",
+          "name": "Pedro Fidel",
+          "overall_score": 60,
+          "potential": 76,
+          "value": 600000,
+          "yearly_wage": 46800
+        },
+        {
+          "currency": "€",
+          "full_name": "Bruno Iribarne Alemán",
+          "name": "Bruno Iribarne",
+          "overall_score": 62,
+          "potential": 76,
+          "value": 850000,
+          "yearly_wage": 36400
+        },
+        {
+          "currency": "€",
+          "full_name": "Rodrigo Ely",
+          "name": "Rodrigo Ely",
+          "overall_score": 72,
+          "potential": 72,
+          "value": 1600000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Houssam Kounia Ait Tamlihat",
+          "name": "Houssam Kounia",
+          "overall_score": 59,
+          "potential": 72,
+          "value": 525000,
+          "yearly_wage": 52000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jesús López Soria",
+          "name": "Jesús López",
+          "overall_score": 58,
+          "potential": 64,
+          "value": 275000,
+          "yearly_wage": 36400
+        },
+        {
+          "currency": "€",
+          "full_name": "Quim Junyent Casanova",
+          "name": "Quim Junyent",
+          "overall_score": 62,
+          "potential": 81,
+          "value": 1000000,
+          "yearly_wage": 52000
+        },
+        {
+          "currency": "€",
+          "full_name": "Selvi Clua Oya",
+          "name": "Selvi",
+          "overall_score": 65,
+          "potential": 77,
+          "value": 1600000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Marko Milovanović",
+          "name": "M. Milovanović",
+          "overall_score": 67,
+          "potential": 77,
+          "value": 2300000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Bruno Alberto Langa",
+          "name": "Bruno Langa",
+          "overall_score": 70,
+          "potential": 70,
+          "value": 1500000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Edgar González Estrada",
+          "name": "Edgar",
+          "overall_score": 71,
+          "potential": 72,
+          "value": 1800000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Arvin Appiah",
+          "name": "A. Appiah",
+          "overall_score": 66,
+          "potential": 71,
+          "value": 1200000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alejandro Pozo Pozo",
+          "name": "Álex Pozo",
+          "overall_score": 69,
+          "potential": 69,
+          "value": 1500000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lucas Robertone",
+          "name": "L. Robertone",
+          "overall_score": 72,
+          "potential": 72,
+          "value": 2300000,
+          "yearly_wage": 364000
+        }
+      ],
+      "team": "UD Almería",
+      "transfer_budget": 10800000,
+      "url": "https://sofifa.com/team/1861/ud-almeria/260037/"
+    },
+    {
+      "player_count": 35,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Dinko Horkaš",
+          "name": "D. Horkaš",
+          "overall_score": 74,
+          "potential": 78,
+          "value": 4500000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Marvin Olawale Akinlabi Park",
+          "name": "Marvin",
+          "overall_score": 68,
+          "potential": 69,
+          "value": 1300000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Sergio Barcia Laranxeira",
+          "name": "Sergio Barcia",
+          "overall_score": 73,
+          "potential": 79,
+          "value": 4400000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mika Mármol Medina",
+          "name": "Mika Mármol",
+          "overall_score": 74,
+          "potential": 81,
+          "value": 8000000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Enrique Clemente Maza",
+          "name": "Clemente",
+          "overall_score": 72,
+          "potential": 73,
+          "value": 2500000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Enzo Loiodice",
+          "name": "E. Loiodice",
+          "overall_score": 73,
+          "potential": 78,
+          "value": 4600000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lorenzo Amatucci",
+          "name": "L. Amatucci",
+          "overall_score": 72,
+          "potential": 82,
+          "value": 5000000,
+          "yearly_wage": 1196000
+        },
+        {
+          "currency": "€",
+          "full_name": "Manuel Fuster Lázaro",
+          "name": "Manu Fuster",
+          "overall_score": 74,
+          "potential": 74,
+          "value": 4500000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alejandro García Mejías",
+          "name": "Ale García",
+          "overall_score": 70,
+          "potential": 79,
+          "value": 3600000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jonathan Viera Ramos",
+          "name": "Jonathan Viera",
+          "overall_score": 66,
+          "potential": 66,
+          "value": 350000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jesé Rodríguez Ruiz",
+          "name": "Jesé",
+          "overall_score": 72,
+          "potential": 72,
+          "value": 1900000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Taisei Miyashiro",
+          "name": "T. Miyashiro",
+          "overall_score": 72,
+          "potential": 73,
+          "value": 2800000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Iker Bravo Solanilla",
+          "name": "Iker Bravo",
+          "overall_score": 66,
+          "potential": 78,
+          "value": 2100000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Sandro Ramírez Castillo",
+          "name": "Sandro",
+          "overall_score": 74,
+          "potential": 74,
+          "value": 4100000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "Iñaki González Zambrano",
+          "name": "Iñaki González",
+          "overall_score": 68,
+          "potential": 79,
+          "value": 2500000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Juan Manuel Herzog González",
+          "name": "Juanma Herzog",
+          "overall_score": 71,
+          "potential": 80,
+          "value": 3900000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Cristian Gutiérrez Vizcaíno",
+          "name": "Cristian Gutiérrez",
+          "overall_score": 70,
+          "potential": 75,
+          "value": 2200000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Adrián Suárez Ortega",
+          "name": "Adri Suárez",
+          "overall_score": 61,
+          "potential": 74,
+          "value": 700000,
+          "yearly_wage": 28600
+        },
+        {
+          "currency": "€",
+          "full_name": "Iván Gil Calero",
+          "name": "Iván Gil",
+          "overall_score": 69,
+          "potential": 72,
+          "value": 1800000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "José Alejandro Suárez Suárez",
+          "name": "Álex Suárez",
+          "overall_score": 70,
+          "potential": 70,
+          "value": 1000000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Víctor Álvarez Rozada",
+          "name": "Viti Rozada",
+          "overall_score": 73,
+          "potential": 73,
+          "value": 2900000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Kirian Rodríguez",
+          "name": "Kirian",
+          "overall_score": 74,
+          "potential": 74,
+          "value": 3600000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "Nicolás Benedetti",
+          "name": "N. Benedetti",
+          "overall_score": 71,
+          "potential": 71,
+          "value": 1900000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Francisco Jesús Crespo García",
+          "name": "Pejiño",
+          "overall_score": 67,
+          "potential": 67,
+          "value": 1000000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Valentín Pezzolesi",
+          "name": "V. Pezzolesi",
+          "overall_score": 64,
+          "potential": 80,
+          "value": 1400000,
+          "yearly_wage": 52000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jeremía Recoba",
+          "name": "J. Recoba",
+          "overall_score": 70,
+          "potential": 81,
+          "value": 3600000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Álvaro Killane Giardini",
+          "name": "Killane",
+          "overall_score": 61,
+          "potential": 75,
+          "value": 700000,
+          "yearly_wage": 28600
+        },
+        {
+          "currency": "€",
+          "full_name": "Sergio Viera García",
+          "name": "Sergio Viera",
+          "overall_score": 62,
+          "potential": 76,
+          "value": 900000,
+          "yearly_wage": 52000
+        },
+        {
+          "currency": "€",
+          "full_name": "Carlos Navarro Marín",
+          "name": "Carlos Navarro",
+          "overall_score": 62,
+          "potential": 75,
+          "value": 925000,
+          "yearly_wage": 52000
+        },
+        {
+          "currency": "€",
+          "full_name": "Estanislau Pedrola Fortuny",
+          "name": "Estanis Pedrola",
+          "overall_score": 70,
+          "potential": 80,
+          "value": 3600000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "José Antonio Caro Díaz",
+          "name": "Caro",
+          "overall_score": 70,
+          "potential": 70,
+          "value": 850000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Arturo Rodríguez Cosano",
+          "name": "Arturo",
+          "overall_score": 61,
+          "potential": 81,
+          "value": 900000,
+          "yearly_wage": 52000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ignacio Nicolau Benlloch",
+          "name": "Nicolau",
+          "overall_score": 61,
+          "potential": 71,
+          "value": 650000,
+          "yearly_wage": 39000
+        },
+        {
+          "currency": "€",
+          "full_name": "Edward Cedeño",
+          "name": "E. Cedeño",
+          "overall_score": 66,
+          "potential": 77,
+          "value": 1900000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Aboubacar Bassinga",
+          "name": "A. Bassinga",
+          "overall_score": 64,
+          "potential": 80,
+          "value": 1500000,
+          "yearly_wage": 104000
+        }
+      ],
+      "team": "UD Las Palmas",
+      "transfer_budget": 6300000,
+      "url": "https://sofifa.com/team/472/ud-las-palmas/260037/"
+    },
+    {
+      "player_count": 31,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Álvaro Fernández Llorente",
+          "name": "Álvaro Ferllo",
+          "overall_score": 72,
+          "potential": 75,
+          "value": 2300000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Adrià Altimira Reynaldos",
+          "name": "Alti",
+          "overall_score": 72,
+          "potential": 77,
+          "value": 3300000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lucas Noubi",
+          "name": "L. Noubi",
+          "overall_score": 69,
+          "potential": 80,
+          "value": 2900000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Miguel Loureiro Ameijenda",
+          "name": "Loureiro",
+          "overall_score": 72,
+          "potential": 73,
+          "value": 2200000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Giacomo Quagliata",
+          "name": "G. Quagliata",
+          "overall_score": 72,
+          "potential": 75,
+          "value": 2900000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Diego Villares Yáñez",
+          "name": "Villares",
+          "overall_score": 72,
+          "potential": 72,
+          "value": 2300000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "José Gragera Amado",
+          "name": "José Gragera",
+          "overall_score": 71,
+          "potential": 74,
+          "value": 2200000,
+          "yearly_wage": 676000
+        },
+        {
+          "currency": "€",
+          "full_name": "David Mella Boullón",
+          "name": "Mella",
+          "overall_score": 71,
+          "potential": 82,
+          "value": 4100000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Yeremay Hernández Cubas",
+          "name": "Yeremay",
+          "overall_score": 76,
+          "potential": 84,
+          "value": 17000000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mario Soriano Carreño",
+          "name": "Mario Soriano",
+          "overall_score": 74,
+          "potential": 80,
+          "value": 6500000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Zakaria Eddahchouri",
+          "name": "Z. Eddahchouri",
+          "overall_score": 70,
+          "potential": 73,
+          "value": 2100000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Luis Miguel Cruz Hernández",
+          "name": "Luismi Cruz",
+          "overall_score": 73,
+          "potential": 76,
+          "value": 4200000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "José Ángel Jurado de la Torre",
+          "name": "José Ángel",
+          "overall_score": 69,
+          "potential": 69,
+          "value": 700000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Charlie Patiño",
+          "name": "C. Patiño",
+          "overall_score": 66,
+          "potential": 77,
+          "value": 1900000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Joaquín Navarro Jiménez",
+          "name": "Ximo Navarro",
+          "overall_score": 72,
+          "potential": 72,
+          "value": 725000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Daniel Barcia Rama",
+          "name": "Dani Barcia",
+          "overall_score": 69,
+          "potential": 75,
+          "value": 2000000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Arnau Comas Freixas",
+          "name": "Arnau Comas",
+          "overall_score": 68,
+          "potential": 72,
+          "value": 1500000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Germán Parreño Boix",
+          "name": "Germán Parreño",
+          "overall_score": 67,
+          "potential": 67,
+          "value": 500000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Samuele Mulattieri",
+          "name": "S. Mulattieri",
+          "overall_score": 71,
+          "potential": 74,
+          "value": 2600000,
+          "yearly_wage": 676000
+        },
+        {
+          "currency": "€",
+          "full_name": "Juan Diego Molina Martínez",
+          "name": "Stoichkov",
+          "overall_score": 71,
+          "potential": 71,
+          "value": 1600000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Sergio Escudero Palomo",
+          "name": "Escudero",
+          "overall_score": 68,
+          "potential": 68,
+          "value": 375000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ricardo Rodríguez Gil",
+          "name": "Riki",
+          "overall_score": 70,
+          "potential": 70,
+          "value": 1700000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Cristian Herrera Pérez",
+          "name": "Cristian Herrera",
+          "overall_score": 64,
+          "potential": 64,
+          "value": 275000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Eric Puerto Huerta",
+          "name": "Eric Puerto",
+          "overall_score": 63,
+          "potential": 70,
+          "value": 825000,
+          "yearly_wage": 49400
+        },
+        {
+          "currency": "€",
+          "full_name": "Noé Carrillo Collazo",
+          "name": "Noé Carrillo",
+          "overall_score": 62,
+          "potential": 80,
+          "value": 1000000,
+          "yearly_wage": 52000
+        },
+        {
+          "currency": "€",
+          "full_name": "Bil Nsongo",
+          "name": "B. Nsongo",
+          "overall_score": 65,
+          "potential": 79,
+          "value": 1700000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alioune Mané",
+          "name": "A. Mané",
+          "overall_score": 60,
+          "potential": 69,
+          "value": 550000,
+          "yearly_wage": 52000
+        },
+        {
+          "currency": "€",
+          "full_name": "Samuel Fernández Leonardo",
+          "name": "Samu Fernández",
+          "overall_score": 59,
+          "potential": 75,
+          "value": 550000,
+          "yearly_wage": 41600
+        },
+        {
+          "currency": "€",
+          "full_name": "Luis Rodríguez Chacón",
+          "name": "Chacón",
+          "overall_score": 70,
+          "potential": 73,
+          "value": 2100000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mohamed Bouldini",
+          "name": "M. Bouldini",
+          "overall_score": 64,
+          "potential": 64,
+          "value": 575000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Álexander Petxarroman",
+          "name": "Álex Petxa",
+          "overall_score": 66,
+          "potential": 66,
+          "value": 775000,
+          "yearly_wage": 156000
+        }
+      ],
+      "team": "RC Deportivo de La Coruña",
+      "transfer_budget": 6800000,
+      "url": "https://sofifa.com/team/242/rc-deportivo-de-la-coruna/260037/"
+    },
+    {
+      "player_count": 33,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Rubén Yáñez Alabart",
+          "name": "Rubén Yáñez",
+          "overall_score": 73,
+          "potential": 73,
+          "value": 1600000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Guillermo Rosas Alonso",
+          "name": "Guille Rosas",
+          "overall_score": 73,
+          "potential": 76,
+          "value": 3700000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "Pablo Vázquez Pérez",
+          "name": "Pablo Vázquez",
+          "overall_score": 70,
+          "potential": 70,
+          "value": 1300000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lucas Perrin",
+          "name": "L. Perrin",
+          "overall_score": 69,
+          "potential": 72,
+          "value": 1600000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Diego Sánchez Pérez",
+          "name": "Diego Sánchez",
+          "overall_score": 70,
+          "potential": 78,
+          "value": 3400000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ignacio Martín Gómez",
+          "name": "Nacho Martín",
+          "overall_score": 70,
+          "potential": 76,
+          "value": 2300000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alexandre Corredera Alardi",
+          "name": "Àlex Corredera",
+          "overall_score": 72,
+          "potential": 72,
+          "value": 2300000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jonathan Dubasin",
+          "name": "Jonathan Dubasin",
+          "overall_score": 74,
+          "potential": 75,
+          "value": 5000000,
+          "yearly_wage": 520000
+        },
+        {
+          "currency": "€",
+          "full_name": "Gaspar Campos-Ansó",
+          "name": "Gaspar Campos",
+          "overall_score": 70,
+          "potential": 71,
+          "value": 1900000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "César Gelabert Piña",
+          "name": "César Gelabert",
+          "overall_score": 74,
+          "potential": 78,
+          "value": 6000000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "Juan Ferney Otero",
+          "name": "J. Otero",
+          "overall_score": 74,
+          "potential": 74,
+          "value": 4100000,
+          "yearly_wage": 624000
+        },
+        {
+          "currency": "€",
+          "full_name": "Andrés Ferrari",
+          "name": "A. Ferrari",
+          "overall_score": 68,
+          "potential": 76,
+          "value": 2700000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Amadou Matar Coundoul",
+          "name": "A. Coundoul",
+          "overall_score": 65,
+          "potential": 72,
+          "value": 1400000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Daniel Queipo Menéndez",
+          "name": "Daniel Queipo",
+          "overall_score": 66,
+          "potential": 72,
+          "value": 1400000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Eric Curbelo de la Fe",
+          "name": "Eric Curbelo",
+          "overall_score": 70,
+          "potential": 70,
+          "value": 1100000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Pablo García Carrasco",
+          "name": "Pablo García",
+          "overall_score": 68,
+          "potential": 71,
+          "value": 1500000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Kevin Vázquez Comesaña",
+          "name": "Kevin",
+          "overall_score": 67,
+          "potential": 67,
+          "value": 700000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Christian Joel Sánchez",
+          "name": "C. Sánchez",
+          "overall_score": 65,
+          "potential": 70,
+          "value": 825000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Brian Oliván Herrero",
+          "name": "Brian Oliván",
+          "overall_score": 70,
+          "potential": 70,
+          "value": 1200000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Manuel Rodríguez Paz",
+          "name": "Manu Rodríguez",
+          "overall_score": 62,
+          "potential": 77,
+          "value": 950000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Iker Martínez Martínez",
+          "name": "Iker Martínez",
+          "overall_score": 61,
+          "potential": 70,
+          "value": 675000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Justin Smith",
+          "name": "J. Smith",
+          "overall_score": 68,
+          "potential": 79,
+          "value": 2600000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jesús José Bernal Villarig",
+          "name": "Jesús Bernal",
+          "overall_score": 68,
+          "potential": 68,
+          "value": 1100000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Pierre Mbemba",
+          "name": "P. Mbemba",
+          "overall_score": 62,
+          "potential": 73,
+          "value": 825000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Nicolás Riestra Coalla",
+          "name": "Nico Riestra",
+          "overall_score": 62,
+          "potential": 80,
+          "value": 1000000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mamadou Loum",
+          "name": "M. Loum",
+          "overall_score": 66,
+          "potential": 66,
+          "value": 750000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Gerard Moreno García",
+          "name": "Gerard Moreno",
+          "overall_score": 56,
+          "potential": 70,
+          "value": 300000,
+          "yearly_wage": 31200
+        },
+        {
+          "currency": "€",
+          "full_name": "Enol Prendes Ortiz",
+          "name": "Enol Prendes",
+          "overall_score": 63,
+          "potential": 71,
+          "value": 1100000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Iker Venteo Plaza",
+          "name": "Iker Venteo",
+          "overall_score": 61,
+          "potential": 71,
+          "value": 650000,
+          "yearly_wage": 52000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alejandro Lozano Cárdenas",
+          "name": "Álex Lozano",
+          "overall_score": 61,
+          "potential": 71,
+          "value": 725000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Andrés Cuenca Cejudo",
+          "name": "Andrés Cuenca",
+          "overall_score": 61,
+          "potential": 82,
+          "value": 1000000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alejandro García Oyón",
+          "name": "Álex Oyón",
+          "overall_score": 61,
+          "potential": 70,
+          "value": 725000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Miguel Conde Piñeiro",
+          "name": "Miguel Conde",
+          "overall_score": 61,
+          "potential": 78,
+          "value": 850000,
+          "yearly_wage": 104000
+        }
+      ],
+      "team": "Real Sporting de Gijón",
+      "transfer_budget": 4800000,
+      "url": "https://sofifa.com/team/459/real-sporting-de-gijon/260037/"
+    },
+    {
+      "player_count": 32,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Jokin Ezkieta Mendiburu",
+          "name": "Ezkieta",
+          "overall_score": 69,
+          "potential": 71,
+          "value": 1200000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Álvaro Mantilla Pérez",
+          "name": "Mantilla",
+          "overall_score": 68,
+          "potential": 71,
+          "value": 1500000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Facundo González",
+          "name": "F. González",
+          "overall_score": 68,
+          "potential": 78,
+          "value": 2500000,
+          "yearly_wage": 1664000
+        },
+        {
+          "currency": "€",
+          "full_name": "Pablo Ramón Parra",
+          "name": "Pablo Ramón",
+          "overall_score": 68,
+          "potential": 77,
+          "value": 2500000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jorge Salinas Viadero",
+          "name": "Jorge Salinas",
+          "overall_score": 67,
+          "potential": 85,
+          "value": 2500000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Aritz Aldasoro Sarriegi",
+          "name": "Aldasoro",
+          "overall_score": 70,
+          "potential": 73,
+          "value": 1900000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Íñigo Sainz-Maza Serna",
+          "name": "Íñigo Sainz-Maza",
+          "overall_score": 67,
+          "potential": 70,
+          "value": 1200000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Andrés Martín García",
+          "name": "Andrés Martín",
+          "overall_score": 77,
+          "potential": 78,
+          "value": 12500000,
+          "yearly_wage": 572000
+        },
+        {
+          "currency": "€",
+          "full_name": "Iñigo Vicente Elorduy",
+          "name": "Iñigo Vicente",
+          "overall_score": 77,
+          "potential": 77,
+          "value": 11000000,
+          "yearly_wage": 624000
+        },
+        {
+          "currency": "€",
+          "full_name": "Peio Canales Urtasun",
+          "name": "Peio Canales",
+          "overall_score": 68,
+          "potential": 82,
+          "value": 2900000,
+          "yearly_wage": 676000
+        },
+        {
+          "currency": "€",
+          "full_name": "Asier Villalibre Molina",
+          "name": "Villalibre",
+          "overall_score": 74,
+          "potential": 74,
+          "value": 4600000,
+          "yearly_wage": 1352000
+        },
+        {
+          "currency": "€",
+          "full_name": "Juan Carlos Arana Gómez",
+          "name": "Arana",
+          "overall_score": 69,
+          "potential": 72,
+          "value": 1900000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Giorgi Guliashvili",
+          "name": "G. Guliashvili",
+          "overall_score": 66,
+          "potential": 71,
+          "value": 1300000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Manex Lozano Carmona",
+          "name": "Manex Lozano",
+          "overall_score": 62,
+          "potential": 82,
+          "value": 1100000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Marco Sangalli Fuentes",
+          "name": "Marco Sangalli",
+          "overall_score": 68,
+          "potential": 68,
+          "value": 750000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Suleiman Camara Sanneh",
+          "name": "Suleiman Camara",
+          "overall_score": 68,
+          "potential": 74,
+          "value": 1900000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Javier Castro Urdín",
+          "name": "Javi Castro",
+          "overall_score": 71,
+          "potential": 78,
+          "value": 3500000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Laro Gómez Rodríguez",
+          "name": "Laro Gómez",
+          "overall_score": 60,
+          "potential": 78,
+          "value": 550000,
+          "yearly_wage": 26000
+        },
+        {
+          "currency": "€",
+          "full_name": "Maguette Gueye",
+          "name": "M. Gueye",
+          "overall_score": 66,
+          "potential": 74,
+          "value": 1800000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mario García Alvear",
+          "name": "Mario García",
+          "overall_score": 67,
+          "potential": 78,
+          "value": 2200000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Gustavo Puerta",
+          "name": "G. Puerta",
+          "overall_score": 71,
+          "potential": 82,
+          "value": 4000000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "José Manuel Hernando Riol",
+          "name": "Manu Hernando",
+          "overall_score": 68,
+          "potential": 71,
+          "value": 1400000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Sergio Martínez Montero",
+          "name": "Sergio Martínez",
+          "overall_score": 63,
+          "potential": 78,
+          "value": 1100000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Damián Rodríguez Sousa",
+          "name": "Damián Rodríguez",
+          "overall_score": 72,
+          "potential": 76,
+          "value": 3400000,
+          "yearly_wage": 884000
+        },
+        {
+          "currency": "€",
+          "full_name": "Diego Díaz Cacho",
+          "name": "Diego Díaz",
+          "overall_score": 59,
+          "potential": 71,
+          "value": 550000,
+          "yearly_wage": 52000
+        },
+        {
+          "currency": "€",
+          "full_name": "Aitor Crespo Gutiérrez",
+          "name": "Aitor Crespo",
+          "overall_score": 60,
+          "potential": 72,
+          "value": 550000,
+          "yearly_wage": 52000
+        },
+        {
+          "currency": "€",
+          "full_name": "Diego Fuentes Pérez",
+          "name": "Diego Fuentes",
+          "overall_score": 60,
+          "potential": 66,
+          "value": 400000,
+          "yearly_wage": 52000
+        },
+        {
+          "currency": "€",
+          "full_name": "Santiago Franco de la Torre",
+          "name": "Santi Franco",
+          "overall_score": 60,
+          "potential": 69,
+          "value": 550000,
+          "yearly_wage": 52000
+        },
+        {
+          "currency": "€",
+          "full_name": "Simon Eriksson",
+          "name": "S. Eriksson",
+          "overall_score": 66,
+          "potential": 81,
+          "value": 1800000,
+          "yearly_wage": 52000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jaime Mata Arnaiz",
+          "name": "Mata",
+          "overall_score": 65,
+          "potential": 65,
+          "value": 240000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Yeray Cabanzón de Arriba",
+          "name": "Yeray",
+          "overall_score": 66,
+          "potential": 75,
+          "value": 1900000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Clément Michelin",
+          "name": "C. Michelin",
+          "overall_score": 68,
+          "potential": 68,
+          "value": 1100000,
+          "yearly_wage": 260000
+        }
+      ],
+      "team": "Racing Santander",
+      "transfer_budget": 2000000,
+      "url": "https://sofifa.com/team/456/racing-santander/260037/"
+    },
+    {
+      "player_count": 31,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Juan Soriano Oropesa",
+          "name": "Juan Soriano",
+          "overall_score": 74,
+          "potential": 75,
+          "value": 3600000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "Rubén Peña Jiménez",
+          "name": "Rubén Peña",
+          "overall_score": 70,
+          "potential": 70,
+          "value": 825000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "Gonzalo Aguilar López",
+          "name": "Lalo Aguilar",
+          "overall_score": 70,
+          "potential": 77,
+          "value": 3000000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jorge Sáenz de Miera",
+          "name": "Jorge Sáenz",
+          "overall_score": 68,
+          "potential": 69,
+          "value": 1100000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Enric Franquesa Dolz",
+          "name": "Franquesa",
+          "overall_score": 68,
+          "potential": 68,
+          "value": 1100000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Amadou Diawara",
+          "name": "A. Diawara",
+          "overall_score": 72,
+          "potential": 72,
+          "value": 2200000,
+          "yearly_wage": 520000
+        },
+        {
+          "currency": "€",
+          "full_name": "Seydouba Cisse",
+          "name": "S. Cisse",
+          "overall_score": 70,
+          "potential": 75,
+          "value": 2400000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Juan Cruz Díaz Espósito",
+          "name": "Juan Cruz",
+          "overall_score": 70,
+          "potential": 71,
+          "value": 1900000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "Luis Lopes",
+          "name": "Duk",
+          "overall_score": 70,
+          "potential": 71,
+          "value": 1900000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "Gonzalo Melero Manzanares",
+          "name": "Melero",
+          "overall_score": 68,
+          "potential": 68,
+          "value": 1000000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Diego García Campos",
+          "name": "Diego García",
+          "overall_score": 66,
+          "potential": 68,
+          "value": 1100000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alejandro Millán Iranzo",
+          "name": "Alex Millán",
+          "overall_score": 70,
+          "potential": 73,
+          "value": 2100000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "Óscar Plano Pedreño",
+          "name": "Óscar Plano",
+          "overall_score": 68,
+          "potential": 68,
+          "value": 575000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Roberto López Alcaide",
+          "name": "Roberto López",
+          "overall_score": 67,
+          "potential": 70,
+          "value": 1300000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Naim García García",
+          "name": "Naim García",
+          "overall_score": 67,
+          "potential": 72,
+          "value": 1500000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ignasi Miquel i Pons",
+          "name": "Ignasi Miquel",
+          "overall_score": 67,
+          "potential": 67,
+          "value": 650000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Rubén Pulido Peñas",
+          "name": "Rubén Pulido",
+          "overall_score": 67,
+          "potential": 71,
+          "value": 1300000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Miguel San Román Ferrándiz",
+          "name": "San Román",
+          "overall_score": 67,
+          "potential": 69,
+          "value": 925000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Luís Asué",
+          "name": "Luís Asué",
+          "overall_score": 65,
+          "potential": 70,
+          "value": 1100000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Marvelous Antolín Garzón",
+          "name": "Marvel",
+          "overall_score": 67,
+          "potential": 73,
+          "value": 1500000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Carlos Guirao Mora",
+          "name": "Guirao",
+          "overall_score": 66,
+          "potential": 72,
+          "value": 1300000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Sebastián Figueredo",
+          "name": "S. Figueredo",
+          "overall_score": 64,
+          "potential": 70,
+          "value": 875000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Javier Garrido López",
+          "name": "Javi Garrido",
+          "overall_score": 59,
+          "potential": 66,
+          "value": 400000,
+          "yearly_wage": 39000
+        },
+        {
+          "currency": "€",
+          "full_name": "Marcos Leiva Calvo",
+          "name": "Marcos Leiva",
+          "overall_score": 62,
+          "potential": 71,
+          "value": 825000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Andrés Campos Bautista",
+          "name": "Andrés Campos",
+          "overall_score": 63,
+          "potential": 69,
+          "value": 750000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Saïd Imigene",
+          "name": "S. Imigene",
+          "overall_score": 59,
+          "potential": 71,
+          "value": 500000,
+          "yearly_wage": 52000
+        },
+        {
+          "currency": "€",
+          "full_name": "Gift Siame",
+          "name": "G. Siame",
+          "overall_score": 58,
+          "potential": 68,
+          "value": 450000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Djibril Gueye",
+          "name": "D. Gueye",
+          "overall_score": 58,
+          "potential": 72,
+          "value": 450000,
+          "yearly_wage": 52000
+        },
+        {
+          "currency": "€",
+          "full_name": "Daniel Rodríguez Vázquez",
+          "name": "Dani Rodríguez",
+          "overall_score": 73,
+          "potential": 73,
+          "value": 1000000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "Miguel de la Fuente",
+          "name": "Miguel de la Fuente",
+          "overall_score": 71,
+          "potential": 74,
+          "value": 2500000,
+          "yearly_wage": 520000
+        },
+        {
+          "currency": "€",
+          "full_name": "Benjamin Pauwels",
+          "name": "B. Pauwels",
+          "overall_score": 65,
+          "potential": 76,
+          "value": 1600000,
+          "yearly_wage": 156000
+        }
+      ],
+      "team": "CD Leganés",
+      "transfer_budget": 4600000,
+      "url": "https://sofifa.com/team/100888/cd-leganes/260037/"
+    },
+    {
+      "player_count": 28,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Romain Matthys",
+          "name": "R. Matthys",
+          "overall_score": 69,
+          "potential": 73,
+          "value": 1500000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jérémy Mellot",
+          "name": "J. Mellot",
+          "overall_score": 71,
+          "potential": 71,
+          "value": 1400000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alberto Jiménez Benítez",
+          "name": "Alberto Jiménez",
+          "overall_score": 69,
+          "potential": 69,
+          "value": 900000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Fabrizio Brignani",
+          "name": "F. Brignani",
+          "overall_score": 69,
+          "potential": 71,
+          "value": 1500000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Salvador Ruíz Rodríguez",
+          "name": "Salva Ruíz",
+          "overall_score": 64,
+          "potential": 64,
+          "value": 475000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Awer Mabil",
+          "name": "A. Mabil",
+          "overall_score": 68,
+          "potential": 68,
+          "value": 1200000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Beñat Gerenabarrena",
+          "name": "Gerenabarrena",
+          "overall_score": 69,
+          "potential": 77,
+          "value": 3100000,
+          "yearly_wage": 832000
+        },
+        {
+          "currency": "€",
+          "full_name": "Diego Hernández Barriuso",
+          "name": "Diego Barri",
+          "overall_score": 70,
+          "potential": 70,
+          "value": 1600000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Brian Cipenga",
+          "name": "B. Cipenga",
+          "overall_score": 73,
+          "potential": 73,
+          "value": 3200000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ousmane Camara",
+          "name": "O. Camara",
+          "overall_score": 69,
+          "potential": 76,
+          "value": 2800000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alejandro Calatrava Torrado",
+          "name": "Cala",
+          "overall_score": 74,
+          "potential": 77,
+          "value": 5500000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "Israel Suero Fernández",
+          "name": "Isra Suero",
+          "overall_score": 69,
+          "potential": 69,
+          "value": 1200000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Adam Jakobsen",
+          "name": "A. Jakobsen",
+          "overall_score": 67,
+          "potential": 68,
+          "value": 1200000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Álvaro García Arana",
+          "name": "Álvaro García",
+          "overall_score": 63,
+          "potential": 65,
+          "value": 600000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Raúl Sánchez Sánchez",
+          "name": "Raúl Sánchez",
+          "overall_score": 70,
+          "potential": 70,
+          "value": 1700000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lucas Alcázar Moreno",
+          "name": "Lucas Alcázar",
+          "overall_score": 70,
+          "potential": 78,
+          "value": 3400000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Agustín Sienra",
+          "name": "A. Sienra",
+          "overall_score": 66,
+          "potential": 71,
+          "value": 1100000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Amir Abedzadeh",
+          "name": "A. Abedzadeh",
+          "overall_score": 69,
+          "potential": 69,
+          "value": 700000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Douglas Aurélio",
+          "name": "Douglas Aurélio",
+          "overall_score": 67,
+          "potential": 68,
+          "value": 1200000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Michał Willmann",
+          "name": "M. Willmann",
+          "overall_score": 63,
+          "potential": 71,
+          "value": 1000000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Marc-Olivier Doué",
+          "name": "M. Doué",
+          "overall_score": 64,
+          "potential": 71,
+          "value": 1100000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Charbel Wehbe",
+          "name": "C. Wehbe",
+          "overall_score": 64,
+          "potential": 75,
+          "value": 1300000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Pablo Santiago López",
+          "name": "Pablo Santiago",
+          "overall_score": 67,
+          "potential": 70,
+          "value": 1400000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Tommaso De Nipoti",
+          "name": "T. De Nipoti",
+          "overall_score": 59,
+          "potential": 70,
+          "value": 500000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Martín Conde Gómez",
+          "name": "Tincho",
+          "overall_score": 60,
+          "potential": 69,
+          "value": 525000,
+          "yearly_wage": 52000
+        },
+        {
+          "currency": "€",
+          "full_name": "Sergi Torner Rosell",
+          "name": "Sergi Torner",
+          "overall_score": 57,
+          "potential": 68,
+          "value": 325000,
+          "yearly_wage": 26000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ismael Fadel Pagés",
+          "name": "Ismael Fadel",
+          "overall_score": 62,
+          "potential": 75,
+          "value": 925000,
+          "yearly_wage": 52000
+        },
+        {
+          "currency": "€",
+          "full_name": "Nicholas Markanich",
+          "name": "N. Markanich",
+          "overall_score": 65,
+          "potential": 68,
+          "value": 950000,
+          "yearly_wage": 156000
+        }
+      ],
+      "team": "CD Castellón",
+      "transfer_budget": 1500000,
+      "url": "https://sofifa.com/team/100852/cd-castellon/260037/"
+    },
+    {
+      "player_count": 28,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Ander Cantero Armendariz",
+          "name": "Cantero",
+          "overall_score": 70,
+          "potential": 70,
+          "value": 1100000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alejandro Lizancos Saldaña",
+          "name": "Alex Lizancos",
+          "overall_score": 67,
+          "potential": 76,
+          "value": 2200000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Sergio González Martínez",
+          "name": "Sergio González",
+          "overall_score": 69,
+          "potential": 70,
+          "value": 1300000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Gregorio Sierra Pérez",
+          "name": "Gregorio Sierra",
+          "overall_score": 67,
+          "potential": 67,
+          "value": 650000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Florian Miguel",
+          "name": "F. Miguel",
+          "overall_score": 70,
+          "potential": 70,
+          "value": 1400000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Iván Morante Ruiz",
+          "name": "Iván Morante",
+          "overall_score": 68,
+          "potential": 75,
+          "value": 2300000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Miguel Ángel Atienza Villa",
+          "name": "Atienza",
+          "overall_score": 71,
+          "potential": 74,
+          "value": 2200000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "David González",
+          "name": "David González",
+          "overall_score": 68,
+          "potential": 77,
+          "value": 2700000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Iñigo Córdoba Querejeta",
+          "name": "Iñigo Córdoba",
+          "overall_score": 71,
+          "potential": 71,
+          "value": 1900000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Francisco José Sánchez Rodríguez",
+          "name": "Curro Sánchez",
+          "overall_score": 70,
+          "potential": 70,
+          "value": 1600000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Fernando Niño Rodríguez",
+          "name": "Fer Niño",
+          "overall_score": 71,
+          "potential": 76,
+          "value": 2900000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mario González Gutiérrez",
+          "name": "Mario González",
+          "overall_score": 69,
+          "potential": 69,
+          "value": 1400000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "José Mateo Mejía Piedrahita",
+          "name": "Mateo Mejía",
+          "overall_score": 62,
+          "potential": 71,
+          "value": 900000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Kévin Appin",
+          "name": "K. Appin",
+          "overall_score": 69,
+          "potential": 69,
+          "value": 1500000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Marcelo Expósito Jiménez",
+          "name": "Marcelo",
+          "overall_score": 61,
+          "potential": 69,
+          "value": 700000,
+          "yearly_wage": 52000
+        },
+        {
+          "currency": "€",
+          "full_name": "Oier Luengo Redondo",
+          "name": "Oier Luengo",
+          "overall_score": 69,
+          "potential": 71,
+          "value": 1500000,
+          "yearly_wage": 780000
+        },
+        {
+          "currency": "€",
+          "full_name": "Brais Martínez Prado",
+          "name": "Brais Martínez",
+          "overall_score": 66,
+          "potential": 72,
+          "value": 1300000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jesús Ruiz Suárez",
+          "name": "Jesús Ruiz",
+          "overall_score": 70,
+          "potential": 72,
+          "value": 1400000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mario Cantero Mariño",
+          "name": "Mario Cantero",
+          "overall_score": 63,
+          "potential": 70,
+          "value": 950000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Víctor Mollejo Carpintero",
+          "name": "Mollejo",
+          "overall_score": 69,
+          "potential": 74,
+          "value": 2100000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Fermín García Murillo",
+          "name": "Fermín García",
+          "overall_score": 61,
+          "potential": 68,
+          "value": 675000,
+          "yearly_wage": 52000
+        },
+        {
+          "currency": "€",
+          "full_name": "Aitor Buñuel Redrado",
+          "name": "Aitor Buñuel",
+          "overall_score": 66,
+          "potential": 66,
+          "value": 825000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Saúl del Cerro García",
+          "name": "del Cerro",
+          "overall_score": 63,
+          "potential": 73,
+          "value": 1100000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Marc Monedero Sánchez",
+          "name": "Monedero",
+          "overall_score": 62,
+          "potential": 76,
+          "value": 850000,
+          "yearly_wage": 33800
+        },
+        {
+          "currency": "€",
+          "full_name": "Ethan Ventosa González",
+          "name": "Ethan",
+          "overall_score": 58,
+          "potential": 67,
+          "value": 450000,
+          "yearly_wage": 52000
+        },
+        {
+          "currency": "€",
+          "full_name": "Hugo Cuenca",
+          "name": "H. Cuenca",
+          "overall_score": 62,
+          "potential": 77,
+          "value": 950000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Diego González Presencio",
+          "name": "Diego González",
+          "overall_score": 57,
+          "potential": 74,
+          "value": 375000,
+          "yearly_wage": 26000
+        },
+        {
+          "currency": "€",
+          "full_name": "Pablo Galdames",
+          "name": "P. Galdames",
+          "overall_score": 69,
+          "potential": 69,
+          "value": 1400000,
+          "yearly_wage": 260000
+        }
+      ],
+      "team": "Burgos CF",
+      "transfer_budget": 1500000,
+      "url": "https://sofifa.com/team/10846/burgos-cf/260037/"
+    },
+    {
+      "player_count": 29,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Carlos Marín Tomás",
+          "name": "Carlos Marín",
+          "overall_score": 68,
+          "potential": 70,
+          "value": 1000000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Carlos Albarrán Sanz",
+          "name": "Albarrán",
+          "overall_score": 68,
+          "potential": 68,
+          "value": 875000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "José Alejandro Martín Valerón",
+          "name": "Álex Martín",
+          "overall_score": 69,
+          "potential": 70,
+          "value": 1400000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Xavier Sintes Egea",
+          "name": "Xavi Sintes",
+          "overall_score": 68,
+          "potential": 72,
+          "value": 1600000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ignasi Vilarrasa Palacios",
+          "name": "Vilarrasa",
+          "overall_score": 69,
+          "potential": 72,
+          "value": 1700000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ismael Ruiz Sánchez",
+          "name": "Isma Ruiz",
+          "overall_score": 70,
+          "potential": 76,
+          "value": 2300000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Daniel Requena Sánchez",
+          "name": "Dani Requena",
+          "overall_score": 70,
+          "potential": 78,
+          "value": 3600000,
+          "yearly_wage": 780000
+        },
+        {
+          "currency": "€",
+          "full_name": "Pedro Ortiz Bernat",
+          "name": "Pedro Ortiz",
+          "overall_score": 68,
+          "potential": 73,
+          "value": 1800000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Christian Carracedo García",
+          "name": "Carracedo",
+          "overall_score": 72,
+          "potential": 72,
+          "value": 2300000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "Adrián Fuentes González",
+          "name": "Adri Fuentes",
+          "overall_score": 74,
+          "potential": 74,
+          "value": 4300000,
+          "yearly_wage": 572000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jacobo González Rodrigáñez",
+          "name": "Jacobo González",
+          "overall_score": 70,
+          "potential": 70,
+          "value": 1600000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Diego Vicente Bri Carrazoni",
+          "name": "Diego Bri",
+          "overall_score": 68,
+          "potential": 73,
+          "value": 1900000,
+          "yearly_wage": 1144000
+        },
+        {
+          "currency": "€",
+          "full_name": "Adilson Mendes-Martins",
+          "name": "Adilson",
+          "overall_score": 67,
+          "potential": 67,
+          "value": 1000000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Nikolay Obolskii",
+          "name": "N. Obolskii",
+          "overall_score": 64,
+          "potential": 64,
+          "value": 600000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alberto del Moral Saelices",
+          "name": "Alberto del Moral",
+          "overall_score": 66,
+          "potential": 71,
+          "value": 1200000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "Rubén González Alves",
+          "name": "Rubén Alves",
+          "overall_score": 68,
+          "potential": 68,
+          "value": 1000000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Juan María Alcedo Serrano",
+          "name": "Alcedo",
+          "overall_score": 64,
+          "potential": 69,
+          "value": 825000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alejandro Arévalo Arrebola",
+          "name": "Alejandro Arévalo",
+          "overall_score": 57,
+          "potential": 71,
+          "value": 325000,
+          "yearly_wage": 26000
+        },
+        {
+          "currency": "€",
+          "full_name": "Kevin Villodres Medina",
+          "name": "Kevin Medina",
+          "overall_score": 69,
+          "potential": 72,
+          "value": 1900000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Théo Zidane",
+          "name": "Théo",
+          "overall_score": 66,
+          "potential": 72,
+          "value": 1300000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Álvaro Pérez Campo",
+          "name": "Trilli",
+          "overall_score": 66,
+          "potential": 73,
+          "value": 1600000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Sergio Guardiola Navarro",
+          "name": "Sergi Guardiola",
+          "overall_score": 67,
+          "potential": 67,
+          "value": 475000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Dalisson de Almeida Leite",
+          "name": "Dalisson",
+          "overall_score": 68,
+          "potential": 71,
+          "value": 1600000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Iker Álvarez de Eulate",
+          "name": "Iker Álvarez",
+          "overall_score": 69,
+          "potential": 75,
+          "value": 1800000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Franck Fomeyem",
+          "name": "F. Fomeyem",
+          "overall_score": 68,
+          "potential": 73,
+          "value": 1600000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mikel Goti López",
+          "name": "Mikel Goti",
+          "overall_score": 69,
+          "potential": 76,
+          "value": 2800000,
+          "yearly_wage": 832000
+        },
+        {
+          "currency": "€",
+          "full_name": "Marcelo Timorán",
+          "name": "M. Timorán",
+          "overall_score": 58,
+          "potential": 69,
+          "value": 400000,
+          "yearly_wage": 52000
+        },
+        {
+          "currency": "€",
+          "full_name": "Diego Pertejo Canseco",
+          "name": "Diego Percan",
+          "overall_score": 64,
+          "potential": 70,
+          "value": 925000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Javier Antras Santos",
+          "name": "Javi Antras",
+          "overall_score": 58,
+          "potential": 74,
+          "value": 525000,
+          "yearly_wage": 52000
+        }
+      ],
+      "team": "Córdoba CF",
+      "transfer_budget": 2200000,
+      "url": "https://sofifa.com/team/1867/cordoba-cf/260037/"
+    },
+    {
+      "player_count": 40,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Esteban Andrada",
+          "name": "E. Andrada",
+          "overall_score": 69,
+          "potential": 69,
+          "value": 240000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Martín Aguirregabiria",
+          "name": "Aguirregabiria",
+          "overall_score": 71,
+          "potential": 71,
+          "value": 1600000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "Aleksandar Radovanović",
+          "name": "A. Radovanović",
+          "overall_score": 66,
+          "potential": 66,
+          "value": 575000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jawad El Yamiq",
+          "name": "J. El Yamiq",
+          "overall_score": 70,
+          "potential": 70,
+          "value": 750000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Daniel Esmorís Tasende",
+          "name": "Dani Tasende",
+          "overall_score": 69,
+          "potential": 74,
+          "value": 2000000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Keidi Bare",
+          "name": "K. Bare",
+          "overall_score": 71,
+          "potential": 71,
+          "value": 1800000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "José Raúl Gutiérrez Parejo",
+          "name": "Raúl Guti",
+          "overall_score": 66,
+          "potential": 66,
+          "value": 850000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Francho Serrano Gracia",
+          "name": "Francho Serrano",
+          "overall_score": 70,
+          "potential": 77,
+          "value": 3200000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Sebastián Moyano Jimenez",
+          "name": "Sebas Moyano",
+          "overall_score": 65,
+          "potential": 65,
+          "value": 725000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mario Soberón Gutiérrez",
+          "name": "Soberón",
+          "overall_score": 64,
+          "potential": 64,
+          "value": 600000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Kenan Kodro",
+          "name": "Kodro",
+          "overall_score": 69,
+          "potential": 69,
+          "value": 1200000,
+          "yearly_wage": 728000
+        },
+        {
+          "currency": "€",
+          "full_name": "Roberto González Bayón",
+          "name": "Rober",
+          "overall_score": 71,
+          "potential": 74,
+          "value": 2600000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Daniel Gómez Alcón",
+          "name": "Dani Gómez",
+          "overall_score": 70,
+          "potential": 71,
+          "value": 1900000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Marcos Cuenca Aranda",
+          "name": "Cuenca",
+          "overall_score": 69,
+          "potential": 77,
+          "value": 3100000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Paul Akouokou",
+          "name": "P. Akouokou",
+          "overall_score": 69,
+          "potential": 70,
+          "value": 1400000,
+          "yearly_wage": 520000
+        },
+        {
+          "currency": "€",
+          "full_name": "Yussif Saidu",
+          "name": "Y. Saidu",
+          "overall_score": 68,
+          "potential": 84,
+          "value": 3200000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Antonio Moya Vega",
+          "name": "Toni Moya",
+          "overall_score": 65,
+          "potential": 65,
+          "value": 750000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Adrián Rodríguez Giménez",
+          "name": "Adrián",
+          "overall_score": 68,
+          "potential": 74,
+          "value": 1500000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Valery Fernández Estrada",
+          "name": "Valery",
+          "overall_score": 68,
+          "potential": 69,
+          "value": 1400000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Pablo Insua Blanco",
+          "name": "Insua",
+          "overall_score": 68,
+          "potential": 68,
+          "value": 825000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Hugo Pinilla Ruiz",
+          "name": "Hugo Pinilla",
+          "overall_score": 66,
+          "potential": 80,
+          "value": 2000000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alberto Rodríguez Baró",
+          "name": "Tachi",
+          "overall_score": 67,
+          "potential": 69,
+          "value": 1100000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Carlos Pomares Rayo",
+          "name": "Pomares",
+          "overall_score": 64,
+          "potential": 64,
+          "value": 400000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alejandro Gomes Furtado",
+          "name": "Ale Gomes",
+          "overall_score": 65,
+          "potential": 81,
+          "value": 1700000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Sinan Bakış",
+          "name": "S. Bakış",
+          "overall_score": 64,
+          "potential": 64,
+          "value": 500000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Carlos Calavia Larroya",
+          "name": "Calavia",
+          "overall_score": 58,
+          "potential": 66,
+          "value": 400000,
+          "yearly_wage": 44200
+        },
+        {
+          "currency": "€",
+          "full_name": "Lucas Terrer Casas",
+          "name": "Lucas Terrer",
+          "overall_score": 62,
+          "potential": 73,
+          "value": 875000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Manuel Obón Salido",
+          "name": "Manu Obón",
+          "overall_score": 59,
+          "potential": 68,
+          "value": 450000,
+          "yearly_wage": 44200
+        },
+        {
+          "currency": "€",
+          "full_name": "Hugo Barrachina Diloy",
+          "name": "Barrachina",
+          "overall_score": 62,
+          "potential": 78,
+          "value": 950000,
+          "yearly_wage": 52000
+        },
+        {
+          "currency": "€",
+          "full_name": "William Agada",
+          "name": "W. Agada",
+          "overall_score": 63,
+          "potential": 66,
+          "value": 650000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Juan Sebastián Serrano",
+          "name": "Juan Sebastián",
+          "overall_score": 67,
+          "potential": 73,
+          "value": 1500000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Paulino de la Fuente Gómez",
+          "name": "Paulino",
+          "overall_score": 67,
+          "potential": 67,
+          "value": 1000000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Nikola Čumić",
+          "name": "N. Čumić",
+          "overall_score": 64,
+          "potential": 64,
+          "value": 650000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Juan Larios López",
+          "name": "Juan Larios",
+          "overall_score": 69,
+          "potential": 80,
+          "value": 3000000,
+          "yearly_wage": 936000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mawuli Mensah",
+          "name": "M. Mensah",
+          "overall_score": 66,
+          "potential": 77,
+          "value": 1900000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Iker Vadillo Nogués",
+          "name": "Iker Vadillo",
+          "overall_score": 61,
+          "potential": 71,
+          "value": 700000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jaime Tobajas Cabeza",
+          "name": "Tobajas",
+          "overall_score": 61,
+          "potential": 72,
+          "value": 700000,
+          "yearly_wage": 52000
+        },
+        {
+          "currency": "€",
+          "full_name": "Adrián Liso Lahoz",
+          "name": "Adrián Liso",
+          "overall_score": 72,
+          "potential": 83,
+          "value": 5000000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Pau Sans López",
+          "name": "Pau Sans",
+          "overall_score": 68,
+          "potential": 78,
+          "value": 2600000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Samed Baždar",
+          "name": "S. Baždar",
+          "overall_score": 67,
+          "potential": 78,
+          "value": 2300000,
+          "yearly_wage": 208000
+        }
+      ],
+      "team": "Real Zaragoza",
+      "transfer_budget": 2700000,
+      "url": "https://sofifa.com/team/244/real-zaragoza/260037/"
+    },
+    {
+      "player_count": 32,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Alfonso Herrero Peinador",
+          "name": "Alfonso Herrero",
+          "overall_score": 75,
+          "potential": 75,
+          "value": 3000000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Carlos Puga Medina",
+          "name": "Puga",
+          "overall_score": 69,
+          "potential": 74,
+          "value": 2000000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Diego Murillo Dominguez",
+          "name": "Murillo",
+          "overall_score": 69,
+          "potential": 73,
+          "value": 1800000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Einar Galilea Azaceta",
+          "name": "Einar Galilea",
+          "overall_score": 67,
+          "potential": 67,
+          "value": 700000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Víctor García Marín",
+          "name": "Víctor García",
+          "overall_score": 63,
+          "potential": 63,
+          "value": 350000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Izan Merino Rodríguez",
+          "name": "Izan Merino",
+          "overall_score": 70,
+          "potential": 83,
+          "value": 3600000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Carlos Dotor Gonzalez",
+          "name": "Dotor",
+          "overall_score": 68,
+          "potential": 73,
+          "value": 1800000,
+          "yearly_wage": 572000
+        },
+        {
+          "currency": "€",
+          "full_name": "Daniel Lorenzo Guerrero",
+          "name": "Dani Lorenzo",
+          "overall_score": 70,
+          "potential": 77,
+          "value": 3200000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "David Larrubia Romano",
+          "name": "Larrubia",
+          "overall_score": 74,
+          "potential": 79,
+          "value": 6500000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Carlos Ruiz Rubio",
+          "name": "Chupe",
+          "overall_score": 74,
+          "potential": 83,
+          "value": 9500000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Joaquín Muñoz Benavides",
+          "name": "Joaquín",
+          "overall_score": 71,
+          "potential": 71,
+          "value": 2000000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Adrián Niño Heredia",
+          "name": "Adrián Niño",
+          "overall_score": 72,
+          "potential": 80,
+          "value": 5500000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Eneko Jauregi Escobar",
+          "name": "Jauregi",
+          "overall_score": 67,
+          "potential": 67,
+          "value": 1000000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Julen Lobete Cienfuegos",
+          "name": "Lobete",
+          "overall_score": 65,
+          "potential": 68,
+          "value": 975000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Aarón Ochoa Moloney",
+          "name": "Aarón Ochoa",
+          "overall_score": 65,
+          "potential": 74,
+          "value": 1500000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Daniel Rodríguez Sánchez",
+          "name": "Dani Sánchez",
+          "overall_score": 65,
+          "potential": 68,
+          "value": 875000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jokin Gabilondo Garmendia",
+          "name": "Gabilondo",
+          "overall_score": 63,
+          "potential": 64,
+          "value": 525000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Carlos López Nogueras",
+          "name": "Carlos López",
+          "overall_score": 61,
+          "potential": 75,
+          "value": 700000,
+          "yearly_wage": 28600
+        },
+        {
+          "currency": "€",
+          "full_name": "Luis Miguel Sánchez Benítez",
+          "name": "Luismi",
+          "overall_score": 69,
+          "potential": 69,
+          "value": 700000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Álex Pastor Carayol",
+          "name": "Álex Pastor",
+          "overall_score": 67,
+          "potential": 70,
+          "value": 1200000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Moussa Diarra",
+          "name": "M. Diarra",
+          "overall_score": 60,
+          "potential": 67,
+          "value": 450000,
+          "yearly_wage": 52000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ramón Enríquez Rodríguez",
+          "name": "Ramón Enríquez",
+          "overall_score": 63,
+          "potential": 68,
+          "value": 725000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Juan Pedro Jiménez Melero",
+          "name": "Juanpe",
+          "overall_score": 66,
+          "potential": 66,
+          "value": 825000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Rafael Rodríguez Ruiz",
+          "name": "Rafa Rodríguez",
+          "overall_score": 66,
+          "potential": 76,
+          "value": 1900000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Haitam Abaida El Achhab",
+          "name": "H. Abaida El Achhab",
+          "overall_score": 62,
+          "potential": 68,
+          "value": 625000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Andrés Céspedes Rubio",
+          "name": "Andrés Céspedes",
+          "overall_score": 58,
+          "potential": 68,
+          "value": 375000,
+          "yearly_wage": 26000
+        },
+        {
+          "currency": "€",
+          "full_name": "Francisco Montero Rubio",
+          "name": "Montero",
+          "overall_score": 68,
+          "potential": 71,
+          "value": 1400000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Josué Dorrio Ortega",
+          "name": "Dorrio",
+          "overall_score": 66,
+          "potential": 66,
+          "value": 700000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Darko Brašanac",
+          "name": "D. Brašanac",
+          "overall_score": 66,
+          "potential": 66,
+          "value": 425000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ángel Recio Gutiérrez",
+          "name": "Ángel Recio",
+          "overall_score": 65,
+          "potential": 72,
+          "value": 1300000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Rafael Garrido Hierro",
+          "name": "Rafita",
+          "overall_score": 67,
+          "potential": 74,
+          "value": 1900000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ibon Badiola A.",
+          "name": "Ibon Badiola",
+          "overall_score": 58,
+          "potential": 67,
+          "value": 450000,
+          "yearly_wage": 49400
+        }
+      ],
+      "team": "Málaga CF",
+      "transfer_budget": 6900000,
+      "url": "https://sofifa.com/team/573/malaga-cf/260037/"
+    },
+    {
+      "player_count": 29,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Jon Mikel Magunagoitia Blasco",
+          "name": "Magunagoitia",
+          "overall_score": 70,
+          "potential": 74,
+          "value": 1800000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Sergio Cubero Ezcurra",
+          "name": "Cubero",
+          "overall_score": 69,
+          "potential": 72,
+          "value": 1700000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Marco Moreno Ojeda",
+          "name": "Marco Moreno",
+          "overall_score": 70,
+          "potential": 76,
+          "value": 2300000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Anaitz Arbilla Zabala",
+          "name": "Arbilla",
+          "overall_score": 69,
+          "potential": 69,
+          "value": 250000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Hodei Arrillaga Elezgarai",
+          "name": "Hodei",
+          "overall_score": 65,
+          "potential": 70,
+          "value": 1000000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Aleix Garrido Cañizares",
+          "name": "Aleix Garrido",
+          "overall_score": 68,
+          "potential": 79,
+          "value": 2700000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Peru Nolaskoain Esnal",
+          "name": "Nolaskoain",
+          "overall_score": 71,
+          "potential": 74,
+          "value": 2200000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "José Corpas Serna",
+          "name": "Corpas",
+          "overall_score": 70,
+          "potential": 70,
+          "value": 1000000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jon Guruzeta Rodríguez",
+          "name": "Guruzeta",
+          "overall_score": 68,
+          "potential": 71,
+          "value": 1600000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jon Magunazelaia",
+          "name": "Magunazelaia",
+          "overall_score": 67,
+          "potential": 72,
+          "value": 1500000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jon Bautista Orgilles",
+          "name": "Jon Bautista",
+          "overall_score": 69,
+          "potential": 69,
+          "value": 1400000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Sergio Álvarez Díaz",
+          "name": "Sergio Álvarez",
+          "overall_score": 70,
+          "potential": 70,
+          "value": 800000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lander Olaetxea",
+          "name": "Olaetxea",
+          "overall_score": 68,
+          "potential": 68,
+          "value": 950000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Javier Martínez Calvo",
+          "name": "Javi Martínez",
+          "overall_score": 67,
+          "potential": 70,
+          "value": 1300000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ander Madariaga Susaeta",
+          "name": "Mada",
+          "overall_score": 67,
+          "potential": 73,
+          "value": 1600000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Juan Bernat Velasco",
+          "name": "Juan Bernat",
+          "overall_score": 71,
+          "potential": 71,
+          "value": 1300000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jair Amador Silos",
+          "name": "Jair Amador",
+          "overall_score": 67,
+          "potential": 67,
+          "value": 275000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Luis Federico López Andúgar",
+          "name": "Luis López",
+          "overall_score": 64,
+          "potential": 70,
+          "value": 750000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Javier Martón Ansó",
+          "name": "Javi Martón",
+          "overall_score": 69,
+          "potential": 70,
+          "value": 1700000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Antonio Villa Suárez",
+          "name": "Toni Villa",
+          "overall_score": 66,
+          "potential": 66,
+          "value": 825000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Malcom Adu Ares Djaló",
+          "name": "Adu Ares",
+          "overall_score": 66,
+          "potential": 72,
+          "value": 1400000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Aritz Arambarri Murua",
+          "name": "Arambarri",
+          "overall_score": 68,
+          "potential": 70,
+          "value": 1300000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Marc Delgado Garciandía",
+          "name": "Marc Delgado",
+          "overall_score": 60,
+          "potential": 69,
+          "value": 550000,
+          "yearly_wage": 52000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alvaro Rodríguez Pérez",
+          "name": "Alvaro Rodríguez",
+          "overall_score": 66,
+          "potential": 66,
+          "value": 725000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ekaitz Redondo Borrajo",
+          "name": "Ekaitz Redondo",
+          "overall_score": 59,
+          "potential": 66,
+          "value": 450000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Oier Llorente Korta",
+          "name": "Korta",
+          "overall_score": 58,
+          "potential": 70,
+          "value": 450000,
+          "yearly_wage": 52000
+        },
+        {
+          "currency": "€",
+          "full_name": "Unai Ayala Cornejo",
+          "name": "Unai Ayala",
+          "overall_score": 56,
+          "potential": 64,
+          "value": 275000,
+          "yearly_wage": 33800
+        },
+        {
+          "currency": "€",
+          "full_name": "Lucas Sarasketa Unamuno",
+          "name": "Sarasketa",
+          "overall_score": 57,
+          "potential": 78,
+          "value": 525000,
+          "yearly_wage": 52000
+        },
+        {
+          "currency": "€",
+          "full_name": "Hugo García Jiménez",
+          "name": "Hugo García",
+          "overall_score": 59,
+          "potential": 68,
+          "value": 475000,
+          "yearly_wage": 52000
+        }
+      ],
+      "team": "SD Eibar",
+      "transfer_budget": 6500000,
+      "url": "https://sofifa.com/team/467/sd-eibar/260037/"
+    },
+    {
+      "player_count": 36,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Guilherme Sousa Carvalho Fernandes",
+          "name": "Guilherme Fernandes",
+          "overall_score": 69,
+          "potential": 75,
+          "value": 1800000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Iván Alejo Peralta",
+          "name": "Iván Alejo",
+          "overall_score": 69,
+          "potential": 69,
+          "value": 1300000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Pablo Tomeo Félez",
+          "name": "Pablo Tomeo",
+          "overall_score": 70,
+          "potential": 75,
+          "value": 2100000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "David Torres Ortiz",
+          "name": "David Torres",
+          "overall_score": 69,
+          "potential": 78,
+          "value": 2900000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Guillermo Bueno López",
+          "name": "Guille Bueno",
+          "overall_score": 68,
+          "potential": 77,
+          "value": 2600000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Stanko Jurić",
+          "name": "S. Jurić",
+          "overall_score": 69,
+          "potential": 69,
+          "value": 1200000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Víctor Meseguer Cavas",
+          "name": "Meseguer",
+          "overall_score": 66,
+          "potential": 67,
+          "value": 1000000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Peter Federico González Carmona",
+          "name": "Peter",
+          "overall_score": 69,
+          "potential": 76,
+          "value": 2800000,
+          "yearly_wage": 728000
+        },
+        {
+          "currency": "€",
+          "full_name": "Stipe Biuk",
+          "name": "S. Biuk",
+          "overall_score": 67,
+          "potential": 74,
+          "value": 2100000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Iván San José Cantalejo",
+          "name": "Chuki",
+          "overall_score": 71,
+          "potential": 82,
+          "value": 4200000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Juan Miguel Latasa Fernández",
+          "name": "Latasa",
+          "overall_score": 68,
+          "potential": 73,
+          "value": 1800000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Vegard Erlien",
+          "name": "V. Erlien",
+          "overall_score": 68,
+          "potential": 69,
+          "value": 1400000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Julien Ponceau",
+          "name": "J. Ponceau",
+          "overall_score": 73,
+          "potential": 76,
+          "value": 4200000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Sergi Canós Tenés",
+          "name": "Sergi Canós",
+          "overall_score": 69,
+          "potential": 69,
+          "value": 1400000,
+          "yearly_wage": 936000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mathis Lachuer",
+          "name": "M. Lachuer",
+          "overall_score": 69,
+          "potential": 73,
+          "value": 2000000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ibrahim Akintunde Alani",
+          "name": "I. Akintunde Alani",
+          "overall_score": 64,
+          "potential": 80,
+          "value": 1500000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jorge Iglesias González",
+          "name": "Koke",
+          "overall_score": 62,
+          "potential": 76,
+          "value": 925000,
+          "yearly_wage": 52000
+        },
+        {
+          "currency": "€",
+          "full_name": "Álvaro Aceves Catalina",
+          "name": "Aceves",
+          "overall_score": 67,
+          "potential": 79,
+          "value": 2200000,
+          "yearly_wage": 52000
+        },
+        {
+          "currency": "€",
+          "full_name": "Marcos André de Sousa Mendonça",
+          "name": "Marcos André",
+          "overall_score": 68,
+          "potential": 68,
+          "value": 1200000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Amath Ndiaye",
+          "name": "A. Ndiaye",
+          "overall_score": 70,
+          "potential": 70,
+          "value": 1600000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Noah Ohio",
+          "name": "N. Ohio",
+          "overall_score": 67,
+          "potential": 76,
+          "value": 2300000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mario Maroto Argüello",
+          "name": "Mario Maroto",
+          "overall_score": 62,
+          "potential": 72,
+          "value": 900000,
+          "yearly_wage": 52000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mario Domínguez Carriles",
+          "name": "Mario Domínguez",
+          "overall_score": 55,
+          "potential": 80,
+          "value": 400000,
+          "yearly_wage": 33800
+        },
+        {
+          "currency": "€",
+          "full_name": "José Luis Aranda Rojas",
+          "name": "Aranda",
+          "overall_score": 61,
+          "potential": 74,
+          "value": 725000,
+          "yearly_wage": 52000
+        },
+        {
+          "currency": "€",
+          "full_name": "Iván Garriel Múñoz",
+          "name": "Iván Garriel",
+          "overall_score": 65,
+          "potential": 77,
+          "value": 1600000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mohamed Jaouab",
+          "name": "M. Jaouab",
+          "overall_score": 64,
+          "potential": 72,
+          "value": 1200000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ramón Martínez Gil",
+          "name": "Ramón Martínez",
+          "overall_score": 63,
+          "potential": 74,
+          "value": 1000000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Iago Parente Novoa",
+          "name": "Iago Parente",
+          "overall_score": 59,
+          "potential": 74,
+          "value": 500000,
+          "yearly_wage": 46800
+        },
+        {
+          "currency": "€",
+          "full_name": "Hugo San Modesto",
+          "name": "Hugo San",
+          "overall_score": 63,
+          "potential": 78,
+          "value": 1100000,
+          "yearly_wage": 52000
+        },
+        {
+          "currency": "€",
+          "full_name": "Carlos Clerc Martínez",
+          "name": "Clerc",
+          "overall_score": 70,
+          "potential": 70,
+          "value": 825000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Clément Michelin",
+          "name": "C. Michelin",
+          "overall_score": 68,
+          "potential": 68,
+          "value": 1100000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lucas Sanseviero",
+          "name": "L. Sanseviero",
+          "overall_score": 66,
+          "potential": 69,
+          "value": 1200000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Álvaro De Pablo Casado",
+          "name": "Álvaro De Pablo",
+          "overall_score": 59,
+          "potential": 69,
+          "value": 450000,
+          "yearly_wage": 33800
+        },
+        {
+          "currency": "€",
+          "full_name": "Ángel Carvajal García",
+          "name": "Carvajal",
+          "overall_score": 63,
+          "potential": 72,
+          "value": 1100000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alejandro Galdeano Carrión",
+          "name": "Galde",
+          "overall_score": 59,
+          "potential": 73,
+          "value": 500000,
+          "yearly_wage": 44200
+        },
+        {
+          "currency": "€",
+          "full_name": "Álvaro Pérez Campo",
+          "name": "Trilli",
+          "overall_score": 66,
+          "potential": 73,
+          "value": 1600000,
+          "yearly_wage": 156000
+        }
+      ],
+      "team": "Real Valladolid CF",
+      "transfer_budget": 3500000,
+      "url": "https://sofifa.com/team/462/real-valladolid-cf/260037/"
+    },
+    {
+      "player_count": 34,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Luca Zidane",
+          "name": "L. Zidane",
+          "overall_score": 68,
+          "potential": 71,
+          "value": 1200000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Oscar Naasei",
+          "name": "O. Naasei",
+          "overall_score": 69,
+          "potential": 82,
+          "value": 3200000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Manuel Lama Maroto",
+          "name": "Manu Lama",
+          "overall_score": 71,
+          "potential": 77,
+          "value": 2700000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Loïc Williams Ntambue",
+          "name": "Loïc Williams",
+          "overall_score": 69,
+          "potential": 78,
+          "value": 2900000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Baïla Diallo",
+          "name": "B. Diallo",
+          "overall_score": 69,
+          "potential": 75,
+          "value": 2100000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Pedro Alemañ Serna",
+          "name": "Alemañ",
+          "overall_score": 70,
+          "potential": 77,
+          "value": 3200000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Rubén Alcaraz Jiménez",
+          "name": "Rubén Alcaraz",
+          "overall_score": 72,
+          "potential": 72,
+          "value": 1100000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Sergio Ruiz Alonso",
+          "name": "Sergio Ruiz",
+          "overall_score": 69,
+          "potential": 69,
+          "value": 1200000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alejandro Sola López-Ocaña",
+          "name": "Álex Sola",
+          "overall_score": 72,
+          "potential": 72,
+          "value": 2600000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jorge Pascual Medina",
+          "name": "Jorge Pascual",
+          "overall_score": 68,
+          "potential": 76,
+          "value": 2700000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "José Manuel Arnáiz Díaz",
+          "name": "José Arnáiz",
+          "overall_score": 71,
+          "potential": 71,
+          "value": 1800000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Gonzalo Petit",
+          "name": "G. Petit",
+          "overall_score": 68,
+          "potential": 77,
+          "value": 2600000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "Babacar Diocou Ndiaye",
+          "name": "Baba",
+          "overall_score": 65,
+          "potential": 76,
+          "value": 1600000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Sergio Rodelas Pintor",
+          "name": "Rodelas",
+          "overall_score": 64,
+          "potential": 74,
+          "value": 1300000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mohamed Bouldini",
+          "name": "M. Bouldini",
+          "overall_score": 64,
+          "potential": 64,
+          "value": 575000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Samuel Cruz Cortés Cortés",
+          "name": "Samu Cortés",
+          "overall_score": 59,
+          "potential": 73,
+          "value": 525000,
+          "yearly_wage": 52000
+        },
+        {
+          "currency": "€",
+          "full_name": "Izan González Muñoz",
+          "name": "Izan González",
+          "overall_score": 70,
+          "potential": 83,
+          "value": 3800000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ander Astralaga Aranguren",
+          "name": "Astralaga",
+          "overall_score": 64,
+          "potential": 76,
+          "value": 1300000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Bambo Diaby",
+          "name": "B. Diaby",
+          "overall_score": 67,
+          "potential": 69,
+          "value": 1100000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "Pablo Sáenz Ezquerra",
+          "name": "Pablo Sáenz",
+          "overall_score": 68,
+          "potential": 71,
+          "value": 1600000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Pau Casadesús Castro",
+          "name": "Casadesús",
+          "overall_score": 63,
+          "potential": 69,
+          "value": 725000,
+          "yearly_wage": 52000
+        },
+        {
+          "currency": "€",
+          "full_name": "Diego Hormigo Iturralde",
+          "name": "Hormigo",
+          "overall_score": 63,
+          "potential": 72,
+          "value": 1000000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Manuel Trigueros Muñoz",
+          "name": "Manu Trigueros",
+          "overall_score": 67,
+          "potential": 67,
+          "value": 625000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Luka Gagnidze",
+          "name": "L. Gagnidze",
+          "overall_score": 63,
+          "potential": 72,
+          "value": 1100000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Dominique Moubeke",
+          "name": "D. Moubeke",
+          "overall_score": 58,
+          "potential": 71,
+          "value": 475000,
+          "yearly_wage": 49400
+        },
+        {
+          "currency": "€",
+          "full_name": "Gael Joel Akogo Esono",
+          "name": "Gael Joel",
+          "overall_score": 58,
+          "potential": 67,
+          "value": 450000,
+          "yearly_wage": 52000
+        },
+        {
+          "currency": "€",
+          "full_name": "Seydou Fall Lázaro",
+          "name": "Seydou Fall",
+          "overall_score": 59,
+          "potential": 69,
+          "value": 450000,
+          "yearly_wage": 49400
+        },
+        {
+          "currency": "€",
+          "full_name": "Iker García Chico",
+          "name": "Iker García",
+          "overall_score": 60,
+          "potential": 74,
+          "value": 500000,
+          "yearly_wage": 26000
+        },
+        {
+          "currency": "€",
+          "full_name": "Álvaro Lemos Collazo",
+          "name": "Álvaro Lemos",
+          "overall_score": 65,
+          "potential": 65,
+          "value": 500000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Juan José Flores Castro",
+          "name": "Juanjo Flores",
+          "overall_score": 61,
+          "potential": 74,
+          "value": 725000,
+          "yearly_wage": 52000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mario Jiménez Gambín",
+          "name": "Gambín",
+          "overall_score": 59,
+          "potential": 74,
+          "value": 525000,
+          "yearly_wage": 46800
+        },
+        {
+          "currency": "€",
+          "full_name": "Rayan Zinebi Talbi",
+          "name": "Zinebi",
+          "overall_score": 58,
+          "potential": 73,
+          "value": 475000,
+          "yearly_wage": 52000
+        },
+        {
+          "currency": "€",
+          "full_name": "Juan Diego Molina Martínez",
+          "name": "Stoichkov",
+          "overall_score": 71,
+          "potential": 71,
+          "value": 1600000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Gerard Gumbau Garriga",
+          "name": "Gumbau",
+          "overall_score": 72,
+          "potential": 72,
+          "value": 2200000,
+          "yearly_wage": 364000
+        }
+      ],
+      "team": "Granada CF",
+      "transfer_budget": 7300000,
+      "url": "https://sofifa.com/team/110832/granada-cf/260037/"
+    },
+    {
+      "player_count": 31,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Diego Mariño Villar",
+          "name": "Diego Mariño",
+          "overall_score": 67,
+          "potential": 67,
+          "value": 110000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Francisco Gámez López",
+          "name": "Fran Gámez",
+          "overall_score": 69,
+          "potential": 69,
+          "value": 725000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "José Sánchez Martínez",
+          "name": "Pepe Sánchez",
+          "overall_score": 68,
+          "potential": 73,
+          "value": 1600000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jesús Vallejo Lázaro",
+          "name": "Vallejo",
+          "overall_score": 71,
+          "potential": 72,
+          "value": 1800000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Carlos Neva Tey",
+          "name": "Carlos Neva",
+          "overall_score": 71,
+          "potential": 71,
+          "value": 1600000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jonathan Germán Gómez",
+          "name": "J. Gómez",
+          "overall_score": 65,
+          "potential": 75,
+          "value": 1500000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Agustín Medina Delgado",
+          "name": "Agus Medina",
+          "overall_score": 71,
+          "potential": 71,
+          "value": 1800000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Antonio Pacheco Ruiz",
+          "name": "Pacheco",
+          "overall_score": 64,
+          "potential": 71,
+          "value": 1200000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alejandro Meléndez Ruiz",
+          "name": "Meléndez",
+          "overall_score": 65,
+          "potential": 66,
+          "value": 825000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "José Carlos Lazo Romero",
+          "name": "Lazo",
+          "overall_score": 68,
+          "potential": 68,
+          "value": 1200000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jefté Betancor Sánchez",
+          "name": "Jefté",
+          "overall_score": 70,
+          "potential": 70,
+          "value": 1300000,
+          "yearly_wage": 988000
+        },
+        {
+          "currency": "€",
+          "full_name": "Higinio Marín Escavy",
+          "name": "Higinio",
+          "overall_score": 67,
+          "potential": 67,
+          "value": 850000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Samuel Obeng",
+          "name": "S. Obeng",
+          "overall_score": 67,
+          "potential": 67,
+          "value": 1000000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Martín Fernández",
+          "name": "M. Fernández",
+          "overall_score": 69,
+          "potential": 76,
+          "value": 2600000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Edward Cedeño",
+          "name": "E. Cedeño",
+          "overall_score": 66,
+          "potential": 77,
+          "value": 1900000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Javier Villar del Fraile",
+          "name": "Javi Villar",
+          "overall_score": 65,
+          "potential": 74,
+          "value": 1600000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lluís López Mármol",
+          "name": "Lluís López",
+          "overall_score": 68,
+          "potential": 69,
+          "value": 1100000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Raúl Lizoain Cruz",
+          "name": "Raúl Lizoain",
+          "overall_score": 69,
+          "potential": 69,
+          "value": 240000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Javier Moreno Arrones Gil",
+          "name": "Javi Moreno",
+          "overall_score": 64,
+          "potential": 69,
+          "value": 775000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Víctor Valverde da Silva",
+          "name": "Víctor Valverde",
+          "overall_score": 65,
+          "potential": 71,
+          "value": 1100000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Antonio José Rodríguez Díaz",
+          "name": "Puertas",
+          "overall_score": 72,
+          "potential": 72,
+          "value": 1500000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mario Ramos Fernández",
+          "name": "Mario Ramos",
+          "overall_score": 59,
+          "potential": 72,
+          "value": 475000,
+          "yearly_wage": 26000
+        },
+        {
+          "currency": "€",
+          "full_name": "Daniel Bernabéu García",
+          "name": "Dani Bernabéu",
+          "overall_score": 61,
+          "potential": 75,
+          "value": 725000,
+          "yearly_wage": 52000
+        },
+        {
+          "currency": "€",
+          "full_name": "Joaquín Domingo Ponce",
+          "name": "Jota",
+          "overall_score": 59,
+          "potential": 71,
+          "value": 500000,
+          "yearly_wage": 52000
+        },
+        {
+          "currency": "€",
+          "full_name": "Hugo Martínez González",
+          "name": "Capi",
+          "overall_score": 61,
+          "potential": 74,
+          "value": 725000,
+          "yearly_wage": 52000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lorenzo Aguado Herrera",
+          "name": "Lorenzo",
+          "overall_score": 65,
+          "potential": 74,
+          "value": 1500000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alberto Morientes Palencia",
+          "name": "Morientes",
+          "overall_score": 58,
+          "potential": 72,
+          "value": 475000,
+          "yearly_wage": 52000
+        },
+        {
+          "currency": "€",
+          "full_name": "Álex Rubio",
+          "name": "Álex Rubio",
+          "overall_score": 65,
+          "potential": 74,
+          "value": 1600000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Víctor San Bartolomé",
+          "name": "San Bartolomé",
+          "overall_score": 65,
+          "potential": 68,
+          "value": 950000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Antonio Velilla Miró",
+          "name": "Antonio Velilla",
+          "overall_score": 54,
+          "potential": 72,
+          "value": 250000,
+          "yearly_wage": 28600
+        },
+        {
+          "currency": "€",
+          "full_name": "Fabio García Moreno Rodríguez",
+          "name": "Fabio García",
+          "overall_score": 59,
+          "potential": 75,
+          "value": 575000,
+          "yearly_wage": 46800
+        }
+      ],
+      "team": "Albacete Balompié",
+      "transfer_budget": 1500000,
+      "url": "https://sofifa.com/team/1854/albacete-balompie/260037/"
+    },
+    {
+      "player_count": 33,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Víctor Wehbi Aznar Ussen",
+          "name": "Víctor Aznar",
+          "overall_score": 70,
+          "potential": 77,
+          "value": 2800000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Isaac Carcelén Valencia",
+          "name": "Iza Carcelén",
+          "overall_score": 68,
+          "potential": 68,
+          "value": 825000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Bojan Kovačević",
+          "name": "B. Kovačević",
+          "overall_score": 67,
+          "potential": 77,
+          "value": 2100000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Iker Recio Ortega",
+          "name": "Iker Recio",
+          "overall_score": 68,
+          "potential": 75,
+          "value": 2200000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mario Climent Plá",
+          "name": "Climent",
+          "overall_score": 68,
+          "potential": 75,
+          "value": 2300000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jesús Joaquín Fernández Sáez",
+          "name": "Suso",
+          "overall_score": 71,
+          "potential": 71,
+          "value": 1600000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "Sergio Ortuño Díaz",
+          "name": "Sergio Ortuño",
+          "overall_score": 68,
+          "potential": 69,
+          "value": 1400000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Moussa Diakité",
+          "name": "M. Diakité",
+          "overall_score": 68,
+          "potential": 78,
+          "value": 2600000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Javier Ontiveros Parra",
+          "name": "Ontiveros",
+          "overall_score": 68,
+          "potential": 68,
+          "value": 1300000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Roger Martí Salvador",
+          "name": "Roger Martí",
+          "overall_score": 66,
+          "potential": 66,
+          "value": 425000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Álvaro Miguel García Pascual",
+          "name": "Á. García Pascual",
+          "overall_score": 68,
+          "potential": 75,
+          "value": 2500000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Brian Ocampo",
+          "name": "B. Ocampo",
+          "overall_score": 69,
+          "potential": 70,
+          "value": 1600000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Dawda Camara",
+          "name": "D. Camara",
+          "overall_score": 68,
+          "potential": 74,
+          "value": 2000000,
+          "yearly_wage": 676000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jerónimo Domina",
+          "name": "J. Domina",
+          "overall_score": 67,
+          "potential": 76,
+          "value": 2200000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "José Antonio de la Rosa Garrido",
+          "name": "De la Rosa",
+          "overall_score": 66,
+          "potential": 72,
+          "value": 1300000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alejandro Fernández Iglesias",
+          "name": "Álex Fernández",
+          "overall_score": 67,
+          "potential": 67,
+          "value": 800000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jorge Moreno San Vidal",
+          "name": "Jorge More",
+          "overall_score": 67,
+          "potential": 73,
+          "value": 1500000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "David Gil Mohedano",
+          "name": "David Gil",
+          "overall_score": 68,
+          "potential": 68,
+          "value": 650000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Iuri Tabatadze",
+          "name": "I. Tabatadze",
+          "overall_score": 70,
+          "potential": 71,
+          "value": 1900000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Youssouf Diarra",
+          "name": "Y. Diarra",
+          "overall_score": 67,
+          "potential": 68,
+          "value": 1200000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lucas Pérez Martínez",
+          "name": "Lucas Pérez",
+          "overall_score": 72,
+          "potential": 72,
+          "value": 800000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Pelayo Fernández Balboa",
+          "name": "Pelayo",
+          "overall_score": 64,
+          "potential": 71,
+          "value": 1100000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alfred Caicedo",
+          "name": "A. Caicedo",
+          "overall_score": 63,
+          "potential": 71,
+          "value": 1000000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Raúl Pereira Vargas",
+          "name": "Raúl Pereira",
+          "overall_score": 64,
+          "potential": 71,
+          "value": 1100000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Sergio Arribas Prieto",
+          "name": "Sergio Arribas",
+          "overall_score": 66,
+          "potential": 72,
+          "value": 1200000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Antonio José Cordero Campillo",
+          "name": "Antoñito Cordero",
+          "overall_score": 67,
+          "potential": 77,
+          "value": 2100000,
+          "yearly_wage": 1352000
+        },
+        {
+          "currency": "€",
+          "full_name": "Fernando Pérez Morillo",
+          "name": "Fer Pérez",
+          "overall_score": 59,
+          "potential": 65,
+          "value": 300000,
+          "yearly_wage": 28600
+        },
+        {
+          "currency": "€",
+          "full_name": "Juan Díaz Peregrina",
+          "name": "Juan Díaz",
+          "overall_score": 63,
+          "potential": 76,
+          "value": 1100000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Rominigue Kouamé",
+          "name": "R. Kouamé",
+          "overall_score": 68,
+          "potential": 68,
+          "value": 1200000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Joaquin Felipe González Rodríguez",
+          "name": "Joaquín González",
+          "overall_score": 64,
+          "potential": 69,
+          "value": 800000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Pablo Arana Gómez",
+          "name": "Pablo Arana",
+          "overall_score": 57,
+          "potential": 70,
+          "value": 400000,
+          "yearly_wage": 52000
+        },
+        {
+          "currency": "€",
+          "full_name": "Víctor Chust García",
+          "name": "Víctor Chust",
+          "overall_score": 73,
+          "potential": 78,
+          "value": 4000000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "Efe Aghama",
+          "name": "E. Aghama",
+          "overall_score": 64,
+          "potential": 78,
+          "value": 1400000,
+          "yearly_wage": 104000
+        }
+      ],
+      "team": "Cádiz CF",
+      "transfer_budget": 2200000,
+      "url": "https://sofifa.com/team/1968/cadiz-cf/260037/"
+    },
+    {
+      "player_count": 30,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Edgar Badia Guardiola",
+          "name": "Edgar Badia",
+          "overall_score": 73,
+          "potential": 73,
+          "value": 1000000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Iván Calero Ruiz",
+          "name": "Iván Calero",
+          "overall_score": 67,
+          "potential": 67,
+          "value": 875000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Matia Barzić Gutiérrez",
+          "name": "Matia Barzić",
+          "overall_score": 67,
+          "potential": 80,
+          "value": 2400000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Rodrigo Suárez Marcos",
+          "name": "Rodri Suárez",
+          "overall_score": 67,
+          "potential": 74,
+          "value": 1900000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Roger Hinojo Estrada",
+          "name": "Roger Hinojo",
+          "overall_score": 67,
+          "potential": 78,
+          "value": 2100000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Thiago Ojeda",
+          "name": "T. Ojeda",
+          "overall_score": 67,
+          "potential": 76,
+          "value": 2200000,
+          "yearly_wage": 624000
+        },
+        {
+          "currency": "€",
+          "full_name": "Sergio Maestre García",
+          "name": "Sergi Maestre",
+          "overall_score": 62,
+          "potential": 62,
+          "value": 140000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Rubén Sobrino Pozuelo",
+          "name": "Rubén Sobrino",
+          "overall_score": 69,
+          "potential": 69,
+          "value": 875000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Rafael Tresaco Blasco",
+          "name": "Tresaco",
+          "overall_score": 67,
+          "potential": 70,
+          "value": 1400000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Luis Rodríguez Chacón",
+          "name": "Chacón",
+          "overall_score": 70,
+          "potential": 73,
+          "value": 2100000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Manuel Justo Román",
+          "name": "Manu Justo",
+          "overall_score": 67,
+          "potential": 67,
+          "value": 1000000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Víctor Moreno Alcalá",
+          "name": "Víctor Moreno",
+          "overall_score": 66,
+          "potential": 78,
+          "value": 2000000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "Javier Fernández Abruñedo",
+          "name": "Bicho",
+          "overall_score": 66,
+          "potential": 66,
+          "value": 825000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mamadou Selu Diallo Diallo",
+          "name": "Selu Diallo",
+          "overall_score": 64,
+          "potential": 73,
+          "value": 1300000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Álvaro Díez Ruiz",
+          "name": "Álvaro Choco",
+          "overall_score": 57,
+          "potential": 67,
+          "value": 350000,
+          "yearly_wage": 52000
+        },
+        {
+          "currency": "€",
+          "full_name": "Eneko Satrústegui Plano",
+          "name": "Satrústegui",
+          "overall_score": 64,
+          "potential": 64,
+          "value": 210000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Víctor García",
+          "name": "V. García",
+          "overall_score": 64,
+          "potential": 64,
+          "value": 425000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Miguel Bañuz Antón",
+          "name": "Miguel Bañuz",
+          "overall_score": 64,
+          "potential": 64,
+          "value": 300000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Enrique Fornos Domínguez",
+          "name": "Quique Fornos",
+          "overall_score": 64,
+          "potential": 64,
+          "value": 500000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lucas Ribeiro Costa",
+          "name": "Lucas Ribeiro",
+          "overall_score": 70,
+          "potential": 70,
+          "value": 1700000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Arnau Rafús Aulet",
+          "name": "Rafús",
+          "overall_score": 61,
+          "potential": 68,
+          "value": 575000,
+          "yearly_wage": 44200
+        },
+        {
+          "currency": "€",
+          "full_name": "Pelayo González Rey",
+          "name": "Yayo",
+          "overall_score": 63,
+          "potential": 71,
+          "value": 1000000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Diego Collado Raya",
+          "name": "Collado",
+          "overall_score": 66,
+          "potential": 71,
+          "value": 1300000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Tomás Aresta Machado Ribeiro",
+          "name": "Tomás Ribeiro",
+          "overall_score": 67,
+          "potential": 70,
+          "value": 1200000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Nicolás Toca Diego",
+          "name": "Nico Toca",
+          "overall_score": 60,
+          "potential": 68,
+          "value": 525000,
+          "yearly_wage": 52000
+        },
+        {
+          "currency": "€",
+          "full_name": "Homam Al Amin",
+          "name": "H. Al Amin",
+          "overall_score": 67,
+          "potential": 70,
+          "value": 1200000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Juan Sánchez Collantes",
+          "name": "Juan Sánchez",
+          "overall_score": 58,
+          "potential": 64,
+          "value": 325000,
+          "yearly_wage": 52000
+        },
+        {
+          "currency": "€",
+          "full_name": "Peru Rodríguez Larrañaga",
+          "name": "Peru Rodríguez",
+          "overall_score": 64,
+          "potential": 73,
+          "value": 1200000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Nemanja Radoja",
+          "name": "N. Radoja",
+          "overall_score": 71,
+          "potential": 71,
+          "value": 1200000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alejandro Morante Simón",
+          "name": "Alejandro Morante",
+          "overall_score": 56,
+          "potential": 71,
+          "value": 350000,
+          "yearly_wage": 52000
+        }
+      ],
+      "team": "Cultural Leonesa",
+      "transfer_budget": 1600000,
+      "url": "https://sofifa.com/team/15012/cultural-leonesa/260037/"
+    },
+    {
+      "player_count": 30,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Daniel Jiménez López",
+          "name": "Dani Jiménez",
+          "overall_score": 73,
+          "potential": 73,
+          "value": 350000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "José Antonio Abad Martínez",
+          "name": "Toni Abad",
+          "overall_score": 65,
+          "potential": 65,
+          "value": 650000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jorge Pulido Mayoral",
+          "name": "Pulido",
+          "overall_score": 70,
+          "potential": 70,
+          "value": 525000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Álvaro Carrillo Alacid",
+          "name": "Álvaro Carrillo",
+          "overall_score": 66,
+          "potential": 73,
+          "value": 1600000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Julio Alonso Sosa",
+          "name": "Julio Alonso",
+          "overall_score": 65,
+          "potential": 66,
+          "value": 775000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Óscar Sielva Moreno",
+          "name": "Óscar Sielva",
+          "overall_score": 70,
+          "potential": 70,
+          "value": 975000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jesús Alvarez Aguado",
+          "name": "Jesús Alvarez",
+          "overall_score": 68,
+          "potential": 71,
+          "value": 1400000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Daniel Luna",
+          "name": "D. Luna",
+          "overall_score": 65,
+          "potential": 73,
+          "value": 1600000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "Liberto Luis Beltrán Martínez",
+          "name": "Liberto Beltrán",
+          "overall_score": 67,
+          "potential": 67,
+          "value": 1000000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Francisco Portillo Soler",
+          "name": "Portillo",
+          "overall_score": 67,
+          "potential": 67,
+          "value": 425000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Sergi Enrich Ametller",
+          "name": "Sergi Enrich",
+          "overall_score": 66,
+          "potential": 66,
+          "value": 375000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Enol Rodríguez Heres",
+          "name": "Enol Rodríguez",
+          "overall_score": 68,
+          "potential": 73,
+          "value": 1800000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Diego Aznar Valero",
+          "name": "Diego Aznar",
+          "overall_score": 63,
+          "potential": 72,
+          "value": 1100000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jorge Martín Camuñas",
+          "name": "Jordi Martín",
+          "overall_score": 67,
+          "potential": 70,
+          "value": 1400000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Javier Mier Martínez",
+          "name": "Javi Mier",
+          "overall_score": 65,
+          "potential": 66,
+          "value": 775000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Iñigo Sebastián Magaña",
+          "name": "Iñigo Piña",
+          "overall_score": 64,
+          "potential": 64,
+          "value": 475000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Rodrigo Abajas Martín",
+          "name": "Ro Abajas",
+          "overall_score": 63,
+          "potential": 71,
+          "value": 1000000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Juan Manuel Pérez Ruiz",
+          "name": "Juan Pérez",
+          "overall_score": 63,
+          "potential": 65,
+          "value": 400000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Nacho Laquintana",
+          "name": "N. Laquintana",
+          "overall_score": 69,
+          "potential": 69,
+          "value": 1500000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jaime Seoane Valenciano",
+          "name": "Jaime Seoane",
+          "overall_score": 70,
+          "potential": 70,
+          "value": 1600000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Joaquín Fernández Moreno",
+          "name": "Joaquín",
+          "overall_score": 68,
+          "potential": 68,
+          "value": 1000000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alejandro Cantero Sánchez",
+          "name": "Álex Cantero",
+          "overall_score": 65,
+          "potential": 66,
+          "value": 850000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Daniel Ojeda Saranova",
+          "name": "Dani Ojeda",
+          "overall_score": 66,
+          "potential": 66,
+          "value": 825000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Daniel Martín Rodríguez",
+          "name": "Dani Martín",
+          "overall_score": 62,
+          "potential": 79,
+          "value": 900000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Efe Aghama",
+          "name": "E. Aghama",
+          "overall_score": 64,
+          "potential": 78,
+          "value": 1400000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jordi Escobar Fernández",
+          "name": "Jordi Escobar",
+          "overall_score": 67,
+          "potential": 73,
+          "value": 1600000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Michael Agbekpornu",
+          "name": "M. Agbekpornu",
+          "overall_score": 65,
+          "potential": 68,
+          "value": 850000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Marc Aznar Baides",
+          "name": "Marc Aznar",
+          "overall_score": 58,
+          "potential": 68,
+          "value": 400000,
+          "yearly_wage": 52000
+        },
+        {
+          "currency": "€",
+          "full_name": "Pablo Osán Ascaso",
+          "name": "Pablo Osán",
+          "overall_score": 58,
+          "potential": 72,
+          "value": 475000,
+          "yearly_wage": 52000
+        },
+        {
+          "currency": "€",
+          "full_name": "Samuel Ntamack",
+          "name": "S. Ntamack",
+          "overall_score": 65,
+          "potential": 70,
+          "value": 1100000,
+          "yearly_wage": 156000
+        }
+      ],
+      "team": "SD Huesca",
+      "transfer_budget": 2100000,
+      "url": "https://sofifa.com/team/110839/sd-huesca/260037/"
+    },
+    {
+      "player_count": 36,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Igor Nikic",
+          "name": "I. Nikic",
+          "overall_score": 70,
+          "potential": 76,
+          "value": 2000000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Hugo Novoa Ramos",
+          "name": "Hugo Novoa",
+          "overall_score": 66,
+          "potential": 73,
+          "value": 1700000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "Juan Gutiérrez Martínez",
+          "name": "Juan Gutiérrez",
+          "overall_score": 70,
+          "potential": 74,
+          "value": 2000000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Sergio Postigo Redondo",
+          "name": "Postigo",
+          "overall_score": 66,
+          "potential": 66,
+          "value": 150000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Iker Córdoba Sánchez",
+          "name": "Iker Córdoba",
+          "overall_score": 64,
+          "potential": 77,
+          "value": 1300000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Fernando Medrano Gastañaga",
+          "name": "Medrano",
+          "overall_score": 65,
+          "potential": 68,
+          "value": 875000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Selvi Clua Oya",
+          "name": "Selvi",
+          "overall_score": 65,
+          "potential": 77,
+          "value": 1600000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Thiago Helguera",
+          "name": "T. Helguera",
+          "overall_score": 66,
+          "potential": 77,
+          "value": 1800000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Rafel Bauzà Sureda",
+          "name": "Rafa Bauza",
+          "overall_score": 66,
+          "potential": 79,
+          "value": 1900000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Carlos Fernández Luna",
+          "name": "Carlos Fernández",
+          "overall_score": 71,
+          "potential": 71,
+          "value": 1900000,
+          "yearly_wage": 1300000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alberto Marí Sánchez",
+          "name": "Alberto Marí",
+          "overall_score": 64,
+          "potential": 68,
+          "value": 850000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "Javier Hernández Coarasa",
+          "name": "Javi Hernández",
+          "overall_score": 68,
+          "potential": 79,
+          "value": 2700000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "Salim El Jebari",
+          "name": "S. El Jebari",
+          "overall_score": 65,
+          "potential": 73,
+          "value": 1600000,
+          "yearly_wage": 572000
+        },
+        {
+          "currency": "€",
+          "full_name": "Adrián Hernández Hernández",
+          "name": "Pica",
+          "overall_score": 67,
+          "potential": 76,
+          "value": 2100000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "Martín Pascual Castillo",
+          "name": "Martín Pascual",
+          "overall_score": 67,
+          "potential": 72,
+          "value": 1300000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Hodei Alutiz Salgado",
+          "name": "Hodei",
+          "overall_score": 56,
+          "potential": 62,
+          "value": 210000,
+          "yearly_wage": 52000
+        },
+        {
+          "currency": "€",
+          "full_name": "Abdoulaye Maiga Koita",
+          "name": "Abdou Maiga",
+          "overall_score": 54,
+          "potential": 68,
+          "value": 230000,
+          "yearly_wage": 36400
+        },
+        {
+          "currency": "€",
+          "full_name": "Juan Palomares Pulpillo",
+          "name": "Juanpa",
+          "overall_score": 64,
+          "potential": 68,
+          "value": 675000,
+          "yearly_wage": 52000
+        },
+        {
+          "currency": "€",
+          "full_name": "Sergio Gabriel de la Vara",
+          "name": "Gabri",
+          "overall_score": 58,
+          "potential": 66,
+          "value": 450000,
+          "yearly_wage": 52000
+        },
+        {
+          "currency": "€",
+          "full_name": "Aarón Martín Luis",
+          "name": "Aarón Martín",
+          "overall_score": 65,
+          "potential": 76,
+          "value": 1500000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Hugo Zárate Calzada",
+          "name": "Zárate",
+          "overall_score": 58,
+          "potential": 66,
+          "value": 450000,
+          "yearly_wage": 52000
+        },
+        {
+          "currency": "€",
+          "full_name": "Pablo Pérez Rico",
+          "name": "Pablo Pérez",
+          "overall_score": 64,
+          "potential": 71,
+          "value": 1100000,
+          "yearly_wage": 572000
+        },
+        {
+          "currency": "€",
+          "full_name": "Marcos Gracia Arriola",
+          "name": "Arriola",
+          "overall_score": 57,
+          "potential": 64,
+          "value": 325000,
+          "yearly_wage": 52000
+        },
+        {
+          "currency": "€",
+          "full_name": "Eduard Coniac Covalciuc",
+          "name": "Edu Coniac",
+          "overall_score": 54,
+          "potential": 64,
+          "value": 220000,
+          "yearly_wage": 39000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alejandro González Gorrín",
+          "name": "Ale Gorrín",
+          "overall_score": 57,
+          "potential": 63,
+          "value": 210000,
+          "yearly_wage": 36400
+        },
+        {
+          "currency": "€",
+          "full_name": "Nikola Maraš",
+          "name": "N. Maraš",
+          "overall_score": 68,
+          "potential": 68,
+          "value": 1000000,
+          "yearly_wage": 676000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ali Houary Jeddoub",
+          "name": "Ali Houary",
+          "overall_score": 65,
+          "potential": 80,
+          "value": 1700000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Toni Tamarit Tamarit",
+          "name": "Toni Tamarit",
+          "overall_score": 62,
+          "potential": 77,
+          "value": 900000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Iker Varela Parra",
+          "name": "Iker Varela",
+          "overall_score": 63,
+          "potential": 72,
+          "value": 1100000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "Pablo López Gómez",
+          "name": "Pablo López",
+          "overall_score": 63,
+          "potential": 81,
+          "value": 1200000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jorge Cabello Trujillo",
+          "name": "Cabello",
+          "overall_score": 66,
+          "potential": 77,
+          "value": 1800000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mickaël Malsa",
+          "name": "M. Malsa",
+          "overall_score": 67,
+          "potential": 67,
+          "value": 875000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Siren Diao Balde",
+          "name": "Siren Diao",
+          "overall_score": 63,
+          "potential": 77,
+          "value": 1200000,
+          "yearly_wage": 520000
+        },
+        {
+          "currency": "€",
+          "full_name": "Diego Sia",
+          "name": "D. Sia",
+          "overall_score": 59,
+          "potential": 74,
+          "value": 525000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Unax del Cura Urra",
+          "name": "Unax del Cura",
+          "overall_score": 61,
+          "potential": 73,
+          "value": 800000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Julen Martínez Landa",
+          "name": "Julen Martínez",
+          "overall_score": 55,
+          "potential": 63,
+          "value": 275000,
+          "yearly_wage": 49400
+        }
+      ],
+      "team": "CD Mirandés",
+      "transfer_budget": 1500000,
+      "url": "https://sofifa.com/team/110069/cd-mirandes/260037/"
+    },
+    {
+      "player_count": 31,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Guillermo Vallejo Delgado",
+          "name": "Guille Vallejo",
+          "overall_score": 68,
+          "potential": 68,
+          "value": 800000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Anuar Mohamed Tuhami",
+          "name": "Anuar",
+          "overall_score": 69,
+          "potential": 69,
+          "value": 1200000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Carlos Hernández Alarcón",
+          "name": "Carlos Hernández",
+          "overall_score": 66,
+          "potential": 66,
+          "value": 275000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Diego González Cabanes",
+          "name": "Diego González",
+          "overall_score": 67,
+          "potential": 70,
+          "value": 1200000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "José Joaquín Matos García",
+          "name": "José Matos",
+          "overall_score": 69,
+          "potential": 69,
+          "value": 1200000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Rubén Díez Adán",
+          "name": "Rubén Díez",
+          "overall_score": 66,
+          "potential": 66,
+          "value": 700000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Youness Lachhab",
+          "name": "Y. Lachhab",
+          "overall_score": 67,
+          "potential": 70,
+          "value": 1200000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "José Luis Zalazar Martinez",
+          "name": "Kuki Zalazar",
+          "overall_score": 67,
+          "potential": 67,
+          "value": 1100000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Aisar Ahmed Ahmed",
+          "name": "Aisar",
+          "overall_score": 68,
+          "potential": 74,
+          "value": 1900000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Marcos Fernández Sánchez",
+          "name": "Marcos Fernández",
+          "overall_score": 68,
+          "potential": 77,
+          "value": 2700000,
+          "yearly_wage": 520000
+        },
+        {
+          "currency": "€",
+          "full_name": "Kialy Abdoul Koné",
+          "name": "K. Koné",
+          "overall_score": 66,
+          "potential": 66,
+          "value": 850000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "José Gómez Campaña",
+          "name": "Campaña",
+          "overall_score": 71,
+          "potential": 71,
+          "value": 1200000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Salvador Sánchez Ponce",
+          "name": "Salvi Sánchez",
+          "overall_score": 68,
+          "potential": 68,
+          "value": 575000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Cristian Rodríguez Pérez",
+          "name": "Cristian",
+          "overall_score": 66,
+          "potential": 66,
+          "value": 825000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Aboubacar Bassinga",
+          "name": "A. Bassinga",
+          "overall_score": 64,
+          "potential": 80,
+          "value": 1500000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Gonzalo Almenara Hernández",
+          "name": "Almenara",
+          "overall_score": 64,
+          "potential": 64,
+          "value": 525000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Manuel Sánchez García",
+          "name": "Manu Sánchez",
+          "overall_score": 64,
+          "potential": 64,
+          "value": 525000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Pedro López Galisteo",
+          "name": "Pedro López",
+          "overall_score": 67,
+          "potential": 67,
+          "value": 675000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Marc Domènech González",
+          "name": "Marc Domènech",
+          "overall_score": 64,
+          "potential": 81,
+          "value": 1500000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Marino Illescas Montaño",
+          "name": "Marino Illescas",
+          "overall_score": 67,
+          "potential": 72,
+          "value": 1500000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Yann Bodiger",
+          "name": "Y. Bodiger",
+          "overall_score": 68,
+          "potential": 68,
+          "value": 1000000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Carlos Redruello Nimo",
+          "name": "Redru",
+          "overall_score": 65,
+          "potential": 65,
+          "value": 650000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Sergio Gonzalez Gonzalez",
+          "name": "Yeyo",
+          "overall_score": 59,
+          "potential": 69,
+          "value": 475000,
+          "yearly_wage": 46800
+        },
+        {
+          "currency": "€",
+          "full_name": "Yago Cantero Pérez",
+          "name": "Yago Cantero",
+          "overall_score": 64,
+          "potential": 68,
+          "value": 725000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Konrad de la Fuente",
+          "name": "K. de la Fuente",
+          "overall_score": 66,
+          "potential": 72,
+          "value": 1400000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Albert Caparrós Guzmán",
+          "name": "Albert Caparrós",
+          "overall_score": 63,
+          "potential": 66,
+          "value": 550000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ignacio Schor",
+          "name": "I. Schor",
+          "overall_score": 69,
+          "potential": 70,
+          "value": 1700000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Pedro García Franco",
+          "name": "Pery",
+          "overall_score": 60,
+          "potential": 70,
+          "value": 475000,
+          "yearly_wage": 28600
+        },
+        {
+          "currency": "€",
+          "full_name": "José Manuel López Pérez",
+          "name": "Josema",
+          "overall_score": 60,
+          "potential": 66,
+          "value": 400000,
+          "yearly_wage": 52000
+        },
+        {
+          "currency": "€",
+          "full_name": "Arick Alejandro Betancourt Pérez",
+          "name": "Arick Betancourt",
+          "overall_score": 60,
+          "potential": 69,
+          "value": 550000,
+          "yearly_wage": 46800
+        },
+        {
+          "currency": "€",
+          "full_name": "Adrián Rueda Colunga",
+          "name": "Adri Rueda",
+          "overall_score": 60,
+          "potential": 75,
+          "value": 600000,
+          "yearly_wage": 49400
+        }
+      ],
+      "team": "AD Ceuta FC",
+      "transfer_budget": 1100000,
+      "url": "https://sofifa.com/team/1894/ad-ceuta-fc/260037/"
+    },
+    {
+      "player_count": 27,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Áron Yaakobishvili",
+          "name": "Á. Yaakobishvili",
+          "overall_score": 70,
+          "potential": 82,
+          "value": 3300000,
+          "yearly_wage": 624000
+        },
+        {
+          "currency": "€",
+          "full_name": "Thomas Carrique",
+          "name": "T. Carrique",
+          "overall_score": 66,
+          "potential": 67,
+          "value": 925000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Marc Bombardó Poyato",
+          "name": "Bomba",
+          "overall_score": 65,
+          "potential": 78,
+          "value": 1600000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Gael Alonso Moreno",
+          "name": "Gael Alonso",
+          "overall_score": 66,
+          "potential": 74,
+          "value": 1800000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Imanol García de Albéniz",
+          "name": "Imanol",
+          "overall_score": 70,
+          "potential": 73,
+          "value": 1900000,
+          "yearly_wage": 676000
+        },
+        {
+          "currency": "€",
+          "full_name": "Sergio Molina Beloqui",
+          "name": "Sergio Molina",
+          "overall_score": 66,
+          "potential": 66,
+          "value": 825000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Álvaro Martín de Frías",
+          "name": "Álvaro Martín",
+          "overall_score": 63,
+          "potential": 68,
+          "value": 725000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Daniel Villahermosa",
+          "name": "Villahermosa",
+          "overall_score": 67,
+          "potential": 70,
+          "value": 1400000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Yeray Cabanzón de Arriba",
+          "name": "Yeray",
+          "overall_score": 66,
+          "potential": 75,
+          "value": 1900000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lautaro de León Billar",
+          "name": "Lautaro",
+          "overall_score": 67,
+          "potential": 72,
+          "value": 1600000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Min Su Kim",
+          "name": "Kim Min Su",
+          "overall_score": 70,
+          "potential": 82,
+          "value": 3800000,
+          "yearly_wage": 676000
+        },
+        {
+          "currency": "€",
+          "full_name": "Manuel Nieto Sánchez",
+          "name": "Manu Nieto",
+          "overall_score": 67,
+          "potential": 67,
+          "value": 1100000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Aingeru Olabarrieta Capelo",
+          "name": "Olabarrieta",
+          "overall_score": 67,
+          "potential": 81,
+          "value": 2400000,
+          "yearly_wage": 572000
+        },
+        {
+          "currency": "€",
+          "full_name": "Antonino Jastin García López",
+          "name": "Jastin",
+          "overall_score": 68,
+          "potential": 80,
+          "value": 3000000,
+          "yearly_wage": 520000
+        },
+        {
+          "currency": "€",
+          "full_name": "Marc Doménech Costa",
+          "name": "Marc Doménech",
+          "overall_score": 64,
+          "potential": 71,
+          "value": 1200000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Edgar González Estrada",
+          "name": "Edgar",
+          "overall_score": 71,
+          "potential": 72,
+          "value": 1800000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Martí Vilà García",
+          "name": "Martí Vilà",
+          "overall_score": 66,
+          "potential": 67,
+          "value": 925000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jesús Lázaro Owono Ngua Akeng",
+          "name": "Owono",
+          "overall_score": 67,
+          "potential": 73,
+          "value": 1300000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Álexander Petxarroman",
+          "name": "Álex Petxa",
+          "overall_score": 66,
+          "potential": 66,
+          "value": 775000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Diego Alende López",
+          "name": "Diego Alende",
+          "overall_score": 66,
+          "potential": 68,
+          "value": 900000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Marc Cardona Rovira",
+          "name": "Marc Cardona",
+          "overall_score": 67,
+          "potential": 67,
+          "value": 1000000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alejandro Calvo Mata",
+          "name": "Álex Calvo",
+          "overall_score": 66,
+          "potential": 72,
+          "value": 1400000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Théo Le Normand",
+          "name": "T. Le Normand",
+          "overall_score": 63,
+          "potential": 66,
+          "value": 650000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Efe Akman",
+          "name": "E. Akman",
+          "overall_score": 64,
+          "potential": 78,
+          "value": 1400000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Nicolás Ratti",
+          "name": "N. Ratti",
+          "overall_score": 68,
+          "potential": 68,
+          "value": 650000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Josep Cerdà Amengual",
+          "name": "Josep Cerdà",
+          "overall_score": 66,
+          "potential": 73,
+          "value": 1700000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Víctor Chumachenko",
+          "name": "V. Chumachenko",
+          "overall_score": 58,
+          "potential": 69,
+          "value": 450000,
+          "yearly_wage": 52000
+        }
+      ],
+      "team": "FC Andorra",
+      "transfer_budget": 1500000,
+      "url": "https://sofifa.com/team/114554/fc-andorra/260037/"
+    },
+    {
+      "player_count": 32,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Aitor Fraga Torres",
+          "name": "Fraga",
+          "overall_score": 66,
+          "potential": 76,
+          "value": 1700000,
+          "yearly_wage": 52000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alberto Dadie Izagirre",
+          "name": "Dadie",
+          "overall_score": 65,
+          "potential": 70,
+          "value": 1000000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Kazunari Kita",
+          "name": "K. Kita",
+          "overall_score": 64,
+          "potential": 79,
+          "value": 1300000,
+          "yearly_wage": 52000
+        },
+        {
+          "currency": "€",
+          "full_name": "Luken Beitia",
+          "name": "Luken Beitia",
+          "overall_score": 67,
+          "potential": 81,
+          "value": 2400000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jon Balda Zubiri",
+          "name": "Jon Balda",
+          "overall_score": 64,
+          "potential": 71,
+          "value": 1100000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Tomás Carbonell del Rio",
+          "name": "Tomy Carbonell",
+          "overall_score": 63,
+          "potential": 77,
+          "value": 1200000,
+          "yearly_wage": 52000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mikel Rodríguez Ulacia",
+          "name": "Mikel Rodríguez",
+          "overall_score": 66,
+          "potential": 73,
+          "value": 1700000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lander Astiazarán Escabias",
+          "name": "Astiazarán",
+          "overall_score": 63,
+          "potential": 79,
+          "value": 1200000,
+          "yearly_wage": 52000
+        },
+        {
+          "currency": "€",
+          "full_name": "Job Nguono Ochieng",
+          "name": "J. Nguono Ochieng",
+          "overall_score": 66,
+          "potential": 73,
+          "value": 1700000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Gorka Gorosabel Añorga",
+          "name": "Gorka Gorosabel",
+          "overall_score": 63,
+          "potential": 79,
+          "value": 1200000,
+          "yearly_wage": 52000
+        },
+        {
+          "currency": "€",
+          "full_name": "Gorka Carrera Zarranz",
+          "name": "Gorka Carrera",
+          "overall_score": 65,
+          "potential": 75,
+          "value": 1600000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jakes Gorosabel Añorga",
+          "name": "Jakes Gorosabel",
+          "overall_score": 63,
+          "potential": 73,
+          "value": 1100000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alex Marchal García",
+          "name": "Alex Marchal",
+          "overall_score": 62,
+          "potential": 82,
+          "value": 1100000,
+          "yearly_wage": 52000
+        },
+        {
+          "currency": "€",
+          "full_name": "Darío Ramírez Ramírez",
+          "name": "Darío Ramírez",
+          "overall_score": 61,
+          "potential": 70,
+          "value": 725000,
+          "yearly_wage": 52000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ekain Orobengoa Arbelaiz",
+          "name": "Orobengoa",
+          "overall_score": 61,
+          "potential": 69,
+          "value": 750000,
+          "yearly_wage": 52000
+        },
+        {
+          "currency": "€",
+          "full_name": "Unax Agote Aranburu",
+          "name": "Unax Agote",
+          "overall_score": 61,
+          "potential": 68,
+          "value": 625000,
+          "yearly_wage": 52000
+        },
+        {
+          "currency": "€",
+          "full_name": "Eneko Astigarraga Alkorta",
+          "name": "Astigarraga",
+          "overall_score": 60,
+          "potential": 73,
+          "value": 575000,
+          "yearly_wage": 46800
+        },
+        {
+          "currency": "€",
+          "full_name": "Egoitz Arana Aizpurua",
+          "name": "Arana",
+          "overall_score": 65,
+          "potential": 73,
+          "value": 1400000,
+          "yearly_wage": 52000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alex Lebarbier",
+          "name": "A. Lebarbier",
+          "overall_score": 62,
+          "potential": 74,
+          "value": 950000,
+          "yearly_wage": 52000
+        },
+        {
+          "currency": "€",
+          "full_name": "Daniel Díaz Gándara",
+          "name": "Dani Díaz",
+          "overall_score": 64,
+          "potential": 82,
+          "value": 1500000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Iñaki Rupérez Urtasun",
+          "name": "Rupérez",
+          "overall_score": 64,
+          "potential": 73,
+          "value": 1300000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Arkaitz Mariezkurrena",
+          "name": "Mariezkurrena",
+          "overall_score": 66,
+          "potential": 80,
+          "value": 2100000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ibai Aguirre Basurco",
+          "name": "Ibai Aguirre",
+          "overall_score": 61,
+          "potential": 74,
+          "value": 750000,
+          "yearly_wage": 52000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jon Eceizabarrena",
+          "name": "Jon Eceizabarrena",
+          "overall_score": 61,
+          "potential": 75,
+          "value": 775000,
+          "yearly_wage": 52000
+        },
+        {
+          "currency": "€",
+          "full_name": "Andrews Adjabeng",
+          "name": "A. Adjabeng",
+          "overall_score": 61,
+          "potential": 76,
+          "value": 775000,
+          "yearly_wage": 52000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jon Garro Larrarte",
+          "name": "Jon Garro",
+          "overall_score": 61,
+          "potential": 72,
+          "value": 675000,
+          "yearly_wage": 52000
+        },
+        {
+          "currency": "€",
+          "full_name": "Joan Oleaga Arregi",
+          "name": "Joan Oleaga",
+          "overall_score": 60,
+          "potential": 72,
+          "value": 575000,
+          "yearly_wage": 46800
+        },
+        {
+          "currency": "€",
+          "full_name": "Iker Calderon Balda",
+          "name": "Iker Calderon",
+          "overall_score": 61,
+          "potential": 76,
+          "value": 725000,
+          "yearly_wage": 52000
+        },
+        {
+          "currency": "€",
+          "full_name": "Unax Ayo Larrañaga",
+          "name": "Unax Ayo",
+          "overall_score": 60,
+          "potential": 77,
+          "value": 600000,
+          "yearly_wage": 41600
+        },
+        {
+          "currency": "€",
+          "full_name": "Theo Mickael Kevin Folgado",
+          "name": "Theo Folgado",
+          "overall_score": 59,
+          "potential": 73,
+          "value": 475000,
+          "yearly_wage": 26000
+        },
+        {
+          "currency": "€",
+          "full_name": "Pello Arana Mugueta",
+          "name": "Pello Arana",
+          "overall_score": 59,
+          "potential": 77,
+          "value": 550000,
+          "yearly_wage": 41600
+        },
+        {
+          "currency": "€",
+          "full_name": "Sydney Ehizogie Osazuwa Omoruyi",
+          "name": "Sydney Osazuwa",
+          "overall_score": 62,
+          "potential": 80,
+          "value": 1000000,
+          "yearly_wage": 52000
+        }
+      ],
+      "team": "Real Sociedad de Fútbol B",
+      "transfer_budget": 1500000,
+      "url": "https://sofifa.com/team/110711/real-sociedad-de-futbol-b/260037/"
+    }
+  ],
+  "total_players": 704
+}

--- a/data/2025/ESP2/teams.json
+++ b/data/2025/ESP2/teams.json
@@ -20,7 +20,11 @@
             "Spain"
           ],
           "number": "25",
-          "position": "Goalkeeper"
+          "overall_score": 72,
+          "position": "Goalkeeper",
+          "potential": 75,
+          "value": 2300000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2026",
@@ -34,7 +38,11 @@
             "Spain"
           ],
           "number": "1",
-          "position": "Goalkeeper"
+          "overall_score": 67,
+          "position": "Goalkeeper",
+          "potential": 67,
+          "value": 500000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2027",
@@ -48,7 +56,11 @@
             "Spain"
           ],
           "number": "13",
-          "position": "Goalkeeper"
+          "overall_score": 63,
+          "position": "Goalkeeper",
+          "potential": 70,
+          "value": 825000,
+          "yearly_wage": 49400
         },
         {
           "contract": "Jun 30, 2029",
@@ -63,7 +75,11 @@
             "Cameroon"
           ],
           "number": "4",
-          "position": "Centre-Back"
+          "overall_score": 69,
+          "position": "Centre-Back",
+          "potential": 80,
+          "value": 2900000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2028",
@@ -77,7 +93,11 @@
             "Spain"
           ],
           "number": "5",
-          "position": "Centre-Back"
+          "overall_score": 69,
+          "position": "Centre-Back",
+          "potential": 75,
+          "value": 2000000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2028",
@@ -91,7 +111,11 @@
             "Spain"
           ],
           "number": "3",
-          "position": "Centre-Back"
+          "overall_score": 68,
+          "position": "Centre-Back",
+          "potential": 72,
+          "value": 1500000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2028",
@@ -105,7 +129,11 @@
             "Italy"
           ],
           "number": "12",
-          "position": "Left-Back"
+          "overall_score": 72,
+          "position": "Left-Back",
+          "potential": 75,
+          "value": 2900000,
+          "yearly_wage": 312000
         },
         {
           "contract": "Jun 30, 2026",
@@ -119,7 +147,11 @@
             "Spain"
           ],
           "number": "18",
-          "position": "Left-Back"
+          "overall_score": 68,
+          "position": "Left-Back",
+          "potential": 68,
+          "value": 375000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2028",
@@ -133,7 +165,11 @@
             "Spain"
           ],
           "number": "2",
-          "position": "Right-Back"
+          "overall_score": 72,
+          "position": "Right-Back",
+          "potential": 77,
+          "value": 3300000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2028",
@@ -147,7 +183,11 @@
             "Spain"
           ],
           "number": "15",
-          "position": "Right-Back"
+          "overall_score": 72,
+          "position": "Right-Back",
+          "potential": 73,
+          "value": 2200000,
+          "yearly_wage": 312000
         },
         {
           "contract": "Jun 30, 2026",
@@ -161,7 +201,11 @@
             "Spain"
           ],
           "number": "23",
-          "position": "Right-Back"
+          "overall_score": 72,
+          "position": "Right-Back",
+          "potential": 72,
+          "value": 725000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2026",
@@ -175,7 +219,11 @@
             "Spain"
           ],
           "number": "16",
-          "position": "Central Midfield"
+          "overall_score": 71,
+          "position": "Central Midfield",
+          "potential": 74,
+          "value": 2200000,
+          "yearly_wage": 676000
         },
         {
           "contract": "Jun 30, 2029",
@@ -189,7 +237,11 @@
             "Spain"
           ],
           "number": "14",
-          "position": "Central Midfield"
+          "overall_score": 70,
+          "position": "Central Midfield",
+          "potential": 70,
+          "value": 1700000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2027",
@@ -203,7 +255,11 @@
             "Spain"
           ],
           "number": "8",
-          "position": "Central Midfield"
+          "overall_score": 72,
+          "position": "Central Midfield",
+          "potential": 72,
+          "value": 2300000,
+          "yearly_wage": 364000
         },
         {
           "contract": "Jun 30, 2028",
@@ -218,7 +274,11 @@
             "Spain"
           ],
           "number": "6",
-          "position": "Central Midfield"
+          "overall_score": 66,
+          "position": "Central Midfield",
+          "potential": 77,
+          "value": 1900000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2026",
@@ -232,7 +292,11 @@
             "Spain"
           ],
           "number": "20",
-          "position": "Central Midfield"
+          "overall_score": 69,
+          "position": "Central Midfield",
+          "potential": 69,
+          "value": 700000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2028",
@@ -246,7 +310,11 @@
             "Spain"
           ],
           "number": "21",
-          "position": "Attacking Midfield"
+          "overall_score": 74,
+          "position": "Attacking Midfield",
+          "potential": 80,
+          "value": 6500000,
+          "yearly_wage": 364000
         },
         {
           "contract": "Jun 30, 2030",
@@ -260,7 +328,11 @@
             "Spain"
           ],
           "number": "10",
-          "position": "Left Winger"
+          "overall_score": 76,
+          "position": "Left Winger",
+          "potential": 84,
+          "value": 17000000,
+          "yearly_wage": 416000
         },
         {
           "contract": "Jun 30, 2029",
@@ -274,7 +346,11 @@
             "Spain"
           ],
           "number": "11",
-          "position": "Right Winger"
+          "overall_score": 71,
+          "position": "Right Winger",
+          "potential": 82,
+          "value": 4100000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2029",
@@ -288,7 +364,11 @@
             "Spain"
           ],
           "number": "19",
-          "position": "Right Winger"
+          "overall_score": 73,
+          "position": "Right Winger",
+          "potential": 76,
+          "value": 4200000,
+          "yearly_wage": 312000
         },
         {
           "contract": "Jun 30, 2026",
@@ -302,7 +382,11 @@
             "Spain"
           ],
           "number": "22",
-          "position": "Second Striker"
+          "overall_score": 71,
+          "position": "Second Striker",
+          "potential": 71,
+          "value": 1600000,
+          "yearly_wage": 364000
         },
         {
           "contract": "Jun 30, 2026",
@@ -316,7 +400,11 @@
             "Italy"
           ],
           "number": "7",
-          "position": "Centre-Forward"
+          "overall_score": 71,
+          "position": "Centre-Forward",
+          "potential": 74,
+          "value": 2600000,
+          "yearly_wage": 676000
         },
         {
           "contract": "Jun 30, 2028",
@@ -331,7 +419,11 @@
             "Morocco"
           ],
           "number": "9",
-          "position": "Centre-Forward"
+          "overall_score": 70,
+          "position": "Centre-Forward",
+          "potential": 73,
+          "value": 2100000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2026",
@@ -345,7 +437,11 @@
             "Spain"
           ],
           "number": "17",
-          "position": "Centre-Forward"
+          "overall_score": 64,
+          "position": "Centre-Forward",
+          "potential": 64,
+          "value": 275000,
+          "yearly_wage": 104000
         }
       ],
       "stadiumName": "Abanca Riazor",
@@ -369,7 +465,11 @@
             "Bosnia-Herzegovina"
           ],
           "number": "1",
-          "position": "Goalkeeper"
+          "overall_score": 74,
+          "position": "Goalkeeper",
+          "potential": 78,
+          "value": 4500000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2026",
@@ -383,7 +483,11 @@
             "Spain"
           ],
           "number": "13",
-          "position": "Goalkeeper"
+          "overall_score": 70,
+          "position": "Goalkeeper",
+          "potential": 70,
+          "value": 850000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2029",
@@ -396,7 +500,11 @@
             "Spain"
           ],
           "number": "35",
-          "position": "Goalkeeper"
+          "overall_score": 61,
+          "position": "Goalkeeper",
+          "potential": 74,
+          "value": 700000,
+          "yearly_wage": 28600
         },
         {
           "contract": "Jun 30, 2026",
@@ -410,7 +518,11 @@
             "Spain"
           ],
           "number": "3",
-          "position": "Centre-Back"
+          "overall_score": 74,
+          "position": "Centre-Back",
+          "potential": 81,
+          "value": 8000000,
+          "yearly_wage": 312000
         },
         {
           "contract": "Jun 30, 2026",
@@ -424,7 +536,11 @@
             "Spain"
           ],
           "number": "6",
-          "position": "Centre-Back"
+          "overall_score": 73,
+          "position": "Centre-Back",
+          "potential": 79,
+          "value": 4400000,
+          "yearly_wage": 416000
         },
         {
           "contract": "Jun 30, 2028",
@@ -439,7 +555,11 @@
             "Germany"
           ],
           "number": "15",
-          "position": "Centre-Back"
+          "overall_score": 71,
+          "position": "Centre-Back",
+          "potential": 80,
+          "value": 3900000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2026",
@@ -453,7 +573,11 @@
             "Spain"
           ],
           "number": "5",
-          "position": "Centre-Back"
+          "overall_score": 72,
+          "position": "Centre-Back",
+          "potential": 73,
+          "value": 2500000,
+          "yearly_wage": 312000
         },
         {
           "contract": "Jun 30, 2028",
@@ -467,7 +591,11 @@
             "Spain"
           ],
           "number": "4",
-          "position": "Centre-Back"
+          "overall_score": 70,
+          "position": "Centre-Back",
+          "potential": 70,
+          "value": 1000000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2028",
@@ -481,7 +609,11 @@
             "Spain"
           ],
           "number": "23",
-          "position": "Left-Back"
+          "overall_score": 70,
+          "position": "Left-Back",
+          "potential": 75,
+          "value": 2200000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2027",
@@ -495,7 +627,11 @@
             "Spain"
           ],
           "number": "17",
-          "position": "Right-Back"
+          "overall_score": 73,
+          "position": "Right-Back",
+          "potential": 73,
+          "value": 2900000,
+          "yearly_wage": 364000
         },
         {
           "contract": "Jun 30, 2028",
@@ -509,7 +645,11 @@
             "Spain"
           ],
           "number": "2",
-          "position": "Right-Back"
+          "overall_score": 68,
+          "position": "Right-Back",
+          "potential": 69,
+          "value": 1300000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2026",
@@ -523,7 +663,11 @@
             "Italy"
           ],
           "number": "16",
-          "position": "Defensive Midfield"
+          "overall_score": 72,
+          "position": "Defensive Midfield",
+          "potential": 82,
+          "value": 5000000,
+          "yearly_wage": 1196000
         },
         {
           "contract": "Jun 30, 2026",
@@ -537,7 +681,11 @@
             "France"
           ],
           "number": "12",
-          "position": "Central Midfield"
+          "overall_score": 73,
+          "position": "Central Midfield",
+          "potential": 78,
+          "value": 4600000,
+          "yearly_wage": 312000
         },
         {
           "contract": "Jun 30, 2027",
@@ -551,7 +699,11 @@
             "Spain"
           ],
           "number": "26",
-          "position": "Central Midfield"
+          "overall_score": 68,
+          "position": "Central Midfield",
+          "potential": 79,
+          "value": 2500000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2026",
@@ -565,7 +717,11 @@
             "Colombia"
           ],
           "number": "7",
-          "position": "Attacking Midfield"
+          "overall_score": 71,
+          "position": "Attacking Midfield",
+          "potential": 71,
+          "value": 1900000,
+          "yearly_wage": 312000
         },
         {
           "contract": "Jun 30, 2028",
@@ -579,7 +735,11 @@
             "Spain"
           ],
           "number": "20",
-          "position": "Attacking Midfield"
+          "overall_score": 74,
+          "position": "Attacking Midfield",
+          "potential": 74,
+          "value": 3600000,
+          "yearly_wage": 416000
         },
         {
           "contract": "Jun 30, 2027",
@@ -593,7 +753,11 @@
             "Spain"
           ],
           "number": "8",
-          "position": "Attacking Midfield"
+          "overall_score": 69,
+          "position": "Attacking Midfield",
+          "potential": 72,
+          "value": 1800000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2026",
@@ -607,7 +771,11 @@
             "Spain"
           ],
           "number": "21",
-          "position": "Attacking Midfield"
+          "overall_score": 66,
+          "position": "Attacking Midfield",
+          "potential": 66,
+          "value": 350000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2028",
@@ -622,7 +790,11 @@
             "Italy"
           ],
           "number": "9",
-          "position": "Left Winger"
+          "overall_score": 70,
+          "position": "Left Winger",
+          "potential": 81,
+          "value": 3600000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2026",
@@ -636,7 +808,11 @@
             "Spain"
           ],
           "number": "39",
-          "position": "Left Winger"
+          "overall_score": 70,
+          "position": "Left Winger",
+          "potential": 80,
+          "value": 3600000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2026",
@@ -650,7 +826,11 @@
             "Spain"
           ],
           "number": "10",
-          "position": "Left Winger"
+          "overall_score": 72,
+          "position": "Left Winger",
+          "potential": 72,
+          "value": 1900000,
+          "yearly_wage": 364000
         },
         {
           "contract": "Jun 30, 2028",
@@ -664,7 +844,11 @@
             "Spain"
           ],
           "number": "14",
-          "position": "Right Winger"
+          "overall_score": 74,
+          "position": "Right Winger",
+          "potential": 74,
+          "value": 4500000,
+          "yearly_wage": 416000
         },
         {
           "contract": "Jun 30, 2029",
@@ -678,7 +862,11 @@
             "Spain"
           ],
           "number": "22",
-          "position": "Right Winger"
+          "overall_score": 70,
+          "position": "Right Winger",
+          "potential": 79,
+          "value": 3600000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2026",
@@ -692,7 +880,11 @@
             "Spain"
           ],
           "number": "24",
-          "position": "Right Winger"
+          "overall_score": 67,
+          "position": "Right Winger",
+          "potential": 67,
+          "value": 1000000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2026",
@@ -706,7 +898,11 @@
             "Spain"
           ],
           "number": "49",
-          "position": "Centre-Forward"
+          "overall_score": 66,
+          "position": "Centre-Forward",
+          "potential": 78,
+          "value": 2100000,
+          "yearly_wage": 312000
         },
         {
           "contract": "Jun 30, 2026",
@@ -720,7 +916,11 @@
             "Japan"
           ],
           "number": "18",
-          "position": "Centre-Forward"
+          "overall_score": 72,
+          "position": "Centre-Forward",
+          "potential": 73,
+          "value": 2800000,
+          "yearly_wage": 312000
         },
         {
           "contract": "Jun 30, 2026",
@@ -734,7 +934,11 @@
             "Spain"
           ],
           "number": "19",
-          "position": "Centre-Forward"
+          "overall_score": 74,
+          "position": "Centre-Forward",
+          "potential": 74,
+          "value": 4100000,
+          "yearly_wage": 416000
         }
       ],
       "stadiumName": "Estadio de Gran Canaria",
@@ -757,7 +961,11 @@
             "Spain"
           ],
           "number": "1",
-          "position": "Goalkeeper"
+          "overall_score": 75,
+          "position": "Goalkeeper",
+          "potential": 75,
+          "value": 3000000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2029",
@@ -771,7 +979,11 @@
             "Spain"
           ],
           "number": "13",
-          "position": "Goalkeeper"
+          "overall_score": 61,
+          "position": "Goalkeeper",
+          "potential": 75,
+          "value": 700000,
+          "yearly_wage": 28600
         },
         {
           "contract": "Jun 30, 2026",
@@ -785,7 +997,11 @@
             "Spain"
           ],
           "number": "20",
-          "position": "Centre-Back"
+          "overall_score": 68,
+          "position": "Centre-Back",
+          "potential": 71,
+          "value": 1400000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2027",
@@ -799,7 +1015,11 @@
             "Spain"
           ],
           "number": "16",
-          "position": "Centre-Back"
+          "overall_score": 69,
+          "position": "Centre-Back",
+          "potential": 73,
+          "value": 1800000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2026",
@@ -813,7 +1033,11 @@
             "Spain"
           ],
           "number": "4",
-          "position": "Centre-Back"
+          "overall_score": 67,
+          "position": "Centre-Back",
+          "potential": 67,
+          "value": 700000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2028",
@@ -826,7 +1050,11 @@
           "nationality": [
             "Spain"
           ],
-          "position": "Centre-Back"
+          "overall_score": 67,
+          "position": "Centre-Back",
+          "potential": 70,
+          "value": 1200000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2026",
@@ -840,7 +1068,11 @@
             "Spain"
           ],
           "number": "36",
-          "position": "Centre-Back"
+          "overall_score": 65,
+          "position": "Centre-Back",
+          "potential": 72,
+          "value": 1300000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2028",
@@ -854,7 +1086,11 @@
             "Mali"
           ],
           "number": "15",
-          "position": "Centre-Back"
+          "overall_score": 60,
+          "position": "Centre-Back",
+          "potential": 67,
+          "value": 450000,
+          "yearly_wage": 52000
         },
         {
           "contract": "Jun 30, 2027",
@@ -868,7 +1104,11 @@
             "Spain"
           ],
           "number": "18",
-          "position": "Left-Back"
+          "overall_score": 65,
+          "position": "Left-Back",
+          "potential": 68,
+          "value": 875000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2026",
@@ -882,7 +1122,11 @@
             "Spain"
           ],
           "number": "14",
-          "position": "Left-Back"
+          "overall_score": 63,
+          "position": "Left-Back",
+          "potential": 63,
+          "value": 350000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2026",
@@ -896,7 +1140,11 @@
             "Spain"
           ],
           "number": "2",
-          "position": "Right-Back"
+          "overall_score": 63,
+          "position": "Right-Back",
+          "potential": 64,
+          "value": 525000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2029",
@@ -910,7 +1158,11 @@
             "Spain"
           ],
           "number": "3",
-          "position": "Right-Back"
+          "overall_score": 69,
+          "position": "Right-Back",
+          "potential": 74,
+          "value": 2000000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2029",
@@ -923,7 +1175,11 @@
             "Spain"
           ],
           "number": "31",
-          "position": "Right-Back"
+          "overall_score": 67,
+          "position": "Right-Back",
+          "potential": 74,
+          "value": 1900000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2026",
@@ -937,7 +1193,11 @@
             "Spain"
           ],
           "number": "19",
-          "position": "Defensive Midfield"
+          "overall_score": 69,
+          "position": "Defensive Midfield",
+          "potential": 69,
+          "value": 700000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2026",
@@ -951,7 +1211,11 @@
             "Spain"
           ],
           "number": "12",
-          "position": "Central Midfield"
+          "overall_score": 68,
+          "position": "Central Midfield",
+          "potential": 73,
+          "value": 1800000,
+          "yearly_wage": 572000
         },
         {
           "contract": "Jun 30, 2028",
@@ -965,7 +1229,11 @@
             "Spain"
           ],
           "number": "23",
-          "position": "Central Midfield"
+          "overall_score": 70,
+          "position": "Central Midfield",
+          "potential": 83,
+          "value": 3600000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2026",
@@ -979,7 +1247,11 @@
             "Serbia"
           ],
           "number": "5",
-          "position": "Central Midfield"
+          "overall_score": 66,
+          "position": "Central Midfield",
+          "potential": 66,
+          "value": 425000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2027",
@@ -993,7 +1265,11 @@
             "Spain"
           ],
           "number": "6",
-          "position": "Central Midfield"
+          "overall_score": 63,
+          "position": "Central Midfield",
+          "potential": 68,
+          "value": 725000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2026",
@@ -1007,7 +1283,11 @@
             "Spain"
           ],
           "number": "8",
-          "position": "Central Midfield"
+          "overall_score": 66,
+          "position": "Central Midfield",
+          "potential": 66,
+          "value": 825000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2028",
@@ -1021,7 +1301,11 @@
             "Spain"
           ],
           "number": "37",
-          "position": "Attacking Midfield"
+          "overall_score": 66,
+          "position": "Attacking Midfield",
+          "potential": 76,
+          "value": 1900000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2027",
@@ -1035,7 +1319,11 @@
             "Spain"
           ],
           "number": "22",
-          "position": "Attacking Midfield"
+          "overall_score": 70,
+          "position": "Attacking Midfield",
+          "potential": 77,
+          "value": 3200000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2027",
@@ -1050,7 +1338,11 @@
             "Spain"
           ],
           "number": "35",
-          "position": "Attacking Midfield"
+          "overall_score": 65,
+          "position": "Attacking Midfield",
+          "potential": 74,
+          "value": 1500000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2027",
@@ -1064,7 +1356,11 @@
             "Spain"
           ],
           "number": "24",
-          "position": "Left Winger"
+          "overall_score": 65,
+          "position": "Left Winger",
+          "potential": 68,
+          "value": 975000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2027",
@@ -1078,7 +1374,11 @@
             "Spain"
           ],
           "number": "11",
-          "position": "Left Winger"
+          "overall_score": 71,
+          "position": "Left Winger",
+          "potential": 71,
+          "value": 2000000,
+          "yearly_wage": 312000
         },
         {
           "contract": "Jun 30, 2028",
@@ -1092,7 +1392,11 @@
             "Spain"
           ],
           "number": "10",
-          "position": "Right Winger"
+          "overall_score": 74,
+          "position": "Right Winger",
+          "potential": 79,
+          "value": 6500000,
+          "yearly_wage": 364000
         },
         {
           "contract": "Jun 30, 2026",
@@ -1106,7 +1410,11 @@
             "Spain"
           ],
           "number": "25",
-          "position": "Right Winger"
+          "overall_score": 66,
+          "position": "Right Winger",
+          "potential": 66,
+          "value": 700000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2027",
@@ -1121,7 +1429,11 @@
             "Spain"
           ],
           "number": "7",
-          "position": "Right Winger"
+          "overall_score": 62,
+          "position": "Right Winger",
+          "potential": 68,
+          "value": 625000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2028",
@@ -1135,7 +1447,11 @@
             "Spain"
           ],
           "number": "9",
-          "position": "Centre-Forward"
+          "overall_score": 74,
+          "position": "Centre-Forward",
+          "potential": 83,
+          "value": 9500000,
+          "yearly_wage": 312000
         },
         {
           "contract": "Jun 30, 2029",
@@ -1149,7 +1465,11 @@
             "Spain"
           ],
           "number": "21",
-          "position": "Centre-Forward"
+          "overall_score": 72,
+          "position": "Centre-Forward",
+          "potential": 80,
+          "value": 5500000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2026",
@@ -1163,7 +1483,11 @@
             "Spain"
           ],
           "number": "17",
-          "position": "Centre-Forward"
+          "overall_score": 67,
+          "position": "Centre-Forward",
+          "potential": 67,
+          "value": 1000000,
+          "yearly_wage": 208000
         }
       ],
       "stadiumName": "La Rosaleda",
@@ -1186,7 +1510,11 @@
             "Spain"
           ],
           "number": "1",
-          "position": "Goalkeeper"
+          "overall_score": 73,
+          "position": "Goalkeeper",
+          "potential": 73,
+          "value": 1600000,
+          "yearly_wage": 312000
         },
         {
           "contract": "Jun 30, 2026",
@@ -1201,7 +1529,11 @@
             "France"
           ],
           "number": "13",
-          "position": "Goalkeeper"
+          "overall_score": 65,
+          "position": "Goalkeeper",
+          "potential": 70,
+          "value": 825000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2027",
@@ -1215,7 +1547,11 @@
             "France"
           ],
           "number": "4",
-          "position": "Centre-Back"
+          "overall_score": 69,
+          "position": "Centre-Back",
+          "potential": 72,
+          "value": 1600000,
+          "yearly_wage": 312000
         },
         {
           "contract": "Jun 30, 2027",
@@ -1229,7 +1565,11 @@
             "Spain"
           ],
           "number": "5",
-          "position": "Centre-Back"
+          "overall_score": 70,
+          "position": "Centre-Back",
+          "potential": 78,
+          "value": 3400000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2026",
@@ -1243,7 +1583,11 @@
             "Spain"
           ],
           "number": "44",
-          "position": "Centre-Back"
+          "overall_score": 61,
+          "position": "Centre-Back",
+          "potential": 82,
+          "value": 1000000,
+          "yearly_wage": 416000
         },
         {
           "contract": "Jun 30, 2026",
@@ -1257,7 +1601,11 @@
             "Spain"
           ],
           "number": "23",
-          "position": "Centre-Back"
+          "overall_score": 70,
+          "position": "Centre-Back",
+          "potential": 70,
+          "value": 1100000,
+          "yearly_wage": 364000
         },
         {
           "contract": "Jun 30, 2027",
@@ -1271,7 +1619,11 @@
             "Spain"
           ],
           "number": "15",
-          "position": "Centre-Back"
+          "overall_score": 70,
+          "position": "Centre-Back",
+          "potential": 70,
+          "value": 1300000,
+          "yearly_wage": 364000
         },
         {
           "contract": "Jun 30, 2026",
@@ -1285,7 +1637,11 @@
             "Spain"
           ],
           "number": "12",
-          "position": "Left-Back"
+          "overall_score": 70,
+          "position": "Left-Back",
+          "potential": 70,
+          "value": 1200000,
+          "yearly_wage": 364000
         },
         {
           "contract": "Jun 30, 2028",
@@ -1299,7 +1655,11 @@
             "Spain"
           ],
           "number": "3",
-          "position": "Left-Back"
+          "overall_score": 68,
+          "position": "Left-Back",
+          "potential": 71,
+          "value": 1500000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2028",
@@ -1313,7 +1673,11 @@
             "Spain"
           ],
           "number": "2",
-          "position": "Right-Back"
+          "overall_score": 73,
+          "position": "Right-Back",
+          "potential": 76,
+          "value": 3700000,
+          "yearly_wage": 468000
         },
         {
           "contract": "Jun 30, 2026",
@@ -1327,7 +1691,11 @@
             "Spain"
           ],
           "number": "20",
-          "position": "Right-Back"
+          "overall_score": 67,
+          "position": "Right-Back",
+          "potential": 67,
+          "value": 700000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2027",
@@ -1341,7 +1709,11 @@
             "Senegal"
           ],
           "number": "21",
-          "position": "Defensive Midfield"
+          "overall_score": 66,
+          "position": "Defensive Midfield",
+          "potential": 66,
+          "value": 750000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2029",
@@ -1355,7 +1727,11 @@
             "Spain"
           ],
           "number": "6",
-          "position": "Central Midfield"
+          "overall_score": 70,
+          "position": "Central Midfield",
+          "potential": 76,
+          "value": 2300000,
+          "yearly_wage": 312000
         },
         {
           "contract": "Jun 30, 2028",
@@ -1369,7 +1745,11 @@
             "Spain"
           ],
           "number": "14",
-          "position": "Central Midfield"
+          "overall_score": 72,
+          "position": "Central Midfield",
+          "potential": 72,
+          "value": 2300000,
+          "yearly_wage": 468000
         },
         {
           "contract": "Jun 30, 2027",
@@ -1383,7 +1763,11 @@
             "Spain"
           ],
           "number": "8",
-          "position": "Central Midfield"
+          "overall_score": 68,
+          "position": "Central Midfield",
+          "potential": 68,
+          "value": 1100000,
+          "yearly_wage": 312000
         },
         {
           "contract": "Jun 30, 2026",
@@ -1398,7 +1782,11 @@
             "France"
           ],
           "number": "24",
-          "position": "Central Midfield"
+          "overall_score": 68,
+          "position": "Central Midfield",
+          "potential": 79,
+          "value": 2600000,
+          "yearly_wage": 468000
         },
         {
           "contract": "Jun 30, 2028",
@@ -1411,7 +1799,11 @@
             "Spain"
           ],
           "number": "36",
-          "position": "Central Midfield"
+          "overall_score": 62,
+          "position": "Central Midfield",
+          "potential": 77,
+          "value": 950000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2028",
@@ -1425,7 +1817,11 @@
             "Spain"
           ],
           "number": "10",
-          "position": "Attacking Midfield"
+          "overall_score": 74,
+          "position": "Attacking Midfield",
+          "potential": 78,
+          "value": 6000000,
+          "yearly_wage": 468000
         },
         {
           "contract": "Jun 30, 2028",
@@ -1440,7 +1836,11 @@
             "Belgium"
           ],
           "number": "17",
-          "position": "Left Winger"
+          "overall_score": 74,
+          "position": "Left Winger",
+          "potential": 75,
+          "value": 5000000,
+          "yearly_wage": 520000
         },
         {
           "contract": "Jun 30, 2028",
@@ -1454,7 +1854,11 @@
             "Spain"
           ],
           "number": "7",
-          "position": "Left Winger"
+          "overall_score": 70,
+          "position": "Left Winger",
+          "potential": 71,
+          "value": 1900000,
+          "yearly_wage": 364000
         },
         {
           "contract": "Jun 30, 2027",
@@ -1468,7 +1872,11 @@
             "Spain"
           ],
           "number": "11",
-          "position": "Left Winger"
+          "overall_score": 66,
+          "position": "Left Winger",
+          "potential": 72,
+          "value": 1400000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2027",
@@ -1482,7 +1890,11 @@
             "Colombia"
           ],
           "number": "19",
-          "position": "Right Winger"
+          "overall_score": 74,
+          "position": "Right Winger",
+          "potential": 74,
+          "value": 4100000,
+          "yearly_wage": 624000
         },
         {
           "contract": "Jun 30, 2027",
@@ -1496,7 +1908,11 @@
             "Spain"
           ],
           "number": "32",
-          "position": "Second Striker"
+          "overall_score": 63,
+          "position": "Second Striker",
+          "potential": 71,
+          "value": 1100000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2026",
@@ -1511,7 +1927,11 @@
             "Italy"
           ],
           "number": "9",
-          "position": "Centre-Forward"
+          "overall_score": 68,
+          "position": "Centre-Forward",
+          "potential": 76,
+          "value": 2700000,
+          "yearly_wage": 364000
         },
         {
           "contract": "Jun 30, 2029",
@@ -1525,7 +1945,11 @@
             "Senegal"
           ],
           "number": "18",
-          "position": "Centre-Forward"
+          "overall_score": 65,
+          "position": "Centre-Forward",
+          "potential": 72,
+          "value": 1400000,
+          "yearly_wage": 156000
         }
       ],
       "stadiumName": "El Molinón - Enrique Castro 'Quini'",
@@ -1548,7 +1972,11 @@
             "Portugal"
           ],
           "number": "13",
-          "position": "Goalkeeper"
+          "overall_score": 69,
+          "position": "Goalkeeper",
+          "potential": 75,
+          "value": 1800000,
+          "yearly_wage": 364000
         },
         {
           "contract": "Jun 30, 2028",
@@ -1562,7 +1990,11 @@
             "Spain"
           ],
           "number": "1",
-          "position": "Goalkeeper"
+          "overall_score": 67,
+          "position": "Goalkeeper",
+          "potential": 79,
+          "value": 2200000,
+          "yearly_wage": 52000
         },
         {
           "contract": "Jun 30, 2026",
@@ -1576,7 +2008,11 @@
             "Spain"
           ],
           "number": "4",
-          "position": "Centre-Back"
+          "overall_score": 69,
+          "position": "Centre-Back",
+          "potential": 78,
+          "value": 2900000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2027",
@@ -1590,7 +2026,11 @@
             "Spain"
           ],
           "number": "15",
-          "position": "Centre-Back"
+          "overall_score": 70,
+          "position": "Centre-Back",
+          "potential": 75,
+          "value": 2100000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2029",
@@ -1604,7 +2044,11 @@
             "Spain"
           ],
           "number": "5",
-          "position": "Centre-Back"
+          "overall_score": 63,
+          "position": "Centre-Back",
+          "potential": 74,
+          "value": 1000000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2028",
@@ -1618,7 +2062,11 @@
             "Morocco"
           ],
           "number": "23",
-          "position": "Centre-Back"
+          "overall_score": 64,
+          "position": "Centre-Back",
+          "potential": 72,
+          "value": 1200000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2028",
@@ -1632,7 +2080,11 @@
             "Spain"
           ],
           "number": "3",
-          "position": "Left-Back"
+          "overall_score": 68,
+          "position": "Left-Back",
+          "potential": 77,
+          "value": 2600000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2026",
@@ -1646,7 +2098,11 @@
             "Spain"
           ],
           "number": "18",
-          "position": "Left-Back"
+          "overall_score": 70,
+          "position": "Left-Back",
+          "potential": 70,
+          "value": 825000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2027",
@@ -1660,7 +2116,11 @@
             "Spain"
           ],
           "number": "27",
-          "position": "Left-Back"
+          "overall_score": 65,
+          "position": "Left-Back",
+          "potential": 77,
+          "value": 1600000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2026",
@@ -1674,7 +2134,11 @@
             "France"
           ],
           "number": "2",
-          "position": "Right-Back"
+          "overall_score": 68,
+          "position": "Right-Back",
+          "potential": 68,
+          "value": 1100000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2027",
@@ -1688,7 +2152,11 @@
             "Spain"
           ],
           "number": "14",
-          "position": "Right-Back"
+          "overall_score": 69,
+          "position": "Right-Back",
+          "potential": 69,
+          "value": 1300000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2027",
@@ -1702,7 +2170,11 @@
             "Croatia"
           ],
           "number": "24",
-          "position": "Defensive Midfield"
+          "overall_score": 69,
+          "position": "Defensive Midfield",
+          "potential": 69,
+          "value": 1200000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2026",
@@ -1717,7 +2189,11 @@
             "Martinique"
           ],
           "number": "6",
-          "position": "Defensive Midfield"
+          "overall_score": 69,
+          "position": "Defensive Midfield",
+          "potential": 73,
+          "value": 2000000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2029",
@@ -1731,7 +2207,11 @@
             "Spain"
           ],
           "number": "8",
-          "position": "Central Midfield"
+          "overall_score": 66,
+          "position": "Central Midfield",
+          "potential": 67,
+          "value": 1000000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2027",
@@ -1745,7 +2225,11 @@
             "Nigeria"
           ],
           "number": "12",
-          "position": "Central Midfield"
+          "overall_score": 64,
+          "position": "Central Midfield",
+          "potential": 80,
+          "value": 1500000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2026",
@@ -1759,7 +2243,11 @@
             "Spain"
           ],
           "number": "16",
-          "position": "Central Midfield"
+          "overall_score": 62,
+          "position": "Central Midfield",
+          "potential": 72,
+          "value": 900000,
+          "yearly_wage": 52000
         },
         {
           "contract": "Jun 30, 2026",
@@ -1773,7 +2261,11 @@
             "Spain"
           ],
           "number": "20",
-          "position": "Attacking Midfield"
+          "overall_score": 71,
+          "position": "Attacking Midfield",
+          "potential": 82,
+          "value": 4200000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2028",
@@ -1788,7 +2280,11 @@
             "Angola"
           ],
           "number": "21",
-          "position": "Attacking Midfield"
+          "overall_score": 73,
+          "position": "Attacking Midfield",
+          "potential": 76,
+          "value": 4200000,
+          "yearly_wage": 312000
         },
         {
           "contract": "Jun 30, 2029",
@@ -1802,7 +2298,11 @@
             "Croatia"
           ],
           "number": "17",
-          "position": "Left Winger"
+          "overall_score": 67,
+          "position": "Left Winger",
+          "potential": 74,
+          "value": 2100000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2026",
@@ -1816,7 +2316,11 @@
             "Spain"
           ],
           "number": "7",
-          "position": "Left Winger"
+          "overall_score": 69,
+          "position": "Left Winger",
+          "potential": 69,
+          "value": 1400000,
+          "yearly_wage": 936000
         },
         {
           "contract": "Jun 30, 2026",
@@ -1831,7 +2335,11 @@
             "Spain"
           ],
           "number": "22",
-          "position": "Right Winger"
+          "overall_score": 69,
+          "position": "Right Winger",
+          "potential": 76,
+          "value": 2800000,
+          "yearly_wage": 728000
         },
         {
           "contract": "Jun 30, 2026",
@@ -1845,7 +2353,11 @@
             "Uruguay"
           ],
           "number": "19",
-          "position": "Right Winger"
+          "overall_score": 66,
+          "position": "Right Winger",
+          "potential": 69,
+          "value": 1200000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2027",
@@ -1860,7 +2372,11 @@
             "Spain"
           ],
           "number": "11",
-          "position": "Right Winger"
+          "overall_score": 70,
+          "position": "Right Winger",
+          "potential": 70,
+          "value": 1600000,
+          "yearly_wage": 312000
         },
         {
           "contract": "Jun 30, 2029",
@@ -1874,7 +2390,11 @@
             "Spain"
           ],
           "number": "9",
-          "position": "Centre-Forward"
+          "overall_score": 68,
+          "position": "Centre-Forward",
+          "potential": 73,
+          "value": 1800000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2027",
@@ -1888,7 +2408,11 @@
             "Norway"
           ],
           "number": "25",
-          "position": "Centre-Forward"
+          "overall_score": 68,
+          "position": "Centre-Forward",
+          "potential": 69,
+          "value": 1400000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2026",
@@ -1903,7 +2427,11 @@
             "England"
           ],
           "number": "39",
-          "position": "Centre-Forward"
+          "overall_score": 67,
+          "position": "Centre-Forward",
+          "potential": 76,
+          "value": 2300000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2029",
@@ -1918,7 +2446,11 @@
             "Spain"
           ],
           "number": "10",
-          "position": "Centre-Forward"
+          "overall_score": 68,
+          "position": "Centre-Forward",
+          "potential": 68,
+          "value": 1200000,
+          "yearly_wage": 260000
         }
       ],
       "stadiumName": "José Zorrilla",
@@ -1941,7 +2473,11 @@
             "Spain"
           ],
           "number": "1",
-          "position": "Goalkeeper"
+          "overall_score": 69,
+          "position": "Goalkeeper",
+          "potential": 71,
+          "value": 1200000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2030",
@@ -1955,7 +2491,11 @@
             "Sweden"
           ],
           "number": "13",
-          "position": "Goalkeeper"
+          "overall_score": 66,
+          "position": "Goalkeeper",
+          "potential": 81,
+          "value": 1800000,
+          "yearly_wage": 52000
         },
         {
           "contract": "Jun 30, 2026",
@@ -1970,7 +2510,11 @@
             "Italy"
           ],
           "number": "16",
-          "position": "Centre-Back"
+          "overall_score": 68,
+          "position": "Centre-Back",
+          "potential": 78,
+          "value": 2500000,
+          "yearly_wage": 1664000
         },
         {
           "contract": "Jun 30, 2026",
@@ -1984,7 +2528,11 @@
             "Spain"
           ],
           "number": "5",
-          "position": "Centre-Back"
+          "overall_score": 71,
+          "position": "Centre-Back",
+          "potential": 78,
+          "value": 3500000,
+          "yearly_wage": 312000
         },
         {
           "contract": "Jun 30, 2028",
@@ -1998,7 +2546,11 @@
             "Spain"
           ],
           "number": "4",
-          "position": "Centre-Back"
+          "overall_score": 68,
+          "position": "Centre-Back",
+          "potential": 71,
+          "value": 1400000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2012,7 +2564,11 @@
             "Spain"
           ],
           "number": "21",
-          "position": "Centre-Back"
+          "overall_score": 68,
+          "position": "Centre-Back",
+          "potential": 77,
+          "value": 2500000,
+          "yearly_wage": 468000
         },
         {
           "contract": "Jun 30, 2029",
@@ -2026,7 +2582,11 @@
             "Spain"
           ],
           "number": "32",
-          "position": "Left-Back"
+          "overall_score": 67,
+          "position": "Left-Back",
+          "potential": 85,
+          "value": 2500000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2027",
@@ -2040,7 +2600,11 @@
             "Spain"
           ],
           "number": "3",
-          "position": "Left-Back"
+          "overall_score": 67,
+          "position": "Left-Back",
+          "potential": 78,
+          "value": 2200000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2028",
@@ -2054,7 +2618,11 @@
             "Spain"
           ],
           "number": "2",
-          "position": "Right-Back"
+          "overall_score": 68,
+          "position": "Right-Back",
+          "potential": 71,
+          "value": 1500000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2068,7 +2636,11 @@
             "Spain"
           ],
           "number": "23",
-          "position": "Defensive Midfield"
+          "overall_score": 72,
+          "position": "Defensive Midfield",
+          "potential": 76,
+          "value": 3400000,
+          "yearly_wage": 884000
         },
         {
           "contract": "Jun 30, 2029",
@@ -2082,7 +2654,11 @@
             "Senegal"
           ],
           "number": "14",
-          "position": "Defensive Midfield"
+          "overall_score": 66,
+          "position": "Defensive Midfield",
+          "potential": 74,
+          "value": 1800000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2029",
@@ -2096,7 +2672,11 @@
             "Colombia"
           ],
           "number": "19",
-          "position": "Central Midfield"
+          "overall_score": 71,
+          "position": "Central Midfield",
+          "potential": 82,
+          "value": 4000000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2029",
@@ -2110,7 +2690,11 @@
             "Spain"
           ],
           "number": "8",
-          "position": "Central Midfield"
+          "overall_score": 70,
+          "position": "Central Midfield",
+          "potential": 73,
+          "value": 1900000,
+          "yearly_wage": 312000
         },
         {
           "contract": "Jun 30, 2028",
@@ -2124,7 +2708,11 @@
             "Spain"
           ],
           "number": "6",
-          "position": "Central Midfield"
+          "overall_score": 67,
+          "position": "Central Midfield",
+          "potential": 70,
+          "value": 1200000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2029",
@@ -2137,7 +2725,11 @@
             "Spain"
           ],
           "number": "36",
-          "position": "Central Midfield"
+          "overall_score": 63,
+          "position": "Central Midfield",
+          "potential": 78,
+          "value": 1100000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2151,7 +2743,11 @@
             "Spain"
           ],
           "number": "18",
-          "position": "Attacking Midfield"
+          "overall_score": 68,
+          "position": "Attacking Midfield",
+          "potential": 82,
+          "value": 2900000,
+          "yearly_wage": 676000
         },
         {
           "contract": "Jun 30, 2030",
@@ -2165,7 +2761,11 @@
             "Spain"
           ],
           "number": "10",
-          "position": "Left Winger"
+          "overall_score": 77,
+          "position": "Left Winger",
+          "potential": 77,
+          "value": 11000000,
+          "yearly_wage": 624000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2180,7 +2780,11 @@
             "Italy"
           ],
           "number": "15",
-          "position": "Left Winger"
+          "overall_score": 68,
+          "position": "Left Winger",
+          "potential": 68,
+          "value": 750000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2028",
@@ -2194,7 +2798,11 @@
             "Spain"
           ],
           "number": "11",
-          "position": "Right Winger"
+          "overall_score": 77,
+          "position": "Right Winger",
+          "potential": 78,
+          "value": 12500000,
+          "yearly_wage": 572000
         },
         {
           "contract": "Jun 30, 2028",
@@ -2209,7 +2817,11 @@
             "Spain"
           ],
           "number": "20",
-          "position": "Right Winger"
+          "overall_score": 68,
+          "position": "Right Winger",
+          "potential": 74,
+          "value": 1900000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2223,7 +2835,11 @@
             "Spain"
           ],
           "number": "12",
-          "position": "Centre-Forward"
+          "overall_score": 74,
+          "position": "Centre-Forward",
+          "potential": 74,
+          "value": 4600000,
+          "yearly_wage": 1352000
         },
         {
           "contract": "Jun 30, 2028",
@@ -2237,7 +2853,11 @@
             "Spain"
           ],
           "number": "9",
-          "position": "Centre-Forward"
+          "overall_score": 69,
+          "position": "Centre-Forward",
+          "potential": 72,
+          "value": 1900000,
+          "yearly_wage": 312000
         },
         {
           "contract": "Jun 30, 2029",
@@ -2251,7 +2871,11 @@
             "Georgia"
           ],
           "number": "7",
-          "position": "Centre-Forward"
+          "overall_score": 66,
+          "position": "Centre-Forward",
+          "potential": 71,
+          "value": 1300000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2263,7 +2887,11 @@
             "Spain"
           ],
           "number": "27",
-          "position": "Centre-Forward"
+          "overall_score": 62,
+          "position": "Centre-Forward",
+          "potential": 82,
+          "value": 1100000,
+          "yearly_wage": 312000
         }
       ],
       "stadiumName": "El Sardinero",
@@ -2286,7 +2914,11 @@
             "Andorra"
           ],
           "number": "1",
-          "position": "Goalkeeper"
+          "overall_score": 69,
+          "position": "Goalkeeper",
+          "potential": 75,
+          "value": 1800000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2028",
@@ -2300,7 +2932,11 @@
             "Spain"
           ],
           "number": "13",
-          "position": "Goalkeeper"
+          "overall_score": 68,
+          "position": "Goalkeeper",
+          "potential": 70,
+          "value": 1000000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2027",
@@ -2314,7 +2950,11 @@
             "Cameroon"
           ],
           "number": "12",
-          "position": "Centre-Back"
+          "overall_score": 68,
+          "position": "Centre-Back",
+          "potential": 73,
+          "value": 1600000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2028",
@@ -2329,7 +2969,11 @@
             "Brazil"
           ],
           "number": "16",
-          "position": "Centre-Back"
+          "overall_score": 68,
+          "position": "Centre-Back",
+          "potential": 68,
+          "value": 1000000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2027",
@@ -2343,7 +2987,11 @@
             "Spain"
           ],
           "number": "4",
-          "position": "Centre-Back"
+          "overall_score": 69,
+          "position": "Centre-Back",
+          "potential": 70,
+          "value": 1400000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2357,7 +3005,11 @@
             "Spain"
           ],
           "number": "15",
-          "position": "Centre-Back"
+          "overall_score": 68,
+          "position": "Centre-Back",
+          "potential": 72,
+          "value": 1600000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2027",
@@ -2371,7 +3023,11 @@
             "Spain"
           ],
           "number": "2",
-          "position": "Left-Back"
+          "overall_score": 69,
+          "position": "Left-Back",
+          "potential": 72,
+          "value": 1700000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2385,7 +3041,11 @@
             "Spain"
           ],
           "number": "3",
-          "position": "Left-Back"
+          "overall_score": 64,
+          "position": "Left-Back",
+          "potential": 69,
+          "value": 825000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2400,7 +3060,11 @@
             "Peru"
           ],
           "number": "33",
-          "position": "Left-Back"
+          "overall_score": 58,
+          "position": "Left-Back",
+          "potential": 69,
+          "value": 400000,
+          "yearly_wage": 52000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2413,7 +3077,11 @@
             "Spain"
           ],
           "number": "21",
-          "position": "Right-Back"
+          "overall_score": 68,
+          "position": "Right-Back",
+          "potential": 68,
+          "value": 875000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2427,7 +3095,11 @@
             "Spain"
           ],
           "number": "22",
-          "position": "Right-Back"
+          "overall_score": 66,
+          "position": "Right-Back",
+          "potential": 73,
+          "value": 1600000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2028",
@@ -2441,7 +3113,11 @@
             "Spain"
           ],
           "number": "8",
-          "position": "Central Midfield"
+          "overall_score": 70,
+          "position": "Central Midfield",
+          "potential": 76,
+          "value": 2300000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2455,7 +3131,11 @@
             "Spain"
           ],
           "number": "20",
-          "position": "Central Midfield"
+          "overall_score": 66,
+          "position": "Central Midfield",
+          "potential": 71,
+          "value": 1200000,
+          "yearly_wage": 468000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2470,7 +3150,11 @@
             "Spain"
           ],
           "number": "7",
-          "position": "Central Midfield"
+          "overall_score": 66,
+          "position": "Central Midfield",
+          "potential": 72,
+          "value": 1300000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2484,7 +3168,11 @@
             "Spain"
           ],
           "number": "24",
-          "position": "Central Midfield"
+          "overall_score": 68,
+          "position": "Central Midfield",
+          "potential": 73,
+          "value": 1800000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2498,7 +3186,11 @@
             "Spain"
           ],
           "number": "30",
-          "position": "Central Midfield"
+          "overall_score": 70,
+          "position": "Central Midfield",
+          "potential": 78,
+          "value": 3600000,
+          "yearly_wage": 780000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2512,7 +3204,11 @@
             "Spain"
           ],
           "number": "25",
-          "position": "Attacking Midfield"
+          "overall_score": 69,
+          "position": "Attacking Midfield",
+          "potential": 76,
+          "value": 2800000,
+          "yearly_wage": 832000
         },
         {
           "contract": "Jun 30, 2027",
@@ -2526,7 +3222,11 @@
             "Brazil"
           ],
           "number": "19",
-          "position": "Attacking Midfield"
+          "overall_score": 68,
+          "position": "Attacking Midfield",
+          "potential": 71,
+          "value": 1600000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2540,7 +3240,11 @@
             "Spain"
           ],
           "number": "10",
-          "position": "Left Winger"
+          "overall_score": 70,
+          "position": "Left Winger",
+          "potential": 70,
+          "value": 1600000,
+          "yearly_wage": 364000
         },
         {
           "contract": "Jun 30, 2027",
@@ -2554,7 +3258,11 @@
             "Spain"
           ],
           "number": "11",
-          "position": "Left Winger"
+          "overall_score": 69,
+          "position": "Left Winger",
+          "potential": 72,
+          "value": 1900000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2027",
@@ -2568,7 +3276,11 @@
             "Portugal"
           ],
           "number": "17",
-          "position": "Left Winger"
+          "overall_score": 67,
+          "position": "Left Winger",
+          "potential": 67,
+          "value": 1000000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2028",
@@ -2582,7 +3294,11 @@
             "Spain"
           ],
           "number": "23",
-          "position": "Right Winger"
+          "overall_score": 72,
+          "position": "Right Winger",
+          "potential": 72,
+          "value": 2300000,
+          "yearly_wage": 468000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2596,7 +3312,11 @@
             "Spain"
           ],
           "number": "5",
-          "position": "Right Winger"
+          "overall_score": 68,
+          "position": "Right Winger",
+          "potential": 73,
+          "value": 1900000,
+          "yearly_wage": 1144000
         },
         {
           "contract": "Jun 30, 2027",
@@ -2610,7 +3330,11 @@
             "Spain"
           ],
           "number": "18",
-          "position": "Centre-Forward"
+          "overall_score": 74,
+          "position": "Centre-Forward",
+          "potential": 74,
+          "value": 4300000,
+          "yearly_wage": 572000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2638,7 +3362,11 @@
             "Spain"
           ],
           "number": "14",
-          "position": "Centre-Forward"
+          "overall_score": 67,
+          "position": "Centre-Forward",
+          "potential": 67,
+          "value": 475000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2027",
@@ -2652,7 +3380,11 @@
             "Spain"
           ],
           "number": "6",
-          "position": "Centre-Forward"
+          "overall_score": 64,
+          "position": "Centre-Forward",
+          "potential": 70,
+          "value": 925000,
+          "yearly_wage": 156000
         }
       ],
       "stadiumName": "Bahrain Victorious Nuevo Arcángel",
@@ -2676,7 +3408,11 @@
             "Spain"
           ],
           "number": "13",
-          "position": "Goalkeeper"
+          "overall_score": 70,
+          "position": "Goalkeeper",
+          "potential": 77,
+          "value": 2800000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2027",
@@ -2690,7 +3426,11 @@
             "Spain"
           ],
           "number": "1",
-          "position": "Goalkeeper"
+          "overall_score": 68,
+          "position": "Goalkeeper",
+          "potential": 68,
+          "value": 650000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2029",
@@ -2704,7 +3444,11 @@
             "Serbia"
           ],
           "number": "14",
-          "position": "Centre-Back"
+          "overall_score": 67,
+          "position": "Centre-Back",
+          "potential": 77,
+          "value": 2100000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2028",
@@ -2718,7 +3462,11 @@
             "Spain"
           ],
           "number": "6",
-          "position": "Centre-Back"
+          "overall_score": 68,
+          "position": "Centre-Back",
+          "potential": 75,
+          "value": 2200000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2028",
@@ -2732,7 +3480,11 @@
             "Spain"
           ],
           "number": "2",
-          "position": "Centre-Back"
+          "overall_score": 67,
+          "position": "Centre-Back",
+          "potential": 73,
+          "value": 1500000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2746,7 +3498,11 @@
             "Spain"
           ],
           "number": "27",
-          "position": "Centre-Back"
+          "overall_score": 64,
+          "position": "Centre-Back",
+          "potential": 71,
+          "value": 1100000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2029",
@@ -2759,7 +3515,11 @@
           "nationality": [
             "Spain"
           ],
-          "position": "Centre-Back"
+          "overall_score": 66,
+          "position": "Centre-Back",
+          "potential": 72,
+          "value": 1200000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2028",
@@ -2773,7 +3533,11 @@
             "Spain"
           ],
           "number": "21",
-          "position": "Left-Back"
+          "overall_score": 68,
+          "position": "Left-Back",
+          "potential": 75,
+          "value": 2300000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2785,7 +3549,11 @@
             "Spain"
           ],
           "number": "33",
-          "position": "Left-Back"
+          "overall_score": 64,
+          "position": "Left-Back",
+          "potential": 71,
+          "value": 1100000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2027",
@@ -2799,7 +3567,11 @@
             "Spain"
           ],
           "number": "20",
-          "position": "Right-Back"
+          "overall_score": 68,
+          "position": "Right-Back",
+          "potential": 68,
+          "value": 825000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2813,7 +3585,11 @@
             "Ecuador"
           ],
           "number": "29",
-          "position": "Right-Back"
+          "overall_score": 63,
+          "position": "Right-Back",
+          "potential": 71,
+          "value": 1000000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2827,7 +3603,11 @@
             "Mali",
             "Cote d'Ivoire"
           ],
-          "position": "Central Midfield"
+          "overall_score": 68,
+          "position": "Central Midfield",
+          "potential": 68,
+          "value": 1200000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2029",
@@ -2841,7 +3621,11 @@
             "Mali"
           ],
           "number": "5",
-          "position": "Central Midfield"
+          "overall_score": 68,
+          "position": "Central Midfield",
+          "potential": 78,
+          "value": 2600000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2028",
@@ -2855,7 +3639,11 @@
             "Spain"
           ],
           "number": "15",
-          "position": "Central Midfield"
+          "overall_score": 68,
+          "position": "Central Midfield",
+          "potential": 69,
+          "value": 1400000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2029",
@@ -2870,7 +3658,11 @@
             "Spain"
           ],
           "number": "18",
-          "position": "Central Midfield"
+          "overall_score": 67,
+          "position": "Central Midfield",
+          "potential": 68,
+          "value": 1200000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2884,7 +3676,11 @@
             "Spain"
           ],
           "number": "8",
-          "position": "Central Midfield"
+          "overall_score": 67,
+          "position": "Central Midfield",
+          "potential": 67,
+          "value": 800000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2030",
@@ -2898,7 +3694,11 @@
             "Spain"
           ],
           "number": "24",
-          "position": "Central Midfield"
+          "overall_score": 64,
+          "position": "Central Midfield",
+          "potential": 69,
+          "value": 800000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2912,7 +3712,11 @@
             "Spain"
           ],
           "number": "16",
-          "position": "Left Winger"
+          "overall_score": 67,
+          "position": "Left Winger",
+          "potential": 77,
+          "value": 2100000,
+          "yearly_wage": 1352000
         },
         {
           "contract": "Jun 30, 2028",
@@ -2926,7 +3730,11 @@
             "Spain"
           ],
           "number": "22",
-          "position": "Left Winger"
+          "overall_score": 68,
+          "position": "Left Winger",
+          "potential": 68,
+          "value": 1300000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2940,7 +3748,11 @@
             "Uruguay"
           ],
           "number": "10",
-          "position": "Left Winger"
+          "overall_score": 69,
+          "position": "Left Winger",
+          "potential": 70,
+          "value": 1600000,
+          "yearly_wage": 312000
         },
         {
           "contract": "Jun 30, 2029",
@@ -2954,7 +3766,11 @@
             "Spain"
           ],
           "number": "11",
-          "position": "Right Winger"
+          "overall_score": 71,
+          "position": "Right Winger",
+          "potential": 71,
+          "value": 1600000,
+          "yearly_wage": 416000
         },
         {
           "contract": "Jun 30, 2028",
@@ -2968,7 +3784,11 @@
             "Georgia"
           ],
           "number": "12",
-          "position": "Right Winger"
+          "overall_score": 70,
+          "position": "Right Winger",
+          "potential": 71,
+          "value": 1900000,
+          "yearly_wage": 312000
         },
         {
           "contract": "Jun 30, 2027",
@@ -2982,7 +3802,11 @@
             "Spain"
           ],
           "number": "19",
-          "position": "Right Winger"
+          "overall_score": 66,
+          "position": "Right Winger",
+          "potential": 72,
+          "value": 1300000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2030",
@@ -2997,7 +3821,11 @@
             "Italy"
           ],
           "number": "37",
-          "position": "Centre-Forward"
+          "overall_score": 67,
+          "position": "Centre-Forward",
+          "potential": 76,
+          "value": 2200000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3012,7 +3840,11 @@
             "Spain"
           ],
           "number": "17",
-          "position": "Centre-Forward"
+          "overall_score": 68,
+          "position": "Centre-Forward",
+          "potential": 74,
+          "value": 2000000,
+          "yearly_wage": 676000
         },
         {
           "contract": "Jun 30, 2028",
@@ -3026,7 +3858,11 @@
             "Spain"
           ],
           "number": "23",
-          "position": "Centre-Forward"
+          "overall_score": 68,
+          "position": "Centre-Forward",
+          "potential": 75,
+          "value": 2500000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3040,7 +3876,11 @@
             "Spain"
           ],
           "number": "9",
-          "position": "Centre-Forward"
+          "overall_score": 66,
+          "position": "Centre-Forward",
+          "potential": 66,
+          "value": 425000,
+          "yearly_wage": 208000
         }
       ],
       "stadiumName": "Nuevo Mirandilla",
@@ -3063,7 +3903,11 @@
             "Argentina"
           ],
           "number": "1",
-          "position": "Goalkeeper"
+          "overall_score": 69,
+          "position": "Goalkeeper",
+          "potential": 69,
+          "value": 240000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3078,7 +3922,11 @@
             "Spain"
           ],
           "number": "13",
-          "position": "Goalkeeper"
+          "overall_score": 68,
+          "position": "Goalkeeper",
+          "potential": 74,
+          "value": 1500000,
+          "yearly_wage": 312000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3091,7 +3939,11 @@
           "nationality": [
             "Morocco"
           ],
-          "position": "Centre-Back"
+          "overall_score": 70,
+          "position": "Centre-Back",
+          "potential": 70,
+          "value": 750000,
+          "yearly_wage": 364000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3105,7 +3957,11 @@
             "Spain"
           ],
           "number": "4",
-          "position": "Centre-Back"
+          "overall_score": 68,
+          "position": "Centre-Back",
+          "potential": 68,
+          "value": 825000,
+          "yearly_wage": 312000
         },
         {
           "contract": "Jun 30, 2027",
@@ -3119,7 +3975,11 @@
             "Spain"
           ],
           "number": "5",
-          "position": "Centre-Back"
+          "overall_score": 67,
+          "position": "Centre-Back",
+          "potential": 69,
+          "value": 1100000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2030",
@@ -3133,7 +3993,11 @@
             "Ghana"
           ],
           "number": "33",
-          "position": "Centre-Back"
+          "overall_score": 68,
+          "position": "Centre-Back",
+          "potential": 84,
+          "value": 3200000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2027",
@@ -3147,7 +4011,11 @@
             "Serbia"
           ],
           "number": "16",
-          "position": "Centre-Back"
+          "overall_score": 66,
+          "position": "Centre-Back",
+          "potential": 66,
+          "value": 575000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2028",
@@ -3162,7 +4030,11 @@
             "Cape Verde"
           ],
           "number": "36",
-          "position": "Centre-Back"
+          "overall_score": 65,
+          "position": "Centre-Back",
+          "potential": 81,
+          "value": 1700000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3175,7 +4047,11 @@
           "nationality": [
             "Spain"
           ],
-          "position": "Left-Back"
+          "overall_score": 69,
+          "position": "Left-Back",
+          "potential": 80,
+          "value": 3000000,
+          "yearly_wage": 936000
         },
         {
           "contract": "Jun 30, 2028",
@@ -3189,7 +4065,11 @@
             "Spain"
           ],
           "number": "3",
-          "position": "Left-Back"
+          "overall_score": 69,
+          "position": "Left-Back",
+          "potential": 74,
+          "value": 2000000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3203,7 +4083,11 @@
             "Spain"
           ],
           "number": "15",
-          "position": "Left-Back"
+          "overall_score": 64,
+          "position": "Left-Back",
+          "potential": 64,
+          "value": 400000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3217,7 +4101,11 @@
             "Spain"
           ],
           "number": "20",
-          "position": "Right-Back"
+          "overall_score": 71,
+          "position": "Right-Back",
+          "potential": 71,
+          "value": 1600000,
+          "yearly_wage": 416000
         },
         {
           "contract": "Jun 30, 2027",
@@ -3231,7 +4119,11 @@
             "Spain"
           ],
           "number": "2",
-          "position": "Right-Back"
+          "overall_score": 67,
+          "position": "Right-Back",
+          "potential": 73,
+          "value": 1500000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3245,7 +4137,11 @@
             "Cote d'Ivoire"
           ],
           "number": "24",
-          "position": "Defensive Midfield"
+          "overall_score": 69,
+          "position": "Defensive Midfield",
+          "potential": 70,
+          "value": 1400000,
+          "yearly_wage": 520000
         },
         {
           "contract": "Jun 30, 2030",
@@ -3259,7 +4155,11 @@
             "Spain"
           ],
           "number": "14",
-          "position": "Central Midfield"
+          "overall_score": 70,
+          "position": "Central Midfield",
+          "potential": 77,
+          "value": 3200000,
+          "yearly_wage": 312000
         },
         {
           "contract": "Jun 30, 2027",
@@ -3273,7 +4173,11 @@
             "Albania"
           ],
           "number": "6",
-          "position": "Central Midfield"
+          "overall_score": 71,
+          "position": "Central Midfield",
+          "potential": 71,
+          "value": 1800000,
+          "yearly_wage": 364000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3287,7 +4191,11 @@
             "Spain"
           ],
           "number": "10",
-          "position": "Central Midfield"
+          "overall_score": 66,
+          "position": "Central Midfield",
+          "potential": 66,
+          "value": 850000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3301,7 +4209,11 @@
             "Spain"
           ],
           "number": "8",
-          "position": "Central Midfield"
+          "overall_score": 65,
+          "position": "Central Midfield",
+          "potential": 65,
+          "value": 750000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3314,7 +4226,11 @@
           "nationality": [
             "Ghana"
           ],
-          "position": "Central Midfield"
+          "overall_score": 66,
+          "position": "Central Midfield",
+          "potential": 77,
+          "value": 1900000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2027",
@@ -3328,7 +4244,11 @@
             "Spain"
           ],
           "number": "17",
-          "position": "Left Winger"
+          "overall_score": 65,
+          "position": "Left Winger",
+          "potential": 65,
+          "value": 725000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3341,7 +4261,11 @@
           "nationality": [
             "Serbia"
           ],
-          "position": "Right Winger"
+          "overall_score": 64,
+          "position": "Right Winger",
+          "potential": 64,
+          "value": 650000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2027",
@@ -3354,7 +4278,11 @@
           "nationality": [
             "Spain"
           ],
-          "position": "Right Winger"
+          "overall_score": 67,
+          "position": "Right Winger",
+          "potential": 67,
+          "value": 1000000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2028",
@@ -3368,7 +4296,11 @@
             "Spain"
           ],
           "number": "21",
-          "position": "Right Winger"
+          "overall_score": 68,
+          "position": "Right Winger",
+          "potential": 69,
+          "value": 1400000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3382,7 +4314,11 @@
             "Spain"
           ],
           "number": "11",
-          "position": "Right Winger"
+          "overall_score": 71,
+          "position": "Right Winger",
+          "potential": 74,
+          "value": 2600000,
+          "yearly_wage": 364000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3396,7 +4332,11 @@
             "Spain"
           ],
           "number": "7",
-          "position": "Centre-Forward"
+          "overall_score": 64,
+          "position": "Centre-Forward",
+          "potential": 64,
+          "value": 600000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2028",
@@ -3410,7 +4350,11 @@
             "Spain"
           ],
           "number": "9",
-          "position": "Centre-Forward"
+          "overall_score": 70,
+          "position": "Centre-Forward",
+          "potential": 71,
+          "value": 1900000,
+          "yearly_wage": 364000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3423,7 +4367,11 @@
             "Nigeria"
           ],
           "number": "22",
-          "position": "Centre-Forward"
+          "overall_score": 63,
+          "position": "Centre-Forward",
+          "potential": 66,
+          "value": 650000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3438,7 +4386,11 @@
             "Spain"
           ],
           "number": "19",
-          "position": "Centre-Forward"
+          "overall_score": 69,
+          "position": "Centre-Forward",
+          "potential": 69,
+          "value": 1200000,
+          "yearly_wage": 728000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3453,7 +4405,11 @@
             "Germany"
           ],
           "number": "12",
-          "position": "Centre-Forward"
+          "overall_score": 64,
+          "position": "Centre-Forward",
+          "potential": 64,
+          "value": 500000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2028",
@@ -3467,7 +4423,11 @@
             "Spain"
           ],
           "number": "23",
-          "position": "Centre-Forward"
+          "overall_score": 69,
+          "position": "Centre-Forward",
+          "potential": 77,
+          "value": 3100000,
+          "yearly_wage": 312000
         }
       ],
       "stadiumName": "Ibercaja Estadio",
@@ -3491,7 +4451,11 @@
             "France"
           ],
           "number": "1",
-          "position": "Goalkeeper"
+          "overall_score": 68,
+          "position": "Goalkeeper",
+          "potential": 71,
+          "value": 1200000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3505,7 +4469,11 @@
             "Spain"
           ],
           "number": "13",
-          "position": "Goalkeeper"
+          "overall_score": 64,
+          "position": "Goalkeeper",
+          "potential": 76,
+          "value": 1300000,
+          "yearly_wage": 312000
         },
         {
           "contract": "Jun 30, 2028",
@@ -3520,7 +4488,11 @@
             "Congo"
           ],
           "number": "24",
-          "position": "Centre-Back"
+          "overall_score": 69,
+          "position": "Centre-Back",
+          "potential": 78,
+          "value": 2900000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3535,7 +4507,11 @@
             "Senegal"
           ],
           "number": "17",
-          "position": "Centre-Back"
+          "overall_score": 67,
+          "position": "Centre-Back",
+          "potential": 69,
+          "value": 1100000,
+          "yearly_wage": 468000
         },
         {
           "contract": "Jun 30, 2027",
@@ -3549,7 +4525,11 @@
             "Ghana"
           ],
           "number": "28",
-          "position": "Centre-Back"
+          "overall_score": 69,
+          "position": "Centre-Back",
+          "potential": 82,
+          "value": 3200000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2027",
@@ -3563,7 +4543,11 @@
             "Spain"
           ],
           "number": "5",
-          "position": "Centre-Back"
+          "overall_score": 71,
+          "position": "Centre-Back",
+          "potential": 77,
+          "value": 2700000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2028",
@@ -3578,7 +4562,11 @@
             "France"
           ],
           "number": "22",
-          "position": "Left-Back"
+          "overall_score": 69,
+          "position": "Left-Back",
+          "potential": 75,
+          "value": 2100000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2028",
@@ -3592,7 +4580,11 @@
             "Spain"
           ],
           "number": "3",
-          "position": "Left-Back"
+          "overall_score": 63,
+          "position": "Left-Back",
+          "potential": 72,
+          "value": 1000000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3606,7 +4598,11 @@
             "Spain"
           ],
           "number": "18",
-          "position": "Right-Back"
+          "overall_score": 65,
+          "position": "Right-Back",
+          "potential": 65,
+          "value": 500000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2028",
@@ -3620,7 +4616,11 @@
             "Spain"
           ],
           "number": "2",
-          "position": "Right-Back"
+          "overall_score": 63,
+          "position": "Right-Back",
+          "potential": 69,
+          "value": 725000,
+          "yearly_wage": 52000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3634,7 +4634,11 @@
             "Spain"
           ],
           "number": "20",
-          "position": "Central Midfield"
+          "overall_score": 69,
+          "position": "Central Midfield",
+          "potential": 69,
+          "value": 1200000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2028",
@@ -3648,7 +4652,11 @@
             "Spain"
           ],
           "number": "8",
-          "position": "Central Midfield"
+          "overall_score": 70,
+          "position": "Central Midfield",
+          "potential": 77,
+          "value": 3200000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3662,7 +4670,11 @@
             "Georgia"
           ],
           "number": "23",
-          "position": "Central Midfield"
+          "overall_score": 63,
+          "position": "Central Midfield",
+          "potential": 72,
+          "value": 1100000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3676,7 +4688,11 @@
             "Spain"
           ],
           "number": "4",
-          "position": "Central Midfield"
+          "overall_score": 72,
+          "position": "Central Midfield",
+          "potential": 72,
+          "value": 1100000,
+          "yearly_wage": 364000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3690,7 +4706,11 @@
             "Spain"
           ],
           "number": "14",
-          "position": "Central Midfield"
+          "overall_score": 67,
+          "position": "Central Midfield",
+          "potential": 67,
+          "value": 625000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3703,7 +4723,11 @@
             "Spain"
           ],
           "number": "41",
-          "position": "Central Midfield"
+          "overall_score": 70,
+          "position": "Central Midfield",
+          "potential": 83,
+          "value": 3800000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2027",
@@ -3717,7 +4741,11 @@
             "Spain"
           ],
           "number": "11",
-          "position": "Attacking Midfield"
+          "overall_score": 71,
+          "position": "Attacking Midfield",
+          "potential": 71,
+          "value": 1800000,
+          "yearly_wage": 364000
         },
         {
           "contract": "Jun 30, 2028",
@@ -3731,7 +4759,11 @@
             "Spain"
           ],
           "number": "26",
-          "position": "Left Winger"
+          "overall_score": 64,
+          "position": "Left Winger",
+          "potential": 74,
+          "value": 1300000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3745,7 +4777,11 @@
             "Spain"
           ],
           "number": "7",
-          "position": "Right Winger"
+          "overall_score": 72,
+          "position": "Right Winger",
+          "potential": 72,
+          "value": 2600000,
+          "yearly_wage": 364000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3759,7 +4795,11 @@
             "Spain"
           ],
           "number": "21",
-          "position": "Right Winger"
+          "overall_score": 68,
+          "position": "Right Winger",
+          "potential": 71,
+          "value": 1600000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3774,7 +4814,11 @@
             "Senegal"
           ],
           "number": "40",
-          "position": "Right Winger"
+          "overall_score": 65,
+          "position": "Right Winger",
+          "potential": 76,
+          "value": 1600000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3788,7 +4832,11 @@
             "Uruguay"
           ],
           "number": "9",
-          "position": "Centre-Forward"
+          "overall_score": 68,
+          "position": "Centre-Forward",
+          "potential": 77,
+          "value": 2600000,
+          "yearly_wage": 468000
         },
         {
           "contract": "Jun 30, 2028",
@@ -3802,7 +4850,11 @@
             "Spain"
           ],
           "number": "19",
-          "position": "Centre-Forward"
+          "overall_score": 68,
+          "position": "Centre-Forward",
+          "potential": 76,
+          "value": 2700000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3816,7 +4868,11 @@
             "Morocco"
           ],
           "number": "10",
-          "position": "Centre-Forward"
+          "overall_score": 64,
+          "position": "Centre-Forward",
+          "potential": 64,
+          "value": 575000,
+          "yearly_wage": 104000
         }
       ],
       "stadiumName": "Nuevo Los Cármenes",
@@ -3839,7 +4895,11 @@
             "Spain"
           ],
           "number": "13",
-          "position": "Goalkeeper"
+          "overall_score": 69,
+          "position": "Goalkeeper",
+          "potential": 69,
+          "value": 150000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2029",
@@ -3853,7 +4913,11 @@
             "Spain"
           ],
           "number": "31",
-          "position": "Goalkeeper"
+          "overall_score": 62,
+          "position": "Goalkeeper",
+          "potential": 76,
+          "value": 850000,
+          "yearly_wage": 36400
         },
         {
           "contract": "Jun 30, 2027",
@@ -3867,7 +4931,11 @@
             "Spain"
           ],
           "number": "1",
-          "position": "Goalkeeper"
+          "overall_score": 72,
+          "position": "Goalkeeper",
+          "potential": 72,
+          "value": 250000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2031",
@@ -3881,7 +4949,11 @@
             "Italy"
           ],
           "number": "18",
-          "position": "Centre-Back"
+          "overall_score": 73,
+          "position": "Centre-Back",
+          "potential": 82,
+          "value": 6500000,
+          "yearly_wage": 364000
         },
         {
           "contract": "Jun 30, 2028",
@@ -3896,7 +4968,11 @@
             "Italy"
           ],
           "number": "5",
-          "position": "Centre-Back"
+          "overall_score": 72,
+          "position": "Centre-Back",
+          "potential": 72,
+          "value": 1600000,
+          "yearly_wage": 364000
         },
         {
           "contract": "Jun 30, 2028",
@@ -3910,7 +4986,11 @@
             "Spain"
           ],
           "number": "21",
-          "position": "Centre-Back"
+          "overall_score": 65,
+          "position": "Centre-Back",
+          "potential": 68,
+          "value": 825000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2028",
@@ -3924,7 +5004,11 @@
             "Portugal"
           ],
           "number": "4",
-          "position": "Centre-Back"
+          "overall_score": 71,
+          "position": "Centre-Back",
+          "potential": 71,
+          "value": 1600000,
+          "yearly_wage": 364000
         },
         {
           "contract": "Jun 30, 2028",
@@ -3938,7 +5022,11 @@
             "Spain"
           ],
           "number": "3",
-          "position": "Left-Back"
+          "overall_score": 74,
+          "position": "Left-Back",
+          "potential": 74,
+          "value": 3600000,
+          "yearly_wage": 468000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3952,7 +5040,11 @@
             "Spain"
           ],
           "number": "20",
-          "position": "Left-Back"
+          "overall_score": 68,
+          "position": "Left-Back",
+          "potential": 71,
+          "value": 1500000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2030",
@@ -3967,7 +5059,11 @@
             "Curacao"
           ],
           "number": "22",
-          "position": "Right-Back"
+          "overall_score": 71,
+          "position": "Right-Back",
+          "potential": 78,
+          "value": 3600000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2030",
@@ -3981,7 +5077,11 @@
             "Spain"
           ],
           "number": "16",
-          "position": "Right-Back"
+          "overall_score": 71,
+          "position": "Right-Back",
+          "potential": 80,
+          "value": 4000000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2029",
@@ -3995,7 +5095,11 @@
             "Senegal"
           ],
           "number": "17",
-          "position": "Defensive Midfield"
+          "overall_score": 73,
+          "position": "Defensive Midfield",
+          "potential": 82,
+          "value": 6500000,
+          "yearly_wage": 364000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4009,7 +5113,11 @@
             "Portugal"
           ],
           "number": "6",
-          "position": "Central Midfield"
+          "overall_score": 70,
+          "position": "Central Midfield",
+          "potential": 70,
+          "value": 1600000,
+          "yearly_wage": 468000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4023,7 +5131,11 @@
             "Spain"
           ],
           "number": "2",
-          "position": "Central Midfield"
+          "overall_score": 71,
+          "position": "Central Midfield",
+          "potential": 74,
+          "value": 2600000,
+          "yearly_wage": 312000
         },
         {
           "contract": "Jun 30, 2027",
@@ -4038,7 +5150,11 @@
             "Spain"
           ],
           "number": "14",
-          "position": "Central Midfield"
+          "overall_score": 71,
+          "position": "Central Midfield",
+          "potential": 71,
+          "value": 1600000,
+          "yearly_wage": 364000
         },
         {
           "contract": "Jun 30, 2030",
@@ -4053,7 +5169,11 @@
             "France"
           ],
           "number": "29",
-          "position": "Central Midfield"
+          "overall_score": 69,
+          "position": "Central Midfield",
+          "potential": 80,
+          "value": 2900000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2028",
@@ -4067,7 +5187,11 @@
             "Portugal"
           ],
           "number": "8",
-          "position": "Central Midfield"
+          "overall_score": 68,
+          "position": "Central Midfield",
+          "potential": 74,
+          "value": 1800000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2029",
@@ -4081,7 +5205,11 @@
             "Spain"
           ],
           "number": "11",
-          "position": "Attacking Midfield"
+          "overall_score": 77,
+          "position": "Attacking Midfield",
+          "potential": 83,
+          "value": 16500000,
+          "yearly_wage": 468000
         },
         {
           "contract": "Jun 30, 2030",
@@ -4096,7 +5224,11 @@
             "Argentina"
           ],
           "number": "10",
-          "position": "Attacking Midfield"
+          "overall_score": 69,
+          "position": "Attacking Midfield",
+          "potential": 72,
+          "value": 1900000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2030",
@@ -4110,7 +5242,11 @@
             "Spain"
           ],
           "number": "7",
-          "position": "Left Winger"
+          "overall_score": 73,
+          "position": "Left Winger",
+          "potential": 73,
+          "value": 3300000,
+          "yearly_wage": 416000
         },
         {
           "contract": "Jun 30, 2028",
@@ -4124,7 +5260,11 @@
             "Cameroon"
           ],
           "number": "19",
-          "position": "Right Winger"
+          "overall_score": 68,
+          "position": "Right Winger",
+          "potential": 68,
+          "value": 1300000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2028",
@@ -4138,7 +5278,11 @@
             "Spain"
           ],
           "number": "23",
-          "position": "Right Winger"
+          "overall_score": 75,
+          "position": "Right Winger",
+          "potential": 75,
+          "value": 3500000,
+          "yearly_wage": 520000
         },
         {
           "contract": "Jun 30, 2031",
@@ -4152,7 +5296,11 @@
             "Brazil"
           ],
           "number": "9",
-          "position": "Centre-Forward"
+          "overall_score": 66,
+          "position": "Centre-Forward",
+          "potential": 79,
+          "value": 2100000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4166,7 +5314,11 @@
             "Spain"
           ],
           "number": "24",
-          "position": "Centre-Forward"
+          "overall_score": 71,
+          "position": "Centre-Forward",
+          "potential": 74,
+          "value": 2500000,
+          "yearly_wage": 520000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4181,7 +5333,11 @@
             "Spain"
           ],
           "number": "12",
-          "position": "Centre-Forward"
+          "overall_score": 71,
+          "position": "Centre-Forward",
+          "potential": 71,
+          "value": 1500000,
+          "yearly_wage": 364000
         },
         {
           "contract": "Jun 30, 2028",
@@ -4217,7 +5373,11 @@
             "Spain"
           ],
           "number": "13",
-          "position": "Goalkeeper"
+          "overall_score": 69,
+          "position": "Goalkeeper",
+          "potential": 69,
+          "value": 240000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2027",
@@ -4231,7 +5391,11 @@
             "Spain"
           ],
           "number": "1",
-          "position": "Goalkeeper"
+          "overall_score": 67,
+          "position": "Goalkeeper",
+          "potential": 67,
+          "value": 110000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2027",
@@ -4245,7 +5409,11 @@
             "Spain"
           ],
           "number": "24",
-          "position": "Centre-Back"
+          "overall_score": 71,
+          "position": "Centre-Back",
+          "potential": 72,
+          "value": 1800000,
+          "yearly_wage": 364000
         },
         {
           "contract": "Jun 30, 2027",
@@ -4259,7 +5427,11 @@
             "Spain"
           ],
           "number": "22",
-          "position": "Centre-Back"
+          "overall_score": 68,
+          "position": "Centre-Back",
+          "potential": 69,
+          "value": 1100000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2027",
@@ -4273,7 +5445,11 @@
             "Spain"
           ],
           "number": "23",
-          "position": "Centre-Back"
+          "overall_score": 68,
+          "position": "Centre-Back",
+          "potential": 73,
+          "value": 1600000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2027",
@@ -4285,7 +5461,11 @@
             "Spain"
           ],
           "number": "5",
-          "position": "Centre-Back"
+          "overall_score": 64,
+          "position": "Centre-Back",
+          "potential": 69,
+          "value": 775000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4299,7 +5479,11 @@
             "Spain"
           ],
           "number": "21",
-          "position": "Left-Back"
+          "overall_score": 71,
+          "position": "Left-Back",
+          "potential": 71,
+          "value": 1600000,
+          "yearly_wage": 364000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4314,7 +5498,11 @@
             "Mexico"
           ],
           "number": "3",
-          "position": "Left-Back"
+          "overall_score": 65,
+          "position": "Left-Back",
+          "potential": 75,
+          "value": 1500000,
+          "yearly_wage": 312000
         },
         {
           "contract": "Jun 30, 2028",
@@ -4328,7 +5516,11 @@
             "Spain"
           ],
           "number": "2",
-          "position": "Right-Back"
+          "overall_score": 65,
+          "position": "Right-Back",
+          "potential": 74,
+          "value": 1500000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4342,7 +5534,11 @@
             "Spain"
           ],
           "number": "15",
-          "position": "Right-Back"
+          "overall_score": 69,
+          "position": "Right-Back",
+          "potential": 69,
+          "value": 725000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4356,7 +5552,11 @@
             "Uruguay"
           ],
           "number": "8",
-          "position": "Defensive Midfield"
+          "overall_score": 69,
+          "position": "Defensive Midfield",
+          "potential": 76,
+          "value": 2600000,
+          "yearly_wage": 312000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4370,7 +5570,11 @@
             "Panama"
           ],
           "number": "12",
-          "position": "Defensive Midfield"
+          "overall_score": 66,
+          "position": "Defensive Midfield",
+          "potential": 77,
+          "value": 1900000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2028",
@@ -4384,7 +5588,11 @@
             "Spain"
           ],
           "number": "4",
-          "position": "Central Midfield"
+          "overall_score": 71,
+          "position": "Central Midfield",
+          "potential": 71,
+          "value": 1800000,
+          "yearly_wage": 364000
         },
         {
           "contract": "Jun 30, 2028",
@@ -4398,7 +5606,11 @@
             "Spain"
           ],
           "number": "6",
-          "position": "Central Midfield"
+          "overall_score": 64,
+          "position": "Central Midfield",
+          "potential": 71,
+          "value": 1200000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2027",
@@ -4412,7 +5624,11 @@
             "Spain"
           ],
           "number": "18",
-          "position": "Central Midfield"
+          "overall_score": 65,
+          "position": "Central Midfield",
+          "potential": 74,
+          "value": 1600000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4425,7 +5641,11 @@
             "Spain"
           ],
           "number": "17",
-          "position": "Central Midfield"
+          "overall_score": 65,
+          "position": "Central Midfield",
+          "potential": 66,
+          "value": 825000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2028",
@@ -4439,7 +5659,11 @@
             "Spain"
           ],
           "number": "14",
-          "position": "Central Midfield"
+          "overall_score": 65,
+          "position": "Central Midfield",
+          "potential": 68,
+          "value": 950000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2027",
@@ -4451,7 +5675,11 @@
             "Spain"
           ],
           "number": "26",
-          "position": "Central Midfield"
+          "overall_score": 61,
+          "position": "Central Midfield",
+          "potential": 74,
+          "value": 725000,
+          "yearly_wage": 52000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4465,7 +5693,11 @@
             "Spain"
           ],
           "number": "16",
-          "position": "Left Winger"
+          "overall_score": 68,
+          "position": "Left Winger",
+          "potential": 68,
+          "value": 1200000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2027",
@@ -4479,7 +5711,11 @@
             "Spain"
           ],
           "number": "7",
-          "position": "Right Winger"
+          "overall_score": 72,
+          "position": "Right Winger",
+          "potential": 72,
+          "value": 1500000,
+          "yearly_wage": 416000
         },
         {
           "contract": "Jun 30, 2028",
@@ -4492,7 +5728,11 @@
             "Brazil"
           ],
           "number": "11",
-          "position": "Right Winger"
+          "overall_score": 65,
+          "position": "Right Winger",
+          "potential": 71,
+          "value": 1100000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4506,7 +5746,11 @@
             "Spain"
           ],
           "number": "10",
-          "position": "Centre-Forward"
+          "overall_score": 70,
+          "position": "Centre-Forward",
+          "potential": 70,
+          "value": 1300000,
+          "yearly_wage": 988000
         },
         {
           "contract": "Jun 30, 2027",
@@ -4520,7 +5764,11 @@
             "Ghana"
           ],
           "number": "20",
-          "position": "Centre-Forward"
+          "overall_score": 67,
+          "position": "Centre-Forward",
+          "potential": 67,
+          "value": 1000000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2027",
@@ -4534,7 +5782,11 @@
             "Spain"
           ],
           "number": "9",
-          "position": "Centre-Forward"
+          "overall_score": 67,
+          "position": "Centre-Forward",
+          "potential": 67,
+          "value": 850000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2030",
@@ -4548,7 +5800,11 @@
             "Spain"
           ],
           "number": "19",
-          "position": "Centre-Forward"
+          "overall_score": 65,
+          "position": "Centre-Forward",
+          "potential": 74,
+          "value": 1600000,
+          "yearly_wage": 156000
         }
       ],
       "stadiumName": "Carlos Belmonte",
@@ -4571,7 +5827,11 @@
             "Belgium"
           ],
           "number": "13",
-          "position": "Goalkeeper"
+          "overall_score": 69,
+          "position": "Goalkeeper",
+          "potential": 73,
+          "value": 1500000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2027",
@@ -4586,7 +5846,11 @@
             "Portugal"
           ],
           "number": "1",
-          "position": "Goalkeeper"
+          "overall_score": 69,
+          "position": "Goalkeeper",
+          "potential": 69,
+          "value": 700000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2029",
@@ -4600,7 +5864,11 @@
             "Italy"
           ],
           "number": "3",
-          "position": "Centre-Back"
+          "overall_score": 69,
+          "position": "Centre-Back",
+          "potential": 71,
+          "value": 1500000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4614,7 +5882,11 @@
             "Argentina"
           ],
           "number": "4",
-          "position": "Centre-Back"
+          "overall_score": 66,
+          "position": "Centre-Back",
+          "potential": 71,
+          "value": 1100000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2028",
@@ -4628,7 +5900,11 @@
             "Spain"
           ],
           "number": "5",
-          "position": "Centre-Back"
+          "overall_score": 69,
+          "position": "Centre-Back",
+          "potential": 69,
+          "value": 900000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2028",
@@ -4642,7 +5918,11 @@
             "Spain"
           ],
           "number": "12",
-          "position": "Left-Back"
+          "overall_score": 70,
+          "position": "Left-Back",
+          "potential": 78,
+          "value": 3400000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2029",
@@ -4655,7 +5935,11 @@
             "Spain"
           ],
           "number": "2",
-          "position": "Left-Back"
+          "overall_score": 60,
+          "position": "Left-Back",
+          "potential": 69,
+          "value": 525000,
+          "yearly_wage": 52000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4669,7 +5953,11 @@
             "Spain"
           ],
           "number": "17",
-          "position": "Left-Back"
+          "overall_score": 64,
+          "position": "Left-Back",
+          "potential": 64,
+          "value": 475000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2027",
@@ -4683,7 +5971,11 @@
             "France"
           ],
           "number": "22",
-          "position": "Right-Back"
+          "overall_score": 71,
+          "position": "Right-Back",
+          "potential": 71,
+          "value": 1400000,
+          "yearly_wage": 364000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4712,7 +6004,11 @@
             "Spain"
           ],
           "number": "8",
-          "position": "Central Midfield"
+          "overall_score": 70,
+          "position": "Central Midfield",
+          "potential": 70,
+          "value": 1600000,
+          "yearly_wage": 312000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4726,7 +6022,11 @@
             "Spain"
           ],
           "number": "15",
-          "position": "Central Midfield"
+          "overall_score": 69,
+          "position": "Central Midfield",
+          "potential": 77,
+          "value": 3100000,
+          "yearly_wage": 832000
         },
         {
           "contract": "Jun 30, 2027",
@@ -4741,7 +6041,11 @@
             "Cote d'Ivoire"
           ],
           "number": "6",
-          "position": "Central Midfield"
+          "overall_score": 64,
+          "position": "Central Midfield",
+          "potential": 71,
+          "value": 1100000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2029",
@@ -4769,7 +6073,11 @@
             "Spain"
           ],
           "number": "10",
-          "position": "Attacking Midfield"
+          "overall_score": 69,
+          "position": "Attacking Midfield",
+          "potential": 69,
+          "value": 1200000,
+          "yearly_wage": 312000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4783,7 +6091,11 @@
             "DR Congo"
           ],
           "number": "16",
-          "position": "Left Winger"
+          "overall_score": 73,
+          "position": "Left Winger",
+          "potential": 73,
+          "value": 3200000,
+          "yearly_wage": 416000
         },
         {
           "contract": "Jun 30, 2028",
@@ -4797,7 +6109,11 @@
             "Spain"
           ],
           "number": "14",
-          "position": "Left Winger"
+          "overall_score": 70,
+          "position": "Left Winger",
+          "potential": 70,
+          "value": 1700000,
+          "yearly_wage": 312000
         },
         {
           "contract": "Jun 30, 2028",
@@ -4811,7 +6127,11 @@
             "Spain"
           ],
           "number": "18",
-          "position": "Left Winger"
+          "overall_score": 67,
+          "position": "Left Winger",
+          "potential": 70,
+          "value": 1400000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2028",
@@ -4826,7 +6146,11 @@
             "Southern Sudan"
           ],
           "number": "7",
-          "position": "Left Winger"
+          "overall_score": 68,
+          "position": "Left Winger",
+          "potential": 68,
+          "value": 1200000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4841,7 +6165,11 @@
             "Portugal"
           ],
           "number": "11",
-          "position": "Right Winger"
+          "overall_score": 67,
+          "position": "Right Winger",
+          "potential": 68,
+          "value": 1200000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4855,7 +6183,11 @@
             "Italy"
           ],
           "number": "29",
-          "position": "Second Striker"
+          "overall_score": 59,
+          "position": "Second Striker",
+          "potential": 70,
+          "value": 500000,
+          "yearly_wage": 312000
         },
         {
           "contract": "Jun 30, 2030",
@@ -4869,7 +6201,11 @@
             "Denmark"
           ],
           "number": "19",
-          "position": "Centre-Forward"
+          "overall_score": 67,
+          "position": "Centre-Forward",
+          "potential": 68,
+          "value": 1200000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2027",
@@ -4883,7 +6219,11 @@
             "Guinea"
           ],
           "number": "9",
-          "position": "Centre-Forward"
+          "overall_score": 69,
+          "position": "Centre-Forward",
+          "potential": 76,
+          "value": 2800000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2028",
@@ -4897,7 +6237,11 @@
             "Spain"
           ],
           "number": "23",
-          "position": "Centre-Forward"
+          "overall_score": 63,
+          "position": "Centre-Forward",
+          "potential": 65,
+          "value": 600000,
+          "yearly_wage": 104000
         }
       ],
       "stadiumName": "SkyFi Castalia",
@@ -4920,7 +6264,11 @@
             "Spain"
           ],
           "number": "13",
-          "position": "Goalkeeper"
+          "overall_score": 73,
+          "position": "Goalkeeper",
+          "potential": 73,
+          "value": 1000000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4934,7 +6282,11 @@
             "Spain"
           ],
           "number": "1",
-          "position": "Goalkeeper"
+          "overall_score": 64,
+          "position": "Goalkeeper",
+          "potential": 64,
+          "value": 300000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4947,7 +6299,11 @@
             "Spain"
           ],
           "number": "26",
-          "position": "Goalkeeper"
+          "overall_score": 61,
+          "position": "Goalkeeper",
+          "potential": 68,
+          "value": 575000,
+          "yearly_wage": 44200
         },
         {
           "contract": "Jun 30, 2026",
@@ -4961,7 +6317,11 @@
             "Portugal"
           ],
           "number": "16",
-          "position": "Centre-Back"
+          "overall_score": 67,
+          "position": "Centre-Back",
+          "potential": 70,
+          "value": 1200000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4976,7 +6336,11 @@
             "Spain"
           ],
           "number": "36",
-          "position": "Centre-Back"
+          "overall_score": 67,
+          "position": "Centre-Back",
+          "potential": 80,
+          "value": 2400000,
+          "yearly_wage": 364000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4989,7 +6353,11 @@
             "Spain"
           ],
           "number": "21",
-          "position": "Centre-Back"
+          "overall_score": 67,
+          "position": "Centre-Back",
+          "potential": 78,
+          "value": 2100000,
+          "yearly_wage": 312000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5002,7 +6370,11 @@
           "nationality": [
             "Spain"
           ],
-          "position": "Centre-Back"
+          "overall_score": 64,
+          "position": "Centre-Back",
+          "potential": 73,
+          "value": 1200000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2027",
@@ -5016,7 +6388,11 @@
             "Spain"
           ],
           "number": "4",
-          "position": "Centre-Back"
+          "overall_score": 67,
+          "position": "Centre-Back",
+          "potential": 74,
+          "value": 1900000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5030,7 +6406,11 @@
             "Spain"
           ],
           "number": "5",
-          "position": "Centre-Back"
+          "overall_score": 64,
+          "position": "Centre-Back",
+          "potential": 64,
+          "value": 500000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5044,7 +6424,11 @@
             "Spain"
           ],
           "number": "3",
-          "position": "Centre-Back"
+          "overall_score": 64,
+          "position": "Centre-Back",
+          "potential": 64,
+          "value": 210000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5059,7 +6443,11 @@
             "Sudan"
           ],
           "number": "12",
-          "position": "Left-Back"
+          "overall_score": 67,
+          "position": "Left-Back",
+          "potential": 70,
+          "value": 1200000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2028",
@@ -5073,7 +6461,11 @@
             "Spain"
           ],
           "number": "17",
-          "position": "Right-Back"
+          "overall_score": 67,
+          "position": "Right-Back",
+          "potential": 67,
+          "value": 875000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5088,7 +6480,11 @@
             "Portugal"
           ],
           "number": "24",
-          "position": "Right-Back"
+          "overall_score": 64,
+          "position": "Right-Back",
+          "potential": 64,
+          "value": 425000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5102,7 +6498,11 @@
             "Argentina"
           ],
           "number": "28",
-          "position": "Central Midfield"
+          "overall_score": 67,
+          "position": "Central Midfield",
+          "potential": 76,
+          "value": 2200000,
+          "yearly_wage": 624000
         },
         {
           "contract": "Jun 30, 2027",
@@ -5116,7 +6516,11 @@
             "Spain"
           ],
           "number": "8",
-          "position": "Central Midfield"
+          "overall_score": 63,
+          "position": "Central Midfield",
+          "potential": 71,
+          "value": 1000000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5131,7 +6535,11 @@
             "Spain"
           ],
           "number": "23",
-          "position": "Central Midfield"
+          "overall_score": 64,
+          "position": "Central Midfield",
+          "potential": 73,
+          "value": 1300000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5145,7 +6553,11 @@
             "Spain"
           ],
           "number": "6",
-          "position": "Central Midfield"
+          "overall_score": 62,
+          "position": "Central Midfield",
+          "potential": 62,
+          "value": 140000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5159,7 +6571,11 @@
             "Spain"
           ],
           "number": "14",
-          "position": "Attacking Midfield"
+          "overall_score": 66,
+          "position": "Attacking Midfield",
+          "potential": 66,
+          "value": 825000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5173,7 +6589,11 @@
             "Spain"
           ],
           "number": "10",
-          "position": "Left Winger"
+          "overall_score": 70,
+          "position": "Left Winger",
+          "potential": 73,
+          "value": 2100000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5187,7 +6607,11 @@
             "Spain"
           ],
           "number": "7",
-          "position": "Left Winger"
+          "overall_score": 66,
+          "position": "Left Winger",
+          "potential": 71,
+          "value": 1300000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5201,7 +6625,11 @@
             "Spain"
           ],
           "number": "20",
-          "position": "Left Winger"
+          "overall_score": 67,
+          "position": "Left Winger",
+          "potential": 70,
+          "value": 1400000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5215,7 +6643,11 @@
             "Brazil"
           ],
           "number": "15",
-          "position": "Right Winger"
+          "overall_score": 70,
+          "position": "Right Winger",
+          "potential": 70,
+          "value": 1700000,
+          "yearly_wage": 312000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5229,7 +6661,11 @@
             "Spain"
           ],
           "number": "11",
-          "position": "Right Winger"
+          "overall_score": 66,
+          "position": "Right Winger",
+          "potential": 78,
+          "value": 2000000,
+          "yearly_wage": 468000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5243,7 +6679,11 @@
             "Spain"
           ],
           "number": "9",
-          "position": "Centre-Forward"
+          "overall_score": 67,
+          "position": "Centre-Forward",
+          "potential": 67,
+          "value": 1000000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5257,7 +6697,11 @@
             "Spain"
           ],
           "number": "19",
-          "position": "Centre-Forward"
+          "overall_score": 69,
+          "position": "Centre-Forward",
+          "potential": 69,
+          "value": 875000,
+          "yearly_wage": 260000
         }
       ],
       "stadiumName": "Reino de León",
@@ -5280,7 +6724,11 @@
             "Spain"
           ],
           "number": "1",
-          "position": "Goalkeeper"
+          "overall_score": 74,
+          "position": "Goalkeeper",
+          "potential": 75,
+          "value": 3600000,
+          "yearly_wage": 416000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5294,7 +6742,11 @@
             "Spain"
           ],
           "number": "13",
-          "position": "Goalkeeper"
+          "overall_score": 67,
+          "position": "Goalkeeper",
+          "potential": 69,
+          "value": 925000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5308,7 +6760,11 @@
             "Spain"
           ],
           "number": "3",
-          "position": "Centre-Back"
+          "overall_score": 68,
+          "position": "Centre-Back",
+          "potential": 69,
+          "value": 1100000,
+          "yearly_wage": 364000
         },
         {
           "contract": "Jun 30, 2029",
@@ -5322,7 +6778,11 @@
             "Spain"
           ],
           "number": "6",
-          "position": "Centre-Back"
+          "overall_score": 70,
+          "position": "Centre-Back",
+          "potential": 77,
+          "value": 3000000,
+          "yearly_wage": 364000
         },
         {
           "contract": "Jun 30, 2028",
@@ -5337,7 +6797,11 @@
             "Nigeria"
           ],
           "number": "2",
-          "position": "Centre-Back"
+          "overall_score": 67,
+          "position": "Centre-Back",
+          "potential": 73,
+          "value": 1500000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5351,7 +6815,11 @@
             "Spain"
           ],
           "number": "5",
-          "position": "Centre-Back"
+          "overall_score": 67,
+          "position": "Centre-Back",
+          "potential": 67,
+          "value": 650000,
+          "yearly_wage": 312000
         },
         {
           "contract": "Jun 30, 2028",
@@ -5365,7 +6833,11 @@
             "Spain"
           ],
           "number": "4",
-          "position": "Centre-Back"
+          "overall_score": 67,
+          "position": "Centre-Back",
+          "potential": 71,
+          "value": 1300000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5379,7 +6851,11 @@
             "Spain"
           ],
           "number": "15",
-          "position": "Left-Back"
+          "overall_score": 68,
+          "position": "Left-Back",
+          "potential": 68,
+          "value": 1100000,
+          "yearly_wage": 364000
         },
         {
           "contract": "Jun 30, 2027",
@@ -5393,7 +6869,11 @@
             "Spain"
           ],
           "number": "7",
-          "position": "Right-Back"
+          "overall_score": 70,
+          "position": "Right-Back",
+          "potential": 70,
+          "value": 825000,
+          "yearly_wage": 416000
         },
         {
           "contract": "Jun 30, 2028",
@@ -5408,7 +6888,11 @@
             "Spain"
           ],
           "number": "22",
-          "position": "Right-Back"
+          "overall_score": 64,
+          "position": "Right-Back",
+          "potential": 70,
+          "value": 875000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2027",
@@ -5422,7 +6906,11 @@
             "Guinea"
           ],
           "number": "24",
-          "position": "Defensive Midfield"
+          "overall_score": 72,
+          "position": "Defensive Midfield",
+          "potential": 72,
+          "value": 2200000,
+          "yearly_wage": 520000
         },
         {
           "contract": "Jun 30, 2029",
@@ -5436,7 +6924,11 @@
             "Spain"
           ],
           "number": "26",
-          "position": "Defensive Midfield"
+          "overall_score": 66,
+          "position": "Defensive Midfield",
+          "potential": 72,
+          "value": 1300000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5450,7 +6942,11 @@
             "Guinea"
           ],
           "number": "8",
-          "position": "Central Midfield"
+          "overall_score": 70,
+          "position": "Central Midfield",
+          "potential": 75,
+          "value": 2400000,
+          "yearly_wage": 364000
         },
         {
           "contract": "Jun 30, 2027",
@@ -5464,7 +6960,11 @@
             "Spain"
           ],
           "number": "16",
-          "position": "Central Midfield"
+          "overall_score": 68,
+          "position": "Central Midfield",
+          "potential": 68,
+          "value": 1000000,
+          "yearly_wage": 364000
         },
         {
           "contract": "Jun 30, 2027",
@@ -5478,7 +6978,11 @@
             "Spain"
           ],
           "number": "14",
-          "position": "Attacking Midfield"
+          "overall_score": 67,
+          "position": "Attacking Midfield",
+          "potential": 70,
+          "value": 1300000,
+          "yearly_wage": 312000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5492,7 +6996,11 @@
             "Spain"
           ],
           "number": "9",
-          "position": "Attacking Midfield"
+          "overall_score": 73,
+          "position": "Attacking Midfield",
+          "potential": 73,
+          "value": 1000000,
+          "yearly_wage": 468000
         },
         {
           "contract": "Jun 30, 2029",
@@ -5507,7 +7015,11 @@
             "Argentina"
           ],
           "number": "10",
-          "position": "Left Winger"
+          "overall_score": 70,
+          "position": "Left Winger",
+          "potential": 71,
+          "value": 1900000,
+          "yearly_wage": 468000
         },
         {
           "contract": "Jun 30, 2027",
@@ -5522,7 +7034,11 @@
             "Portugal"
           ],
           "number": "11",
-          "position": "Left Winger"
+          "overall_score": 70,
+          "position": "Left Winger",
+          "potential": 71,
+          "value": 1900000,
+          "yearly_wage": 468000
         },
         {
           "contract": "Jun 30, 2027",
@@ -5535,7 +7051,11 @@
             "Spain"
           ],
           "number": "21",
-          "position": "Left Winger"
+          "overall_score": 63,
+          "position": "Left Winger",
+          "potential": 69,
+          "value": 750000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2027",
@@ -5549,7 +7069,11 @@
             "Spain"
           ],
           "number": "17",
-          "position": "Right Winger"
+          "overall_score": 67,
+          "position": "Right Winger",
+          "potential": 72,
+          "value": 1500000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5563,7 +7087,11 @@
             "Spain"
           ],
           "number": "20",
-          "position": "Second Striker"
+          "overall_score": 68,
+          "position": "Second Striker",
+          "potential": 68,
+          "value": 575000,
+          "yearly_wage": 364000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5578,7 +7106,11 @@
             "Spain"
           ],
           "number": "12",
-          "position": "Centre-Forward"
+          "overall_score": 65,
+          "position": "Centre-Forward",
+          "potential": 70,
+          "value": 1100000,
+          "yearly_wage": 312000
         },
         {
           "contract": "Jun 30, 2028",
@@ -5592,7 +7124,11 @@
             "Spain"
           ],
           "number": "19",
-          "position": "Centre-Forward"
+          "overall_score": 66,
+          "position": "Centre-Forward",
+          "potential": 68,
+          "value": 1100000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2027",
@@ -5606,7 +7142,11 @@
             "Spain"
           ],
           "number": "23",
-          "position": "Centre-Forward"
+          "overall_score": 70,
+          "position": "Centre-Forward",
+          "potential": 73,
+          "value": 2100000,
+          "yearly_wage": 468000
         }
       ],
       "stadiumName": "Butarque",
@@ -5629,7 +7169,11 @@
             "Spain"
           ],
           "number": "13",
-          "position": "Goalkeeper"
+          "overall_score": 70,
+          "position": "Goalkeeper",
+          "potential": 70,
+          "value": 1100000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5643,7 +7187,11 @@
             "Spain"
           ],
           "number": "1",
-          "position": "Goalkeeper"
+          "overall_score": 70,
+          "position": "Goalkeeper",
+          "potential": 72,
+          "value": 1400000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5657,7 +7205,11 @@
             "Spain"
           ],
           "number": "3",
-          "position": "Centre-Back"
+          "overall_score": 69,
+          "position": "Centre-Back",
+          "potential": 71,
+          "value": 1500000,
+          "yearly_wage": 780000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5671,7 +7223,11 @@
             "Spain"
           ],
           "number": "8",
-          "position": "Centre-Back"
+          "overall_score": 67,
+          "position": "Centre-Back",
+          "potential": 67,
+          "value": 650000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5686,7 +7242,11 @@
             "Portugal"
           ],
           "number": "12",
-          "position": "Left-Back"
+          "overall_score": 70,
+          "position": "Left-Back",
+          "potential": 70,
+          "value": 1400000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2027",
@@ -5700,7 +7260,11 @@
             "Spain"
           ],
           "number": "22",
-          "position": "Left-Back"
+          "overall_score": 66,
+          "position": "Left-Back",
+          "potential": 72,
+          "value": 1300000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2029",
@@ -5712,7 +7276,11 @@
             "Spain"
           ],
           "number": "2",
-          "position": "Right-Back"
+          "overall_score": 67,
+          "position": "Right-Back",
+          "potential": 76,
+          "value": 2200000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5726,7 +7294,11 @@
             "Spain"
           ],
           "number": "15",
-          "position": "Right-Back"
+          "overall_score": 66,
+          "position": "Right-Back",
+          "potential": 66,
+          "value": 825000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2027",
@@ -5740,7 +7312,11 @@
             "Chile"
           ],
           "number": "4",
-          "position": "Central Midfield"
+          "overall_score": 69,
+          "position": "Central Midfield",
+          "potential": 69,
+          "value": 1400000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5754,7 +7330,11 @@
             "Spain"
           ],
           "number": "5",
-          "position": "Central Midfield"
+          "overall_score": 71,
+          "position": "Central Midfield",
+          "potential": 74,
+          "value": 2200000,
+          "yearly_wage": 312000
         },
         {
           "contract": "Jun 30, 2029",
@@ -5768,7 +7348,11 @@
             "Spain"
           ],
           "number": "14",
-          "position": "Central Midfield"
+          "overall_score": 68,
+          "position": "Central Midfield",
+          "potential": 77,
+          "value": 2700000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2027",
@@ -5783,7 +7367,11 @@
             "France"
           ],
           "number": "10",
-          "position": "Central Midfield"
+          "overall_score": 69,
+          "position": "Central Midfield",
+          "potential": 69,
+          "value": 1500000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5797,7 +7385,11 @@
             "Spain"
           ],
           "number": "23",
-          "position": "Central Midfield"
+          "overall_score": 68,
+          "position": "Central Midfield",
+          "potential": 75,
+          "value": 2300000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5811,7 +7403,11 @@
             "Spain"
           ],
           "number": "6",
-          "position": "Central Midfield"
+          "overall_score": 69,
+          "position": "Central Midfield",
+          "potential": 70,
+          "value": 1300000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2027",
@@ -5825,7 +7421,11 @@
             "Spain"
           ],
           "number": "28",
-          "position": "Central Midfield"
+          "overall_score": 63,
+          "position": "Central Midfield",
+          "potential": 73,
+          "value": 1100000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2027",
@@ -5839,7 +7439,11 @@
             "Spain"
           ],
           "number": "17",
-          "position": "Central Midfield"
+          "overall_score": 63,
+          "position": "Central Midfield",
+          "potential": 70,
+          "value": 950000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2028",
@@ -5853,7 +7457,11 @@
             "Spain"
           ],
           "number": "33",
-          "position": "Central Midfield"
+          "overall_score": 61,
+          "position": "Central Midfield",
+          "potential": 69,
+          "value": 700000,
+          "yearly_wage": 52000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5867,7 +7475,11 @@
             "Paraguay",
             "Spain"
           ],
-          "position": "Attacking Midfield"
+          "overall_score": 62,
+          "position": "Attacking Midfield",
+          "potential": 77,
+          "value": 950000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5881,7 +7493,11 @@
             "Spain"
           ],
           "number": "21",
-          "position": "Left Winger"
+          "overall_score": 71,
+          "position": "Left Winger",
+          "potential": 71,
+          "value": 1900000,
+          "yearly_wage": 312000
         },
         {
           "contract": "Jun 30, 2027",
@@ -5895,7 +7511,11 @@
             "Spain"
           ],
           "number": "16",
-          "position": "Right Winger"
+          "overall_score": 70,
+          "position": "Right Winger",
+          "potential": 70,
+          "value": 1600000,
+          "yearly_wage": 312000
         },
         {
           "contract": "Jun 30, 2028",
@@ -5909,7 +7529,11 @@
             "Spain"
           ],
           "number": "11",
-          "position": "Right Winger"
+          "overall_score": 69,
+          "position": "Right Winger",
+          "potential": 74,
+          "value": 2100000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5921,7 +7545,11 @@
             "Spain"
           ],
           "number": "31",
-          "position": "Right Winger"
+          "overall_score": 61,
+          "position": "Right Winger",
+          "potential": 68,
+          "value": 675000,
+          "yearly_wage": 52000
         },
         {
           "contract": "Jun 30, 2029",
@@ -5935,7 +7563,11 @@
             "Spain"
           ],
           "number": "9",
-          "position": "Centre-Forward"
+          "overall_score": 71,
+          "position": "Centre-Forward",
+          "potential": 76,
+          "value": 2900000,
+          "yearly_wage": 312000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5949,7 +7581,11 @@
             "Spain"
           ],
           "number": "20",
-          "position": "Centre-Forward"
+          "overall_score": 69,
+          "position": "Centre-Forward",
+          "potential": 69,
+          "value": 1400000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2028",
@@ -5964,7 +7600,11 @@
             "Spain"
           ],
           "number": "7",
-          "position": "Centre-Forward"
+          "overall_score": 62,
+          "position": "Centre-Forward",
+          "potential": 71,
+          "value": 900000,
+          "yearly_wage": 104000
         }
       ],
       "stadiumName": "El Plantío",
@@ -5987,7 +7627,11 @@
             "Spain"
           ],
           "number": "1",
-          "position": "Goalkeeper"
+          "overall_score": 63,
+          "position": "Goalkeeper",
+          "potential": 65,
+          "value": 400000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6001,7 +7645,11 @@
             "Spain"
           ],
           "number": "30",
-          "position": "Goalkeeper"
+          "overall_score": 62,
+          "position": "Goalkeeper",
+          "potential": 79,
+          "value": 900000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2027",
@@ -6015,7 +7663,11 @@
             "Spain"
           ],
           "number": "13",
-          "position": "Goalkeeper"
+          "overall_score": 73,
+          "position": "Goalkeeper",
+          "potential": 73,
+          "value": 350000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6029,7 +7681,11 @@
             "Spain"
           ],
           "number": "12",
-          "position": "Centre-Back"
+          "overall_score": 68,
+          "position": "Centre-Back",
+          "potential": 68,
+          "value": 1000000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6043,7 +7699,11 @@
             "Spain"
           ],
           "number": "4",
-          "position": "Centre-Back"
+          "overall_score": 66,
+          "position": "Centre-Back",
+          "potential": 73,
+          "value": 1600000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6057,7 +7717,11 @@
             "Spain"
           ],
           "number": "14",
-          "position": "Centre-Back"
+          "overall_score": 70,
+          "position": "Centre-Back",
+          "potential": 70,
+          "value": 525000,
+          "yearly_wage": 364000
         },
         {
           "contract": "Jun 30, 2027",
@@ -6071,7 +7735,11 @@
             "Spain"
           ],
           "number": "5",
-          "position": "Centre-Back"
+          "overall_score": 64,
+          "position": "Centre-Back",
+          "potential": 64,
+          "value": 475000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2027",
@@ -6085,7 +7753,11 @@
             "Spain"
           ],
           "number": "8",
-          "position": "Left-Back"
+          "overall_score": 67,
+          "position": "Left-Back",
+          "potential": 70,
+          "value": 1400000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6099,7 +7771,11 @@
             "Spain"
           ],
           "number": "17",
-          "position": "Left-Back"
+          "overall_score": 65,
+          "position": "Left-Back",
+          "potential": 66,
+          "value": 775000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2028",
@@ -6113,7 +7789,11 @@
             "Spain"
           ],
           "number": "3",
-          "position": "Left-Back"
+          "overall_score": 63,
+          "position": "Left-Back",
+          "potential": 71,
+          "value": 1000000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6127,7 +7807,11 @@
             "Spain"
           ],
           "number": "2",
-          "position": "Right-Back"
+          "overall_score": 65,
+          "position": "Right-Back",
+          "potential": 65,
+          "value": 650000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6141,7 +7825,11 @@
             "Spain"
           ],
           "number": "10",
-          "position": "Central Midfield"
+          "overall_score": 70,
+          "position": "Central Midfield",
+          "potential": 70,
+          "value": 1600000,
+          "yearly_wage": 364000
         },
         {
           "contract": "Jun 30, 2027",
@@ -6155,7 +7843,11 @@
             "Spain"
           ],
           "number": "16",
-          "position": "Central Midfield"
+          "overall_score": 68,
+          "position": "Central Midfield",
+          "potential": 71,
+          "value": 1400000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6169,7 +7861,11 @@
             "Spain"
           ],
           "number": "6",
-          "position": "Central Midfield"
+          "overall_score": 65,
+          "position": "Central Midfield",
+          "potential": 66,
+          "value": 775000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2029",
@@ -6183,7 +7879,11 @@
             "Spain"
           ],
           "number": "23",
-          "position": "Central Midfield"
+          "overall_score": 70,
+          "position": "Central Midfield",
+          "potential": 70,
+          "value": 975000,
+          "yearly_wage": 364000
         },
         {
           "contract": "Jun 30, 2028",
@@ -6196,7 +7896,11 @@
           "nationality": [
             "Ghana"
           ],
-          "position": "Central Midfield"
+          "overall_score": 65,
+          "position": "Central Midfield",
+          "potential": 68,
+          "value": 850000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6210,7 +7914,11 @@
             "Colombia"
           ],
           "number": "33",
-          "position": "Attacking Midfield"
+          "overall_score": 65,
+          "position": "Attacking Midfield",
+          "potential": 73,
+          "value": 1600000,
+          "yearly_wage": 416000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6224,7 +7932,11 @@
             "Spain"
           ],
           "number": "20",
-          "position": "Attacking Midfield"
+          "overall_score": 67,
+          "position": "Attacking Midfield",
+          "potential": 67,
+          "value": 425000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2027",
@@ -6238,7 +7950,11 @@
             "Spain"
           ],
           "number": "21",
-          "position": "Left Winger"
+          "overall_score": 66,
+          "position": "Left Winger",
+          "potential": 66,
+          "value": 825000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6252,7 +7968,11 @@
             "Nigeria"
           ],
           "number": "24",
-          "position": "Left Winger"
+          "overall_score": 64,
+          "position": "Left Winger",
+          "potential": 78,
+          "value": 1400000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2027",
@@ -6266,7 +7986,11 @@
             "Spain"
           ],
           "number": "15",
-          "position": "Left Winger"
+          "overall_score": 65,
+          "position": "Left Winger",
+          "potential": 66,
+          "value": 850000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2027",
@@ -6280,7 +8004,11 @@
             "Spain"
           ],
           "number": "11",
-          "position": "Left Winger"
+          "overall_score": 67,
+          "position": "Left Winger",
+          "potential": 67,
+          "value": 1000000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6307,7 +8035,11 @@
             "Spain"
           ],
           "number": "18",
-          "position": "Centre-Forward"
+          "overall_score": 68,
+          "position": "Centre-Forward",
+          "potential": 73,
+          "value": 1800000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2028",
@@ -6319,7 +8051,11 @@
             "Spain"
           ],
           "number": "31",
-          "position": "Centre-Forward"
+          "overall_score": 63,
+          "position": "Centre-Forward",
+          "potential": 72,
+          "value": 1100000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2028",
@@ -6333,7 +8069,11 @@
             "Spain"
           ],
           "number": "7",
-          "position": "Centre-Forward"
+          "overall_score": 67,
+          "position": "Centre-Forward",
+          "potential": 73,
+          "value": 1600000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2027",
@@ -6347,7 +8087,11 @@
             "Spain"
           ],
           "number": "9",
-          "position": "Centre-Forward"
+          "overall_score": 66,
+          "position": "Centre-Forward",
+          "potential": 66,
+          "value": 375000,
+          "yearly_wage": 156000
         }
       ],
       "stadiumName": "El Alcoraz",
@@ -6370,7 +8114,11 @@
             "Spain"
           ],
           "number": "13",
-          "position": "Goalkeeper"
+          "overall_score": 70,
+          "position": "Goalkeeper",
+          "potential": 74,
+          "value": 1800000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2027",
@@ -6384,7 +8132,11 @@
             "Spain"
           ],
           "number": "1",
-          "position": "Goalkeeper"
+          "overall_score": 64,
+          "position": "Goalkeeper",
+          "potential": 70,
+          "value": 750000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2027",
@@ -6398,7 +8150,11 @@
             "Spain"
           ],
           "number": "21",
-          "position": "Centre-Back"
+          "overall_score": 70,
+          "position": "Centre-Back",
+          "potential": 76,
+          "value": 2300000,
+          "yearly_wage": 312000
         },
         {
           "contract": "Jun 30, 2027",
@@ -6412,7 +8168,11 @@
             "Spain"
           ],
           "number": "4",
-          "position": "Centre-Back"
+          "overall_score": 68,
+          "position": "Centre-Back",
+          "potential": 70,
+          "value": 1300000,
+          "yearly_wage": 312000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6427,7 +8187,11 @@
             "Spain"
           ],
           "number": "15",
-          "position": "Centre-Back"
+          "overall_score": 67,
+          "position": "Centre-Back",
+          "potential": 67,
+          "value": 275000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6441,7 +8205,11 @@
             "Spain"
           ],
           "number": "23",
-          "position": "Centre-Back"
+          "overall_score": 69,
+          "position": "Centre-Back",
+          "potential": 69,
+          "value": 250000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2027",
@@ -6455,7 +8223,11 @@
             "Spain"
           ],
           "number": "3",
-          "position": "Left-Back"
+          "overall_score": 65,
+          "position": "Left-Back",
+          "potential": 70,
+          "value": 1000000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2027",
@@ -6469,7 +8241,11 @@
             "Spain"
           ],
           "number": "2",
-          "position": "Right-Back"
+          "overall_score": 69,
+          "position": "Right-Back",
+          "potential": 72,
+          "value": 1700000,
+          "yearly_wage": 312000
         },
         {
           "contract": "Jun 30, 2027",
@@ -6483,7 +8259,11 @@
             "Spain"
           ],
           "number": "22",
-          "position": "Right-Back"
+          "overall_score": 66,
+          "position": "Right-Back",
+          "potential": 66,
+          "value": 725000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2027",
@@ -6497,7 +8277,11 @@
             "Spain"
           ],
           "number": "8",
-          "position": "Defensive Midfield"
+          "overall_score": 71,
+          "position": "Defensive Midfield",
+          "potential": 74,
+          "value": 2200000,
+          "yearly_wage": 416000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6511,7 +8295,11 @@
             "Spain"
           ],
           "number": "6",
-          "position": "Defensive Midfield"
+          "overall_score": 70,
+          "position": "Defensive Midfield",
+          "potential": 70,
+          "value": 800000,
+          "yearly_wage": 364000
         },
         {
           "contract": "Jun 30, 2028",
@@ -6525,7 +8313,11 @@
             "Spain"
           ],
           "number": "30",
-          "position": "Central Midfield"
+          "overall_score": 68,
+          "position": "Central Midfield",
+          "potential": 79,
+          "value": 2700000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2027",
@@ -6539,7 +8331,11 @@
             "Spain"
           ],
           "number": "14",
-          "position": "Central Midfield"
+          "overall_score": 68,
+          "position": "Central Midfield",
+          "potential": 68,
+          "value": 950000,
+          "yearly_wage": 312000
         },
         {
           "contract": "Jun 30, 2028",
@@ -6552,7 +8348,11 @@
             "Spain"
           ],
           "number": "16",
-          "position": "Central Midfield"
+          "overall_score": 67,
+          "position": "Central Midfield",
+          "potential": 73,
+          "value": 1600000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2028",
@@ -6566,7 +8366,11 @@
             "Spain"
           ],
           "number": "11",
-          "position": "Attacking Midfield"
+          "overall_score": 67,
+          "position": "Attacking Midfield",
+          "potential": 72,
+          "value": 1500000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2027",
@@ -6580,7 +8384,11 @@
             "Spain"
           ],
           "number": "5",
-          "position": "Attacking Midfield"
+          "overall_score": 67,
+          "position": "Attacking Midfield",
+          "potential": 70,
+          "value": 1300000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6594,7 +8402,11 @@
             "Spain"
           ],
           "number": "19",
-          "position": "Left Winger"
+          "overall_score": 66,
+          "position": "Left Winger",
+          "potential": 66,
+          "value": 825000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2030",
@@ -6609,7 +8421,11 @@
             "Guinea-Bissau"
           ],
           "number": "18",
-          "position": "Right Winger"
+          "overall_score": 66,
+          "position": "Right Winger",
+          "potential": 72,
+          "value": 1400000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6637,7 +8453,11 @@
             "Spain"
           ],
           "number": "10",
-          "position": "Right Winger"
+          "overall_score": 68,
+          "position": "Right Winger",
+          "potential": 71,
+          "value": 1600000,
+          "yearly_wage": 312000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6651,7 +8471,11 @@
             "Spain"
           ],
           "number": "17",
-          "position": "Right Winger"
+          "overall_score": 70,
+          "position": "Right Winger",
+          "potential": 70,
+          "value": 1000000,
+          "yearly_wage": 416000
         },
         {
           "contract": "Jun 30, 2028",
@@ -6665,7 +8489,11 @@
             "Spain"
           ],
           "number": "9",
-          "position": "Centre-Forward"
+          "overall_score": 69,
+          "position": "Centre-Forward",
+          "potential": 69,
+          "value": 1400000,
+          "yearly_wage": 364000
         },
         {
           "contract": "Jun 30, 2028",
@@ -6679,7 +8507,11 @@
             "Spain"
           ],
           "number": "20",
-          "position": "Centre-Forward"
+          "overall_score": 69,
+          "position": "Centre-Forward",
+          "potential": 70,
+          "value": 1700000,
+          "yearly_wage": 364000
         }
       ],
       "stadiumName": "Ipurua",
@@ -6702,7 +8534,11 @@
             "Spain"
           ],
           "number": "13",
-          "position": "Goalkeeper"
+          "overall_score": 68,
+          "position": "Goalkeeper",
+          "potential": 68,
+          "value": 800000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6716,7 +8552,11 @@
             "Spain"
           ],
           "number": "1",
-          "position": "Goalkeeper"
+          "overall_score": 67,
+          "position": "Goalkeeper",
+          "potential": 67,
+          "value": 675000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6730,7 +8570,11 @@
             "Spain"
           ],
           "number": "15",
-          "position": "Centre-Back"
+          "overall_score": 67,
+          "position": "Centre-Back",
+          "potential": 70,
+          "value": 1200000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6744,7 +8588,11 @@
             "Spain"
           ],
           "number": "24",
-          "position": "Centre-Back"
+          "overall_score": 64,
+          "position": "Centre-Back",
+          "potential": 68,
+          "value": 725000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6758,7 +8606,11 @@
             "Spain"
           ],
           "number": "4",
-          "position": "Centre-Back"
+          "overall_score": 63,
+          "position": "Centre-Back",
+          "potential": 66,
+          "value": 550000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6772,7 +8624,11 @@
             "Spain"
           ],
           "number": "6",
-          "position": "Centre-Back"
+          "overall_score": 66,
+          "position": "Centre-Back",
+          "potential": 66,
+          "value": 275000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2027",
@@ -6786,7 +8642,11 @@
             "Spain"
           ],
           "number": "3",
-          "position": "Left-Back"
+          "overall_score": 69,
+          "position": "Left-Back",
+          "potential": 69,
+          "value": 1200000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6800,7 +8660,11 @@
             "Spain"
           ],
           "number": "16",
-          "position": "Left-Back"
+          "overall_score": 65,
+          "position": "Left-Back",
+          "potential": 65,
+          "value": 650000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6814,7 +8678,11 @@
             "Spain"
           ],
           "number": "17",
-          "position": "Right-Back"
+          "overall_score": 64,
+          "position": "Right-Back",
+          "potential": 64,
+          "value": 525000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2027",
@@ -6828,7 +8696,11 @@
             "Spain"
           ],
           "number": "2",
-          "position": "Right-Back"
+          "overall_score": 64,
+          "position": "Right-Back",
+          "potential": 64,
+          "value": 525000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6842,7 +8714,11 @@
             "Spain"
           ],
           "number": "20",
-          "position": "Central Midfield"
+          "overall_score": 71,
+          "position": "Central Midfield",
+          "potential": 71,
+          "value": 1200000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6857,7 +8733,11 @@
             "Spain"
           ],
           "number": "5",
-          "position": "Central Midfield"
+          "overall_score": 67,
+          "position": "Central Midfield",
+          "potential": 70,
+          "value": 1200000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6871,7 +8751,11 @@
             "France"
           ],
           "number": "14",
-          "position": "Central Midfield"
+          "overall_score": 68,
+          "position": "Central Midfield",
+          "potential": 68,
+          "value": 1000000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2027",
@@ -6885,7 +8769,11 @@
             "Spain"
           ],
           "number": "10",
-          "position": "Central Midfield"
+          "overall_score": 66,
+          "position": "Central Midfield",
+          "potential": 66,
+          "value": 825000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6898,7 +8786,11 @@
             "Cote d'Ivoire"
           ],
           "number": "26",
-          "position": "Central Midfield"
+          "overall_score": 64,
+          "position": "Central Midfield",
+          "potential": 80,
+          "value": 1500000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6912,7 +8804,11 @@
             "Morocco"
           ],
           "number": "7",
-          "position": "Attacking Midfield"
+          "overall_score": 68,
+          "position": "Attacking Midfield",
+          "potential": 74,
+          "value": 1900000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6927,7 +8823,11 @@
             "Uruguay"
           ],
           "number": "8",
-          "position": "Attacking Midfield"
+          "overall_score": 67,
+          "position": "Attacking Midfield",
+          "potential": 67,
+          "value": 1100000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2027",
@@ -6941,7 +8841,11 @@
             "Spain"
           ],
           "number": "12",
-          "position": "Attacking Midfield"
+          "overall_score": 67,
+          "position": "Attacking Midfield",
+          "potential": 72,
+          "value": 1500000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6955,7 +8859,11 @@
             "Spain"
           ],
           "number": "19",
-          "position": "Attacking Midfield"
+          "overall_score": 66,
+          "position": "Attacking Midfield",
+          "potential": 66,
+          "value": 700000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6969,7 +8877,11 @@
             "United States"
           ],
           "number": "18",
-          "position": "Left Winger"
+          "overall_score": 66,
+          "position": "Left Winger",
+          "potential": 72,
+          "value": 1400000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6983,7 +8895,11 @@
             "Cote d'Ivoire"
           ],
           "number": "22",
-          "position": "Left Winger"
+          "overall_score": 66,
+          "position": "Left Winger",
+          "potential": 66,
+          "value": 850000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2027",
@@ -6998,7 +8914,11 @@
             "Spain"
           ],
           "number": "23",
-          "position": "Right Winger"
+          "overall_score": 69,
+          "position": "Right Winger",
+          "potential": 69,
+          "value": 1200000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2026",
@@ -7012,7 +8932,11 @@
             "Spain"
           ],
           "number": "25",
-          "position": "Right Winger"
+          "overall_score": 68,
+          "position": "Right Winger",
+          "potential": 68,
+          "value": 575000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2026",
@@ -7026,7 +8950,11 @@
             "Spain"
           ],
           "number": "27",
-          "position": "Centre-Forward"
+          "overall_score": 64,
+          "position": "Centre-Forward",
+          "potential": 81,
+          "value": 1500000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2026",
@@ -7040,7 +8968,11 @@
             "Spain"
           ],
           "number": "9",
-          "position": "Centre-Forward"
+          "overall_score": 68,
+          "position": "Centre-Forward",
+          "potential": 77,
+          "value": 2700000,
+          "yearly_wage": 520000
         }
       ],
       "stadiumName": "Alfonso Murube",
@@ -7063,7 +8995,11 @@
             "Montenegro"
           ],
           "number": "1",
-          "position": "Goalkeeper"
+          "overall_score": 70,
+          "position": "Goalkeeper",
+          "potential": 76,
+          "value": 2000000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2026",
@@ -7077,7 +9013,11 @@
             "Spain"
           ],
           "number": "13",
-          "position": "Goalkeeper"
+          "overall_score": 64,
+          "position": "Goalkeeper",
+          "potential": 68,
+          "value": 675000,
+          "yearly_wage": 52000
         },
         {
           "contract": "Jun 30, 2026",
@@ -7091,7 +9031,11 @@
             "Spain"
           ],
           "number": "5",
-          "position": "Centre-Back"
+          "overall_score": 67,
+          "position": "Centre-Back",
+          "potential": 76,
+          "value": 2100000,
+          "yearly_wage": 468000
         },
         {
           "contract": "Jun 30, 2026",
@@ -7105,7 +9049,11 @@
             "Spain"
           ],
           "number": "15",
-          "position": "Centre-Back"
+          "overall_score": 66,
+          "position": "Centre-Back",
+          "potential": 77,
+          "value": 1800000,
+          "yearly_wage": 364000
         },
         {
           "contract": "Jun 30, 2026",
@@ -7119,7 +9067,11 @@
             "Serbia"
           ],
           "number": "19",
-          "position": "Centre-Back"
+          "overall_score": 68,
+          "position": "Centre-Back",
+          "potential": 68,
+          "value": 1000000,
+          "yearly_wage": 676000
         },
         {
           "contract": "Jun 30, 2026",
@@ -7133,7 +9085,11 @@
             "Spain"
           ],
           "number": "22",
-          "position": "Centre-Back"
+          "overall_score": 70,
+          "position": "Centre-Back",
+          "potential": 74,
+          "value": 2000000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2026",
@@ -7147,7 +9103,11 @@
             "Spain"
           ],
           "number": "24",
-          "position": "Centre-Back"
+          "overall_score": 64,
+          "position": "Centre-Back",
+          "potential": 77,
+          "value": 1300000,
+          "yearly_wage": 312000
         },
         {
           "contract": "Jun 30, 2026",
@@ -7161,7 +9121,11 @@
             "Spain"
           ],
           "number": "4",
-          "position": "Centre-Back"
+          "overall_score": 67,
+          "position": "Centre-Back",
+          "potential": 72,
+          "value": 1300000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2026",
@@ -7175,7 +9139,11 @@
             "Spain"
           ],
           "number": "21",
-          "position": "Centre-Back"
+          "overall_score": 66,
+          "position": "Centre-Back",
+          "potential": 66,
+          "value": 150000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2026",
@@ -7189,7 +9157,11 @@
             "Spain"
           ],
           "number": "3",
-          "position": "Left-Back"
+          "overall_score": 65,
+          "position": "Left-Back",
+          "potential": 68,
+          "value": 875000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2026",
@@ -7203,7 +9175,11 @@
             "Spain"
           ],
           "number": "17",
-          "position": "Left-Back"
+          "overall_score": 64,
+          "position": "Left-Back",
+          "potential": 71,
+          "value": 1100000,
+          "yearly_wage": 572000
         },
         {
           "contract": "Jun 30, 2026",
@@ -7217,7 +9193,11 @@
             "Spain"
           ],
           "number": "2",
-          "position": "Right-Back"
+          "overall_score": 66,
+          "position": "Right-Back",
+          "potential": 73,
+          "value": 1700000,
+          "yearly_wage": 416000
         },
         {
           "contract": "Jun 30, 2026",
@@ -7231,7 +9211,11 @@
             "Uruguay"
           ],
           "number": "6",
-          "position": "Defensive Midfield"
+          "overall_score": 66,
+          "position": "Defensive Midfield",
+          "potential": 77,
+          "value": 1800000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2026",
@@ -7245,7 +9229,11 @@
             "Spain"
           ],
           "number": "16",
-          "position": "Defensive Midfield"
+          "overall_score": 65,
+          "position": "Defensive Midfield",
+          "potential": 77,
+          "value": 1600000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2026",
@@ -7259,7 +9247,11 @@
             "Spain"
           ],
           "number": "8",
-          "position": "Central Midfield"
+          "overall_score": 65,
+          "position": "Central Midfield",
+          "potential": 76,
+          "value": 1500000,
+          "yearly_wage": 312000
         },
         {
           "contract": "Jun 30, 2026",
@@ -7273,7 +9265,11 @@
             "Spain"
           ],
           "number": "18",
-          "position": "Central Midfield"
+          "overall_score": 66,
+          "position": "Central Midfield",
+          "potential": 79,
+          "value": 1900000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2026",
@@ -7287,7 +9283,11 @@
             "Spain"
           ],
           "number": "28",
-          "position": "Attacking Midfield"
+          "overall_score": 68,
+          "position": "Attacking Midfield",
+          "potential": 79,
+          "value": 2700000,
+          "yearly_wage": 416000
         },
         {
           "contract": "Jun 30, 2026",
@@ -7299,7 +9299,11 @@
           "nationality": [
             "Italy"
           ],
-          "position": "Left Winger"
+          "overall_score": 59,
+          "position": "Left Winger",
+          "potential": 74,
+          "value": 525000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2026",
@@ -7314,7 +9318,11 @@
             "Spain"
           ],
           "number": "30",
-          "position": "Left Winger"
+          "overall_score": 65,
+          "position": "Left Winger",
+          "potential": 73,
+          "value": 1600000,
+          "yearly_wage": 572000
         },
         {
           "contract": "Jun 30, 2026",
@@ -7327,7 +9335,11 @@
           "nationality": [
             "Spain"
           ],
-          "position": "Left Winger"
+          "overall_score": 63,
+          "position": "Left Winger",
+          "potential": 81,
+          "value": 1200000,
+          "yearly_wage": 312000
         },
         {
           "contract": "Jun 30, 2026",
@@ -7341,7 +9353,11 @@
             "Spain"
           ],
           "number": "7",
-          "position": "Left Winger"
+          "overall_score": 63,
+          "position": "Left Winger",
+          "potential": 72,
+          "value": 1100000,
+          "yearly_wage": 416000
         },
         {
           "contract": "Jun 30, 2026",
@@ -7355,7 +9371,11 @@
             "Spain"
           ],
           "number": "27",
-          "position": "Right Winger"
+          "overall_score": 62,
+          "position": "Right Winger",
+          "potential": 77,
+          "value": 900000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2026",
@@ -7370,7 +9390,11 @@
             "Spain"
           ],
           "number": "29",
-          "position": "Second Striker"
+          "overall_score": 65,
+          "position": "Second Striker",
+          "potential": 80,
+          "value": 1700000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2026",
@@ -7385,7 +9409,11 @@
             "Senegal"
           ],
           "number": "9",
-          "position": "Centre-Forward"
+          "overall_score": 63,
+          "position": "Centre-Forward",
+          "potential": 77,
+          "value": 1200000,
+          "yearly_wage": 520000
         },
         {
           "contract": "Jun 30, 2026",
@@ -7399,7 +9427,11 @@
             "Spain"
           ],
           "number": "10",
-          "position": "Centre-Forward"
+          "overall_score": 71,
+          "position": "Centre-Forward",
+          "potential": 71,
+          "value": 1900000,
+          "yearly_wage": 1300000
         },
         {
           "contract": "Jun 30, 2026",
@@ -7413,7 +9445,11 @@
             "Spain"
           ],
           "number": "14",
-          "position": "Centre-Forward"
+          "overall_score": 64,
+          "position": "Centre-Forward",
+          "potential": 68,
+          "value": 850000,
+          "yearly_wage": 468000
         }
       ],
       "stadiumName": "Anduva",
@@ -7437,7 +9473,11 @@
             "Georgia"
           ],
           "number": "25",
-          "position": "Goalkeeper"
+          "overall_score": 70,
+          "position": "Goalkeeper",
+          "potential": 82,
+          "value": 3300000,
+          "yearly_wage": 624000
         },
         {
           "contract": "Jun 30, 2026",
@@ -7452,7 +9492,11 @@
             "Spain"
           ],
           "number": "13",
-          "position": "Goalkeeper"
+          "overall_score": 67,
+          "position": "Goalkeeper",
+          "potential": 73,
+          "value": 1300000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2026",
@@ -7466,7 +9510,11 @@
             "Italy"
           ],
           "number": "1",
-          "position": "Goalkeeper"
+          "overall_score": 68,
+          "position": "Goalkeeper",
+          "potential": 68,
+          "value": 650000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2026",
@@ -7480,7 +9528,11 @@
             "Spain"
           ],
           "number": "12",
-          "position": "Centre-Back"
+          "overall_score": 71,
+          "position": "Centre-Back",
+          "potential": 72,
+          "value": 1800000,
+          "yearly_wage": 364000
         },
         {
           "contract": "Jun 30, 2028",
@@ -7494,7 +9546,11 @@
             "Spain"
           ],
           "number": "4",
-          "position": "Centre-Back"
+          "overall_score": 66,
+          "position": "Centre-Back",
+          "potential": 74,
+          "value": 1800000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2027",
@@ -7508,7 +9564,11 @@
             "Spain"
           ],
           "number": "5",
-          "position": "Centre-Back"
+          "overall_score": 65,
+          "position": "Centre-Back",
+          "potential": 78,
+          "value": 1600000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2027",
@@ -7521,7 +9581,11 @@
             "Spain"
           ],
           "number": "23",
-          "position": "Centre-Back"
+          "overall_score": 66,
+          "position": "Centre-Back",
+          "potential": 68,
+          "value": 900000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2026",
@@ -7535,7 +9599,11 @@
             "Spain"
           ],
           "number": "19",
-          "position": "Left-Back"
+          "overall_score": 70,
+          "position": "Left-Back",
+          "potential": 73,
+          "value": 1900000,
+          "yearly_wage": 676000
         },
         {
           "contract": "Jun 30, 2026",
@@ -7549,7 +9617,11 @@
             "Spain"
           ],
           "number": "20",
-          "position": "Left-Back"
+          "overall_score": 66,
+          "position": "Left-Back",
+          "potential": 67,
+          "value": 925000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2027",
@@ -7563,7 +9635,11 @@
             "France"
           ],
           "number": "17",
-          "position": "Right-Back"
+          "overall_score": 66,
+          "position": "Right-Back",
+          "potential": 67,
+          "value": 925000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2026",
@@ -7577,7 +9653,11 @@
             "Spain"
           ],
           "number": "2",
-          "position": "Right-Back"
+          "overall_score": 66,
+          "position": "Right-Back",
+          "potential": 66,
+          "value": 775000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2029",
@@ -7591,7 +9671,11 @@
             "Türkiye"
           ],
           "number": "8",
-          "position": "Defensive Midfield"
+          "overall_score": 64,
+          "position": "Defensive Midfield",
+          "potential": 78,
+          "value": 1400000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2026",
@@ -7605,7 +9689,11 @@
             "Spain"
           ],
           "number": "6",
-          "position": "Central Midfield"
+          "overall_score": 67,
+          "position": "Central Midfield",
+          "potential": 70,
+          "value": 1400000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2028",
@@ -7619,7 +9707,11 @@
             "Spain"
           ],
           "number": "18",
-          "position": "Central Midfield"
+          "overall_score": 64,
+          "position": "Central Midfield",
+          "potential": 71,
+          "value": 1200000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2028",
@@ -7633,7 +9725,11 @@
             "Spain"
           ],
           "number": "14",
-          "position": "Central Midfield"
+          "overall_score": 66,
+          "position": "Central Midfield",
+          "potential": 66,
+          "value": 825000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2026",
@@ -7646,7 +9742,11 @@
             "France"
           ],
           "number": "24",
-          "position": "Central Midfield"
+          "overall_score": 63,
+          "position": "Central Midfield",
+          "potential": 66,
+          "value": 650000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2026",
@@ -7673,7 +9773,11 @@
             "Korea, South"
           ],
           "number": "29",
-          "position": "Left Winger"
+          "overall_score": 70,
+          "position": "Left Winger",
+          "potential": 82,
+          "value": 3800000,
+          "yearly_wage": 676000
         },
         {
           "contract": "Jun 30, 2026",
@@ -7687,7 +9791,11 @@
             "Spain"
           ],
           "number": "10",
-          "position": "Left Winger"
+          "overall_score": 63,
+          "position": "Left Winger",
+          "potential": 68,
+          "value": 725000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2027",
@@ -7701,7 +9809,11 @@
             "Spain"
           ],
           "number": "21",
-          "position": "Left Winger"
+          "overall_score": 66,
+          "position": "Left Winger",
+          "potential": 73,
+          "value": 1700000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2026",
@@ -7716,7 +9828,11 @@
             "Spain"
           ],
           "number": "16",
-          "position": "Left Winger"
+          "overall_score": 68,
+          "position": "Left Winger",
+          "potential": 80,
+          "value": 3000000,
+          "yearly_wage": 520000
         },
         {
           "contract": "Jun 30, 2026",
@@ -7730,7 +9846,11 @@
             "Spain"
           ],
           "number": "15",
-          "position": "Right Winger"
+          "overall_score": 67,
+          "position": "Right Winger",
+          "potential": 81,
+          "value": 2400000,
+          "yearly_wage": 572000
         },
         {
           "contract": "Jun 30, 2026",
@@ -7744,7 +9864,11 @@
             "Spain"
           ],
           "number": "3",
-          "position": "Right Winger"
+          "overall_score": 66,
+          "position": "Right Winger",
+          "potential": 75,
+          "value": 1900000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2028",
@@ -7758,7 +9882,11 @@
             "Spain"
           ],
           "number": "7",
-          "position": "Right Winger"
+          "overall_score": 66,
+          "position": "Right Winger",
+          "potential": 72,
+          "value": 1400000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2028",
@@ -7773,7 +9901,11 @@
             "Spain"
           ],
           "number": "11",
-          "position": "Centre-Forward"
+          "overall_score": 67,
+          "position": "Centre-Forward",
+          "potential": 72,
+          "value": 1600000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2026",
@@ -7787,7 +9919,11 @@
             "Spain"
           ],
           "number": "9",
-          "position": "Centre-Forward"
+          "overall_score": 67,
+          "position": "Centre-Forward",
+          "potential": 67,
+          "value": 1100000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2026",
@@ -7801,7 +9937,11 @@
             "Spain"
           ],
           "number": "22",
-          "position": "Centre-Forward"
+          "overall_score": 67,
+          "position": "Centre-Forward",
+          "potential": 67,
+          "value": 1000000,
+          "yearly_wage": 208000
         }
       ],
       "stadiumName": "Estadi Nacional d'Andorra",
@@ -7824,7 +9964,11 @@
             "Spain"
           ],
           "number": "1",
-          "position": "Goalkeeper"
+          "overall_score": 66,
+          "position": "Goalkeeper",
+          "potential": 76,
+          "value": 1700000,
+          "yearly_wage": 52000
         },
         {
           "contract": "Jun 30, 2026",
@@ -7838,7 +9982,11 @@
             "Spain"
           ],
           "number": "13",
-          "position": "Goalkeeper"
+          "overall_score": 65,
+          "position": "Goalkeeper",
+          "potential": 73,
+          "value": 1400000,
+          "yearly_wage": 52000
         },
         {
           "contract": "Jun 30, 2029",
@@ -7852,7 +10000,11 @@
             "Spain"
           ],
           "number": "4",
-          "position": "Centre-Back"
+          "overall_score": 67,
+          "position": "Centre-Back",
+          "potential": 81,
+          "value": 2400000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2026",
@@ -7866,7 +10018,11 @@
             "Japan"
           ],
           "number": "15",
-          "position": "Centre-Back"
+          "overall_score": 64,
+          "position": "Centre-Back",
+          "potential": 79,
+          "value": 1300000,
+          "yearly_wage": 52000
         },
         {
           "contract": "Jun 30, 2027",
@@ -7880,7 +10036,11 @@
             "Spain"
           ],
           "number": "27",
-          "position": "Centre-Back"
+          "overall_score": 60,
+          "position": "Centre-Back",
+          "potential": 73,
+          "value": 575000,
+          "yearly_wage": 46800
         },
         {
           "contract": "Jun 30, 2028",
@@ -7894,7 +10054,11 @@
             "Spain"
           ],
           "number": "3",
-          "position": "Left-Back"
+          "overall_score": 64,
+          "position": "Left-Back",
+          "potential": 71,
+          "value": 1100000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2026",
@@ -7908,7 +10072,11 @@
             "Spain"
           ],
           "number": "23",
-          "position": "Left-Back"
+          "overall_score": 61,
+          "position": "Left-Back",
+          "potential": 68,
+          "value": 625000,
+          "yearly_wage": 52000
         },
         {
           "contract": "Jun 30, 2029",
@@ -7922,7 +10090,11 @@
             "Spain"
           ],
           "number": "2",
-          "position": "Right-Back"
+          "overall_score": 64,
+          "position": "Right-Back",
+          "potential": 73,
+          "value": 1300000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2027",
@@ -7936,7 +10108,11 @@
             "Spain"
           ],
           "number": "29",
-          "position": "Right-Back"
+          "overall_score": 61,
+          "position": "Right-Back",
+          "potential": 72,
+          "value": 675000,
+          "yearly_wage": 52000
         },
         {
           "contract": "Jun 30, 2027",
@@ -7950,7 +10126,11 @@
             "Spain"
           ],
           "number": "8",
-          "position": "Central Midfield"
+          "overall_score": 66,
+          "position": "Central Midfield",
+          "potential": 73,
+          "value": 1700000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2028",
@@ -7964,7 +10144,11 @@
             "Spain"
           ],
           "number": "16",
-          "position": "Central Midfield"
+          "overall_score": 63,
+          "position": "Central Midfield",
+          "potential": 79,
+          "value": 1200000,
+          "yearly_wage": 52000
         },
         {
           "contract": "Jun 30, 2027",
@@ -7979,7 +10163,11 @@
             "Cameroon"
           ],
           "number": "6",
-          "position": "Central Midfield"
+          "overall_score": 62,
+          "position": "Central Midfield",
+          "potential": 74,
+          "value": 950000,
+          "yearly_wage": 52000
         },
         {
           "contract": "Jun 30, 2028",
@@ -7993,7 +10181,11 @@
             "Spain"
           ],
           "number": "14",
-          "position": "Central Midfield"
+          "overall_score": 63,
+          "position": "Central Midfield",
+          "potential": 77,
+          "value": 1200000,
+          "yearly_wage": 52000
         },
         {
           "contract": "Jun 30, 2027",
@@ -8007,7 +10199,11 @@
             "Spain"
           ],
           "number": "21",
-          "position": "Central Midfield"
+          "overall_score": 61,
+          "position": "Central Midfield",
+          "potential": 75,
+          "value": 775000,
+          "yearly_wage": 52000
         },
         {
           "contract": "Jun 30, 2028",
@@ -8018,7 +10214,11 @@
             "Spain"
           ],
           "number": "31",
-          "position": "Central Midfield"
+          "overall_score": 61,
+          "position": "Central Midfield",
+          "potential": 74,
+          "value": 750000,
+          "yearly_wage": 52000
         },
         {
           "contract": "Jun 30, 2027",
@@ -8032,7 +10232,11 @@
             "Spain"
           ],
           "number": "17",
-          "position": "Attacking Midfield"
+          "overall_score": 63,
+          "position": "Attacking Midfield",
+          "potential": 79,
+          "value": 1200000,
+          "yearly_wage": 52000
         },
         {
           "contract": "Jun 30, 2029",
@@ -8046,7 +10250,11 @@
             "Spain"
           ],
           "number": "10",
-          "position": "Left Winger"
+          "overall_score": 66,
+          "position": "Left Winger",
+          "potential": 80,
+          "value": 2100000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2027",
@@ -8060,7 +10268,11 @@
             "Spain"
           ],
           "number": "19",
-          "position": "Left Winger"
+          "overall_score": 62,
+          "position": "Left Winger",
+          "potential": 82,
+          "value": 1100000,
+          "yearly_wage": 52000
         },
         {
           "contract": "Jun 30, 2027",
@@ -8074,7 +10286,11 @@
             "Spain"
           ],
           "number": "26",
-          "position": "Left Winger"
+          "overall_score": 61,
+          "position": "Left Winger",
+          "potential": 70,
+          "value": 725000,
+          "yearly_wage": 52000
         },
         {
           "contract": "Jun 30, 2029",
@@ -8088,7 +10304,11 @@
             "Spain"
           ],
           "number": "7",
-          "position": "Right Winger"
+          "overall_score": 64,
+          "position": "Right Winger",
+          "potential": 82,
+          "value": 1500000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2026",
@@ -8102,7 +10322,11 @@
             "Kenya"
           ],
           "number": "11",
-          "position": "Right Winger"
+          "overall_score": 66,
+          "position": "Right Winger",
+          "potential": 73,
+          "value": 1700000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2026",
@@ -8116,7 +10340,11 @@
             "Spain"
           ],
           "number": "22",
-          "position": "Right Winger"
+          "overall_score": 65,
+          "position": "Right Winger",
+          "potential": 70,
+          "value": 1000000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2028",
@@ -8130,7 +10358,11 @@
             "Spain"
           ],
           "number": "18",
-          "position": "Centre-Forward"
+          "overall_score": 65,
+          "position": "Centre-Forward",
+          "potential": 75,
+          "value": 1600000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2028",
@@ -8144,7 +10376,11 @@
             "Spain"
           ],
           "number": "9",
-          "position": "Centre-Forward"
+          "overall_score": 61,
+          "position": "Centre-Forward",
+          "potential": 69,
+          "value": 750000,
+          "yearly_wage": 52000
         }
       ],
       "stadiumName": "Zubieta",

--- a/data/2025/FRA1/sofifa.json
+++ b/data/2025/FRA1/sofifa.json
@@ -1,0 +1,5633 @@
+{
+  "league": "France Ligue 1",
+  "scraped_at": "2026-06-12T14:25:40.711Z",
+  "team_count": 18,
+  "teams": [
+    {
+      "player_count": 32,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Matvey Safonov",
+          "name": "M. Safonov",
+          "overall_score": 82,
+          "potential": 86,
+          "value": 33000000,
+          "yearly_wage": 3016000
+        },
+        {
+          "currency": "€",
+          "full_name": "Achraf Hakimi",
+          "name": "A. Hakimi",
+          "overall_score": 89,
+          "potential": 90,
+          "value": 111000000,
+          "yearly_wage": 8840000
+        },
+        {
+          "currency": "€",
+          "full_name": "Marcos Aoás Corrêa",
+          "name": "Marquinhos",
+          "overall_score": 87,
+          "potential": 87,
+          "value": 54500000,
+          "yearly_wage": 7540000
+        },
+        {
+          "currency": "€",
+          "full_name": "Willian Pacho",
+          "name": "W. Pacho",
+          "overall_score": 88,
+          "potential": 90,
+          "value": 105500000,
+          "yearly_wage": 7020000
+        },
+        {
+          "currency": "€",
+          "full_name": "Nuno Alexandre Tavares Mendes",
+          "name": "Nuno Mendes",
+          "overall_score": 88,
+          "potential": 91,
+          "value": 115500000,
+          "yearly_wage": 7020000
+        },
+        {
+          "currency": "€",
+          "full_name": "João Pedro Gonçalves Neves",
+          "name": "João Neves",
+          "overall_score": 88,
+          "potential": 93,
+          "value": 135000000,
+          "yearly_wage": 6240000
+        },
+        {
+          "currency": "€",
+          "full_name": "Vítor Machado Ferreira",
+          "name": "Vitinha",
+          "overall_score": 90,
+          "potential": 92,
+          "value": 149000000,
+          "yearly_wage": 9620000
+        },
+        {
+          "currency": "€",
+          "full_name": "Fabián Ruiz Peña",
+          "name": "Fabián Ruiz",
+          "overall_score": 85,
+          "potential": 85,
+          "value": 52500000,
+          "yearly_wage": 6760000
+        },
+        {
+          "currency": "€",
+          "full_name": "Désiré Doué",
+          "name": "D. Doué",
+          "overall_score": 86,
+          "potential": 91,
+          "value": 101000000,
+          "yearly_wage": 5720000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ousmane Dembélé",
+          "name": "O. Dembélé",
+          "overall_score": 90,
+          "potential": 90,
+          "value": 122500000,
+          "yearly_wage": 11440000
+        },
+        {
+          "currency": "€",
+          "full_name": "Khvicha Kvaratskhelia",
+          "name": "K. Kvaratskhelia",
+          "overall_score": 88,
+          "potential": 91,
+          "value": 125000000,
+          "yearly_wage": 7800000
+        },
+        {
+          "currency": "€",
+          "full_name": "Bradley Barcola",
+          "name": "B. Barcola",
+          "overall_score": 84,
+          "potential": 88,
+          "value": 61500000,
+          "yearly_wage": 5720000
+        },
+        {
+          "currency": "€",
+          "full_name": "Warren Zaïre-Emery",
+          "name": "W. Zaïre-Emery",
+          "overall_score": 83,
+          "potential": 89,
+          "value": 55000000,
+          "yearly_wage": 3796000
+        },
+        {
+          "currency": "€",
+          "full_name": "Senny Mayulu",
+          "name": "S. Mayulu",
+          "overall_score": 77,
+          "potential": 86,
+          "value": 22500000,
+          "yearly_wage": 2392000
+        },
+        {
+          "currency": "€",
+          "full_name": "Pedro Fernández",
+          "name": "Dro Fernández",
+          "overall_score": 70,
+          "potential": 85,
+          "value": 3600000,
+          "yearly_wage": 988000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lucas Hernández",
+          "name": "L. Hernández",
+          "overall_score": 81,
+          "potential": 81,
+          "value": 22500000,
+          "yearly_wage": 4628000
+        },
+        {
+          "currency": "€",
+          "full_name": "Illia Zabarnyi",
+          "name": "I. Zabarnyi",
+          "overall_score": 80,
+          "potential": 85,
+          "value": 29500000,
+          "yearly_wage": 3536000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lucas Chevalier",
+          "name": "L. Chevalier",
+          "overall_score": 82,
+          "potential": 86,
+          "value": 34500000,
+          "yearly_wage": 2392000
+        },
+        {
+          "currency": "€",
+          "full_name": "Kang In Lee",
+          "name": "Lee Kang In",
+          "overall_score": 80,
+          "potential": 83,
+          "value": 29000000,
+          "yearly_wage": 4056000
+        },
+        {
+          "currency": "€",
+          "full_name": "Gonçalo Matias Ramos",
+          "name": "Gonçalo Ramos",
+          "overall_score": 80,
+          "potential": 84,
+          "value": 30500000,
+          "yearly_wage": 4108000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lucas Lopes Beraldo",
+          "name": "Lucas Beraldo",
+          "overall_score": 78,
+          "potential": 83,
+          "value": 19500000,
+          "yearly_wage": 2548000
+        },
+        {
+          "currency": "€",
+          "full_name": "Renato Bellucci Marin",
+          "name": "Renato Marin",
+          "overall_score": 70,
+          "potential": 83,
+          "value": 3200000,
+          "yearly_wage": 520000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ibrahim Mbaye",
+          "name": "I. Mbaye",
+          "overall_score": 74,
+          "potential": 85,
+          "value": 8500000,
+          "yearly_wage": 1664000
+        },
+        {
+          "currency": "€",
+          "full_name": "Noah Nsoki",
+          "name": "N. Nsoki",
+          "overall_score": 64,
+          "potential": 79,
+          "value": 1400000,
+          "yearly_wage": 624000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mathis Jangeal",
+          "name": "M. Jangeal",
+          "overall_score": 63,
+          "potential": 79,
+          "value": 1200000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "Dimitri Lucea",
+          "name": "D. Lucea",
+          "overall_score": 63,
+          "potential": 78,
+          "value": 1000000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "Pierre Mounguengue",
+          "name": "P. Mounguengue",
+          "overall_score": 62,
+          "potential": 77,
+          "value": 925000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "Quentin Ndjantou",
+          "name": "Q. Ndjantou",
+          "overall_score": 69,
+          "potential": 83,
+          "value": 3200000,
+          "yearly_wage": 988000
+        },
+        {
+          "currency": "€",
+          "full_name": "Gabriel Silva Moscardo de Salles",
+          "name": "Gabriel Moscardo",
+          "overall_score": 72,
+          "potential": 82,
+          "value": 4800000,
+          "yearly_wage": 1560000
+        },
+        {
+          "currency": "€",
+          "full_name": "Randal Kolo Muani",
+          "name": "R. Kolo Muani",
+          "overall_score": 79,
+          "potential": 80,
+          "value": 21000000,
+          "yearly_wage": 4420000
+        },
+        {
+          "currency": "€",
+          "full_name": "Noham Kamara",
+          "name": "N. Kamara",
+          "overall_score": 66,
+          "potential": 82,
+          "value": 2000000,
+          "yearly_wage": 676000
+        },
+        {
+          "currency": "€",
+          "full_name": "Naoufel El Hannach",
+          "name": "N. El Hannach",
+          "overall_score": 64,
+          "potential": 82,
+          "value": 1400000,
+          "yearly_wage": 520000
+        }
+      ],
+      "team": "Paris Saint-Germain",
+      "transfer_budget": 232400000,
+      "url": "https://sofifa.com/team/73/paris-saint-germain/260037/"
+    },
+    {
+      "player_count": 37,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Gerónimo Rulli",
+          "name": "G. Rulli",
+          "overall_score": 81,
+          "potential": 81,
+          "value": 8500000,
+          "yearly_wage": 1716000
+        },
+        {
+          "currency": "€",
+          "full_name": "Timothy Weah",
+          "name": "T. Weah",
+          "overall_score": 77,
+          "potential": 78,
+          "value": 12500000,
+          "yearly_wage": 4472000
+        },
+        {
+          "currency": "€",
+          "full_name": "Leonardo Balerdi",
+          "name": "L. Balerdi",
+          "overall_score": 80,
+          "potential": 83,
+          "value": 24500000,
+          "yearly_wage": 2340000
+        },
+        {
+          "currency": "€",
+          "full_name": "Facundo Medina",
+          "name": "F. Medina",
+          "overall_score": 79,
+          "potential": 83,
+          "value": 21500000,
+          "yearly_wage": 1612000
+        },
+        {
+          "currency": "€",
+          "full_name": "Emerson Palmieri dos Santos",
+          "name": "Emerson",
+          "overall_score": 77,
+          "potential": 77,
+          "value": 9000000,
+          "yearly_wage": 1976000
+        },
+        {
+          "currency": "€",
+          "full_name": "Geoffrey Kondogbia",
+          "name": "G. Kondogbia",
+          "overall_score": 77,
+          "potential": 77,
+          "value": 7000000,
+          "yearly_wage": 1976000
+        },
+        {
+          "currency": "€",
+          "full_name": "Pierre-Emile Højbjerg",
+          "name": "P. Højbjerg",
+          "overall_score": 81,
+          "potential": 81,
+          "value": 22000000,
+          "yearly_wage": 2600000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mason Greenwood",
+          "name": "M. Greenwood",
+          "overall_score": 83,
+          "potential": 86,
+          "value": 49500000,
+          "yearly_wage": 2652000
+        },
+        {
+          "currency": "€",
+          "full_name": "Igor Guilherme Barbosa da Paixão",
+          "name": "Igor Paixão",
+          "overall_score": 80,
+          "potential": 83,
+          "value": 28000000,
+          "yearly_wage": 2340000
+        },
+        {
+          "currency": "€",
+          "full_name": "Quinten Timber",
+          "name": "Q. Timber",
+          "overall_score": 80,
+          "potential": 85,
+          "value": 31500000,
+          "yearly_wage": 2132000
+        },
+        {
+          "currency": "€",
+          "full_name": "Amine Gouiri",
+          "name": "A. Gouiri",
+          "overall_score": 79,
+          "potential": 82,
+          "value": 23500000,
+          "yearly_wage": 2392000
+        },
+        {
+          "currency": "€",
+          "full_name": "Hamed Junior Traoré",
+          "name": "H. Traoré",
+          "overall_score": 77,
+          "potential": 78,
+          "value": 12500000,
+          "yearly_wage": 3172000
+        },
+        {
+          "currency": "€",
+          "full_name": "Arthur Vermeeren",
+          "name": "A. Vermeeren",
+          "overall_score": 77,
+          "potential": 86,
+          "value": 23000000,
+          "yearly_wage": 1820000
+        },
+        {
+          "currency": "€",
+          "full_name": "Himad Abdelli",
+          "name": "H. Abdelli",
+          "overall_score": 76,
+          "potential": 78,
+          "value": 9500000,
+          "yearly_wage": 1768000
+        },
+        {
+          "currency": "€",
+          "full_name": "Bilal Nadir",
+          "name": "B. Nadir",
+          "overall_score": 73,
+          "potential": 77,
+          "value": 4400000,
+          "yearly_wage": 1092000
+        },
+        {
+          "currency": "€",
+          "full_name": "Benjamin Pavard",
+          "name": "B. Pavard",
+          "overall_score": 81,
+          "potential": 81,
+          "value": 21500000,
+          "yearly_wage": 2080000
+        },
+        {
+          "currency": "€",
+          "full_name": "Nayef Aguerd",
+          "name": "N. Aguerd",
+          "overall_score": 81,
+          "potential": 81,
+          "value": 21500000,
+          "yearly_wage": 2600000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jeffrey de Lange",
+          "name": "J. de Lange",
+          "overall_score": 74,
+          "potential": 77,
+          "value": 4100000,
+          "yearly_wage": 988000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ethan Nwaneri",
+          "name": "E. Nwaneri",
+          "overall_score": 76,
+          "potential": 87,
+          "value": 16000000,
+          "yearly_wage": 3484000
+        },
+        {
+          "currency": "€",
+          "full_name": "Pierre-Emerick Aubameyang",
+          "name": "P. Aubameyang",
+          "overall_score": 81,
+          "potential": 81,
+          "value": 9000000,
+          "yearly_wage": 2236000
+        },
+        {
+          "currency": "€",
+          "full_name": "CJ Egan-Riley",
+          "name": "C. Egan-Riley",
+          "overall_score": 75,
+          "potential": 80,
+          "value": 8000000,
+          "yearly_wage": 1456000
+        },
+        {
+          "currency": "€",
+          "full_name": "Tochukwu Nnadi",
+          "name": "T. Nnadi",
+          "overall_score": 66,
+          "potential": 77,
+          "value": 1800000,
+          "yearly_wage": 520000
+        },
+        {
+          "currency": "€",
+          "full_name": "Tadjidine Mmadi",
+          "name": "T. Mmadi",
+          "overall_score": 64,
+          "potential": 75,
+          "value": 1200000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jelle Van Neck",
+          "name": "J. Van Neck",
+          "overall_score": 61,
+          "potential": 71,
+          "value": 650000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Théo Vermot",
+          "name": "T. Vermot",
+          "overall_score": 60,
+          "potential": 61,
+          "value": 200000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Yanis Sellami",
+          "name": "Y. Sellami",
+          "overall_score": 62,
+          "potential": 74,
+          "value": 925000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ugo Lamare El Kadmiri",
+          "name": "U. Lamare El Kadmiri",
+          "overall_score": 61,
+          "potential": 75,
+          "value": 775000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Nouhoum Kamissoko",
+          "name": "N. Kamissoko",
+          "overall_score": 60,
+          "potential": 69,
+          "value": 500000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ange Lago",
+          "name": "A. Lago",
+          "overall_score": 59,
+          "potential": 69,
+          "value": 500000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Hilan Hamzaoui Slimani",
+          "name": "H. Hamzaoui Slimani",
+          "overall_score": 58,
+          "potential": 69,
+          "value": 400000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Bamo Meïté",
+          "name": "B. Meïté",
+          "overall_score": 75,
+          "potential": 79,
+          "value": 7000000,
+          "yearly_wage": 1456000
+        },
+        {
+          "currency": "€",
+          "full_name": "Faris Pemi Moumbagna",
+          "name": "F. Moumbagna",
+          "overall_score": 72,
+          "potential": 76,
+          "value": 3300000,
+          "yearly_wage": 1404000
+        },
+        {
+          "currency": "€",
+          "full_name": "Derek Cornelius",
+          "name": "D. Cornelius",
+          "overall_score": 74,
+          "potential": 76,
+          "value": 4500000,
+          "yearly_wage": 1560000
+        },
+        {
+          "currency": "€",
+          "full_name": "Angel Gomes",
+          "name": "A. Gomes",
+          "overall_score": 76,
+          "potential": 81,
+          "value": 11500000,
+          "yearly_wage": 1612000
+        },
+        {
+          "currency": "€",
+          "full_name": "Amine Harit",
+          "name": "A. Harit",
+          "overall_score": 74,
+          "potential": 74,
+          "value": 4200000,
+          "yearly_wage": 1716000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ulisses Garcia",
+          "name": "U. Garcia",
+          "overall_score": 74,
+          "potential": 74,
+          "value": 3700000,
+          "yearly_wage": 1612000
+        },
+        {
+          "currency": "€",
+          "full_name": "Neal Maupay",
+          "name": "N. Maupay",
+          "overall_score": 74,
+          "potential": 74,
+          "value": 4300000,
+          "yearly_wage": 1820000
+        }
+      ],
+      "team": "Olympique de Marseille",
+      "transfer_budget": 38900000,
+      "url": "https://sofifa.com/team/219/olympique-de-marseille/260037/"
+    },
+    {
+      "player_count": 34,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Lukáš Hrádecký",
+          "name": "L. Hrádecký",
+          "overall_score": 80,
+          "potential": 80,
+          "value": 2300000,
+          "yearly_wage": 780000
+        },
+        {
+          "currency": "€",
+          "full_name": "Thilo Kehrer",
+          "name": "T. Kehrer",
+          "overall_score": 78,
+          "potential": 79,
+          "value": 13500000,
+          "yearly_wage": 1716000
+        },
+        {
+          "currency": "€",
+          "full_name": "Denis Zakaria",
+          "name": "D. Zakaria",
+          "overall_score": 81,
+          "potential": 81,
+          "value": 22500000,
+          "yearly_wage": 2184000
+        },
+        {
+          "currency": "€",
+          "full_name": "Christian Mawissa",
+          "name": "C. Mawissa",
+          "overall_score": 75,
+          "potential": 84,
+          "value": 11500000,
+          "yearly_wage": 988000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jordan Teze",
+          "name": "J. Teze",
+          "overall_score": 78,
+          "potential": 81,
+          "value": 17000000,
+          "yearly_wage": 1560000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lamine Camara",
+          "name": "L. Camara",
+          "overall_score": 79,
+          "potential": 85,
+          "value": 28000000,
+          "yearly_wage": 1404000
+        },
+        {
+          "currency": "€",
+          "full_name": "Aladji Bamba",
+          "name": "A. Bamba",
+          "overall_score": 70,
+          "potential": 83,
+          "value": 3700000,
+          "yearly_wage": 572000
+        },
+        {
+          "currency": "€",
+          "full_name": "Caio Henrique Oliveira Silva",
+          "name": "Caio Henrique",
+          "overall_score": 77,
+          "potential": 77,
+          "value": 10000000,
+          "yearly_wage": 1560000
+        },
+        {
+          "currency": "€",
+          "full_name": "Maghnes Akliouche",
+          "name": "M. Akliouche",
+          "overall_score": 80,
+          "potential": 86,
+          "value": 33500000,
+          "yearly_wage": 1820000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alexandr Golovin",
+          "name": "A. Golovin",
+          "overall_score": 79,
+          "potential": 79,
+          "value": 17000000,
+          "yearly_wage": 2028000
+        },
+        {
+          "currency": "€",
+          "full_name": "Folarin Balogun",
+          "name": "F. Balogun",
+          "overall_score": 79,
+          "potential": 83,
+          "value": 25500000,
+          "yearly_wage": 1820000
+        },
+        {
+          "currency": "€",
+          "full_name": "Paul Pogba",
+          "name": "P. Pogba",
+          "overall_score": 77,
+          "potential": 77,
+          "value": 8500000,
+          "yearly_wage": 1716000
+        },
+        {
+          "currency": "€",
+          "full_name": "Anssumane Fati",
+          "name": "Ansu Fati",
+          "overall_score": 75,
+          "potential": 81,
+          "value": 9000000,
+          "yearly_wage": 2912000
+        },
+        {
+          "currency": "€",
+          "full_name": "Krépin Diatta",
+          "name": "K. Diatta",
+          "overall_score": 74,
+          "potential": 74,
+          "value": 4600000,
+          "yearly_wage": 1352000
+        },
+        {
+          "currency": "€",
+          "full_name": "Vanderson de Oliveira Campos",
+          "name": "Vanderson",
+          "overall_score": 77,
+          "potential": 83,
+          "value": 15500000,
+          "yearly_wage": 1352000
+        },
+        {
+          "currency": "€",
+          "full_name": "Wout Faes",
+          "name": "W. Faes",
+          "overall_score": 74,
+          "potential": 75,
+          "value": 4200000,
+          "yearly_wage": 1820000
+        },
+        {
+          "currency": "€",
+          "full_name": "Kassoum Ouattara",
+          "name": "K. Ouattara",
+          "overall_score": 72,
+          "potential": 80,
+          "value": 4900000,
+          "yearly_wage": 780000
+        },
+        {
+          "currency": "€",
+          "full_name": "Philipp Köhn",
+          "name": "P. Köhn",
+          "overall_score": 77,
+          "potential": 80,
+          "value": 10500000,
+          "yearly_wage": 988000
+        },
+        {
+          "currency": "€",
+          "full_name": "Simon Adingra",
+          "name": "S. Adingra",
+          "overall_score": 76,
+          "potential": 82,
+          "value": 12000000,
+          "yearly_wage": 2496000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mika Biereth",
+          "name": "M. Biereth",
+          "overall_score": 77,
+          "potential": 84,
+          "value": 21500000,
+          "yearly_wage": 1560000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mamadou Coulibaly",
+          "name": "M. Coulibaly",
+          "overall_score": 71,
+          "potential": 82,
+          "value": 4200000,
+          "yearly_wage": 728000
+        },
+        {
+          "currency": "€",
+          "full_name": "Eric Dier",
+          "name": "E. Dier",
+          "overall_score": 78,
+          "potential": 78,
+          "value": 9500000,
+          "yearly_wage": 1716000
+        },
+        {
+          "currency": "€",
+          "full_name": "Stanis Idumbo",
+          "name": "S. Idumbo",
+          "overall_score": 68,
+          "potential": 80,
+          "value": 2900000,
+          "yearly_wage": 520000
+        },
+        {
+          "currency": "€",
+          "full_name": "Paris Brunner",
+          "name": "P. Brunner",
+          "overall_score": 66,
+          "potential": 79,
+          "value": 2000000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "Pape Cabral",
+          "name": "P. Cabral",
+          "overall_score": 63,
+          "potential": 78,
+          "value": 1100000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Yann Lienard",
+          "name": "Y. Lienard",
+          "overall_score": 65,
+          "potential": 75,
+          "value": 1400000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Samuel Nibombe",
+          "name": "S. Nibombe",
+          "overall_score": 62,
+          "potential": 78,
+          "value": 950000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jules Stawiecki",
+          "name": "J. Stawiecki",
+          "overall_score": 60,
+          "potential": 77,
+          "value": 550000,
+          "yearly_wage": 52000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ilane Touré",
+          "name": "I. Touré",
+          "overall_score": 62,
+          "potential": 77,
+          "value": 875000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Takumi Minamino",
+          "name": "T. Minamino",
+          "overall_score": 78,
+          "potential": 78,
+          "value": 13500000,
+          "yearly_wage": 1820000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mohammed Salisu",
+          "name": "M. Salisu",
+          "overall_score": 77,
+          "potential": 80,
+          "value": 12000000,
+          "yearly_wage": 1560000
+        },
+        {
+          "currency": "€",
+          "full_name": "Edan Diop",
+          "name": "E. Diop",
+          "overall_score": 68,
+          "potential": 80,
+          "value": 2900000,
+          "yearly_wage": 520000
+        },
+        {
+          "currency": "€",
+          "full_name": "Radosław Majecki",
+          "name": "R. Majecki",
+          "overall_score": 75,
+          "potential": 78,
+          "value": 6000000,
+          "yearly_wage": 832000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lucas Michal",
+          "name": "L. Michal",
+          "overall_score": 66,
+          "potential": 79,
+          "value": 2100000,
+          "yearly_wage": 416000
+        }
+      ],
+      "team": "AS Monaco",
+      "transfer_budget": 36000000,
+      "url": "https://sofifa.com/team/69/as-monaco/260037/"
+    },
+    {
+      "player_count": 36,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Robin Risser",
+          "name": "R. Risser",
+          "overall_score": 78,
+          "potential": 85,
+          "value": 23500000,
+          "yearly_wage": 520000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ismaëlo Ganiou",
+          "name": "I. Ganiou",
+          "overall_score": 75,
+          "potential": 83,
+          "value": 11500000,
+          "yearly_wage": 884000
+        },
+        {
+          "currency": "€",
+          "full_name": "Samson Baidoo",
+          "name": "S. Baidoo",
+          "overall_score": 76,
+          "potential": 83,
+          "value": 14000000,
+          "yearly_wage": 936000
+        },
+        {
+          "currency": "€",
+          "full_name": "Malang Sarr",
+          "name": "M. Sarr",
+          "overall_score": 78,
+          "potential": 81,
+          "value": 16500000,
+          "yearly_wage": 1456000
+        },
+        {
+          "currency": "€",
+          "full_name": "Saud Abdulhamid",
+          "name": "S. Abdulhamid",
+          "overall_score": 76,
+          "potential": 78,
+          "value": 8500000,
+          "yearly_wage": 2132000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mamadou Sangaré",
+          "name": "M. Sangaré",
+          "overall_score": 80,
+          "potential": 87,
+          "value": 42000000,
+          "yearly_wage": 1508000
+        },
+        {
+          "currency": "€",
+          "full_name": "Adrien Thomasson",
+          "name": "A. Thomasson",
+          "overall_score": 80,
+          "potential": 80,
+          "value": 17500000,
+          "yearly_wage": 1820000
+        },
+        {
+          "currency": "€",
+          "full_name": "Matthieu Udol",
+          "name": "M. Udol",
+          "overall_score": 80,
+          "potential": 80,
+          "value": 18500000,
+          "yearly_wage": 1768000
+        },
+        {
+          "currency": "€",
+          "full_name": "Florian Thauvin",
+          "name": "F. Thauvin",
+          "overall_score": 81,
+          "potential": 81,
+          "value": 20500000,
+          "yearly_wage": 2080000
+        },
+        {
+          "currency": "€",
+          "full_name": "Odsonne Édouard",
+          "name": "O. Édouard",
+          "overall_score": 77,
+          "potential": 77,
+          "value": 11500000,
+          "yearly_wage": 1560000
+        },
+        {
+          "currency": "€",
+          "full_name": "Wesley Saïd",
+          "name": "W. Saïd",
+          "overall_score": 77,
+          "potential": 77,
+          "value": 10000000,
+          "yearly_wage": 1560000
+        },
+        {
+          "currency": "€",
+          "full_name": "Allan Saint-Maximin",
+          "name": "A. Saint-Maximin",
+          "overall_score": 77,
+          "potential": 77,
+          "value": 10500000,
+          "yearly_wage": 1560000
+        },
+        {
+          "currency": "€",
+          "full_name": "Amadou Haidara",
+          "name": "A. Haidara",
+          "overall_score": 75,
+          "potential": 75,
+          "value": 6000000,
+          "yearly_wage": 1248000
+        },
+        {
+          "currency": "€",
+          "full_name": "Andrija Bulatović",
+          "name": "A. Bulatović",
+          "overall_score": 71,
+          "potential": 81,
+          "value": 3900000,
+          "yearly_wage": 572000
+        },
+        {
+          "currency": "€",
+          "full_name": "Fodé Sylla",
+          "name": "F. Sylla",
+          "overall_score": 65,
+          "potential": 78,
+          "value": 1700000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ruben Aguilar",
+          "name": "R. Aguilar",
+          "overall_score": 77,
+          "potential": 77,
+          "value": 7500000,
+          "yearly_wage": 1404000
+        },
+        {
+          "currency": "€",
+          "full_name": "Nidal Čelik",
+          "name": "N. Čelik",
+          "overall_score": 69,
+          "potential": 80,
+          "value": 2700000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mathieu Gorgelin",
+          "name": "M. Gorgelin",
+          "overall_score": 70,
+          "potential": 70,
+          "value": 275000,
+          "yearly_wage": 520000
+        },
+        {
+          "currency": "€",
+          "full_name": "Florian Sotoca",
+          "name": "F. Sotoca",
+          "overall_score": 74,
+          "potential": 74,
+          "value": 2100000,
+          "yearly_wage": 1300000
+        },
+        {
+          "currency": "€",
+          "full_name": "Rayan Fofana",
+          "name": "R. Fofana",
+          "overall_score": 72,
+          "potential": 82,
+          "value": 5000000,
+          "yearly_wage": 780000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ilan Jourdren",
+          "name": "I. Jourdren",
+          "overall_score": 62,
+          "potential": 78,
+          "value": 875000,
+          "yearly_wage": 36400
+        },
+        {
+          "currency": "€",
+          "full_name": "Abdallah Sima",
+          "name": "A. Sima",
+          "overall_score": 73,
+          "potential": 77,
+          "value": 4400000,
+          "yearly_wage": 988000
+        },
+        {
+          "currency": "€",
+          "full_name": "Kyllian Antonio",
+          "name": "K. Antonio",
+          "overall_score": 66,
+          "potential": 80,
+          "value": 1800000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Arthur Masuaku",
+          "name": "A. Masuaku",
+          "overall_score": 75,
+          "potential": 75,
+          "value": 4100000,
+          "yearly_wage": 2548000
+        },
+        {
+          "currency": "€",
+          "full_name": "Anthony Bermont",
+          "name": "A. Bermont",
+          "overall_score": 68,
+          "potential": 78,
+          "value": 2600000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alpha Diallo",
+          "name": "A. Diallo",
+          "overall_score": 62,
+          "potential": 75,
+          "value": 950000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Erawan Garnier",
+          "name": "E. Garnier",
+          "overall_score": 62,
+          "potential": 75,
+          "value": 950000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Régis Gurtner",
+          "name": "R. Gurtner",
+          "overall_score": 69,
+          "potential": 69,
+          "value": 150000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jonathan Gradit",
+          "name": "J. Gradit",
+          "overall_score": 77,
+          "potential": 77,
+          "value": 7000000,
+          "yearly_wage": 1404000
+        },
+        {
+          "currency": "€",
+          "full_name": "Rémy Labeau Lascary",
+          "name": "R. Labeau Lascary",
+          "overall_score": 73,
+          "potential": 80,
+          "value": 6000000,
+          "yearly_wage": 936000
+        },
+        {
+          "currency": "€",
+          "full_name": "Goduine Koyalipou",
+          "name": "G. Koyalipou",
+          "overall_score": 72,
+          "potential": 75,
+          "value": 3100000,
+          "yearly_wage": 988000
+        },
+        {
+          "currency": "€",
+          "full_name": "Hervé Koffi",
+          "name": "H. Koffi",
+          "overall_score": 78,
+          "potential": 80,
+          "value": 12000000,
+          "yearly_wage": 988000
+        },
+        {
+          "currency": "€",
+          "full_name": "Facundo Medina",
+          "name": "F. Medina",
+          "overall_score": 79,
+          "potential": 83,
+          "value": 21500000,
+          "yearly_wage": 1612000
+        },
+        {
+          "currency": "€",
+          "full_name": "Angelo Fulgini",
+          "name": "A. Fulgini",
+          "overall_score": 73,
+          "potential": 73,
+          "value": 3000000,
+          "yearly_wage": 1092000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mattia Fortin",
+          "name": "M. Fortin",
+          "overall_score": 67,
+          "potential": 76,
+          "value": 2000000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jeremy Agbonifo",
+          "name": "J. Agbonifo",
+          "overall_score": 66,
+          "potential": 78,
+          "value": 2000000,
+          "yearly_wage": 312000
+        }
+      ],
+      "team": "RC Lens",
+      "transfer_budget": 11600000,
+      "url": "https://sofifa.com/team/64/rc-lens/260037/"
+    },
+    {
+      "player_count": 36,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Berke Özer",
+          "name": "B. Özer",
+          "overall_score": 78,
+          "potential": 82,
+          "value": 15500000,
+          "yearly_wage": 936000
+        },
+        {
+          "currency": "€",
+          "full_name": "Thomas Meunier",
+          "name": "T. Meunier",
+          "overall_score": 77,
+          "potential": 77,
+          "value": 5500000,
+          "yearly_wage": 1508000
+        },
+        {
+          "currency": "€",
+          "full_name": "Nathan Ngoy",
+          "name": "N. Ngoy",
+          "overall_score": 75,
+          "potential": 83,
+          "value": 12000000,
+          "yearly_wage": 1144000
+        },
+        {
+          "currency": "€",
+          "full_name": "Aïssa Mandi",
+          "name": "A. Mandi",
+          "overall_score": 77,
+          "potential": 77,
+          "value": 5000000,
+          "yearly_wage": 1508000
+        },
+        {
+          "currency": "€",
+          "full_name": "Romain Perraud",
+          "name": "R. Perraud",
+          "overall_score": 76,
+          "potential": 76,
+          "value": 7000000,
+          "yearly_wage": 1352000
+        },
+        {
+          "currency": "€",
+          "full_name": "Benjamin André",
+          "name": "B. André",
+          "overall_score": 80,
+          "potential": 80,
+          "value": 7000000,
+          "yearly_wage": 1872000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ayyoub Bouaddi",
+          "name": "A. Bouaddi",
+          "overall_score": 78,
+          "potential": 86,
+          "value": 27000000,
+          "yearly_wage": 780000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ngal'ayel Mukau",
+          "name": "N. Mukau",
+          "overall_score": 74,
+          "potential": 82,
+          "value": 8500000,
+          "yearly_wage": 884000
+        },
+        {
+          "currency": "€",
+          "full_name": "Félix Alexandre A. Sanches Correia",
+          "name": "Félix Correia",
+          "overall_score": 75,
+          "potential": 78,
+          "value": 7500000,
+          "yearly_wage": 1196000
+        },
+        {
+          "currency": "€",
+          "full_name": "Hákon Arnar Haraldsson",
+          "name": "H. Haraldsson",
+          "overall_score": 78,
+          "potential": 83,
+          "value": 21500000,
+          "yearly_wage": 1456000
+        },
+        {
+          "currency": "€",
+          "full_name": "Matias Fernandez-Pardo",
+          "name": "M. Fernandez-Pardo",
+          "overall_score": 76,
+          "potential": 84,
+          "value": 16500000,
+          "yearly_wage": 1040000
+        },
+        {
+          "currency": "€",
+          "full_name": "Nabil Bentaleb",
+          "name": "N. Bentaleb",
+          "overall_score": 77,
+          "potential": 77,
+          "value": 9000000,
+          "yearly_wage": 1508000
+        },
+        {
+          "currency": "€",
+          "full_name": "Gaëtan Perrin",
+          "name": "G. Perrin",
+          "overall_score": 77,
+          "potential": 77,
+          "value": 10500000,
+          "yearly_wage": 1560000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ethan Mbappé",
+          "name": "E. Mbappé",
+          "overall_score": 72,
+          "potential": 82,
+          "value": 4900000,
+          "yearly_wage": 676000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alexsandro de Souza Ribeiro",
+          "name": "Alexsandro",
+          "overall_score": 79,
+          "potential": 83,
+          "value": 22000000,
+          "yearly_wage": 1612000
+        },
+        {
+          "currency": "€",
+          "full_name": "Chancel Mbemba",
+          "name": "C. Mbemba",
+          "overall_score": 75,
+          "potential": 75,
+          "value": 4600000,
+          "yearly_wage": 1352000
+        },
+        {
+          "currency": "€",
+          "full_name": "Tiago Carvalho Santos",
+          "name": "Tiago Santos",
+          "overall_score": 75,
+          "potential": 79,
+          "value": 7500000,
+          "yearly_wage": 1144000
+        },
+        {
+          "currency": "€",
+          "full_name": "Arnaud Bodart",
+          "name": "A. Bodart",
+          "overall_score": 73,
+          "potential": 75,
+          "value": 2800000,
+          "yearly_wage": 676000
+        },
+        {
+          "currency": "€",
+          "full_name": "Marius Broholm",
+          "name": "M. Broholm",
+          "overall_score": 69,
+          "potential": 79,
+          "value": 3100000,
+          "yearly_wage": 520000
+        },
+        {
+          "currency": "€",
+          "full_name": "Olivier Giroud",
+          "name": "O. Giroud",
+          "overall_score": 78,
+          "potential": 78,
+          "value": 4800000,
+          "yearly_wage": 1404000
+        },
+        {
+          "currency": "€",
+          "full_name": "Soriba Diaoune",
+          "name": "S. Diaoune",
+          "overall_score": 66,
+          "potential": 79,
+          "value": 1900000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Calvin Verdonk",
+          "name": "C. Verdonk",
+          "overall_score": 72,
+          "potential": 72,
+          "value": 2100000,
+          "yearly_wage": 1040000
+        },
+        {
+          "currency": "€",
+          "full_name": "Maxima Goffi",
+          "name": "M. Goffi",
+          "overall_score": 64,
+          "potential": 77,
+          "value": 1200000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Noah Edjouma",
+          "name": "N. Edjouma",
+          "overall_score": 68,
+          "potential": 80,
+          "value": 2900000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "Rafael Tavares Gomes Fernandes",
+          "name": "Rafael Fernandes",
+          "overall_score": 63,
+          "potential": 74,
+          "value": 1000000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Marc-Aurèle Caillard",
+          "name": "M. Caillard",
+          "overall_score": 67,
+          "potential": 67,
+          "value": 550000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Osame Sahraoui",
+          "name": "O. Sahraoui",
+          "overall_score": 76,
+          "potential": 80,
+          "value": 11000000,
+          "yearly_wage": 1248000
+        },
+        {
+          "currency": "€",
+          "full_name": "Hamza Igamane",
+          "name": "H. Igamane",
+          "overall_score": 75,
+          "potential": 83,
+          "value": 12500000,
+          "yearly_wage": 1300000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ousmane Touré",
+          "name": "O. Touré",
+          "overall_score": 65,
+          "potential": 77,
+          "value": 1600000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lisandru Olmeta",
+          "name": "L. Olmeta",
+          "overall_score": 65,
+          "potential": 80,
+          "value": 1500000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ignacio Miramón",
+          "name": "I. Miramón",
+          "overall_score": 67,
+          "potential": 77,
+          "value": 2200000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "Tiago Fontoura F. Morais",
+          "name": "Tiago Morais",
+          "overall_score": 69,
+          "potential": 78,
+          "value": 3100000,
+          "yearly_wage": 520000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mohamed Bayo",
+          "name": "M. Bayo",
+          "overall_score": 74,
+          "potential": 75,
+          "value": 4900000,
+          "yearly_wage": 1352000
+        },
+        {
+          "currency": "€",
+          "full_name": "Isaac Cossier",
+          "name": "I. Cossier",
+          "overall_score": 65,
+          "potential": 78,
+          "value": 1600000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ugo Raghouber",
+          "name": "U. Raghouber",
+          "overall_score": 71,
+          "potential": 81,
+          "value": 4000000,
+          "yearly_wage": 676000
+        },
+        {
+          "currency": "€",
+          "full_name": "Vincent Burlet",
+          "name": "V. Burlet",
+          "overall_score": 67,
+          "potential": 78,
+          "value": 2100000,
+          "yearly_wage": 364000
+        }
+      ],
+      "team": "Lille OSC",
+      "transfer_budget": 18900000,
+      "url": "https://sofifa.com/team/65/lille-osc/260037/"
+    },
+    {
+      "player_count": 36,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Dominik Greif",
+          "name": "D. Greif",
+          "overall_score": 80,
+          "potential": 82,
+          "value": 18000000,
+          "yearly_wage": 936000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ainsley Maitland-Niles",
+          "name": "A. Maitland-Niles",
+          "overall_score": 77,
+          "potential": 77,
+          "value": 10000000,
+          "yearly_wage": 1092000
+        },
+        {
+          "currency": "€",
+          "full_name": "Clinton Mukoni Mata Pedro Lourenço",
+          "name": "Clinton Mata",
+          "overall_score": 76,
+          "potential": 76,
+          "value": 4900000,
+          "yearly_wage": 1040000
+        },
+        {
+          "currency": "€",
+          "full_name": "Moussa Niakhaté",
+          "name": "M. Niakhaté",
+          "overall_score": 80,
+          "potential": 80,
+          "value": 17500000,
+          "yearly_wage": 1404000
+        },
+        {
+          "currency": "€",
+          "full_name": "Abner Vinícius da Silva Santos",
+          "name": "Abner Vinícius",
+          "overall_score": 75,
+          "potential": 78,
+          "value": 7000000,
+          "yearly_wage": 936000
+        },
+        {
+          "currency": "€",
+          "full_name": "Khalis Merah",
+          "name": "K. Merah",
+          "overall_score": 70,
+          "potential": 80,
+          "value": 3400000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "Tyler Morton",
+          "name": "T. Morton",
+          "overall_score": 79,
+          "potential": 84,
+          "value": 24500000,
+          "yearly_wage": 1092000
+        },
+        {
+          "currency": "€",
+          "full_name": "Corentin Tolisso",
+          "name": "C. Tolisso",
+          "overall_score": 82,
+          "potential": 82,
+          "value": 29000000,
+          "yearly_wage": 1716000
+        },
+        {
+          "currency": "€",
+          "full_name": "Endrick Felipe Moreira de Sousa",
+          "name": "Endrick",
+          "overall_score": 78,
+          "potential": 89,
+          "value": 30000000,
+          "yearly_wage": 5200000
+        },
+        {
+          "currency": "€",
+          "full_name": "Roman Yaremchuk",
+          "name": "R. Yaremchuk",
+          "overall_score": 75,
+          "potential": 75,
+          "value": 5500000,
+          "yearly_wage": 1612000
+        },
+        {
+          "currency": "€",
+          "full_name": "Afonso Bastardo Moreira",
+          "name": "Afonso Moreira",
+          "overall_score": 75,
+          "potential": 84,
+          "value": 12500000,
+          "yearly_wage": 728000
+        },
+        {
+          "currency": "€",
+          "full_name": "Malick Fofana",
+          "name": "M. Fofana",
+          "overall_score": 78,
+          "potential": 86,
+          "value": 31000000,
+          "yearly_wage": 884000
+        },
+        {
+          "currency": "€",
+          "full_name": "Orel Mangala",
+          "name": "O. Mangala",
+          "overall_score": 76,
+          "potential": 77,
+          "value": 7500000,
+          "yearly_wage": 988000
+        },
+        {
+          "currency": "€",
+          "full_name": "Adam Karabec",
+          "name": "A. Karabec",
+          "overall_score": 73,
+          "potential": 79,
+          "value": 4900000,
+          "yearly_wage": 728000
+        },
+        {
+          "currency": "€",
+          "full_name": "Noah Nartey",
+          "name": "N. Nartey",
+          "overall_score": 69,
+          "potential": 83,
+          "value": 3300000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Nicolás Tagliafico",
+          "name": "N. Tagliafico",
+          "overall_score": 78,
+          "potential": 78,
+          "value": 9500000,
+          "yearly_wage": 1196000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ruben Kluivert",
+          "name": "R. Kluivert",
+          "overall_score": 74,
+          "potential": 81,
+          "value": 8000000,
+          "yearly_wage": 780000
+        },
+        {
+          "currency": "€",
+          "full_name": "Rémy Descamps",
+          "name": "R. Descamps",
+          "overall_score": 75,
+          "potential": 76,
+          "value": 4300000,
+          "yearly_wage": 676000
+        },
+        {
+          "currency": "€",
+          "full_name": "Tanner Tessmann",
+          "name": "T. Tessmann",
+          "overall_score": 76,
+          "potential": 82,
+          "value": 11000000,
+          "yearly_wage": 884000
+        },
+        {
+          "currency": "€",
+          "full_name": "Pavel Šulc",
+          "name": "P. Šulc",
+          "overall_score": 78,
+          "potential": 81,
+          "value": 19000000,
+          "yearly_wage": 1092000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ernest Nuamah",
+          "name": "E. Nuamah",
+          "overall_score": 75,
+          "potential": 82,
+          "value": 11500000,
+          "yearly_wage": 728000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mathys De Carvalho Soares",
+          "name": "Mathys De Carvalho",
+          "overall_score": 68,
+          "potential": 79,
+          "value": 2500000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Rachid Ghezzal",
+          "name": "R. Ghezzal",
+          "overall_score": 72,
+          "potential": 72,
+          "value": 1500000,
+          "yearly_wage": 780000
+        },
+        {
+          "currency": "€",
+          "full_name": "Noham Kamara",
+          "name": "N. Kamara",
+          "overall_score": 66,
+          "potential": 82,
+          "value": 2000000,
+          "yearly_wage": 676000
+        },
+        {
+          "currency": "€",
+          "full_name": "Hans Hateboer",
+          "name": "H. Hateboer",
+          "overall_score": 74,
+          "potential": 74,
+          "value": 2900000,
+          "yearly_wage": 1144000
+        },
+        {
+          "currency": "€",
+          "full_name": "Rémi Himbert",
+          "name": "R. Himbert",
+          "overall_score": 68,
+          "potential": 82,
+          "value": 2800000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lassine Diarra",
+          "name": "L. Diarra",
+          "overall_score": 64,
+          "potential": 74,
+          "value": 1100000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Achraf Laâziri",
+          "name": "A. Laâziri",
+          "overall_score": 65,
+          "potential": 74,
+          "value": 1500000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Adil Hamdani",
+          "name": "A. Hamdani",
+          "overall_score": 64,
+          "potential": 79,
+          "value": 1300000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Steeve Kango",
+          "name": "S. Kango",
+          "overall_score": 66,
+          "potential": 80,
+          "value": 1900000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mahamadou Diawara",
+          "name": "M. Diawara",
+          "overall_score": 69,
+          "potential": 77,
+          "value": 3000000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "Paul Akouokou",
+          "name": "P. Akouokou",
+          "overall_score": 69,
+          "potential": 70,
+          "value": 1400000,
+          "yearly_wage": 520000
+        },
+        {
+          "currency": "€",
+          "full_name": "Matt Turner",
+          "name": "M. Turner",
+          "overall_score": 74,
+          "potential": 74,
+          "value": 2200000,
+          "yearly_wage": 624000
+        },
+        {
+          "currency": "€",
+          "full_name": "Duje Ćaleta-Car",
+          "name": "D. Ćaleta-Car",
+          "overall_score": 74,
+          "potential": 74,
+          "value": 3600000,
+          "yearly_wage": 936000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alejandro Gomes Rodríguez",
+          "name": "A. Gomes Rodríguez",
+          "overall_score": 64,
+          "potential": 79,
+          "value": 1300000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Enzo Molebe",
+          "name": "E. Molebe",
+          "overall_score": 64,
+          "potential": 79,
+          "value": 1300000,
+          "yearly_wage": 156000
+        }
+      ],
+      "team": "Olympique Lyonnais",
+      "transfer_budget": 18200000,
+      "url": "https://sofifa.com/team/66/olympique-lyonnais/260037/"
+    },
+    {
+      "player_count": 32,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Brice Samba",
+          "name": "B. Samba",
+          "overall_score": 80,
+          "potential": 80,
+          "value": 11000000,
+          "yearly_wage": 1144000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alidu Seidu",
+          "name": "A. Seidu",
+          "overall_score": 74,
+          "potential": 79,
+          "value": 5500000,
+          "yearly_wage": 1040000
+        },
+        {
+          "currency": "€",
+          "full_name": "Abdelhamid Ait Boudlal",
+          "name": "A. Ait Boudlal",
+          "overall_score": 71,
+          "potential": 82,
+          "value": 3800000,
+          "yearly_wage": 572000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lilian Brassier",
+          "name": "L. Brassier",
+          "overall_score": 76,
+          "potential": 80,
+          "value": 9500000,
+          "yearly_wage": 1196000
+        },
+        {
+          "currency": "€",
+          "full_name": "Quentin Merlin",
+          "name": "Q. Merlin",
+          "overall_score": 76,
+          "potential": 82,
+          "value": 11000000,
+          "yearly_wage": 1092000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ludovic Blas",
+          "name": "L. Blas",
+          "overall_score": 76,
+          "potential": 76,
+          "value": 8000000,
+          "yearly_wage": 1300000
+        },
+        {
+          "currency": "€",
+          "full_name": "Valentin Rongier",
+          "name": "V. Rongier",
+          "overall_score": 80,
+          "potential": 80,
+          "value": 17500000,
+          "yearly_wage": 1768000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mahdi Camara",
+          "name": "M. Camara",
+          "overall_score": 77,
+          "potential": 78,
+          "value": 12000000,
+          "yearly_wage": 1404000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mousa Al Tamari",
+          "name": "M. Al Tamari",
+          "overall_score": 76,
+          "potential": 76,
+          "value": 7500000,
+          "yearly_wage": 1352000
+        },
+        {
+          "currency": "€",
+          "full_name": "Estéban Lepaul",
+          "name": "E. Lepaul",
+          "overall_score": 79,
+          "potential": 82,
+          "value": 23500000,
+          "yearly_wage": 1716000
+        },
+        {
+          "currency": "€",
+          "full_name": "Breel Embolo",
+          "name": "B. Embolo",
+          "overall_score": 77,
+          "potential": 77,
+          "value": 11000000,
+          "yearly_wage": 1612000
+        },
+        {
+          "currency": "€",
+          "full_name": "Djaoui Cissé",
+          "name": "D. Cissé",
+          "overall_score": 73,
+          "potential": 83,
+          "value": 7000000,
+          "yearly_wage": 780000
+        },
+        {
+          "currency": "€",
+          "full_name": "Arnaud Nordin",
+          "name": "A. Nordin",
+          "overall_score": 73,
+          "potential": 73,
+          "value": 3200000,
+          "yearly_wage": 1092000
+        },
+        {
+          "currency": "€",
+          "full_name": "Nordan Mukiele",
+          "name": "N. Mukiele",
+          "overall_score": 64,
+          "potential": 78,
+          "value": 1400000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Przemysław Frankowski",
+          "name": "P. Frankowski",
+          "overall_score": 76,
+          "potential": 76,
+          "value": 6500000,
+          "yearly_wage": 2288000
+        },
+        {
+          "currency": "€",
+          "full_name": "Anthony Rouault",
+          "name": "A. Rouault",
+          "overall_score": 76,
+          "potential": 81,
+          "value": 10000000,
+          "yearly_wage": 1092000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mahamadou Nagida",
+          "name": "M. Nagida",
+          "overall_score": 68,
+          "potential": 80,
+          "value": 2800000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mathys Silistrie",
+          "name": "M. Silistrie",
+          "overall_score": 65,
+          "potential": 77,
+          "value": 1500000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Sebastian Szymański",
+          "name": "S. Szymański",
+          "overall_score": 77,
+          "potential": 78,
+          "value": 12500000,
+          "yearly_wage": 1456000
+        },
+        {
+          "currency": "€",
+          "full_name": "Yassir Zabiri",
+          "name": "Y. Zabiri",
+          "overall_score": 66,
+          "potential": 80,
+          "value": 2100000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Glen Kamara",
+          "name": "G. Kamara",
+          "overall_score": 73,
+          "potential": 73,
+          "value": 2600000,
+          "yearly_wage": 1040000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lucas Rosier",
+          "name": "L. Rosier",
+          "overall_score": 63,
+          "potential": 80,
+          "value": 1200000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Elías Legendre Quiñonez",
+          "name": "E. Legendre Quiñonez",
+          "overall_score": 61,
+          "potential": 77,
+          "value": 825000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Henrick Do Marcolino",
+          "name": "H. Do Marcolino",
+          "overall_score": 62,
+          "potential": 79,
+          "value": 1000000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jérémy Jacquet",
+          "name": "J. Jacquet",
+          "overall_score": 76,
+          "potential": 85,
+          "value": 15000000,
+          "yearly_wage": 884000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mikayil Faye",
+          "name": "M. Faye",
+          "overall_score": 68,
+          "potential": 82,
+          "value": 2700000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ayanda Sishuba",
+          "name": "A. Sishuba",
+          "overall_score": 62,
+          "potential": 76,
+          "value": 950000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jordan James",
+          "name": "J. James",
+          "overall_score": 73,
+          "potential": 80,
+          "value": 6000000,
+          "yearly_wage": 780000
+        },
+        {
+          "currency": "€",
+          "full_name": "Albert Grønbæk",
+          "name": "A. Grønbæk",
+          "overall_score": 73,
+          "potential": 78,
+          "value": 4600000,
+          "yearly_wage": 936000
+        },
+        {
+          "currency": "€",
+          "full_name": "Hans Hateboer",
+          "name": "H. Hateboer",
+          "overall_score": 74,
+          "potential": 74,
+          "value": 2900000,
+          "yearly_wage": 1144000
+        },
+        {
+          "currency": "€",
+          "full_name": "Seko Fofana",
+          "name": "S. Fofana",
+          "overall_score": 77,
+          "potential": 77,
+          "value": 10000000,
+          "yearly_wage": 1456000
+        },
+        {
+          "currency": "€",
+          "full_name": "Rayan Bamba",
+          "name": "R. Bamba",
+          "overall_score": 65,
+          "potential": 76,
+          "value": 1500000,
+          "yearly_wage": 260000
+        }
+      ],
+      "team": "Stade Rennais FC",
+      "transfer_budget": 15700000,
+      "url": "https://sofifa.com/team/74/stade-rennais-fc/260037/"
+    },
+    {
+      "player_count": 40,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Mike Penders",
+          "name": "M. Penders",
+          "overall_score": 77,
+          "potential": 86,
+          "value": 19500000,
+          "yearly_wage": 1456000
+        },
+        {
+          "currency": "€",
+          "full_name": "Guéla Doué",
+          "name": "G. Doué",
+          "overall_score": 77,
+          "potential": 82,
+          "value": 15000000,
+          "yearly_wage": 2080000
+        },
+        {
+          "currency": "€",
+          "full_name": "Andrew Omobamidele",
+          "name": "A. Omobamidele",
+          "overall_score": 73,
+          "potential": 78,
+          "value": 4200000,
+          "yearly_wage": 1560000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ismaël Doukouré",
+          "name": "I. Doukouré",
+          "overall_score": 77,
+          "potential": 83,
+          "value": 15500000,
+          "yearly_wage": 1768000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ben Chilwell",
+          "name": "B. Chilwell",
+          "overall_score": 77,
+          "potential": 77,
+          "value": 9500000,
+          "yearly_wage": 2548000
+        },
+        {
+          "currency": "€",
+          "full_name": "Samir El Mourabet",
+          "name": "S. El Mourabet",
+          "overall_score": 73,
+          "potential": 82,
+          "value": 6500000,
+          "yearly_wage": 1300000
+        },
+        {
+          "currency": "€",
+          "full_name": "Valentín Barco",
+          "name": "V. Barco",
+          "overall_score": 78,
+          "potential": 84,
+          "value": 21500000,
+          "yearly_wage": 1976000
+        },
+        {
+          "currency": "€",
+          "full_name": "Diego Manuel J. da Silva Moreira",
+          "name": "Diego Moreira",
+          "overall_score": 78,
+          "potential": 84,
+          "value": 22000000,
+          "yearly_wage": 1976000
+        },
+        {
+          "currency": "€",
+          "full_name": "Martial Godo",
+          "name": "M. Godo",
+          "overall_score": 74,
+          "potential": 82,
+          "value": 9500000,
+          "yearly_wage": 1820000
+        },
+        {
+          "currency": "€",
+          "full_name": "Julio César Enciso",
+          "name": "J. Enciso",
+          "overall_score": 75,
+          "potential": 84,
+          "value": 12500000,
+          "yearly_wage": 1716000
+        },
+        {
+          "currency": "€",
+          "full_name": "Emanuel Emegha",
+          "name": "E. Emegha",
+          "overall_score": 78,
+          "potential": 83,
+          "value": 22000000,
+          "yearly_wage": 2600000
+        },
+        {
+          "currency": "€",
+          "full_name": "Sebastian Nanasi",
+          "name": "S. Nanasi",
+          "overall_score": 75,
+          "potential": 82,
+          "value": 11500000,
+          "yearly_wage": 1976000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mathis Amougou",
+          "name": "M. Amougou",
+          "overall_score": 71,
+          "potential": 79,
+          "value": 4000000,
+          "yearly_wage": 1092000
+        },
+        {
+          "currency": "€",
+          "full_name": "Abdoul Ouattara",
+          "name": "A. Ouattara",
+          "overall_score": 71,
+          "potential": 80,
+          "value": 4000000,
+          "yearly_wage": 1092000
+        },
+        {
+          "currency": "€",
+          "full_name": "Gessime Yassine",
+          "name": "G. Yassine",
+          "overall_score": 70,
+          "potential": 83,
+          "value": 3800000,
+          "yearly_wage": 988000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lucas Høgsberg",
+          "name": "L. Høgsberg",
+          "overall_score": 73,
+          "potential": 82,
+          "value": 6000000,
+          "yearly_wage": 1248000
+        },
+        {
+          "currency": "€",
+          "full_name": "Aarón Anselmino",
+          "name": "A. Anselmino",
+          "overall_score": 73,
+          "potential": 81,
+          "value": 6000000,
+          "yearly_wage": 2496000
+        },
+        {
+          "currency": "€",
+          "full_name": "Karl-Johan Johnsson",
+          "name": "K. Johnsson",
+          "overall_score": 69,
+          "potential": 69,
+          "value": 150000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "Samuel Amo-Ameyaw",
+          "name": "S. Amo-Ameyaw",
+          "overall_score": 70,
+          "potential": 80,
+          "value": 3400000,
+          "yearly_wage": 936000
+        },
+        {
+          "currency": "€",
+          "full_name": "David Datro Fofana",
+          "name": "D. Fofana",
+          "overall_score": 72,
+          "potential": 80,
+          "value": 5500000,
+          "yearly_wage": 3120000
+        },
+        {
+          "currency": "€",
+          "full_name": "Maxi Oyedele",
+          "name": "M. Oyedele",
+          "overall_score": 70,
+          "potential": 78,
+          "value": 3500000,
+          "yearly_wage": 1040000
+        },
+        {
+          "currency": "€",
+          "full_name": "Rafael Filipe G. Soares Luís",
+          "name": "Rafael Luís",
+          "overall_score": 69,
+          "potential": 81,
+          "value": 3200000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Junior Mwanga",
+          "name": "J. Mwanga",
+          "overall_score": 72,
+          "potential": 76,
+          "value": 3100000,
+          "yearly_wage": 1404000
+        },
+        {
+          "currency": "€",
+          "full_name": "Stefan Bajic",
+          "name": "S. Bajic",
+          "overall_score": 65,
+          "potential": 70,
+          "value": 875000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Joaquín Panichelli",
+          "name": "J. Panichelli",
+          "overall_score": 77,
+          "potential": 85,
+          "value": 24000000,
+          "yearly_wage": 2444000
+        },
+        {
+          "currency": "€",
+          "full_name": "Amadou Cissé",
+          "name": "A. Cissé",
+          "overall_score": 63,
+          "potential": 73,
+          "value": 975000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Idrissa Sabaly",
+          "name": "I. Sabaly",
+          "overall_score": 62,
+          "potential": 76,
+          "value": 850000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Yaya Diémé",
+          "name": "Y. Diémé",
+          "overall_score": 62,
+          "potential": 76,
+          "value": 900000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jean-Baptiste Bosey",
+          "name": "J. Bosey",
+          "overall_score": 60,
+          "potential": 76,
+          "value": 625000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Tyrese Noubissie",
+          "name": "T. Noubissie",
+          "overall_score": 61,
+          "potential": 79,
+          "value": 825000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Óscar Perea",
+          "name": "Ó. Perea",
+          "overall_score": 67,
+          "potential": 75,
+          "value": 2200000,
+          "yearly_wage": 676000
+        },
+        {
+          "currency": "€",
+          "full_name": "Pape Demba Diop",
+          "name": "P. Diop",
+          "overall_score": 70,
+          "potential": 79,
+          "value": 3600000,
+          "yearly_wage": 1040000
+        },
+        {
+          "currency": "€",
+          "full_name": "Abakar Sylla",
+          "name": "A. Sylla",
+          "overall_score": 70,
+          "potential": 78,
+          "value": 3300000,
+          "yearly_wage": 1144000
+        },
+        {
+          "currency": "€",
+          "full_name": "Soumaila Coulibaly",
+          "name": "S. Coulibaly",
+          "overall_score": 72,
+          "potential": 80,
+          "value": 4900000,
+          "yearly_wage": 1196000
+        },
+        {
+          "currency": "€",
+          "full_name": "Saïdou Sow",
+          "name": "S. Sow",
+          "overall_score": 70,
+          "potential": 75,
+          "value": 2200000,
+          "yearly_wage": 1144000
+        },
+        {
+          "currency": "€",
+          "full_name": "Sékou Mara",
+          "name": "S. Mara",
+          "overall_score": 70,
+          "potential": 77,
+          "value": 3300000,
+          "yearly_wage": 1300000
+        },
+        {
+          "currency": "€",
+          "full_name": "Rayane Messi",
+          "name": "R. Messi",
+          "overall_score": 65,
+          "potential": 80,
+          "value": 1700000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "Pape Diong",
+          "name": "P. Diong",
+          "overall_score": 65,
+          "potential": 79,
+          "value": 1600000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "Rabby Nzingoula",
+          "name": "R. Nzingoula",
+          "overall_score": 70,
+          "potential": 78,
+          "value": 3200000,
+          "yearly_wage": 884000
+        },
+        {
+          "currency": "€",
+          "full_name": "Miloš Luković",
+          "name": "M. Luković",
+          "overall_score": 67,
+          "potential": 81,
+          "value": 2400000,
+          "yearly_wage": 780000
+        }
+      ],
+      "team": "RC Strasbourg Alsace",
+      "transfer_budget": 21700000,
+      "url": "https://sofifa.com/team/76/rc-strasbourg-alsace/260037/"
+    },
+    {
+      "player_count": 36,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Kevin Trapp",
+          "name": "K. Trapp",
+          "overall_score": 79,
+          "potential": 79,
+          "value": 3000000,
+          "yearly_wage": 1820000
+        },
+        {
+          "currency": "€",
+          "full_name": "Adama Camara",
+          "name": "A. Camara",
+          "overall_score": 71,
+          "potential": 71,
+          "value": 1900000,
+          "yearly_wage": 1508000
+        },
+        {
+          "currency": "€",
+          "full_name": "Diego Coppola",
+          "name": "D. Coppola",
+          "overall_score": 74,
+          "potential": 80,
+          "value": 6000000,
+          "yearly_wage": 2236000
+        },
+        {
+          "currency": "€",
+          "full_name": "Moustapha Mbow",
+          "name": "M. Mbow",
+          "overall_score": 73,
+          "potential": 76,
+          "value": 3600000,
+          "yearly_wage": 1612000
+        },
+        {
+          "currency": "€",
+          "full_name": "Nhoa Sangui",
+          "name": "N. Sangui",
+          "overall_score": 70,
+          "potential": 82,
+          "value": 3600000,
+          "yearly_wage": 832000
+        },
+        {
+          "currency": "€",
+          "full_name": "Pierre Lees-Melou",
+          "name": "P. Lees-Melou",
+          "overall_score": 77,
+          "potential": 77,
+          "value": 7000000,
+          "yearly_wage": 2340000
+        },
+        {
+          "currency": "€",
+          "full_name": "Marshall Munetsi",
+          "name": "M. Munetsi",
+          "overall_score": 75,
+          "potential": 75,
+          "value": 5500000,
+          "yearly_wage": 2912000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jonathan Ikoné",
+          "name": "J. Ikoné",
+          "overall_score": 75,
+          "potential": 75,
+          "value": 6000000,
+          "yearly_wage": 2236000
+        },
+        {
+          "currency": "€",
+          "full_name": "Moses Simon",
+          "name": "M. Simon",
+          "overall_score": 76,
+          "potential": 76,
+          "value": 7500000,
+          "yearly_wage": 2444000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ilan Kebbal",
+          "name": "I. Kebbal",
+          "overall_score": 77,
+          "potential": 77,
+          "value": 11500000,
+          "yearly_wage": 2496000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ciro Immobile",
+          "name": "C. Immobile",
+          "overall_score": 77,
+          "potential": 77,
+          "value": 4500000,
+          "yearly_wage": 2028000
+        },
+        {
+          "currency": "€",
+          "full_name": "Maxime Lopez",
+          "name": "M. Lopez",
+          "overall_score": 76,
+          "potential": 76,
+          "value": 8000000,
+          "yearly_wage": 2184000
+        },
+        {
+          "currency": "€",
+          "full_name": "Rudy Matondo",
+          "name": "R. Matondo",
+          "overall_score": 70,
+          "potential": 84,
+          "value": 3600000,
+          "yearly_wage": 676000
+        },
+        {
+          "currency": "€",
+          "full_name": "Hamari Traoré",
+          "name": "H. Traoré",
+          "overall_score": 77,
+          "potential": 77,
+          "value": 5500000,
+          "yearly_wage": 2340000
+        },
+        {
+          "currency": "€",
+          "full_name": "Otávio Ataíde da Silva",
+          "name": "Otávio",
+          "overall_score": 74,
+          "potential": 79,
+          "value": 6000000,
+          "yearly_wage": 1612000
+        },
+        {
+          "currency": "€",
+          "full_name": "Thibault De Smet",
+          "name": "T. De Smet",
+          "overall_score": 71,
+          "potential": 71,
+          "value": 1800000,
+          "yearly_wage": 1352000
+        },
+        {
+          "currency": "€",
+          "full_name": "Timothée Kolodziejczak",
+          "name": "T. Kolodziejczak",
+          "overall_score": 69,
+          "potential": 69,
+          "value": 675000,
+          "yearly_wage": 1144000
+        },
+        {
+          "currency": "€",
+          "full_name": "Obed Nkambadio",
+          "name": "O. Nkambadio",
+          "overall_score": 74,
+          "potential": 82,
+          "value": 8000000,
+          "yearly_wage": 936000
+        },
+        {
+          "currency": "€",
+          "full_name": "Luca Koleosho",
+          "name": "L. Koleosho",
+          "overall_score": 72,
+          "potential": 79,
+          "value": 4600000,
+          "yearly_wage": 1560000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jean-Philippe Krasso",
+          "name": "J. Krasso",
+          "overall_score": 73,
+          "potential": 73,
+          "value": 3300000,
+          "yearly_wage": 1872000
+        },
+        {
+          "currency": "€",
+          "full_name": "Samir Chergui",
+          "name": "S. Chergui",
+          "overall_score": 70,
+          "potential": 73,
+          "value": 1800000,
+          "yearly_wage": 1248000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alimami Gory",
+          "name": "A. Gory",
+          "overall_score": 70,
+          "potential": 70,
+          "value": 1600000,
+          "yearly_wage": 1352000
+        },
+        {
+          "currency": "€",
+          "full_name": "Tuomas Ollila",
+          "name": "T. Ollila",
+          "overall_score": 68,
+          "potential": 71,
+          "value": 1500000,
+          "yearly_wage": 936000
+        },
+        {
+          "currency": "€",
+          "full_name": "Willem Geubbels",
+          "name": "W. Geubbels",
+          "overall_score": 72,
+          "potential": 77,
+          "value": 3600000,
+          "yearly_wage": 1508000
+        },
+        {
+          "currency": "€",
+          "full_name": "Vincent Marchetti",
+          "name": "V. Marchetti",
+          "overall_score": 70,
+          "potential": 70,
+          "value": 1700000,
+          "yearly_wage": 1300000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mathieu Cafaro",
+          "name": "M. Cafaro",
+          "overall_score": 72,
+          "potential": 72,
+          "value": 2400000,
+          "yearly_wage": 1768000
+        },
+        {
+          "currency": "€",
+          "full_name": "Julien Lopez",
+          "name": "J. Lopez",
+          "overall_score": 67,
+          "potential": 67,
+          "value": 625000,
+          "yearly_wage": 988000
+        },
+        {
+          "currency": "€",
+          "full_name": "Pierre-Yves Hamel",
+          "name": "P. Hamel",
+          "overall_score": 67,
+          "potential": 67,
+          "value": 850000,
+          "yearly_wage": 988000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mohamed Dao",
+          "name": "M. Dao",
+          "overall_score": 63,
+          "potential": 77,
+          "value": 1100000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Rémy Riou",
+          "name": "R. Riou",
+          "overall_score": 67,
+          "potential": 67,
+          "value": 110000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lamine Gueye",
+          "name": "L. Gueye",
+          "overall_score": 64,
+          "potential": 64,
+          "value": 625000,
+          "yearly_wage": 624000
+        },
+        {
+          "currency": "€",
+          "full_name": "Sofiane Alakouch",
+          "name": "S. Alakouch",
+          "overall_score": 65,
+          "potential": 66,
+          "value": 775000,
+          "yearly_wage": 624000
+        },
+        {
+          "currency": "€",
+          "full_name": "Omar Sissoko",
+          "name": "O. Sissoko",
+          "overall_score": 61,
+          "potential": 78,
+          "value": 825000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mathys Tourraine",
+          "name": "M. Tourraine",
+          "overall_score": 67,
+          "potential": 72,
+          "value": 1400000,
+          "yearly_wage": 728000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lohann Doucet",
+          "name": "L. Doucet",
+          "overall_score": 68,
+          "potential": 75,
+          "value": 2300000,
+          "yearly_wage": 832000
+        },
+        {
+          "currency": "€",
+          "full_name": "Yoan Koré",
+          "name": "Y. Koré",
+          "overall_score": 65,
+          "potential": 73,
+          "value": 1500000,
+          "yearly_wage": 468000
+        }
+      ],
+      "team": "Paris FC",
+      "transfer_budget": 26500000,
+      "url": "https://sofifa.com/team/111817/paris-fc/260037/"
+    },
+    {
+      "player_count": 39,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Yehvann Diouf",
+          "name": "Y. Diouf",
+          "overall_score": 77,
+          "potential": 82,
+          "value": 12500000,
+          "yearly_wage": 780000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jonathan Clauss",
+          "name": "J. Clauss",
+          "overall_score": 78,
+          "potential": 78,
+          "value": 9500000,
+          "yearly_wage": 1508000
+        },
+        {
+          "currency": "€",
+          "full_name": "Antoine Mendy",
+          "name": "A. Mendy",
+          "overall_score": 72,
+          "potential": 81,
+          "value": 4900000,
+          "yearly_wage": 676000
+        },
+        {
+          "currency": "€",
+          "full_name": "Abdulai Juma Bah",
+          "name": "A. Bah",
+          "overall_score": 73,
+          "potential": 81,
+          "value": 6000000,
+          "yearly_wage": 2340000
+        },
+        {
+          "currency": "€",
+          "full_name": "Kojo Peprah Oppong",
+          "name": "K. Oppong",
+          "overall_score": 72,
+          "potential": 79,
+          "value": 4400000,
+          "yearly_wage": 676000
+        },
+        {
+          "currency": "€",
+          "full_name": "Melvin Bard",
+          "name": "M. Bard",
+          "overall_score": 77,
+          "potential": 81,
+          "value": 14000000,
+          "yearly_wage": 1144000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mohamed-Ali Cho",
+          "name": "M. Cho",
+          "overall_score": 75,
+          "potential": 82,
+          "value": 11500000,
+          "yearly_wage": 1040000
+        },
+        {
+          "currency": "€",
+          "full_name": "Morgan Sanson",
+          "name": "M. Sanson",
+          "overall_score": 76,
+          "potential": 76,
+          "value": 7000000,
+          "yearly_wage": 1352000
+        },
+        {
+          "currency": "€",
+          "full_name": "Charles Vanhoutte",
+          "name": "C. Vanhoutte",
+          "overall_score": 77,
+          "potential": 80,
+          "value": 12500000,
+          "yearly_wage": 1352000
+        },
+        {
+          "currency": "€",
+          "full_name": "Sofiane Diop",
+          "name": "S. Diop",
+          "overall_score": 76,
+          "potential": 78,
+          "value": 9500000,
+          "yearly_wage": 1352000
+        },
+        {
+          "currency": "€",
+          "full_name": "Elye Wahi",
+          "name": "E. Wahi",
+          "overall_score": 74,
+          "potential": 81,
+          "value": 8500000,
+          "yearly_wage": 1300000
+        },
+        {
+          "currency": "€",
+          "full_name": "Hicham Boudaoui",
+          "name": "H. Boudaoui",
+          "overall_score": 76,
+          "potential": 79,
+          "value": 10000000,
+          "yearly_wage": 1248000
+        },
+        {
+          "currency": "€",
+          "full_name": "Tanguy Ndombele",
+          "name": "T. Ndombele",
+          "overall_score": 73,
+          "potential": 73,
+          "value": 3000000,
+          "yearly_wage": 1092000
+        },
+        {
+          "currency": "€",
+          "full_name": "Tom Louchet",
+          "name": "T. Louchet",
+          "overall_score": 73,
+          "potential": 81,
+          "value": 7000000,
+          "yearly_wage": 936000
+        },
+        {
+          "currency": "€",
+          "full_name": "Salis Abdul Samed",
+          "name": "S. Abdul Samed",
+          "overall_score": 72,
+          "potential": 74,
+          "value": 2600000,
+          "yearly_wage": 884000
+        },
+        {
+          "currency": "€",
+          "full_name": "Dante Bonfim Costa Santos",
+          "name": "Dante",
+          "overall_score": 75,
+          "potential": 75,
+          "value": 0,
+          "yearly_wage": 832000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ali Abdi",
+          "name": "A. Abdi",
+          "overall_score": 75,
+          "potential": 75,
+          "value": 4100000,
+          "yearly_wage": 1248000
+        },
+        {
+          "currency": "€",
+          "full_name": "Maxime Dupé",
+          "name": "M. Dupé",
+          "overall_score": 75,
+          "potential": 75,
+          "value": 2800000,
+          "yearly_wage": 832000
+        },
+        {
+          "currency": "€",
+          "full_name": "Tiago Maria Antunes Gouveia",
+          "name": "Tiago Gouveia",
+          "overall_score": 73,
+          "potential": 79,
+          "value": 4800000,
+          "yearly_wage": 728000
+        },
+        {
+          "currency": "€",
+          "full_name": "Kevin Carlos Omoruyi Benjamin",
+          "name": "Kevin Carlos",
+          "overall_score": 71,
+          "potential": 76,
+          "value": 2900000,
+          "yearly_wage": 832000
+        },
+        {
+          "currency": "€",
+          "full_name": "Kaïl Boudache",
+          "name": "K. Boudache",
+          "overall_score": 67,
+          "potential": 77,
+          "value": 2200000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Isak Jansson",
+          "name": "I. Jansson",
+          "overall_score": 71,
+          "potential": 76,
+          "value": 2800000,
+          "yearly_wage": 832000
+        },
+        {
+          "currency": "€",
+          "full_name": "Youssouf Ndayishimiye",
+          "name": "Y. Ndayishimiye",
+          "overall_score": 76,
+          "potential": 78,
+          "value": 8000000,
+          "yearly_wage": 1248000
+        },
+        {
+          "currency": "€",
+          "full_name": "Brad-Hamilton Mantsounga",
+          "name": "B. Mantsounga",
+          "overall_score": 63,
+          "potential": 75,
+          "value": 1000000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Bartosz Żelazowski",
+          "name": "B. Żelazowski",
+          "overall_score": 62,
+          "potential": 76,
+          "value": 850000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Gabin Bernardeau",
+          "name": "G. Bernardeau",
+          "overall_score": 67,
+          "potential": 77,
+          "value": 2200000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Djibril Coulibaly",
+          "name": "D. Coulibaly",
+          "overall_score": 61,
+          "potential": 76,
+          "value": 750000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Zoumana Diallo",
+          "name": "Z. Diallo",
+          "overall_score": 64,
+          "potential": 75,
+          "value": 1300000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Everton Pereira da Silva",
+          "name": "Everton",
+          "overall_score": 64,
+          "potential": 77,
+          "value": 1300000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mohamed Abdelmonem",
+          "name": "M. Abdelmonem",
+          "overall_score": 73,
+          "potential": 76,
+          "value": 3500000,
+          "yearly_wage": 988000
+        },
+        {
+          "currency": "€",
+          "full_name": "Moïse Bombito",
+          "name": "M. Bombito",
+          "overall_score": 75,
+          "potential": 80,
+          "value": 7500000,
+          "yearly_wage": 1144000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mattia Viti",
+          "name": "M. Viti",
+          "overall_score": 71,
+          "potential": 80,
+          "value": 3900000,
+          "yearly_wage": 728000
+        },
+        {
+          "currency": "€",
+          "full_name": "Rareș Ilie",
+          "name": "R. Ilie",
+          "overall_score": 69,
+          "potential": 78,
+          "value": 3100000,
+          "yearly_wage": 572000
+        },
+        {
+          "currency": "€",
+          "full_name": "Aliou Baldé",
+          "name": "A. Baldé",
+          "overall_score": 67,
+          "potential": 75,
+          "value": 2300000,
+          "yearly_wage": 520000
+        },
+        {
+          "currency": "€",
+          "full_name": "Terem Moffi",
+          "name": "T. Moffi",
+          "overall_score": 74,
+          "potential": 75,
+          "value": 5000000,
+          "yearly_wage": 1248000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jérémie Boga",
+          "name": "J. Boga",
+          "overall_score": 76,
+          "potential": 76,
+          "value": 7500000,
+          "yearly_wage": 1456000
+        },
+        {
+          "currency": "€",
+          "full_name": "Hamza Koutoune",
+          "name": "H. Koutoune",
+          "overall_score": 60,
+          "potential": 76,
+          "value": 600000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Victor Orakpo",
+          "name": "V. Orakpo",
+          "overall_score": 62,
+          "potential": 77,
+          "value": 950000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Issiaga Camara",
+          "name": "I. Camara",
+          "overall_score": 66,
+          "potential": 79,
+          "value": 1900000,
+          "yearly_wage": 312000
+        }
+      ],
+      "team": "OGC Nice",
+      "transfer_budget": 17300000,
+      "url": "https://sofifa.com/team/72/ogc-nice/260037/"
+    },
+    {
+      "player_count": 26,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Grégoire Coudert",
+          "name": "G. Coudert",
+          "overall_score": 75,
+          "potential": 77,
+          "value": 5500000,
+          "yearly_wage": 728000
+        },
+        {
+          "currency": "€",
+          "full_name": "Kenny Lala",
+          "name": "K. Lala",
+          "overall_score": 76,
+          "potential": 76,
+          "value": 3900000,
+          "yearly_wage": 1196000
+        },
+        {
+          "currency": "€",
+          "full_name": "Brendan Chardonnet",
+          "name": "B. Chardonnet",
+          "overall_score": 77,
+          "potential": 77,
+          "value": 8500000,
+          "yearly_wage": 1300000
+        },
+        {
+          "currency": "€",
+          "full_name": "Junior Diaz",
+          "name": "J. Diaz",
+          "overall_score": 72,
+          "potential": 80,
+          "value": 4900000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Bradley Locko",
+          "name": "B. Locko",
+          "overall_score": 75,
+          "potential": 80,
+          "value": 8000000,
+          "yearly_wage": 936000
+        },
+        {
+          "currency": "€",
+          "full_name": "Joris Chotard",
+          "name": "J. Chotard",
+          "overall_score": 74,
+          "potential": 78,
+          "value": 5500000,
+          "yearly_wage": 884000
+        },
+        {
+          "currency": "€",
+          "full_name": "Hugo Magnetti",
+          "name": "H. Magnetti",
+          "overall_score": 76,
+          "potential": 78,
+          "value": 8000000,
+          "yearly_wage": 1144000
+        },
+        {
+          "currency": "€",
+          "full_name": "Romain Del Castillo",
+          "name": "R. Del Castillo",
+          "overall_score": 76,
+          "potential": 76,
+          "value": 7500000,
+          "yearly_wage": 1248000
+        },
+        {
+          "currency": "€",
+          "full_name": "Junior Dina Ebimbe",
+          "name": "J. Dina Ebimbe",
+          "overall_score": 72,
+          "potential": 75,
+          "value": 3200000,
+          "yearly_wage": 988000
+        },
+        {
+          "currency": "€",
+          "full_name": "Kamory Doumbia",
+          "name": "K. Doumbia",
+          "overall_score": 75,
+          "potential": 81,
+          "value": 9000000,
+          "yearly_wage": 1040000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ludovic Ajorque",
+          "name": "L. Ajorque",
+          "overall_score": 77,
+          "potential": 77,
+          "value": 9000000,
+          "yearly_wage": 1456000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lucas Tousart",
+          "name": "L. Tousart",
+          "overall_score": 74,
+          "potential": 74,
+          "value": 3700000,
+          "yearly_wage": 1092000
+        },
+        {
+          "currency": "€",
+          "full_name": "Rémy Labeau Lascary",
+          "name": "R. Labeau Lascary",
+          "overall_score": 73,
+          "potential": 80,
+          "value": 6000000,
+          "yearly_wage": 936000
+        },
+        {
+          "currency": "€",
+          "full_name": "Hamidou Makalou",
+          "name": "H. Makalou",
+          "overall_score": 64,
+          "potential": 81,
+          "value": 1400000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Soumaila Coulibaly",
+          "name": "S. Coulibaly",
+          "overall_score": 72,
+          "potential": 80,
+          "value": 4900000,
+          "yearly_wage": 1196000
+        },
+        {
+          "currency": "€",
+          "full_name": "Daouda Guindo",
+          "name": "D. Guindo",
+          "overall_score": 70,
+          "potential": 75,
+          "value": 2300000,
+          "yearly_wage": 572000
+        },
+        {
+          "currency": "€",
+          "full_name": "Luck Zogbé",
+          "name": "L. Zogbé",
+          "overall_score": 68,
+          "potential": 78,
+          "value": 2500000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "Radosław Majecki",
+          "name": "R. Majecki",
+          "overall_score": 75,
+          "potential": 78,
+          "value": 6000000,
+          "yearly_wage": 832000
+        },
+        {
+          "currency": "€",
+          "full_name": "Pathé Mboup",
+          "name": "P. Mboup",
+          "overall_score": 70,
+          "potential": 79,
+          "value": 3600000,
+          "yearly_wage": 520000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mama Samba Baldé",
+          "name": "Mama Baldé",
+          "overall_score": 73,
+          "potential": 73,
+          "value": 3000000,
+          "yearly_wage": 1092000
+        },
+        {
+          "currency": "€",
+          "full_name": "Raphaël Le Guen",
+          "name": "R. Le Guen",
+          "overall_score": 64,
+          "potential": 76,
+          "value": 1300000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Noah Jauny",
+          "name": "N. Jauny",
+          "overall_score": 58,
+          "potential": 71,
+          "value": 425000,
+          "yearly_wage": 52000
+        },
+        {
+          "currency": "€",
+          "full_name": "Serigne Saliou Diop",
+          "name": "S. Diop",
+          "overall_score": 58,
+          "potential": 70,
+          "value": 500000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ibrahim Kanté",
+          "name": "I. Kanté",
+          "overall_score": 59,
+          "potential": 75,
+          "value": 575000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Axel Camblan",
+          "name": "A. Camblan",
+          "overall_score": 64,
+          "potential": 72,
+          "value": 1300000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Justin Bourgault",
+          "name": "J. Bourgault",
+          "overall_score": 65,
+          "potential": 76,
+          "value": 1500000,
+          "yearly_wage": 260000
+        }
+      ],
+      "team": "Stade Brestois 29",
+      "transfer_budget": 9100000,
+      "url": "https://sofifa.com/team/378/stade-brestois-29/260037/"
+    },
+    {
+      "player_count": 31,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Yvon Mvogo",
+          "name": "Y. Mvogo",
+          "overall_score": 76,
+          "potential": 76,
+          "value": 4000000,
+          "yearly_wage": 676000
+        },
+        {
+          "currency": "€",
+          "full_name": "Bamo Meïté",
+          "name": "B. Meïté",
+          "overall_score": 75,
+          "potential": 79,
+          "value": 7000000,
+          "yearly_wage": 1456000
+        },
+        {
+          "currency": "€",
+          "full_name": "Montassar Talbi",
+          "name": "M. Talbi",
+          "overall_score": 75,
+          "potential": 77,
+          "value": 6000000,
+          "yearly_wage": 936000
+        },
+        {
+          "currency": "€",
+          "full_name": "Abdoulaye Faye",
+          "name": "A. Faye",
+          "overall_score": 69,
+          "potential": 81,
+          "value": 3200000,
+          "yearly_wage": 1092000
+        },
+        {
+          "currency": "€",
+          "full_name": "Théo Le Bris",
+          "name": "T. Le Bris",
+          "overall_score": 73,
+          "potential": 80,
+          "value": 6000000,
+          "yearly_wage": 728000
+        },
+        {
+          "currency": "€",
+          "full_name": "Noah Cadiou",
+          "name": "N. Cadiou",
+          "overall_score": 71,
+          "potential": 74,
+          "value": 2200000,
+          "yearly_wage": 624000
+        },
+        {
+          "currency": "€",
+          "full_name": "Laurent Abergel",
+          "name": "L. Abergel",
+          "overall_score": 76,
+          "potential": 76,
+          "value": 5000000,
+          "yearly_wage": 1040000
+        },
+        {
+          "currency": "€",
+          "full_name": "Arsène Kouassi",
+          "name": "A. Kouassi",
+          "overall_score": 74,
+          "potential": 82,
+          "value": 9000000,
+          "yearly_wage": 624000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jean-Victor Makengo",
+          "name": "J. Makengo",
+          "overall_score": 72,
+          "potential": 73,
+          "value": 2700000,
+          "yearly_wage": 780000
+        },
+        {
+          "currency": "€",
+          "full_name": "Pablo Pagis",
+          "name": "P. Pagis",
+          "overall_score": 73,
+          "potential": 81,
+          "value": 7000000,
+          "yearly_wage": 728000
+        },
+        {
+          "currency": "€",
+          "full_name": "Bamba Dieng",
+          "name": "B. Dieng",
+          "overall_score": 74,
+          "potential": 77,
+          "value": 5500000,
+          "yearly_wage": 936000
+        },
+        {
+          "currency": "€",
+          "full_name": "Aiyegun Tosin",
+          "name": "A. Tosin",
+          "overall_score": 72,
+          "potential": 73,
+          "value": 2700000,
+          "yearly_wage": 832000
+        },
+        {
+          "currency": "€",
+          "full_name": "Arthur Avom Ebong",
+          "name": "A. Avom Ebong",
+          "overall_score": 74,
+          "potential": 82,
+          "value": 9000000,
+          "yearly_wage": 676000
+        },
+        {
+          "currency": "€",
+          "full_name": "Dermane Karim",
+          "name": "D. Karim",
+          "overall_score": 70,
+          "potential": 80,
+          "value": 3600000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "Panos Katseris",
+          "name": "P. Katseris",
+          "overall_score": 70,
+          "potential": 75,
+          "value": 2400000,
+          "yearly_wage": 520000
+        },
+        {
+          "currency": "€",
+          "full_name": "Igor Silva de Almeida",
+          "name": "Igor Silva",
+          "overall_score": 71,
+          "potential": 71,
+          "value": 1700000,
+          "yearly_wage": 676000
+        },
+        {
+          "currency": "€",
+          "full_name": "Nathaniel Adjei",
+          "name": "N. Adjei",
+          "overall_score": 69,
+          "potential": 78,
+          "value": 2900000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "Bingourou Kamara",
+          "name": "B. Kamara",
+          "overall_score": 70,
+          "potential": 71,
+          "value": 1300000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mohamed Bamba",
+          "name": "M. Bamba",
+          "overall_score": 70,
+          "potential": 75,
+          "value": 2400000,
+          "yearly_wage": 572000
+        },
+        {
+          "currency": "€",
+          "full_name": "Sambou Soumano",
+          "name": "S. Soumano",
+          "overall_score": 72,
+          "potential": 77,
+          "value": 3600000,
+          "yearly_wage": 728000
+        },
+        {
+          "currency": "€",
+          "full_name": "Isaak Touré",
+          "name": "I. Touré",
+          "overall_score": 71,
+          "potential": 79,
+          "value": 3900000,
+          "yearly_wage": 572000
+        },
+        {
+          "currency": "€",
+          "full_name": "Darlin Yongwa",
+          "name": "D. Yongwa",
+          "overall_score": 71,
+          "potential": 75,
+          "value": 2500000,
+          "yearly_wage": 572000
+        },
+        {
+          "currency": "€",
+          "full_name": "Trevan Sanusi",
+          "name": "T. Sanusi",
+          "overall_score": 61,
+          "potential": 82,
+          "value": 1000000,
+          "yearly_wage": 624000
+        },
+        {
+          "currency": "€",
+          "full_name": "Benjamin Leroy",
+          "name": "B. Leroy",
+          "overall_score": 68,
+          "potential": 68,
+          "value": 130000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Martin Bley",
+          "name": "M. Bley",
+          "overall_score": 60,
+          "potential": 73,
+          "value": 575000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Daniel Xavier Semedo",
+          "name": "Daniel Semedo",
+          "overall_score": 61,
+          "potential": 70,
+          "value": 725000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Bandiougou Fadiga",
+          "name": "B. Fadiga",
+          "overall_score": 63,
+          "potential": 68,
+          "value": 725000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Dembo Sylla",
+          "name": "D. Sylla",
+          "overall_score": 66,
+          "potential": 75,
+          "value": 1900000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Joel Mvuka",
+          "name": "J. Mvuka",
+          "overall_score": 71,
+          "potential": 78,
+          "value": 3800000,
+          "yearly_wage": 572000
+        },
+        {
+          "currency": "€",
+          "full_name": "Formose Mendy",
+          "name": "F. Mendy",
+          "overall_score": 70,
+          "potential": 77,
+          "value": 3000000,
+          "yearly_wage": 520000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jérémy Hatchi",
+          "name": "J. Hatchi",
+          "overall_score": 64,
+          "potential": 77,
+          "value": 1400000,
+          "yearly_wage": 208000
+        }
+      ],
+      "team": "FC Lorient",
+      "transfer_budget": 8200000,
+      "url": "https://sofifa.com/team/217/fc-lorient/260037/"
+    },
+    {
+      "player_count": 37,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Guillaume Restes",
+          "name": "G. Restes",
+          "overall_score": 78,
+          "potential": 85,
+          "value": 23500000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mark McKenzie",
+          "name": "M. McKenzie",
+          "overall_score": 74,
+          "potential": 77,
+          "value": 4900000,
+          "yearly_wage": 1040000
+        },
+        {
+          "currency": "€",
+          "full_name": "Charlie Cresswell",
+          "name": "C. Cresswell",
+          "overall_score": 77,
+          "potential": 83,
+          "value": 15500000,
+          "yearly_wage": 1092000
+        },
+        {
+          "currency": "€",
+          "full_name": "Rasmus Nicolaisen",
+          "name": "R. Nicolaisen",
+          "overall_score": 76,
+          "potential": 77,
+          "value": 7000000,
+          "yearly_wage": 1196000
+        },
+        {
+          "currency": "€",
+          "full_name": "Djibril Sidibé",
+          "name": "D. Sidibé",
+          "overall_score": 75,
+          "potential": 75,
+          "value": 3900000,
+          "yearly_wage": 1144000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alexis Vossah",
+          "name": "A. Vossah",
+          "overall_score": 70,
+          "potential": 83,
+          "value": 3400000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Cristian Cásseres Jr",
+          "name": "C. Cásseres Jr",
+          "overall_score": 75,
+          "potential": 80,
+          "value": 7500000,
+          "yearly_wage": 1040000
+        },
+        {
+          "currency": "€",
+          "full_name": "Dayann Methalie",
+          "name": "D. Methalie",
+          "overall_score": 72,
+          "potential": 82,
+          "value": 4800000,
+          "yearly_wage": 572000
+        },
+        {
+          "currency": "€",
+          "full_name": "Aron Dønnum",
+          "name": "A. Dønnum",
+          "overall_score": 76,
+          "potential": 76,
+          "value": 8000000,
+          "yearly_wage": 1196000
+        },
+        {
+          "currency": "€",
+          "full_name": "Emersonn Correia da Silva",
+          "name": "Emersonn",
+          "overall_score": 72,
+          "potential": 81,
+          "value": 5000000,
+          "yearly_wage": 728000
+        },
+        {
+          "currency": "€",
+          "full_name": "Yann Gboho",
+          "name": "Y. Gboho",
+          "overall_score": 76,
+          "potential": 79,
+          "value": 10000000,
+          "yearly_wage": 1144000
+        },
+        {
+          "currency": "€",
+          "full_name": "Santiago Hidalgo",
+          "name": "S. Hidalgo",
+          "overall_score": 70,
+          "potential": 81,
+          "value": 3500000,
+          "yearly_wage": 572000
+        },
+        {
+          "currency": "€",
+          "full_name": "Pape Demba Diop",
+          "name": "P. Diop",
+          "overall_score": 70,
+          "potential": 79,
+          "value": 3600000,
+          "yearly_wage": 1040000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mario Sauer",
+          "name": "M. Sauer",
+          "overall_score": 68,
+          "potential": 78,
+          "value": 2700000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "Warren Kamanzi",
+          "name": "W. Kamanzi",
+          "overall_score": 72,
+          "potential": 77,
+          "value": 3300000,
+          "yearly_wage": 728000
+        },
+        {
+          "currency": "€",
+          "full_name": "Rafik Messali",
+          "name": "R. Messali",
+          "overall_score": 70,
+          "potential": 79,
+          "value": 3400000,
+          "yearly_wage": 572000
+        },
+        {
+          "currency": "€",
+          "full_name": "Seny Koumbassa",
+          "name": "S. Koumbassa",
+          "overall_score": 65,
+          "potential": 78,
+          "value": 1600000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Kjetil Haug",
+          "name": "K. Haug",
+          "overall_score": 71,
+          "potential": 75,
+          "value": 2000000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jacen Russell-Rowe",
+          "name": "J. Russell-Rowe",
+          "overall_score": 68,
+          "potential": 76,
+          "value": 2700000,
+          "yearly_wage": 572000
+        },
+        {
+          "currency": "€",
+          "full_name": "Frank Magri",
+          "name": "F. Magri",
+          "overall_score": 72,
+          "potential": 75,
+          "value": 3100000,
+          "yearly_wage": 936000
+        },
+        {
+          "currency": "€",
+          "full_name": "Julián Vignolo",
+          "name": "J. Vignolo",
+          "overall_score": 66,
+          "potential": 78,
+          "value": 2000000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Álex Domínguez Romero",
+          "name": "Álex Domínguez",
+          "overall_score": 66,
+          "potential": 70,
+          "value": 925000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Noah Lahmadi",
+          "name": "N. Lahmadi",
+          "overall_score": 62,
+          "potential": 72,
+          "value": 875000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ilyas Azizi",
+          "name": "I. Azizi",
+          "overall_score": 62,
+          "potential": 78,
+          "value": 1000000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Nicolas Wasbauer",
+          "name": "N. Wasbauer",
+          "overall_score": 62,
+          "potential": 74,
+          "value": 900000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Frédéric Efuele Ngoyala",
+          "name": "F. Efuele Ngoyala",
+          "overall_score": 61,
+          "potential": 74,
+          "value": 750000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Darris Zema",
+          "name": "D. Zema",
+          "overall_score": 62,
+          "potential": 76,
+          "value": 925000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Enzo Faty",
+          "name": "E. Faty",
+          "overall_score": 61,
+          "potential": 76,
+          "value": 775000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Naïme Saïd Mchindra",
+          "name": "N. Saïd Mchindra",
+          "overall_score": 58,
+          "potential": 70,
+          "value": 425000,
+          "yearly_wage": 52000
+        },
+        {
+          "currency": "€",
+          "full_name": "Gaëtan Bakhouche",
+          "name": "G. Bakhouche",
+          "overall_score": 59,
+          "potential": 71,
+          "value": 500000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Abu Francis",
+          "name": "A. Francis",
+          "overall_score": 68,
+          "potential": 73,
+          "value": 1800000,
+          "yearly_wage": 520000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ylies Aradj",
+          "name": "Y. Aradj",
+          "overall_score": 62,
+          "potential": 77,
+          "value": 925000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ibrahim Cissoko",
+          "name": "I. Cissoko",
+          "overall_score": 68,
+          "potential": 77,
+          "value": 2700000,
+          "yearly_wage": 520000
+        },
+        {
+          "currency": "€",
+          "full_name": "Niklas Schmidt",
+          "name": "N. Schmidt",
+          "overall_score": 72,
+          "potential": 72,
+          "value": 2500000,
+          "yearly_wage": 884000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mathis Saka",
+          "name": "M. Saka",
+          "overall_score": 61,
+          "potential": 80,
+          "value": 825000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mathys Niflore",
+          "name": "M. Niflore",
+          "overall_score": 65,
+          "potential": 81,
+          "value": 1600000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Edhy Zuliani",
+          "name": "E. Zuliani",
+          "overall_score": 62,
+          "potential": 76,
+          "value": 950000,
+          "yearly_wage": 208000
+        }
+      ],
+      "team": "Toulouse FC",
+      "transfer_budget": 10100000,
+      "url": "https://sofifa.com/team/1809/toulouse-fc/260037/"
+    },
+    {
+      "player_count": 33,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Anthony Lopes",
+          "name": "A. Lopes",
+          "overall_score": 76,
+          "potential": 76,
+          "value": 1300000,
+          "yearly_wage": 624000
+        },
+        {
+          "currency": "€",
+          "full_name": "Frédéric Guilbert",
+          "name": "F. Guilbert",
+          "overall_score": 74,
+          "potential": 74,
+          "value": 3600000,
+          "yearly_wage": 884000
+        },
+        {
+          "currency": "€",
+          "full_name": "Chidozie Awaziem",
+          "name": "C. Awaziem",
+          "overall_score": 72,
+          "potential": 73,
+          "value": 2200000,
+          "yearly_wage": 728000
+        },
+        {
+          "currency": "€",
+          "full_name": "Nicolas Cozza",
+          "name": "N. Cozza",
+          "overall_score": 70,
+          "potential": 71,
+          "value": 1700000,
+          "yearly_wage": 1144000
+        },
+        {
+          "currency": "€",
+          "full_name": "Deiver Machado",
+          "name": "D. Machado",
+          "overall_score": 74,
+          "potential": 74,
+          "value": 3100000,
+          "yearly_wage": 884000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ibrahima Sissoko",
+          "name": "I. Sissoko",
+          "overall_score": 74,
+          "potential": 75,
+          "value": 4300000,
+          "yearly_wage": 832000
+        },
+        {
+          "currency": "€",
+          "full_name": "Dehmaine Tabibou",
+          "name": "D. Tabibou",
+          "overall_score": 68,
+          "potential": 77,
+          "value": 2600000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mohamed Kaba",
+          "name": "M. Kaba",
+          "overall_score": 68,
+          "potential": 75,
+          "value": 2300000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Johann Lepenant",
+          "name": "J. Lepenant",
+          "overall_score": 73,
+          "potential": 79,
+          "value": 4900000,
+          "yearly_wage": 676000
+        },
+        {
+          "currency": "€",
+          "full_name": "Matthis Abline",
+          "name": "M. Abline",
+          "overall_score": 76,
+          "potential": 82,
+          "value": 12000000,
+          "yearly_wage": 936000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ignatius Ganago",
+          "name": "I. Ganago",
+          "overall_score": 71,
+          "potential": 72,
+          "value": 2200000,
+          "yearly_wage": 676000
+        },
+        {
+          "currency": "€",
+          "full_name": "Bahereba Guirassy",
+          "name": "B. Guirassy",
+          "overall_score": 71,
+          "potential": 80,
+          "value": 4000000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "Rémy Cabella",
+          "name": "R. Cabella",
+          "overall_score": 74,
+          "potential": 74,
+          "value": 1700000,
+          "yearly_wage": 1040000
+        },
+        {
+          "currency": "€",
+          "full_name": "Francis Coquelin",
+          "name": "F. Coquelin",
+          "overall_score": 72,
+          "potential": 72,
+          "value": 1100000,
+          "yearly_wage": 728000
+        },
+        {
+          "currency": "€",
+          "full_name": "Louis Leroux",
+          "name": "L. Leroux",
+          "overall_score": 71,
+          "potential": 80,
+          "value": 4000000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ali Youssif",
+          "name": "A. Youssif",
+          "overall_score": 70,
+          "potential": 75,
+          "value": 2200000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "Tylel Tati",
+          "name": "T. Tati",
+          "overall_score": 69,
+          "potential": 83,
+          "value": 3000000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Patrik Carlgren",
+          "name": "P. Carlgren",
+          "overall_score": 71,
+          "potential": 71,
+          "value": 600000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mostafa Mohamed",
+          "name": "M. Mohamed",
+          "overall_score": 71,
+          "potential": 71,
+          "value": 2000000,
+          "yearly_wage": 676000
+        },
+        {
+          "currency": "€",
+          "full_name": "Youssef El Arabi",
+          "name": "Y. El Arabi",
+          "overall_score": 72,
+          "potential": 72,
+          "value": 800000,
+          "yearly_wage": 624000
+        },
+        {
+          "currency": "€",
+          "full_name": "Abakar Sylla",
+          "name": "A. Sylla",
+          "overall_score": 70,
+          "potential": 78,
+          "value": 3300000,
+          "yearly_wage": 1144000
+        },
+        {
+          "currency": "€",
+          "full_name": "Bahmed Deuff",
+          "name": "B. Deuff",
+          "overall_score": 64,
+          "potential": 79,
+          "value": 1300000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Amady Camara",
+          "name": "A. Camara",
+          "overall_score": 62,
+          "potential": 67,
+          "value": 600000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Uroš Radaković",
+          "name": "U. Radaković",
+          "overall_score": 66,
+          "potential": 66,
+          "value": 575000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Sékou Doucouré",
+          "name": "S. Doucouré",
+          "overall_score": 64,
+          "potential": 77,
+          "value": 1300000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mathieu Acapandié",
+          "name": "M. Acapandié",
+          "overall_score": 62,
+          "potential": 73,
+          "value": 825000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alexis Mirbach",
+          "name": "A. Mirbach",
+          "overall_score": 58,
+          "potential": 72,
+          "value": 425000,
+          "yearly_wage": 52000
+        },
+        {
+          "currency": "€",
+          "full_name": "Kelvin Amian",
+          "name": "K. Amian",
+          "overall_score": 72,
+          "potential": 72,
+          "value": 2300000,
+          "yearly_wage": 676000
+        },
+        {
+          "currency": "€",
+          "full_name": "Fabien Centonze",
+          "name": "F. Centonze",
+          "overall_score": 70,
+          "potential": 70,
+          "value": 1400000,
+          "yearly_wage": 572000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lamine Diack",
+          "name": "L. Diack",
+          "overall_score": 65,
+          "potential": 70,
+          "value": 1000000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Yassine Benhattab",
+          "name": "Y. Benhattab",
+          "overall_score": 69,
+          "potential": 77,
+          "value": 3100000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jean-Kévin Duverne",
+          "name": "J. Duverne",
+          "overall_score": 72,
+          "potential": 72,
+          "value": 2200000,
+          "yearly_wage": 676000
+        },
+        {
+          "currency": "€",
+          "full_name": "Malang Gomes",
+          "name": "M. Gomes",
+          "overall_score": 63,
+          "potential": 78,
+          "value": 1100000,
+          "yearly_wage": 156000
+        }
+      ],
+      "team": "FC Nantes",
+      "transfer_budget": 8200000,
+      "url": "https://sofifa.com/team/71/fc-nantes/260037/"
+    },
+    {
+      "player_count": 27,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Hervé Koffi",
+          "name": "H. Koffi",
+          "overall_score": 78,
+          "potential": 80,
+          "value": 12000000,
+          "yearly_wage": 988000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lilian Raolisoa",
+          "name": "L. Raolisoa",
+          "overall_score": 71,
+          "potential": 75,
+          "value": 2400000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "Marius Louër",
+          "name": "M. Louër",
+          "overall_score": 62,
+          "potential": 76,
+          "value": 875000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ousmane Camara",
+          "name": "O. Camara",
+          "overall_score": 73,
+          "potential": 78,
+          "value": 4200000,
+          "yearly_wage": 520000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jordan Lefort",
+          "name": "J. Lefort",
+          "overall_score": 75,
+          "potential": 75,
+          "value": 3800000,
+          "yearly_wage": 780000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jacques Ekomié",
+          "name": "J. Ekomié",
+          "overall_score": 72,
+          "potential": 79,
+          "value": 4500000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "Branco van den Boomen",
+          "name": "B. van den Boomen",
+          "overall_score": 72,
+          "potential": 72,
+          "value": 2300000,
+          "yearly_wage": 728000
+        },
+        {
+          "currency": "€",
+          "full_name": "Louis Mouton",
+          "name": "L. Mouton",
+          "overall_score": 72,
+          "potential": 79,
+          "value": 4700000,
+          "yearly_wage": 520000
+        },
+        {
+          "currency": "€",
+          "full_name": "Haris Belkebla",
+          "name": "H. Belkebla",
+          "overall_score": 75,
+          "potential": 75,
+          "value": 3900000,
+          "yearly_wage": 780000
+        },
+        {
+          "currency": "€",
+          "full_name": "Prosper Peter",
+          "name": "P. Peter",
+          "overall_score": 69,
+          "potential": 79,
+          "value": 2900000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Amine Sbaï",
+          "name": "A. Sbaï",
+          "overall_score": 72,
+          "potential": 74,
+          "value": 3000000,
+          "yearly_wage": 520000
+        },
+        {
+          "currency": "€",
+          "full_name": "Pierrick Capelle",
+          "name": "P. Capelle",
+          "overall_score": 68,
+          "potential": 68,
+          "value": 240000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Harouna Djibirin",
+          "name": "H. Djibirin",
+          "overall_score": 67,
+          "potential": 78,
+          "value": 2100000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Marius Courcoul",
+          "name": "M. Courcoul",
+          "overall_score": 67,
+          "potential": 81,
+          "value": 2200000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Carlens Arcus",
+          "name": "C. Arcus",
+          "overall_score": 72,
+          "potential": 72,
+          "value": 2100000,
+          "yearly_wage": 572000
+        },
+        {
+          "currency": "€",
+          "full_name": "Florent Hanin",
+          "name": "F. Hanin",
+          "overall_score": 71,
+          "potential": 71,
+          "value": 575000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "Emmanuel Biumla",
+          "name": "E. Biumla",
+          "overall_score": 70,
+          "potential": 77,
+          "value": 2900000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Melvin Zinga",
+          "name": "M. Zinga",
+          "overall_score": 65,
+          "potential": 73,
+          "value": 1400000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Goduine Koyalipou",
+          "name": "G. Koyalipou",
+          "overall_score": 72,
+          "potential": 75,
+          "value": 3100000,
+          "yearly_wage": 988000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lanroy Machine",
+          "name": "L. Machine",
+          "overall_score": 61,
+          "potential": 71,
+          "value": 725000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Abdoulaye Bamba",
+          "name": "A. Bamba",
+          "overall_score": 68,
+          "potential": 68,
+          "value": 325000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Oumar Pona",
+          "name": "O. Pona",
+          "overall_score": 59,
+          "potential": 72,
+          "value": 475000,
+          "yearly_wage": 39000
+        },
+        {
+          "currency": "€",
+          "full_name": "Dan Sinaté",
+          "name": "D. Sinaté",
+          "overall_score": 57,
+          "potential": 71,
+          "value": 375000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Bané Diatta",
+          "name": "B. Diatta",
+          "overall_score": 59,
+          "potential": 76,
+          "value": 525000,
+          "yearly_wage": 52000
+        },
+        {
+          "currency": "€",
+          "full_name": "Yassin Belkhdim",
+          "name": "Y. Belkhdim",
+          "overall_score": 72,
+          "potential": 79,
+          "value": 4700000,
+          "yearly_wage": 520000
+        },
+        {
+          "currency": "€",
+          "full_name": "Sidiki Chérif",
+          "name": "S. Chérif",
+          "overall_score": 72,
+          "potential": 83,
+          "value": 5000000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jim Allevinah",
+          "name": "J. Allevinah",
+          "overall_score": 69,
+          "potential": 69,
+          "value": 1300000,
+          "yearly_wage": 468000
+        }
+      ],
+      "team": "Angers SCO",
+      "transfer_budget": 5300000,
+      "url": "https://sofifa.com/team/1530/angers-sco/260037/"
+    },
+    {
+      "player_count": 29,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Mory Diaw",
+          "name": "M. Diaw",
+          "overall_score": 72,
+          "potential": 72,
+          "value": 1200000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "Arouna Sangante",
+          "name": "A. Sangante",
+          "overall_score": 74,
+          "potential": 80,
+          "value": 6000000,
+          "yearly_wage": 572000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ayumu Seko",
+          "name": "A. Seko",
+          "overall_score": 72,
+          "potential": 77,
+          "value": 3100000,
+          "yearly_wage": 520000
+        },
+        {
+          "currency": "€",
+          "full_name": "Gautier Lloris",
+          "name": "G. Lloris",
+          "overall_score": 74,
+          "potential": 74,
+          "value": 3500000,
+          "yearly_wage": 728000
+        },
+        {
+          "currency": "€",
+          "full_name": "Yanis Zouaoui",
+          "name": "Y. Zouaoui",
+          "overall_score": 70,
+          "potential": 70,
+          "value": 1500000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lucas Gourna-Douath",
+          "name": "L. Gourna-Douath",
+          "overall_score": 69,
+          "potential": 79,
+          "value": 3000000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Rassoul Ndiaye",
+          "name": "R. Ndiaye",
+          "overall_score": 71,
+          "potential": 76,
+          "value": 2800000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "Fodé Doucouré",
+          "name": "F. Doucouré",
+          "overall_score": 70,
+          "potential": 74,
+          "value": 2100000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "Issa Soumaré",
+          "name": "I. Soumaré",
+          "overall_score": 73,
+          "potential": 76,
+          "value": 4200000,
+          "yearly_wage": 572000
+        },
+        {
+          "currency": "€",
+          "full_name": "Sofiane Boufal",
+          "name": "S. Boufal",
+          "overall_score": 74,
+          "potential": 74,
+          "value": 3500000,
+          "yearly_wage": 780000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ally Samatta",
+          "name": "A. Samatta",
+          "overall_score": 71,
+          "potential": 71,
+          "value": 1500000,
+          "yearly_wage": 624000
+        },
+        {
+          "currency": "€",
+          "full_name": "Abdoulaye Touré",
+          "name": "A. Touré",
+          "overall_score": 75,
+          "potential": 75,
+          "value": 3900000,
+          "yearly_wage": 780000
+        },
+        {
+          "currency": "€",
+          "full_name": "Yassine Kechta",
+          "name": "Y. Kechta",
+          "overall_score": 73,
+          "potential": 80,
+          "value": 6000000,
+          "yearly_wage": 572000
+        },
+        {
+          "currency": "€",
+          "full_name": "Simon Ebonog",
+          "name": "S. Ebonog",
+          "overall_score": 68,
+          "potential": 79,
+          "value": 2600000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Loïc Négo",
+          "name": "L. Négo",
+          "overall_score": 71,
+          "potential": 71,
+          "value": 700000,
+          "yearly_wage": 520000
+        },
+        {
+          "currency": "€",
+          "full_name": "Étienne Youté Kinkoué",
+          "name": "É. Youté Kinkoué",
+          "overall_score": 71,
+          "potential": 77,
+          "value": 2700000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "Stephan Zagadou",
+          "name": "S. Zagadou",
+          "overall_score": 65,
+          "potential": 79,
+          "value": 1500000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lionel Mpasi",
+          "name": "L. Mpasi",
+          "overall_score": 70,
+          "potential": 70,
+          "value": 1100000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Kenny Quetant",
+          "name": "K. Quetant",
+          "overall_score": 64,
+          "potential": 76,
+          "value": 1400000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Félix Mambimbi",
+          "name": "F. Mambimbi",
+          "overall_score": 67,
+          "potential": 72,
+          "value": 1600000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Reda Khadra",
+          "name": "R. Khadra",
+          "overall_score": 71,
+          "potential": 77,
+          "value": 3000000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Godson Kyeremeh",
+          "name": "G. Kyeremeh",
+          "overall_score": 68,
+          "potential": 71,
+          "value": 1600000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Paul Argney",
+          "name": "P. Argney",
+          "overall_score": 61,
+          "potential": 77,
+          "value": 750000,
+          "yearly_wage": 46800
+        },
+        {
+          "currency": "€",
+          "full_name": "Timothée Pembélé",
+          "name": "T. Pembélé",
+          "overall_score": 70,
+          "potential": 78,
+          "value": 3400000,
+          "yearly_wage": 1300000
+        },
+        {
+          "currency": "€",
+          "full_name": "Daren Mosengo",
+          "name": "D. Mosengo",
+          "overall_score": 63,
+          "potential": 76,
+          "value": 1100000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Enzo Koffi",
+          "name": "E. Koffi",
+          "overall_score": 65,
+          "potential": 77,
+          "value": 1600000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Noam Obougou",
+          "name": "N. Obougou",
+          "overall_score": 62,
+          "potential": 74,
+          "value": 950000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Guy Noël Zohouri",
+          "name": "G. Zohouri",
+          "overall_score": 61,
+          "potential": 76,
+          "value": 750000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Georges Gomis",
+          "name": "G. Gomis",
+          "overall_score": 60,
+          "potential": 76,
+          "value": 575000,
+          "yearly_wage": 52000
+        }
+      ],
+      "team": "Le Havre AC",
+      "transfer_budget": 5100000,
+      "url": "https://sofifa.com/team/1738/le-havre-ac/260037/"
+    },
+    {
+      "player_count": 34,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Donovan Léon",
+          "name": "D. Léon",
+          "overall_score": 76,
+          "potential": 76,
+          "value": 3700000,
+          "yearly_wage": 780000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lamine Sy",
+          "name": "L. Sy",
+          "overall_score": 68,
+          "potential": 77,
+          "value": 2600000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "Sinaly Diomandé",
+          "name": "S. Diomandé",
+          "overall_score": 73,
+          "potential": 77,
+          "value": 3900000,
+          "yearly_wage": 832000
+        },
+        {
+          "currency": "€",
+          "full_name": "Bryan Okoh",
+          "name": "B. Okoh",
+          "overall_score": 71,
+          "potential": 79,
+          "value": 3900000,
+          "yearly_wage": 676000
+        },
+        {
+          "currency": "€",
+          "full_name": "Gideon Mensah",
+          "name": "G. Mensah",
+          "overall_score": 74,
+          "potential": 75,
+          "value": 4500000,
+          "yearly_wage": 1040000
+        },
+        {
+          "currency": "€",
+          "full_name": "Elisha Owusu",
+          "name": "E. Owusu",
+          "overall_score": 73,
+          "potential": 74,
+          "value": 3100000,
+          "yearly_wage": 936000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lassine Sinayoko",
+          "name": "L. Sinayoko",
+          "overall_score": 75,
+          "potential": 78,
+          "value": 7500000,
+          "yearly_wage": 1196000
+        },
+        {
+          "currency": "€",
+          "full_name": "Naouirou Ahamada",
+          "name": "N. Ahamada",
+          "overall_score": 68,
+          "potential": 74,
+          "value": 1900000,
+          "yearly_wage": 520000
+        },
+        {
+          "currency": "€",
+          "full_name": "Kévin Danois",
+          "name": "K. Danois",
+          "overall_score": 75,
+          "potential": 83,
+          "value": 12500000,
+          "yearly_wage": 884000
+        },
+        {
+          "currency": "€",
+          "full_name": "Danny Namaso",
+          "name": "D. Namaso",
+          "overall_score": 73,
+          "potential": 76,
+          "value": 4200000,
+          "yearly_wage": 520000
+        },
+        {
+          "currency": "€",
+          "full_name": "Sékou Mara",
+          "name": "S. Mara",
+          "overall_score": 70,
+          "potential": 77,
+          "value": 3300000,
+          "yearly_wage": 1300000
+        },
+        {
+          "currency": "€",
+          "full_name": "Oussama El Azzouzi",
+          "name": "O. El Azzouzi",
+          "overall_score": 70,
+          "potential": 75,
+          "value": 2200000,
+          "yearly_wage": 1040000
+        },
+        {
+          "currency": "€",
+          "full_name": "Assane Dioussé",
+          "name": "A. Dioussé",
+          "overall_score": 69,
+          "potential": 70,
+          "value": 1400000,
+          "yearly_wage": 624000
+        },
+        {
+          "currency": "€",
+          "full_name": "Clément Akpa",
+          "name": "C. Akpa",
+          "overall_score": 74,
+          "potential": 80,
+          "value": 6000000,
+          "yearly_wage": 884000
+        },
+        {
+          "currency": "€",
+          "full_name": "Francisco Sierralta",
+          "name": "F. Sierralta",
+          "overall_score": 70,
+          "potential": 70,
+          "value": 1400000,
+          "yearly_wage": 728000
+        },
+        {
+          "currency": "€",
+          "full_name": "Marvin Senaya",
+          "name": "M. Senaya",
+          "overall_score": 70,
+          "potential": 75,
+          "value": 2200000,
+          "yearly_wage": 572000
+        },
+        {
+          "currency": "€",
+          "full_name": "Fredrik Oppegård",
+          "name": "F. Oppegård",
+          "overall_score": 68,
+          "potential": 77,
+          "value": 2600000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "Théo De Percin",
+          "name": "T. De Percin",
+          "overall_score": 68,
+          "potential": 74,
+          "value": 1500000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Romain Faivre",
+          "name": "R. Faivre",
+          "overall_score": 76,
+          "potential": 76,
+          "value": 8000000,
+          "yearly_wage": 3120000
+        },
+        {
+          "currency": "€",
+          "full_name": "Josué Casimir",
+          "name": "J. Casimir",
+          "overall_score": 71,
+          "potential": 76,
+          "value": 2800000,
+          "yearly_wage": 676000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lasso Coulibaly",
+          "name": "L. Coulibaly",
+          "overall_score": 68,
+          "potential": 76,
+          "value": 2700000,
+          "yearly_wage": 520000
+        },
+        {
+          "currency": "€",
+          "full_name": "Telli Siwe",
+          "name": "T. Siwe",
+          "overall_score": 63,
+          "potential": 78,
+          "value": 1100000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ryan Rodin",
+          "name": "R. Rodin",
+          "overall_score": 59,
+          "potential": 71,
+          "value": 550000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Tom Negrel",
+          "name": "T. Negrel",
+          "overall_score": 59,
+          "potential": 69,
+          "value": 450000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Yvan Zaddy",
+          "name": "Y. Zaddy",
+          "overall_score": 60,
+          "potential": 72,
+          "value": 550000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Tidiane Devernois",
+          "name": "T. Devernois",
+          "overall_score": 58,
+          "potential": 75,
+          "value": 500000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mamoudou Cissokho",
+          "name": "M. Cissokho",
+          "overall_score": 58,
+          "potential": 73,
+          "value": 475000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Elikya Legros",
+          "name": "E. Legros",
+          "overall_score": 59,
+          "potential": 74,
+          "value": 475000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Louis Mezerette",
+          "name": "L. Mezerette",
+          "overall_score": 58,
+          "potential": 74,
+          "value": 450000,
+          "yearly_wage": 49400
+        },
+        {
+          "currency": "€",
+          "full_name": "Nathan Buayi-Kiala",
+          "name": "N. Buayi-Kiala",
+          "overall_score": 62,
+          "potential": 73,
+          "value": 900000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Paul Joly",
+          "name": "P. Joly",
+          "overall_score": 72,
+          "potential": 76,
+          "value": 3000000,
+          "yearly_wage": 832000
+        },
+        {
+          "currency": "€",
+          "full_name": "Eros Maddy",
+          "name": "E. Maddy",
+          "overall_score": 63,
+          "potential": 66,
+          "value": 650000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Theo Bair",
+          "name": "T. Bair",
+          "overall_score": 69,
+          "potential": 72,
+          "value": 1900000,
+          "yearly_wage": 676000
+        },
+        {
+          "currency": "€",
+          "full_name": "Aristide Zossou",
+          "name": "A. Zossou",
+          "overall_score": 62,
+          "potential": 76,
+          "value": 950000,
+          "yearly_wage": 208000
+        }
+      ],
+      "team": "AJ Auxerre",
+      "transfer_budget": 6500000,
+      "url": "https://sofifa.com/team/57/aj-auxerre/260037/"
+    },
+    {
+      "player_count": 34,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Pape Sy",
+          "name": "P. Sy",
+          "overall_score": 67,
+          "potential": 69,
+          "value": 875000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Koffi Kouao",
+          "name": "K. Kouao",
+          "overall_score": 71,
+          "potential": 71,
+          "value": 1800000,
+          "yearly_wage": 520000
+        },
+        {
+          "currency": "€",
+          "full_name": "Sadibou Sané",
+          "name": "S. Sané",
+          "overall_score": 70,
+          "potential": 81,
+          "value": 3300000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jean-Philippe Gbamin",
+          "name": "J. Gbamin",
+          "overall_score": 71,
+          "potential": 71,
+          "value": 1600000,
+          "yearly_wage": 520000
+        },
+        {
+          "currency": "€",
+          "full_name": "Maxime Colin",
+          "name": "M. Colin",
+          "overall_score": 70,
+          "potential": 70,
+          "value": 825000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jessy Deminguet",
+          "name": "J. Deminguet",
+          "overall_score": 72,
+          "potential": 72,
+          "value": 2500000,
+          "yearly_wage": 572000
+        },
+        {
+          "currency": "€",
+          "full_name": "Boubacar Traoré",
+          "name": "B. Traoré",
+          "overall_score": 71,
+          "potential": 76,
+          "value": 2600000,
+          "yearly_wage": 1560000
+        },
+        {
+          "currency": "€",
+          "full_name": "Bouna Sarr",
+          "name": "B. Sarr",
+          "overall_score": 69,
+          "potential": 69,
+          "value": 725000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "Giorgi Tsitaishvili",
+          "name": "G. Tsitaishvili",
+          "overall_score": 72,
+          "potential": 75,
+          "value": 3200000,
+          "yearly_wage": 728000
+        },
+        {
+          "currency": "€",
+          "full_name": "Gauthier Hein",
+          "name": "G. Hein",
+          "overall_score": 76,
+          "potential": 76,
+          "value": 7500000,
+          "yearly_wage": 884000
+        },
+        {
+          "currency": "€",
+          "full_name": "Habib Diallo",
+          "name": "H. Diallo",
+          "overall_score": 72,
+          "potential": 72,
+          "value": 2300000,
+          "yearly_wage": 676000
+        },
+        {
+          "currency": "€",
+          "full_name": "Benjamin Stambouli",
+          "name": "B. Stambouli",
+          "overall_score": 72,
+          "potential": 72,
+          "value": 800000,
+          "yearly_wage": 572000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alpha Touré",
+          "name": "A. Touré",
+          "overall_score": 67,
+          "potential": 81,
+          "value": 2300000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lucas Michal",
+          "name": "L. Michal",
+          "overall_score": 66,
+          "potential": 79,
+          "value": 2100000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "Fodé Ballo-Touré",
+          "name": "F. Ballo-Touré",
+          "overall_score": 72,
+          "potential": 72,
+          "value": 2100000,
+          "yearly_wage": 572000
+        },
+        {
+          "currency": "€",
+          "full_name": "Terry Yegbe",
+          "name": "T. Yegbe",
+          "overall_score": 70,
+          "potential": 77,
+          "value": 3000000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "Urie-Michel Mboula",
+          "name": "U. Mboula",
+          "overall_score": 68,
+          "potential": 76,
+          "value": 2500000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jonathan Fischer",
+          "name": "J. Fischer",
+          "overall_score": 72,
+          "potential": 78,
+          "value": 3000000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Giorgi Abuashvili",
+          "name": "G. Abuashvili",
+          "overall_score": 67,
+          "potential": 75,
+          "value": 2300000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Giorgi Kvilitaia",
+          "name": "G. Kvilitaia",
+          "overall_score": 70,
+          "potential": 70,
+          "value": 1300000,
+          "yearly_wage": 520000
+        },
+        {
+          "currency": "€",
+          "full_name": "Nathan Mbala",
+          "name": "N. Mbala",
+          "overall_score": 64,
+          "potential": 77,
+          "value": 1300000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Cléo Mélières",
+          "name": "C. Mélières",
+          "overall_score": 61,
+          "potential": 73,
+          "value": 750000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ismaël Guerti",
+          "name": "I. Guerti",
+          "overall_score": 57,
+          "potential": 69,
+          "value": 400000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Yannis Lawson",
+          "name": "Y. Lawson",
+          "overall_score": 66,
+          "potential": 77,
+          "value": 1800000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Joseph Mangondo",
+          "name": "J. Mangondo",
+          "overall_score": 60,
+          "potential": 76,
+          "value": 650000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ousmane Ba",
+          "name": "O. Ba",
+          "overall_score": 63,
+          "potential": 73,
+          "value": 925000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jahyann Pandore",
+          "name": "J. Pandore",
+          "overall_score": 57,
+          "potential": 72,
+          "value": 375000,
+          "yearly_wage": 52000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ibou Sané",
+          "name": "I. Sané",
+          "overall_score": 65,
+          "potential": 78,
+          "value": 1700000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Joseph Nduquidi",
+          "name": "J. Nduquidi",
+          "overall_score": 63,
+          "potential": 78,
+          "value": 1100000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Kévin Van Den Kerkhof",
+          "name": "K. Van Den Kerkhof",
+          "overall_score": 71,
+          "potential": 71,
+          "value": 1800000,
+          "yearly_wage": 572000
+        },
+        {
+          "currency": "€",
+          "full_name": "Joel Asoro",
+          "name": "J. Asoro",
+          "overall_score": 67,
+          "potential": 67,
+          "value": 1100000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Idrissa Gueye",
+          "name": "I. Gueye",
+          "overall_score": 69,
+          "potential": 79,
+          "value": 3000000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Pape Moussa Fall",
+          "name": "P. Fall",
+          "overall_score": 62,
+          "potential": 73,
+          "value": 875000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Morgan Bokele",
+          "name": "M. Bokele",
+          "overall_score": 65,
+          "potential": 77,
+          "value": 1800000,
+          "yearly_wage": 156000
+        }
+      ],
+      "team": "FC Metz",
+      "transfer_budget": 5200000,
+      "url": "https://sofifa.com/team/68/fc-metz/260037/"
+    }
+  ],
+  "total_players": 609
+}

--- a/data/2025/FRA1/teams.json
+++ b/data/2025/FRA1/teams.json
@@ -19,7 +19,11 @@
             "Italy"
           ],
           "number": "1",
-          "position": "Goalkeeper"
+          "overall_score": 81,
+          "position": "Goalkeeper",
+          "potential": 81,
+          "value": 8500000,
+          "yearly_wage": 1716000
         },
         {
           "contract": "Jun 30, 2027",
@@ -33,7 +37,11 @@
             "Netherlands"
           ],
           "number": "12",
-          "position": "Goalkeeper"
+          "overall_score": 74,
+          "position": "Goalkeeper",
+          "potential": 77,
+          "value": 4100000,
+          "yearly_wage": 988000
         },
         {
           "contract": "Jun 30, 2027",
@@ -46,7 +54,11 @@
             "Belgium"
           ],
           "number": "40",
-          "position": "Goalkeeper"
+          "overall_score": 61,
+          "position": "Goalkeeper",
+          "potential": 71,
+          "value": 650000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2026",
@@ -59,7 +71,11 @@
             "France"
           ],
           "number": "92",
-          "position": "Goalkeeper"
+          "overall_score": 60,
+          "position": "Goalkeeper",
+          "potential": 61,
+          "value": 200000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2030",
@@ -73,7 +89,11 @@
             "Morocco"
           ],
           "number": "21",
-          "position": "Centre-Back"
+          "overall_score": 81,
+          "position": "Centre-Back",
+          "potential": 81,
+          "value": 21500000,
+          "yearly_wage": 2600000
         },
         {
           "contract": "Jun 30, 2028",
@@ -88,7 +108,11 @@
             "Italy"
           ],
           "number": "5",
-          "position": "Centre-Back"
+          "overall_score": 80,
+          "position": "Centre-Back",
+          "potential": 83,
+          "value": 24500000,
+          "yearly_wage": 2340000
         },
         {
           "contract": "Jun 30, 2026",
@@ -102,7 +126,11 @@
             "France"
           ],
           "number": "28",
-          "position": "Centre-Back"
+          "overall_score": 81,
+          "position": "Centre-Back",
+          "potential": 81,
+          "value": 21500000,
+          "yearly_wage": 2080000
         },
         {
           "contract": "Jun 30, 2026",
@@ -116,7 +144,11 @@
             "Argentina"
           ],
           "number": "32",
-          "position": "Centre-Back"
+          "overall_score": 79,
+          "position": "Centre-Back",
+          "potential": 83,
+          "value": 21500000,
+          "yearly_wage": 1612000
         },
         {
           "contract": "Jun 30, 2029",
@@ -131,7 +163,11 @@
             "Ireland"
           ],
           "number": "4",
-          "position": "Centre-Back"
+          "overall_score": 75,
+          "position": "Centre-Back",
+          "potential": 80,
+          "value": 8000000,
+          "yearly_wage": 1456000
         },
         {
           "contract": "Jun 30, 2027",
@@ -146,7 +182,11 @@
             "Brazil"
           ],
           "number": "33",
-          "position": "Left-Back"
+          "overall_score": 77,
+          "position": "Left-Back",
+          "potential": 77,
+          "value": 9000000,
+          "yearly_wage": 1976000
         },
         {
           "contract": "Jun 30, 2026",
@@ -160,7 +200,11 @@
             "Belgium"
           ],
           "number": "18",
-          "position": "Defensive Midfield"
+          "overall_score": 77,
+          "position": "Defensive Midfield",
+          "potential": 86,
+          "value": 23000000,
+          "yearly_wage": 1820000
         },
         {
           "contract": "Jun 30, 2028",
@@ -175,7 +219,11 @@
             "France"
           ],
           "number": "23",
-          "position": "Defensive Midfield"
+          "overall_score": 81,
+          "position": "Defensive Midfield",
+          "potential": 81,
+          "value": 22000000,
+          "yearly_wage": 2600000
         },
         {
           "contract": "Jun 30, 2027",
@@ -190,7 +238,11 @@
             "France"
           ],
           "number": "19",
-          "position": "Defensive Midfield"
+          "overall_score": 77,
+          "position": "Defensive Midfield",
+          "potential": 77,
+          "value": 7000000,
+          "yearly_wage": 1976000
         },
         {
           "contract": "Jun 30, 2030",
@@ -204,7 +256,11 @@
             "Nigeria"
           ],
           "number": "6",
-          "position": "Defensive Midfield"
+          "overall_score": 66,
+          "position": "Defensive Midfield",
+          "potential": 77,
+          "value": 1800000,
+          "yearly_wage": 520000
         },
         {
           "contract": "Jun 30, 2030",
@@ -219,7 +275,11 @@
             "Curacao"
           ],
           "number": "27",
-          "position": "Central Midfield"
+          "overall_score": 80,
+          "position": "Central Midfield",
+          "potential": 85,
+          "value": 31500000,
+          "yearly_wage": 2132000
         },
         {
           "contract": "Jun 30, 2026",
@@ -234,7 +294,11 @@
             "France"
           ],
           "number": "26",
-          "position": "Central Midfield"
+          "overall_score": 73,
+          "position": "Central Midfield",
+          "potential": 77,
+          "value": 4400000,
+          "yearly_wage": 1092000
         },
         {
           "contract": "Jun 30, 2026",
@@ -249,7 +313,11 @@
             "Nigeria"
           ],
           "number": "11",
-          "position": "Attacking Midfield"
+          "overall_score": 76,
+          "position": "Attacking Midfield",
+          "potential": 87,
+          "value": 16000000,
+          "yearly_wage": 3484000
         },
         {
           "contract": "Jun 30, 2030",
@@ -264,7 +332,11 @@
             "France"
           ],
           "number": "8",
-          "position": "Attacking Midfield"
+          "overall_score": 76,
+          "position": "Attacking Midfield",
+          "potential": 78,
+          "value": 9500000,
+          "yearly_wage": 1768000
         },
         {
           "contract": "Jun 30, 2030",
@@ -278,7 +350,11 @@
             "Brazil"
           ],
           "number": "14",
-          "position": "Left Winger"
+          "overall_score": 80,
+          "position": "Left Winger",
+          "potential": 83,
+          "value": 28000000,
+          "yearly_wage": 2340000
         },
         {
           "contract": "Jun 30, 2026",
@@ -292,7 +368,11 @@
             "Cote d'Ivoire"
           ],
           "number": "20",
-          "position": "Left Winger"
+          "overall_score": 77,
+          "position": "Left Winger",
+          "potential": 78,
+          "value": 12500000,
+          "yearly_wage": 3172000
         },
         {
           "contract": "Jun 30, 2029",
@@ -307,7 +387,11 @@
             "Jamaica"
           ],
           "number": "10",
-          "position": "Right Winger"
+          "overall_score": 83,
+          "position": "Right Winger",
+          "potential": 86,
+          "value": 49500000,
+          "yearly_wage": 2652000
         },
         {
           "contract": "Jun 30, 2026",
@@ -322,7 +406,11 @@
             "France"
           ],
           "number": "22",
-          "position": "Right Winger"
+          "overall_score": 77,
+          "position": "Right Winger",
+          "potential": 78,
+          "value": 12500000,
+          "yearly_wage": 4472000
         },
         {
           "contract": "Jun 30, 2029",
@@ -337,7 +425,11 @@
             "France"
           ],
           "number": "9",
-          "position": "Centre-Forward"
+          "overall_score": 79,
+          "position": "Centre-Forward",
+          "potential": 82,
+          "value": 23500000,
+          "yearly_wage": 2392000
         },
         {
           "contract": "Jun 30, 2027",
@@ -352,7 +444,11 @@
             "France"
           ],
           "number": "97",
-          "position": "Centre-Forward"
+          "overall_score": 81,
+          "position": "Centre-Forward",
+          "potential": 81,
+          "value": 9000000,
+          "yearly_wage": 2236000
         }
       ],
       "stadiumName": "Orange Vélodrome",
@@ -375,7 +471,11 @@
             "Slovakia"
           ],
           "number": "1",
-          "position": "Goalkeeper"
+          "overall_score": 80,
+          "position": "Goalkeeper",
+          "potential": 82,
+          "value": 18000000,
+          "yearly_wage": 936000
         },
         {
           "contract": "Jun 30, 2027",
@@ -389,7 +489,11 @@
             "France"
           ],
           "number": "40",
-          "position": "Goalkeeper"
+          "overall_score": 75,
+          "position": "Goalkeeper",
+          "potential": 76,
+          "value": 4300000,
+          "yearly_wage": 676000
         },
         {
           "contract": "Jun 30, 2028",
@@ -403,7 +507,11 @@
             "Mali"
           ],
           "number": "50",
-          "position": "Goalkeeper"
+          "overall_score": 64,
+          "position": "Goalkeeper",
+          "potential": 74,
+          "value": 1100000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2028",
@@ -418,7 +526,11 @@
             "France"
           ],
           "number": "19",
-          "position": "Centre-Back"
+          "overall_score": 80,
+          "position": "Centre-Back",
+          "potential": 80,
+          "value": 17500000,
+          "yearly_wage": 1404000
         },
         {
           "contract": "Jun 30, 2028",
@@ -433,7 +545,11 @@
             "Belgium"
           ],
           "number": "22",
-          "position": "Centre-Back"
+          "overall_score": 76,
+          "position": "Centre-Back",
+          "potential": 76,
+          "value": 4900000,
+          "yearly_wage": 1040000
         },
         {
           "contract": "Jun 30, 2030",
@@ -448,7 +564,11 @@
             "Suriname"
           ],
           "number": "21",
-          "position": "Centre-Back"
+          "overall_score": 74,
+          "position": "Centre-Back",
+          "potential": 81,
+          "value": 8000000,
+          "yearly_wage": 780000
         },
         {
           "contract": "Jun 30, 2026",
@@ -463,7 +583,11 @@
             "Senegal"
           ],
           "number": "85",
-          "position": "Centre-Back"
+          "overall_score": 66,
+          "position": "Centre-Back",
+          "potential": 82,
+          "value": 2000000,
+          "yearly_wage": 676000
         },
         {
           "contract": "Jun 30, 2029",
@@ -477,7 +601,11 @@
             "Brazil"
           ],
           "number": "16",
-          "position": "Left-Back"
+          "overall_score": 75,
+          "position": "Left-Back",
+          "potential": 78,
+          "value": 7000000,
+          "yearly_wage": 936000
         },
         {
           "contract": "Jun 30, 2027",
@@ -492,7 +620,11 @@
             "Italy"
           ],
           "number": "3",
-          "position": "Left-Back"
+          "overall_score": 78,
+          "position": "Left-Back",
+          "potential": 78,
+          "value": 9500000,
+          "yearly_wage": 1196000
         },
         {
           "contract": "Jun 30, 2027",
@@ -506,7 +638,11 @@
             "Morocco"
           ],
           "number": "36",
-          "position": "Left-Back"
+          "overall_score": 65,
+          "position": "Left-Back",
+          "potential": 74,
+          "value": 1500000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2027",
@@ -521,7 +657,11 @@
             "Jamaica"
           ],
           "number": "98",
-          "position": "Right-Back"
+          "overall_score": 77,
+          "position": "Right-Back",
+          "potential": 77,
+          "value": 10000000,
+          "yearly_wage": 1092000
         },
         {
           "contract": "Jun 30, 2026",
@@ -535,7 +675,11 @@
             "Netherlands"
           ],
           "number": "33",
-          "position": "Right-Back"
+          "overall_score": 74,
+          "position": "Right-Back",
+          "potential": 74,
+          "value": 2900000,
+          "yearly_wage": 1144000
         },
         {
           "contract": "Jun 30, 2030",
@@ -549,7 +693,11 @@
             "England"
           ],
           "number": "23",
-          "position": "Defensive Midfield"
+          "overall_score": 79,
+          "position": "Defensive Midfield",
+          "potential": 84,
+          "value": 24500000,
+          "yearly_wage": 1092000
         },
         {
           "contract": "Jun 30, 2029",
@@ -563,7 +711,11 @@
             "United States"
           ],
           "number": "6",
-          "position": "Defensive Midfield"
+          "overall_score": 76,
+          "position": "Defensive Midfield",
+          "potential": 82,
+          "value": 11000000,
+          "yearly_wage": 884000
         },
         {
           "contract": "Jun 30, 2028",
@@ -578,7 +730,11 @@
             "DR Congo"
           ],
           "number": "5",
-          "position": "Defensive Midfield"
+          "overall_score": 76,
+          "position": "Defensive Midfield",
+          "potential": 77,
+          "value": 7500000,
+          "yearly_wage": 988000
         },
         {
           "contract": "Jun 30, 2028",
@@ -593,7 +749,11 @@
             "France"
           ],
           "number": "39",
-          "position": "Defensive Midfield"
+          "overall_score": 68,
+          "position": "Defensive Midfield",
+          "potential": 79,
+          "value": 2500000,
+          "yearly_wage": 364000
         },
         {
           "contract": "Jun 30, 2027",
@@ -608,7 +768,11 @@
             "Togo"
           ],
           "number": "8",
-          "position": "Central Midfield"
+          "overall_score": 82,
+          "position": "Central Midfield",
+          "potential": 82,
+          "value": 29000000,
+          "yearly_wage": 1716000
         },
         {
           "contract": "Jun 30, 2029",
@@ -623,7 +787,11 @@
             "Algeria"
           ],
           "number": "44",
-          "position": "Central Midfield"
+          "overall_score": 70,
+          "position": "Central Midfield",
+          "potential": 80,
+          "value": 3400000,
+          "yearly_wage": 416000
         },
         {
           "contract": "Jun 30, 2029",
@@ -637,7 +805,11 @@
             "Czech Republic"
           ],
           "number": "10",
-          "position": "Attacking Midfield"
+          "overall_score": 78,
+          "position": "Attacking Midfield",
+          "potential": 81,
+          "value": 19000000,
+          "yearly_wage": 1092000
         },
         {
           "contract": "Jun 30, 2026",
@@ -651,7 +823,11 @@
             "Czech Republic"
           ],
           "number": "7",
-          "position": "Attacking Midfield"
+          "overall_score": 73,
+          "position": "Attacking Midfield",
+          "potential": 79,
+          "value": 4900000,
+          "yearly_wage": 728000
         },
         {
           "contract": "Jun 30, 2030",
@@ -666,7 +842,11 @@
             "Ghana"
           ],
           "number": "99",
-          "position": "Attacking Midfield"
+          "overall_score": 69,
+          "position": "Attacking Midfield",
+          "potential": 83,
+          "value": 3300000,
+          "yearly_wage": 364000
         },
         {
           "contract": "Jun 30, 2028",
@@ -681,7 +861,11 @@
             "Guinea"
           ],
           "number": "11",
-          "position": "Left Winger"
+          "overall_score": 78,
+          "position": "Left Winger",
+          "potential": 86,
+          "value": 31000000,
+          "yearly_wage": 884000
         },
         {
           "contract": "Jun 30, 2029",
@@ -695,7 +879,11 @@
             "Portugal"
           ],
           "number": "17",
-          "position": "Left Winger"
+          "overall_score": 75,
+          "position": "Left Winger",
+          "potential": 84,
+          "value": 12500000,
+          "yearly_wage": 728000
         },
         {
           "contract": "-",
@@ -709,7 +897,11 @@
             "France"
           ],
           "number": "45",
-          "position": "Left Winger"
+          "overall_score": 68,
+          "position": "Left Winger",
+          "potential": 82,
+          "value": 2800000,
+          "yearly_wage": 312000
         },
         {
           "contract": "Jun 30, 2028",
@@ -723,7 +915,11 @@
             "Ghana"
           ],
           "number": "37",
-          "position": "Right Winger"
+          "overall_score": 75,
+          "position": "Right Winger",
+          "potential": 82,
+          "value": 11500000,
+          "yearly_wage": 728000
         },
         {
           "contract": "Jun 30, 2026",
@@ -738,7 +934,11 @@
             "France"
           ],
           "number": "18",
-          "position": "Right Winger"
+          "overall_score": 72,
+          "position": "Right Winger",
+          "potential": 72,
+          "value": 1500000,
+          "yearly_wage": 780000
         },
         {
           "contract": "Jun 30, 2026",
@@ -752,7 +952,11 @@
             "Brazil"
           ],
           "number": "9",
-          "position": "Centre-Forward"
+          "overall_score": 78,
+          "position": "Centre-Forward",
+          "potential": 89,
+          "value": 30000000,
+          "yearly_wage": 5200000
         },
         {
           "contract": "Jun 30, 2026",
@@ -766,7 +970,11 @@
             "Ukraine"
           ],
           "number": "77",
-          "position": "Centre-Forward"
+          "overall_score": 75,
+          "position": "Centre-Forward",
+          "potential": 75,
+          "value": 5500000,
+          "yearly_wage": 1612000
         }
       ],
       "stadiumName": "Groupama Stadium",
@@ -789,7 +997,11 @@
             "Türkiye"
           ],
           "number": "1",
-          "position": "Goalkeeper"
+          "overall_score": 78,
+          "position": "Goalkeeper",
+          "potential": 82,
+          "value": 15500000,
+          "yearly_wage": 936000
         },
         {
           "contract": "Jun 30, 2027",
@@ -803,7 +1015,11 @@
             "Belgium"
           ],
           "number": "16",
-          "position": "Goalkeeper"
+          "overall_score": 73,
+          "position": "Goalkeeper",
+          "potential": 75,
+          "value": 2800000,
+          "yearly_wage": 676000
         },
         {
           "contract": "Jun 30, 2026",
@@ -817,7 +1033,11 @@
             "France"
           ],
           "number": "30",
-          "position": "Goalkeeper"
+          "overall_score": 67,
+          "position": "Goalkeeper",
+          "potential": 67,
+          "value": 550000,
+          "yearly_wage": 364000
         },
         {
           "contract": "Jun 30, 2028",
@@ -831,7 +1051,11 @@
             "Brazil"
           ],
           "number": "4",
-          "position": "Centre-Back"
+          "overall_score": 79,
+          "position": "Centre-Back",
+          "potential": 83,
+          "value": 22000000,
+          "yearly_wage": 1612000
         },
         {
           "contract": "Jun 30, 2029",
@@ -846,7 +1070,11 @@
             "DR Congo"
           ],
           "number": "3",
-          "position": "Centre-Back"
+          "overall_score": 75,
+          "position": "Centre-Back",
+          "potential": 83,
+          "value": 12000000,
+          "yearly_wage": 1144000
         },
         {
           "contract": "Jun 30, 2026",
@@ -860,7 +1088,11 @@
             "DR Congo"
           ],
           "number": "18",
-          "position": "Centre-Back"
+          "overall_score": 75,
+          "position": "Centre-Back",
+          "potential": 75,
+          "value": 4600000,
+          "yearly_wage": 1352000
         },
         {
           "contract": "Jun 30, 2026",
@@ -875,7 +1107,11 @@
             "France"
           ],
           "number": "23",
-          "position": "Centre-Back"
+          "overall_score": 77,
+          "position": "Centre-Back",
+          "potential": 77,
+          "value": 5000000,
+          "yearly_wage": 1508000
         },
         {
           "contract": "Jun 30, 2028",
@@ -888,7 +1124,11 @@
           "nationality": [
             "Portugal"
           ],
-          "position": "Centre-Back"
+          "overall_score": 63,
+          "position": "Centre-Back",
+          "potential": 74,
+          "value": 1000000,
+          "yearly_wage": 312000
         },
         {
           "contract": "Jun 30, 2028",
@@ -903,7 +1143,11 @@
             "Mali"
           ],
           "number": "36",
-          "position": "Centre-Back"
+          "overall_score": 65,
+          "position": "Centre-Back",
+          "potential": 77,
+          "value": 1600000,
+          "yearly_wage": 312000
         },
         {
           "contract": "Jun 30, 2028",
@@ -917,7 +1161,11 @@
             "France"
           ],
           "number": "15",
-          "position": "Left-Back"
+          "overall_score": 76,
+          "position": "Left-Back",
+          "potential": 76,
+          "value": 7000000,
+          "yearly_wage": 1352000
         },
         {
           "contract": "Jun 30, 2028",
@@ -932,7 +1180,11 @@
             "Netherlands"
           ],
           "number": "24",
-          "position": "Left-Back"
+          "overall_score": 72,
+          "position": "Left-Back",
+          "potential": 72,
+          "value": 2100000,
+          "yearly_wage": 1040000
         },
         {
           "contract": "Jun 30, 2029",
@@ -946,7 +1198,11 @@
             "Portugal"
           ],
           "number": "22",
-          "position": "Right-Back"
+          "overall_score": 75,
+          "position": "Right-Back",
+          "potential": 79,
+          "value": 7500000,
+          "yearly_wage": 1144000
         },
         {
           "contract": "Jun 30, 2026",
@@ -960,7 +1216,11 @@
             "Belgium"
           ],
           "number": "12",
-          "position": "Right-Back"
+          "overall_score": 77,
+          "position": "Right-Back",
+          "potential": 77,
+          "value": 5500000,
+          "yearly_wage": 1508000
         },
         {
           "contract": "Jun 30, 2028",
@@ -975,7 +1235,11 @@
             "Belgium"
           ],
           "number": "17",
-          "position": "Defensive Midfield"
+          "overall_score": 74,
+          "position": "Defensive Midfield",
+          "potential": 82,
+          "value": 8500000,
+          "yearly_wage": 884000
         },
         {
           "contract": "Jun 30, 2026",
@@ -990,7 +1254,11 @@
             "France"
           ],
           "number": "6",
-          "position": "Defensive Midfield"
+          "overall_score": 77,
+          "position": "Defensive Midfield",
+          "potential": 77,
+          "value": 9000000,
+          "yearly_wage": 1508000
         },
         {
           "contract": "Jun 30, 2028",
@@ -1004,7 +1272,11 @@
             "France"
           ],
           "number": "21",
-          "position": "Defensive Midfield"
+          "overall_score": 80,
+          "position": "Defensive Midfield",
+          "potential": 80,
+          "value": 7000000,
+          "yearly_wage": 1872000
         },
         {
           "contract": "Jun 30, 2029",
@@ -1019,7 +1291,11 @@
             "Morocco"
           ],
           "number": "32",
-          "position": "Central Midfield"
+          "overall_score": 78,
+          "position": "Central Midfield",
+          "potential": 86,
+          "value": 27000000,
+          "yearly_wage": 780000
         },
         {
           "contract": "Jun 30, 2026",
@@ -1047,7 +1323,11 @@
             "Iceland"
           ],
           "number": "10",
-          "position": "Attacking Midfield"
+          "overall_score": 78,
+          "position": "Attacking Midfield",
+          "potential": 83,
+          "value": 21500000,
+          "yearly_wage": 1456000
         },
         {
           "contract": "Jun 30, 2029",
@@ -1062,7 +1342,11 @@
             "Belgium"
           ],
           "number": "7",
-          "position": "Left Winger"
+          "overall_score": 76,
+          "position": "Left Winger",
+          "potential": 84,
+          "value": 16500000,
+          "yearly_wage": 1040000
         },
         {
           "contract": "Jun 30, 2029",
@@ -1077,7 +1361,11 @@
             "Norway"
           ],
           "number": "11",
-          "position": "Left Winger"
+          "overall_score": 76,
+          "position": "Left Winger",
+          "potential": 80,
+          "value": 11000000,
+          "yearly_wage": 1248000
         },
         {
           "contract": "Jun 30, 2029",
@@ -1092,7 +1380,11 @@
             "Sao Tome and Principe"
           ],
           "number": "27",
-          "position": "Left Winger"
+          "overall_score": 75,
+          "position": "Left Winger",
+          "potential": 78,
+          "value": 7500000,
+          "yearly_wage": 1196000
         },
         {
           "contract": "Jun 30, 2027",
@@ -1107,7 +1399,11 @@
             "Cameroon"
           ],
           "number": "8",
-          "position": "Right Winger"
+          "overall_score": 72,
+          "position": "Right Winger",
+          "potential": 82,
+          "value": 4900000,
+          "yearly_wage": 676000
         },
         {
           "contract": "Jun 30, 2030",
@@ -1121,7 +1417,11 @@
             "Norway"
           ],
           "number": "14",
-          "position": "Right Winger"
+          "overall_score": 69,
+          "position": "Right Winger",
+          "potential": 79,
+          "value": 3100000,
+          "yearly_wage": 520000
         },
         {
           "contract": "Jun 30, 2028",
@@ -1135,7 +1435,11 @@
             "France"
           ],
           "number": "28",
-          "position": "Right Winger"
+          "overall_score": 77,
+          "position": "Right Winger",
+          "potential": 77,
+          "value": 10500000,
+          "yearly_wage": 1560000
         },
         {
           "contract": "Jun 30, 2030",
@@ -1150,7 +1454,11 @@
             "Cameroon"
           ],
           "number": "20",
-          "position": "Right Winger"
+          "overall_score": 68,
+          "position": "Right Winger",
+          "potential": 80,
+          "value": 2900000,
+          "yearly_wage": 468000
         },
         {
           "contract": "Jun 30, 2030",
@@ -1164,7 +1472,11 @@
             "Morocco"
           ],
           "number": "29",
-          "position": "Centre-Forward"
+          "overall_score": 75,
+          "position": "Centre-Forward",
+          "potential": 83,
+          "value": 12500000,
+          "yearly_wage": 1300000
         },
         {
           "contract": "Jun 30, 2026",
@@ -1178,7 +1490,11 @@
             "France"
           ],
           "number": "9",
-          "position": "Centre-Forward"
+          "overall_score": 78,
+          "position": "Centre-Forward",
+          "potential": 78,
+          "value": 4800000,
+          "yearly_wage": 1404000
         }
       ],
       "stadiumName": "Decathlon Arena-Stade Pierre-Mauroy",
@@ -1201,7 +1517,11 @@
             "France"
           ],
           "number": "30",
-          "position": "Goalkeeper"
+          "overall_score": 82,
+          "position": "Goalkeeper",
+          "potential": 86,
+          "value": 34500000,
+          "yearly_wage": 2392000
         },
         {
           "contract": "Jun 30, 2029",
@@ -1215,7 +1535,11 @@
             "Russia"
           ],
           "number": "39",
-          "position": "Goalkeeper"
+          "overall_score": 82,
+          "position": "Goalkeeper",
+          "potential": 86,
+          "value": 33000000,
+          "yearly_wage": 3016000
         },
         {
           "contract": "Jun 30, 2030",
@@ -1230,7 +1554,11 @@
             "Brazil"
           ],
           "number": "89",
-          "position": "Goalkeeper"
+          "overall_score": 70,
+          "position": "Goalkeeper",
+          "potential": 83,
+          "value": 3200000,
+          "yearly_wage": 520000
         },
         {
           "contract": "Jun 30, 2029",
@@ -1244,7 +1572,11 @@
             "Ecuador"
           ],
           "number": "51",
-          "position": "Centre-Back"
+          "overall_score": 88,
+          "position": "Centre-Back",
+          "potential": 90,
+          "value": 105500000,
+          "yearly_wage": 7020000
         },
         {
           "contract": "Jun 30, 2030",
@@ -1258,7 +1590,11 @@
             "Ukraine"
           ],
           "number": "6",
-          "position": "Centre-Back"
+          "overall_score": 80,
+          "position": "Centre-Back",
+          "potential": 85,
+          "value": 29500000,
+          "yearly_wage": 3536000
         },
         {
           "contract": "Jun 30, 2028",
@@ -1273,7 +1609,11 @@
             "Portugal"
           ],
           "number": "5",
-          "position": "Centre-Back"
+          "overall_score": 87,
+          "position": "Centre-Back",
+          "potential": 87,
+          "value": 54500000,
+          "yearly_wage": 7540000
         },
         {
           "contract": "Jun 30, 2028",
@@ -1287,7 +1627,11 @@
             "Brazil"
           ],
           "number": "4",
-          "position": "Centre-Back"
+          "overall_score": 78,
+          "position": "Centre-Back",
+          "potential": 83,
+          "value": 19500000,
+          "yearly_wage": 2548000
         },
         {
           "contract": "Jun 30, 2029",
@@ -1301,7 +1645,11 @@
             "Portugal"
           ],
           "number": "25",
-          "position": "Left-Back"
+          "overall_score": 88,
+          "position": "Left-Back",
+          "potential": 91,
+          "value": 115500000,
+          "yearly_wage": 7020000
         },
         {
           "contract": "Jun 30, 2028",
@@ -1316,7 +1664,11 @@
             "Spain"
           ],
           "number": "21",
-          "position": "Left-Back"
+          "overall_score": 81,
+          "position": "Left-Back",
+          "potential": 81,
+          "value": 22500000,
+          "yearly_wage": 4628000
         },
         {
           "contract": "Jun 30, 2029",
@@ -1331,7 +1683,11 @@
             "Spain"
           ],
           "number": "2",
-          "position": "Right-Back"
+          "overall_score": 89,
+          "position": "Right-Back",
+          "potential": 90,
+          "value": 111000000,
+          "yearly_wage": 8840000
         },
         {
           "contract": "Jun 30, 2029",
@@ -1345,7 +1701,11 @@
             "Portugal"
           ],
           "number": "17",
-          "position": "Defensive Midfield"
+          "overall_score": 90,
+          "position": "Defensive Midfield",
+          "potential": 92,
+          "value": 149000000,
+          "yearly_wage": 9620000
         },
         {
           "contract": "Jun 30, 2029",
@@ -1359,7 +1719,11 @@
             "Portugal"
           ],
           "number": "87",
-          "position": "Central Midfield"
+          "overall_score": 88,
+          "position": "Central Midfield",
+          "potential": 93,
+          "value": 135000000,
+          "yearly_wage": 6240000
         },
         {
           "contract": "Jun 30, 2029",
@@ -1374,7 +1738,11 @@
             "Martinique"
           ],
           "number": "33",
-          "position": "Central Midfield"
+          "overall_score": 83,
+          "position": "Central Midfield",
+          "potential": 89,
+          "value": 55000000,
+          "yearly_wage": 3796000
         },
         {
           "contract": "Jun 30, 2027",
@@ -1388,7 +1756,11 @@
             "Spain"
           ],
           "number": "8",
-          "position": "Central Midfield"
+          "overall_score": 85,
+          "position": "Central Midfield",
+          "potential": 85,
+          "value": 52500000,
+          "yearly_wage": 6760000
         },
         {
           "contract": "Jun 30, 2027",
@@ -1403,7 +1775,11 @@
             "DR Congo"
           ],
           "number": "24",
-          "position": "Central Midfield"
+          "overall_score": 77,
+          "position": "Central Midfield",
+          "potential": 86,
+          "value": 22500000,
+          "yearly_wage": 2392000
         },
         {
           "contract": "Jun 30, 2028",
@@ -1417,7 +1793,11 @@
             "Korea, South"
           ],
           "number": "19",
-          "position": "Attacking Midfield"
+          "overall_score": 80,
+          "position": "Attacking Midfield",
+          "potential": 83,
+          "value": 29000000,
+          "yearly_wage": 4056000
         },
         {
           "contract": "Jun 30, 2030",
@@ -1432,7 +1812,11 @@
             "Philippines"
           ],
           "number": "27",
-          "position": "Attacking Midfield"
+          "overall_score": 70,
+          "position": "Attacking Midfield",
+          "potential": 85,
+          "value": 3600000,
+          "yearly_wage": 988000
         },
         {
           "contract": "Jun 30, 2029",
@@ -1446,7 +1830,11 @@
             "Georgia"
           ],
           "number": "7",
-          "position": "Left Winger"
+          "overall_score": 88,
+          "position": "Left Winger",
+          "potential": 91,
+          "value": 125000000,
+          "yearly_wage": 7800000
         },
         {
           "contract": "Jun 30, 2028",
@@ -1461,7 +1849,11 @@
             "Togo"
           ],
           "number": "29",
-          "position": "Left Winger"
+          "overall_score": 84,
+          "position": "Left Winger",
+          "potential": 88,
+          "value": 61500000,
+          "yearly_wage": 5720000
         },
         {
           "contract": "Jun 30, 2028",
@@ -1476,7 +1868,11 @@
             "Cameroon"
           ],
           "number": "47",
-          "position": "Left Winger"
+          "overall_score": 69,
+          "position": "Left Winger",
+          "potential": 83,
+          "value": 3200000,
+          "yearly_wage": 988000
         },
         {
           "contract": "Jun 30, 2029",
@@ -1491,7 +1887,11 @@
             "Cote d'Ivoire"
           ],
           "number": "14",
-          "position": "Right Winger"
+          "overall_score": 86,
+          "position": "Right Winger",
+          "potential": 91,
+          "value": 101000000,
+          "yearly_wage": 5720000
         },
         {
           "contract": "Jun 30, 2028",
@@ -1506,7 +1906,11 @@
             "France"
           ],
           "number": "49",
-          "position": "Right Winger"
+          "overall_score": 74,
+          "position": "Right Winger",
+          "potential": 85,
+          "value": 8500000,
+          "yearly_wage": 1664000
         },
         {
           "contract": "Jun 30, 2028",
@@ -1520,7 +1924,11 @@
             "France"
           ],
           "number": "10",
-          "position": "Centre-Forward"
+          "overall_score": 90,
+          "position": "Centre-Forward",
+          "potential": 90,
+          "value": 122500000,
+          "yearly_wage": 11440000
         },
         {
           "contract": "Jun 30, 2028",
@@ -1534,7 +1942,11 @@
             "Portugal"
           ],
           "number": "9",
-          "position": "Centre-Forward"
+          "overall_score": 80,
+          "position": "Centre-Forward",
+          "potential": 84,
+          "value": 30500000,
+          "yearly_wage": 4108000
         }
       ],
       "stadiumName": "Parc des Princes",
@@ -1557,7 +1969,11 @@
             "France"
           ],
           "number": "40",
-          "position": "Goalkeeper"
+          "overall_score": 78,
+          "position": "Goalkeeper",
+          "potential": 85,
+          "value": 23500000,
+          "yearly_wage": 520000
         },
         {
           "contract": "Jun 30, 2026",
@@ -1571,7 +1987,11 @@
             "France"
           ],
           "number": "16",
-          "position": "Goalkeeper"
+          "overall_score": 70,
+          "position": "Goalkeeper",
+          "potential": 70,
+          "value": 275000,
+          "yearly_wage": 520000
         },
         {
           "contract": "Jun 30, 2026",
@@ -1585,7 +2005,11 @@
             "France"
           ],
           "number": "1",
-          "position": "Goalkeeper"
+          "overall_score": 69,
+          "position": "Goalkeeper",
+          "potential": 69,
+          "value": 150000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2029",
@@ -1597,7 +2021,11 @@
             "France"
           ],
           "number": "60",
-          "position": "Goalkeeper"
+          "overall_score": 62,
+          "position": "Goalkeeper",
+          "potential": 78,
+          "value": 875000,
+          "yearly_wage": 36400
         },
         {
           "contract": "Jun 30, 2030",
@@ -1612,7 +2040,11 @@
             "Ghana"
           ],
           "number": "6",
-          "position": "Centre-Back"
+          "overall_score": 76,
+          "position": "Centre-Back",
+          "potential": 83,
+          "value": 14000000,
+          "yearly_wage": 936000
         },
         {
           "contract": "Jun 30, 2026",
@@ -1627,7 +2059,11 @@
             "Senegal"
           ],
           "number": "20",
-          "position": "Centre-Back"
+          "overall_score": 78,
+          "position": "Centre-Back",
+          "potential": 81,
+          "value": 16500000,
+          "yearly_wage": 1456000
         },
         {
           "contract": "Jun 30, 2028",
@@ -1641,7 +2077,11 @@
             "France"
           ],
           "number": "24",
-          "position": "Centre-Back"
+          "overall_score": 77,
+          "position": "Centre-Back",
+          "potential": 77,
+          "value": 7000000,
+          "yearly_wage": 1404000
         },
         {
           "contract": "Jun 30, 2027",
@@ -1656,7 +2096,11 @@
             "France"
           ],
           "number": "25",
-          "position": "Centre-Back"
+          "overall_score": 75,
+          "position": "Centre-Back",
+          "potential": 83,
+          "value": 11500000,
+          "yearly_wage": 884000
         },
         {
           "contract": "Jun 30, 2029",
@@ -1670,7 +2114,11 @@
             "Bosnia-Herzegovina"
           ],
           "number": "4",
-          "position": "Centre-Back"
+          "overall_score": 69,
+          "position": "Centre-Back",
+          "potential": 80,
+          "value": 2700000,
+          "yearly_wage": 416000
         },
         {
           "contract": "-",
@@ -1684,7 +2132,11 @@
             "France"
           ],
           "number": "32",
-          "position": "Centre-Back"
+          "overall_score": 66,
+          "position": "Centre-Back",
+          "potential": 80,
+          "value": 1800000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2028",
@@ -1699,7 +2151,11 @@
             "Guadeloupe"
           ],
           "number": "14",
-          "position": "Left-Back"
+          "overall_score": 80,
+          "position": "Left-Back",
+          "potential": 80,
+          "value": 18500000,
+          "yearly_wage": 1768000
         },
         {
           "contract": "Jun 30, 2028",
@@ -1728,7 +2184,11 @@
             "France"
           ],
           "number": "27",
-          "position": "Left-Back"
+          "overall_score": 75,
+          "position": "Left-Back",
+          "potential": 75,
+          "value": 4100000,
+          "yearly_wage": 2548000
         },
         {
           "contract": "Jun 30, 2028",
@@ -1743,7 +2203,11 @@
             "Spain"
           ],
           "number": "2",
-          "position": "Right-Back"
+          "overall_score": 77,
+          "position": "Right-Back",
+          "potential": 77,
+          "value": 7500000,
+          "yearly_wage": 1404000
         },
         {
           "contract": "Jun 30, 2026",
@@ -1757,7 +2221,11 @@
             "Saudi Arabia"
           ],
           "number": "23",
-          "position": "Right-Back"
+          "overall_score": 76,
+          "position": "Right-Back",
+          "potential": 78,
+          "value": 8500000,
+          "yearly_wage": 2132000
         },
         {
           "contract": "Jun 30, 2028",
@@ -1772,7 +2240,11 @@
             "Guinea"
           ],
           "number": "18",
-          "position": "Defensive Midfield"
+          "overall_score": 65,
+          "position": "Defensive Midfield",
+          "potential": 78,
+          "value": 1700000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2030",
@@ -1786,7 +2258,11 @@
             "Mali"
           ],
           "number": "8",
-          "position": "Central Midfield"
+          "overall_score": 80,
+          "position": "Central Midfield",
+          "potential": 87,
+          "value": 42000000,
+          "yearly_wage": 1508000
         },
         {
           "contract": "Jun 30, 2029",
@@ -1800,7 +2276,11 @@
             "Mali"
           ],
           "number": "21",
-          "position": "Central Midfield"
+          "overall_score": 75,
+          "position": "Central Midfield",
+          "potential": 75,
+          "value": 6000000,
+          "yearly_wage": 1248000
         },
         {
           "contract": "Jun 30, 2026",
@@ -1815,7 +2295,11 @@
             "Croatia"
           ],
           "number": "28",
-          "position": "Central Midfield"
+          "overall_score": 80,
+          "position": "Central Midfield",
+          "potential": 80,
+          "value": 17500000,
+          "yearly_wage": 1820000
         },
         {
           "contract": "Jun 30, 2028",
@@ -1829,7 +2313,11 @@
             "Montenegro"
           ],
           "number": "5",
-          "position": "Central Midfield"
+          "overall_score": 71,
+          "position": "Central Midfield",
+          "potential": 81,
+          "value": 3900000,
+          "yearly_wage": 572000
         },
         {
           "contract": "Jun 30, 2027",
@@ -1843,7 +2331,11 @@
             "Guinea"
           ],
           "number": "31",
-          "position": "Attacking Midfield"
+          "overall_score": 62,
+          "position": "Attacking Midfield",
+          "potential": 75,
+          "value": 950000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2026",
@@ -1858,7 +2350,11 @@
             "Guadeloupe"
           ],
           "number": "9",
-          "position": "Left Winger"
+          "overall_score": 77,
+          "position": "Left Winger",
+          "potential": 77,
+          "value": 10500000,
+          "yearly_wage": 1560000
         },
         {
           "contract": "Jun 30, 2029",
@@ -1872,7 +2368,11 @@
             "Senegal"
           ],
           "number": "19",
-          "position": "Left Winger"
+          "overall_score": 73,
+          "position": "Left Winger",
+          "potential": 77,
+          "value": 4400000,
+          "yearly_wage": 988000
         },
         {
           "contract": "Jun 30, 2029",
@@ -1886,7 +2386,11 @@
             "France"
           ],
           "number": "26",
-          "position": "Left Winger"
+          "overall_score": 68,
+          "position": "Left Winger",
+          "potential": 78,
+          "value": 2600000,
+          "yearly_wage": 468000
         },
         {
           "contract": "Jun 30, 2028",
@@ -1900,7 +2404,11 @@
             "France"
           ],
           "number": "10",
-          "position": "Right Winger"
+          "overall_score": 81,
+          "position": "Right Winger",
+          "potential": 81,
+          "value": 20500000,
+          "yearly_wage": 2080000
         },
         {
           "contract": "Jun 30, 2028",
@@ -1915,7 +2423,11 @@
             "Haiti"
           ],
           "number": "11",
-          "position": "Centre-Forward"
+          "overall_score": 77,
+          "position": "Centre-Forward",
+          "potential": 77,
+          "value": 11500000,
+          "yearly_wage": 1560000
         },
         {
           "contract": "Jun 30, 2029",
@@ -1930,7 +2442,11 @@
             "Cote d'Ivoire"
           ],
           "number": "38",
-          "position": "Centre-Forward"
+          "overall_score": 72,
+          "position": "Centre-Forward",
+          "potential": 82,
+          "value": 5000000,
+          "yearly_wage": 780000
         },
         {
           "contract": "Jun 30, 2026",
@@ -1945,7 +2461,11 @@
             "Comoros"
           ],
           "number": "22",
-          "position": "Centre-Forward"
+          "overall_score": 77,
+          "position": "Centre-Forward",
+          "potential": 77,
+          "value": 10000000,
+          "yearly_wage": 1560000
         },
         {
           "contract": "Jun 30, 2026",
@@ -1959,7 +2479,11 @@
             "France"
           ],
           "number": "7",
-          "position": "Centre-Forward"
+          "overall_score": 74,
+          "position": "Centre-Forward",
+          "potential": 74,
+          "value": 2100000,
+          "yearly_wage": 1300000
         }
       ],
       "stadiumName": "Stade Bollaert-Delelis",
@@ -1983,7 +2507,11 @@
             "France"
           ],
           "number": "80",
-          "position": "Goalkeeper"
+          "overall_score": 77,
+          "position": "Goalkeeper",
+          "potential": 82,
+          "value": 12500000,
+          "yearly_wage": 780000
         },
         {
           "contract": "Jun 30, 2026",
@@ -1997,7 +2525,11 @@
             "France"
           ],
           "number": "31",
-          "position": "Goalkeeper"
+          "overall_score": 75,
+          "position": "Goalkeeper",
+          "potential": 75,
+          "value": 2800000,
+          "yearly_wage": 832000
         },
         {
           "contract": "-",
@@ -2010,7 +2542,11 @@
             "Poland"
           ],
           "number": "30",
-          "position": "Goalkeeper"
+          "overall_score": 62,
+          "position": "Goalkeeper",
+          "potential": 76,
+          "value": 850000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2027",
@@ -2024,7 +2560,11 @@
             "Burundi"
           ],
           "number": "55",
-          "position": "Centre-Back"
+          "overall_score": 76,
+          "position": "Centre-Back",
+          "potential": 78,
+          "value": 8000000,
+          "yearly_wage": 1248000
         },
         {
           "contract": "Jun 30, 2028",
@@ -2039,7 +2579,11 @@
             "DR Congo"
           ],
           "number": "64",
-          "position": "Centre-Back"
+          "overall_score": 75,
+          "position": "Centre-Back",
+          "potential": 80,
+          "value": 7500000,
+          "yearly_wage": 1144000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2053,7 +2597,11 @@
             "Sierra Leone"
           ],
           "number": "28",
-          "position": "Centre-Back"
+          "overall_score": 73,
+          "position": "Centre-Back",
+          "potential": 81,
+          "value": 6000000,
+          "yearly_wage": 2340000
         },
         {
           "contract": "Jun 30, 2028",
@@ -2068,7 +2616,11 @@
             "France"
           ],
           "number": "33",
-          "position": "Centre-Back"
+          "overall_score": 72,
+          "position": "Centre-Back",
+          "potential": 81,
+          "value": 4900000,
+          "yearly_wage": 676000
         },
         {
           "contract": "Jun 30, 2029",
@@ -2082,7 +2634,11 @@
             "Ghana"
           ],
           "number": "37",
-          "position": "Centre-Back"
+          "overall_score": 72,
+          "position": "Centre-Back",
+          "potential": 79,
+          "value": 4400000,
+          "yearly_wage": 676000
         },
         {
           "contract": "Jun 30, 2028",
@@ -2096,7 +2652,11 @@
             "Egypt"
           ],
           "number": "5",
-          "position": "Centre-Back"
+          "overall_score": 73,
+          "position": "Centre-Back",
+          "potential": 76,
+          "value": 3500000,
+          "yearly_wage": 988000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2110,7 +2670,11 @@
             "Brazil"
           ],
           "number": "4",
-          "position": "Centre-Back"
+          "overall_score": 75,
+          "position": "Centre-Back",
+          "potential": 75,
+          "value": 0,
+          "yearly_wage": 832000
         },
         {
           "contract": "Jun 30, 2028",
@@ -2124,7 +2688,11 @@
             "France"
           ],
           "number": "26",
-          "position": "Left-Back"
+          "overall_score": 77,
+          "position": "Left-Back",
+          "potential": 81,
+          "value": 14000000,
+          "yearly_wage": 1144000
         },
         {
           "contract": "Jun 30, 2027",
@@ -2138,7 +2706,11 @@
             "Tunisia"
           ],
           "number": "2",
-          "position": "Left-Back"
+          "overall_score": 75,
+          "position": "Left-Back",
+          "potential": 75,
+          "value": 4100000,
+          "yearly_wage": 1248000
         },
         {
           "contract": "Jun 30, 2028",
@@ -2152,7 +2724,11 @@
             "France"
           ],
           "number": "92",
-          "position": "Right-Back"
+          "overall_score": 78,
+          "position": "Right-Back",
+          "potential": 78,
+          "value": 9500000,
+          "yearly_wage": 1508000
         },
         {
           "contract": "Jun 30, 2029",
@@ -2166,7 +2742,11 @@
             "Belgium"
           ],
           "number": "24",
-          "position": "Defensive Midfield"
+          "overall_score": 77,
+          "position": "Defensive Midfield",
+          "potential": 80,
+          "value": 12500000,
+          "yearly_wage": 1352000
         },
         {
           "contract": "Jun 30, 2028",
@@ -2181,7 +2761,11 @@
             "Cote d'Ivoire"
           ],
           "number": "99",
-          "position": "Defensive Midfield"
+          "overall_score": 72,
+          "position": "Defensive Midfield",
+          "potential": 74,
+          "value": 2600000,
+          "yearly_wage": 884000
         },
         {
           "contract": "Jun 30, 2027",
@@ -2195,7 +2779,11 @@
             "Algeria"
           ],
           "number": "6",
-          "position": "Central Midfield"
+          "overall_score": 76,
+          "position": "Central Midfield",
+          "potential": 79,
+          "value": 10000000,
+          "yearly_wage": 1248000
         },
         {
           "contract": "Jun 30, 2027",
@@ -2209,7 +2797,11 @@
             "France"
           ],
           "number": "8",
-          "position": "Central Midfield"
+          "overall_score": 76,
+          "position": "Central Midfield",
+          "potential": 76,
+          "value": 7000000,
+          "yearly_wage": 1352000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2224,7 +2816,11 @@
             "DR Congo"
           ],
           "number": "22",
-          "position": "Central Midfield"
+          "overall_score": 73,
+          "position": "Central Midfield",
+          "potential": 73,
+          "value": 3000000,
+          "yearly_wage": 1092000
         },
         {
           "contract": "Jun 30, 2028",
@@ -2239,7 +2835,11 @@
             "Mali"
           ],
           "number": "39",
-          "position": "Central Midfield"
+          "overall_score": 61,
+          "position": "Central Midfield",
+          "potential": 76,
+          "value": 750000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2027",
@@ -2253,7 +2853,11 @@
             "France"
           ],
           "number": "20",
-          "position": "Right Midfield"
+          "overall_score": 73,
+          "position": "Right Midfield",
+          "potential": 81,
+          "value": 7000000,
+          "yearly_wage": 936000
         },
         {
           "contract": "Jun 30, 2028",
@@ -2267,7 +2871,11 @@
             "France"
           ],
           "number": "23",
-          "position": "Attacking Midfield"
+          "overall_score": 67,
+          "position": "Attacking Midfield",
+          "potential": 77,
+          "value": 2200000,
+          "yearly_wage": 364000
         },
         {
           "contract": "Jun 30, 2027",
@@ -2282,7 +2890,11 @@
             "France"
           ],
           "number": "10",
-          "position": "Left Winger"
+          "overall_score": 76,
+          "position": "Left Winger",
+          "potential": 78,
+          "value": 9500000,
+          "yearly_wage": 1352000
         },
         {
           "contract": "-",
@@ -2296,7 +2908,11 @@
             "Sweden"
           ],
           "number": "21",
-          "position": "Left Winger"
+          "overall_score": 71,
+          "position": "Left Winger",
+          "potential": 76,
+          "value": 2800000,
+          "yearly_wage": 832000
         },
         {
           "contract": "Jun 30, 2028",
@@ -2311,7 +2927,11 @@
             "England"
           ],
           "number": "25",
-          "position": "Right Winger"
+          "overall_score": 75,
+          "position": "Right Winger",
+          "potential": 82,
+          "value": 11500000,
+          "yearly_wage": 1040000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2325,7 +2945,11 @@
             "Portugal"
           ],
           "number": "47",
-          "position": "Right Winger"
+          "overall_score": 73,
+          "position": "Right Winger",
+          "potential": 79,
+          "value": 4800000,
+          "yearly_wage": 728000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2340,7 +2964,11 @@
             "Cote d'Ivoire"
           ],
           "number": "11",
-          "position": "Centre-Forward"
+          "overall_score": 74,
+          "position": "Centre-Forward",
+          "potential": 81,
+          "value": 8500000,
+          "yearly_wage": 1300000
         },
         {
           "contract": "Jun 30, 2030",
@@ -2355,7 +2983,11 @@
             "Nigeria"
           ],
           "number": "90",
-          "position": "Centre-Forward"
+          "overall_score": 71,
+          "position": "Centre-Forward",
+          "potential": 76,
+          "value": 2900000,
+          "yearly_wage": 832000
         }
       ],
       "stadiumName": "Allianz Riviera",
@@ -2379,7 +3011,11 @@
             "France"
           ],
           "number": "1",
-          "position": "Goalkeeper"
+          "overall_score": 76,
+          "position": "Goalkeeper",
+          "potential": 76,
+          "value": 1300000,
+          "yearly_wage": 624000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2393,7 +3029,11 @@
             "Sweden"
           ],
           "number": "30",
-          "position": "Goalkeeper"
+          "overall_score": 71,
+          "position": "Goalkeeper",
+          "potential": 71,
+          "value": 600000,
+          "yearly_wage": 416000
         },
         {
           "contract": "Jun 30, 2028",
@@ -2407,7 +3047,11 @@
             "France"
           ],
           "number": "50",
-          "position": "Goalkeeper"
+          "overall_score": 58,
+          "position": "Goalkeeper",
+          "potential": 72,
+          "value": 425000,
+          "yearly_wage": 52000
         },
         {
           "contract": "Jun 30, 2028",
@@ -2422,7 +3066,11 @@
             "Senegal"
           ],
           "number": "78",
-          "position": "Centre-Back"
+          "overall_score": 69,
+          "position": "Centre-Back",
+          "potential": 83,
+          "value": 3000000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2436,7 +3084,11 @@
             "Cote d'Ivoire"
           ],
           "number": "4",
-          "position": "Centre-Back"
+          "overall_score": 70,
+          "position": "Centre-Back",
+          "potential": 78,
+          "value": 3300000,
+          "yearly_wage": 1144000
         },
         {
           "contract": "Jun 30, 2028",
@@ -2451,7 +3103,11 @@
             "Portugal"
           ],
           "number": "6",
-          "position": "Centre-Back"
+          "overall_score": 72,
+          "position": "Centre-Back",
+          "potential": 73,
+          "value": 2200000,
+          "yearly_wage": 728000
         },
         {
           "contract": "Jun 30, 2028",
@@ -2465,7 +3121,11 @@
             "Libya"
           ],
           "number": "2",
-          "position": "Centre-Back"
+          "overall_score": 70,
+          "position": "Centre-Back",
+          "potential": 75,
+          "value": 2200000,
+          "yearly_wage": 468000
         },
         {
           "contract": "Jun 30, 2027",
@@ -2479,7 +3139,11 @@
             "Serbia"
           ],
           "number": "26",
-          "position": "Centre-Back"
+          "overall_score": 66,
+          "position": "Centre-Back",
+          "potential": 66,
+          "value": 575000,
+          "yearly_wage": 364000
         },
         {
           "contract": "Jun 30, 2027",
@@ -2494,7 +3158,11 @@
             "France"
           ],
           "number": "72",
-          "position": "Centre-Back"
+          "overall_score": 64,
+          "position": "Centre-Back",
+          "potential": 77,
+          "value": 1300000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2509,7 +3177,11 @@
             "Italy"
           ],
           "number": "3",
-          "position": "Left-Back"
+          "overall_score": 70,
+          "position": "Left-Back",
+          "potential": 71,
+          "value": 1700000,
+          "yearly_wage": 1144000
         },
         {
           "contract": "Jun 30, 2028",
@@ -2523,7 +3195,11 @@
             "Colombia"
           ],
           "number": "27",
-          "position": "Left-Back"
+          "overall_score": 74,
+          "position": "Left-Back",
+          "potential": 74,
+          "value": 3100000,
+          "yearly_wage": 884000
         },
         {
           "contract": "Jun 30, 2028",
@@ -2538,7 +3214,11 @@
             "Cote d'Ivoire"
           ],
           "number": "98",
-          "position": "Right-Back"
+          "overall_score": 72,
+          "position": "Right-Back",
+          "potential": 72,
+          "value": 2300000,
+          "yearly_wage": 676000
         },
         {
           "contract": "Jun 30, 2027",
@@ -2552,7 +3232,11 @@
             "France"
           ],
           "number": "18",
-          "position": "Right-Back"
+          "overall_score": 70,
+          "position": "Right-Back",
+          "potential": 70,
+          "value": 1400000,
+          "yearly_wage": 572000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2566,7 +3250,11 @@
             "France"
           ],
           "number": "24",
-          "position": "Right-Back"
+          "overall_score": 74,
+          "position": "Right-Back",
+          "potential": 74,
+          "value": 3600000,
+          "yearly_wage": 884000
         },
         {
           "contract": "Jun 30, 2029",
@@ -2580,7 +3268,11 @@
             "France"
           ],
           "number": "8",
-          "position": "Defensive Midfield"
+          "overall_score": 73,
+          "position": "Defensive Midfield",
+          "potential": 79,
+          "value": 4900000,
+          "yearly_wage": 676000
         },
         {
           "contract": "Jun 30, 2028",
@@ -2595,7 +3287,11 @@
             "France"
           ],
           "number": "28",
-          "position": "Defensive Midfield"
+          "overall_score": 74,
+          "position": "Defensive Midfield",
+          "potential": 75,
+          "value": 4300000,
+          "yearly_wage": 832000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2610,7 +3306,11 @@
             "Réunion"
           ],
           "number": "13",
-          "position": "Defensive Midfield"
+          "overall_score": 72,
+          "position": "Defensive Midfield",
+          "potential": 72,
+          "value": 1100000,
+          "yearly_wage": 728000
         },
         {
           "contract": "Jun 30, 2029",
@@ -2625,7 +3325,11 @@
             "Mauritania"
           ],
           "number": "52",
-          "position": "Defensive Midfield"
+          "overall_score": 64,
+          "position": "Defensive Midfield",
+          "potential": 79,
+          "value": 1300000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2030",
@@ -2640,7 +3344,11 @@
             "Comoros"
           ],
           "number": "17",
-          "position": "Central Midfield"
+          "overall_score": 68,
+          "position": "Central Midfield",
+          "potential": 77,
+          "value": 2600000,
+          "yearly_wage": 364000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2655,7 +3363,11 @@
             "Guinea"
           ],
           "number": "21",
-          "position": "Central Midfield"
+          "overall_score": 68,
+          "position": "Central Midfield",
+          "potential": 75,
+          "value": 2300000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2030",
@@ -2669,7 +3381,11 @@
             "France"
           ],
           "number": "66",
-          "position": "Attacking Midfield"
+          "overall_score": 71,
+          "position": "Attacking Midfield",
+          "potential": 80,
+          "value": 4000000,
+          "yearly_wage": 468000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2684,7 +3400,11 @@
             "Italy"
           ],
           "number": "20",
-          "position": "Attacking Midfield"
+          "overall_score": 74,
+          "position": "Attacking Midfield",
+          "potential": 74,
+          "value": 1700000,
+          "yearly_wage": 1040000
         },
         {
           "contract": "Jun 30, 2028",
@@ -2713,7 +3433,11 @@
             "France"
           ],
           "number": "10",
-          "position": "Centre-Forward"
+          "overall_score": 76,
+          "position": "Centre-Forward",
+          "potential": 82,
+          "value": 12000000,
+          "yearly_wage": 936000
         },
         {
           "contract": "Jun 30, 2027",
@@ -2727,7 +3451,11 @@
             "Egypt"
           ],
           "number": "31",
-          "position": "Centre-Forward"
+          "overall_score": 71,
+          "position": "Centre-Forward",
+          "potential": 71,
+          "value": 2000000,
+          "yearly_wage": 676000
         },
         {
           "contract": "Jun 30, 2027",
@@ -2742,7 +3470,11 @@
             "Nigeria"
           ],
           "number": "37",
-          "position": "Centre-Forward"
+          "overall_score": 71,
+          "position": "Centre-Forward",
+          "potential": 72,
+          "value": 2200000,
+          "yearly_wage": 676000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2756,7 +3488,11 @@
             "Mali"
           ],
           "number": "14",
-          "position": "Centre-Forward"
+          "overall_score": 62,
+          "position": "Centre-Forward",
+          "potential": 67,
+          "value": 600000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2771,7 +3507,11 @@
             "France"
           ],
           "number": "19",
-          "position": "Centre-Forward"
+          "overall_score": 72,
+          "position": "Centre-Forward",
+          "potential": 72,
+          "value": 800000,
+          "yearly_wage": 624000
         }
       ],
       "stadiumName": "Stade de la Beaujoire",
@@ -2795,7 +3535,11 @@
             "Cote d'Ivoire"
           ],
           "number": "1",
-          "position": "Goalkeeper"
+          "overall_score": 78,
+          "position": "Goalkeeper",
+          "potential": 85,
+          "value": 23500000,
+          "yearly_wage": 468000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2809,7 +3553,11 @@
             "Norway"
           ],
           "number": "16",
-          "position": "Goalkeeper"
+          "overall_score": 71,
+          "position": "Goalkeeper",
+          "potential": 75,
+          "value": 2000000,
+          "yearly_wage": 468000
         },
         {
           "contract": "Jun 30, 2027",
@@ -2823,7 +3571,11 @@
             "Spain"
           ],
           "number": "30",
-          "position": "Goalkeeper"
+          "overall_score": 66,
+          "position": "Goalkeeper",
+          "potential": 70,
+          "value": 925000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2028",
@@ -2837,7 +3589,11 @@
             "England"
           ],
           "number": "4",
-          "position": "Centre-Back"
+          "overall_score": 77,
+          "position": "Centre-Back",
+          "potential": 83,
+          "value": 15500000,
+          "yearly_wage": 1092000
         },
         {
           "contract": "Jun 30, 2027",
@@ -2852,7 +3608,11 @@
             "Jamaica"
           ],
           "number": "3",
-          "position": "Centre-Back"
+          "overall_score": 74,
+          "position": "Centre-Back",
+          "potential": 77,
+          "value": 4900000,
+          "yearly_wage": 1040000
         },
         {
           "contract": "Jun 30, 2027",
@@ -2866,7 +3626,11 @@
             "Denmark"
           ],
           "number": "2",
-          "position": "Centre-Back"
+          "overall_score": 76,
+          "position": "Centre-Back",
+          "potential": 77,
+          "value": 7000000,
+          "yearly_wage": 1196000
         },
         {
           "contract": "Jun 30, 2028",
@@ -2881,7 +3645,11 @@
             "Guinea"
           ],
           "number": "35",
-          "position": "Centre-Back"
+          "overall_score": 65,
+          "position": "Centre-Back",
+          "potential": 78,
+          "value": 1600000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2895,7 +3663,11 @@
             "Norway"
           ],
           "number": "12",
-          "position": "Right-Back"
+          "overall_score": 72,
+          "position": "Right-Back",
+          "potential": 77,
+          "value": 3300000,
+          "yearly_wage": 728000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2910,7 +3682,11 @@
             "Mali"
           ],
           "number": "19",
-          "position": "Right-Back"
+          "overall_score": 75,
+          "position": "Right-Back",
+          "potential": 75,
+          "value": 3900000,
+          "yearly_wage": 1144000
         },
         {
           "contract": "Jun 30, 2027",
@@ -2924,7 +3700,11 @@
             "Venezuela"
           ],
           "number": "23",
-          "position": "Central Midfield"
+          "overall_score": 75,
+          "position": "Central Midfield",
+          "potential": 80,
+          "value": 7500000,
+          "yearly_wage": 1040000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2938,7 +3718,11 @@
             "Senegal"
           ],
           "number": "18",
-          "position": "Central Midfield"
+          "overall_score": 70,
+          "position": "Central Midfield",
+          "potential": 79,
+          "value": 3600000,
+          "yearly_wage": 1040000
         },
         {
           "contract": "Jun 30, 2028",
@@ -2953,7 +3737,11 @@
             "Togo"
           ],
           "number": "45",
-          "position": "Central Midfield"
+          "overall_score": 70,
+          "position": "Central Midfield",
+          "potential": 83,
+          "value": 3400000,
+          "yearly_wage": 364000
         },
         {
           "contract": "Jun 30, 2029",
@@ -2967,7 +3755,11 @@
             "Ghana"
           ],
           "number": "17",
-          "position": "Central Midfield"
+          "overall_score": 68,
+          "position": "Central Midfield",
+          "potential": 73,
+          "value": 1800000,
+          "yearly_wage": 520000
         },
         {
           "contract": "-",
@@ -2981,7 +3773,11 @@
             "Slovakia"
           ],
           "number": "77",
-          "position": "Central Midfield"
+          "overall_score": 68,
+          "position": "Central Midfield",
+          "potential": 78,
+          "value": 2700000,
+          "yearly_wage": 416000
         },
         {
           "contract": "Jun 30, 2027",
@@ -2995,7 +3791,11 @@
             "Norway"
           ],
           "number": "15",
-          "position": "Right Midfield"
+          "overall_score": 76,
+          "position": "Right Midfield",
+          "potential": 76,
+          "value": 8000000,
+          "yearly_wage": 1196000
         },
         {
           "contract": "Jun 30, 2028",
@@ -3010,7 +3810,11 @@
             "France"
           ],
           "number": "22",
-          "position": "Right Midfield"
+          "overall_score": 70,
+          "position": "Right Midfield",
+          "potential": 79,
+          "value": 3400000,
+          "yearly_wage": 572000
         },
         {
           "contract": "Jun 30, 2030",
@@ -3025,7 +3829,11 @@
             "Martinique"
           ],
           "number": "24",
-          "position": "Left Midfield"
+          "overall_score": 72,
+          "position": "Left Midfield",
+          "potential": 82,
+          "value": 4800000,
+          "yearly_wage": 572000
         },
         {
           "contract": "Jun 30, 2027",
@@ -3040,7 +3848,11 @@
             "Cote d'Ivoire"
           ],
           "number": "10",
-          "position": "Left Winger"
+          "overall_score": 76,
+          "position": "Left Winger",
+          "potential": 79,
+          "value": 10000000,
+          "yearly_wage": 1144000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3055,7 +3867,11 @@
             "France"
           ],
           "number": "9",
-          "position": "Centre-Forward"
+          "overall_score": 72,
+          "position": "Centre-Forward",
+          "potential": 75,
+          "value": 3100000,
+          "yearly_wage": 936000
         },
         {
           "contract": "-",
@@ -3069,7 +3885,11 @@
             "Brazil"
           ],
           "number": "20",
-          "position": "Centre-Forward"
+          "overall_score": 72,
+          "position": "Centre-Forward",
+          "potential": 81,
+          "value": 5000000,
+          "yearly_wage": 728000
         },
         {
           "contract": "Jun 30, 2029",
@@ -3084,7 +3904,11 @@
             "Jamaica"
           ],
           "number": "13",
-          "position": "Centre-Forward"
+          "overall_score": 68,
+          "position": "Centre-Forward",
+          "potential": 76,
+          "value": 2700000,
+          "yearly_wage": 572000
         },
         {
           "contract": "Jun 30, 2029",
@@ -3099,7 +3923,11 @@
             "Italy"
           ],
           "number": "11",
-          "position": "Centre-Forward"
+          "overall_score": 70,
+          "position": "Centre-Forward",
+          "potential": 81,
+          "value": 3500000,
+          "yearly_wage": 572000
         },
         {
           "contract": "Jun 30, 2029",
@@ -3113,7 +3941,11 @@
             "Argentina"
           ],
           "number": "7",
-          "position": "Centre-Forward"
+          "overall_score": 66,
+          "position": "Centre-Forward",
+          "potential": 78,
+          "value": 2000000,
+          "yearly_wage": 312000
         },
         {
           "contract": "Jun 30, 2027",
@@ -3141,7 +3973,11 @@
             "Senegal"
           ],
           "number": "21",
-          "position": "Centre-Forward"
+          "overall_score": 61,
+          "position": "Centre-Forward",
+          "potential": 76,
+          "value": 775000,
+          "yearly_wage": 156000
         }
       ],
       "stadiumName": "Stadium Municipal",
@@ -3165,7 +4001,11 @@
             "Congo"
           ],
           "number": "30",
-          "position": "Goalkeeper"
+          "overall_score": 80,
+          "position": "Goalkeeper",
+          "potential": 80,
+          "value": 11000000,
+          "yearly_wage": 1144000
         },
         {
           "contract": "Jun 30, 2029",
@@ -3177,7 +4017,11 @@
             "Guadeloupe"
           ],
           "number": "50",
-          "position": "Goalkeeper"
+          "overall_score": 65,
+          "position": "Goalkeeper",
+          "potential": 77,
+          "value": 1500000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2029",
@@ -3192,7 +4036,11 @@
             "Guadeloupe"
           ],
           "number": "97",
-          "position": "Centre-Back"
+          "overall_score": 76,
+          "position": "Centre-Back",
+          "potential": 85,
+          "value": 15000000,
+          "yearly_wage": 884000
         },
         {
           "contract": "Jun 30, 2029",
@@ -3207,7 +4055,11 @@
             "Togo"
           ],
           "number": "3",
-          "position": "Centre-Back"
+          "overall_score": 76,
+          "position": "Centre-Back",
+          "potential": 80,
+          "value": 9500000,
+          "yearly_wage": 1196000
         },
         {
           "contract": "Jun 30, 2028",
@@ -3221,7 +4073,11 @@
             "Morocco"
           ],
           "number": "48",
-          "position": "Centre-Back"
+          "overall_score": 71,
+          "position": "Centre-Back",
+          "potential": 82,
+          "value": 3800000,
+          "yearly_wage": 572000
         },
         {
           "contract": "Jun 30, 2029",
@@ -3235,7 +4091,11 @@
             "France"
           ],
           "number": "24",
-          "position": "Centre-Back"
+          "overall_score": 76,
+          "position": "Centre-Back",
+          "potential": 81,
+          "value": 10000000,
+          "yearly_wage": 1092000
         },
         {
           "contract": "Jun 30, 2029",
@@ -3249,7 +4109,11 @@
             "Ghana"
           ],
           "number": "36",
-          "position": "Centre-Back"
+          "overall_score": 74,
+          "position": "Centre-Back",
+          "potential": 79,
+          "value": 5500000,
+          "yearly_wage": 1040000
         },
         {
           "contract": "Jun 30, 2029",
@@ -3263,7 +4127,11 @@
             "Cameroon"
           ],
           "number": "18",
-          "position": "Left-Back"
+          "overall_score": 68,
+          "position": "Left-Back",
+          "potential": 80,
+          "value": 2800000,
+          "yearly_wage": 416000
         },
         {
           "contract": "Jun 30, 2030",
@@ -3278,7 +4146,11 @@
             "Mali"
           ],
           "number": "6",
-          "position": "Central Midfield"
+          "overall_score": 73,
+          "position": "Central Midfield",
+          "potential": 83,
+          "value": 7000000,
+          "yearly_wage": 780000
         },
         {
           "contract": "Jun 30, 2029",
@@ -3293,7 +4165,11 @@
             "The Gambia"
           ],
           "number": "45",
-          "position": "Central Midfield"
+          "overall_score": 77,
+          "position": "Central Midfield",
+          "potential": 78,
+          "value": 12000000,
+          "yearly_wage": 1404000
         },
         {
           "contract": "Jun 30, 2028",
@@ -3307,7 +4183,11 @@
             "France"
           ],
           "number": "21",
-          "position": "Central Midfield"
+          "overall_score": 80,
+          "position": "Central Midfield",
+          "potential": 80,
+          "value": 17500000,
+          "yearly_wage": 1768000
         },
         {
           "contract": "Jun 30, 2028",
@@ -3322,7 +4202,11 @@
             "Sierra Leone"
           ],
           "number": "4",
-          "position": "Central Midfield"
+          "overall_score": 73,
+          "position": "Central Midfield",
+          "potential": 73,
+          "value": 2600000,
+          "yearly_wage": 1040000
         },
         {
           "contract": "Jun 30, 2027",
@@ -3337,7 +4221,11 @@
             "Martinique"
           ],
           "number": "10",
-          "position": "Right Midfield"
+          "overall_score": 76,
+          "position": "Right Midfield",
+          "potential": 76,
+          "value": 8000000,
+          "yearly_wage": 1300000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3351,7 +4239,11 @@
             "Poland"
           ],
           "number": "95",
-          "position": "Right Midfield"
+          "overall_score": 76,
+          "position": "Right Midfield",
+          "potential": 76,
+          "value": 6500000,
+          "yearly_wage": 2288000
         },
         {
           "contract": "Jun 30, 2029",
@@ -3365,7 +4257,11 @@
             "France"
           ],
           "number": "26",
-          "position": "Left Midfield"
+          "overall_score": 76,
+          "position": "Left Midfield",
+          "potential": 82,
+          "value": 11000000,
+          "yearly_wage": 1092000
         },
         {
           "contract": "Jun 30, 2028",
@@ -3379,7 +4275,11 @@
             "Jordan"
           ],
           "number": "11",
-          "position": "Left Midfield"
+          "overall_score": 76,
+          "position": "Left Midfield",
+          "potential": 76,
+          "value": 7500000,
+          "yearly_wage": 1352000
         },
         {
           "contract": "Jun 30, 2029",
@@ -3393,7 +4293,11 @@
             "Poland"
           ],
           "number": "17",
-          "position": "Attacking Midfield"
+          "overall_score": 77,
+          "position": "Attacking Midfield",
+          "potential": 78,
+          "value": 12500000,
+          "yearly_wage": 1456000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3408,7 +4312,11 @@
             "Martinique"
           ],
           "number": "70",
-          "position": "Right Winger"
+          "overall_score": 73,
+          "position": "Right Winger",
+          "potential": 73,
+          "value": 3200000,
+          "yearly_wage": 1092000
         },
         {
           "contract": "Jun 30, 2028",
@@ -3423,7 +4331,11 @@
             "DR Congo"
           ],
           "number": "65",
-          "position": "Right Winger"
+          "overall_score": 64,
+          "position": "Right Winger",
+          "potential": 78,
+          "value": 1400000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2029",
@@ -3437,7 +4349,11 @@
             "France"
           ],
           "number": "75",
-          "position": "Right Winger"
+          "overall_score": 61,
+          "position": "Right Winger",
+          "potential": 77,
+          "value": 825000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2029",
@@ -3451,7 +4367,11 @@
             "France"
           ],
           "number": "9",
-          "position": "Centre-Forward"
+          "overall_score": 79,
+          "position": "Centre-Forward",
+          "potential": 82,
+          "value": 23500000,
+          "yearly_wage": 1716000
         },
         {
           "contract": "Jun 30, 2029",
@@ -3466,7 +4386,11 @@
             "Cameroon"
           ],
           "number": "7",
-          "position": "Centre-Forward"
+          "overall_score": 77,
+          "position": "Centre-Forward",
+          "potential": 77,
+          "value": 11000000,
+          "yearly_wage": 1612000
         },
         {
           "contract": "Jun 30, 2029",
@@ -3480,7 +4404,11 @@
             "Morocco"
           ],
           "number": "77",
-          "position": "Centre-Forward"
+          "overall_score": 66,
+          "position": "Centre-Forward",
+          "potential": 80,
+          "value": 2100000,
+          "yearly_wage": 364000
         }
       ],
       "stadiumName": "Roazhon Park",
@@ -3503,7 +4431,11 @@
             "Denmark"
           ],
           "number": "1",
-          "position": "Goalkeeper"
+          "overall_score": 72,
+          "position": "Goalkeeper",
+          "potential": 78,
+          "value": 3000000,
+          "yearly_wage": 312000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3517,7 +4449,11 @@
             "Senegal"
           ],
           "number": "61",
-          "position": "Goalkeeper"
+          "overall_score": 67,
+          "position": "Goalkeeper",
+          "potential": 69,
+          "value": 875000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2027",
@@ -3531,7 +4467,11 @@
             "Senegal"
           ],
           "number": "40",
-          "position": "Goalkeeper"
+          "overall_score": 63,
+          "position": "Goalkeeper",
+          "potential": 73,
+          "value": 925000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2027",
@@ -3545,7 +4485,11 @@
             "Senegal"
           ],
           "number": "38",
-          "position": "Centre-Back"
+          "overall_score": 70,
+          "position": "Centre-Back",
+          "potential": 81,
+          "value": 3300000,
+          "yearly_wage": 364000
         },
         {
           "contract": "Jun 30, 2029",
@@ -3559,7 +4503,11 @@
             "Ghana"
           ],
           "number": "15",
-          "position": "Centre-Back"
+          "overall_score": 70,
+          "position": "Centre-Back",
+          "potential": 77,
+          "value": 3000000,
+          "yearly_wage": 416000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3574,7 +4522,11 @@
             "France"
           ],
           "number": "5",
-          "position": "Centre-Back"
+          "overall_score": 71,
+          "position": "Centre-Back",
+          "potential": 71,
+          "value": 1600000,
+          "yearly_wage": 520000
         },
         {
           "contract": "Jun 30, 2028",
@@ -3588,7 +4540,11 @@
             "Gabon"
           ],
           "number": "4",
-          "position": "Centre-Back"
+          "overall_score": 68,
+          "position": "Centre-Back",
+          "potential": 76,
+          "value": 2500000,
+          "yearly_wage": 312000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3603,7 +4559,11 @@
             "France"
           ],
           "number": "97",
-          "position": "Left-Back"
+          "overall_score": 72,
+          "position": "Left-Back",
+          "potential": 72,
+          "value": 2100000,
+          "yearly_wage": 572000
         },
         {
           "contract": "Jun 30, 2028",
@@ -3617,7 +4577,11 @@
             "Belgium"
           ],
           "number": "27",
-          "position": "Left-Back"
+          "overall_score": 66,
+          "position": "Left-Back",
+          "potential": 77,
+          "value": 1800000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3631,7 +4595,11 @@
             "Cote d'Ivoire"
           ],
           "number": "39",
-          "position": "Right-Back"
+          "overall_score": 71,
+          "position": "Right-Back",
+          "potential": 71,
+          "value": 1800000,
+          "yearly_wage": 520000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3646,7 +4614,11 @@
             "France"
           ],
           "number": "70",
-          "position": "Right-Back"
+          "overall_score": 69,
+          "position": "Right-Back",
+          "potential": 69,
+          "value": 725000,
+          "yearly_wage": 416000
         },
         {
           "contract": "Jun 30, 2027",
@@ -3660,7 +4632,11 @@
             "France"
           ],
           "number": "2",
-          "position": "Right-Back"
+          "overall_score": 70,
+          "position": "Right-Back",
+          "potential": 70,
+          "value": 825000,
+          "yearly_wage": 468000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3673,7 +4649,11 @@
             "France"
           ],
           "number": "25",
-          "position": "Right-Back"
+          "overall_score": 61,
+          "position": "Right-Back",
+          "potential": 73,
+          "value": 750000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3687,7 +4667,11 @@
             "Mali"
           ],
           "number": "8",
-          "position": "Defensive Midfield"
+          "overall_score": 71,
+          "position": "Defensive Midfield",
+          "potential": 76,
+          "value": 2600000,
+          "yearly_wage": 1560000
         },
         {
           "contract": "Jun 30, 2028",
@@ -3701,7 +4685,11 @@
             "Senegal"
           ],
           "number": "12",
-          "position": "Defensive Midfield"
+          "overall_score": 67,
+          "position": "Defensive Midfield",
+          "potential": 81,
+          "value": 2300000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3716,7 +4704,11 @@
             "Algeria"
           ],
           "number": "21",
-          "position": "Defensive Midfield"
+          "overall_score": 72,
+          "position": "Defensive Midfield",
+          "potential": 72,
+          "value": 800000,
+          "yearly_wage": 572000
         },
         {
           "contract": "Jun 30, 2028",
@@ -3730,7 +4722,11 @@
             "France"
           ],
           "number": "20",
-          "position": "Central Midfield"
+          "overall_score": 72,
+          "position": "Central Midfield",
+          "potential": 72,
+          "value": 2500000,
+          "yearly_wage": 572000
         },
         {
           "contract": "Jun 30, 2027",
@@ -3745,7 +4741,11 @@
             "France"
           ],
           "number": "29",
-          "position": "Attacking Midfield"
+          "overall_score": 57,
+          "position": "Attacking Midfield",
+          "potential": 69,
+          "value": 400000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3760,7 +4760,11 @@
             "Martinique"
           ],
           "number": "19",
-          "position": "Left Winger"
+          "overall_score": 66,
+          "position": "Left Winger",
+          "potential": 79,
+          "value": 2100000,
+          "yearly_wage": 416000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3774,7 +4778,11 @@
             "Georgia"
           ],
           "number": "9",
-          "position": "Left Winger"
+          "overall_score": 67,
+          "position": "Left Winger",
+          "potential": 75,
+          "value": 2300000,
+          "yearly_wage": 312000
         },
         {
           "contract": "Jun 30, 2028",
@@ -3788,7 +4796,11 @@
             "France"
           ],
           "number": "10",
-          "position": "Right Winger"
+          "overall_score": 76,
+          "position": "Right Winger",
+          "potential": 76,
+          "value": 7500000,
+          "yearly_wage": 884000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3803,7 +4815,11 @@
             "Ukraine"
           ],
           "number": "7",
-          "position": "Right Winger"
+          "overall_score": 72,
+          "position": "Right Winger",
+          "potential": 75,
+          "value": 3200000,
+          "yearly_wage": 728000
         },
         {
           "contract": "Jun 30, 2027",
@@ -3818,7 +4834,11 @@
             "Nigeria"
           ],
           "number": "99",
-          "position": "Right Winger"
+          "overall_score": 67,
+          "position": "Right Winger",
+          "potential": 67,
+          "value": 1100000,
+          "yearly_wage": 364000
         },
         {
           "contract": "Jun 30, 2028",
@@ -3833,7 +4853,11 @@
             "France"
           ],
           "number": "30",
-          "position": "Centre-Forward"
+          "overall_score": 72,
+          "position": "Centre-Forward",
+          "potential": 72,
+          "value": 2300000,
+          "yearly_wage": 676000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3847,7 +4871,11 @@
             "Georgia"
           ],
           "number": "11",
-          "position": "Centre-Forward"
+          "overall_score": 70,
+          "position": "Centre-Forward",
+          "potential": 70,
+          "value": 1300000,
+          "yearly_wage": 520000
         },
         {
           "contract": "Jun 30, 2028",
@@ -3862,7 +4890,11 @@
             "Cameroon"
           ],
           "number": "17",
-          "position": "Centre-Forward"
+          "overall_score": 60,
+          "position": "Centre-Forward",
+          "potential": 76,
+          "value": 650000,
+          "yearly_wage": 104000
         }
       ],
       "stadiumName": "Stade Saint-Symphorien",
@@ -3885,7 +4917,11 @@
             "Belgium"
           ],
           "number": "39",
-          "position": "Goalkeeper"
+          "overall_score": 77,
+          "position": "Goalkeeper",
+          "potential": 86,
+          "value": 19500000,
+          "yearly_wage": 1456000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3900,7 +4936,11 @@
             "Serbia"
           ],
           "number": "50",
-          "position": "Goalkeeper"
+          "overall_score": 65,
+          "position": "Goalkeeper",
+          "potential": 70,
+          "value": 875000,
+          "yearly_wage": 312000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3914,7 +4954,11 @@
             "Sweden"
           ],
           "number": "1",
-          "position": "Goalkeeper"
+          "overall_score": 69,
+          "position": "Goalkeeper",
+          "potential": 69,
+          "value": 150000,
+          "yearly_wage": 468000
         },
         {
           "contract": "Jun 30, 2028",
@@ -3929,7 +4973,11 @@
             "Cote d'Ivoire"
           ],
           "number": "6",
-          "position": "Centre-Back"
+          "overall_score": 77,
+          "position": "Centre-Back",
+          "potential": 83,
+          "value": 15500000,
+          "yearly_wage": 1768000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3943,7 +4991,11 @@
             "Argentina"
           ],
           "number": "5",
-          "position": "Centre-Back"
+          "overall_score": 73,
+          "position": "Centre-Back",
+          "potential": 81,
+          "value": 6000000,
+          "yearly_wage": 2496000
         },
         {
           "contract": "Jun 30, 2030",
@@ -3957,7 +5009,11 @@
             "Denmark"
           ],
           "number": "24",
-          "position": "Centre-Back"
+          "overall_score": 73,
+          "position": "Centre-Back",
+          "potential": 82,
+          "value": 6000000,
+          "yearly_wage": 1248000
         },
         {
           "contract": "Jun 30, 2029",
@@ -3972,7 +5028,11 @@
             "Nigeria"
           ],
           "number": "2",
-          "position": "Centre-Back"
+          "overall_score": 73,
+          "position": "Centre-Back",
+          "potential": 78,
+          "value": 4200000,
+          "yearly_wage": 1560000
         },
         {
           "contract": "Jun 30, 2027",
@@ -3987,7 +5047,11 @@
             "New Zealand"
           ],
           "number": "3",
-          "position": "Left-Back"
+          "overall_score": 77,
+          "position": "Left-Back",
+          "potential": 77,
+          "value": 9500000,
+          "yearly_wage": 2548000
         },
         {
           "contract": "Jun 30, 2029",
@@ -4002,7 +5066,11 @@
             "France"
           ],
           "number": "22",
-          "position": "Right-Back"
+          "overall_score": 77,
+          "position": "Right-Back",
+          "potential": 82,
+          "value": 15000000,
+          "yearly_wage": 2080000
         },
         {
           "contract": "Jun 30, 2027",
@@ -4017,7 +5085,11 @@
             "DR Congo"
           ],
           "number": "18",
-          "position": "Defensive Midfield"
+          "overall_score": 72,
+          "position": "Defensive Midfield",
+          "potential": 76,
+          "value": 3100000,
+          "yearly_wage": 1404000
         },
         {
           "contract": "Jun 30, 2030",
@@ -4032,7 +5104,11 @@
             "England"
           ],
           "number": "8",
-          "position": "Defensive Midfield"
+          "overall_score": 70,
+          "position": "Defensive Midfield",
+          "potential": 78,
+          "value": 3500000,
+          "yearly_wage": 1040000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4046,7 +5122,11 @@
             "Portugal"
           ],
           "number": "83",
-          "position": "Defensive Midfield"
+          "overall_score": 69,
+          "position": "Defensive Midfield",
+          "potential": 81,
+          "value": 3200000,
+          "yearly_wage": 364000
         },
         {
           "contract": "Jun 30, 2029",
@@ -4060,7 +5140,11 @@
             "Argentina"
           ],
           "number": "32",
-          "position": "Central Midfield"
+          "overall_score": 78,
+          "position": "Central Midfield",
+          "potential": 84,
+          "value": 21500000,
+          "yearly_wage": 1976000
         },
         {
           "contract": "Jun 30, 2030",
@@ -4075,7 +5159,11 @@
             "Cameroon"
           ],
           "number": "17",
-          "position": "Central Midfield"
+          "overall_score": 71,
+          "position": "Central Midfield",
+          "potential": 79,
+          "value": 4000000,
+          "yearly_wage": 1092000
         },
         {
           "contract": "Jun 30, 2030",
@@ -4090,7 +5178,11 @@
             "France"
           ],
           "number": "29",
-          "position": "Central Midfield"
+          "overall_score": 73,
+          "position": "Central Midfield",
+          "potential": 82,
+          "value": 6500000,
+          "yearly_wage": 1300000
         },
         {
           "contract": "Jun 30, 2029",
@@ -4105,7 +5197,11 @@
             "Portugal"
           ],
           "number": "7",
-          "position": "Left Midfield"
+          "overall_score": 78,
+          "position": "Left Midfield",
+          "potential": 84,
+          "value": 22000000,
+          "yearly_wage": 1976000
         },
         {
           "contract": "Jun 30, 2029",
@@ -4120,7 +5216,11 @@
             "Hungary"
           ],
           "number": "11",
-          "position": "Left Midfield"
+          "overall_score": 75,
+          "position": "Left Midfield",
+          "potential": 82,
+          "value": 11500000,
+          "yearly_wage": 1976000
         },
         {
           "contract": "Jun 30, 2029",
@@ -4134,7 +5234,11 @@
             "Paraguay"
           ],
           "number": "19",
-          "position": "Attacking Midfield"
+          "overall_score": 75,
+          "position": "Attacking Midfield",
+          "potential": 84,
+          "value": 12500000,
+          "yearly_wage": 1716000
         },
         {
           "contract": "Jun 30, 2030",
@@ -4149,7 +5253,11 @@
             "England"
           ],
           "number": "20",
-          "position": "Left Winger"
+          "overall_score": 74,
+          "position": "Left Winger",
+          "potential": 82,
+          "value": 9500000,
+          "yearly_wage": 1820000
         },
         {
           "contract": "Jun 30, 2029",
@@ -4163,7 +5271,11 @@
             "France"
           ],
           "number": "42",
-          "position": "Right Winger"
+          "overall_score": 71,
+          "position": "Right Winger",
+          "potential": 80,
+          "value": 4000000,
+          "yearly_wage": 1092000
         },
         {
           "contract": "Jun 30, 2029",
@@ -4178,7 +5290,11 @@
             "Ghana"
           ],
           "number": "27",
-          "position": "Right Winger"
+          "overall_score": 70,
+          "position": "Right Winger",
+          "potential": 80,
+          "value": 3400000,
+          "yearly_wage": 936000
         },
         {
           "contract": "Jun 30, 2030",
@@ -4193,7 +5309,11 @@
             "France"
           ],
           "number": "80",
-          "position": "Right Winger"
+          "overall_score": 70,
+          "position": "Right Winger",
+          "potential": 83,
+          "value": 3800000,
+          "yearly_wage": 988000
         },
         {
           "contract": "Jun 30, 2028",
@@ -4208,7 +5328,11 @@
             "Nigeria"
           ],
           "number": "10",
-          "position": "Centre-Forward"
+          "overall_score": 78,
+          "position": "Centre-Forward",
+          "potential": 83,
+          "value": 22000000,
+          "yearly_wage": 2600000
         },
         {
           "contract": "Jun 30, 2030",
@@ -4222,7 +5346,11 @@
             "Argentina"
           ],
           "number": "9",
-          "position": "Centre-Forward"
+          "overall_score": 77,
+          "position": "Centre-Forward",
+          "potential": 85,
+          "value": 24000000,
+          "yearly_wage": 2444000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4236,7 +5364,11 @@
             "Cote d'Ivoire"
           ],
           "number": "15",
-          "position": "Centre-Forward"
+          "overall_score": 72,
+          "position": "Centre-Forward",
+          "potential": 80,
+          "value": 5500000,
+          "yearly_wage": 3120000
         }
       ],
       "stadiumName": "Stade de la Meinau",
@@ -4260,7 +5392,11 @@
             "France"
           ],
           "number": "99",
-          "position": "Goalkeeper"
+          "overall_score": 72,
+          "position": "Goalkeeper",
+          "potential": 72,
+          "value": 1200000,
+          "yearly_wage": 416000
         },
         {
           "contract": "Jun 30, 2027",
@@ -4275,7 +5411,11 @@
             "France"
           ],
           "number": "77",
-          "position": "Goalkeeper"
+          "overall_score": 70,
+          "position": "Goalkeeper",
+          "potential": 70,
+          "value": 1100000,
+          "yearly_wage": 312000
         },
         {
           "contract": "Jun 30, 2027",
@@ -4289,7 +5429,11 @@
             "France"
           ],
           "number": "50",
-          "position": "Goalkeeper"
+          "overall_score": 61,
+          "position": "Goalkeeper",
+          "potential": 77,
+          "value": 750000,
+          "yearly_wage": 46800
         },
         {
           "contract": "Jun 30, 2026",
@@ -4304,7 +5448,11 @@
             "Guinea-Bissau"
           ],
           "number": "93",
-          "position": "Centre-Back"
+          "overall_score": 74,
+          "position": "Centre-Back",
+          "potential": 80,
+          "value": 6000000,
+          "yearly_wage": 572000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4318,7 +5466,11 @@
             "France"
           ],
           "number": "4",
-          "position": "Centre-Back"
+          "overall_score": 74,
+          "position": "Centre-Back",
+          "potential": 74,
+          "value": 3500000,
+          "yearly_wage": 728000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4333,7 +5485,11 @@
             "Cameroon"
           ],
           "number": "6",
-          "position": "Centre-Back"
+          "overall_score": 71,
+          "position": "Centre-Back",
+          "potential": 77,
+          "value": 2700000,
+          "yearly_wage": 468000
         },
         {
           "contract": "-",
@@ -4348,7 +5504,11 @@
             "Cote d'Ivoire"
           ],
           "number": "29",
-          "position": "Centre-Back"
+          "overall_score": 65,
+          "position": "Centre-Back",
+          "potential": 79,
+          "value": 1500000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2027",
@@ -4363,7 +5523,11 @@
             "Algeria"
           ],
           "number": "18",
-          "position": "Left-Back"
+          "overall_score": 70,
+          "position": "Left-Back",
+          "potential": 70,
+          "value": 1500000,
+          "yearly_wage": 468000
         },
         {
           "contract": "Jun 30, 2027",
@@ -4377,7 +5541,11 @@
             "Mali"
           ],
           "number": "13",
-          "position": "Right-Back"
+          "overall_score": 70,
+          "position": "Right-Back",
+          "potential": 74,
+          "value": 2100000,
+          "yearly_wage": 416000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4392,7 +5560,11 @@
             "DR Congo"
           ],
           "number": "32",
-          "position": "Right-Back"
+          "overall_score": 70,
+          "position": "Right-Back",
+          "potential": 78,
+          "value": 3400000,
+          "yearly_wage": 1300000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4407,7 +5579,11 @@
             "France"
           ],
           "number": "7",
-          "position": "Right-Back"
+          "overall_score": 71,
+          "position": "Right-Back",
+          "potential": 71,
+          "value": 700000,
+          "yearly_wage": 520000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4422,7 +5598,11 @@
             "Central African Republic"
           ],
           "number": "19",
-          "position": "Defensive Midfield"
+          "overall_score": 69,
+          "position": "Defensive Midfield",
+          "potential": 79,
+          "value": 3000000,
+          "yearly_wage": 364000
         },
         {
           "contract": "Jun 30, 2027",
@@ -4436,7 +5616,11 @@
             "Japan"
           ],
           "number": "15",
-          "position": "Defensive Midfield"
+          "overall_score": 72,
+          "position": "Defensive Midfield",
+          "potential": 77,
+          "value": 3100000,
+          "yearly_wage": 520000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4451,7 +5635,11 @@
             "France"
           ],
           "number": "94",
-          "position": "Defensive Midfield"
+          "overall_score": 75,
+          "position": "Defensive Midfield",
+          "potential": 75,
+          "value": 3900000,
+          "yearly_wage": 780000
         },
         {
           "contract": "-",
@@ -4466,7 +5654,11 @@
             "DR Congo"
           ],
           "number": "78",
-          "position": "Defensive Midfield"
+          "overall_score": 63,
+          "position": "Defensive Midfield",
+          "potential": 76,
+          "value": 1100000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4481,7 +5673,11 @@
             "France"
           ],
           "number": "8",
-          "position": "Central Midfield"
+          "overall_score": 73,
+          "position": "Central Midfield",
+          "potential": 80,
+          "value": 6000000,
+          "yearly_wage": 572000
         },
         {
           "contract": "Jun 30, 2028",
@@ -4496,7 +5692,11 @@
             "France"
           ],
           "number": "14",
-          "position": "Central Midfield"
+          "overall_score": 71,
+          "position": "Central Midfield",
+          "potential": 76,
+          "value": 2800000,
+          "yearly_wage": 468000
         },
         {
           "contract": "Jun 30, 2029",
@@ -4511,7 +5711,11 @@
             "Cameroon"
           ],
           "number": "26",
-          "position": "Central Midfield"
+          "overall_score": 68,
+          "position": "Central Midfield",
+          "potential": 79,
+          "value": 2600000,
+          "yearly_wage": 312000
         },
         {
           "contract": "Jun 30, 2027",
@@ -4525,7 +5729,11 @@
             "France"
           ],
           "number": "24",
-          "position": "Central Midfield"
+          "overall_score": 61,
+          "position": "Central Midfield",
+          "potential": 76,
+          "value": 750000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4540,7 +5748,11 @@
             "France"
           ],
           "number": "17",
-          "position": "Attacking Midfield"
+          "overall_score": 74,
+          "position": "Attacking Midfield",
+          "potential": 74,
+          "value": 3500000,
+          "yearly_wage": 780000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4555,7 +5767,11 @@
             "Lebanon"
           ],
           "number": "30",
-          "position": "Attacking Midfield"
+          "overall_score": 71,
+          "position": "Attacking Midfield",
+          "potential": 77,
+          "value": 3000000,
+          "yearly_wage": 312000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4570,7 +5786,11 @@
             "Mauritania"
           ],
           "number": "45",
-          "position": "Left Winger"
+          "overall_score": 73,
+          "position": "Left Winger",
+          "potential": 76,
+          "value": 4200000,
+          "yearly_wage": 572000
         },
         {
           "contract": "Jun 30, 2027",
@@ -4585,7 +5805,11 @@
             "DR Congo"
           ],
           "number": "10",
-          "position": "Left Winger"
+          "overall_score": 67,
+          "position": "Left Winger",
+          "potential": 72,
+          "value": 1600000,
+          "yearly_wage": 312000
         },
         {
           "contract": "Jun 30, 2027",
@@ -4600,7 +5824,11 @@
             "Ghana"
           ],
           "number": "11",
-          "position": "Right Winger"
+          "overall_score": 68,
+          "position": "Right Winger",
+          "potential": 71,
+          "value": 1600000,
+          "yearly_wage": 364000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4614,7 +5842,11 @@
             "Tanzania"
           ],
           "number": "25",
-          "position": "Centre-Forward"
+          "overall_score": 71,
+          "position": "Centre-Forward",
+          "potential": 71,
+          "value": 1500000,
+          "yearly_wage": 624000
         },
         {
           "contract": "-",
@@ -4627,7 +5859,11 @@
             "Cameroon"
           ],
           "number": "20",
-          "position": "Centre-Forward"
+          "overall_score": 62,
+          "position": "Centre-Forward",
+          "potential": 74,
+          "value": 950000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4641,7 +5877,11 @@
             "France"
           ],
           "number": "34",
-          "position": "Centre-Forward"
+          "overall_score": 64,
+          "position": "Centre-Forward",
+          "potential": 76,
+          "value": 1400000,
+          "yearly_wage": 156000
         }
       ],
       "stadiumName": "Stade Océane",
@@ -4665,7 +5905,11 @@
             "DR Congo"
           ],
           "number": "16",
-          "position": "Goalkeeper"
+          "overall_score": 74,
+          "position": "Goalkeeper",
+          "potential": 82,
+          "value": 8000000,
+          "yearly_wage": 936000
         },
         {
           "contract": "Jun 30, 2028",
@@ -4679,7 +5923,11 @@
             "Germany"
           ],
           "number": "35",
-          "position": "Goalkeeper"
+          "overall_score": 79,
+          "position": "Goalkeeper",
+          "potential": 79,
+          "value": 3000000,
+          "yearly_wage": 1820000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4693,7 +5941,11 @@
             "France"
           ],
           "number": "1",
-          "position": "Goalkeeper"
+          "overall_score": 67,
+          "position": "Goalkeeper",
+          "potential": 67,
+          "value": 110000,
+          "yearly_wage": 364000
         },
         {
           "contract": "Jun 30, 2030",
@@ -4707,7 +5959,11 @@
             "Brazil"
           ],
           "number": "6",
-          "position": "Centre-Back"
+          "overall_score": 74,
+          "position": "Centre-Back",
+          "potential": 79,
+          "value": 6000000,
+          "yearly_wage": 1612000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4722,7 +5978,11 @@
             "Netherlands"
           ],
           "number": "42",
-          "position": "Centre-Back"
+          "overall_score": 74,
+          "position": "Centre-Back",
+          "potential": 80,
+          "value": 6000000,
+          "yearly_wage": 2236000
         },
         {
           "contract": "Jun 30, 2028",
@@ -4736,7 +5996,11 @@
             "Senegal"
           ],
           "number": "5",
-          "position": "Centre-Back"
+          "overall_score": 73,
+          "position": "Centre-Back",
+          "potential": 76,
+          "value": 3600000,
+          "yearly_wage": 1612000
         },
         {
           "contract": "-",
@@ -4751,7 +6015,11 @@
             "France"
           ],
           "number": "31",
-          "position": "Centre-Back"
+          "overall_score": 70,
+          "position": "Centre-Back",
+          "potential": 73,
+          "value": 1800000,
+          "yearly_wage": 1248000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4766,7 +6034,11 @@
             "Poland"
           ],
           "number": "15",
-          "position": "Centre-Back"
+          "overall_score": 69,
+          "position": "Centre-Back",
+          "potential": 69,
+          "value": 675000,
+          "yearly_wage": 1144000
         },
         {
           "contract": "Jun 30, 2030",
@@ -4781,7 +6053,11 @@
             "Congo"
           ],
           "number": "19",
-          "position": "Left-Back"
+          "overall_score": 70,
+          "position": "Left-Back",
+          "potential": 82,
+          "value": 3600000,
+          "yearly_wage": 832000
         },
         {
           "contract": "Jun 30, 2027",
@@ -4795,7 +6071,11 @@
             "Belgium"
           ],
           "number": "28",
-          "position": "Left-Back"
+          "overall_score": 71,
+          "position": "Left-Back",
+          "potential": 71,
+          "value": 1800000,
+          "yearly_wage": 1352000
         },
         {
           "contract": "Jun 30, 2027",
@@ -4809,7 +6089,11 @@
             "Finland"
           ],
           "number": "2",
-          "position": "Left-Back"
+          "overall_score": 68,
+          "position": "Left-Back",
+          "potential": 71,
+          "value": 1500000,
+          "yearly_wage": 936000
         },
         {
           "contract": "Jun 30, 2027",
@@ -4823,7 +6107,11 @@
             "Mali"
           ],
           "number": "14",
-          "position": "Right-Back"
+          "overall_score": 77,
+          "position": "Right-Back",
+          "potential": 77,
+          "value": 5500000,
+          "yearly_wage": 2340000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4838,7 +6126,11 @@
             "France"
           ],
           "number": "22",
-          "position": "Right-Back"
+          "overall_score": 65,
+          "position": "Right-Back",
+          "potential": 66,
+          "value": 775000,
+          "yearly_wage": 624000
         },
         {
           "contract": "Jun 30, 2027",
@@ -4853,7 +6145,11 @@
             "Algeria"
           ],
           "number": "21",
-          "position": "Defensive Midfield"
+          "overall_score": 76,
+          "position": "Defensive Midfield",
+          "potential": 76,
+          "value": 8000000,
+          "yearly_wage": 2184000
         },
         {
           "contract": "Jun 30, 2027",
@@ -4867,7 +6163,11 @@
             "France"
           ],
           "number": "33",
-          "position": "Defensive Midfield"
+          "overall_score": 77,
+          "position": "Defensive Midfield",
+          "potential": 77,
+          "value": 7000000,
+          "yearly_wage": 2340000
         },
         {
           "contract": "Jun 30, 2027",
@@ -4882,7 +6182,11 @@
             "Mali"
           ],
           "number": "17",
-          "position": "Defensive Midfield"
+          "overall_score": 71,
+          "position": "Defensive Midfield",
+          "potential": 71,
+          "value": 1900000,
+          "yearly_wage": 1508000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4896,7 +6200,11 @@
             "Zimbabwe"
           ],
           "number": "18",
-          "position": "Central Midfield"
+          "overall_score": 75,
+          "position": "Central Midfield",
+          "potential": 75,
+          "value": 5500000,
+          "yearly_wage": 2912000
         },
         {
           "contract": "-",
@@ -4911,7 +6219,11 @@
             "Congo"
           ],
           "number": "23",
-          "position": "Central Midfield"
+          "overall_score": 70,
+          "position": "Central Midfield",
+          "potential": 84,
+          "value": 3600000,
+          "yearly_wage": 676000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4925,7 +6237,11 @@
             "France"
           ],
           "number": "4",
-          "position": "Central Midfield"
+          "overall_score": 70,
+          "position": "Central Midfield",
+          "potential": 70,
+          "value": 1700000,
+          "yearly_wage": 1300000
         },
         {
           "contract": "Jun 30, 2028",
@@ -4939,7 +6255,11 @@
             "Nigeria"
           ],
           "number": "27",
-          "position": "Left Winger"
+          "overall_score": 76,
+          "position": "Left Winger",
+          "potential": 76,
+          "value": 7500000,
+          "yearly_wage": 2444000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4954,7 +6274,11 @@
             "Mali"
           ],
           "number": "7",
-          "position": "Left Winger"
+          "overall_score": 70,
+          "position": "Left Winger",
+          "potential": 70,
+          "value": 1600000,
+          "yearly_wage": 1352000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4969,7 +6293,11 @@
             "France"
           ],
           "number": "20",
-          "position": "Left Winger"
+          "overall_score": 67,
+          "position": "Left Winger",
+          "potential": 67,
+          "value": 625000,
+          "yearly_wage": 988000
         },
         {
           "contract": "Jun 30, 2028",
@@ -4984,7 +6312,11 @@
             "France"
           ],
           "number": "10",
-          "position": "Right Winger"
+          "overall_score": 77,
+          "position": "Right Winger",
+          "potential": 77,
+          "value": 11500000,
+          "yearly_wage": 2496000
         },
         {
           "contract": "Jun 30, 2027",
@@ -4999,7 +6331,11 @@
             "DR Congo"
           ],
           "number": "93",
-          "position": "Right Winger"
+          "overall_score": 75,
+          "position": "Right Winger",
+          "potential": 75,
+          "value": 6000000,
+          "yearly_wage": 2236000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5014,7 +6350,11 @@
             "United States"
           ],
           "number": "24",
-          "position": "Right Winger"
+          "overall_score": 72,
+          "position": "Right Winger",
+          "potential": 79,
+          "value": 4600000,
+          "yearly_wage": 1560000
         },
         {
           "contract": "Jun 30, 2027",
@@ -5028,7 +6368,11 @@
             "France"
           ],
           "number": "13",
-          "position": "Right Winger"
+          "overall_score": 72,
+          "position": "Right Winger",
+          "potential": 72,
+          "value": 2400000,
+          "yearly_wage": 1768000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5042,7 +6386,11 @@
             "Senegal"
           ],
           "number": "26",
-          "position": "Right Winger"
+          "overall_score": 64,
+          "position": "Right Winger",
+          "potential": 64,
+          "value": 625000,
+          "yearly_wage": 624000
         },
         {
           "contract": "Jun 30, 2030",
@@ -5057,7 +6405,11 @@
             "Netherlands"
           ],
           "number": "9",
-          "position": "Centre-Forward"
+          "overall_score": 72,
+          "position": "Centre-Forward",
+          "potential": 77,
+          "value": 3600000,
+          "yearly_wage": 1508000
         },
         {
           "contract": "Jun 30, 2027",
@@ -5072,7 +6424,11 @@
             "France"
           ],
           "number": "11",
-          "position": "Centre-Forward"
+          "overall_score": 73,
+          "position": "Centre-Forward",
+          "potential": 73,
+          "value": 3300000,
+          "yearly_wage": 1872000
         },
         {
           "contract": "Jun 30, 2027",
@@ -5086,7 +6442,11 @@
             "Italy"
           ],
           "number": "36",
-          "position": "Centre-Forward"
+          "overall_score": 77,
+          "position": "Centre-Forward",
+          "potential": 77,
+          "value": 4500000,
+          "yearly_wage": 2028000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5100,7 +6460,11 @@
             "France"
           ],
           "number": "29",
-          "position": "Centre-Forward"
+          "overall_score": 67,
+          "position": "Centre-Forward",
+          "potential": 67,
+          "value": 850000,
+          "yearly_wage": 988000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5139,7 +6503,11 @@
             "Cote d'Ivoire"
           ],
           "number": "12",
-          "position": "Goalkeeper"
+          "overall_score": 78,
+          "position": "Goalkeeper",
+          "potential": 80,
+          "value": 12000000,
+          "yearly_wage": 988000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5153,7 +6521,11 @@
             "France"
           ],
           "number": "16",
-          "position": "Goalkeeper"
+          "overall_score": 65,
+          "position": "Goalkeeper",
+          "potential": 73,
+          "value": 1400000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2027",
@@ -5168,7 +6540,11 @@
             "France"
           ],
           "number": "40",
-          "position": "Goalkeeper"
+          "overall_score": 59,
+          "position": "Goalkeeper",
+          "potential": 72,
+          "value": 475000,
+          "yearly_wage": 39000
         },
         {
           "contract": "Jun 30, 2029",
@@ -5183,7 +6559,11 @@
             "France"
           ],
           "number": "4",
-          "position": "Centre-Back"
+          "overall_score": 73,
+          "position": "Centre-Back",
+          "potential": 78,
+          "value": 4200000,
+          "yearly_wage": 520000
         },
         {
           "contract": "Jun 30, 2028",
@@ -5198,7 +6578,11 @@
             "Cameroon"
           ],
           "number": "24",
-          "position": "Centre-Back"
+          "overall_score": 70,
+          "position": "Centre-Back",
+          "potential": 77,
+          "value": 2900000,
+          "yearly_wage": 364000
         },
         {
           "contract": "Jun 30, 2029",
@@ -5212,7 +6596,11 @@
             "France"
           ],
           "number": "21",
-          "position": "Centre-Back"
+          "overall_score": 75,
+          "position": "Centre-Back",
+          "potential": 75,
+          "value": 3800000,
+          "yearly_wage": 780000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5227,7 +6615,11 @@
             "Italy"
           ],
           "number": "25",
-          "position": "Centre-Back"
+          "overall_score": 68,
+          "position": "Centre-Back",
+          "potential": 68,
+          "value": 325000,
+          "yearly_wage": 312000
         },
         {
           "contract": "Jun 30, 2027",
@@ -5242,7 +6634,11 @@
             "France"
           ],
           "number": "3",
-          "position": "Left-Back"
+          "overall_score": 72,
+          "position": "Left-Back",
+          "potential": 79,
+          "value": 4500000,
+          "yearly_wage": 416000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5256,7 +6652,11 @@
             "France"
           ],
           "number": "26",
-          "position": "Left-Back"
+          "overall_score": 71,
+          "position": "Left-Back",
+          "potential": 71,
+          "value": 575000,
+          "yearly_wage": 416000
         },
         {
           "contract": "Jun 30, 2029",
@@ -5270,7 +6670,11 @@
             "France"
           ],
           "number": "23",
-          "position": "Left-Back"
+          "overall_score": 57,
+          "position": "Left-Back",
+          "potential": 71,
+          "value": 375000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5284,7 +6688,11 @@
             "Haiti"
           ],
           "number": "2",
-          "position": "Right-Back"
+          "overall_score": 72,
+          "position": "Right-Back",
+          "potential": 72,
+          "value": 2100000,
+          "yearly_wage": 572000
         },
         {
           "contract": "Jun 30, 2028",
@@ -5299,7 +6707,11 @@
             "Madagascar"
           ],
           "number": "27",
-          "position": "Right-Back"
+          "overall_score": 71,
+          "position": "Right-Back",
+          "potential": 75,
+          "value": 2400000,
+          "yearly_wage": 468000
         },
         {
           "contract": "Jun 30, 2028",
@@ -5313,7 +6725,11 @@
             "France"
           ],
           "number": "20",
-          "position": "Right-Back"
+          "overall_score": 62,
+          "position": "Right-Back",
+          "potential": 76,
+          "value": 875000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5327,7 +6743,11 @@
             "France"
           ],
           "number": "5",
-          "position": "Defensive Midfield"
+          "overall_score": 67,
+          "position": "Defensive Midfield",
+          "potential": 81,
+          "value": 2200000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2028",
@@ -5342,7 +6762,11 @@
             "France"
           ],
           "number": "14",
-          "position": "Central Midfield"
+          "overall_score": 72,
+          "position": "Central Midfield",
+          "potential": 79,
+          "value": 4700000,
+          "yearly_wage": 520000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5356,7 +6780,11 @@
             "Netherlands"
           ],
           "number": "8",
-          "position": "Central Midfield"
+          "overall_score": 72,
+          "position": "Central Midfield",
+          "potential": 72,
+          "value": 2300000,
+          "yearly_wage": 728000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5371,7 +6799,11 @@
             "France"
           ],
           "number": "93",
-          "position": "Central Midfield"
+          "overall_score": 75,
+          "position": "Central Midfield",
+          "potential": 75,
+          "value": 3900000,
+          "yearly_wage": 780000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5385,7 +6817,11 @@
             "France"
           ],
           "number": "15",
-          "position": "Central Midfield"
+          "overall_score": 68,
+          "position": "Central Midfield",
+          "potential": 68,
+          "value": 240000,
+          "yearly_wage": 312000
         },
         {
           "contract": "Jun 30, 2028",
@@ -5399,7 +6835,11 @@
             "France"
           ],
           "number": "6",
-          "position": "Attacking Midfield"
+          "overall_score": 72,
+          "position": "Attacking Midfield",
+          "potential": 79,
+          "value": 4700000,
+          "yearly_wage": 520000
         },
         {
           "contract": "Jun 30, 2027",
@@ -5414,7 +6854,11 @@
             "France"
           ],
           "number": "7",
-          "position": "Left Winger"
+          "overall_score": 72,
+          "position": "Left Winger",
+          "potential": 74,
+          "value": 3000000,
+          "yearly_wage": 520000
         },
         {
           "contract": "Jun 30, 2029",
@@ -5428,7 +6872,11 @@
             "Cameroon"
           ],
           "number": "31",
-          "position": "Right Winger"
+          "overall_score": 67,
+          "position": "Right Winger",
+          "potential": 78,
+          "value": 2100000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2027",
@@ -5443,7 +6891,11 @@
             "Nigeria"
           ],
           "number": "35",
-          "position": "Centre-Forward"
+          "overall_score": 69,
+          "position": "Centre-Forward",
+          "potential": 79,
+          "value": 2900000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5458,7 +6910,11 @@
             "France"
           ],
           "number": "9",
-          "position": "Centre-Forward"
+          "overall_score": 72,
+          "position": "Centre-Forward",
+          "potential": 75,
+          "value": 3100000,
+          "yearly_wage": 988000
         },
         {
           "contract": "-",
@@ -5473,7 +6929,11 @@
             "French Guiana"
           ],
           "number": "36",
-          "position": "Centre-Forward"
+          "overall_score": 61,
+          "position": "Centre-Forward",
+          "potential": 71,
+          "value": 725000,
+          "yearly_wage": 104000
         }
       ],
       "stadiumName": "Stade Raymond-Kopa",
@@ -5497,7 +6957,11 @@
             "France"
           ],
           "number": "16",
-          "position": "Goalkeeper"
+          "overall_score": 76,
+          "position": "Goalkeeper",
+          "potential": 76,
+          "value": 3700000,
+          "yearly_wage": 780000
         },
         {
           "contract": "Jun 30, 2028",
@@ -5512,7 +6976,11 @@
             "Martinique"
           ],
           "number": "40",
-          "position": "Goalkeeper"
+          "overall_score": 68,
+          "position": "Goalkeeper",
+          "potential": 74,
+          "value": 1500000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5526,7 +6994,11 @@
             "France"
           ],
           "number": "30",
-          "position": "Goalkeeper"
+          "overall_score": 59,
+          "position": "Goalkeeper",
+          "potential": 69,
+          "value": 450000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2028",
@@ -5538,7 +7010,11 @@
             "France"
           ],
           "number": "37",
-          "position": "Goalkeeper"
+          "overall_score": 58,
+          "position": "Goalkeeper",
+          "potential": 74,
+          "value": 450000,
+          "yearly_wage": 49400
         },
         {
           "contract": "Jun 30, 2028",
@@ -5553,7 +7029,11 @@
             "France"
           ],
           "number": "92",
-          "position": "Centre-Back"
+          "overall_score": 74,
+          "position": "Centre-Back",
+          "potential": 80,
+          "value": 6000000,
+          "yearly_wage": 884000
         },
         {
           "contract": "Jun 30, 2027",
@@ -5567,7 +7047,11 @@
             "Cote d'Ivoire"
           ],
           "number": "20",
-          "position": "Centre-Back"
+          "overall_score": 73,
+          "position": "Centre-Back",
+          "potential": 77,
+          "value": 3900000,
+          "yearly_wage": 832000
         },
         {
           "contract": "Jun 30, 2029",
@@ -5582,7 +7066,11 @@
             "Spain"
           ],
           "number": "4",
-          "position": "Centre-Back"
+          "overall_score": 70,
+          "position": "Centre-Back",
+          "potential": 70,
+          "value": 1400000,
+          "yearly_wage": 728000
         },
         {
           "contract": "Jun 30, 2029",
@@ -5597,7 +7085,11 @@
             "United States"
           ],
           "number": "24",
-          "position": "Centre-Back"
+          "overall_score": 71,
+          "position": "Centre-Back",
+          "potential": 79,
+          "value": 3900000,
+          "yearly_wage": 676000
         },
         {
           "contract": "Jun 30, 2029",
@@ -5611,7 +7103,11 @@
             "Cameroon"
           ],
           "number": "13",
-          "position": "Centre-Back"
+          "overall_score": 63,
+          "position": "Centre-Back",
+          "potential": 78,
+          "value": 1100000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2028",
@@ -5624,7 +7120,11 @@
             "DR Congo"
           ],
           "number": "35",
-          "position": "Centre-Back"
+          "overall_score": 59,
+          "position": "Centre-Back",
+          "potential": 74,
+          "value": 475000,
+          "yearly_wage": 104000
         },
         {
           "contract": "-",
@@ -5652,7 +7152,11 @@
             "Ghana"
           ],
           "number": "14",
-          "position": "Left-Back"
+          "overall_score": 74,
+          "position": "Left-Back",
+          "potential": 75,
+          "value": 4500000,
+          "yearly_wage": 1040000
         },
         {
           "contract": "Jun 30, 2028",
@@ -5666,7 +7170,11 @@
             "Norway"
           ],
           "number": "22",
-          "position": "Left-Back"
+          "overall_score": 68,
+          "position": "Left-Back",
+          "potential": 77,
+          "value": 2600000,
+          "yearly_wage": 468000
         },
         {
           "contract": "Jun 30, 2029",
@@ -5681,7 +7189,11 @@
             "Togo"
           ],
           "number": "29",
-          "position": "Right-Back"
+          "overall_score": 70,
+          "position": "Right-Back",
+          "potential": 75,
+          "value": 2200000,
+          "yearly_wage": 572000
         },
         {
           "contract": "Jun 30, 2029",
@@ -5696,7 +7208,11 @@
             "Senegal"
           ],
           "number": "27",
-          "position": "Right-Back"
+          "overall_score": 68,
+          "position": "Right-Back",
+          "potential": 77,
+          "value": 2600000,
+          "yearly_wage": 468000
         },
         {
           "contract": "Jun 30, 2027",
@@ -5711,7 +7227,11 @@
             "France"
           ],
           "number": "42",
-          "position": "Defensive Midfield"
+          "overall_score": 73,
+          "position": "Defensive Midfield",
+          "potential": 74,
+          "value": 3100000,
+          "yearly_wage": 936000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5726,7 +7246,11 @@
             "Netherlands"
           ],
           "number": "17",
-          "position": "Defensive Midfield"
+          "overall_score": 70,
+          "position": "Defensive Midfield",
+          "potential": 75,
+          "value": 2200000,
+          "yearly_wage": 1040000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5740,7 +7264,11 @@
             "Senegal"
           ],
           "number": "18",
-          "position": "Defensive Midfield"
+          "overall_score": 69,
+          "position": "Defensive Midfield",
+          "potential": 70,
+          "value": 1400000,
+          "yearly_wage": 624000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5754,7 +7282,11 @@
             "France",
             "DR Congo"
           ],
-          "position": "Defensive Midfield"
+          "overall_score": 62,
+          "position": "Defensive Midfield",
+          "potential": 73,
+          "value": 900000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2029",
@@ -5769,7 +7301,11 @@
             "Guadeloupe"
           ],
           "number": "5",
-          "position": "Central Midfield"
+          "overall_score": 75,
+          "position": "Central Midfield",
+          "potential": 83,
+          "value": 12500000,
+          "yearly_wage": 884000
         },
         {
           "contract": "Jun 30, 2027",
@@ -5784,7 +7320,11 @@
             "Comoros"
           ],
           "number": "8",
-          "position": "Central Midfield"
+          "overall_score": 68,
+          "position": "Central Midfield",
+          "potential": 74,
+          "value": 1900000,
+          "yearly_wage": 520000
         },
         {
           "contract": "Jun 30, 2028",
@@ -5799,7 +7339,11 @@
             "Senegal"
           ],
           "number": "36",
-          "position": "Central Midfield"
+          "overall_score": 58,
+          "position": "Central Midfield",
+          "potential": 75,
+          "value": 500000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5814,7 +7358,11 @@
             "Algeria"
           ],
           "number": "28",
-          "position": "Attacking Midfield"
+          "overall_score": 76,
+          "position": "Attacking Midfield",
+          "potential": 76,
+          "value": 8000000,
+          "yearly_wage": 3120000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5829,7 +7377,11 @@
             "England"
           ],
           "number": "19",
-          "position": "Left Winger"
+          "overall_score": 73,
+          "position": "Left Winger",
+          "potential": 76,
+          "value": 4200000,
+          "yearly_wage": 520000
         },
         {
           "contract": "Jun 30, 2028",
@@ -5844,7 +7396,11 @@
             "Guadeloupe"
           ],
           "number": "7",
-          "position": "Right Winger"
+          "overall_score": 71,
+          "position": "Right Winger",
+          "potential": 76,
+          "value": 2800000,
+          "yearly_wage": 676000
         },
         {
           "contract": "Jun 30, 2028",
@@ -5858,7 +7414,11 @@
             "Cote d'Ivoire"
           ],
           "number": "21",
-          "position": "Right Winger"
+          "overall_score": 68,
+          "position": "Right Winger",
+          "potential": 76,
+          "value": 2700000,
+          "yearly_wage": 520000
         },
         {
           "contract": "Jun 30, 2027",
@@ -5873,7 +7433,11 @@
             "France"
           ],
           "number": "10",
-          "position": "Centre-Forward"
+          "overall_score": 75,
+          "position": "Centre-Forward",
+          "potential": 78,
+          "value": 7500000,
+          "yearly_wage": 1196000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5888,7 +7452,11 @@
             "Senegal"
           ],
           "number": "9",
-          "position": "Centre-Forward"
+          "overall_score": 70,
+          "position": "Centre-Forward",
+          "potential": 77,
+          "value": 3300000,
+          "yearly_wage": 1300000
         },
         {
           "contract": "Jun 30, 2028",
@@ -5903,7 +7471,11 @@
             "Martinique"
           ],
           "number": "31",
-          "position": "Centre-Forward"
+          "overall_score": 59,
+          "position": "Centre-Forward",
+          "potential": 71,
+          "value": 550000,
+          "yearly_wage": 156000
         }
       ],
       "stadiumName": "Stade de l'Abbé-Deschamps",
@@ -5927,7 +7499,11 @@
             "Germany"
           ],
           "number": "16",
-          "position": "Goalkeeper"
+          "overall_score": 77,
+          "position": "Goalkeeper",
+          "potential": 80,
+          "value": 10500000,
+          "yearly_wage": 988000
         },
         {
           "contract": "Jun 30, 2027",
@@ -5942,7 +7518,11 @@
             "Slovakia"
           ],
           "number": "1",
-          "position": "Goalkeeper"
+          "overall_score": 80,
+          "position": "Goalkeeper",
+          "potential": 80,
+          "value": 2300000,
+          "yearly_wage": 780000
         },
         {
           "contract": "Jun 30, 2029",
@@ -5957,7 +7537,11 @@
             "Poland"
           ],
           "number": "40",
-          "position": "Goalkeeper"
+          "overall_score": 60,
+          "position": "Goalkeeper",
+          "potential": 77,
+          "value": 550000,
+          "yearly_wage": 52000
         },
         {
           "contract": "Jun 30, 2027",
@@ -5971,7 +7555,11 @@
             "France"
           ],
           "number": "50",
-          "position": "Goalkeeper"
+          "overall_score": 65,
+          "position": "Goalkeeper",
+          "potential": 75,
+          "value": 1400000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2028",
@@ -5986,7 +7574,11 @@
             "Burundi"
           ],
           "number": "5",
-          "position": "Centre-Back"
+          "overall_score": 78,
+          "position": "Centre-Back",
+          "potential": 79,
+          "value": 13500000,
+          "yearly_wage": 1716000
         },
         {
           "contract": "Jun 30, 2029",
@@ -6001,7 +7593,11 @@
             "DR Congo"
           ],
           "number": "13",
-          "position": "Centre-Back"
+          "overall_score": 75,
+          "position": "Centre-Back",
+          "potential": 84,
+          "value": 11500000,
+          "yearly_wage": 988000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6015,7 +7611,11 @@
             "Belgium"
           ],
           "number": "25",
-          "position": "Centre-Back"
+          "overall_score": 74,
+          "position": "Centre-Back",
+          "potential": 75,
+          "value": 4200000,
+          "yearly_wage": 1820000
         },
         {
           "contract": "Jun 30, 2028",
@@ -6029,7 +7629,11 @@
             "Ghana"
           ],
           "number": "22",
-          "position": "Centre-Back"
+          "overall_score": 77,
+          "position": "Centre-Back",
+          "potential": 80,
+          "value": 12000000,
+          "yearly_wage": 1560000
         },
         {
           "contract": "Jun 30, 2028",
@@ -6044,7 +7648,11 @@
             "Portugal"
           ],
           "number": "3",
-          "position": "Centre-Back"
+          "overall_score": 78,
+          "position": "Centre-Back",
+          "potential": 78,
+          "value": 9500000,
+          "yearly_wage": 1716000
         },
         {
           "contract": "Jun 30, 2027",
@@ -6059,7 +7667,11 @@
             "Spain"
           ],
           "number": "12",
-          "position": "Left-Back"
+          "overall_score": 77,
+          "position": "Left-Back",
+          "potential": 77,
+          "value": 10000000,
+          "yearly_wage": 1560000
         },
         {
           "contract": "Jun 30, 2028",
@@ -6074,7 +7686,11 @@
             "Cote d'Ivoire"
           ],
           "number": "20",
-          "position": "Left-Back"
+          "overall_score": 72,
+          "position": "Left-Back",
+          "potential": 80,
+          "value": 4900000,
+          "yearly_wage": 780000
         },
         {
           "contract": "Jun 30, 2028",
@@ -6088,7 +7704,11 @@
             "Brazil"
           ],
           "number": "2",
-          "position": "Right-Back"
+          "overall_score": 77,
+          "position": "Right-Back",
+          "potential": 83,
+          "value": 15500000,
+          "yearly_wage": 1352000
         },
         {
           "contract": "Jun 30, 2029",
@@ -6103,7 +7723,11 @@
             "DR Congo"
           ],
           "number": "4",
-          "position": "Right-Back"
+          "overall_score": 78,
+          "position": "Right-Back",
+          "potential": 81,
+          "value": 17000000,
+          "yearly_wage": 1560000
         },
         {
           "contract": "Jun 30, 2028",
@@ -6118,7 +7742,11 @@
             "DR Congo"
           ],
           "number": "6",
-          "position": "Defensive Midfield"
+          "overall_score": 81,
+          "position": "Defensive Midfield",
+          "potential": 81,
+          "value": 22500000,
+          "yearly_wage": 2184000
         },
         {
           "contract": "Jun 30, 2030",
@@ -6133,7 +7761,11 @@
             "Guinea"
           ],
           "number": "23",
-          "position": "Defensive Midfield"
+          "overall_score": 70,
+          "position": "Defensive Midfield",
+          "potential": 83,
+          "value": 3700000,
+          "yearly_wage": 572000
         },
         {
           "contract": "Jun 30, 2029",
@@ -6147,7 +7779,11 @@
             "Senegal"
           ],
           "number": "15",
-          "position": "Central Midfield"
+          "overall_score": 79,
+          "position": "Central Midfield",
+          "potential": 85,
+          "value": 28000000,
+          "yearly_wage": 1404000
         },
         {
           "contract": "Jun 30, 2028",
@@ -6162,7 +7798,11 @@
             "Mali"
           ],
           "number": "28",
-          "position": "Central Midfield"
+          "overall_score": 71,
+          "position": "Central Midfield",
+          "potential": 82,
+          "value": 4200000,
+          "yearly_wage": 728000
         },
         {
           "contract": "Jun 30, 2027",
@@ -6177,7 +7817,11 @@
             "Guinea"
           ],
           "number": "8",
-          "position": "Central Midfield"
+          "overall_score": 77,
+          "position": "Central Midfield",
+          "potential": 77,
+          "value": 8500000,
+          "yearly_wage": 1716000
         },
         {
           "contract": "Jun 30, 2029",
@@ -6191,7 +7835,11 @@
             "Russia"
           ],
           "number": "10",
-          "position": "Attacking Midfield"
+          "overall_score": 79,
+          "position": "Attacking Midfield",
+          "potential": 79,
+          "value": 17000000,
+          "yearly_wage": 2028000
         },
         {
           "contract": "Jun 30, 2030",
@@ -6206,7 +7854,11 @@
             "DR Congo"
           ],
           "number": "17",
-          "position": "Attacking Midfield"
+          "overall_score": 68,
+          "position": "Attacking Midfield",
+          "potential": 80,
+          "value": 2900000,
+          "yearly_wage": 520000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6220,7 +7872,11 @@
             "Cote d'Ivoire"
           ],
           "number": "24",
-          "position": "Left Winger"
+          "overall_score": 76,
+          "position": "Left Winger",
+          "potential": 82,
+          "value": 12000000,
+          "yearly_wage": 2496000
         },
         {
           "contract": "Jun 30, 2027",
@@ -6234,7 +7890,11 @@
             "Japan"
           ],
           "number": "18",
-          "position": "Left Winger"
+          "overall_score": 78,
+          "position": "Left Winger",
+          "potential": 78,
+          "value": 13500000,
+          "yearly_wage": 1820000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6249,7 +7909,11 @@
             "Guinea-Bissau"
           ],
           "number": "31",
-          "position": "Left Winger"
+          "overall_score": 75,
+          "position": "Left Winger",
+          "potential": 81,
+          "value": 9000000,
+          "yearly_wage": 2912000
         },
         {
           "contract": "Jun 30, 2028",
@@ -6264,7 +7928,11 @@
             "Algeria"
           ],
           "number": "11",
-          "position": "Right Winger"
+          "overall_score": 80,
+          "position": "Right Winger",
+          "potential": 86,
+          "value": 33500000,
+          "yearly_wage": 1820000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6278,7 +7946,11 @@
             "Senegal"
           ],
           "number": "27",
-          "position": "Right Winger"
+          "overall_score": 74,
+          "position": "Right Winger",
+          "potential": 74,
+          "value": 4600000,
+          "yearly_wage": 1352000
         },
         {
           "contract": "Jun 30, 2028",
@@ -6293,7 +7965,11 @@
             "England"
           ],
           "number": "9",
-          "position": "Centre-Forward"
+          "overall_score": 79,
+          "position": "Centre-Forward",
+          "potential": 83,
+          "value": 25500000,
+          "yearly_wage": 1820000
         },
         {
           "contract": "Jun 30, 2030",
@@ -6308,7 +7984,11 @@
             "England"
           ],
           "number": "14",
-          "position": "Centre-Forward"
+          "overall_score": 77,
+          "position": "Centre-Forward",
+          "potential": 84,
+          "value": 21500000,
+          "yearly_wage": 1560000
         },
         {
           "contract": "Jun 30, 2028",
@@ -6323,7 +8003,11 @@
             "DR Congo"
           ],
           "number": "29",
-          "position": "Centre-Forward"
+          "overall_score": 66,
+          "position": "Centre-Forward",
+          "potential": 79,
+          "value": 2000000,
+          "yearly_wage": 416000
         }
       ],
       "stadiumName": "Stade Louis-II",
@@ -6347,7 +8031,11 @@
             "Cameroon"
           ],
           "number": "38",
-          "position": "Goalkeeper"
+          "overall_score": 76,
+          "position": "Goalkeeper",
+          "potential": 76,
+          "value": 4000000,
+          "yearly_wage": 676000
         },
         {
           "contract": "Jun 30, 2027",
@@ -6362,7 +8050,11 @@
             "France"
           ],
           "number": "21",
-          "position": "Goalkeeper"
+          "overall_score": 70,
+          "position": "Goalkeeper",
+          "potential": 71,
+          "value": 1300000,
+          "yearly_wage": 416000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6376,7 +8068,11 @@
             "France"
           ],
           "number": "1",
-          "position": "Goalkeeper"
+          "overall_score": 68,
+          "position": "Goalkeeper",
+          "potential": 68,
+          "value": 130000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2027",
@@ -6391,7 +8087,11 @@
             "France"
           ],
           "number": "3",
-          "position": "Centre-Back"
+          "overall_score": 75,
+          "position": "Centre-Back",
+          "potential": 77,
+          "value": 6000000,
+          "yearly_wage": 936000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6406,7 +8106,11 @@
             "France"
           ],
           "number": "5",
-          "position": "Centre-Back"
+          "overall_score": 75,
+          "position": "Centre-Back",
+          "potential": 79,
+          "value": 7000000,
+          "yearly_wage": 1456000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6420,7 +8124,11 @@
             "Senegal"
           ],
           "number": "25",
-          "position": "Centre-Back"
+          "overall_score": 69,
+          "position": "Centre-Back",
+          "potential": 81,
+          "value": 3200000,
+          "yearly_wage": 1092000
         },
         {
           "contract": "Jun 30, 2028",
@@ -6435,7 +8143,11 @@
             "Cote d'Ivoire"
           ],
           "number": "95",
-          "position": "Centre-Back"
+          "overall_score": 71,
+          "position": "Centre-Back",
+          "potential": 79,
+          "value": 3900000,
+          "yearly_wage": 572000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6449,7 +8161,11 @@
             "Ghana"
           ],
           "number": "32",
-          "position": "Centre-Back"
+          "overall_score": 69,
+          "position": "Centre-Back",
+          "potential": 78,
+          "value": 2900000,
+          "yearly_wage": 416000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6463,7 +8179,11 @@
             "Cameroon"
           ],
           "number": "44",
-          "position": "Left-Back"
+          "overall_score": 71,
+          "position": "Left-Back",
+          "potential": 75,
+          "value": 2500000,
+          "yearly_wage": 572000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6477,7 +8197,11 @@
             "Brazil"
           ],
           "number": "2",
-          "position": "Right-Back"
+          "overall_score": 71,
+          "position": "Right-Back",
+          "potential": 71,
+          "value": 1700000,
+          "yearly_wage": 676000
         },
         {
           "contract": "Jun 30, 2029",
@@ -6491,7 +8215,11 @@
             "France"
           ],
           "number": "6",
-          "position": "Defensive Midfield"
+          "overall_score": 76,
+          "position": "Defensive Midfield",
+          "potential": 76,
+          "value": 5000000,
+          "yearly_wage": 1040000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6505,7 +8233,11 @@
             "Cameroon"
           ],
           "number": "62",
-          "position": "Central Midfield"
+          "overall_score": 74,
+          "position": "Central Midfield",
+          "potential": 82,
+          "value": 9000000,
+          "yearly_wage": 676000
         },
         {
           "contract": "Jun 30, 2029",
@@ -6520,7 +8252,11 @@
             "France"
           ],
           "number": "8",
-          "position": "Central Midfield"
+          "overall_score": 71,
+          "position": "Central Midfield",
+          "potential": 74,
+          "value": 2200000,
+          "yearly_wage": 624000
         },
         {
           "contract": "Jun 30, 2027",
@@ -6534,7 +8270,11 @@
             "France"
           ],
           "number": "11",
-          "position": "Right Midfield"
+          "overall_score": 73,
+          "position": "Right Midfield",
+          "potential": 80,
+          "value": 6000000,
+          "yearly_wage": 728000
         },
         {
           "contract": "Jun 30, 2028",
@@ -6548,7 +8288,11 @@
             "Greece"
           ],
           "number": "77",
-          "position": "Right Midfield"
+          "overall_score": 70,
+          "position": "Right Midfield",
+          "potential": 75,
+          "value": 2400000,
+          "yearly_wage": 520000
         },
         {
           "contract": "Jun 30, 2029",
@@ -6563,7 +8307,11 @@
             "Cote d'Ivoire"
           ],
           "number": "43",
-          "position": "Left Midfield"
+          "overall_score": 74,
+          "position": "Left Midfield",
+          "potential": 82,
+          "value": 9000000,
+          "yearly_wage": 624000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6577,7 +8325,11 @@
             "Togo"
           ],
           "number": "29",
-          "position": "Attacking Midfield"
+          "overall_score": 70,
+          "position": "Attacking Midfield",
+          "potential": 80,
+          "value": 3600000,
+          "yearly_wage": 468000
         },
         {
           "contract": "Jun 30, 2027",
@@ -6592,7 +8344,11 @@
             "DR Congo"
           ],
           "number": "17",
-          "position": "Attacking Midfield"
+          "overall_score": 72,
+          "position": "Attacking Midfield",
+          "potential": 73,
+          "value": 2700000,
+          "yearly_wage": 780000
         },
         {
           "contract": "Jun 30, 2028",
@@ -6607,7 +8363,11 @@
             "Mali"
           ],
           "number": "7",
-          "position": "Attacking Midfield"
+          "overall_score": 63,
+          "position": "Attacking Midfield",
+          "potential": 68,
+          "value": 725000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2027",
@@ -6621,7 +8381,11 @@
             "France"
           ],
           "number": "10",
-          "position": "Left Winger"
+          "overall_score": 73,
+          "position": "Left Winger",
+          "potential": 81,
+          "value": 7000000,
+          "yearly_wage": 728000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6636,7 +8400,11 @@
             "Nigeria"
           ],
           "number": "14",
-          "position": "Left Winger"
+          "overall_score": 61,
+          "position": "Left Winger",
+          "potential": 82,
+          "value": 1000000,
+          "yearly_wage": 624000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6650,7 +8418,11 @@
             "Senegal"
           ],
           "number": "28",
-          "position": "Centre-Forward"
+          "overall_score": 72,
+          "position": "Centre-Forward",
+          "potential": 77,
+          "value": 3600000,
+          "yearly_wage": 728000
         },
         {
           "contract": "Jun 30, 2028",
@@ -6665,7 +8437,11 @@
             "Guinea"
           ],
           "number": "9",
-          "position": "Centre-Forward"
+          "overall_score": 70,
+          "position": "Centre-Forward",
+          "potential": 75,
+          "value": 2400000,
+          "yearly_wage": 572000
         },
         {
           "contract": "Jun 30, 2027",
@@ -6680,7 +8456,11 @@
             "Nigeria"
           ],
           "number": "15",
-          "position": "Centre-Forward"
+          "overall_score": 72,
+          "position": "Centre-Forward",
+          "potential": 73,
+          "value": 2700000,
+          "yearly_wage": 832000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6694,7 +8474,11 @@
             "Senegal"
           ],
           "number": "12",
-          "position": "Centre-Forward"
+          "overall_score": 74,
+          "position": "Centre-Forward",
+          "potential": 77,
+          "value": 5500000,
+          "yearly_wage": 936000
         }
       ],
       "stadiumName": "Stade du Moustoir",
@@ -6717,7 +8501,11 @@
             "Poland"
           ],
           "number": "1",
-          "position": "Goalkeeper"
+          "overall_score": 75,
+          "position": "Goalkeeper",
+          "potential": 78,
+          "value": 6000000,
+          "yearly_wage": 832000
         },
         {
           "contract": "Jun 30, 2027",
@@ -6731,7 +8519,11 @@
             "France"
           ],
           "number": "30",
-          "position": "Goalkeeper"
+          "overall_score": 75,
+          "position": "Goalkeeper",
+          "potential": 77,
+          "value": 5500000,
+          "yearly_wage": 728000
         },
         {
           "contract": "Jun 30, 2027",
@@ -6744,7 +8536,11 @@
             "Ireland"
           ],
           "number": "50",
-          "position": "Goalkeeper"
+          "overall_score": 58,
+          "position": "Goalkeeper",
+          "potential": 71,
+          "value": 425000,
+          "yearly_wage": 52000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6759,7 +8555,11 @@
             "Mali"
           ],
           "number": "44",
-          "position": "Centre-Back"
+          "overall_score": 72,
+          "position": "Centre-Back",
+          "potential": 80,
+          "value": 4900000,
+          "yearly_wage": 1196000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6774,7 +8574,11 @@
             "France"
           ],
           "number": "4",
-          "position": "Centre-Back"
+          "overall_score": 72,
+          "position": "Centre-Back",
+          "potential": 80,
+          "value": 4900000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2027",
@@ -6788,7 +8592,11 @@
             "France"
           ],
           "number": "5",
-          "position": "Centre-Back"
+          "overall_score": 77,
+          "position": "Centre-Back",
+          "potential": 77,
+          "value": 8500000,
+          "yearly_wage": 1300000
         },
         {
           "contract": "Jun 30, 2029",
@@ -6802,7 +8610,11 @@
             "France"
           ],
           "number": "71",
-          "position": "Centre-Back"
+          "overall_score": 64,
+          "position": "Centre-Back",
+          "potential": 76,
+          "value": 1300000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2027",
@@ -6817,7 +8629,11 @@
             "Congo"
           ],
           "number": "2",
-          "position": "Left-Back"
+          "overall_score": 75,
+          "position": "Left-Back",
+          "potential": 80,
+          "value": 8000000,
+          "yearly_wage": 936000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6831,7 +8647,11 @@
             "Mali"
           ],
           "number": "27",
-          "position": "Left-Back"
+          "overall_score": 70,
+          "position": "Left-Back",
+          "potential": 75,
+          "value": 2300000,
+          "yearly_wage": 572000
         },
         {
           "contract": "Jun 30, 2029",
@@ -6845,7 +8665,11 @@
             "Cote d'Ivoire"
           ],
           "number": "12",
-          "position": "Right-Back"
+          "overall_score": 68,
+          "position": "Right-Back",
+          "potential": 78,
+          "value": 2500000,
+          "yearly_wage": 416000
         },
         {
           "contract": "Jun 30, 2027",
@@ -6860,7 +8684,11 @@
             "Martinique"
           ],
           "number": "77",
-          "position": "Right-Back"
+          "overall_score": 76,
+          "position": "Right-Back",
+          "potential": 76,
+          "value": 3900000,
+          "yearly_wage": 1196000
         },
         {
           "contract": "Jun 30, 2029",
@@ -6874,7 +8702,11 @@
             "France"
           ],
           "number": "13",
-          "position": "Defensive Midfield"
+          "overall_score": 74,
+          "position": "Defensive Midfield",
+          "potential": 78,
+          "value": 5500000,
+          "yearly_wage": 884000
         },
         {
           "contract": "Jun 30, 2029",
@@ -6888,7 +8720,11 @@
             "Mali"
           ],
           "number": "33",
-          "position": "Defensive Midfield"
+          "overall_score": 64,
+          "position": "Defensive Midfield",
+          "potential": 81,
+          "value": 1400000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2027",
@@ -6902,7 +8738,11 @@
             "France"
           ],
           "number": "8",
-          "position": "Central Midfield"
+          "overall_score": 76,
+          "position": "Central Midfield",
+          "potential": 78,
+          "value": 8000000,
+          "yearly_wage": 1144000
         },
         {
           "contract": "Jun 30, 2027",
@@ -6916,7 +8756,11 @@
             "France"
           ],
           "number": "24",
-          "position": "Central Midfield"
+          "overall_score": 74,
+          "position": "Central Midfield",
+          "potential": 74,
+          "value": 3700000,
+          "yearly_wage": 1092000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6931,7 +8775,11 @@
             "France"
           ],
           "number": "7",
-          "position": "Right Midfield"
+          "overall_score": 72,
+          "position": "Right Midfield",
+          "potential": 75,
+          "value": 3200000,
+          "yearly_wage": 988000
         },
         {
           "contract": "Jun 30, 2029",
@@ -6945,7 +8793,11 @@
             "Mali"
           ],
           "number": "23",
-          "position": "Attacking Midfield"
+          "overall_score": 75,
+          "position": "Attacking Midfield",
+          "potential": 81,
+          "value": 9000000,
+          "yearly_wage": 1040000
         },
         {
           "contract": "Jun 30, 2030",
@@ -6959,7 +8811,11 @@
             "Senegal"
           ],
           "number": "99",
-          "position": "Left Winger"
+          "overall_score": 70,
+          "position": "Left Winger",
+          "potential": 79,
+          "value": 3600000,
+          "yearly_wage": 520000
         },
         {
           "contract": "Jun 30, 2027",
@@ -6974,7 +8830,11 @@
             "Spain"
           ],
           "number": "10",
-          "position": "Right Winger"
+          "overall_score": 76,
+          "position": "Right Winger",
+          "potential": 76,
+          "value": 7500000,
+          "yearly_wage": 1248000
         },
         {
           "contract": "Jun 30, 2027",
@@ -6989,7 +8849,11 @@
             "Portugal"
           ],
           "number": "17",
-          "position": "Centre-Forward"
+          "overall_score": 73,
+          "position": "Centre-Forward",
+          "potential": 73,
+          "value": 3000000,
+          "yearly_wage": 1092000
         },
         {
           "contract": "Jun 30, 2027",
@@ -7004,7 +8868,11 @@
             "Réunion"
           ],
           "number": "19",
-          "position": "Centre-Forward"
+          "overall_score": 77,
+          "position": "Centre-Forward",
+          "potential": 77,
+          "value": 9000000,
+          "yearly_wage": 1456000
         },
         {
           "contract": "Jun 30, 2026",
@@ -7019,7 +8887,11 @@
             "Guadeloupe"
           ],
           "number": "14",
-          "position": "Centre-Forward"
+          "overall_score": 73,
+          "position": "Centre-Forward",
+          "potential": 80,
+          "value": 6000000,
+          "yearly_wage": 936000
         },
         {
           "contract": "Jun 30, 2026",
@@ -7033,7 +8905,11 @@
             "Senegal"
           ],
           "number": "29",
-          "position": "Centre-Forward"
+          "overall_score": 58,
+          "position": "Centre-Forward",
+          "potential": 70,
+          "value": 500000,
+          "yearly_wage": 156000
         }
       ],
       "stadiumName": "Stade Francis-Le Blé",

--- a/data/2025/ITA1/sofifa.json
+++ b/data/2025/ITA1/sofifa.json
@@ -1,0 +1,7233 @@
+{
+  "league": "Italy Serie A",
+  "scraped_at": "2026-06-12T14:26:43.053Z",
+  "team_count": 20,
+  "teams": [
+    {
+      "player_count": 41,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Yann Sommer",
+          "name": "Y. Sommer",
+          "overall_score": 86,
+          "potential": 86,
+          "value": 7500000,
+          "yearly_wage": 1248000
+        },
+        {
+          "currency": "€",
+          "full_name": "Denzel Dumfries",
+          "name": "D. Dumfries",
+          "overall_score": 84,
+          "potential": 84,
+          "value": 37000000,
+          "yearly_wage": 2652000
+        },
+        {
+          "currency": "€",
+          "full_name": "Yann Aurel Bisseck",
+          "name": "Y. Bisseck",
+          "overall_score": 76,
+          "potential": 80,
+          "value": 9500000,
+          "yearly_wage": 1196000
+        },
+        {
+          "currency": "€",
+          "full_name": "Manuel Akanji",
+          "name": "M. Akanji",
+          "overall_score": 83,
+          "potential": 83,
+          "value": 30500000,
+          "yearly_wage": 7540000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alessandro Bastoni",
+          "name": "A. Bastoni",
+          "overall_score": 87,
+          "potential": 89,
+          "value": 87000000,
+          "yearly_wage": 3276000
+        },
+        {
+          "currency": "€",
+          "full_name": "Federico Dimarco",
+          "name": "F. Dimarco",
+          "overall_score": 86,
+          "potential": 86,
+          "value": 65500000,
+          "yearly_wage": 3016000
+        },
+        {
+          "currency": "€",
+          "full_name": "Piotr Zieliński",
+          "name": "P. Zieliński",
+          "overall_score": 81,
+          "potential": 81,
+          "value": 21000000,
+          "yearly_wage": 2132000
+        },
+        {
+          "currency": "€",
+          "full_name": "Nicolò Barella",
+          "name": "N. Barella",
+          "overall_score": 88,
+          "potential": 88,
+          "value": 91500000,
+          "yearly_wage": 3952000
+        },
+        {
+          "currency": "€",
+          "full_name": "Petar Sučić",
+          "name": "P. Sučić",
+          "overall_score": 77,
+          "potential": 83,
+          "value": 17000000,
+          "yearly_wage": 1144000
+        },
+        {
+          "currency": "€",
+          "full_name": "Marcus Thuram",
+          "name": "M. Thuram",
+          "overall_score": 85,
+          "potential": 85,
+          "value": 58500000,
+          "yearly_wage": 3172000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lautaro Martínez",
+          "name": "L. Martínez",
+          "overall_score": 88,
+          "potential": 88,
+          "value": 99000000,
+          "yearly_wage": 4108000
+        },
+        {
+          "currency": "€",
+          "full_name": "Yoan Bonny",
+          "name": "Y. Bonny",
+          "overall_score": 78,
+          "potential": 86,
+          "value": 32000000,
+          "yearly_wage": 1352000
+        },
+        {
+          "currency": "€",
+          "full_name": "Francesco Pio Esposito",
+          "name": "F. Esposito",
+          "overall_score": 76,
+          "potential": 84,
+          "value": 16500000,
+          "yearly_wage": 1196000
+        },
+        {
+          "currency": "€",
+          "full_name": "Henrikh Mkhitaryan",
+          "name": "H. Mkhitaryan",
+          "overall_score": 83,
+          "potential": 83,
+          "value": 11500000,
+          "yearly_wage": 1924000
+        },
+        {
+          "currency": "€",
+          "full_name": "Luis Henrique Tomaz de Lima",
+          "name": "Luis Henrique",
+          "overall_score": 78,
+          "potential": 83,
+          "value": 21000000,
+          "yearly_wage": 1456000
+        },
+        {
+          "currency": "€",
+          "full_name": "Francesco Acerbi",
+          "name": "F. Acerbi",
+          "overall_score": 83,
+          "potential": 83,
+          "value": 6500000,
+          "yearly_wage": 1820000
+        },
+        {
+          "currency": "€",
+          "full_name": "Carlos Augusto Zopolato Neves",
+          "name": "Carlos Augusto",
+          "overall_score": 81,
+          "potential": 82,
+          "value": 27500000,
+          "yearly_wage": 1976000
+        },
+        {
+          "currency": "€",
+          "full_name": "Josep Martínez Riera",
+          "name": "Josep Martínez",
+          "overall_score": 75,
+          "potential": 77,
+          "value": 5000000,
+          "yearly_wage": 832000
+        },
+        {
+          "currency": "€",
+          "full_name": "Stefan de Vrij",
+          "name": "S. de Vrij",
+          "overall_score": 83,
+          "potential": 83,
+          "value": 17500000,
+          "yearly_wage": 2444000
+        },
+        {
+          "currency": "€",
+          "full_name": "Hakan Çalhanoğlu",
+          "name": "H. Çalhanoğlu",
+          "overall_score": 86,
+          "potential": 86,
+          "value": 47500000,
+          "yearly_wage": 3172000
+        },
+        {
+          "currency": "€",
+          "full_name": "Raffaele Di Gennaro",
+          "name": "R. Di Gennaro",
+          "overall_score": 68,
+          "potential": 68,
+          "value": 650000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alain Taho",
+          "name": "A. Taho",
+          "overall_score": 65,
+          "potential": 80,
+          "value": 1400000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Leon Jakirović",
+          "name": "L. Jakirović",
+          "overall_score": 61,
+          "potential": 82,
+          "value": 975000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Matteo Darmian",
+          "name": "M. Darmian",
+          "overall_score": 78,
+          "potential": 78,
+          "value": 4300000,
+          "yearly_wage": 1248000
+        },
+        {
+          "currency": "€",
+          "full_name": "Matteo Cocchi",
+          "name": "M. Cocchi",
+          "overall_score": 67,
+          "potential": 82,
+          "value": 2300000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Andy Diouf",
+          "name": "A. Diouf",
+          "overall_score": 75,
+          "potential": 81,
+          "value": 9000000,
+          "yearly_wage": 1196000
+        },
+        {
+          "currency": "€",
+          "full_name": "Davide Frattesi",
+          "name": "D. Frattesi",
+          "overall_score": 81,
+          "potential": 83,
+          "value": 32000000,
+          "yearly_wage": 1976000
+        },
+        {
+          "currency": "€",
+          "full_name": "Luka Topalovič",
+          "name": "L. Topalovič",
+          "overall_score": 65,
+          "potential": 78,
+          "value": 1700000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Matteo Lavelli",
+          "name": "M. Lavelli",
+          "overall_score": 66,
+          "potential": 79,
+          "value": 2000000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mattia Mosconi",
+          "name": "M. Mosconi",
+          "overall_score": 61,
+          "potential": 76,
+          "value": 775000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Giacomo Stabile",
+          "name": "G. Stabile",
+          "overall_score": 65,
+          "potential": 74,
+          "value": 1500000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Valentín Carboni",
+          "name": "V. Carboni",
+          "overall_score": 73,
+          "potential": 82,
+          "value": 6500000,
+          "yearly_wage": 884000
+        },
+        {
+          "currency": "€",
+          "full_name": "Franco Carboni",
+          "name": "F. Carboni",
+          "overall_score": 63,
+          "potential": 68,
+          "value": 700000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Yanis Massolin",
+          "name": "Y. Massolin",
+          "overall_score": 68,
+          "potential": 76,
+          "value": 2700000,
+          "yearly_wage": 572000
+        },
+        {
+          "currency": "€",
+          "full_name": "Tomás Palacios",
+          "name": "T. Palacios",
+          "overall_score": 70,
+          "potential": 79,
+          "value": 3300000,
+          "yearly_wage": 728000
+        },
+        {
+          "currency": "€",
+          "full_name": "Kristjan Asllani",
+          "name": "K. Asllani",
+          "overall_score": 73,
+          "potential": 78,
+          "value": 4200000,
+          "yearly_wage": 936000
+        },
+        {
+          "currency": "€",
+          "full_name": "Sebastiano Esposito",
+          "name": "S. Esposito",
+          "overall_score": 75,
+          "potential": 82,
+          "value": 11500000,
+          "yearly_wage": 1300000
+        },
+        {
+          "currency": "€",
+          "full_name": "Benjamin Pavard",
+          "name": "B. Pavard",
+          "overall_score": 81,
+          "potential": 81,
+          "value": 21500000,
+          "yearly_wage": 2080000
+        },
+        {
+          "currency": "€",
+          "full_name": "Luca Di Maggio",
+          "name": "L. Di Maggio",
+          "overall_score": 62,
+          "potential": 76,
+          "value": 950000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Giacomo De Pieri",
+          "name": "G. De Pieri",
+          "overall_score": 65,
+          "potential": 80,
+          "value": 1700000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ebenezer Akinsanmiro",
+          "name": "E. Akinsanmiro",
+          "overall_score": 67,
+          "potential": 80,
+          "value": 2400000,
+          "yearly_wage": 468000
+        }
+      ],
+      "team": "Inter",
+      "transfer_budget": 34800000,
+      "url": "https://sofifa.com/team/44/inter/260037/"
+    },
+    {
+      "player_count": 42,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Vanja Milinković-Savić",
+          "name": "V. Milinković-Savić",
+          "overall_score": 79,
+          "potential": 81,
+          "value": 15000000,
+          "yearly_wage": 1508000
+        },
+        {
+          "currency": "€",
+          "full_name": "Sam Beukema",
+          "name": "S. Beukema",
+          "overall_score": 78,
+          "potential": 80,
+          "value": 15500000,
+          "yearly_wage": 4056000
+        },
+        {
+          "currency": "€",
+          "full_name": "Amir Rrahmani",
+          "name": "A. Rrahmani",
+          "overall_score": 83,
+          "potential": 83,
+          "value": 25000000,
+          "yearly_wage": 6240000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alessandro Buongiorno",
+          "name": "A. Buongiorno",
+          "overall_score": 82,
+          "potential": 86,
+          "value": 37500000,
+          "yearly_wage": 5460000
+        },
+        {
+          "currency": "€",
+          "full_name": "Matteo Politano",
+          "name": "M. Politano",
+          "overall_score": 81,
+          "potential": 81,
+          "value": 21500000,
+          "yearly_wage": 5980000
+        },
+        {
+          "currency": "€",
+          "full_name": "Stanislav Lobotka",
+          "name": "S. Lobotka",
+          "overall_score": 83,
+          "potential": 83,
+          "value": 34500000,
+          "yearly_wage": 6500000
+        },
+        {
+          "currency": "€",
+          "full_name": "Scott McTominay",
+          "name": "S. McTominay",
+          "overall_score": 86,
+          "potential": 86,
+          "value": 68000000,
+          "yearly_wage": 8580000
+        },
+        {
+          "currency": "€",
+          "full_name": "Leonardo Spinazzola",
+          "name": "L. Spinazzola",
+          "overall_score": 80,
+          "potential": 80,
+          "value": 14500000,
+          "yearly_wage": 4940000
+        },
+        {
+          "currency": "€",
+          "full_name": "Kevin De Bruyne",
+          "name": "K. De Bruyne",
+          "overall_score": 87,
+          "potential": 87,
+          "value": 36500000,
+          "yearly_wage": 9100000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alisson de Almeida Santos",
+          "name": "Alisson",
+          "overall_score": 70,
+          "potential": 78,
+          "value": 3600000,
+          "yearly_wage": 520000
+        },
+        {
+          "currency": "€",
+          "full_name": "Rasmus Højlund",
+          "name": "R. Højlund",
+          "overall_score": 78,
+          "potential": 83,
+          "value": 22000000,
+          "yearly_wage": 3744000
+        },
+        {
+          "currency": "€",
+          "full_name": "André-Franck Zambo Anguissa",
+          "name": "A. Zambo Anguissa",
+          "overall_score": 83,
+          "potential": 83,
+          "value": 35500000,
+          "yearly_wage": 6500000
+        },
+        {
+          "currency": "€",
+          "full_name": "Eljif Elmas",
+          "name": "E. Elmas",
+          "overall_score": 77,
+          "potential": 77,
+          "value": 11500000,
+          "yearly_wage": 2392000
+        },
+        {
+          "currency": "€",
+          "full_name": "Billy Gilmour",
+          "name": "B. Gilmour",
+          "overall_score": 75,
+          "potential": 79,
+          "value": 8000000,
+          "yearly_wage": 3068000
+        },
+        {
+          "currency": "€",
+          "full_name": "Giovanni Di Lorenzo",
+          "name": "G. Di Lorenzo",
+          "overall_score": 83,
+          "potential": 83,
+          "value": 26500000,
+          "yearly_wage": 6240000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mathías Olivera",
+          "name": "M. Olivera",
+          "overall_score": 77,
+          "potential": 77,
+          "value": 10000000,
+          "yearly_wage": 3796000
+        },
+        {
+          "currency": "€",
+          "full_name": "Juan Guilherme Nunes Jesus",
+          "name": "Juan Jesus",
+          "overall_score": 75,
+          "potential": 75,
+          "value": 1800000,
+          "yearly_wage": 3536000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alex Meret",
+          "name": "A. Meret",
+          "overall_score": 82,
+          "potential": 84,
+          "value": 26000000,
+          "yearly_wage": 3744000
+        },
+        {
+          "currency": "€",
+          "full_name": "Pasquale Mazzocchi",
+          "name": "P. Mazzocchi",
+          "overall_score": 71,
+          "potential": 71,
+          "value": 1600000,
+          "yearly_wage": 2444000
+        },
+        {
+          "currency": "€",
+          "full_name": "Miguel Gutiérrez Ortega",
+          "name": "Miguel Gutiérrez",
+          "overall_score": 81,
+          "potential": 85,
+          "value": 34500000,
+          "yearly_wage": 4368000
+        },
+        {
+          "currency": "€",
+          "full_name": "Nikita Contini",
+          "name": "N. Contini",
+          "overall_score": 67,
+          "potential": 68,
+          "value": 775000,
+          "yearly_wage": 988000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mathias Ferrante",
+          "name": "M. Ferrante",
+          "overall_score": 54,
+          "potential": 68,
+          "value": 220000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Antonio Vergara",
+          "name": "A. Vergara",
+          "overall_score": 67,
+          "potential": 76,
+          "value": 2300000,
+          "yearly_wage": 1404000
+        },
+        {
+          "currency": "€",
+          "full_name": "David Neres Campos",
+          "name": "David Neres",
+          "overall_score": 81,
+          "potential": 81,
+          "value": 26000000,
+          "yearly_wage": 5980000
+        },
+        {
+          "currency": "€",
+          "full_name": "Giovane Santana",
+          "name": "Giovane",
+          "overall_score": 69,
+          "potential": 79,
+          "value": 3200000,
+          "yearly_wage": 1560000
+        },
+        {
+          "currency": "€",
+          "full_name": "Romelu Lukaku",
+          "name": "R. Lukaku",
+          "overall_score": 83,
+          "potential": 83,
+          "value": 29500000,
+          "yearly_wage": 7020000
+        },
+        {
+          "currency": "€",
+          "full_name": "Luca Marianucci",
+          "name": "L. Marianucci",
+          "overall_score": 68,
+          "potential": 79,
+          "value": 2500000,
+          "yearly_wage": 1196000
+        },
+        {
+          "currency": "€",
+          "full_name": "Rafael Marín Zamora",
+          "name": "Rafa Marín",
+          "overall_score": 76,
+          "potential": 83,
+          "value": 14000000,
+          "yearly_wage": 3068000
+        },
+        {
+          "currency": "€",
+          "full_name": "Giuseppe Ambrosino",
+          "name": "G. Ambrosino",
+          "overall_score": 67,
+          "potential": 77,
+          "value": 2300000,
+          "yearly_wage": 1248000
+        },
+        {
+          "currency": "€",
+          "full_name": "Michael Folorunsho",
+          "name": "M. Folorunsho",
+          "overall_score": 74,
+          "potential": 74,
+          "value": 4500000,
+          "yearly_wage": 3276000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alessandro Zanoli",
+          "name": "A. Zanoli",
+          "overall_score": 73,
+          "potential": 77,
+          "value": 4100000,
+          "yearly_wage": 2444000
+        },
+        {
+          "currency": "€",
+          "full_name": "Walid Cheddira",
+          "name": "W. Cheddira",
+          "overall_score": 72,
+          "potential": 72,
+          "value": 2500000,
+          "yearly_wage": 2912000
+        },
+        {
+          "currency": "€",
+          "full_name": "Cyril Ngonge",
+          "name": "C. Ngonge",
+          "overall_score": 72,
+          "potential": 73,
+          "value": 2800000,
+          "yearly_wage": 2756000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jesper Lindstrøm",
+          "name": "J. Lindstrøm",
+          "overall_score": 74,
+          "potential": 75,
+          "value": 5000000,
+          "yearly_wage": 3120000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jens-Lys Cajuste",
+          "name": "J. Cajuste",
+          "overall_score": 74,
+          "potential": 77,
+          "value": 5000000,
+          "yearly_wage": 2964000
+        },
+        {
+          "currency": "€",
+          "full_name": "Noa Lang",
+          "name": "N. Lang",
+          "overall_score": 79,
+          "potential": 80,
+          "value": 20500000,
+          "yearly_wage": 4940000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alessio Zerbin",
+          "name": "A. Zerbin",
+          "overall_score": 73,
+          "potential": 73,
+          "value": 3300000,
+          "yearly_wage": 2964000
+        },
+        {
+          "currency": "€",
+          "full_name": "Giovanni Simeone",
+          "name": "G. Simeone",
+          "overall_score": 76,
+          "potential": 76,
+          "value": 7500000,
+          "yearly_wage": 4160000
+        },
+        {
+          "currency": "€",
+          "full_name": "Emanuele Rao",
+          "name": "E. Rao",
+          "overall_score": 66,
+          "potential": 76,
+          "value": 1800000,
+          "yearly_wage": 988000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lorenzo Sgarbi",
+          "name": "L. Sgarbi",
+          "overall_score": 65,
+          "potential": 70,
+          "value": 1100000,
+          "yearly_wage": 1040000
+        },
+        {
+          "currency": "€",
+          "full_name": "Nosa Edward Obaretin",
+          "name": "N. Obaretin",
+          "overall_score": 67,
+          "potential": 74,
+          "value": 1900000,
+          "yearly_wage": 1248000
+        },
+        {
+          "currency": "€",
+          "full_name": "Luis Hasa",
+          "name": "L. Hasa",
+          "overall_score": 69,
+          "potential": 76,
+          "value": 2800000,
+          "yearly_wage": 1404000
+        }
+      ],
+      "team": "Napoli",
+      "transfer_budget": 62600000,
+      "url": "https://sofifa.com/team/48/napoli/260037/"
+    },
+    {
+      "player_count": 37,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Mike Maignan",
+          "name": "M. Maignan",
+          "overall_score": 87,
+          "potential": 88,
+          "value": 61000000,
+          "yearly_wage": 3172000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alexis Saelemaekers",
+          "name": "A. Saelemaekers",
+          "overall_score": 80,
+          "potential": 80,
+          "value": 23000000,
+          "yearly_wage": 2756000
+        },
+        {
+          "currency": "€",
+          "full_name": "Fikayo Tomori",
+          "name": "F. Tomori",
+          "overall_score": 81,
+          "potential": 83,
+          "value": 27500000,
+          "yearly_wage": 2808000
+        },
+        {
+          "currency": "€",
+          "full_name": "Matteo Gabbia",
+          "name": "M. Gabbia",
+          "overall_score": 80,
+          "potential": 83,
+          "value": 25000000,
+          "yearly_wage": 2496000
+        },
+        {
+          "currency": "€",
+          "full_name": "Strahinja Pavlović",
+          "name": "S. Pavlović",
+          "overall_score": 77,
+          "potential": 83,
+          "value": 15000000,
+          "yearly_wage": 1820000
+        },
+        {
+          "currency": "€",
+          "full_name": "Davide Bartesaghi",
+          "name": "D. Bartesaghi",
+          "overall_score": 71,
+          "potential": 81,
+          "value": 3900000,
+          "yearly_wage": 884000
+        },
+        {
+          "currency": "€",
+          "full_name": "Luka Modrić",
+          "name": "L. Modrić",
+          "overall_score": 85,
+          "potential": 85,
+          "value": 17000000,
+          "yearly_wage": 2912000
+        },
+        {
+          "currency": "€",
+          "full_name": "Youssouf Fofana",
+          "name": "Y. Fofana",
+          "overall_score": 81,
+          "potential": 84,
+          "value": 30500000,
+          "yearly_wage": 2808000
+        },
+        {
+          "currency": "€",
+          "full_name": "Adrien Rabiot",
+          "name": "A. Rabiot",
+          "overall_score": 85,
+          "potential": 85,
+          "value": 51500000,
+          "yearly_wage": 4316000
+        },
+        {
+          "currency": "€",
+          "full_name": "Christopher Nkunku",
+          "name": "C. Nkunku",
+          "overall_score": 81,
+          "potential": 81,
+          "value": 27500000,
+          "yearly_wage": 3016000
+        },
+        {
+          "currency": "€",
+          "full_name": "Rafael da Conceição Leão",
+          "name": "Rafael Leão",
+          "overall_score": 84,
+          "potential": 85,
+          "value": 49500000,
+          "yearly_wage": 4108000
+        },
+        {
+          "currency": "€",
+          "full_name": "Christian Pulisic",
+          "name": "C. Pulisic",
+          "overall_score": 85,
+          "potential": 85,
+          "value": 59000000,
+          "yearly_wage": 4472000
+        },
+        {
+          "currency": "€",
+          "full_name": "Niclas Füllkrug",
+          "name": "N. Füllkrug",
+          "overall_score": 78,
+          "potential": 78,
+          "value": 11500000,
+          "yearly_wage": 3744000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ruben Loftus-Cheek",
+          "name": "R. Loftus-Cheek",
+          "overall_score": 80,
+          "potential": 80,
+          "value": 20500000,
+          "yearly_wage": 2860000
+        },
+        {
+          "currency": "€",
+          "full_name": "Samuele Ricci",
+          "name": "S. Ricci",
+          "overall_score": 79,
+          "potential": 85,
+          "value": 25500000,
+          "yearly_wage": 2132000
+        },
+        {
+          "currency": "€",
+          "full_name": "Pervis Estupiñán",
+          "name": "P. Estupiñán",
+          "overall_score": 79,
+          "potential": 79,
+          "value": 17000000,
+          "yearly_wage": 2496000
+        },
+        {
+          "currency": "€",
+          "full_name": "Koni De Winter",
+          "name": "K. De Winter",
+          "overall_score": 75,
+          "potential": 84,
+          "value": 11500000,
+          "yearly_wage": 1612000
+        },
+        {
+          "currency": "€",
+          "full_name": "Pietro Terracciano",
+          "name": "P. Terracciano",
+          "overall_score": 78,
+          "potential": 78,
+          "value": 1600000,
+          "yearly_wage": 936000
+        },
+        {
+          "currency": "€",
+          "full_name": "Zachary Athekame",
+          "name": "Z. Athekame",
+          "overall_score": 65,
+          "potential": 78,
+          "value": 1600000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "Santiago Giménez",
+          "name": "S. Giménez",
+          "overall_score": 79,
+          "potential": 84,
+          "value": 27000000,
+          "yearly_wage": 2496000
+        },
+        {
+          "currency": "€",
+          "full_name": "Matteo Pittarella",
+          "name": "M. Pittarella",
+          "overall_score": 52,
+          "potential": 67,
+          "value": 160000,
+          "yearly_wage": 31200
+        },
+        {
+          "currency": "€",
+          "full_name": "Lorenzo Torriani",
+          "name": "L. Torriani",
+          "overall_score": 62,
+          "potential": 76,
+          "value": 850000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "David Odogu",
+          "name": "D. Odogu",
+          "overall_score": 65,
+          "potential": 83,
+          "value": 1700000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ardon Jashari",
+          "name": "A. Jashari",
+          "overall_score": 77,
+          "potential": 86,
+          "value": 22500000,
+          "yearly_wage": 1820000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jacopo Sardo",
+          "name": "J. Sardo",
+          "overall_score": 59,
+          "potential": 73,
+          "value": 550000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Cheveyo Balentien",
+          "name": "C. Balentien",
+          "overall_score": 62,
+          "potential": 76,
+          "value": 925000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Francesco Camarda",
+          "name": "F. Camarda",
+          "overall_score": 65,
+          "potential": 87,
+          "value": 2300000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Kevin Zeroli",
+          "name": "K. Zeroli",
+          "overall_score": 65,
+          "potential": 78,
+          "value": 1700000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alphadjo Cissè",
+          "name": "A. Cissè",
+          "overall_score": 65,
+          "potential": 78,
+          "value": 1700000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "Filippo Terracciano",
+          "name": "F. Terracciano",
+          "overall_score": 71,
+          "potential": 80,
+          "value": 3900000,
+          "yearly_wage": 1144000
+        },
+        {
+          "currency": "€",
+          "full_name": "Warren Bondo",
+          "name": "W. Bondo",
+          "overall_score": 71,
+          "potential": 78,
+          "value": 3800000,
+          "yearly_wage": 988000
+        },
+        {
+          "currency": "€",
+          "full_name": "Yunus Musah",
+          "name": "Y. Musah",
+          "overall_score": 73,
+          "potential": 81,
+          "value": 7000000,
+          "yearly_wage": 1456000
+        },
+        {
+          "currency": "€",
+          "full_name": "Samuel Chukwueze",
+          "name": "S. Chukwueze",
+          "overall_score": 79,
+          "potential": 79,
+          "value": 19000000,
+          "yearly_wage": 2600000
+        },
+        {
+          "currency": "€",
+          "full_name": "Álvaro Borja Morata Martín",
+          "name": "Morata",
+          "overall_score": 79,
+          "potential": 79,
+          "value": 14000000,
+          "yearly_wage": 2912000
+        },
+        {
+          "currency": "€",
+          "full_name": "Maximilian Ibrahimović",
+          "name": "M. Ibrahimović",
+          "overall_score": 63,
+          "potential": 81,
+          "value": 1200000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Christian Comotto",
+          "name": "C. Comotto",
+          "overall_score": 64,
+          "potential": 83,
+          "value": 1500000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Diego Sia",
+          "name": "D. Sia",
+          "overall_score": 59,
+          "potential": 74,
+          "value": 525000,
+          "yearly_wage": 260000
+        }
+      ],
+      "team": "AC Milan",
+      "transfer_budget": 58800000,
+      "url": "https://sofifa.com/team/47/ac-milan/260037/"
+    },
+    {
+      "player_count": 42,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Michele Di Gregorio",
+          "name": "M. Di Gregorio",
+          "overall_score": 81,
+          "potential": 84,
+          "value": 25500000,
+          "yearly_wage": 3796000
+        },
+        {
+          "currency": "€",
+          "full_name": "Pierre Kalulu",
+          "name": "P. Kalulu",
+          "overall_score": 80,
+          "potential": 85,
+          "value": 28000000,
+          "yearly_wage": 5200000
+        },
+        {
+          "currency": "€",
+          "full_name": "Gleison Bremer Silva Nascimento",
+          "name": "Bremer",
+          "overall_score": 86,
+          "potential": 86,
+          "value": 58500000,
+          "yearly_wage": 9620000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lloyd Kelly",
+          "name": "L. Kelly",
+          "overall_score": 78,
+          "potential": 80,
+          "value": 15500000,
+          "yearly_wage": 4680000
+        },
+        {
+          "currency": "€",
+          "full_name": "Weston McKennie",
+          "name": "W. McKennie",
+          "overall_score": 79,
+          "potential": 79,
+          "value": 19000000,
+          "yearly_wage": 5460000
+        },
+        {
+          "currency": "€",
+          "full_name": "Manuel Locatelli",
+          "name": "M. Locatelli",
+          "overall_score": 84,
+          "potential": 85,
+          "value": 43000000,
+          "yearly_wage": 7800000
+        },
+        {
+          "currency": "€",
+          "full_name": "Khéphren Thuram",
+          "name": "K. Thuram",
+          "overall_score": 81,
+          "potential": 85,
+          "value": 36500000,
+          "yearly_wage": 5460000
+        },
+        {
+          "currency": "€",
+          "full_name": "Andrea Cambiaso",
+          "name": "A. Cambiaso",
+          "overall_score": 80,
+          "potential": 82,
+          "value": 24500000,
+          "yearly_wage": 5200000
+        },
+        {
+          "currency": "€",
+          "full_name": "Francisco F. da Conceição",
+          "name": "Francisco Conceição",
+          "overall_score": 79,
+          "potential": 86,
+          "value": 35500000,
+          "yearly_wage": 4940000
+        },
+        {
+          "currency": "€",
+          "full_name": "Kenan Yıldız",
+          "name": "K. Yıldız",
+          "overall_score": 82,
+          "potential": 89,
+          "value": 60500000,
+          "yearly_wage": 5200000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jonathan David",
+          "name": "J. David",
+          "overall_score": 81,
+          "potential": 84,
+          "value": 34500000,
+          "yearly_wage": 6500000
+        },
+        {
+          "currency": "€",
+          "full_name": "Dušan Vlahović",
+          "name": "D. Vlahović",
+          "overall_score": 81,
+          "potential": 84,
+          "value": 34500000,
+          "yearly_wage": 6500000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jérémie Boga",
+          "name": "J. Boga",
+          "overall_score": 76,
+          "potential": 76,
+          "value": 7500000,
+          "yearly_wage": 1456000
+        },
+        {
+          "currency": "€",
+          "full_name": "Teun Koopmeiners",
+          "name": "T. Koopmeiners",
+          "overall_score": 80,
+          "potential": 80,
+          "value": 22500000,
+          "yearly_wage": 5980000
+        },
+        {
+          "currency": "€",
+          "full_name": "Fabio Miretti",
+          "name": "F. Miretti",
+          "overall_score": 75,
+          "potential": 80,
+          "value": 8500000,
+          "yearly_wage": 3068000
+        },
+        {
+          "currency": "€",
+          "full_name": "Federico Gatti",
+          "name": "F. Gatti",
+          "overall_score": 80,
+          "potential": 83,
+          "value": 24000000,
+          "yearly_wage": 5460000
+        },
+        {
+          "currency": "€",
+          "full_name": "Emil Holm",
+          "name": "E. Holm",
+          "overall_score": 75,
+          "potential": 78,
+          "value": 7000000,
+          "yearly_wage": 1924000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mattia Perin",
+          "name": "M. Perin",
+          "overall_score": 78,
+          "potential": 78,
+          "value": 7000000,
+          "yearly_wage": 3224000
+        },
+        {
+          "currency": "€",
+          "full_name": "Filip Kostić",
+          "name": "F. Kostić",
+          "overall_score": 80,
+          "potential": 80,
+          "value": 16500000,
+          "yearly_wage": 5980000
+        },
+        {
+          "currency": "€",
+          "full_name": "Loïs Openda",
+          "name": "L. Openda",
+          "overall_score": 82,
+          "potential": 84,
+          "value": 38500000,
+          "yearly_wage": 3640000
+        },
+        {
+          "currency": "€",
+          "full_name": "Carlo Pinsoglio",
+          "name": "C. Pinsoglio",
+          "overall_score": 69,
+          "potential": 69,
+          "value": 150000,
+          "yearly_wage": 884000
+        },
+        {
+          "currency": "€",
+          "full_name": "Simone Scaglia",
+          "name": "S. Scaglia",
+          "overall_score": 63,
+          "potential": 74,
+          "value": 900000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Juan David Cabal",
+          "name": "J. Cabal",
+          "overall_score": 74,
+          "potential": 79,
+          "value": 6000000,
+          "yearly_wage": 3172000
+        },
+        {
+          "currency": "€",
+          "full_name": "Edon Zhegrova",
+          "name": "E. Zhegrova",
+          "overall_score": 79,
+          "potential": 79,
+          "value": 19000000,
+          "yearly_wage": 5460000
+        },
+        {
+          "currency": "€",
+          "full_name": "Vasilije Adžić",
+          "name": "V. Adžić",
+          "overall_score": 69,
+          "potential": 79,
+          "value": 3000000,
+          "yearly_wage": 1612000
+        },
+        {
+          "currency": "€",
+          "full_name": "Leonardo Cerri",
+          "name": "L. Cerri",
+          "overall_score": 67,
+          "potential": 76,
+          "value": 2300000,
+          "yearly_wage": 1716000
+        },
+        {
+          "currency": "€",
+          "full_name": "Arkadiusz Milik",
+          "name": "A. Milik",
+          "overall_score": 78,
+          "potential": 78,
+          "value": 12000000,
+          "yearly_wage": 5720000
+        },
+        {
+          "currency": "€",
+          "full_name": "Giovanni Daffara",
+          "name": "G. Daffara",
+          "overall_score": 65,
+          "potential": 74,
+          "value": 1400000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alessandro Sersanti",
+          "name": "A. Sersanti",
+          "overall_score": 69,
+          "potential": 74,
+          "value": 2100000,
+          "yearly_wage": 1924000
+        },
+        {
+          "currency": "€",
+          "full_name": "Facundo González",
+          "name": "F. González",
+          "overall_score": 68,
+          "potential": 78,
+          "value": 2500000,
+          "yearly_wage": 1664000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mattia Compagnon",
+          "name": "M. Compagnon",
+          "overall_score": 65,
+          "potential": 70,
+          "value": 1100000,
+          "yearly_wage": 1092000
+        },
+        {
+          "currency": "€",
+          "full_name": "Emanuele Pecorino",
+          "name": "E. Pecorino",
+          "overall_score": 68,
+          "potential": 72,
+          "value": 1800000,
+          "yearly_wage": 1924000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alessandro Pietrelli",
+          "name": "A. Pietrelli",
+          "overall_score": 66,
+          "potential": 69,
+          "value": 1200000,
+          "yearly_wage": 1300000
+        },
+        {
+          "currency": "€",
+          "full_name": "João Mário Neto Lopes",
+          "name": "João Mário",
+          "overall_score": 77,
+          "potential": 80,
+          "value": 13000000,
+          "yearly_wage": 4264000
+        },
+        {
+          "currency": "€",
+          "full_name": "Timothy Weah",
+          "name": "T. Weah",
+          "overall_score": 77,
+          "potential": 78,
+          "value": 12500000,
+          "yearly_wage": 4472000
+        },
+        {
+          "currency": "€",
+          "full_name": "Nico Gonzalez",
+          "name": "N. Gonzalez",
+          "overall_score": 79,
+          "potential": 79,
+          "value": 18500000,
+          "yearly_wage": 5460000
+        },
+        {
+          "currency": "€",
+          "full_name": "Douglas Luiz Soares de Paulo",
+          "name": "Douglas Luiz",
+          "overall_score": 79,
+          "potential": 79,
+          "value": 16500000,
+          "yearly_wage": 5200000
+        },
+        {
+          "currency": "€",
+          "full_name": "Daniele Rugani",
+          "name": "D. Rugani",
+          "overall_score": 75,
+          "potential": 75,
+          "value": 4600000,
+          "yearly_wage": 4160000
+        },
+        {
+          "currency": "€",
+          "full_name": "Pedro Felipe de Jesus Gomes",
+          "name": "Pedro Felipe",
+          "overall_score": 69,
+          "potential": 79,
+          "value": 2900000,
+          "yearly_wage": 1560000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lorenzo Villa",
+          "name": "L. Villa",
+          "overall_score": 61,
+          "potential": 74,
+          "value": 750000,
+          "yearly_wage": 572000
+        },
+        {
+          "currency": "€",
+          "full_name": "Brando Moruzzi",
+          "name": "B. Moruzzi",
+          "overall_score": 68,
+          "potential": 74,
+          "value": 1800000,
+          "yearly_wage": 1404000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jonas Rouhi",
+          "name": "J. Rouhi",
+          "overall_score": 66,
+          "potential": 77,
+          "value": 1800000,
+          "yearly_wage": 1040000
+        }
+      ],
+      "team": "Juventus",
+      "transfer_budget": 125500000,
+      "url": "https://sofifa.com/team/45/juventus/260037/"
+    },
+    {
+      "player_count": 40,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Mile Svilar",
+          "name": "M. Svilar",
+          "overall_score": 84,
+          "potential": 87,
+          "value": 43000000,
+          "yearly_wage": 2444000
+        },
+        {
+          "currency": "€",
+          "full_name": "Gianluca Mancini",
+          "name": "G. Mancini",
+          "overall_score": 84,
+          "potential": 84,
+          "value": 35500000,
+          "yearly_wage": 4316000
+        },
+        {
+          "currency": "€",
+          "full_name": "Evan Ndicka",
+          "name": "E. Ndicka",
+          "overall_score": 81,
+          "potential": 83,
+          "value": 28500000,
+          "yearly_wage": 3016000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mario Hermoso Canseco",
+          "name": "Mario Hermoso",
+          "overall_score": 79,
+          "potential": 79,
+          "value": 14500000,
+          "yearly_wage": 2912000
+        },
+        {
+          "currency": "€",
+          "full_name": "Zeki Çelik",
+          "name": "Z. Çelik",
+          "overall_score": 78,
+          "potential": 78,
+          "value": 12500000,
+          "yearly_wage": 2652000
+        },
+        {
+          "currency": "€",
+          "full_name": "Bryan Cristante",
+          "name": "B. Cristante",
+          "overall_score": 81,
+          "potential": 81,
+          "value": 24500000,
+          "yearly_wage": 3484000
+        },
+        {
+          "currency": "€",
+          "full_name": "Kouadio Manu Koné",
+          "name": "K. Koné",
+          "overall_score": 80,
+          "potential": 84,
+          "value": 30000000,
+          "yearly_wage": 2704000
+        },
+        {
+          "currency": "€",
+          "full_name": "Wesley Vinícius França Lima",
+          "name": "Wesley",
+          "overall_score": 79,
+          "potential": 85,
+          "value": 28000000,
+          "yearly_wage": 2184000
+        },
+        {
+          "currency": "€",
+          "full_name": "Matías Soulé",
+          "name": "M. Soulé",
+          "overall_score": 79,
+          "potential": 85,
+          "value": 28000000,
+          "yearly_wage": 2600000
+        },
+        {
+          "currency": "€",
+          "full_name": "Paulo Dybala",
+          "name": "P. Dybala",
+          "overall_score": 85,
+          "potential": 85,
+          "value": 44500000,
+          "yearly_wage": 4940000
+        },
+        {
+          "currency": "€",
+          "full_name": "Donyell Malen",
+          "name": "D. Malen",
+          "overall_score": 80,
+          "potential": 80,
+          "value": 23500000,
+          "yearly_wage": 6240000
+        },
+        {
+          "currency": "€",
+          "full_name": "Artem Dovbyk",
+          "name": "A. Dovbyk",
+          "overall_score": 81,
+          "potential": 81,
+          "value": 26500000,
+          "yearly_wage": 3744000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lorenzo Pellegrini",
+          "name": "L. Pellegrini",
+          "overall_score": 80,
+          "potential": 80,
+          "value": 20500000,
+          "yearly_wage": 3276000
+        },
+        {
+          "currency": "€",
+          "full_name": "Stephan El Shaarawy",
+          "name": "S. El Shaarawy",
+          "overall_score": 78,
+          "potential": 78,
+          "value": 11000000,
+          "yearly_wage": 2756000
+        },
+        {
+          "currency": "€",
+          "full_name": "Neil El Aynaoui",
+          "name": "N. El Aynaoui",
+          "overall_score": 76,
+          "potential": 81,
+          "value": 11500000,
+          "yearly_wage": 2028000
+        },
+        {
+          "currency": "€",
+          "full_name": "José Ángel Esmoris Tasende",
+          "name": "Angeliño",
+          "overall_score": 79,
+          "potential": 79,
+          "value": 16000000,
+          "yearly_wage": 2912000
+        },
+        {
+          "currency": "€",
+          "full_name": "Devyne Rensch",
+          "name": "D. Rensch",
+          "overall_score": 74,
+          "potential": 79,
+          "value": 6000000,
+          "yearly_wage": 1716000
+        },
+        {
+          "currency": "€",
+          "full_name": "Pierluigi Gollini",
+          "name": "P. Gollini",
+          "overall_score": 74,
+          "potential": 74,
+          "value": 2800000,
+          "yearly_wage": 1352000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jan Ziółkowski",
+          "name": "J. Ziółkowski",
+          "overall_score": 69,
+          "potential": 79,
+          "value": 2900000,
+          "yearly_wage": 832000
+        },
+        {
+          "currency": "€",
+          "full_name": "Niccolò Pisilli",
+          "name": "N. Pisilli",
+          "overall_score": 72,
+          "potential": 84,
+          "value": 5500000,
+          "yearly_wage": 1248000
+        },
+        {
+          "currency": "€",
+          "full_name": "Radosław Żelezny",
+          "name": "R. Żelezny",
+          "overall_score": 64,
+          "potential": 78,
+          "value": 1200000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Daniele Ghilardi",
+          "name": "D. Ghilardi",
+          "overall_score": 72,
+          "potential": 80,
+          "value": 4900000,
+          "yearly_wage": 1404000
+        },
+        {
+          "currency": "€",
+          "full_name": "Kostas Tsimikas",
+          "name": "K. Tsimikas",
+          "overall_score": 77,
+          "potential": 77,
+          "value": 9500000,
+          "yearly_wage": 4160000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lorenzo Venturino",
+          "name": "L. Venturino",
+          "overall_score": 62,
+          "potential": 76,
+          "value": 950000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Bryan Zaragoza Martínez",
+          "name": "Bryan Zaragoza",
+          "overall_score": 77,
+          "potential": 83,
+          "value": 16500000,
+          "yearly_wage": 2548000
+        },
+        {
+          "currency": "€",
+          "full_name": "Antonio Arena",
+          "name": "A. Arena",
+          "overall_score": 60,
+          "potential": 81,
+          "value": 775000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Evan Ferguson",
+          "name": "E. Ferguson",
+          "overall_score": 74,
+          "potential": 82,
+          "value": 9500000,
+          "yearly_wage": 2652000
+        },
+        {
+          "currency": "€",
+          "full_name": "Robinio Vaz",
+          "name": "R. Vaz",
+          "overall_score": 70,
+          "potential": 86,
+          "value": 4100000,
+          "yearly_wage": 988000
+        },
+        {
+          "currency": "€",
+          "full_name": "Aboubacar Sangaré Traoré",
+          "name": "Buba Sangaré",
+          "overall_score": 65,
+          "potential": 79,
+          "value": 1600000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Luigi Cherubini",
+          "name": "L. Cherubini",
+          "overall_score": 69,
+          "potential": 76,
+          "value": 2800000,
+          "yearly_wage": 884000
+        },
+        {
+          "currency": "€",
+          "full_name": "Riccardo Pagano",
+          "name": "R. Pagano",
+          "overall_score": 61,
+          "potential": 71,
+          "value": 725000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Tommaso Baldanzi",
+          "name": "T. Baldanzi",
+          "overall_score": 74,
+          "potential": 80,
+          "value": 7000000,
+          "yearly_wage": 1820000
+        },
+        {
+          "currency": "€",
+          "full_name": "Anass Salah-Eddine",
+          "name": "A. Salah-Eddine",
+          "overall_score": 75,
+          "potential": 81,
+          "value": 8500000,
+          "yearly_wage": 1820000
+        },
+        {
+          "currency": "€",
+          "full_name": "Saud Abdulhamid",
+          "name": "S. Abdulhamid",
+          "overall_score": 76,
+          "potential": 78,
+          "value": 8500000,
+          "yearly_wage": 2132000
+        },
+        {
+          "currency": "€",
+          "full_name": "Marash Kumbulla",
+          "name": "M. Kumbulla",
+          "overall_score": 76,
+          "potential": 79,
+          "value": 9000000,
+          "yearly_wage": 2132000
+        },
+        {
+          "currency": "€",
+          "full_name": "Eldor Shomurodov",
+          "name": "E. Shomurodov",
+          "overall_score": 75,
+          "potential": 75,
+          "value": 5500000,
+          "yearly_wage": 2496000
+        },
+        {
+          "currency": "€",
+          "full_name": "Devis Vásquez",
+          "name": "D. Vásquez",
+          "overall_score": 72,
+          "potential": 75,
+          "value": 2300000,
+          "yearly_wage": 1040000
+        },
+        {
+          "currency": "€",
+          "full_name": "Filippo Reale",
+          "name": "F. Reale",
+          "overall_score": 63,
+          "potential": 75,
+          "value": 1100000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mattia Mannini",
+          "name": "M. Mannini",
+          "overall_score": 65,
+          "potential": 78,
+          "value": 1600000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alessandro Romano",
+          "name": "A. Romano",
+          "overall_score": 65,
+          "potential": 79,
+          "value": 1600000,
+          "yearly_wage": 468000
+        }
+      ],
+      "team": "Roma",
+      "transfer_budget": 40000000,
+      "url": "https://sofifa.com/team/52/roma/260037/"
+    },
+    {
+      "player_count": 42,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Marco Carnesecchi",
+          "name": "M. Carnesecchi",
+          "overall_score": 85,
+          "potential": 88,
+          "value": 55000000,
+          "yearly_wage": 3120000
+        },
+        {
+          "currency": "€",
+          "full_name": "Giorgio Scalvini",
+          "name": "G. Scalvini",
+          "overall_score": 78,
+          "potential": 86,
+          "value": 29500000,
+          "yearly_wage": 2184000
+        },
+        {
+          "currency": "€",
+          "full_name": "Berat Djimsiti",
+          "name": "B. Djimsiti",
+          "overall_score": 79,
+          "potential": 79,
+          "value": 11500000,
+          "yearly_wage": 3432000
+        },
+        {
+          "currency": "€",
+          "full_name": "Sead Kolašinac",
+          "name": "S. Kolašinac",
+          "overall_score": 78,
+          "potential": 78,
+          "value": 9000000,
+          "yearly_wage": 3120000
+        },
+        {
+          "currency": "€",
+          "full_name": "Davide Zappacosta",
+          "name": "D. Zappacosta",
+          "overall_score": 79,
+          "potential": 79,
+          "value": 11000000,
+          "yearly_wage": 3588000
+        },
+        {
+          "currency": "€",
+          "full_name": "Marten de Roon",
+          "name": "M. de Roon",
+          "overall_score": 81,
+          "potential": 81,
+          "value": 12000000,
+          "yearly_wage": 4056000
+        },
+        {
+          "currency": "€",
+          "full_name": "Éderson José dos Santos",
+          "name": "Éderson",
+          "overall_score": 82,
+          "potential": 85,
+          "value": 40000000,
+          "yearly_wage": 4004000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lorenzo Bernasconi",
+          "name": "L. Bernasconi",
+          "overall_score": 70,
+          "potential": 78,
+          "value": 3600000,
+          "yearly_wage": 1196000
+        },
+        {
+          "currency": "€",
+          "full_name": "Charles De Ketelaere",
+          "name": "C. De Ketelaere",
+          "overall_score": 82,
+          "potential": 86,
+          "value": 43500000,
+          "yearly_wage": 3744000
+        },
+        {
+          "currency": "€",
+          "full_name": "Giacomo Raspadori",
+          "name": "G. Raspadori",
+          "overall_score": 78,
+          "potential": 81,
+          "value": 19000000,
+          "yearly_wage": 3224000
+        },
+        {
+          "currency": "€",
+          "full_name": "Nikola Krstović",
+          "name": "N. Krstović",
+          "overall_score": 76,
+          "potential": 79,
+          "value": 10000000,
+          "yearly_wage": 2808000
+        },
+        {
+          "currency": "€",
+          "full_name": "Gianluca Scamacca",
+          "name": "G. Scamacca",
+          "overall_score": 78,
+          "potential": 79,
+          "value": 17000000,
+          "yearly_wage": 3380000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mario Pašalić",
+          "name": "M. Pašalić",
+          "overall_score": 79,
+          "potential": 79,
+          "value": 17000000,
+          "yearly_wage": 3588000
+        },
+        {
+          "currency": "€",
+          "full_name": "Raoul Bellanova",
+          "name": "R. Bellanova",
+          "overall_score": 77,
+          "potential": 78,
+          "value": 12500000,
+          "yearly_wage": 2756000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lazar Samardžić",
+          "name": "L. Samardžić",
+          "overall_score": 77,
+          "potential": 82,
+          "value": 16000000,
+          "yearly_wage": 2600000
+        },
+        {
+          "currency": "€",
+          "full_name": "Isak Hien",
+          "name": "I. Hien",
+          "overall_score": 78,
+          "potential": 81,
+          "value": 16500000,
+          "yearly_wage": 2964000
+        },
+        {
+          "currency": "€",
+          "full_name": "Honest Ahanor",
+          "name": "H. Ahanor",
+          "overall_score": 72,
+          "potential": 81,
+          "value": 4500000,
+          "yearly_wage": 936000
+        },
+        {
+          "currency": "€",
+          "full_name": "Marco Sportiello",
+          "name": "M. Sportiello",
+          "overall_score": 76,
+          "potential": 76,
+          "value": 2400000,
+          "yearly_wage": 1768000
+        },
+        {
+          "currency": "€",
+          "full_name": "Odilon Kossounou",
+          "name": "O. Kossounou",
+          "overall_score": 80,
+          "potential": 85,
+          "value": 29000000,
+          "yearly_wage": 2964000
+        },
+        {
+          "currency": "€",
+          "full_name": "Nicola Zalewski",
+          "name": "N. Zalewski",
+          "overall_score": 77,
+          "potential": 79,
+          "value": 13500000,
+          "yearly_wage": 2548000
+        },
+        {
+          "currency": "€",
+          "full_name": "Francesco Rossi",
+          "name": "F. Rossi",
+          "overall_score": 62,
+          "potential": 62,
+          "value": 70000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "Relja Obrić",
+          "name": "R. Obrić",
+          "overall_score": 65,
+          "potential": 76,
+          "value": 1400000,
+          "yearly_wage": 520000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mitchel Bakker",
+          "name": "M. Bakker",
+          "overall_score": 75,
+          "potential": 80,
+          "value": 7500000,
+          "yearly_wage": 2340000
+        },
+        {
+          "currency": "€",
+          "full_name": "Yunus Musah",
+          "name": "Y. Musah",
+          "overall_score": 73,
+          "potential": 81,
+          "value": 7000000,
+          "yearly_wage": 1456000
+        },
+        {
+          "currency": "€",
+          "full_name": "Kamaldeen Sulemana",
+          "name": "K. Sulemana",
+          "overall_score": 73,
+          "potential": 76,
+          "value": 4200000,
+          "yearly_wage": 1924000
+        },
+        {
+          "currency": "€",
+          "full_name": "Dominic Vavassori",
+          "name": "D. Vavassori",
+          "overall_score": 62,
+          "potential": 75,
+          "value": 950000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "Tommaso Del Lungo",
+          "name": "T. Del Lungo",
+          "overall_score": 65,
+          "potential": 75,
+          "value": 1500000,
+          "yearly_wage": 572000
+        },
+        {
+          "currency": "€",
+          "full_name": "Leonardo Mendicino",
+          "name": "L. Mendicino",
+          "overall_score": 61,
+          "potential": 76,
+          "value": 725000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Giovanni Bonfanti",
+          "name": "G. Bonfanti",
+          "overall_score": 67,
+          "potential": 76,
+          "value": 2100000,
+          "yearly_wage": 936000
+        },
+        {
+          "currency": "€",
+          "full_name": "Marco Palestra",
+          "name": "M. Palestra",
+          "overall_score": 75,
+          "potential": 84,
+          "value": 12000000,
+          "yearly_wage": 1820000
+        },
+        {
+          "currency": "€",
+          "full_name": "Federico Zuccon",
+          "name": "F. Zuccon",
+          "overall_score": 66,
+          "potential": 75,
+          "value": 1900000,
+          "yearly_wage": 832000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ibrahim Sulemana",
+          "name": "I. Sulemana",
+          "overall_score": 73,
+          "potential": 80,
+          "value": 6000000,
+          "yearly_wage": 1768000
+        },
+        {
+          "currency": "€",
+          "full_name": "Andrea Oliveri",
+          "name": "A. Oliveri",
+          "overall_score": 63,
+          "potential": 72,
+          "value": 1100000,
+          "yearly_wage": 572000
+        },
+        {
+          "currency": "€",
+          "full_name": "Samuel Giovane",
+          "name": "S. Giovane",
+          "overall_score": 67,
+          "potential": 75,
+          "value": 2300000,
+          "yearly_wage": 988000
+        },
+        {
+          "currency": "€",
+          "full_name": "Tommaso De Nipoti",
+          "name": "T. De Nipoti",
+          "overall_score": 59,
+          "potential": 70,
+          "value": 500000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Giorgio Cittadini",
+          "name": "G. Cittadini",
+          "overall_score": 67,
+          "potential": 75,
+          "value": 2100000,
+          "yearly_wage": 936000
+        },
+        {
+          "currency": "€",
+          "full_name": "Marco Brescianini",
+          "name": "M. Brescianini",
+          "overall_score": 72,
+          "potential": 75,
+          "value": 3100000,
+          "yearly_wage": 1872000
+        },
+        {
+          "currency": "€",
+          "full_name": "Daniel Maldini",
+          "name": "D. Maldini",
+          "overall_score": 74,
+          "potential": 81,
+          "value": 8500000,
+          "yearly_wage": 2132000
+        },
+        {
+          "currency": "€",
+          "full_name": "El Bilal Touré",
+          "name": "E. Touré",
+          "overall_score": 73,
+          "potential": 80,
+          "value": 6000000,
+          "yearly_wage": 2080000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ben Godfrey",
+          "name": "B. Godfrey",
+          "overall_score": 73,
+          "potential": 73,
+          "value": 2800000,
+          "yearly_wage": 2080000
+        },
+        {
+          "currency": "€",
+          "full_name": "Siren Diao Balde",
+          "name": "Siren Diao",
+          "overall_score": 63,
+          "potential": 77,
+          "value": 1200000,
+          "yearly_wage": 520000
+        },
+        {
+          "currency": "€",
+          "full_name": "Vanja Vlahović",
+          "name": "V. Vlahović",
+          "overall_score": 66,
+          "potential": 77,
+          "value": 1900000,
+          "yearly_wage": 780000
+        }
+      ],
+      "team": "Atalanta",
+      "transfer_budget": 54100000,
+      "url": "https://sofifa.com/team/39/atalanta/260037/"
+    },
+    {
+      "player_count": 36,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Edoardo Motta",
+          "name": "E. Motta",
+          "overall_score": 67,
+          "potential": 74,
+          "value": 1700000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Adam Marušić",
+          "name": "A. Marušić",
+          "overall_score": 77,
+          "potential": 77,
+          "value": 7500000,
+          "yearly_wage": 1664000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mario Gila Fuentes",
+          "name": "Mario Gila",
+          "overall_score": 81,
+          "potential": 84,
+          "value": 31500000,
+          "yearly_wage": 1820000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alessio Romagnoli",
+          "name": "A. Romagnoli",
+          "overall_score": 82,
+          "potential": 82,
+          "value": 25000000,
+          "yearly_wage": 2392000
+        },
+        {
+          "currency": "€",
+          "full_name": "Nuno Albertino Varela Tavares",
+          "name": "Nuno Tavares",
+          "overall_score": 76,
+          "potential": 79,
+          "value": 9000000,
+          "yearly_wage": 1404000
+        },
+        {
+          "currency": "€",
+          "full_name": "Nicolò Rovella",
+          "name": "N. Rovella",
+          "overall_score": 79,
+          "potential": 84,
+          "value": 24500000,
+          "yearly_wage": 1612000
+        },
+        {
+          "currency": "€",
+          "full_name": "Toma Bašić",
+          "name": "T. Bašić",
+          "overall_score": 75,
+          "potential": 75,
+          "value": 5500000,
+          "yearly_wage": 1560000
+        },
+        {
+          "currency": "€",
+          "full_name": "Kenneth Taylor",
+          "name": "K. Taylor",
+          "overall_score": 78,
+          "potential": 83,
+          "value": 21000000,
+          "yearly_wage": 1560000
+        },
+        {
+          "currency": "€",
+          "full_name": "Matteo Cancellieri",
+          "name": "M. Cancellieri",
+          "overall_score": 74,
+          "potential": 79,
+          "value": 6500000,
+          "yearly_wage": 1300000
+        },
+        {
+          "currency": "€",
+          "full_name": "Daniel Maldini",
+          "name": "D. Maldini",
+          "overall_score": 74,
+          "potential": 81,
+          "value": 8500000,
+          "yearly_wage": 2132000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mattia Zaccagni",
+          "name": "M. Zaccagni",
+          "overall_score": 83,
+          "potential": 83,
+          "value": 35000000,
+          "yearly_wage": 2912000
+        },
+        {
+          "currency": "€",
+          "full_name": "Boulaye Dia",
+          "name": "B. Dia",
+          "overall_score": 78,
+          "potential": 78,
+          "value": 14500000,
+          "yearly_wage": 2028000
+        },
+        {
+          "currency": "€",
+          "full_name": "Danilo Cataldi",
+          "name": "D. Cataldi",
+          "overall_score": 78,
+          "potential": 78,
+          "value": 13500000,
+          "yearly_wage": 1872000
+        },
+        {
+          "currency": "€",
+          "full_name": "Gustav Isaksen",
+          "name": "G. Isaksen",
+          "overall_score": 76,
+          "potential": 79,
+          "value": 10000000,
+          "yearly_wage": 1352000
+        },
+        {
+          "currency": "€",
+          "full_name": "Manuel Lazzari",
+          "name": "M. Lazzari",
+          "overall_score": 76,
+          "potential": 76,
+          "value": 5500000,
+          "yearly_wage": 1560000
+        },
+        {
+          "currency": "€",
+          "full_name": "Luca Pellegrini",
+          "name": "L. Pellegrini",
+          "overall_score": 74,
+          "potential": 75,
+          "value": 4500000,
+          "yearly_wage": 1300000
+        },
+        {
+          "currency": "€",
+          "full_name": "Oliver Provstgaard",
+          "name": "O. Provstgaard",
+          "overall_score": 69,
+          "potential": 76,
+          "value": 2600000,
+          "yearly_wage": 676000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alessio Furlanetto",
+          "name": "A. Furlanetto",
+          "overall_score": 61,
+          "potential": 66,
+          "value": 400000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Pedro Rodríguez Ledesma",
+          "name": "Pedro",
+          "overall_score": 76,
+          "potential": 76,
+          "value": 2400000,
+          "yearly_wage": 1196000
+        },
+        {
+          "currency": "€",
+          "full_name": "Tijjani Noslin",
+          "name": "T. Noslin",
+          "overall_score": 74,
+          "potential": 77,
+          "value": 5500000,
+          "yearly_wage": 1456000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ivan Provedel",
+          "name": "I. Provedel",
+          "overall_score": 83,
+          "potential": 83,
+          "value": 19000000,
+          "yearly_wage": 1716000
+        },
+        {
+          "currency": "€",
+          "full_name": "Samuel Gigot",
+          "name": "S. Gigot",
+          "overall_score": 76,
+          "potential": 76,
+          "value": 5000000,
+          "yearly_wage": 1560000
+        },
+        {
+          "currency": "€",
+          "full_name": "Patricio Gabarrón Gil",
+          "name": "Patric",
+          "overall_score": 75,
+          "potential": 75,
+          "value": 3600000,
+          "yearly_wage": 1508000
+        },
+        {
+          "currency": "€",
+          "full_name": "Elseid Hysaj",
+          "name": "E. Hysaj",
+          "overall_score": 72,
+          "potential": 72,
+          "value": 1700000,
+          "yearly_wage": 1144000
+        },
+        {
+          "currency": "€",
+          "full_name": "Reda Belahyane",
+          "name": "R. Belahyane",
+          "overall_score": 67,
+          "potential": 76,
+          "value": 2300000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "Valerio Farcomeni",
+          "name": "V. Farcomeni",
+          "overall_score": 59,
+          "potential": 74,
+          "value": 525000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Cristobal Muñoz López",
+          "name": "Cristo Muñoz",
+          "overall_score": 65,
+          "potential": 75,
+          "value": 1600000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Fisayo Dele-Bashiru",
+          "name": "F. Dele-Bashiru",
+          "overall_score": 73,
+          "potential": 77,
+          "value": 4400000,
+          "yearly_wage": 1092000
+        },
+        {
+          "currency": "€",
+          "full_name": "Adrian Przyborek",
+          "name": "A. Przyborek",
+          "overall_score": 66,
+          "potential": 78,
+          "value": 2000000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Petar Ratkov",
+          "name": "P. Ratkov",
+          "overall_score": 68,
+          "potential": 78,
+          "value": 2700000,
+          "yearly_wage": 624000
+        },
+        {
+          "currency": "€",
+          "full_name": "Saná Fernandes",
+          "name": "Saná Fernandes",
+          "overall_score": 62,
+          "potential": 75,
+          "value": 950000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Christos Mandas",
+          "name": "C. Mandas",
+          "overall_score": 74,
+          "potential": 80,
+          "value": 5500000,
+          "yearly_wage": 676000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alessandro Milani",
+          "name": "A. Milani",
+          "overall_score": 62,
+          "potential": 76,
+          "value": 925000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Filipe Bordon",
+          "name": "Filipe Bordon",
+          "overall_score": 65,
+          "potential": 75,
+          "value": 1500000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Romano Floriani Mussolini",
+          "name": "R. Floriani Mussolini",
+          "overall_score": 69,
+          "potential": 77,
+          "value": 3100000,
+          "yearly_wage": 676000
+        },
+        {
+          "currency": "€",
+          "full_name": "Gabriele Artistico",
+          "name": "G. Artistico",
+          "overall_score": 67,
+          "potential": 72,
+          "value": 1600000,
+          "yearly_wage": 624000
+        }
+      ],
+      "team": "Lazio",
+      "transfer_budget": 17900000,
+      "url": "https://sofifa.com/team/46/lazio/260037/"
+    },
+    {
+      "player_count": 45,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Jean Butez",
+          "name": "J. Butez",
+          "overall_score": 78,
+          "potential": 78,
+          "value": 9500000,
+          "yearly_wage": 2704000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ivan Smolčić",
+          "name": "I. Smolčić",
+          "overall_score": 75,
+          "potential": 78,
+          "value": 7000000,
+          "yearly_wage": 2860000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jacobo Ramón Naveros",
+          "name": "Jacobo Ramón",
+          "overall_score": 74,
+          "potential": 84,
+          "value": 8500000,
+          "yearly_wage": 2236000
+        },
+        {
+          "currency": "€",
+          "full_name": "Marc-Oliver Kempf",
+          "name": "M. Kempf",
+          "overall_score": 75,
+          "potential": 75,
+          "value": 4600000,
+          "yearly_wage": 3432000
+        },
+        {
+          "currency": "€",
+          "full_name": "Álex Valle Gómez",
+          "name": "Álex Valle",
+          "overall_score": 74,
+          "potential": 84,
+          "value": 9000000,
+          "yearly_wage": 2236000
+        },
+        {
+          "currency": "€",
+          "full_name": "Máximo Perrone",
+          "name": "M. Perrone",
+          "overall_score": 76,
+          "potential": 84,
+          "value": 16000000,
+          "yearly_wage": 3016000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lucas Da Cunha",
+          "name": "L. Da Cunha",
+          "overall_score": 76,
+          "potential": 80,
+          "value": 10000000,
+          "yearly_wage": 3016000
+        },
+        {
+          "currency": "€",
+          "full_name": "Assane Diao",
+          "name": "A. Diao",
+          "overall_score": 76,
+          "potential": 87,
+          "value": 16000000,
+          "yearly_wage": 2548000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jesús Rodríguez Caraballo",
+          "name": "Jesús Rodríguez",
+          "overall_score": 77,
+          "potential": 85,
+          "value": 23000000,
+          "yearly_wage": 2704000
+        },
+        {
+          "currency": "€",
+          "full_name": "Nicolás Paz Martínez",
+          "name": "Nico Paz",
+          "overall_score": 82,
+          "potential": 89,
+          "value": 60500000,
+          "yearly_wage": 4264000
+        },
+        {
+          "currency": "€",
+          "full_name": "Tasos Douvikas",
+          "name": "T. Douvikas",
+          "overall_score": 76,
+          "potential": 79,
+          "value": 10000000,
+          "yearly_wage": 3796000
+        },
+        {
+          "currency": "€",
+          "full_name": "Álvaro Borja Morata Martín",
+          "name": "Morata",
+          "overall_score": 79,
+          "potential": 79,
+          "value": 14000000,
+          "yearly_wage": 2912000
+        },
+        {
+          "currency": "€",
+          "full_name": "Martin Baturina",
+          "name": "M. Baturina",
+          "overall_score": 79,
+          "potential": 84,
+          "value": 27000000,
+          "yearly_wage": 4056000
+        },
+        {
+          "currency": "€",
+          "full_name": "Maxence Caqueret",
+          "name": "M. Caqueret",
+          "overall_score": 78,
+          "potential": 80,
+          "value": 17500000,
+          "yearly_wage": 3952000
+        },
+        {
+          "currency": "€",
+          "full_name": "Diego Carlos Santos Silva",
+          "name": "Diego Carlos",
+          "overall_score": 79,
+          "potential": 79,
+          "value": 11500000,
+          "yearly_wage": 2860000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mërgim Vojvoda",
+          "name": "M. Vojvoda",
+          "overall_score": 76,
+          "potential": 76,
+          "value": 6500000,
+          "yearly_wage": 3640000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alberto Moreno Pérez",
+          "name": "Alberto Moreno",
+          "overall_score": 75,
+          "potential": 75,
+          "value": 3900000,
+          "yearly_wage": 3432000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mauro Vigorito",
+          "name": "M. Vigorito",
+          "overall_score": 64,
+          "potential": 64,
+          "value": 60000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ignace Van der Brempt",
+          "name": "I. Van der Brempt",
+          "overall_score": 72,
+          "potential": 78,
+          "value": 3500000,
+          "yearly_wage": 2184000
+        },
+        {
+          "currency": "€",
+          "full_name": "Sergio Roberto Carnicer",
+          "name": "Sergi Roberto",
+          "overall_score": 76,
+          "potential": 76,
+          "value": 3700000,
+          "yearly_wage": 3640000
+        },
+        {
+          "currency": "€",
+          "full_name": "Nikola Čavlina",
+          "name": "N. Čavlina",
+          "overall_score": 67,
+          "potential": 73,
+          "value": 1300000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Henrique Menke Lopes",
+          "name": "Henrique Menke",
+          "overall_score": 58,
+          "potential": 74,
+          "value": 450000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Noel Törnqvist",
+          "name": "N. Törnqvist",
+          "overall_score": 73,
+          "potential": 81,
+          "value": 6000000,
+          "yearly_wage": 1404000
+        },
+        {
+          "currency": "€",
+          "full_name": "Edoardo Goldaniga",
+          "name": "E. Goldaniga",
+          "overall_score": 72,
+          "potential": 72,
+          "value": 1600000,
+          "yearly_wage": 2652000
+        },
+        {
+          "currency": "€",
+          "full_name": "Adrian Lahdo",
+          "name": "A. Lahdo",
+          "overall_score": 60,
+          "potential": 77,
+          "value": 600000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jayden Addai",
+          "name": "J. Addai",
+          "overall_score": 70,
+          "potential": 84,
+          "value": 3800000,
+          "yearly_wage": 1456000
+        },
+        {
+          "currency": "€",
+          "full_name": "Nicolas Kühn",
+          "name": "N. Kühn",
+          "overall_score": 77,
+          "potential": 78,
+          "value": 12500000,
+          "yearly_wage": 4004000
+        },
+        {
+          "currency": "€",
+          "full_name": "Fabio Rispoli",
+          "name": "F. Rispoli",
+          "overall_score": 65,
+          "potential": 74,
+          "value": 1500000,
+          "yearly_wage": 676000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alessandro Gabrielloni",
+          "name": "A. Gabrielloni",
+          "overall_score": 68,
+          "potential": 68,
+          "value": 1200000,
+          "yearly_wage": 1924000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alieu Fadera",
+          "name": "A. Fadera",
+          "overall_score": 71,
+          "potential": 77,
+          "value": 3000000,
+          "yearly_wage": 2236000
+        },
+        {
+          "currency": "€",
+          "full_name": "Yannik Engelhardt",
+          "name": "Y. Engelhardt",
+          "overall_score": 73,
+          "potential": 76,
+          "value": 3800000,
+          "yearly_wage": 2392000
+        },
+        {
+          "currency": "€",
+          "full_name": "Iván Azón Monzón",
+          "name": "Iván Azón",
+          "overall_score": 69,
+          "potential": 78,
+          "value": 3200000,
+          "yearly_wage": 1768000
+        },
+        {
+          "currency": "€",
+          "full_name": "Tommaso Cassandro",
+          "name": "T. Cassandro",
+          "overall_score": 68,
+          "potential": 69,
+          "value": 1300000,
+          "yearly_wage": 1560000
+        },
+        {
+          "currency": "€",
+          "full_name": "Matthias Braunöder",
+          "name": "M. Braunöder",
+          "overall_score": 68,
+          "potential": 75,
+          "value": 2400000,
+          "yearly_wage": 1456000
+        },
+        {
+          "currency": "€",
+          "full_name": "Marlon Suliman Mustapha",
+          "name": "M. Mustapha",
+          "overall_score": 65,
+          "potential": 70,
+          "value": 1100000,
+          "yearly_wage": 988000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ben Lhassine Kone",
+          "name": "B. Kone",
+          "overall_score": 67,
+          "potential": 69,
+          "value": 1300000,
+          "yearly_wage": 1404000
+        },
+        {
+          "currency": "€",
+          "full_name": "Patrick Cutrone",
+          "name": "P. Cutrone",
+          "overall_score": 74,
+          "potential": 74,
+          "value": 4600000,
+          "yearly_wage": 3484000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alberto Dossena",
+          "name": "A. Dossena",
+          "overall_score": 73,
+          "potential": 76,
+          "value": 3500000,
+          "yearly_wage": 2756000
+        },
+        {
+          "currency": "€",
+          "full_name": "Emil Audero",
+          "name": "E. Audero",
+          "overall_score": 79,
+          "potential": 79,
+          "value": 12500000,
+          "yearly_wage": 2964000
+        },
+        {
+          "currency": "€",
+          "full_name": "Stefan Posch",
+          "name": "S. Posch",
+          "overall_score": 78,
+          "potential": 78,
+          "value": 12000000,
+          "yearly_wage": 4160000
+        },
+        {
+          "currency": "€",
+          "full_name": "Luca Mazzitelli",
+          "name": "L. Mazzitelli",
+          "overall_score": 73,
+          "potential": 73,
+          "value": 3000000,
+          "yearly_wage": 3016000
+        },
+        {
+          "currency": "€",
+          "full_name": "Andréa Le Borgne",
+          "name": "A. Le Borgne",
+          "overall_score": 61,
+          "potential": 76,
+          "value": 725000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "Fellipe Jack",
+          "name": "Fellipe Jack",
+          "overall_score": 65,
+          "potential": 78,
+          "value": 1600000,
+          "yearly_wage": 676000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ali Jasim",
+          "name": "A. Jasim",
+          "overall_score": 62,
+          "potential": 74,
+          "value": 975000,
+          "yearly_wage": 572000
+        },
+        {
+          "currency": "€",
+          "full_name": "Tommaso Fumagalli",
+          "name": "T. Fumagalli",
+          "overall_score": 69,
+          "potential": 72,
+          "value": 1900000,
+          "yearly_wage": 1924000
+        }
+      ],
+      "team": "Como",
+      "transfer_budget": 51600000,
+      "url": "https://sofifa.com/team/1745/como/260037/"
+    },
+    {
+      "player_count": 44,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "David De Gea Quintana",
+          "name": "De Gea",
+          "overall_score": 84,
+          "potential": 84,
+          "value": 7000000,
+          "yearly_wage": 2652000
+        },
+        {
+          "currency": "€",
+          "full_name": "Domilson Cordeiro dos Santos",
+          "name": "Dodô",
+          "overall_score": 78,
+          "potential": 79,
+          "value": 15000000,
+          "yearly_wage": 2392000
+        },
+        {
+          "currency": "€",
+          "full_name": "Marin Pongračić",
+          "name": "M. Pongračić",
+          "overall_score": 73,
+          "potential": 75,
+          "value": 3200000,
+          "yearly_wage": 1664000
+        },
+        {
+          "currency": "€",
+          "full_name": "Luca Ranieri",
+          "name": "L. Ranieri",
+          "overall_score": 75,
+          "potential": 78,
+          "value": 6500000,
+          "yearly_wage": 1976000
+        },
+        {
+          "currency": "€",
+          "full_name": "Robin Gosens",
+          "name": "R. Gosens",
+          "overall_score": 79,
+          "potential": 79,
+          "value": 15000000,
+          "yearly_wage": 2756000
+        },
+        {
+          "currency": "€",
+          "full_name": "Nicolò Fagioli",
+          "name": "N. Fagioli",
+          "overall_score": 76,
+          "potential": 81,
+          "value": 11500000,
+          "yearly_wage": 1924000
+        },
+        {
+          "currency": "€",
+          "full_name": "Rolando Mandragora",
+          "name": "R. Mandragora",
+          "overall_score": 76,
+          "potential": 76,
+          "value": 7500000,
+          "yearly_wage": 2288000
+        },
+        {
+          "currency": "€",
+          "full_name": "Cher Ndour",
+          "name": "C. Ndour",
+          "overall_score": 72,
+          "potential": 83,
+          "value": 5000000,
+          "yearly_wage": 1196000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jack Harrison",
+          "name": "J. Harrison",
+          "overall_score": 73,
+          "potential": 73,
+          "value": 3100000,
+          "yearly_wage": 2340000
+        },
+        {
+          "currency": "€",
+          "full_name": "Moise Kean",
+          "name": "M. Kean",
+          "overall_score": 83,
+          "potential": 86,
+          "value": 48500000,
+          "yearly_wage": 3848000
+        },
+        {
+          "currency": "€",
+          "full_name": "Albert Guðmundsson",
+          "name": "A. Guðmundsson",
+          "overall_score": 78,
+          "potential": 78,
+          "value": 14500000,
+          "yearly_wage": 2808000
+        },
+        {
+          "currency": "€",
+          "full_name": "Roberto Piccoli",
+          "name": "R. Piccoli",
+          "overall_score": 75,
+          "potential": 80,
+          "value": 8500000,
+          "yearly_wage": 1976000
+        },
+        {
+          "currency": "€",
+          "full_name": "Marco Brescianini",
+          "name": "M. Brescianini",
+          "overall_score": 72,
+          "potential": 75,
+          "value": 3100000,
+          "yearly_wage": 1872000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jacopo Fazzini",
+          "name": "J. Fazzini",
+          "overall_score": 72,
+          "potential": 81,
+          "value": 5500000,
+          "yearly_wage": 1404000
+        },
+        {
+          "currency": "€",
+          "full_name": "Niccolò Fortini",
+          "name": "N. Fortini",
+          "overall_score": 67,
+          "potential": 80,
+          "value": 2400000,
+          "yearly_wage": 624000
+        },
+        {
+          "currency": "€",
+          "full_name": "Fabiano Parisi",
+          "name": "F. Parisi",
+          "overall_score": 75,
+          "potential": 80,
+          "value": 8000000,
+          "yearly_wage": 1716000
+        },
+        {
+          "currency": "€",
+          "full_name": "Pietro Comuzzo",
+          "name": "P. Comuzzo",
+          "overall_score": 75,
+          "potential": 86,
+          "value": 11500000,
+          "yearly_wage": 1456000
+        },
+        {
+          "currency": "€",
+          "full_name": "Oliver Christensen",
+          "name": "O. Christensen",
+          "overall_score": 71,
+          "potential": 74,
+          "value": 1900000,
+          "yearly_wage": 884000
+        },
+        {
+          "currency": "€",
+          "full_name": "Giovanni Fabbian",
+          "name": "G. Fabbian",
+          "overall_score": 73,
+          "potential": 82,
+          "value": 7000000,
+          "yearly_wage": 1508000
+        },
+        {
+          "currency": "€",
+          "full_name": "Manor Solomon",
+          "name": "M. Solomon",
+          "overall_score": 77,
+          "potential": 77,
+          "value": 11500000,
+          "yearly_wage": 4056000
+        },
+        {
+          "currency": "€",
+          "full_name": "Luca Lezzerini",
+          "name": "L. Lezzerini",
+          "overall_score": 69,
+          "potential": 69,
+          "value": 925000,
+          "yearly_wage": 728000
+        },
+        {
+          "currency": "€",
+          "full_name": "Eman Košpo",
+          "name": "E. Košpo",
+          "overall_score": 61,
+          "potential": 76,
+          "value": 725000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Eddy Kouadio",
+          "name": "E. Kouadio",
+          "overall_score": 62,
+          "potential": 76,
+          "value": 875000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Daniele Rugani",
+          "name": "D. Rugani",
+          "overall_score": 75,
+          "potential": 75,
+          "value": 4600000,
+          "yearly_wage": 4160000
+        },
+        {
+          "currency": "€",
+          "full_name": "Tariq Lamptey",
+          "name": "T. Lamptey",
+          "overall_score": 73,
+          "potential": 76,
+          "value": 3800000,
+          "yearly_wage": 1456000
+        },
+        {
+          "currency": "€",
+          "full_name": "Luís Balbo",
+          "name": "L. Balbo",
+          "overall_score": 60,
+          "potential": 75,
+          "value": 550000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Abdelhamid Sabiri",
+          "name": "A. Sabiri",
+          "overall_score": 72,
+          "potential": 72,
+          "value": 2400000,
+          "yearly_wage": 1664000
+        },
+        {
+          "currency": "€",
+          "full_name": "Riccardo Braschi",
+          "name": "R. Braschi",
+          "overall_score": 56,
+          "potential": 71,
+          "value": 325000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Christian Kouamé",
+          "name": "C. Kouamé",
+          "overall_score": 73,
+          "potential": 73,
+          "value": 3300000,
+          "yearly_wage": 1872000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lorenzo Lucchesi",
+          "name": "L. Lucchesi",
+          "overall_score": 65,
+          "potential": 76,
+          "value": 1500000,
+          "yearly_wage": 520000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lorenzo Amatucci",
+          "name": "L. Amatucci",
+          "overall_score": 72,
+          "potential": 82,
+          "value": 5000000,
+          "yearly_wage": 1196000
+        },
+        {
+          "currency": "€",
+          "full_name": "Filippo Distefano",
+          "name": "F. Distefano",
+          "overall_score": 65,
+          "potential": 76,
+          "value": 1600000,
+          "yearly_wage": 520000
+        },
+        {
+          "currency": "€",
+          "full_name": "Matías Moreno",
+          "name": "M. Moreno",
+          "overall_score": 73,
+          "potential": 79,
+          "value": 4400000,
+          "yearly_wage": 1196000
+        },
+        {
+          "currency": "€",
+          "full_name": "Tommaso Martinelli",
+          "name": "T. Martinelli",
+          "overall_score": 69,
+          "potential": 79,
+          "value": 2600000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Nicolás Valentini",
+          "name": "N. Valentini",
+          "overall_score": 73,
+          "potential": 79,
+          "value": 4400000,
+          "yearly_wage": 1456000
+        },
+        {
+          "currency": "€",
+          "full_name": "Amir Richardson",
+          "name": "A. Richardson",
+          "overall_score": 71,
+          "potential": 77,
+          "value": 2900000,
+          "yearly_wage": 1248000
+        },
+        {
+          "currency": "€",
+          "full_name": "Gino Infantino",
+          "name": "G. Infantino",
+          "overall_score": 66,
+          "potential": 73,
+          "value": 1700000,
+          "yearly_wage": 676000
+        },
+        {
+          "currency": "€",
+          "full_name": "Riccardo Sottil",
+          "name": "R. Sottil",
+          "overall_score": 74,
+          "potential": 75,
+          "value": 5000000,
+          "yearly_wage": 1924000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lucas Beltrán",
+          "name": "L. Beltrán",
+          "overall_score": 75,
+          "potential": 79,
+          "value": 8000000,
+          "yearly_wage": 1976000
+        },
+        {
+          "currency": "€",
+          "full_name": "Simon Sohm",
+          "name": "S. Sohm",
+          "overall_score": 74,
+          "potential": 79,
+          "value": 6500000,
+          "yearly_wage": 1664000
+        },
+        {
+          "currency": "€",
+          "full_name": "M'Bala Nzola",
+          "name": "M. Nzola",
+          "overall_score": 73,
+          "potential": 73,
+          "value": 3100000,
+          "yearly_wage": 1976000
+        },
+        {
+          "currency": "€",
+          "full_name": "Antonín Barák",
+          "name": "A. Barák",
+          "overall_score": 72,
+          "potential": 72,
+          "value": 2200000,
+          "yearly_wage": 1664000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jonas Harder",
+          "name": "J. Harder",
+          "overall_score": 64,
+          "potential": 75,
+          "value": 1300000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "Tommaso Rubino",
+          "name": "T. Rubino",
+          "overall_score": 64,
+          "potential": 76,
+          "value": 1400000,
+          "yearly_wage": 416000
+        }
+      ],
+      "team": "Fiorentina",
+      "transfer_budget": 36200000,
+      "url": "https://sofifa.com/team/110374/fiorentina/260037/"
+    },
+    {
+      "player_count": 37,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Łukasz Skorupski",
+          "name": "Ł. Skorupski",
+          "overall_score": 78,
+          "potential": 78,
+          "value": 2400000,
+          "yearly_wage": 1612000
+        },
+        {
+          "currency": "€",
+          "full_name": "João Mário Neto Lopes",
+          "name": "João Mário",
+          "overall_score": 77,
+          "potential": 80,
+          "value": 13000000,
+          "yearly_wage": 4264000
+        },
+        {
+          "currency": "€",
+          "full_name": "Eivind Helland",
+          "name": "E. Helland",
+          "overall_score": 67,
+          "potential": 79,
+          "value": 2300000,
+          "yearly_wage": 624000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jhon Lucumí",
+          "name": "J. Lucumí",
+          "overall_score": 76,
+          "potential": 78,
+          "value": 8000000,
+          "yearly_wage": 2080000
+        },
+        {
+          "currency": "€",
+          "full_name": "Juan Miranda González",
+          "name": "Juan Miranda",
+          "overall_score": 76,
+          "potential": 79,
+          "value": 9000000,
+          "yearly_wage": 1976000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lewis Ferguson",
+          "name": "L. Ferguson",
+          "overall_score": 78,
+          "potential": 81,
+          "value": 17000000,
+          "yearly_wage": 2288000
+        },
+        {
+          "currency": "€",
+          "full_name": "Remo Freuler",
+          "name": "R. Freuler",
+          "overall_score": 82,
+          "potential": 82,
+          "value": 15000000,
+          "yearly_wage": 3380000
+        },
+        {
+          "currency": "€",
+          "full_name": "Federico Bernardeschi",
+          "name": "F. Bernardeschi",
+          "overall_score": 75,
+          "potential": 75,
+          "value": 4700000,
+          "yearly_wage": 2184000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jonathan Rowe",
+          "name": "J. Rowe",
+          "overall_score": 75,
+          "potential": 82,
+          "value": 11500000,
+          "yearly_wage": 1820000
+        },
+        {
+          "currency": "€",
+          "full_name": "Simon Sohm",
+          "name": "S. Sohm",
+          "overall_score": 74,
+          "potential": 79,
+          "value": 6500000,
+          "yearly_wage": 1664000
+        },
+        {
+          "currency": "€",
+          "full_name": "Santiago Castro",
+          "name": "S. Castro",
+          "overall_score": 77,
+          "potential": 84,
+          "value": 21000000,
+          "yearly_wage": 1924000
+        },
+        {
+          "currency": "€",
+          "full_name": "Thijs Dallinga",
+          "name": "T. Dallinga",
+          "overall_score": 75,
+          "potential": 80,
+          "value": 8500000,
+          "yearly_wage": 1976000
+        },
+        {
+          "currency": "€",
+          "full_name": "Riccardo Orsolini",
+          "name": "R. Orsolini",
+          "overall_score": 83,
+          "potential": 83,
+          "value": 36500000,
+          "yearly_wage": 3848000
+        },
+        {
+          "currency": "€",
+          "full_name": "Nicolò Cambiaghi",
+          "name": "N. Cambiaghi",
+          "overall_score": 76,
+          "potential": 78,
+          "value": 9500000,
+          "yearly_wage": 1924000
+        },
+        {
+          "currency": "€",
+          "full_name": "Tommaso Pobega",
+          "name": "T. Pobega",
+          "overall_score": 74,
+          "potential": 76,
+          "value": 5500000,
+          "yearly_wage": 1820000
+        },
+        {
+          "currency": "€",
+          "full_name": "Torbjørn Heggem",
+          "name": "T. Heggem",
+          "overall_score": 74,
+          "potential": 76,
+          "value": 4600000,
+          "yearly_wage": 1820000
+        },
+        {
+          "currency": "€",
+          "full_name": "Nadir Zortea",
+          "name": "N. Zortea",
+          "overall_score": 73,
+          "potential": 74,
+          "value": 3300000,
+          "yearly_wage": 1664000
+        },
+        {
+          "currency": "€",
+          "full_name": "Federico Ravaglia",
+          "name": "F. Ravaglia",
+          "overall_score": 72,
+          "potential": 75,
+          "value": 2400000,
+          "yearly_wage": 884000
+        },
+        {
+          "currency": "€",
+          "full_name": "Nikola Moro",
+          "name": "N. Moro",
+          "overall_score": 75,
+          "potential": 75,
+          "value": 5500000,
+          "yearly_wage": 1976000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jens Odgaard",
+          "name": "J. Odgaard",
+          "overall_score": 77,
+          "potential": 78,
+          "value": 12500000,
+          "yearly_wage": 2392000
+        },
+        {
+          "currency": "€",
+          "full_name": "Massimo Pessina",
+          "name": "M. Pessina",
+          "overall_score": 54,
+          "potential": 74,
+          "value": 250000,
+          "yearly_wage": 33800
+        },
+        {
+          "currency": "€",
+          "full_name": "Nicolò Casale",
+          "name": "N. Casale",
+          "overall_score": 74,
+          "potential": 76,
+          "value": 4500000,
+          "yearly_wage": 1820000
+        },
+        {
+          "currency": "€",
+          "full_name": "Martin Vitík",
+          "name": "M. Vitík",
+          "overall_score": 74,
+          "potential": 80,
+          "value": 6000000,
+          "yearly_wage": 1612000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lorenzo De Silvestri",
+          "name": "L. De Silvestri",
+          "overall_score": 71,
+          "potential": 71,
+          "value": 425000,
+          "yearly_wage": 1040000
+        },
+        {
+          "currency": "€",
+          "full_name": "Charalampos Lykogiannis",
+          "name": "C. Lykogiannis",
+          "overall_score": 73,
+          "potential": 73,
+          "value": 2200000,
+          "yearly_wage": 1768000
+        },
+        {
+          "currency": "€",
+          "full_name": "Benjamín Domínguez",
+          "name": "B. Domínguez",
+          "overall_score": 73,
+          "potential": 83,
+          "value": 7000000,
+          "yearly_wage": 1300000
+        },
+        {
+          "currency": "€",
+          "full_name": "Tommaso Corazza",
+          "name": "T. Corazza",
+          "overall_score": 67,
+          "potential": 77,
+          "value": 2200000,
+          "yearly_wage": 624000
+        },
+        {
+          "currency": "€",
+          "full_name": "Niklas Pyyhtiä",
+          "name": "N. Pyyhtiä",
+          "overall_score": 70,
+          "potential": 77,
+          "value": 3200000,
+          "yearly_wage": 936000
+        },
+        {
+          "currency": "€",
+          "full_name": "Giovanni Fabbian",
+          "name": "G. Fabbian",
+          "overall_score": 73,
+          "potential": 82,
+          "value": 7000000,
+          "yearly_wage": 1508000
+        },
+        {
+          "currency": "€",
+          "full_name": "Oussama El Azzouzi",
+          "name": "O. El Azzouzi",
+          "overall_score": 70,
+          "potential": 75,
+          "value": 2200000,
+          "yearly_wage": 1040000
+        },
+        {
+          "currency": "€",
+          "full_name": "Antonio Raimondo",
+          "name": "A. Raimondo",
+          "overall_score": 69,
+          "potential": 79,
+          "value": 3200000,
+          "yearly_wage": 936000
+        },
+        {
+          "currency": "€",
+          "full_name": "Thomas Gillier",
+          "name": "T. Gillier",
+          "overall_score": 67,
+          "potential": 79,
+          "value": 2200000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Emil Holm",
+          "name": "E. Holm",
+          "overall_score": 75,
+          "potential": 78,
+          "value": 7000000,
+          "yearly_wage": 1924000
+        },
+        {
+          "currency": "€",
+          "full_name": "Michel Aebischer",
+          "name": "M. Aebischer",
+          "overall_score": 74,
+          "potential": 74,
+          "value": 4200000,
+          "yearly_wage": 2028000
+        },
+        {
+          "currency": "€",
+          "full_name": "Orji Okwonkwo",
+          "name": "O. Okwonkwo",
+          "overall_score": 67,
+          "potential": 67,
+          "value": 1100000,
+          "yearly_wage": 988000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jesper Karlsson",
+          "name": "J. Karlsson",
+          "overall_score": 74,
+          "potential": 74,
+          "value": 4600000,
+          "yearly_wage": 2080000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mihajlo Ilić",
+          "name": "M. Ilić",
+          "overall_score": 68,
+          "potential": 80,
+          "value": 2800000,
+          "yearly_wage": 728000
+        }
+      ],
+      "team": "Bologna",
+      "transfer_budget": 38900000,
+      "url": "https://sofifa.com/team/189/bologna/260037/"
+    },
+    {
+      "player_count": 41,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Alberto Paleari",
+          "name": "A. Paleari",
+          "overall_score": 70,
+          "potential": 70,
+          "value": 800000,
+          "yearly_wage": 676000
+        },
+        {
+          "currency": "€",
+          "full_name": "Valentino Lazaro",
+          "name": "V. Lazaro",
+          "overall_score": 76,
+          "potential": 76,
+          "value": 7500000,
+          "yearly_wage": 1924000
+        },
+        {
+          "currency": "€",
+          "full_name": "Saúl Basilio Coco Bassey Oubiña",
+          "name": "Saúl Coco",
+          "overall_score": 76,
+          "potential": 79,
+          "value": 8500000,
+          "yearly_wage": 1768000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ardian Ismajli",
+          "name": "A. Ismajli",
+          "overall_score": 74,
+          "potential": 74,
+          "value": 3600000,
+          "yearly_wage": 1612000
+        },
+        {
+          "currency": "€",
+          "full_name": "Enzo Ebosse",
+          "name": "E. Ebosse",
+          "overall_score": 70,
+          "potential": 73,
+          "value": 1800000,
+          "yearly_wage": 572000
+        },
+        {
+          "currency": "€",
+          "full_name": "Rafael Obrador Burguera",
+          "name": "Obrador",
+          "overall_score": 69,
+          "potential": 77,
+          "value": 3000000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Emirhan İlkhan",
+          "name": "E. İlkhan",
+          "overall_score": 67,
+          "potential": 74,
+          "value": 2100000,
+          "yearly_wage": 572000
+        },
+        {
+          "currency": "€",
+          "full_name": "Nikola Vlašić",
+          "name": "N. Vlašić",
+          "overall_score": 80,
+          "potential": 80,
+          "value": 22500000,
+          "yearly_wage": 2444000
+        },
+        {
+          "currency": "€",
+          "full_name": "Gvidas Gineitis",
+          "name": "G. Gineitis",
+          "overall_score": 70,
+          "potential": 79,
+          "value": 3600000,
+          "yearly_wage": 780000
+        },
+        {
+          "currency": "€",
+          "full_name": "Duván Zapata",
+          "name": "D. Zapata",
+          "overall_score": 81,
+          "potential": 81,
+          "value": 12500000,
+          "yearly_wage": 2912000
+        },
+        {
+          "currency": "€",
+          "full_name": "Giovanni Simeone",
+          "name": "G. Simeone",
+          "overall_score": 76,
+          "potential": 76,
+          "value": 7500000,
+          "yearly_wage": 4160000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ché Adams",
+          "name": "C. Adams",
+          "overall_score": 78,
+          "potential": 78,
+          "value": 14500000,
+          "yearly_wage": 2340000
+        },
+        {
+          "currency": "€",
+          "full_name": "Cesare Casadei",
+          "name": "C. Casadei",
+          "overall_score": 75,
+          "potential": 83,
+          "value": 12500000,
+          "yearly_wage": 1508000
+        },
+        {
+          "currency": "€",
+          "full_name": "Adrien Tameze",
+          "name": "A. Tameze",
+          "overall_score": 74,
+          "potential": 74,
+          "value": 3000000,
+          "yearly_wage": 1612000
+        },
+        {
+          "currency": "€",
+          "full_name": "Zakaria Aboukhlal",
+          "name": "Z. Aboukhlal",
+          "overall_score": 74,
+          "potential": 77,
+          "value": 5500000,
+          "yearly_wage": 1560000
+        },
+        {
+          "currency": "€",
+          "full_name": "Guillermo Maripán",
+          "name": "G. Maripán",
+          "overall_score": 76,
+          "potential": 76,
+          "value": 5000000,
+          "yearly_wage": 1820000
+        },
+        {
+          "currency": "€",
+          "full_name": "Marcus Pedersen",
+          "name": "M. Pedersen",
+          "overall_score": 73,
+          "potential": 75,
+          "value": 3600000,
+          "yearly_wage": 1196000
+        },
+        {
+          "currency": "€",
+          "full_name": "Franco Israel",
+          "name": "F. Israel",
+          "overall_score": 75,
+          "potential": 80,
+          "value": 6500000,
+          "yearly_wage": 988000
+        },
+        {
+          "currency": "€",
+          "full_name": "Cristiano Biraghi",
+          "name": "C. Biraghi",
+          "overall_score": 77,
+          "potential": 77,
+          "value": 7500000,
+          "yearly_wage": 1976000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ivan Ilić",
+          "name": "I. Ilić",
+          "overall_score": 75,
+          "potential": 80,
+          "value": 8000000,
+          "yearly_wage": 1456000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lapo Siviero",
+          "name": "L. Siviero",
+          "overall_score": 56,
+          "potential": 75,
+          "value": 325000,
+          "yearly_wage": 52000
+        },
+        {
+          "currency": "€",
+          "full_name": "Luca Marianucci",
+          "name": "L. Marianucci",
+          "overall_score": 68,
+          "potential": 79,
+          "value": 2500000,
+          "yearly_wage": 1196000
+        },
+        {
+          "currency": "€",
+          "full_name": "Saba Sazonov",
+          "name": "S. Sazonov",
+          "overall_score": 73,
+          "potential": 78,
+          "value": 4200000,
+          "yearly_wage": 1196000
+        },
+        {
+          "currency": "€",
+          "full_name": "Matteo Prati",
+          "name": "M. Prati",
+          "overall_score": 72,
+          "potential": 81,
+          "value": 5000000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Tino Anjorin",
+          "name": "T. Anjorin",
+          "overall_score": 68,
+          "potential": 75,
+          "value": 2400000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Sergiu Perciun",
+          "name": "S. Perciun",
+          "overall_score": 59,
+          "potential": 74,
+          "value": 525000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Niels Nkounkou",
+          "name": "N. Nkounkou",
+          "overall_score": 73,
+          "potential": 76,
+          "value": 4200000,
+          "yearly_wage": 1040000
+        },
+        {
+          "currency": "€",
+          "full_name": "Tommaso Gabellini",
+          "name": "T. Gabellini",
+          "overall_score": 56,
+          "potential": 71,
+          "value": 325000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Sandro Kulenović",
+          "name": "S. Kulenović",
+          "overall_score": 70,
+          "potential": 73,
+          "value": 2100000,
+          "yearly_wage": 1092000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alieu Njie",
+          "name": "A. Njie",
+          "overall_score": 65,
+          "potential": 77,
+          "value": 1700000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "Senan Mullen",
+          "name": "S. Mullen",
+          "overall_score": 61,
+          "potential": 73,
+          "value": 750000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ali Bina Dembélé",
+          "name": "A. Dembélé",
+          "overall_score": 62,
+          "potential": 73,
+          "value": 850000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Sebastian Walukiewicz",
+          "name": "S. Walukiewicz",
+          "overall_score": 72,
+          "potential": 76,
+          "value": 2900000,
+          "yearly_wage": 1196000
+        },
+        {
+          "currency": "€",
+          "full_name": "Pietro Pellegri",
+          "name": "P. Pellegri",
+          "overall_score": 68,
+          "potential": 73,
+          "value": 1800000,
+          "yearly_wage": 832000
+        },
+        {
+          "currency": "€",
+          "full_name": "Vanja Milinković-Savić",
+          "name": "V. Milinković-Savić",
+          "overall_score": 79,
+          "potential": 81,
+          "value": 15000000,
+          "yearly_wage": 1508000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alessio Cacciamani",
+          "name": "A. Cacciamani",
+          "overall_score": 62,
+          "potential": 74,
+          "value": 925000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Marco Dalla Vecchia",
+          "name": "M. Dalla Vecchia",
+          "overall_score": 65,
+          "potential": 75,
+          "value": 1600000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alessandro Dellavalle",
+          "name": "A. Dellavalle",
+          "overall_score": 65,
+          "potential": 78,
+          "value": 1700000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jonathan Silva Pertinhes",
+          "name": "Jonathan Silva",
+          "overall_score": 64,
+          "potential": 75,
+          "value": 1300000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Aaron Ciammaglichella",
+          "name": "A. Ciammaglichella",
+          "overall_score": 62,
+          "potential": 76,
+          "value": 950000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Côme Bianay Balcot",
+          "name": "C. Bianay Balcot",
+          "overall_score": 62,
+          "potential": 72,
+          "value": 825000,
+          "yearly_wage": 260000
+        }
+      ],
+      "team": "Torino",
+      "transfer_budget": 22000000,
+      "url": "https://sofifa.com/team/54/torino/260037/"
+    },
+    {
+      "player_count": 45,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Arijanet Murić",
+          "name": "A. Murić",
+          "overall_score": 74,
+          "potential": 76,
+          "value": 4000000,
+          "yearly_wage": 1456000
+        },
+        {
+          "currency": "€",
+          "full_name": "Sebastian Walukiewicz",
+          "name": "S. Walukiewicz",
+          "overall_score": 72,
+          "potential": 76,
+          "value": 2900000,
+          "yearly_wage": 1196000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jay Idzes",
+          "name": "J. Idzes",
+          "overall_score": 73,
+          "potential": 77,
+          "value": 3800000,
+          "yearly_wage": 780000
+        },
+        {
+          "currency": "€",
+          "full_name": "Tarik Muharemović",
+          "name": "T. Muharemović",
+          "overall_score": 74,
+          "potential": 80,
+          "value": 6000000,
+          "yearly_wage": 780000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ulisses Garcia",
+          "name": "U. Garcia",
+          "overall_score": 74,
+          "potential": 74,
+          "value": 3700000,
+          "yearly_wage": 1612000
+        },
+        {
+          "currency": "€",
+          "full_name": "Nemanja Matić",
+          "name": "N. Matić",
+          "overall_score": 77,
+          "potential": 77,
+          "value": 2100000,
+          "yearly_wage": 884000
+        },
+        {
+          "currency": "€",
+          "full_name": "Kristian Thorstvedt",
+          "name": "K. Thorstvedt",
+          "overall_score": 76,
+          "potential": 76,
+          "value": 8000000,
+          "yearly_wage": 1092000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ismaël Koné",
+          "name": "I. Koné",
+          "overall_score": 75,
+          "potential": 79,
+          "value": 8000000,
+          "yearly_wage": 936000
+        },
+        {
+          "currency": "€",
+          "full_name": "Domenico Berardi",
+          "name": "D. Berardi",
+          "overall_score": 82,
+          "potential": 82,
+          "value": 29500000,
+          "yearly_wage": 1872000
+        },
+        {
+          "currency": "€",
+          "full_name": "Andrea Pinamonti",
+          "name": "A. Pinamonti",
+          "overall_score": 75,
+          "potential": 76,
+          "value": 6500000,
+          "yearly_wage": 1144000
+        },
+        {
+          "currency": "€",
+          "full_name": "Armand Laurienté",
+          "name": "A. Laurienté",
+          "overall_score": 80,
+          "potential": 80,
+          "value": 23000000,
+          "yearly_wage": 1560000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alieu Fadera",
+          "name": "A. Fadera",
+          "overall_score": 71,
+          "potential": 77,
+          "value": 3000000,
+          "yearly_wage": 2236000
+        },
+        {
+          "currency": "€",
+          "full_name": "Cristian Volpato",
+          "name": "C. Volpato",
+          "overall_score": 70,
+          "potential": 78,
+          "value": 3600000,
+          "yearly_wage": 520000
+        },
+        {
+          "currency": "€",
+          "full_name": "Aster Vranckx",
+          "name": "A. Vranckx",
+          "overall_score": 72,
+          "potential": 77,
+          "value": 3600000,
+          "yearly_wage": 1300000
+        },
+        {
+          "currency": "€",
+          "full_name": "Josh Doig",
+          "name": "J. Doig",
+          "overall_score": 73,
+          "potential": 78,
+          "value": 4300000,
+          "yearly_wage": 728000
+        },
+        {
+          "currency": "€",
+          "full_name": "Woyo Coulibaly",
+          "name": "W. Coulibaly",
+          "overall_score": 72,
+          "potential": 73,
+          "value": 2500000,
+          "yearly_wage": 1508000
+        },
+        {
+          "currency": "€",
+          "full_name": "Fali Candé",
+          "name": "Fali Candé",
+          "overall_score": 71,
+          "potential": 73,
+          "value": 2000000,
+          "yearly_wage": 676000
+        },
+        {
+          "currency": "€",
+          "full_name": "Stefano Turati",
+          "name": "S. Turati",
+          "overall_score": 72,
+          "potential": 79,
+          "value": 4000000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Luca Lipani",
+          "name": "L. Lipani",
+          "overall_score": 69,
+          "potential": 77,
+          "value": 3000000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "M'Bala Nzola",
+          "name": "M. Nzola",
+          "overall_score": 73,
+          "potential": 73,
+          "value": 3100000,
+          "yearly_wage": 1976000
+        },
+        {
+          "currency": "€",
+          "full_name": "Giacomo Satalino",
+          "name": "G. Satalino",
+          "overall_score": 66,
+          "potential": 69,
+          "value": 850000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Gioele Zacchi",
+          "name": "G. Zacchi",
+          "overall_score": 62,
+          "potential": 71,
+          "value": 775000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Tommaso Macchioni",
+          "name": "T. Macchioni",
+          "overall_score": 61,
+          "potential": 76,
+          "value": 725000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Pedro Felipe de Jesus Gomes",
+          "name": "Pedro Felipe",
+          "overall_score": 69,
+          "potential": 79,
+          "value": 2900000,
+          "yearly_wage": 1560000
+        },
+        {
+          "currency": "€",
+          "full_name": "Filippo Romagna",
+          "name": "F. Romagna",
+          "overall_score": 70,
+          "potential": 70,
+          "value": 1400000,
+          "yearly_wage": 624000
+        },
+        {
+          "currency": "€",
+          "full_name": "Edoardo Pieragnolo",
+          "name": "E. Pieragnolo",
+          "overall_score": 67,
+          "potential": 71,
+          "value": 1400000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Daniel Boloca",
+          "name": "D. Boloca",
+          "overall_score": 72,
+          "potential": 72,
+          "value": 2500000,
+          "yearly_wage": 780000
+        },
+        {
+          "currency": "€",
+          "full_name": "Christian Frangella",
+          "name": "C. Frangella",
+          "overall_score": 60,
+          "potential": 75,
+          "value": 575000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Edoardo Iannoni",
+          "name": "E. Iannoni",
+          "overall_score": 67,
+          "potential": 72,
+          "value": 1500000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "Darryl Bakola",
+          "name": "D. Bakola",
+          "overall_score": 66,
+          "potential": 81,
+          "value": 1900000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Luca Moro",
+          "name": "L. Moro",
+          "overall_score": 68,
+          "potential": 73,
+          "value": 1800000,
+          "yearly_wage": 520000
+        },
+        {
+          "currency": "€",
+          "full_name": "Luca D'Andrea",
+          "name": "L. D'Andrea",
+          "overall_score": 64,
+          "potential": 76,
+          "value": 1400000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Patrick Nuamah",
+          "name": "P. Nuamah",
+          "overall_score": 65,
+          "potential": 75,
+          "value": 1500000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Yeferson Paz",
+          "name": "Y. Paz",
+          "overall_score": 68,
+          "potential": 74,
+          "value": 1800000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "Filippo Missori",
+          "name": "F. Missori",
+          "overall_score": 65,
+          "potential": 73,
+          "value": 1500000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Riccardo Ciervo",
+          "name": "R. Ciervo",
+          "overall_score": 69,
+          "potential": 74,
+          "value": 2100000,
+          "yearly_wage": 520000
+        },
+        {
+          "currency": "€",
+          "full_name": "Cas Odenthal",
+          "name": "C. Odenthal",
+          "overall_score": 69,
+          "potential": 72,
+          "value": 1700000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "Agustín Álvarez",
+          "name": "A. Álvarez",
+          "overall_score": 72,
+          "potential": 77,
+          "value": 3600000,
+          "yearly_wage": 780000
+        },
+        {
+          "currency": "€",
+          "full_name": "Laurs Skjellerup",
+          "name": "L. Skjellerup",
+          "overall_score": 65,
+          "potential": 72,
+          "value": 1500000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Andrea Ghion",
+          "name": "A. Ghion",
+          "overall_score": 70,
+          "potential": 72,
+          "value": 2000000,
+          "yearly_wage": 624000
+        },
+        {
+          "currency": "€",
+          "full_name": "Janis Antiste",
+          "name": "J. Antiste",
+          "overall_score": 67,
+          "potential": 74,
+          "value": 2100000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "Fabrizio Caligara",
+          "name": "F. Caligara",
+          "overall_score": 67,
+          "potential": 70,
+          "value": 1300000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "Samuele Mulattieri",
+          "name": "S. Mulattieri",
+          "overall_score": 71,
+          "potential": 74,
+          "value": 2600000,
+          "yearly_wage": 676000
+        },
+        {
+          "currency": "€",
+          "full_name": "Nicholas Pierini",
+          "name": "N. Pierini",
+          "overall_score": 71,
+          "potential": 71,
+          "value": 2100000,
+          "yearly_wage": 780000
+        },
+        {
+          "currency": "€",
+          "full_name": "Justin Kumi",
+          "name": "J. Kumi",
+          "overall_score": 65,
+          "potential": 78,
+          "value": 1700000,
+          "yearly_wage": 260000
+        }
+      ],
+      "team": "Sassuolo",
+      "transfer_budget": 18100000,
+      "url": "https://sofifa.com/team/111974/sassuolo/260037/"
+    },
+    {
+      "player_count": 35,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Emil Audero",
+          "name": "E. Audero",
+          "overall_score": 79,
+          "potential": 79,
+          "value": 12500000,
+          "yearly_wage": 2964000
+        },
+        {
+          "currency": "€",
+          "full_name": "Filippo Terracciano",
+          "name": "F. Terracciano",
+          "overall_score": 71,
+          "potential": 80,
+          "value": 3900000,
+          "yearly_wage": 1144000
+        },
+        {
+          "currency": "€",
+          "full_name": "Matteo Bianchetti",
+          "name": "M. Bianchetti",
+          "overall_score": 71,
+          "potential": 71,
+          "value": 1200000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "Sebastiano Luperto",
+          "name": "S. Luperto",
+          "overall_score": 75,
+          "potential": 76,
+          "value": 5500000,
+          "yearly_wage": 676000
+        },
+        {
+          "currency": "€",
+          "full_name": "Giuseppe Pezzella",
+          "name": "G. Pezzella",
+          "overall_score": 71,
+          "potential": 71,
+          "value": 2000000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alessio Zerbin",
+          "name": "A. Zerbin",
+          "overall_score": 73,
+          "potential": 73,
+          "value": 3300000,
+          "yearly_wage": 2964000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alberto Grassi",
+          "name": "A. Grassi",
+          "overall_score": 70,
+          "potential": 70,
+          "value": 1500000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "Youssef Maleh",
+          "name": "Y. Maleh",
+          "overall_score": 71,
+          "potential": 72,
+          "value": 2200000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jari Vandeputte",
+          "name": "J. Vandeputte",
+          "overall_score": 72,
+          "potential": 72,
+          "value": 2300000,
+          "yearly_wage": 520000
+        },
+        {
+          "currency": "€",
+          "full_name": "Federico Bonazzoli",
+          "name": "F. Bonazzoli",
+          "overall_score": 72,
+          "potential": 72,
+          "value": 2400000,
+          "yearly_wage": 572000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jamie Vardy",
+          "name": "J. Vardy",
+          "overall_score": 75,
+          "potential": 75,
+          "value": 1900000,
+          "yearly_wage": 572000
+        },
+        {
+          "currency": "€",
+          "full_name": "Antonio Sanabria",
+          "name": "A. Sanabria",
+          "overall_score": 75,
+          "potential": 75,
+          "value": 5500000,
+          "yearly_wage": 728000
+        },
+        {
+          "currency": "€",
+          "full_name": "Martín Payero",
+          "name": "M. Payero",
+          "overall_score": 73,
+          "potential": 73,
+          "value": 3300000,
+          "yearly_wage": 780000
+        },
+        {
+          "currency": "€",
+          "full_name": "Morten Thorsby",
+          "name": "M. Thorsby",
+          "overall_score": 72,
+          "potential": 72,
+          "value": 2300000,
+          "yearly_wage": 520000
+        },
+        {
+          "currency": "€",
+          "full_name": "Warren Bondo",
+          "name": "W. Bondo",
+          "overall_score": 71,
+          "potential": 78,
+          "value": 3800000,
+          "yearly_wage": 988000
+        },
+        {
+          "currency": "€",
+          "full_name": "Federico Baschirotto",
+          "name": "F. Baschirotto",
+          "overall_score": 75,
+          "potential": 76,
+          "value": 5500000,
+          "yearly_wage": 676000
+        },
+        {
+          "currency": "€",
+          "full_name": "Tommaso Barbieri",
+          "name": "T. Barbieri",
+          "overall_score": 71,
+          "potential": 76,
+          "value": 2700000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Marco Silvestri",
+          "name": "M. Silvestri",
+          "overall_score": 72,
+          "potential": 72,
+          "value": 400000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Federico Ceccherini",
+          "name": "F. Ceccherini",
+          "overall_score": 71,
+          "potential": 71,
+          "value": 900000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "Romano Floriani Mussolini",
+          "name": "R. Floriani Mussolini",
+          "overall_score": 69,
+          "potential": 77,
+          "value": 3100000,
+          "yearly_wage": 676000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lapo Nava",
+          "name": "L. Nava",
+          "overall_score": 60,
+          "potential": 72,
+          "value": 525000,
+          "yearly_wage": 36400
+        },
+        {
+          "currency": "€",
+          "full_name": "Mikayil Faye",
+          "name": "M. Faye",
+          "overall_score": 68,
+          "potential": 82,
+          "value": 2700000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "Francesco Folino",
+          "name": "F. Folino",
+          "overall_score": 65,
+          "potential": 73,
+          "value": 1500000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Michele Collocolo",
+          "name": "M. Collocolo",
+          "overall_score": 72,
+          "potential": 75,
+          "value": 3100000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "Simone Lottici Tessadri",
+          "name": "S. Lottici Tessadri",
+          "overall_score": 58,
+          "potential": 68,
+          "value": 450000,
+          "yearly_wage": 52000
+        },
+        {
+          "currency": "€",
+          "full_name": "Milan Đurić",
+          "name": "M. Đurić",
+          "overall_score": 70,
+          "potential": 70,
+          "value": 675000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Faris Pemi Moumbagna",
+          "name": "F. Moumbagna",
+          "overall_score": 72,
+          "potential": 76,
+          "value": 3300000,
+          "yearly_wage": 1404000
+        },
+        {
+          "currency": "€",
+          "full_name": "David Okereke",
+          "name": "D. Okereke",
+          "overall_score": 72,
+          "potential": 72,
+          "value": 2500000,
+          "yearly_wage": 520000
+        },
+        {
+          "currency": "€",
+          "full_name": "Marco Nasti",
+          "name": "M. Nasti",
+          "overall_score": 67,
+          "potential": 75,
+          "value": 2300000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Frank Tsadjout",
+          "name": "F. Tsadjout",
+          "overall_score": 68,
+          "potential": 70,
+          "value": 1500000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Manuel De Luca",
+          "name": "M. De Luca",
+          "overall_score": 69,
+          "potential": 70,
+          "value": 1700000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Luca Zanimacchia",
+          "name": "L. Zanimacchia",
+          "overall_score": 72,
+          "potential": 72,
+          "value": 2600000,
+          "yearly_wage": 520000
+        },
+        {
+          "currency": "€",
+          "full_name": "Leonardo Sernicola",
+          "name": "L. Sernicola",
+          "overall_score": 69,
+          "potential": 69,
+          "value": 1300000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Andrea Fulignati",
+          "name": "A. Fulignati",
+          "overall_score": 71,
+          "potential": 71,
+          "value": 1200000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Dachi Lordkipanidze",
+          "name": "D. Lordkipanidze",
+          "overall_score": 56,
+          "potential": 68,
+          "value": 350000,
+          "yearly_wage": 52000
+        }
+      ],
+      "team": "Cremonese",
+      "transfer_budget": 5300000,
+      "url": "https://sofifa.com/team/111434/cremonese/260037/"
+    },
+    {
+      "player_count": 39,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Justin Bijlow",
+          "name": "J. Bijlow",
+          "overall_score": 75,
+          "potential": 76,
+          "value": 4800000,
+          "yearly_wage": 728000
+        },
+        {
+          "currency": "€",
+          "full_name": "Stefano Sabelli",
+          "name": "S. Sabelli",
+          "overall_score": 71,
+          "potential": 71,
+          "value": 1300000,
+          "yearly_wage": 780000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alessandro Marcandalli",
+          "name": "A. Marcandalli",
+          "overall_score": 70,
+          "potential": 75,
+          "value": 2200000,
+          "yearly_wage": 572000
+        },
+        {
+          "currency": "€",
+          "full_name": "Leo Østigård",
+          "name": "L. Østigård",
+          "overall_score": 75,
+          "potential": 80,
+          "value": 7500000,
+          "yearly_wage": 1040000
+        },
+        {
+          "currency": "€",
+          "full_name": "Johan Vásquez",
+          "name": "J. Vásquez",
+          "overall_score": 75,
+          "potential": 78,
+          "value": 6500000,
+          "yearly_wage": 1092000
+        },
+        {
+          "currency": "€",
+          "full_name": "Aarón Martín Caricol",
+          "name": "Aarón Martín",
+          "overall_score": 74,
+          "potential": 74,
+          "value": 3800000,
+          "yearly_wage": 1092000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alexsandro Amorim",
+          "name": "Alex Amorim",
+          "overall_score": 67,
+          "potential": 75,
+          "value": 2200000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Morten Frendrup",
+          "name": "M. Frendrup",
+          "overall_score": 76,
+          "potential": 80,
+          "value": 10000000,
+          "yearly_wage": 988000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mikael Egill Ellertsson",
+          "name": "M. Ellertsson",
+          "overall_score": 71,
+          "potential": 76,
+          "value": 2800000,
+          "yearly_wage": 676000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lorenzo Colombo",
+          "name": "L. Colombo",
+          "overall_score": 72,
+          "potential": 79,
+          "value": 4700000,
+          "yearly_wage": 832000
+        },
+        {
+          "currency": "€",
+          "full_name": "Vítor Manuel Carvalho Oliveira",
+          "name": "Vitinha",
+          "overall_score": 75,
+          "potential": 78,
+          "value": 7500000,
+          "yearly_wage": 1196000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jeff Ekhator",
+          "name": "J. Ekhator",
+          "overall_score": 67,
+          "potential": 78,
+          "value": 2200000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ruslan Malinovskyi",
+          "name": "R. Malinovskyi",
+          "overall_score": 75,
+          "potential": 75,
+          "value": 4400000,
+          "yearly_wage": 1196000
+        },
+        {
+          "currency": "€",
+          "full_name": "Tommaso Baldanzi",
+          "name": "T. Baldanzi",
+          "overall_score": 74,
+          "potential": 80,
+          "value": 7000000,
+          "yearly_wage": 1820000
+        },
+        {
+          "currency": "€",
+          "full_name": "Patrizio Masini",
+          "name": "P. Masini",
+          "overall_score": 68,
+          "potential": 72,
+          "value": 1600000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "Brooke Norton-Cuffy",
+          "name": "B. Norton-Cuffy",
+          "overall_score": 74,
+          "potential": 80,
+          "value": 6500000,
+          "yearly_wage": 728000
+        },
+        {
+          "currency": "€",
+          "full_name": "Sebastian Otoa",
+          "name": "S. Otoa",
+          "overall_score": 67,
+          "potential": 74,
+          "value": 1900000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Nicola Leali",
+          "name": "N. Leali",
+          "overall_score": 73,
+          "potential": 73,
+          "value": 1500000,
+          "yearly_wage": 624000
+        },
+        {
+          "currency": "€",
+          "full_name": "Junior Messias",
+          "name": "Junior Messias",
+          "overall_score": 72,
+          "potential": 72,
+          "value": 1100000,
+          "yearly_wage": 936000
+        },
+        {
+          "currency": "€",
+          "full_name": "Caleb Ekuban",
+          "name": "C. Ekuban",
+          "overall_score": 70,
+          "potential": 70,
+          "value": 1300000,
+          "yearly_wage": 832000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ernestas Lysionok",
+          "name": "E. Lysionok",
+          "overall_score": 56,
+          "potential": 74,
+          "value": 325000,
+          "yearly_wage": 49400
+        },
+        {
+          "currency": "€",
+          "full_name": "Benjamin Siegrist",
+          "name": "B. Siegrist",
+          "overall_score": 70,
+          "potential": 70,
+          "value": 525000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Daniele Sommariva",
+          "name": "D. Sommariva",
+          "overall_score": 62,
+          "potential": 65,
+          "value": 400000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mamedi Doucouré",
+          "name": "M. Doucouré",
+          "overall_score": 61,
+          "potential": 76,
+          "value": 725000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Nils Zätterström",
+          "name": "N. Zätterström",
+          "overall_score": 64,
+          "potential": 78,
+          "value": 1300000,
+          "yearly_wage": 520000
+        },
+        {
+          "currency": "€",
+          "full_name": "Latif Ouedraogo",
+          "name": "L. Ouedraogo",
+          "overall_score": 59,
+          "potential": 74,
+          "value": 500000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jacopo Grossi",
+          "name": "J. Grossi",
+          "overall_score": 58,
+          "potential": 69,
+          "value": 400000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Gaël Lafont",
+          "name": "G. Lafont",
+          "overall_score": 62,
+          "potential": 76,
+          "value": 950000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jean Onana",
+          "name": "J. Onana",
+          "overall_score": 71,
+          "potential": 74,
+          "value": 2500000,
+          "yearly_wage": 1144000
+        },
+        {
+          "currency": "€",
+          "full_name": "Filippo Carbone",
+          "name": "F. Carbone",
+          "overall_score": 61,
+          "potential": 74,
+          "value": 750000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Maxwel Cornet",
+          "name": "M. Cornet",
+          "overall_score": 73,
+          "potential": 73,
+          "value": 3100000,
+          "yearly_wage": 2444000
+        },
+        {
+          "currency": "€",
+          "full_name": "Joi Nuredini",
+          "name": "J. Nuredini",
+          "overall_score": 58,
+          "potential": 76,
+          "value": 500000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Seydou Fini",
+          "name": "S. Fini",
+          "overall_score": 65,
+          "potential": 82,
+          "value": 1800000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alan Matturro",
+          "name": "A. Matturro",
+          "overall_score": 70,
+          "potential": 80,
+          "value": 3300000,
+          "yearly_wage": 520000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lorenzo Venturino",
+          "name": "L. Venturino",
+          "overall_score": 62,
+          "potential": 76,
+          "value": 950000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Hugo Cuenca",
+          "name": "H. Cuenca",
+          "overall_score": 62,
+          "potential": 77,
+          "value": 950000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Gabriele Calvani",
+          "name": "G. Calvani",
+          "overall_score": 69,
+          "potential": 74,
+          "value": 1900000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alessandro Debenedetti",
+          "name": "A. Debenedetti",
+          "overall_score": 66,
+          "potential": 77,
+          "value": 1900000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Franz Stolz",
+          "name": "F. Stolz",
+          "overall_score": 66,
+          "potential": 70,
+          "value": 975000,
+          "yearly_wage": 208000
+        }
+      ],
+      "team": "Genoa",
+      "transfer_budget": 20900000,
+      "url": "https://sofifa.com/team/110556/genoa/260037/"
+    },
+    {
+      "player_count": 36,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Zion Suzuki",
+          "name": "Z. Suzuki",
+          "overall_score": 74,
+          "potential": 80,
+          "value": 5500000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "Enrico Delprato",
+          "name": "E. Delprato",
+          "overall_score": 75,
+          "potential": 78,
+          "value": 6500000,
+          "yearly_wage": 936000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alessandro Circati",
+          "name": "A. Circati",
+          "overall_score": 72,
+          "potential": 80,
+          "value": 4900000,
+          "yearly_wage": 572000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mariano Troilo",
+          "name": "M. Troilo",
+          "overall_score": 66,
+          "potential": 78,
+          "value": 2000000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lautaro Valenti",
+          "name": "L. Valenti",
+          "overall_score": 69,
+          "potential": 70,
+          "value": 1400000,
+          "yearly_wage": 520000
+        },
+        {
+          "currency": "€",
+          "full_name": "Emanuele Valeri",
+          "name": "E. Valeri",
+          "overall_score": 75,
+          "potential": 76,
+          "value": 6000000,
+          "yearly_wage": 988000
+        },
+        {
+          "currency": "€",
+          "full_name": "Hans Nicolussi Caviglia",
+          "name": "H. Nicolussi Caviglia",
+          "overall_score": 75,
+          "potential": 79,
+          "value": 7000000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Adrián Bernabé García",
+          "name": "Adrián Bernabé",
+          "overall_score": 76,
+          "potential": 81,
+          "value": 11500000,
+          "yearly_wage": 936000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mandela Keita",
+          "name": "M. Keita",
+          "overall_score": 73,
+          "potential": 79,
+          "value": 4400000,
+          "yearly_wage": 728000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mateo Pellegrino",
+          "name": "M. Pellegrino",
+          "overall_score": 69,
+          "potential": 75,
+          "value": 2200000,
+          "yearly_wage": 520000
+        },
+        {
+          "currency": "€",
+          "full_name": "Gabriel Tadeu Strefezza Rebelato",
+          "name": "Gabriel Strefezza",
+          "overall_score": 76,
+          "potential": 76,
+          "value": 7500000,
+          "yearly_wage": 1560000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jacob Ondrejka",
+          "name": "J. Ondrejka",
+          "overall_score": 73,
+          "potential": 79,
+          "value": 4900000,
+          "yearly_wage": 832000
+        },
+        {
+          "currency": "€",
+          "full_name": "Oliver Sørensen",
+          "name": "O. Sørensen",
+          "overall_score": 72,
+          "potential": 77,
+          "value": 3500000,
+          "yearly_wage": 676000
+        },
+        {
+          "currency": "€",
+          "full_name": "Pontus Almqvist",
+          "name": "P. Almqvist",
+          "overall_score": 71,
+          "potential": 72,
+          "value": 2200000,
+          "yearly_wage": 676000
+        },
+        {
+          "currency": "€",
+          "full_name": "Nahuel Estévez",
+          "name": "N. Estévez",
+          "overall_score": 71,
+          "potential": 71,
+          "value": 1600000,
+          "yearly_wage": 728000
+        },
+        {
+          "currency": "€",
+          "full_name": "Abdoulaye Ndiaye",
+          "name": "A. Ndiaye",
+          "overall_score": 74,
+          "potential": 78,
+          "value": 5500000,
+          "yearly_wage": 780000
+        },
+        {
+          "currency": "€",
+          "full_name": "Sascha Britschgi",
+          "name": "S. Britschgi",
+          "overall_score": 65,
+          "potential": 75,
+          "value": 1400000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Edoardo Corvi",
+          "name": "E. Corvi",
+          "overall_score": 68,
+          "potential": 71,
+          "value": 1300000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Christian Ordoñez",
+          "name": "C. Ordoñez",
+          "overall_score": 71,
+          "potential": 81,
+          "value": 3900000,
+          "yearly_wage": 520000
+        },
+        {
+          "currency": "€",
+          "full_name": "Gaetano Oristanio",
+          "name": "G. Oristanio",
+          "overall_score": 73,
+          "potential": 79,
+          "value": 4900000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Gianluca Astaldi",
+          "name": "G. Astaldi",
+          "overall_score": 56,
+          "potential": 68,
+          "value": 300000,
+          "yearly_wage": 52000
+        },
+        {
+          "currency": "€",
+          "full_name": "Filippo Rinaldi",
+          "name": "F. Rinaldi",
+          "overall_score": 63,
+          "potential": 69,
+          "value": 625000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Franco Carboni",
+          "name": "F. Carboni",
+          "overall_score": 63,
+          "potential": 68,
+          "value": 700000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Benjamin Cremaschi",
+          "name": "B. Cremaschi",
+          "overall_score": 68,
+          "potential": 79,
+          "value": 2600000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Elia Plicco",
+          "name": "E. Plicco",
+          "overall_score": 53,
+          "potential": 68,
+          "value": 220000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alessandro Cardinali",
+          "name": "A. Cardinali",
+          "overall_score": 61,
+          "potential": 76,
+          "value": 775000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Nesta Elphege",
+          "name": "N. Elphege",
+          "overall_score": 64,
+          "potential": 67,
+          "value": 800000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Matija Frigan",
+          "name": "M. Frigan",
+          "overall_score": 73,
+          "potential": 78,
+          "value": 4700000,
+          "yearly_wage": 832000
+        },
+        {
+          "currency": "€",
+          "full_name": "Daniel Mikołajewski",
+          "name": "D. Mikołajewski",
+          "overall_score": 62,
+          "potential": 74,
+          "value": 950000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Peter Amoran",
+          "name": "P. Amoran",
+          "overall_score": 61,
+          "potential": 74,
+          "value": 750000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Rachid Kouda",
+          "name": "R. Kouda",
+          "overall_score": 64,
+          "potential": 72,
+          "value": 1300000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Tjaš Begić",
+          "name": "T. Begić",
+          "overall_score": 69,
+          "potential": 78,
+          "value": 3100000,
+          "yearly_wage": 520000
+        },
+        {
+          "currency": "€",
+          "full_name": "Antoine Joujou",
+          "name": "A. Joujou",
+          "overall_score": 69,
+          "potential": 75,
+          "value": 2200000,
+          "yearly_wage": 520000
+        },
+        {
+          "currency": "€",
+          "full_name": "Botond Balogh",
+          "name": "B. Balogh",
+          "overall_score": 70,
+          "potential": 79,
+          "value": 3300000,
+          "yearly_wage": 520000
+        },
+        {
+          "currency": "€",
+          "full_name": "Adrian Benedyczak",
+          "name": "A. Benedyczak",
+          "overall_score": 71,
+          "potential": 74,
+          "value": 2600000,
+          "yearly_wage": 624000
+        },
+        {
+          "currency": "€",
+          "full_name": "Anthony Partipilo",
+          "name": "A. Partipilo",
+          "overall_score": 69,
+          "potential": 69,
+          "value": 1400000,
+          "yearly_wage": 624000
+        }
+      ],
+      "team": "Parma",
+      "transfer_budget": 18900000,
+      "url": "https://sofifa.com/team/50/parma/260037/"
+    },
+    {
+      "player_count": 37,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Elia Caprile",
+          "name": "E. Caprile",
+          "overall_score": 78,
+          "potential": 84,
+          "value": 18000000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Marco Palestra",
+          "name": "M. Palestra",
+          "overall_score": 75,
+          "potential": 84,
+          "value": 12000000,
+          "yearly_wage": 1820000
+        },
+        {
+          "currency": "€",
+          "full_name": "José Pedro da Silva Figueiredo",
+          "name": "Zé Pedro",
+          "overall_score": 73,
+          "potential": 75,
+          "value": 3100000,
+          "yearly_wage": 572000
+        },
+        {
+          "currency": "€",
+          "full_name": "Yerry Mina",
+          "name": "Y. Mina",
+          "overall_score": 76,
+          "potential": 76,
+          "value": 6000000,
+          "yearly_wage": 676000
+        },
+        {
+          "currency": "€",
+          "full_name": "Juan Rodríguez",
+          "name": "J. Rodríguez",
+          "overall_score": 71,
+          "potential": 78,
+          "value": 3400000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Adam Obert",
+          "name": "A. Obert",
+          "overall_score": 73,
+          "potential": 79,
+          "value": 4600000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "Gianluca Gaetano",
+          "name": "G. Gaetano",
+          "overall_score": 73,
+          "potential": 76,
+          "value": 4000000,
+          "yearly_wage": 520000
+        },
+        {
+          "currency": "€",
+          "full_name": "Michel Ndary Adopo",
+          "name": "M. Adopo",
+          "overall_score": 73,
+          "potential": 76,
+          "value": 4100000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alessandro Deiola",
+          "name": "A. Deiola",
+          "overall_score": 70,
+          "potential": 70,
+          "value": 1600000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "Gennaro Borrelli",
+          "name": "G. Borrelli",
+          "overall_score": 69,
+          "potential": 71,
+          "value": 1800000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Sebastiano Esposito",
+          "name": "S. Esposito",
+          "overall_score": 75,
+          "potential": 82,
+          "value": 11500000,
+          "yearly_wage": 1300000
+        },
+        {
+          "currency": "€",
+          "full_name": "Semih Kılıçsoy",
+          "name": "S. Kılıçsoy",
+          "overall_score": 74,
+          "potential": 81,
+          "value": 8500000,
+          "yearly_wage": 1248000
+        },
+        {
+          "currency": "€",
+          "full_name": "Michael Folorunsho",
+          "name": "M. Folorunsho",
+          "overall_score": 74,
+          "potential": 74,
+          "value": 4500000,
+          "yearly_wage": 3276000
+        },
+        {
+          "currency": "€",
+          "full_name": "Luca Mazzitelli",
+          "name": "L. Mazzitelli",
+          "overall_score": 73,
+          "potential": 73,
+          "value": 3000000,
+          "yearly_wage": 3016000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ibrahim Sulemana",
+          "name": "I. Sulemana",
+          "overall_score": 73,
+          "potential": 80,
+          "value": 6000000,
+          "yearly_wage": 1768000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alberto Dossena",
+          "name": "A. Dossena",
+          "overall_score": 73,
+          "potential": 76,
+          "value": 3500000,
+          "yearly_wage": 2756000
+        },
+        {
+          "currency": "€",
+          "full_name": "Gabriele Zappa",
+          "name": "G. Zappa",
+          "overall_score": 73,
+          "potential": 76,
+          "value": 3700000,
+          "yearly_wage": 520000
+        },
+        {
+          "currency": "€",
+          "full_name": "Giuseppe Ciocci",
+          "name": "G. Ciocci",
+          "overall_score": 59,
+          "potential": 67,
+          "value": 425000,
+          "yearly_wage": 49400
+        },
+        {
+          "currency": "€",
+          "full_name": "Mattia Felici",
+          "name": "M. Felici",
+          "overall_score": 72,
+          "potential": 75,
+          "value": 3200000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "Paul Mendy",
+          "name": "P. Mendy",
+          "overall_score": 62,
+          "potential": 76,
+          "value": 925000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Vincenzo Sarno",
+          "name": "V. Sarno",
+          "overall_score": 52,
+          "potential": 67,
+          "value": 160000,
+          "yearly_wage": 26000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alen Sherri",
+          "name": "A. Sherri",
+          "overall_score": 66,
+          "potential": 68,
+          "value": 775000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Othniël Raterink",
+          "name": "O. Raterink",
+          "overall_score": 62,
+          "potential": 75,
+          "value": 900000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Riyad Idrissi",
+          "name": "R. Idrissi",
+          "overall_score": 69,
+          "potential": 76,
+          "value": 2600000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Joseph Liteta",
+          "name": "J. Liteta",
+          "overall_score": 66,
+          "potential": 74,
+          "value": 1800000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Agustín Albarracín",
+          "name": "A. Albarracín",
+          "overall_score": 69,
+          "potential": 77,
+          "value": 3000000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Andrea Belotti",
+          "name": "A. Belotti",
+          "overall_score": 74,
+          "potential": 74,
+          "value": 3600000,
+          "yearly_wage": 676000
+        },
+        {
+          "currency": "€",
+          "full_name": "Leonardo Pavoletti",
+          "name": "L. Pavoletti",
+          "overall_score": 67,
+          "potential": 67,
+          "value": 350000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Yael Trepy",
+          "name": "Y. Trepy",
+          "overall_score": 62,
+          "potential": 74,
+          "value": 950000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Davide Veroli",
+          "name": "D. Veroli",
+          "overall_score": 68,
+          "potential": 79,
+          "value": 2500000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Matteo Prati",
+          "name": "M. Prati",
+          "overall_score": 72,
+          "potential": 81,
+          "value": 5000000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Nicolò Cavuoti",
+          "name": "N. Cavuoti",
+          "overall_score": 64,
+          "potential": 73,
+          "value": 1300000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Nik Prelec",
+          "name": "N. Prelec",
+          "overall_score": 69,
+          "potential": 73,
+          "value": 2000000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Zito André Sebastião Luvumbo",
+          "name": "Zito Luvumbo",
+          "overall_score": 71,
+          "potential": 78,
+          "value": 3800000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "Boris Radunović",
+          "name": "B. Radunović",
+          "overall_score": 70,
+          "potential": 70,
+          "value": 1100000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mateusz Wieteska",
+          "name": "M. Wieteska",
+          "overall_score": 70,
+          "potential": 71,
+          "value": 1500000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "Kingstone Mutandwa",
+          "name": "K. Mutandwa",
+          "overall_score": 67,
+          "potential": 75,
+          "value": 2300000,
+          "yearly_wage": 260000
+        }
+      ],
+      "team": "Cagliari",
+      "transfer_budget": 9800000,
+      "url": "https://sofifa.com/team/1842/cagliari/260037/"
+    },
+    {
+      "player_count": 35,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Lorenzo Montipò",
+          "name": "L. Montipò",
+          "overall_score": 76,
+          "potential": 77,
+          "value": 6000000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "Rafik Belghali",
+          "name": "R. Belghali",
+          "overall_score": 70,
+          "potential": 74,
+          "value": 2100000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Armel Bella-Kotchap",
+          "name": "A. Bella-Kotchap",
+          "overall_score": 72,
+          "potential": 78,
+          "value": 3400000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "Victor Nelsson",
+          "name": "V. Nelsson",
+          "overall_score": 74,
+          "potential": 76,
+          "value": 4600000,
+          "yearly_wage": 1924000
+        },
+        {
+          "currency": "€",
+          "full_name": "Andrias Edmundsson",
+          "name": "A. Edmundsson",
+          "overall_score": 67,
+          "potential": 71,
+          "value": 1300000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Martin Frese",
+          "name": "M. Frese",
+          "overall_score": 72,
+          "potential": 72,
+          "value": 2300000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "Roberto Gagliardini",
+          "name": "R. Gagliardini",
+          "overall_score": 72,
+          "potential": 72,
+          "value": 1600000,
+          "yearly_wage": 520000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jean-Daniel Akpa Akpro",
+          "name": "J. Akpa Akpro",
+          "overall_score": 72,
+          "potential": 72,
+          "value": 1800000,
+          "yearly_wage": 520000
+        },
+        {
+          "currency": "€",
+          "full_name": "Antoine Bernede",
+          "name": "A. Bernede",
+          "overall_score": 72,
+          "potential": 73,
+          "value": 2700000,
+          "yearly_wage": 520000
+        },
+        {
+          "currency": "€",
+          "full_name": "Kieron Bowie",
+          "name": "K. Bowie",
+          "overall_score": 67,
+          "potential": 75,
+          "value": 2300000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Gift Orban",
+          "name": "G. Orban",
+          "overall_score": 74,
+          "potential": 81,
+          "value": 8500000,
+          "yearly_wage": 1404000
+        },
+        {
+          "currency": "€",
+          "full_name": "Amin Sarr",
+          "name": "A. Sarr",
+          "overall_score": 71,
+          "potential": 76,
+          "value": 2900000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "Suat Serdar",
+          "name": "S. Serdar",
+          "overall_score": 76,
+          "potential": 76,
+          "value": 7500000,
+          "yearly_wage": 728000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ali Al Musrati",
+          "name": "A. Al Musrati",
+          "overall_score": 76,
+          "potential": 76,
+          "value": 6500000,
+          "yearly_wage": 1820000
+        },
+        {
+          "currency": "€",
+          "full_name": "Cheikh Niasse",
+          "name": "C. Niasse",
+          "overall_score": 71,
+          "potential": 76,
+          "value": 2500000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "Nicolás Valentini",
+          "name": "N. Valentini",
+          "overall_score": 73,
+          "potential": 79,
+          "value": 4400000,
+          "yearly_wage": 1456000
+        },
+        {
+          "currency": "€",
+          "full_name": "Domagoj Bradarić",
+          "name": "D. Bradarić",
+          "overall_score": 72,
+          "potential": 74,
+          "value": 2700000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "Simone Perilli",
+          "name": "S. Perilli",
+          "overall_score": 67,
+          "potential": 67,
+          "value": 675000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Abdou Harroui",
+          "name": "A. Harroui",
+          "overall_score": 71,
+          "potential": 71,
+          "value": 2000000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "Tomáš Suslov",
+          "name": "T. Suslov",
+          "overall_score": 72,
+          "potential": 80,
+          "value": 5000000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "Giacomo Toniolo",
+          "name": "G. Toniolo",
+          "overall_score": 56,
+          "potential": 66,
+          "value": 275000,
+          "yearly_wage": 36400
+        },
+        {
+          "currency": "€",
+          "full_name": "Daniel Oyegoke",
+          "name": "D. Oyegoke",
+          "overall_score": 64,
+          "potential": 74,
+          "value": 1200000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Tobias Slotsager",
+          "name": "T. Slotsager",
+          "overall_score": 69,
+          "potential": 82,
+          "value": 3100000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Fallou Cham",
+          "name": "F. Cham",
+          "overall_score": 66,
+          "potential": 75,
+          "value": 1800000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Pol Mikel Lirola Kosok",
+          "name": "Pol Lirola",
+          "overall_score": 73,
+          "potential": 73,
+          "value": 2900000,
+          "yearly_wage": 520000
+        },
+        {
+          "currency": "€",
+          "full_name": "Sandi Lovrič",
+          "name": "S. Lovrič",
+          "overall_score": 73,
+          "potential": 73,
+          "value": 3200000,
+          "yearly_wage": 780000
+        },
+        {
+          "currency": "€",
+          "full_name": "Junior Ajayi",
+          "name": "J. Ajayi",
+          "overall_score": 56,
+          "potential": 70,
+          "value": 350000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Isaac Aguiar Tomich",
+          "name": "Isaac",
+          "overall_score": 67,
+          "potential": 76,
+          "value": 2300000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Daniel Mosquera",
+          "name": "D. Mosquera",
+          "overall_score": 71,
+          "potential": 74,
+          "value": 2500000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ioan Vermeșan",
+          "name": "I. Vermeșan",
+          "overall_score": 59,
+          "potential": 74,
+          "value": 525000,
+          "yearly_wage": 52000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lima Pontes Charlys Matheus",
+          "name": "Charlys",
+          "overall_score": 65,
+          "potential": 70,
+          "value": 1100000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Nicolò Calabrese",
+          "name": "N. Calabrese",
+          "overall_score": 64,
+          "potential": 70,
+          "value": 825000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mathis Lambourde",
+          "name": "M. Lambourde",
+          "overall_score": 64,
+          "potential": 80,
+          "value": 1500000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jesús Santiago Pérez",
+          "name": "Yellu Santiago",
+          "overall_score": 68,
+          "potential": 80,
+          "value": 2800000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Dailon Rocha Livramento",
+          "name": "Dailon Livramento",
+          "overall_score": 69,
+          "potential": 74,
+          "value": 2100000,
+          "yearly_wage": 364000
+        }
+      ],
+      "team": "Hellas Verona FC",
+      "transfer_budget": 10500000,
+      "url": "https://sofifa.com/team/206/hellas-verona-fc/260037/"
+    },
+    {
+      "player_count": 39,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Maduka Okoye",
+          "name": "M. Okoye",
+          "overall_score": 74,
+          "potential": 78,
+          "value": 4600000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "Kingsley Ehizibue",
+          "name": "K. Ehizibue",
+          "overall_score": 71,
+          "potential": 71,
+          "value": 1600000,
+          "yearly_wage": 624000
+        },
+        {
+          "currency": "€",
+          "full_name": "Thomas Kristensen",
+          "name": "T. Kristensen",
+          "overall_score": 73,
+          "potential": 81,
+          "value": 6500000,
+          "yearly_wage": 624000
+        },
+        {
+          "currency": "€",
+          "full_name": "Christian Kabasele",
+          "name": "C. Kabasele",
+          "overall_score": 73,
+          "potential": 73,
+          "value": 1000000,
+          "yearly_wage": 780000
+        },
+        {
+          "currency": "€",
+          "full_name": "Oumar Solet",
+          "name": "O. Solet",
+          "overall_score": 78,
+          "potential": 83,
+          "value": 18500000,
+          "yearly_wage": 1040000
+        },
+        {
+          "currency": "€",
+          "full_name": "Hassane Kamara",
+          "name": "H. Kamara",
+          "overall_score": 72,
+          "potential": 72,
+          "value": 1700000,
+          "yearly_wage": 728000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jesper Karlström",
+          "name": "J. Karlström",
+          "overall_score": 75,
+          "potential": 75,
+          "value": 4700000,
+          "yearly_wage": 936000
+        },
+        {
+          "currency": "€",
+          "full_name": "Arthur Atta",
+          "name": "A. Atta",
+          "overall_score": 74,
+          "potential": 82,
+          "value": 9500000,
+          "yearly_wage": 728000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jurgen Ekkelenkamp",
+          "name": "J. Ekkelenkamp",
+          "overall_score": 74,
+          "potential": 77,
+          "value": 5500000,
+          "yearly_wage": 832000
+        },
+        {
+          "currency": "€",
+          "full_name": "Nicolò Zaniolo",
+          "name": "N. Zaniolo",
+          "overall_score": 75,
+          "potential": 76,
+          "value": 7000000,
+          "yearly_wage": 2236000
+        },
+        {
+          "currency": "€",
+          "full_name": "Keinan Davis",
+          "name": "K. Davis",
+          "overall_score": 74,
+          "potential": 74,
+          "value": 4600000,
+          "yearly_wage": 936000
+        },
+        {
+          "currency": "€",
+          "full_name": "Adam Buksa",
+          "name": "A. Buksa",
+          "overall_score": 72,
+          "potential": 72,
+          "value": 2400000,
+          "yearly_wage": 780000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jakub Piotrowski",
+          "name": "J. Piotrowski",
+          "overall_score": 72,
+          "potential": 72,
+          "value": 2500000,
+          "yearly_wage": 728000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lennon Miller",
+          "name": "L. Miller",
+          "overall_score": 70,
+          "potential": 84,
+          "value": 3700000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alessandro Zanoli",
+          "name": "A. Zanoli",
+          "overall_score": 73,
+          "potential": 77,
+          "value": 4100000,
+          "yearly_wage": 2444000
+        },
+        {
+          "currency": "€",
+          "full_name": "Nicolò Bertola",
+          "name": "N. Bertola",
+          "overall_score": 72,
+          "potential": 78,
+          "value": 3400000,
+          "yearly_wage": 572000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jordan Zemura",
+          "name": "J. Zemura",
+          "overall_score": 71,
+          "potential": 73,
+          "value": 2200000,
+          "yearly_wage": 572000
+        },
+        {
+          "currency": "€",
+          "full_name": "Răzvan Sava",
+          "name": "R. Sava",
+          "overall_score": 71,
+          "potential": 81,
+          "value": 3600000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Oier Zarraga Egaña",
+          "name": "Oier Zarraga",
+          "overall_score": 71,
+          "potential": 71,
+          "value": 2000000,
+          "yearly_wage": 624000
+        },
+        {
+          "currency": "€",
+          "full_name": "Vakoun Issouf Bayo",
+          "name": "V. Bayo",
+          "overall_score": 69,
+          "potential": 69,
+          "value": 1400000,
+          "yearly_wage": 572000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alessandro Nunziante",
+          "name": "A. Nunziante",
+          "overall_score": 56,
+          "potential": 75,
+          "value": 325000,
+          "yearly_wage": 39000
+        },
+        {
+          "currency": "€",
+          "full_name": "Daniele Padelli",
+          "name": "D. Padelli",
+          "overall_score": 65,
+          "potential": 65,
+          "value": 80000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Branimir Mlačić",
+          "name": "B. Mlačić",
+          "overall_score": 65,
+          "potential": 80,
+          "value": 1600000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Abdoulaye Camara",
+          "name": "A. Camara",
+          "overall_score": 54,
+          "potential": 76,
+          "value": 325000,
+          "yearly_wage": 52000
+        },
+        {
+          "currency": "€",
+          "full_name": "Juan David Arizala",
+          "name": "J. Arizala",
+          "overall_score": 63,
+          "potential": 78,
+          "value": 1100000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Idrissa Gueye",
+          "name": "I. Gueye",
+          "overall_score": 69,
+          "potential": 79,
+          "value": 3000000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Rui Manuel Muati Modesto",
+          "name": "Rui Modesto",
+          "overall_score": 70,
+          "potential": 70,
+          "value": 1800000,
+          "yearly_wage": 572000
+        },
+        {
+          "currency": "€",
+          "full_name": "Simone Pafundi",
+          "name": "S. Pafundi",
+          "overall_score": 69,
+          "potential": 84,
+          "value": 3300000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Luca Kjerrumgaard",
+          "name": "L. Kjerrumgaard",
+          "overall_score": 68,
+          "potential": 77,
+          "value": 2700000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lorenzo Lucca",
+          "name": "L. Lucca",
+          "overall_score": 75,
+          "potential": 79,
+          "value": 8000000,
+          "yearly_wage": 884000
+        },
+        {
+          "currency": "€",
+          "full_name": "Damián Pizarro",
+          "name": "D. Pizarro",
+          "overall_score": 64,
+          "potential": 78,
+          "value": 1400000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Leonardo Daniel Ulineia Buta",
+          "name": "Leonardo Buta",
+          "overall_score": 69,
+          "potential": 76,
+          "value": 2700000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "Iker Bravo Solanilla",
+          "name": "Iker Bravo",
+          "overall_score": 66,
+          "potential": 78,
+          "value": 2100000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "James Abankwah",
+          "name": "J. Abankwah",
+          "overall_score": 66,
+          "potential": 76,
+          "value": 1800000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Enzo Ebosse",
+          "name": "E. Ebosse",
+          "overall_score": 70,
+          "potential": 73,
+          "value": 1800000,
+          "yearly_wage": 572000
+        },
+        {
+          "currency": "€",
+          "full_name": "Martín Payero",
+          "name": "M. Payero",
+          "overall_score": 73,
+          "potential": 73,
+          "value": 3300000,
+          "yearly_wage": 780000
+        },
+        {
+          "currency": "€",
+          "full_name": "Sandi Lovrič",
+          "name": "S. Lovrič",
+          "overall_score": 73,
+          "potential": 73,
+          "value": 3200000,
+          "yearly_wage": 780000
+        },
+        {
+          "currency": "€",
+          "full_name": "Matteo Palma",
+          "name": "M. Palma",
+          "overall_score": 65,
+          "potential": 82,
+          "value": 1700000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Saba Goglichidze",
+          "name": "S. Goglichidze",
+          "overall_score": 69,
+          "potential": 79,
+          "value": 2900000,
+          "yearly_wage": 364000
+        }
+      ],
+      "team": "Udinese",
+      "transfer_budget": 16500000,
+      "url": "https://sofifa.com/team/55/udinese/260037/"
+    },
+    {
+      "player_count": 38,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "David Nicolás Andrade",
+          "name": "Nicolas",
+          "overall_score": 67,
+          "potential": 67,
+          "value": 110000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Idrissa Touré",
+          "name": "I. Touré",
+          "overall_score": 71,
+          "potential": 71,
+          "value": 2000000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "Arturo Calabresi",
+          "name": "A. Calabresi",
+          "overall_score": 68,
+          "potential": 68,
+          "value": 1000000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Antonio Caracciolo",
+          "name": "A. Caracciolo",
+          "overall_score": 71,
+          "potential": 71,
+          "value": 500000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Simone Canestrelli",
+          "name": "S. Canestrelli",
+          "overall_score": 72,
+          "potential": 75,
+          "value": 2900000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Samuele Angori",
+          "name": "S. Angori",
+          "overall_score": 71,
+          "potential": 78,
+          "value": 3800000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ebenezer Akinsanmiro",
+          "name": "E. Akinsanmiro",
+          "overall_score": 67,
+          "potential": 80,
+          "value": 2400000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "Felipe Loyola",
+          "name": "F. Loyola",
+          "overall_score": 73,
+          "potential": 76,
+          "value": 4100000,
+          "yearly_wage": 520000
+        },
+        {
+          "currency": "€",
+          "full_name": "Michel Aebischer",
+          "name": "M. Aebischer",
+          "overall_score": 74,
+          "potential": 74,
+          "value": 4200000,
+          "yearly_wage": 2028000
+        },
+        {
+          "currency": "€",
+          "full_name": "Stefano Moreo",
+          "name": "S. Moreo",
+          "overall_score": 72,
+          "potential": 72,
+          "value": 1900000,
+          "yearly_wage": 520000
+        },
+        {
+          "currency": "€",
+          "full_name": "Filip Stojilković",
+          "name": "F. Stojilković",
+          "overall_score": 68,
+          "potential": 71,
+          "value": 1600000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Juan Cuadrado",
+          "name": "J. Cuadrado",
+          "overall_score": 75,
+          "potential": 75,
+          "value": 1800000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mattéo Tramoni",
+          "name": "M. Tramoni",
+          "overall_score": 74,
+          "potential": 77,
+          "value": 5500000,
+          "yearly_wage": 520000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mehdi Léris",
+          "name": "M. Léris",
+          "overall_score": 70,
+          "potential": 70,
+          "value": 1700000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Marius Marin",
+          "name": "M. Marin",
+          "overall_score": 68,
+          "potential": 69,
+          "value": 1400000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Gabriele Piccinini",
+          "name": "G. Piccinini",
+          "overall_score": 68,
+          "potential": 73,
+          "value": 1800000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Rosen Bozhinov",
+          "name": "R. Bozhinov",
+          "overall_score": 63,
+          "potential": 77,
+          "value": 1100000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Simone Scuffet",
+          "name": "S. Scuffet",
+          "overall_score": 71,
+          "potential": 72,
+          "value": 1400000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Francesco Coppola",
+          "name": "F. Coppola",
+          "overall_score": 61,
+          "potential": 76,
+          "value": 750000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Henrik Meister",
+          "name": "H. Meister",
+          "overall_score": 69,
+          "potential": 76,
+          "value": 2900000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Adrian Šemper",
+          "name": "A. Šemper",
+          "overall_score": 71,
+          "potential": 74,
+          "value": 1800000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Daniel Denoon",
+          "name": "D. Denoon",
+          "overall_score": 62,
+          "potential": 73,
+          "value": 825000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Raúl Albiol Tortajada",
+          "name": "Raúl Albiol",
+          "overall_score": 75,
+          "potential": 75,
+          "value": 1000000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Malthe Højholt",
+          "name": "M. Højholt",
+          "overall_score": 66,
+          "potential": 72,
+          "value": 1200000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Brando Bettazzi",
+          "name": "B. Bettazzi",
+          "overall_score": 56,
+          "potential": 68,
+          "value": 325000,
+          "yearly_wage": 46800
+        },
+        {
+          "currency": "€",
+          "full_name": "İsak Vural",
+          "name": "İ. Vural",
+          "overall_score": 63,
+          "potential": 79,
+          "value": 1200000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Samuel Iling-Junior",
+          "name": "S. Iling-Junior",
+          "overall_score": 72,
+          "potential": 80,
+          "value": 5500000,
+          "yearly_wage": 2288000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lorran Lucas Pereira de Sousa",
+          "name": "Lorran",
+          "overall_score": 65,
+          "potential": 80,
+          "value": 1700000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Calvin Stengs",
+          "name": "C. Stengs",
+          "overall_score": 76,
+          "potential": 77,
+          "value": 9000000,
+          "yearly_wage": 832000
+        },
+        {
+          "currency": "€",
+          "full_name": "Rafiu Durosinmi",
+          "name": "R. Durosinmi",
+          "overall_score": 75,
+          "potential": 81,
+          "value": 9000000,
+          "yearly_wage": 572000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mateus Henrique Vanelli Lusuardi",
+          "name": "Mateus Lusuardi",
+          "overall_score": 65,
+          "potential": 74,
+          "value": 1500000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ante Vuković",
+          "name": "A. Vuković",
+          "overall_score": 65,
+          "potential": 74,
+          "value": 1400000,
+          "yearly_wage": 52000
+        },
+        {
+          "currency": "€",
+          "full_name": "Nicholas Bonfanti",
+          "name": "N. Bonfanti",
+          "overall_score": 67,
+          "potential": 74,
+          "value": 2100000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Leonardo Loria",
+          "name": "L. Loria",
+          "overall_score": 63,
+          "potential": 67,
+          "value": 525000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Alexander Lind",
+          "name": "A. Lind",
+          "overall_score": 72,
+          "potential": 78,
+          "value": 3700000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "Tomás Lago Pontes Esteves",
+          "name": "Tomás Esteves",
+          "overall_score": 67,
+          "potential": 74,
+          "value": 1900000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Pietro Beruatto",
+          "name": "P. Beruatto",
+          "overall_score": 68,
+          "potential": 68,
+          "value": 1300000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jan Mlakar",
+          "name": "J. Mlakar",
+          "overall_score": 67,
+          "potential": 67,
+          "value": 1100000,
+          "yearly_wage": 260000
+        }
+      ],
+      "team": "Pisa",
+      "transfer_budget": 8400000,
+      "url": "https://sofifa.com/team/110738/pisa/260037/"
+    },
+    {
+      "player_count": 34,
+      "players": [
+        {
+          "currency": "€",
+          "full_name": "Wladimiro Falcone",
+          "name": "W. Falcone",
+          "overall_score": 82,
+          "potential": 82,
+          "value": 20500000,
+          "yearly_wage": 676000
+        },
+        {
+          "currency": "€",
+          "full_name": "Danilo Filipe Melo Veiga",
+          "name": "Danilo Veiga",
+          "overall_score": 69,
+          "potential": 78,
+          "value": 3000000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jamil Siebert",
+          "name": "J. Siebert",
+          "overall_score": 70,
+          "potential": 78,
+          "value": 3300000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Tiago Gabriel Coelho Oliveira",
+          "name": "Tiago Gabriel",
+          "overall_score": 69,
+          "potential": 77,
+          "value": 2900000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Antonino Gallo",
+          "name": "A. Gallo",
+          "overall_score": 75,
+          "potential": 78,
+          "value": 7000000,
+          "yearly_wage": 624000
+        },
+        {
+          "currency": "€",
+          "full_name": "Ylber Ramadani",
+          "name": "Y. Ramadani",
+          "overall_score": 70,
+          "potential": 70,
+          "value": 1400000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lassana Coulibaly",
+          "name": "L. Coulibaly",
+          "overall_score": 74,
+          "potential": 74,
+          "value": 3600000,
+          "yearly_wage": 624000
+        },
+        {
+          "currency": "€",
+          "full_name": "Santiago Pierotti",
+          "name": "S. Pierotti",
+          "overall_score": 70,
+          "potential": 73,
+          "value": 2200000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Lameck Banda",
+          "name": "L. Banda",
+          "overall_score": 70,
+          "potential": 73,
+          "value": 2200000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Omri Gandelman",
+          "name": "O. Gandelman",
+          "overall_score": 72,
+          "potential": 75,
+          "value": 3100000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "Walid Cheddira",
+          "name": "W. Cheddira",
+          "overall_score": 72,
+          "potential": 72,
+          "value": 2500000,
+          "yearly_wage": 2912000
+        },
+        {
+          "currency": "€",
+          "full_name": "Nikola Štulić",
+          "name": "N. Štulić",
+          "overall_score": 70,
+          "potential": 76,
+          "value": 2500000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Riccardo Sottil",
+          "name": "R. Sottil",
+          "overall_score": 74,
+          "potential": 75,
+          "value": 5000000,
+          "yearly_wage": 1924000
+        },
+        {
+          "currency": "€",
+          "full_name": "Medon Berisha",
+          "name": "M. Berisha",
+          "overall_score": 69,
+          "potential": 78,
+          "value": 3100000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Konan N'Dri",
+          "name": "K. N'Dri",
+          "overall_score": 68,
+          "potential": 71,
+          "value": 1600000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Oumar Ngom",
+          "name": "O. Ngom",
+          "overall_score": 64,
+          "potential": 74,
+          "value": 1300000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Kialonda Gaspar",
+          "name": "Kialonda Gaspar",
+          "overall_score": 72,
+          "potential": 74,
+          "value": 2500000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "Christian Früchtl",
+          "name": "C. Früchtl",
+          "overall_score": 70,
+          "potential": 75,
+          "value": 1900000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Corrie Ndaba",
+          "name": "C. Ndaba",
+          "overall_score": 66,
+          "potential": 68,
+          "value": 975000,
+          "yearly_wage": 208000
+        },
+        {
+          "currency": "€",
+          "full_name": "Francesco Camarda",
+          "name": "F. Camarda",
+          "overall_score": 65,
+          "potential": 87,
+          "value": 2300000,
+          "yearly_wage": 364000
+        },
+        {
+          "currency": "€",
+          "full_name": "Jasper Samooja",
+          "name": "J. Samooja",
+          "overall_score": 61,
+          "potential": 69,
+          "value": 650000,
+          "yearly_wage": 44200
+        },
+        {
+          "currency": "€",
+          "full_name": "Gaby Jean",
+          "name": "G. Jean",
+          "overall_score": 69,
+          "potential": 74,
+          "value": 1800000,
+          "yearly_wage": 312000
+        },
+        {
+          "currency": "€",
+          "full_name": "Matías Pérez",
+          "name": "M. Pérez",
+          "overall_score": 66,
+          "potential": 76,
+          "value": 1800000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Àlex Sala Herrero",
+          "name": "Àlex Sala",
+          "overall_score": 72,
+          "potential": 76,
+          "value": 3100000,
+          "yearly_wage": 416000
+        },
+        {
+          "currency": "€",
+          "full_name": "Sadik Fofana",
+          "name": "S. Fofana",
+          "overall_score": 65,
+          "potential": 72,
+          "value": 1400000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Olaf Gorter",
+          "name": "O. Gorter",
+          "overall_score": 62,
+          "potential": 71,
+          "value": 825000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Þórir Jóhann Helgason",
+          "name": "Þ. Helgason",
+          "overall_score": 68,
+          "potential": 73,
+          "value": 1800000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Niko Kovač",
+          "name": "N. Kovač",
+          "overall_score": 62,
+          "potential": 71,
+          "value": 875000,
+          "yearly_wage": 104000
+        },
+        {
+          "currency": "€",
+          "full_name": "Filip Marchwiński",
+          "name": "F. Marchwiński",
+          "overall_score": 67,
+          "potential": 74,
+          "value": 2000000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Rares Burnete",
+          "name": "R. Burnete",
+          "overall_score": 64,
+          "potential": 75,
+          "value": 1300000,
+          "yearly_wage": 156000
+        },
+        {
+          "currency": "€",
+          "full_name": "Sebastian Esposito",
+          "name": "S. Esposito",
+          "overall_score": 52,
+          "potential": 67,
+          "value": 180000,
+          "yearly_wage": 52000
+        },
+        {
+          "currency": "€",
+          "full_name": "Mohamed Kaba",
+          "name": "M. Kaba",
+          "overall_score": 68,
+          "potential": 75,
+          "value": 2300000,
+          "yearly_wage": 260000
+        },
+        {
+          "currency": "€",
+          "full_name": "Youssef Maleh",
+          "name": "Y. Maleh",
+          "overall_score": 71,
+          "potential": 72,
+          "value": 2200000,
+          "yearly_wage": 468000
+        },
+        {
+          "currency": "€",
+          "full_name": "Owen Kouassi",
+          "name": "O. Kouassi",
+          "overall_score": 67,
+          "potential": 74,
+          "value": 2000000,
+          "yearly_wage": 260000
+        }
+      ],
+      "team": "Lecce",
+      "transfer_budget": 9400000,
+      "url": "https://sofifa.com/team/347/lecce/260037/"
+    }
+  ],
+  "total_players": 785
+}

--- a/data/2025/ITA1/teams.json
+++ b/data/2025/ITA1/teams.json
@@ -19,7 +19,11 @@
             "French Guiana"
           ],
           "number": "16",
-          "position": "Goalkeeper"
+          "overall_score": 87,
+          "position": "Goalkeeper",
+          "potential": 88,
+          "value": 61000000,
+          "yearly_wage": 3172000
         },
         {
           "contract": "Jun 30, 2026",
@@ -33,7 +37,11 @@
             "Italy"
           ],
           "number": "1",
-          "position": "Goalkeeper"
+          "overall_score": 78,
+          "position": "Goalkeeper",
+          "potential": 78,
+          "value": 1600000,
+          "yearly_wage": 936000
         },
         {
           "contract": "Jun 30, 2030",
@@ -47,7 +55,11 @@
             "Italy"
           ],
           "number": "96",
-          "position": "Goalkeeper"
+          "overall_score": 62,
+          "position": "Goalkeeper",
+          "potential": 76,
+          "value": 850000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2028",
@@ -61,7 +73,11 @@
             "Serbia"
           ],
           "number": "31",
-          "position": "Centre-Back"
+          "overall_score": 77,
+          "position": "Centre-Back",
+          "potential": 83,
+          "value": 15000000,
+          "yearly_wage": 1820000
         },
         {
           "contract": "Jun 30, 2030",
@@ -75,7 +91,11 @@
             "Belgium"
           ],
           "number": "5",
-          "position": "Centre-Back"
+          "overall_score": 75,
+          "position": "Centre-Back",
+          "potential": 84,
+          "value": 11500000,
+          "yearly_wage": 1612000
         },
         {
           "contract": "Jun 30, 2027",
@@ -90,7 +110,11 @@
             "Canada"
           ],
           "number": "23",
-          "position": "Centre-Back"
+          "overall_score": 81,
+          "position": "Centre-Back",
+          "potential": 83,
+          "value": 27500000,
+          "yearly_wage": 2808000
         },
         {
           "contract": "Jun 30, 2029",
@@ -104,7 +128,11 @@
             "Italy"
           ],
           "number": "46",
-          "position": "Centre-Back"
+          "overall_score": 80,
+          "position": "Centre-Back",
+          "potential": 83,
+          "value": 25000000,
+          "yearly_wage": 2496000
         },
         {
           "contract": "Jun 30, 2029",
@@ -119,7 +147,11 @@
             "Nigeria"
           ],
           "number": "27",
-          "position": "Centre-Back"
+          "overall_score": 65,
+          "position": "Centre-Back",
+          "potential": 83,
+          "value": 1700000,
+          "yearly_wage": 416000
         },
         {
           "contract": "Jun 30, 2030",
@@ -133,7 +165,11 @@
             "Italy"
           ],
           "number": "33",
-          "position": "Left-Back"
+          "overall_score": 71,
+          "position": "Left-Back",
+          "potential": 81,
+          "value": 3900000,
+          "yearly_wage": 884000
         },
         {
           "contract": "Jun 30, 2030",
@@ -148,7 +184,11 @@
             "Spain"
           ],
           "number": "2",
-          "position": "Left-Back"
+          "overall_score": 79,
+          "position": "Left-Back",
+          "potential": 79,
+          "value": 17000000,
+          "yearly_wage": 2496000
         },
         {
           "contract": "Jun 30, 2030",
@@ -163,7 +203,11 @@
             "Nigeria"
           ],
           "number": "24",
-          "position": "Right-Back"
+          "overall_score": 65,
+          "position": "Right-Back",
+          "potential": 78,
+          "value": 1600000,
+          "yearly_wage": 416000
         },
         {
           "contract": "Jun 30, 2030",
@@ -178,7 +222,11 @@
             "North Macedonia"
           ],
           "number": "30",
-          "position": "Defensive Midfield"
+          "overall_score": 77,
+          "position": "Defensive Midfield",
+          "potential": 86,
+          "value": 22500000,
+          "yearly_wage": 1820000
         },
         {
           "contract": "Jun 30, 2028",
@@ -193,7 +241,11 @@
             "Mali"
           ],
           "number": "19",
-          "position": "Defensive Midfield"
+          "overall_score": 81,
+          "position": "Defensive Midfield",
+          "potential": 84,
+          "value": 30500000,
+          "yearly_wage": 2808000
         },
         {
           "contract": "Jun 30, 2029",
@@ -207,7 +259,11 @@
             "Italy"
           ],
           "number": "4",
-          "position": "Defensive Midfield"
+          "overall_score": 79,
+          "position": "Defensive Midfield",
+          "potential": 85,
+          "value": 25500000,
+          "yearly_wage": 2132000
         },
         {
           "contract": "Jun 30, 2028",
@@ -221,7 +277,11 @@
             "France"
           ],
           "number": "12",
-          "position": "Central Midfield"
+          "overall_score": 85,
+          "position": "Central Midfield",
+          "potential": 85,
+          "value": 51500000,
+          "yearly_wage": 4316000
         },
         {
           "contract": "Jun 30, 2027",
@@ -236,7 +296,11 @@
             "Guyana"
           ],
           "number": "8",
-          "position": "Central Midfield"
+          "overall_score": 80,
+          "position": "Central Midfield",
+          "potential": 80,
+          "value": 20500000,
+          "yearly_wage": 2860000
         },
         {
           "contract": "Jun 30, 2026",
@@ -250,7 +314,11 @@
             "Croatia"
           ],
           "number": "14",
-          "position": "Central Midfield"
+          "overall_score": 85,
+          "position": "Central Midfield",
+          "potential": 85,
+          "value": 17000000,
+          "yearly_wage": 2912000
         },
         {
           "contract": "Jun 30, 2031",
@@ -264,7 +332,11 @@
             "Belgium"
           ],
           "number": "56",
-          "position": "Right Midfield"
+          "overall_score": 80,
+          "position": "Right Midfield",
+          "potential": 80,
+          "value": 23000000,
+          "yearly_wage": 2756000
         },
         {
           "contract": "Jun 30, 2028",
@@ -279,7 +351,11 @@
             "Angola"
           ],
           "number": "10",
-          "position": "Left Winger"
+          "overall_score": 84,
+          "position": "Left Winger",
+          "potential": 85,
+          "value": 49500000,
+          "yearly_wage": 4108000
         },
         {
           "contract": "Jun 30, 2027",
@@ -294,7 +370,11 @@
             "Croatia"
           ],
           "number": "11",
-          "position": "Right Winger"
+          "overall_score": 85,
+          "position": "Right Winger",
+          "potential": 85,
+          "value": 59000000,
+          "yearly_wage": 4472000
         },
         {
           "contract": "Jun 30, 2030",
@@ -309,7 +389,11 @@
             "DR Congo"
           ],
           "number": "18",
-          "position": "Centre-Forward"
+          "overall_score": 81,
+          "position": "Centre-Forward",
+          "potential": 81,
+          "value": 27500000,
+          "yearly_wage": 3016000
         },
         {
           "contract": "Jun 30, 2029",
@@ -324,7 +408,11 @@
             "Italy"
           ],
           "number": "7",
-          "position": "Centre-Forward"
+          "overall_score": 79,
+          "position": "Centre-Forward",
+          "potential": 84,
+          "value": 27000000,
+          "yearly_wage": 2496000
         },
         {
           "contract": "Jun 30, 2026",
@@ -338,7 +426,11 @@
             "Germany"
           ],
           "number": "9",
-          "position": "Centre-Forward"
+          "overall_score": 78,
+          "position": "Centre-Forward",
+          "potential": 78,
+          "value": 11500000,
+          "yearly_wage": 3744000
         }
       ],
       "stadiumName": "San Siro",
@@ -361,7 +453,11 @@
             "Spain"
           ],
           "number": "13",
-          "position": "Goalkeeper"
+          "overall_score": 75,
+          "position": "Goalkeeper",
+          "potential": 77,
+          "value": 5000000,
+          "yearly_wage": 832000
         },
         {
           "contract": "Jun 30, 2026",
@@ -375,7 +471,11 @@
             "Switzerland"
           ],
           "number": "1",
-          "position": "Goalkeeper"
+          "overall_score": 86,
+          "position": "Goalkeeper",
+          "potential": 86,
+          "value": 7500000,
+          "yearly_wage": 1248000
         },
         {
           "contract": "Jun 30, 2026",
@@ -389,7 +489,11 @@
             "Italy"
           ],
           "number": "12",
-          "position": "Goalkeeper"
+          "overall_score": 68,
+          "position": "Goalkeeper",
+          "potential": 68,
+          "value": 650000,
+          "yearly_wage": 468000
         },
         {
           "contract": "Jun 30, 2028",
@@ -403,7 +507,11 @@
             "Italy"
           ],
           "number": "95",
-          "position": "Centre-Back"
+          "overall_score": 87,
+          "position": "Centre-Back",
+          "potential": 89,
+          "value": 87000000,
+          "yearly_wage": 3276000
         },
         {
           "contract": "Jun 30, 2029",
@@ -418,7 +526,11 @@
             "Cameroon"
           ],
           "number": "31",
-          "position": "Centre-Back"
+          "overall_score": 76,
+          "position": "Centre-Back",
+          "potential": 80,
+          "value": 9500000,
+          "yearly_wage": 1196000
         },
         {
           "contract": "Jun 30, 2026",
@@ -433,7 +545,11 @@
             "Nigeria"
           ],
           "number": "25",
-          "position": "Centre-Back"
+          "overall_score": 83,
+          "position": "Centre-Back",
+          "potential": 83,
+          "value": 30500000,
+          "yearly_wage": 7540000
         },
         {
           "contract": "Jun 30, 2026",
@@ -447,7 +563,11 @@
             "Netherlands"
           ],
           "number": "6",
-          "position": "Centre-Back"
+          "overall_score": 83,
+          "position": "Centre-Back",
+          "potential": 83,
+          "value": 17500000,
+          "yearly_wage": 2444000
         },
         {
           "contract": "Jun 30, 2026",
@@ -461,7 +581,11 @@
             "Italy"
           ],
           "number": "15",
-          "position": "Centre-Back"
+          "overall_score": 83,
+          "position": "Centre-Back",
+          "potential": 83,
+          "value": 6500000,
+          "yearly_wage": 1820000
         },
         {
           "contract": "Jun 30, 2027",
@@ -475,7 +599,11 @@
             "Italy"
           ],
           "number": "32",
-          "position": "Left-Back"
+          "overall_score": 86,
+          "position": "Left-Back",
+          "potential": 86,
+          "value": 65500000,
+          "yearly_wage": 3016000
         },
         {
           "contract": "Jun 30, 2028",
@@ -490,7 +618,11 @@
             "Italy"
           ],
           "number": "30",
-          "position": "Left-Back"
+          "overall_score": 81,
+          "position": "Left-Back",
+          "potential": 82,
+          "value": 27500000,
+          "yearly_wage": 1976000
         },
         {
           "contract": "Jun 30, 2028",
@@ -505,7 +637,11 @@
             "Aruba"
           ],
           "number": "2",
-          "position": "Right-Back"
+          "overall_score": 84,
+          "position": "Right-Back",
+          "potential": 84,
+          "value": 37000000,
+          "yearly_wage": 2652000
         },
         {
           "contract": "Jun 30, 2026",
@@ -519,7 +655,11 @@
             "Italy"
           ],
           "number": "36",
-          "position": "Right-Back"
+          "overall_score": 78,
+          "position": "Right-Back",
+          "potential": 78,
+          "value": 4300000,
+          "yearly_wage": 1248000
         },
         {
           "contract": "Jun 30, 2027",
@@ -534,7 +674,11 @@
             "Germany"
           ],
           "number": "20",
-          "position": "Defensive Midfield"
+          "overall_score": 86,
+          "position": "Defensive Midfield",
+          "potential": 86,
+          "value": 47500000,
+          "yearly_wage": 3172000
         },
         {
           "contract": "Jun 30, 2029",
@@ -548,7 +692,11 @@
             "Italy"
           ],
           "number": "23",
-          "position": "Central Midfield"
+          "overall_score": 88,
+          "position": "Central Midfield",
+          "potential": 88,
+          "value": 91500000,
+          "yearly_wage": 3952000
         },
         {
           "contract": "Jun 30, 2030",
@@ -563,7 +711,11 @@
             "Bosnia-Herzegovina"
           ],
           "number": "8",
-          "position": "Central Midfield"
+          "overall_score": 77,
+          "position": "Central Midfield",
+          "potential": 83,
+          "value": 17000000,
+          "yearly_wage": 1144000
         },
         {
           "contract": "Jun 30, 2028",
@@ -577,7 +729,11 @@
             "Italy"
           ],
           "number": "16",
-          "position": "Central Midfield"
+          "overall_score": 81,
+          "position": "Central Midfield",
+          "potential": 83,
+          "value": 32000000,
+          "yearly_wage": 1976000
         },
         {
           "contract": "Jun 30, 2030",
@@ -592,7 +748,11 @@
             "Senegal"
           ],
           "number": "17",
-          "position": "Central Midfield"
+          "overall_score": 75,
+          "position": "Central Midfield",
+          "potential": 81,
+          "value": 9000000,
+          "yearly_wage": 1196000
         },
         {
           "contract": "Jun 30, 2028",
@@ -607,7 +767,11 @@
             "Italy"
           ],
           "number": "7",
-          "position": "Central Midfield"
+          "overall_score": 81,
+          "position": "Central Midfield",
+          "potential": 81,
+          "value": 21000000,
+          "yearly_wage": 2132000
         },
         {
           "contract": "Jun 30, 2026",
@@ -621,7 +785,11 @@
             "Armenia"
           ],
           "number": "22",
-          "position": "Central Midfield"
+          "overall_score": 83,
+          "position": "Central Midfield",
+          "potential": 83,
+          "value": 11500000,
+          "yearly_wage": 1924000
         },
         {
           "contract": "Jun 30, 2030",
@@ -635,7 +803,11 @@
             "Brazil"
           ],
           "number": "11",
-          "position": "Right Midfield"
+          "overall_score": 78,
+          "position": "Right Midfield",
+          "potential": 83,
+          "value": 21000000,
+          "yearly_wage": 1456000
         },
         {
           "contract": "Jun 30, 2029",
@@ -649,7 +821,11 @@
             "Argentina"
           ],
           "number": "10",
-          "position": "Centre-Forward"
+          "overall_score": 88,
+          "position": "Centre-Forward",
+          "potential": 88,
+          "value": 99000000,
+          "yearly_wage": 4108000
         },
         {
           "contract": "Jun 30, 2028",
@@ -664,7 +840,11 @@
             "Guadeloupe"
           ],
           "number": "9",
-          "position": "Centre-Forward"
+          "overall_score": 85,
+          "position": "Centre-Forward",
+          "potential": 85,
+          "value": 58500000,
+          "yearly_wage": 3172000
         },
         {
           "contract": "Jun 30, 2030",
@@ -679,7 +859,11 @@
             "Cote d'Ivoire"
           ],
           "number": "14",
-          "position": "Centre-Forward"
+          "overall_score": 78,
+          "position": "Centre-Forward",
+          "potential": 86,
+          "value": 32000000,
+          "yearly_wage": 1352000
         },
         {
           "contract": "Jun 30, 2030",
@@ -693,7 +877,11 @@
             "Italy"
           ],
           "number": "94",
-          "position": "Centre-Forward"
+          "overall_score": 76,
+          "position": "Centre-Forward",
+          "potential": 84,
+          "value": 16500000,
+          "yearly_wage": 1196000
         }
       ],
       "stadiumName": "Giuseppe Meazza",
@@ -717,7 +905,11 @@
             "Belgium"
           ],
           "number": "99",
-          "position": "Goalkeeper"
+          "overall_score": 84,
+          "position": "Goalkeeper",
+          "potential": 87,
+          "value": 43000000,
+          "yearly_wage": 2444000
         },
         {
           "contract": "Jun 30, 2027",
@@ -731,7 +923,11 @@
             "Italy"
           ],
           "number": "95",
-          "position": "Goalkeeper"
+          "overall_score": 74,
+          "position": "Goalkeeper",
+          "potential": 74,
+          "value": 2800000,
+          "yearly_wage": 1352000
         },
         {
           "contract": "Jun 30, 2029",
@@ -745,7 +941,11 @@
             "Poland"
           ],
           "number": "91",
-          "position": "Goalkeeper"
+          "overall_score": 64,
+          "position": "Goalkeeper",
+          "potential": 78,
+          "value": 1200000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2028",
@@ -760,7 +960,11 @@
             "France"
           ],
           "number": "5",
-          "position": "Centre-Back"
+          "overall_score": 81,
+          "position": "Centre-Back",
+          "potential": 83,
+          "value": 28500000,
+          "yearly_wage": 3016000
         },
         {
           "contract": "Jun 30, 2027",
@@ -774,7 +978,11 @@
             "Italy"
           ],
           "number": "23",
-          "position": "Centre-Back"
+          "overall_score": 84,
+          "position": "Centre-Back",
+          "potential": 84,
+          "value": 35500000,
+          "yearly_wage": 4316000
         },
         {
           "contract": "Jun 30, 2026",
@@ -788,7 +996,11 @@
             "Italy"
           ],
           "number": "87",
-          "position": "Centre-Back"
+          "overall_score": 72,
+          "position": "Centre-Back",
+          "potential": 80,
+          "value": 4900000,
+          "yearly_wage": 1404000
         },
         {
           "contract": "Jun 30, 2030",
@@ -816,7 +1028,11 @@
             "Spain"
           ],
           "number": "22",
-          "position": "Centre-Back"
+          "overall_score": 79,
+          "position": "Centre-Back",
+          "potential": 79,
+          "value": 14500000,
+          "yearly_wage": 2912000
         },
         {
           "contract": "Jun 30, 2028",
@@ -830,7 +1046,11 @@
             "Spain"
           ],
           "number": "3",
-          "position": "Left-Back"
+          "overall_score": 79,
+          "position": "Left-Back",
+          "potential": 79,
+          "value": 16000000,
+          "yearly_wage": 2912000
         },
         {
           "contract": "Jun 30, 2026",
@@ -844,7 +1064,11 @@
             "Greece"
           ],
           "number": "12",
-          "position": "Left-Back"
+          "overall_score": 77,
+          "position": "Left-Back",
+          "potential": 77,
+          "value": 9500000,
+          "yearly_wage": 4160000
         },
         {
           "contract": "Jun 30, 2030",
@@ -858,7 +1082,11 @@
             "Brazil"
           ],
           "number": "43",
-          "position": "Right-Back"
+          "overall_score": 79,
+          "position": "Right-Back",
+          "potential": 85,
+          "value": 28000000,
+          "yearly_wage": 2184000
         },
         {
           "contract": "Jun 30, 2026",
@@ -872,7 +1100,11 @@
             "Türkiye"
           ],
           "number": "19",
-          "position": "Right-Back"
+          "overall_score": 78,
+          "position": "Right-Back",
+          "potential": 78,
+          "value": 12500000,
+          "yearly_wage": 2652000
         },
         {
           "contract": "Jun 30, 2029",
@@ -887,7 +1119,11 @@
             "Suriname"
           ],
           "number": "2",
-          "position": "Right-Back"
+          "overall_score": 74,
+          "position": "Right-Back",
+          "potential": 79,
+          "value": 6000000,
+          "yearly_wage": 1716000
         },
         {
           "contract": "Jun 30, 2027",
@@ -902,7 +1138,11 @@
             "Canada"
           ],
           "number": "4",
-          "position": "Defensive Midfield"
+          "overall_score": 81,
+          "position": "Defensive Midfield",
+          "potential": 81,
+          "value": 24500000,
+          "yearly_wage": 3484000
         },
         {
           "contract": "Jun 30, 2029",
@@ -917,7 +1157,11 @@
             "Cote d'Ivoire"
           ],
           "number": "17",
-          "position": "Central Midfield"
+          "overall_score": 80,
+          "position": "Central Midfield",
+          "potential": 84,
+          "value": 30000000,
+          "yearly_wage": 2704000
         },
         {
           "contract": "Jun 30, 2030",
@@ -932,7 +1176,11 @@
             "France"
           ],
           "number": "8",
-          "position": "Central Midfield"
+          "overall_score": 76,
+          "position": "Central Midfield",
+          "potential": 81,
+          "value": 11500000,
+          "yearly_wage": 2028000
         },
         {
           "contract": "Jun 30, 2029",
@@ -946,7 +1194,11 @@
             "Italy"
           ],
           "number": "61",
-          "position": "Central Midfield"
+          "overall_score": 72,
+          "position": "Central Midfield",
+          "potential": 84,
+          "value": 5500000,
+          "yearly_wage": 1248000
         },
         {
           "contract": "Jun 30, 2026",
@@ -960,7 +1212,11 @@
             "Italy"
           ],
           "number": "7",
-          "position": "Attacking Midfield"
+          "overall_score": 80,
+          "position": "Attacking Midfield",
+          "potential": 80,
+          "value": 20500000,
+          "yearly_wage": 3276000
         },
         {
           "contract": "Jun 30, 2026",
@@ -974,7 +1230,11 @@
             "Spain"
           ],
           "number": "97",
-          "position": "Left Winger"
+          "overall_score": 77,
+          "position": "Left Winger",
+          "potential": 83,
+          "value": 16500000,
+          "yearly_wage": 2548000
         },
         {
           "contract": "Jun 30, 2026",
@@ -989,7 +1249,11 @@
             "Egypt"
           ],
           "number": "92",
-          "position": "Left Winger"
+          "overall_score": 78,
+          "position": "Left Winger",
+          "potential": 78,
+          "value": 11000000,
+          "yearly_wage": 2756000
         },
         {
           "contract": "Jun 30, 2029",
@@ -1004,7 +1268,11 @@
             "Italy"
           ],
           "number": "18",
-          "position": "Right Winger"
+          "overall_score": 79,
+          "position": "Right Winger",
+          "potential": 85,
+          "value": 28000000,
+          "yearly_wage": 2600000
         },
         {
           "contract": "Jun 30, 2026",
@@ -1018,7 +1286,11 @@
             "Italy"
           ],
           "number": "20",
-          "position": "Right Winger"
+          "overall_score": 62,
+          "position": "Right Winger",
+          "potential": 76,
+          "value": 950000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2026",
@@ -1033,7 +1305,11 @@
             "Italy"
           ],
           "number": "21",
-          "position": "Second Striker"
+          "overall_score": 85,
+          "position": "Second Striker",
+          "potential": 85,
+          "value": 44500000,
+          "yearly_wage": 4940000
         },
         {
           "contract": "Jun 30, 2026",
@@ -1048,7 +1324,11 @@
             "England"
           ],
           "number": "11",
-          "position": "Centre-Forward"
+          "overall_score": 74,
+          "position": "Centre-Forward",
+          "potential": 82,
+          "value": 9500000,
+          "yearly_wage": 2652000
         },
         {
           "contract": "Jun 30, 2026",
@@ -1063,7 +1343,11 @@
             "Suriname"
           ],
           "number": "14",
-          "position": "Centre-Forward"
+          "overall_score": 80,
+          "position": "Centre-Forward",
+          "potential": 80,
+          "value": 23500000,
+          "yearly_wage": 6240000
         },
         {
           "contract": "Jun 30, 2029",
@@ -1077,7 +1361,11 @@
             "Ukraine"
           ],
           "number": "9",
-          "position": "Centre-Forward"
+          "overall_score": 81,
+          "position": "Centre-Forward",
+          "potential": 81,
+          "value": 26500000,
+          "yearly_wage": 3744000
         },
         {
           "contract": "Jun 30, 2030",
@@ -1092,7 +1380,11 @@
             "Guinea-Bissau"
           ],
           "number": "78",
-          "position": "Centre-Forward"
+          "overall_score": 70,
+          "position": "Centre-Forward",
+          "potential": 86,
+          "value": 4100000,
+          "yearly_wage": 988000
         }
       ],
       "stadiumName": "Olimpico di Roma",
@@ -1115,7 +1407,11 @@
             "Italy"
           ],
           "number": "94",
-          "position": "Goalkeeper"
+          "overall_score": 83,
+          "position": "Goalkeeper",
+          "potential": 83,
+          "value": 19000000,
+          "yearly_wage": 1716000
         },
         {
           "contract": "Jun 30, 2030",
@@ -1129,7 +1425,11 @@
             "Italy"
           ],
           "number": "40",
-          "position": "Goalkeeper"
+          "overall_score": 67,
+          "position": "Goalkeeper",
+          "potential": 74,
+          "value": 1700000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2028",
@@ -1143,7 +1443,11 @@
             "Italy"
           ],
           "number": "55",
-          "position": "Goalkeeper"
+          "overall_score": 61,
+          "position": "Goalkeeper",
+          "potential": 66,
+          "value": 400000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2027",
@@ -1157,7 +1461,11 @@
             "Spain"
           ],
           "number": "34",
-          "position": "Centre-Back"
+          "overall_score": 81,
+          "position": "Centre-Back",
+          "potential": 84,
+          "value": 31500000,
+          "yearly_wage": 1820000
         },
         {
           "contract": "Jun 30, 2027",
@@ -1171,7 +1479,11 @@
             "Italy"
           ],
           "number": "13",
-          "position": "Centre-Back"
+          "overall_score": 82,
+          "position": "Centre-Back",
+          "potential": 82,
+          "value": 25000000,
+          "yearly_wage": 2392000
         },
         {
           "contract": "Jun 30, 2029",
@@ -1185,7 +1497,11 @@
             "Denmark"
           ],
           "number": "25",
-          "position": "Centre-Back"
+          "overall_score": 69,
+          "position": "Centre-Back",
+          "potential": 76,
+          "value": 2600000,
+          "yearly_wage": 676000
         },
         {
           "contract": "Jun 30, 2027",
@@ -1199,7 +1515,11 @@
             "France"
           ],
           "number": "2",
-          "position": "Centre-Back"
+          "overall_score": 76,
+          "position": "Centre-Back",
+          "potential": 76,
+          "value": 5000000,
+          "yearly_wage": 1560000
         },
         {
           "contract": "Jun 30, 2027",
@@ -1213,7 +1533,11 @@
             "Spain"
           ],
           "number": "4",
-          "position": "Centre-Back"
+          "overall_score": 75,
+          "position": "Centre-Back",
+          "potential": 75,
+          "value": 3600000,
+          "yearly_wage": 1508000
         },
         {
           "contract": "Jun 30, 2029",
@@ -1228,7 +1552,11 @@
             "Cape Verde"
           ],
           "number": "17",
-          "position": "Left-Back"
+          "overall_score": 76,
+          "position": "Left-Back",
+          "potential": 79,
+          "value": 9000000,
+          "yearly_wage": 1404000
         },
         {
           "contract": "Jun 30, 2027",
@@ -1242,7 +1570,11 @@
             "Italy"
           ],
           "number": "3",
-          "position": "Left-Back"
+          "overall_score": 74,
+          "position": "Left-Back",
+          "potential": 75,
+          "value": 4500000,
+          "yearly_wage": 1300000
         },
         {
           "contract": "Jun 30, 2028",
@@ -1257,7 +1589,11 @@
             "Serbia"
           ],
           "number": "77",
-          "position": "Right-Back"
+          "overall_score": 77,
+          "position": "Right-Back",
+          "potential": 77,
+          "value": 7500000,
+          "yearly_wage": 1664000
         },
         {
           "contract": "Jun 30, 2027",
@@ -1271,7 +1607,11 @@
             "Italy"
           ],
           "number": "29",
-          "position": "Right-Back"
+          "overall_score": 76,
+          "position": "Right-Back",
+          "potential": 76,
+          "value": 5500000,
+          "yearly_wage": 1560000
         },
         {
           "contract": "Jun 30, 2026",
@@ -1285,7 +1625,11 @@
             "Albania"
           ],
           "number": "23",
-          "position": "Right-Back"
+          "overall_score": 72,
+          "position": "Right-Back",
+          "potential": 72,
+          "value": 1700000,
+          "yearly_wage": 1144000
         },
         {
           "contract": "Jun 30, 2028",
@@ -1299,7 +1643,11 @@
             "Italy"
           ],
           "number": "6",
-          "position": "Defensive Midfield"
+          "overall_score": 79,
+          "position": "Defensive Midfield",
+          "potential": 84,
+          "value": 24500000,
+          "yearly_wage": 1612000
         },
         {
           "contract": "Jun 30, 2029",
@@ -1314,7 +1662,11 @@
             "France"
           ],
           "number": "21",
-          "position": "Defensive Midfield"
+          "overall_score": 67,
+          "position": "Defensive Midfield",
+          "potential": 76,
+          "value": 2300000,
+          "yearly_wage": 468000
         },
         {
           "contract": "Jun 30, 2027",
@@ -1328,7 +1680,11 @@
             "Italy"
           ],
           "number": "32",
-          "position": "Defensive Midfield"
+          "overall_score": 78,
+          "position": "Defensive Midfield",
+          "potential": 78,
+          "value": 13500000,
+          "yearly_wage": 1872000
         },
         {
           "contract": "Jun 30, 2030",
@@ -1342,7 +1698,11 @@
             "Netherlands"
           ],
           "number": "24",
-          "position": "Central Midfield"
+          "overall_score": 78,
+          "position": "Central Midfield",
+          "potential": 83,
+          "value": 21000000,
+          "yearly_wage": 1560000
         },
         {
           "contract": "Jun 30, 2026",
@@ -1356,7 +1716,11 @@
             "Croatia"
           ],
           "number": "26",
-          "position": "Central Midfield"
+          "overall_score": 75,
+          "position": "Central Midfield",
+          "potential": 75,
+          "value": 5500000,
+          "yearly_wage": 1560000
         },
         {
           "contract": "Jun 30, 2026",
@@ -1371,7 +1735,11 @@
             "Venezuela"
           ],
           "number": "27",
-          "position": "Attacking Midfield"
+          "overall_score": 74,
+          "position": "Attacking Midfield",
+          "potential": 81,
+          "value": 8500000,
+          "yearly_wage": 2132000
         },
         {
           "contract": "Jun 30, 2030",
@@ -1385,7 +1753,11 @@
             "Poland"
           ],
           "number": "28",
-          "position": "Attacking Midfield"
+          "overall_score": 66,
+          "position": "Attacking Midfield",
+          "potential": 78,
+          "value": 2000000,
+          "yearly_wage": 364000
         },
         {
           "contract": "Jun 30, 2028",
@@ -1400,7 +1772,11 @@
             "England"
           ],
           "number": "7",
-          "position": "Attacking Midfield"
+          "overall_score": 73,
+          "position": "Attacking Midfield",
+          "potential": 77,
+          "value": 4400000,
+          "yearly_wage": 1092000
         },
         {
           "contract": "Jun 30, 2029",
@@ -1414,7 +1790,11 @@
             "Italy"
           ],
           "number": "10",
-          "position": "Left Winger"
+          "overall_score": 83,
+          "position": "Left Winger",
+          "potential": 83,
+          "value": 35000000,
+          "yearly_wage": 2912000
         },
         {
           "contract": "Jun 30, 2028",
@@ -1428,7 +1808,11 @@
             "Denmark"
           ],
           "number": "18",
-          "position": "Right Winger"
+          "overall_score": 76,
+          "position": "Right Winger",
+          "potential": 79,
+          "value": 10000000,
+          "yearly_wage": 1352000
         },
         {
           "contract": "Jun 30, 2029",
@@ -1443,7 +1827,11 @@
             "Suriname"
           ],
           "number": "14",
-          "position": "Right Winger"
+          "overall_score": 74,
+          "position": "Right Winger",
+          "potential": 77,
+          "value": 5500000,
+          "yearly_wage": 1456000
         },
         {
           "contract": "Jun 30, 2027",
@@ -1457,7 +1845,11 @@
             "Italy"
           ],
           "number": "22",
-          "position": "Right Winger"
+          "overall_score": 74,
+          "position": "Right Winger",
+          "potential": 79,
+          "value": 6500000,
+          "yearly_wage": 1300000
         },
         {
           "contract": "Jun 30, 2026",
@@ -1471,7 +1863,11 @@
             "Spain"
           ],
           "number": "9",
-          "position": "Right Winger"
+          "overall_score": 76,
+          "position": "Right Winger",
+          "potential": 76,
+          "value": 2400000,
+          "yearly_wage": 1196000
         },
         {
           "contract": "Jun 30, 2026",
@@ -1486,7 +1882,11 @@
             "France"
           ],
           "number": "19",
-          "position": "Centre-Forward"
+          "overall_score": 78,
+          "position": "Centre-Forward",
+          "potential": 78,
+          "value": 14500000,
+          "yearly_wage": 2028000
         },
         {
           "contract": "Jun 30, 2030",
@@ -1501,7 +1901,11 @@
             "Croatia"
           ],
           "number": "20",
-          "position": "Centre-Forward"
+          "overall_score": 68,
+          "position": "Centre-Forward",
+          "potential": 78,
+          "value": 2700000,
+          "yearly_wage": 624000
         }
       ],
       "stadiumName": "Olimpico di Roma",
@@ -1525,7 +1929,11 @@
             "Spain"
           ],
           "number": "32",
-          "position": "Goalkeeper"
+          "overall_score": 79,
+          "position": "Goalkeeper",
+          "potential": 81,
+          "value": 15000000,
+          "yearly_wage": 1508000
         },
         {
           "contract": "Jun 30, 2027",
@@ -1539,7 +1947,11 @@
             "Italy"
           ],
           "number": "1",
-          "position": "Goalkeeper"
+          "overall_score": 82,
+          "position": "Goalkeeper",
+          "potential": 84,
+          "value": 26000000,
+          "yearly_wage": 3744000
         },
         {
           "contract": "Jun 30, 2031",
@@ -1554,7 +1966,11 @@
             "Ukraine"
           ],
           "number": "14",
-          "position": "Goalkeeper"
+          "overall_score": 67,
+          "position": "Goalkeeper",
+          "potential": 68,
+          "value": 775000,
+          "yearly_wage": 988000
         },
         {
           "contract": "Jun 30, 2030",
@@ -1568,7 +1984,11 @@
             "Italy"
           ],
           "number": "25",
-          "position": "Goalkeeper"
+          "overall_score": 54,
+          "position": "Goalkeeper",
+          "potential": 68,
+          "value": 220000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2029",
@@ -1582,7 +2002,11 @@
             "Italy"
           ],
           "number": "4",
-          "position": "Centre-Back"
+          "overall_score": 82,
+          "position": "Centre-Back",
+          "potential": 86,
+          "value": 37500000,
+          "yearly_wage": 5460000
         },
         {
           "contract": "Jun 30, 2030",
@@ -1596,7 +2020,11 @@
             "Netherlands"
           ],
           "number": "31",
-          "position": "Centre-Back"
+          "overall_score": 78,
+          "position": "Centre-Back",
+          "potential": 80,
+          "value": 15500000,
+          "yearly_wage": 4056000
         },
         {
           "contract": "Jun 30, 2027",
@@ -1611,7 +2039,11 @@
             "Albania"
           ],
           "number": "13",
-          "position": "Centre-Back"
+          "overall_score": 83,
+          "position": "Centre-Back",
+          "potential": 83,
+          "value": 25000000,
+          "yearly_wage": 6240000
         },
         {
           "contract": "Jun 30, 2026",
@@ -1626,7 +2058,11 @@
             "Italy"
           ],
           "number": "5",
-          "position": "Centre-Back"
+          "overall_score": 75,
+          "position": "Centre-Back",
+          "potential": 75,
+          "value": 1800000,
+          "yearly_wage": 3536000
         },
         {
           "contract": "Jun 30, 2030",
@@ -1641,7 +2077,11 @@
             "Spain"
           ],
           "number": "17",
-          "position": "Left-Back"
+          "overall_score": 77,
+          "position": "Left-Back",
+          "potential": 77,
+          "value": 10000000,
+          "yearly_wage": 3796000
         },
         {
           "contract": "Jun 30, 2030",
@@ -1655,7 +2095,11 @@
             "Spain"
           ],
           "number": "3",
-          "position": "Left-Back"
+          "overall_score": 81,
+          "position": "Left-Back",
+          "potential": 85,
+          "value": 34500000,
+          "yearly_wage": 4368000
         },
         {
           "contract": "Jun 30, 2026",
@@ -1669,7 +2113,11 @@
             "Italy"
           ],
           "number": "37",
-          "position": "Left-Back"
+          "overall_score": 80,
+          "position": "Left-Back",
+          "potential": 80,
+          "value": 14500000,
+          "yearly_wage": 4940000
         },
         {
           "contract": "Jun 30, 2028",
@@ -1683,7 +2131,11 @@
             "Italy"
           ],
           "number": "22",
-          "position": "Right-Back"
+          "overall_score": 83,
+          "position": "Right-Back",
+          "potential": 83,
+          "value": 26500000,
+          "yearly_wage": 6240000
         },
         {
           "contract": "Jun 30, 2027",
@@ -1697,7 +2149,11 @@
             "Italy"
           ],
           "number": "30",
-          "position": "Right-Back"
+          "overall_score": 71,
+          "position": "Right-Back",
+          "potential": 71,
+          "value": 1600000,
+          "yearly_wage": 2444000
         },
         {
           "contract": "Jun 30, 2029",
@@ -1711,7 +2167,11 @@
             "Scotland"
           ],
           "number": "6",
-          "position": "Defensive Midfield"
+          "overall_score": 75,
+          "position": "Defensive Midfield",
+          "potential": 79,
+          "value": 8000000,
+          "yearly_wage": 3068000
         },
         {
           "contract": "Jun 30, 2027",
@@ -1725,7 +2185,11 @@
             "Slovakia"
           ],
           "number": "68",
-          "position": "Defensive Midfield"
+          "overall_score": 83,
+          "position": "Defensive Midfield",
+          "potential": 83,
+          "value": 34500000,
+          "yearly_wage": 6500000
         },
         {
           "contract": "Jun 30, 2028",
@@ -1740,7 +2204,11 @@
             "England"
           ],
           "number": "8",
-          "position": "Central Midfield"
+          "overall_score": 86,
+          "position": "Central Midfield",
+          "potential": 86,
+          "value": 68000000,
+          "yearly_wage": 8580000
         },
         {
           "contract": "Jun 30, 2027",
@@ -1768,7 +2236,11 @@
             "Belgium"
           ],
           "number": "11",
-          "position": "Attacking Midfield"
+          "overall_score": 87,
+          "position": "Attacking Midfield",
+          "potential": 87,
+          "value": 36500000,
+          "yearly_wage": 9100000
         },
         {
           "contract": "Jun 30, 2026",
@@ -1782,7 +2254,11 @@
             "North Macedonia"
           ],
           "number": "20",
-          "position": "Attacking Midfield"
+          "overall_score": 77,
+          "position": "Attacking Midfield",
+          "potential": 77,
+          "value": 11500000,
+          "yearly_wage": 2392000
         },
         {
           "contract": "Jun 30, 2030",
@@ -1796,7 +2272,11 @@
             "Italy"
           ],
           "number": "26",
-          "position": "Attacking Midfield"
+          "overall_score": 67,
+          "position": "Attacking Midfield",
+          "potential": 76,
+          "value": 2300000,
+          "yearly_wage": 1404000
         },
         {
           "contract": "Jun 30, 2026",
@@ -1811,7 +2291,11 @@
             "Tunisia"
           ],
           "number": "27",
-          "position": "Left Winger"
+          "overall_score": 70,
+          "position": "Left Winger",
+          "potential": 78,
+          "value": 3600000,
+          "yearly_wage": 520000
         },
         {
           "contract": "Jun 30, 2028",
@@ -1825,7 +2309,11 @@
             "Brazil"
           ],
           "number": "7",
-          "position": "Right Winger"
+          "overall_score": 81,
+          "position": "Right Winger",
+          "potential": 81,
+          "value": 26000000,
+          "yearly_wage": 5980000
         },
         {
           "contract": "Jun 30, 2028",
@@ -1839,7 +2327,11 @@
             "Italy"
           ],
           "number": "21",
-          "position": "Right Winger"
+          "overall_score": 81,
+          "position": "Right Winger",
+          "potential": 81,
+          "value": 21500000,
+          "yearly_wage": 5980000
         },
         {
           "contract": "Jun 30, 2026",
@@ -1853,7 +2345,11 @@
             "Denmark"
           ],
           "number": "19",
-          "position": "Centre-Forward"
+          "overall_score": 78,
+          "position": "Centre-Forward",
+          "potential": 83,
+          "value": 22000000,
+          "yearly_wage": 3744000
         },
         {
           "contract": "Jun 30, 2027",
@@ -1868,7 +2364,11 @@
             "DR Congo"
           ],
           "number": "9",
-          "position": "Centre-Forward"
+          "overall_score": 83,
+          "position": "Centre-Forward",
+          "potential": 83,
+          "value": 29500000,
+          "yearly_wage": 7020000
         },
         {
           "contract": "Jun 30, 2030",
@@ -1882,7 +2382,11 @@
             "Brazil"
           ],
           "number": "23",
-          "position": "Centre-Forward"
+          "overall_score": 69,
+          "position": "Centre-Forward",
+          "potential": 79,
+          "value": 3200000,
+          "yearly_wage": 1560000
         }
       ],
       "stadiumName": "Diego Armando Maradona",
@@ -1905,7 +2409,11 @@
             "Spain"
           ],
           "number": "43",
-          "position": "Goalkeeper"
+          "overall_score": 84,
+          "position": "Goalkeeper",
+          "potential": 84,
+          "value": 7000000,
+          "yearly_wage": 2652000
         },
         {
           "contract": "Jun 30, 2028",
@@ -1919,7 +2427,11 @@
             "Denmark"
           ],
           "number": "53",
-          "position": "Goalkeeper"
+          "overall_score": 71,
+          "position": "Goalkeeper",
+          "potential": 74,
+          "value": 1900000,
+          "yearly_wage": 884000
         },
         {
           "contract": "Jun 30, 2026",
@@ -1933,7 +2445,11 @@
             "Italy"
           ],
           "number": "1",
-          "position": "Goalkeeper"
+          "overall_score": 69,
+          "position": "Goalkeeper",
+          "potential": 69,
+          "value": 925000,
+          "yearly_wage": 728000
         },
         {
           "contract": "Jun 30, 2029",
@@ -1947,7 +2463,11 @@
             "Italy"
           ],
           "number": "15",
-          "position": "Centre-Back"
+          "overall_score": 75,
+          "position": "Centre-Back",
+          "potential": 86,
+          "value": 11500000,
+          "yearly_wage": 1456000
         },
         {
           "contract": "Jun 30, 2029",
@@ -1962,7 +2482,11 @@
             "Germany"
           ],
           "number": "5",
-          "position": "Centre-Back"
+          "overall_score": 73,
+          "position": "Centre-Back",
+          "potential": 75,
+          "value": 3200000,
+          "yearly_wage": 1664000
         },
         {
           "contract": "Jun 30, 2028",
@@ -1976,7 +2500,11 @@
             "Italy"
           ],
           "number": "6",
-          "position": "Centre-Back"
+          "overall_score": 75,
+          "position": "Centre-Back",
+          "potential": 78,
+          "value": 6500000,
+          "yearly_wage": 1976000
         },
         {
           "contract": "Jun 30, 2030",
@@ -1991,7 +2519,11 @@
             "Cote d'Ivoire"
           ],
           "number": "60",
-          "position": "Centre-Back"
+          "overall_score": 62,
+          "position": "Centre-Back",
+          "potential": 76,
+          "value": 875000,
+          "yearly_wage": 312000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2005,7 +2537,11 @@
             "Italy"
           ],
           "number": "3",
-          "position": "Centre-Back"
+          "overall_score": 75,
+          "position": "Centre-Back",
+          "potential": 75,
+          "value": 4600000,
+          "yearly_wage": 4160000
         },
         {
           "contract": "Jun 30, 2030",
@@ -2020,7 +2556,11 @@
             "Switzerland"
           ],
           "number": "23",
-          "position": "Centre-Back"
+          "overall_score": 61,
+          "position": "Centre-Back",
+          "potential": 76,
+          "value": 725000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2027",
@@ -2034,7 +2574,11 @@
             "Italy"
           ],
           "number": "29",
-          "position": "Left-Back"
+          "overall_score": 67,
+          "position": "Left-Back",
+          "potential": 80,
+          "value": 2400000,
+          "yearly_wage": 624000
         },
         {
           "contract": "Jun 30, 2028",
@@ -2049,7 +2593,11 @@
             "Netherlands"
           ],
           "number": "21",
-          "position": "Left-Back"
+          "overall_score": 79,
+          "position": "Left-Back",
+          "potential": 79,
+          "value": 15000000,
+          "yearly_wage": 2756000
         },
         {
           "contract": "Jun 30, 2029",
@@ -2063,7 +2611,11 @@
             "Italy"
           ],
           "number": "65",
-          "position": "Left-Back"
+          "overall_score": 75,
+          "position": "Left-Back",
+          "potential": 80,
+          "value": 8000000,
+          "yearly_wage": 1716000
         },
         {
           "contract": "Jun 30, 2028",
@@ -2078,7 +2630,11 @@
             "Portugal"
           ],
           "number": "62",
-          "position": "Left-Back"
+          "overall_score": 60,
+          "position": "Left-Back",
+          "potential": 75,
+          "value": 550000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2027",
@@ -2092,7 +2648,11 @@
             "Brazil"
           ],
           "number": "2",
-          "position": "Right-Back"
+          "overall_score": 78,
+          "position": "Right-Back",
+          "potential": 79,
+          "value": 15000000,
+          "yearly_wage": 2392000
         },
         {
           "contract": "Jun 30, 2028",
@@ -2107,7 +2667,11 @@
             "England"
           ],
           "number": "48",
-          "position": "Right-Back"
+          "overall_score": 73,
+          "position": "Right-Back",
+          "potential": 76,
+          "value": 3800000,
+          "yearly_wage": 1456000
         },
         {
           "contract": "Jun 30, 2028",
@@ -2121,7 +2685,11 @@
             "Italy"
           ],
           "number": "8",
-          "position": "Defensive Midfield"
+          "overall_score": 76,
+          "position": "Defensive Midfield",
+          "potential": 76,
+          "value": 7500000,
+          "yearly_wage": 2288000
         },
         {
           "contract": "Jun 30, 2028",
@@ -2135,7 +2703,11 @@
             "Italy"
           ],
           "number": "44",
-          "position": "Central Midfield"
+          "overall_score": 76,
+          "position": "Central Midfield",
+          "potential": 81,
+          "value": 11500000,
+          "yearly_wage": 1924000
         },
         {
           "contract": "Jun 30, 2030",
@@ -2149,7 +2721,11 @@
             "Italy"
           ],
           "number": "22",
-          "position": "Central Midfield"
+          "overall_score": 72,
+          "position": "Central Midfield",
+          "potential": 81,
+          "value": 5500000,
+          "yearly_wage": 1404000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2163,7 +2739,11 @@
             "Italy"
           ],
           "number": "4",
-          "position": "Central Midfield"
+          "overall_score": 72,
+          "position": "Central Midfield",
+          "potential": 75,
+          "value": 3100000,
+          "yearly_wage": 1872000
         },
         {
           "contract": "Jun 30, 2029",
@@ -2178,7 +2758,11 @@
             "Senegal"
           ],
           "number": "27",
-          "position": "Central Midfield"
+          "overall_score": 72,
+          "position": "Central Midfield",
+          "potential": 83,
+          "value": 5000000,
+          "yearly_wage": 1196000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2192,7 +2776,11 @@
             "Italy"
           ],
           "number": "80",
-          "position": "Attacking Midfield"
+          "overall_score": 73,
+          "position": "Attacking Midfield",
+          "potential": 82,
+          "value": 7000000,
+          "yearly_wage": 1508000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2207,7 +2795,11 @@
             "Germany"
           ],
           "number": "11",
-          "position": "Attacking Midfield"
+          "overall_score": 72,
+          "position": "Attacking Midfield",
+          "potential": 72,
+          "value": 2400000,
+          "yearly_wage": 1664000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2221,7 +2813,11 @@
             "England"
           ],
           "number": "17",
-          "position": "Left Winger"
+          "overall_score": 73,
+          "position": "Left Winger",
+          "potential": 73,
+          "value": 3100000,
+          "yearly_wage": 2340000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2236,7 +2832,11 @@
             "Portugal"
           ],
           "number": "19",
-          "position": "Left Winger"
+          "overall_score": 77,
+          "position": "Left Winger",
+          "potential": 77,
+          "value": 11500000,
+          "yearly_wage": 4056000
         },
         {
           "contract": "Jun 30, 2029",
@@ -2265,7 +2865,11 @@
             "Cote d'Ivoire"
           ],
           "number": "20",
-          "position": "Centre-Forward"
+          "overall_score": 83,
+          "position": "Centre-Forward",
+          "potential": 86,
+          "value": 48500000,
+          "yearly_wage": 3848000
         },
         {
           "contract": "Jun 30, 2030",
@@ -2279,7 +2883,11 @@
             "Italy"
           ],
           "number": "91",
-          "position": "Centre-Forward"
+          "overall_score": 75,
+          "position": "Centre-Forward",
+          "potential": 80,
+          "value": 8500000,
+          "yearly_wage": 1976000
         }
       ],
       "stadiumName": "Artemio Franchi",
@@ -2302,7 +2910,11 @@
             "Italy"
           ],
           "number": "16",
-          "position": "Goalkeeper"
+          "overall_score": 81,
+          "position": "Goalkeeper",
+          "potential": 84,
+          "value": 25500000,
+          "yearly_wage": 3796000
         },
         {
           "contract": "Jun 30, 2027",
@@ -2316,7 +2928,11 @@
             "Italy"
           ],
           "number": "1",
-          "position": "Goalkeeper"
+          "overall_score": 78,
+          "position": "Goalkeeper",
+          "potential": 78,
+          "value": 7000000,
+          "yearly_wage": 3224000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2330,7 +2946,11 @@
             "Italy"
           ],
           "number": "23",
-          "position": "Goalkeeper"
+          "overall_score": 69,
+          "position": "Goalkeeper",
+          "potential": 69,
+          "value": 150000,
+          "yearly_wage": 884000
         },
         {
           "contract": "Jun 30, 2029",
@@ -2344,7 +2964,11 @@
             "Brazil"
           ],
           "number": "3",
-          "position": "Centre-Back"
+          "overall_score": 86,
+          "position": "Centre-Back",
+          "potential": 86,
+          "value": 58500000,
+          "yearly_wage": 9620000
         },
         {
           "contract": "Jun 30, 2029",
@@ -2359,7 +2983,11 @@
             "DR Congo"
           ],
           "number": "15",
-          "position": "Centre-Back"
+          "overall_score": 80,
+          "position": "Centre-Back",
+          "potential": 85,
+          "value": 28000000,
+          "yearly_wage": 5200000
         },
         {
           "contract": "Jun 30, 2030",
@@ -2373,7 +3001,11 @@
             "Italy"
           ],
           "number": "4",
-          "position": "Centre-Back"
+          "overall_score": 80,
+          "position": "Centre-Back",
+          "potential": 83,
+          "value": 24000000,
+          "yearly_wage": 5460000
         },
         {
           "contract": "Jun 30, 2029",
@@ -2388,7 +3020,11 @@
             "Jamaica"
           ],
           "number": "6",
-          "position": "Centre-Back"
+          "overall_score": 78,
+          "position": "Centre-Back",
+          "potential": 80,
+          "value": 15500000,
+          "yearly_wage": 4680000
         },
         {
           "contract": "Jun 30, 2029",
@@ -2402,7 +3038,11 @@
             "Colombia"
           ],
           "number": "32",
-          "position": "Left-Back"
+          "overall_score": 74,
+          "position": "Left-Back",
+          "potential": 79,
+          "value": 6000000,
+          "yearly_wage": 3172000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2416,7 +3056,11 @@
             "Sweden"
           ],
           "number": "2",
-          "position": "Right-Back"
+          "overall_score": 75,
+          "position": "Right-Back",
+          "potential": 78,
+          "value": 7000000,
+          "yearly_wage": 1924000
         },
         {
           "contract": "Jun 30, 2028",
@@ -2430,7 +3074,11 @@
             "Italy"
           ],
           "number": "5",
-          "position": "Defensive Midfield"
+          "overall_score": 84,
+          "position": "Defensive Midfield",
+          "potential": 85,
+          "value": 43000000,
+          "yearly_wage": 7800000
         },
         {
           "contract": "Jun 30, 2029",
@@ -2445,7 +3093,11 @@
             "Guadeloupe"
           ],
           "number": "19",
-          "position": "Central Midfield"
+          "overall_score": 81,
+          "position": "Central Midfield",
+          "potential": 85,
+          "value": 36500000,
+          "yearly_wage": 5460000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2459,7 +3111,11 @@
             "United States"
           ],
           "number": "22",
-          "position": "Central Midfield"
+          "overall_score": 79,
+          "position": "Central Midfield",
+          "potential": 79,
+          "value": 19000000,
+          "yearly_wage": 5460000
         },
         {
           "contract": "Jun 30, 2028",
@@ -2473,7 +3129,11 @@
             "Italy"
           ],
           "number": "21",
-          "position": "Central Midfield"
+          "overall_score": 75,
+          "position": "Central Midfield",
+          "potential": 80,
+          "value": 8500000,
+          "yearly_wage": 3068000
         },
         {
           "contract": "Jun 30, 2029",
@@ -2487,7 +3147,11 @@
             "Italy"
           ],
           "number": "27",
-          "position": "Left Midfield"
+          "overall_score": 80,
+          "position": "Left Midfield",
+          "potential": 82,
+          "value": 24500000,
+          "yearly_wage": 5200000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2501,7 +3165,11 @@
             "Serbia"
           ],
           "number": "18",
-          "position": "Left Midfield"
+          "overall_score": 80,
+          "position": "Left Midfield",
+          "potential": 80,
+          "value": 16500000,
+          "yearly_wage": 5980000
         },
         {
           "contract": "Jun 30, 2029",
@@ -2515,7 +3183,11 @@
             "Netherlands"
           ],
           "number": "8",
-          "position": "Attacking Midfield"
+          "overall_score": 80,
+          "position": "Attacking Midfield",
+          "potential": 80,
+          "value": 22500000,
+          "yearly_wage": 5980000
         },
         {
           "contract": "Jun 30, 2029",
@@ -2529,7 +3201,11 @@
             "Montenegro"
           ],
           "number": "17",
-          "position": "Attacking Midfield"
+          "overall_score": 69,
+          "position": "Attacking Midfield",
+          "potential": 79,
+          "value": 3000000,
+          "yearly_wage": 1612000
         },
         {
           "contract": "Jun 30, 2030",
@@ -2544,7 +3220,11 @@
             "Germany"
           ],
           "number": "10",
-          "position": "Left Winger"
+          "overall_score": 82,
+          "position": "Left Winger",
+          "potential": 89,
+          "value": 60500000,
+          "yearly_wage": 5200000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2559,7 +3239,11 @@
             "France"
           ],
           "number": "13",
-          "position": "Left Winger"
+          "overall_score": 76,
+          "position": "Left Winger",
+          "potential": 76,
+          "value": 7500000,
+          "yearly_wage": 1456000
         },
         {
           "contract": "Jun 30, 2030",
@@ -2573,7 +3257,11 @@
             "Portugal"
           ],
           "number": "7",
-          "position": "Right Winger"
+          "overall_score": 79,
+          "position": "Right Winger",
+          "potential": 86,
+          "value": 35500000,
+          "yearly_wage": 4940000
         },
         {
           "contract": "Jun 30, 2030",
@@ -2588,7 +3276,11 @@
             "Albania"
           ],
           "number": "11",
-          "position": "Right Winger"
+          "overall_score": 79,
+          "position": "Right Winger",
+          "potential": 79,
+          "value": 19000000,
+          "yearly_wage": 5460000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2603,7 +3295,11 @@
             "Morocco"
           ],
           "number": "20",
-          "position": "Centre-Forward"
+          "overall_score": 82,
+          "position": "Centre-Forward",
+          "potential": 84,
+          "value": 38500000,
+          "yearly_wage": 3640000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2617,7 +3313,11 @@
             "Serbia"
           ],
           "number": "9",
-          "position": "Centre-Forward"
+          "overall_score": 81,
+          "position": "Centre-Forward",
+          "potential": 84,
+          "value": 34500000,
+          "yearly_wage": 6500000
         },
         {
           "contract": "Jun 30, 2030",
@@ -2632,7 +3332,11 @@
             "United States"
           ],
           "number": "30",
-          "position": "Centre-Forward"
+          "overall_score": 81,
+          "position": "Centre-Forward",
+          "potential": 84,
+          "value": 34500000,
+          "yearly_wage": 6500000
         },
         {
           "contract": "Jun 30, 2027",
@@ -2646,7 +3350,11 @@
             "Poland"
           ],
           "number": "14",
-          "position": "Centre-Forward"
+          "overall_score": 78,
+          "position": "Centre-Forward",
+          "potential": 78,
+          "value": 12000000,
+          "yearly_wage": 5720000
         }
       ],
       "stadiumName": "Allianz Stadium",
@@ -2669,7 +3377,11 @@
             "Italy"
           ],
           "number": "1",
-          "position": "Goalkeeper"
+          "overall_score": 76,
+          "position": "Goalkeeper",
+          "potential": 77,
+          "value": 6000000,
+          "yearly_wage": 468000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2683,7 +3395,11 @@
             "Italy"
           ],
           "number": "34",
-          "position": "Goalkeeper"
+          "overall_score": 67,
+          "position": "Goalkeeper",
+          "potential": 67,
+          "value": 675000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2697,7 +3413,11 @@
             "Italy"
           ],
           "number": "94",
-          "position": "Goalkeeper"
+          "overall_score": 56,
+          "position": "Goalkeeper",
+          "potential": 66,
+          "value": 275000,
+          "yearly_wage": 36400
         },
         {
           "contract": "Jun 30, 2029",
@@ -2725,7 +3445,11 @@
             "Denmark"
           ],
           "number": "15",
-          "position": "Centre-Back"
+          "overall_score": 74,
+          "position": "Centre-Back",
+          "potential": 76,
+          "value": 4600000,
+          "yearly_wage": 1924000
         },
         {
           "contract": "Jun 30, 2030",
@@ -2740,7 +3464,11 @@
             "Cameroon"
           ],
           "number": "37",
-          "position": "Centre-Back"
+          "overall_score": 72,
+          "position": "Centre-Back",
+          "potential": 78,
+          "value": 3400000,
+          "yearly_wage": 416000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2755,7 +3483,11 @@
             "Italy"
           ],
           "number": "6",
-          "position": "Centre-Back"
+          "overall_score": 73,
+          "position": "Centre-Back",
+          "potential": 79,
+          "value": 4400000,
+          "yearly_wage": 1456000
         },
         {
           "contract": "Jun 30, 2028",
@@ -2769,7 +3501,11 @@
             "Denmark"
           ],
           "number": "19",
-          "position": "Centre-Back"
+          "overall_score": 69,
+          "position": "Centre-Back",
+          "potential": 82,
+          "value": 3100000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2029",
@@ -2783,7 +3519,11 @@
             "Faroe Islands"
           ],
           "number": "5",
-          "position": "Centre-Back"
+          "overall_score": 67,
+          "position": "Centre-Back",
+          "potential": 71,
+          "value": 1300000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2027",
@@ -2797,7 +3537,11 @@
             "Denmark"
           ],
           "number": "3",
-          "position": "Left-Back"
+          "overall_score": 72,
+          "position": "Left-Back",
+          "potential": 72,
+          "value": 2300000,
+          "yearly_wage": 468000
         },
         {
           "contract": "Jun 30, 2028",
@@ -2811,7 +3555,11 @@
             "Croatia"
           ],
           "number": "12",
-          "position": "Left-Back"
+          "overall_score": 72,
+          "position": "Left-Back",
+          "potential": 74,
+          "value": 2700000,
+          "yearly_wage": 468000
         },
         {
           "contract": "Jun 30, 2029",
@@ -2826,7 +3574,11 @@
             "Belgium"
           ],
           "number": "7",
-          "position": "Right-Back"
+          "overall_score": 70,
+          "position": "Right-Back",
+          "potential": 74,
+          "value": 2100000,
+          "yearly_wage": 364000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2840,7 +3592,11 @@
             "Spain"
           ],
           "number": "14",
-          "position": "Right-Back"
+          "overall_score": 73,
+          "position": "Right-Back",
+          "potential": 73,
+          "value": 2900000,
+          "yearly_wage": 520000
         },
         {
           "contract": "-",
@@ -2855,7 +3611,11 @@
             "Senegal"
           ],
           "number": "70",
-          "position": "Right-Back"
+          "overall_score": 66,
+          "position": "Right-Back",
+          "potential": 75,
+          "value": 1800000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2028",
@@ -2870,7 +3630,11 @@
             "Nigeria"
           ],
           "number": "2",
-          "position": "Right-Back"
+          "overall_score": 64,
+          "position": "Right-Back",
+          "potential": 74,
+          "value": 1200000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2900,7 +3664,11 @@
             "France"
           ],
           "number": "36",
-          "position": "Defensive Midfield"
+          "overall_score": 71,
+          "position": "Defensive Midfield",
+          "potential": 76,
+          "value": 2500000,
+          "yearly_wage": 416000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2915,7 +3683,11 @@
             "Austria"
           ],
           "number": "4",
-          "position": "Central Midfield"
+          "overall_score": 73,
+          "position": "Central Midfield",
+          "potential": 73,
+          "value": 3200000,
+          "yearly_wage": 780000
         },
         {
           "contract": "Jun 30, 2028",
@@ -2930,7 +3702,11 @@
             "Türkiye"
           ],
           "number": "8",
-          "position": "Central Midfield"
+          "overall_score": 76,
+          "position": "Central Midfield",
+          "potential": 76,
+          "value": 7500000,
+          "yearly_wage": 728000
         },
         {
           "contract": "Jun 30, 2028",
@@ -2945,7 +3721,11 @@
             "Cameroon"
           ],
           "number": "24",
-          "position": "Central Midfield"
+          "overall_score": 72,
+          "position": "Central Midfield",
+          "potential": 73,
+          "value": 2700000,
+          "yearly_wage": 520000
         },
         {
           "contract": "Jun 30, 2028",
@@ -2960,7 +3740,11 @@
             "Netherlands"
           ],
           "number": "21",
-          "position": "Central Midfield"
+          "overall_score": 71,
+          "position": "Central Midfield",
+          "potential": 71,
+          "value": 2000000,
+          "yearly_wage": 468000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2974,7 +3758,11 @@
             "Italy"
           ],
           "number": "63",
-          "position": "Central Midfield"
+          "overall_score": 72,
+          "position": "Central Midfield",
+          "potential": 72,
+          "value": 1600000,
+          "yearly_wage": 520000
         },
         {
           "contract": "Jun 30, 2026",
@@ -2989,7 +3777,11 @@
             "France"
           ],
           "number": "11",
-          "position": "Central Midfield"
+          "overall_score": 72,
+          "position": "Central Midfield",
+          "potential": 72,
+          "value": 1800000,
+          "yearly_wage": 520000
         },
         {
           "contract": "Jun 30, 2027",
@@ -3003,7 +3795,11 @@
             "Slovakia"
           ],
           "number": "10",
-          "position": "Attacking Midfield"
+          "overall_score": 72,
+          "position": "Attacking Midfield",
+          "potential": 80,
+          "value": 5000000,
+          "yearly_wage": 468000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3018,7 +3814,11 @@
             "Togo"
           ],
           "number": "16",
-          "position": "Centre-Forward"
+          "overall_score": 74,
+          "position": "Centre-Forward",
+          "potential": 81,
+          "value": 8500000,
+          "yearly_wage": 1404000
         },
         {
           "contract": "Jun 30, 2029",
@@ -3033,7 +3833,11 @@
             "Senegal"
           ],
           "number": "9",
-          "position": "Centre-Forward"
+          "overall_score": 71,
+          "position": "Centre-Forward",
+          "potential": 76,
+          "value": 2900000,
+          "yearly_wage": 416000
         },
         {
           "contract": "Jun 30, 2030",
@@ -3047,7 +3851,11 @@
             "Scotland"
           ],
           "number": "18",
-          "position": "Centre-Forward"
+          "overall_score": 67,
+          "position": "Centre-Forward",
+          "potential": 75,
+          "value": 2300000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2028",
@@ -3061,7 +3869,11 @@
             "Colombia"
           ],
           "number": "25",
-          "position": "Centre-Forward"
+          "overall_score": 71,
+          "position": "Centre-Forward",
+          "potential": 74,
+          "value": 2500000,
+          "yearly_wage": 468000
         },
         {
           "contract": "Jun 30, 2029",
@@ -3076,7 +3888,11 @@
             "Croatia"
           ],
           "number": "41",
-          "position": "Centre-Forward"
+          "overall_score": 67,
+          "position": "Centre-Forward",
+          "potential": 76,
+          "value": 2300000,
+          "yearly_wage": 260000
         },
         {
           "contract": "-",
@@ -3090,7 +3906,11 @@
             "Cote d'Ivoire"
           ],
           "number": "72",
-          "position": "Centre-Forward"
+          "overall_score": 56,
+          "position": "Centre-Forward",
+          "potential": 70,
+          "value": 350000,
+          "yearly_wage": 104000
         }
       ],
       "stadiumName": "Marcantonio Bentegodi",
@@ -3127,7 +3947,11 @@
             "Italy"
           ],
           "number": "13",
-          "position": "Goalkeeper"
+          "overall_score": 72,
+          "position": "Goalkeeper",
+          "potential": 75,
+          "value": 2400000,
+          "yearly_wage": 884000
         },
         {
           "contract": "Jun 30, 2028",
@@ -3141,7 +3965,11 @@
             "Italy"
           ],
           "number": "25",
-          "position": "Goalkeeper"
+          "overall_score": 54,
+          "position": "Goalkeeper",
+          "potential": 74,
+          "value": 250000,
+          "yearly_wage": 33800
         },
         {
           "contract": "Jun 30, 2027",
@@ -3155,7 +3983,11 @@
             "Colombia"
           ],
           "number": "26",
-          "position": "Centre-Back"
+          "overall_score": 76,
+          "position": "Centre-Back",
+          "potential": 78,
+          "value": 8000000,
+          "yearly_wage": 2080000
         },
         {
           "contract": "Jun 30, 2029",
@@ -3169,7 +4001,11 @@
             "Norway"
           ],
           "number": "14",
-          "position": "Centre-Back"
+          "overall_score": 74,
+          "position": "Centre-Back",
+          "potential": 76,
+          "value": 4600000,
+          "yearly_wage": 1820000
         },
         {
           "contract": "Jun 30, 2029",
@@ -3183,7 +4019,11 @@
             "Czech Republic"
           ],
           "number": "41",
-          "position": "Centre-Back"
+          "overall_score": 74,
+          "position": "Centre-Back",
+          "potential": 80,
+          "value": 6000000,
+          "yearly_wage": 1612000
         },
         {
           "contract": "Jun 30, 2030",
@@ -3197,7 +4037,11 @@
             "Norway"
           ],
           "number": "5",
-          "position": "Centre-Back"
+          "overall_score": 67,
+          "position": "Centre-Back",
+          "potential": 79,
+          "value": 2300000,
+          "yearly_wage": 624000
         },
         {
           "contract": "Jun 30, 2028",
@@ -3211,7 +4055,11 @@
             "Italy"
           ],
           "number": "16",
-          "position": "Centre-Back"
+          "overall_score": 74,
+          "position": "Centre-Back",
+          "potential": 76,
+          "value": 4500000,
+          "yearly_wage": 1820000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3238,7 +4086,11 @@
             "Spain"
           ],
           "number": "33",
-          "position": "Left-Back"
+          "overall_score": 76,
+          "position": "Left-Back",
+          "potential": 79,
+          "value": 9000000,
+          "yearly_wage": 1976000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3252,7 +4104,11 @@
             "Greece"
           ],
           "number": "22",
-          "position": "Left-Back"
+          "overall_score": 73,
+          "position": "Left-Back",
+          "potential": 73,
+          "value": 2200000,
+          "yearly_wage": 1768000
         },
         {
           "contract": "Jun 30, 2029",
@@ -3266,7 +4122,11 @@
             "Italy"
           ],
           "number": "20",
-          "position": "Right-Back"
+          "overall_score": 73,
+          "position": "Right-Back",
+          "potential": 74,
+          "value": 3300000,
+          "yearly_wage": 1664000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3280,7 +4140,11 @@
             "Italy"
           ],
           "number": "29",
-          "position": "Right-Back"
+          "overall_score": 71,
+          "position": "Right-Back",
+          "potential": 71,
+          "value": 425000,
+          "yearly_wage": 1040000
         },
         {
           "contract": "Jun 30, 2027",
@@ -3294,7 +4158,11 @@
             "Croatia"
           ],
           "number": "6",
-          "position": "Defensive Midfield"
+          "overall_score": 75,
+          "position": "Defensive Midfield",
+          "potential": 75,
+          "value": 5500000,
+          "yearly_wage": 1976000
         },
         {
           "contract": "Jun 30, 2028",
@@ -3308,7 +4176,11 @@
             "Scotland"
           ],
           "number": "19",
-          "position": "Central Midfield"
+          "overall_score": 78,
+          "position": "Central Midfield",
+          "potential": 81,
+          "value": 17000000,
+          "yearly_wage": 2288000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3322,7 +4194,11 @@
             "Italy"
           ],
           "number": "4",
-          "position": "Central Midfield"
+          "overall_score": 74,
+          "position": "Central Midfield",
+          "potential": 76,
+          "value": 5500000,
+          "yearly_wage": 1820000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3337,7 +4213,11 @@
             "Nigeria"
           ],
           "number": "23",
-          "position": "Central Midfield"
+          "overall_score": 74,
+          "position": "Central Midfield",
+          "potential": 79,
+          "value": 6500000,
+          "yearly_wage": 1664000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3351,7 +4231,11 @@
             "Switzerland"
           ],
           "number": "8",
-          "position": "Central Midfield"
+          "overall_score": 82,
+          "position": "Central Midfield",
+          "potential": 82,
+          "value": 15000000,
+          "yearly_wage": 3380000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3365,7 +4249,11 @@
             "Portugal"
           ],
           "number": "17",
-          "position": "Right Midfield"
+          "overall_score": 77,
+          "position": "Right Midfield",
+          "potential": 80,
+          "value": 13000000,
+          "yearly_wage": 4264000
         },
         {
           "contract": "Jun 30, 2027",
@@ -3379,7 +4267,11 @@
             "Denmark"
           ],
           "number": "21",
-          "position": "Attacking Midfield"
+          "overall_score": 77,
+          "position": "Attacking Midfield",
+          "potential": 78,
+          "value": 12500000,
+          "yearly_wage": 2392000
         },
         {
           "contract": "Jun 30, 2029",
@@ -3393,7 +4285,11 @@
             "Italy"
           ],
           "number": "28",
-          "position": "Left Winger"
+          "overall_score": 76,
+          "position": "Left Winger",
+          "potential": 78,
+          "value": 9500000,
+          "yearly_wage": 1924000
         },
         {
           "contract": "Jun 30, 2029",
@@ -3408,7 +4304,11 @@
             "Jamaica"
           ],
           "number": "11",
-          "position": "Left Winger"
+          "overall_score": 75,
+          "position": "Left Winger",
+          "potential": 82,
+          "value": 11500000,
+          "yearly_wage": 1820000
         },
         {
           "contract": "Jun 30, 2029",
@@ -3422,7 +4322,11 @@
             "Argentina"
           ],
           "number": "30",
-          "position": "Left Winger"
+          "overall_score": 73,
+          "position": "Left Winger",
+          "potential": 83,
+          "value": 7000000,
+          "yearly_wage": 1300000
         },
         {
           "contract": "Jun 30, 2027",
@@ -3436,7 +4340,11 @@
             "Italy"
           ],
           "number": "7",
-          "position": "Right Winger"
+          "overall_score": 83,
+          "position": "Right Winger",
+          "potential": 83,
+          "value": 36500000,
+          "yearly_wage": 3848000
         },
         {
           "contract": "Jun 30, 2027",
@@ -3450,7 +4358,11 @@
             "Italy"
           ],
           "number": "10",
-          "position": "Right Winger"
+          "overall_score": 75,
+          "position": "Right Winger",
+          "potential": 75,
+          "value": 4700000,
+          "yearly_wage": 2184000
         },
         {
           "contract": "Jun 30, 2028",
@@ -3465,7 +4377,11 @@
             "Italy"
           ],
           "number": "9",
-          "position": "Centre-Forward"
+          "overall_score": 77,
+          "position": "Centre-Forward",
+          "potential": 84,
+          "value": 21000000,
+          "yearly_wage": 1924000
         },
         {
           "contract": "Jun 30, 2028",
@@ -3479,7 +4395,11 @@
             "Netherlands"
           ],
           "number": "24",
-          "position": "Centre-Forward"
+          "overall_score": 75,
+          "position": "Centre-Forward",
+          "potential": 80,
+          "value": 8500000,
+          "yearly_wage": 1976000
         }
       ],
       "stadiumName": "Stadio Renato Dall’Ara",
@@ -3502,7 +4422,11 @@
             "Netherlands"
           ],
           "number": "16",
-          "position": "Goalkeeper"
+          "overall_score": 75,
+          "position": "Goalkeeper",
+          "potential": 76,
+          "value": 4800000,
+          "yearly_wage": 728000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3516,7 +4440,11 @@
             "Italy"
           ],
           "number": "1",
-          "position": "Goalkeeper"
+          "overall_score": 73,
+          "position": "Goalkeeper",
+          "potential": 73,
+          "value": 1500000,
+          "yearly_wage": 624000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3530,7 +4458,11 @@
             "Switzerland"
           ],
           "number": "31",
-          "position": "Goalkeeper"
+          "overall_score": 70,
+          "position": "Goalkeeper",
+          "potential": 70,
+          "value": 525000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2028",
@@ -3544,7 +4476,11 @@
             "Lithuania"
           ],
           "number": "35",
-          "position": "Goalkeeper"
+          "overall_score": 56,
+          "position": "Goalkeeper",
+          "potential": 74,
+          "value": 325000,
+          "yearly_wage": 49400
         },
         {
           "contract": "Jun 30, 2026",
@@ -3558,7 +4494,11 @@
             "Italy"
           ],
           "number": "39",
-          "position": "Goalkeeper"
+          "overall_score": 62,
+          "position": "Goalkeeper",
+          "potential": 65,
+          "value": 400000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2028",
@@ -3572,7 +4512,11 @@
             "Mexico"
           ],
           "number": "22",
-          "position": "Centre-Back"
+          "overall_score": 75,
+          "position": "Centre-Back",
+          "potential": 78,
+          "value": 6500000,
+          "yearly_wage": 1092000
         },
         {
           "contract": "Jun 30, 2030",
@@ -3586,7 +4530,11 @@
             "Norway"
           ],
           "number": "5",
-          "position": "Centre-Back"
+          "overall_score": 75,
+          "position": "Centre-Back",
+          "potential": 80,
+          "value": 7500000,
+          "yearly_wage": 1040000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3600,7 +4548,11 @@
             "Sweden"
           ],
           "number": "13",
-          "position": "Centre-Back"
+          "overall_score": 64,
+          "position": "Centre-Back",
+          "potential": 78,
+          "value": 1300000,
+          "yearly_wage": 520000
         },
         {
           "contract": "Jun 30, 2029",
@@ -3615,7 +4567,11 @@
             "Nigeria"
           ],
           "number": "27",
-          "position": "Centre-Back"
+          "overall_score": 70,
+          "position": "Centre-Back",
+          "potential": 75,
+          "value": 2200000,
+          "yearly_wage": 572000
         },
         {
           "contract": "Jun 30, 2028",
@@ -3629,7 +4585,11 @@
             "Denmark"
           ],
           "number": "34",
-          "position": "Centre-Back"
+          "overall_score": 67,
+          "position": "Centre-Back",
+          "potential": 74,
+          "value": 1900000,
+          "yearly_wage": 364000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3643,7 +4603,11 @@
             "Spain"
           ],
           "number": "3",
-          "position": "Left-Back"
+          "overall_score": 74,
+          "position": "Left-Back",
+          "potential": 74,
+          "value": 3800000,
+          "yearly_wage": 1092000
         },
         {
           "contract": "Jun 30, 2029",
@@ -3658,7 +4622,11 @@
             "Dominica"
           ],
           "number": "15",
-          "position": "Right-Back"
+          "overall_score": 74,
+          "position": "Right-Back",
+          "potential": 80,
+          "value": 6500000,
+          "yearly_wage": 728000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3672,7 +4640,11 @@
             "Italy"
           ],
           "number": "20",
-          "position": "Right-Back"
+          "overall_score": 71,
+          "position": "Right-Back",
+          "potential": 71,
+          "value": 1300000,
+          "yearly_wage": 780000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3686,7 +4658,11 @@
             "Cameroon"
           ],
           "number": "14",
-          "position": "Defensive Midfield"
+          "overall_score": 71,
+          "position": "Defensive Midfield",
+          "potential": 74,
+          "value": 2500000,
+          "yearly_wage": 1144000
         },
         {
           "contract": "Jun 30, 2028",
@@ -3700,7 +4676,11 @@
             "Denmark"
           ],
           "number": "32",
-          "position": "Central Midfield"
+          "overall_score": 76,
+          "position": "Central Midfield",
+          "potential": 80,
+          "value": 10000000,
+          "yearly_wage": 988000
         },
         {
           "contract": "Jun 30, 2028",
@@ -3714,7 +4694,11 @@
             "Italy"
           ],
           "number": "73",
-          "position": "Central Midfield"
+          "overall_score": 68,
+          "position": "Central Midfield",
+          "potential": 72,
+          "value": 1600000,
+          "yearly_wage": 468000
         },
         {
           "contract": "Jun 30, 2029",
@@ -3729,7 +4713,11 @@
             "Indonesia"
           ],
           "number": "77",
-          "position": "Central Midfield"
+          "overall_score": 71,
+          "position": "Central Midfield",
+          "potential": 76,
+          "value": 2800000,
+          "yearly_wage": 676000
         },
         {
           "contract": "Jun 30, 2030",
@@ -3743,7 +4731,11 @@
             "Brazil"
           ],
           "number": "4",
-          "position": "Central Midfield"
+          "overall_score": 67,
+          "position": "Central Midfield",
+          "potential": 75,
+          "value": 2200000,
+          "yearly_wage": 364000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3757,7 +4749,11 @@
             "Italy"
           ],
           "number": "8",
-          "position": "Attacking Midfield"
+          "overall_score": 74,
+          "position": "Attacking Midfield",
+          "potential": 80,
+          "value": 7000000,
+          "yearly_wage": 1820000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3771,7 +4767,11 @@
             "Ukraine"
           ],
           "number": "17",
-          "position": "Attacking Midfield"
+          "overall_score": 75,
+          "position": "Attacking Midfield",
+          "potential": 75,
+          "value": 4400000,
+          "yearly_wage": 1196000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3786,7 +4786,11 @@
             "France"
           ],
           "number": "70",
-          "position": "Left Winger"
+          "overall_score": 73,
+          "position": "Left Winger",
+          "potential": 73,
+          "value": 3100000,
+          "yearly_wage": 2444000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3801,7 +4805,11 @@
             "Italy"
           ],
           "number": "10",
-          "position": "Right Winger"
+          "overall_score": 72,
+          "position": "Right Winger",
+          "potential": 72,
+          "value": 1100000,
+          "yearly_wage": 936000
         },
         {
           "contract": "Jun 30, 2028",
@@ -3815,7 +4823,11 @@
             "Portugal"
           ],
           "number": "9",
-          "position": "Centre-Forward"
+          "overall_score": 75,
+          "position": "Centre-Forward",
+          "potential": 78,
+          "value": 7500000,
+          "yearly_wage": 1196000
         },
         {
           "contract": "Jun 30, 2029",
@@ -3830,7 +4842,11 @@
             "Nigeria"
           ],
           "number": "21",
-          "position": "Centre-Forward"
+          "overall_score": 67,
+          "position": "Centre-Forward",
+          "potential": 78,
+          "value": 2200000,
+          "yearly_wage": 364000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3844,7 +4860,11 @@
             "Italy"
           ],
           "number": "29",
-          "position": "Centre-Forward"
+          "overall_score": 72,
+          "position": "Centre-Forward",
+          "potential": 79,
+          "value": 4700000,
+          "yearly_wage": 832000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3859,7 +4879,11 @@
             "Italy"
           ],
           "number": "18",
-          "position": "Centre-Forward"
+          "overall_score": 70,
+          "position": "Centre-Forward",
+          "potential": 70,
+          "value": 1300000,
+          "yearly_wage": 832000
         }
       ],
       "stadiumName": "Luigi Ferraris",
@@ -3882,7 +4906,11 @@
             "Italy"
           ],
           "number": "30",
-          "position": "Goalkeeper"
+          "overall_score": 82,
+          "position": "Goalkeeper",
+          "potential": 82,
+          "value": 20500000,
+          "yearly_wage": 676000
         },
         {
           "contract": "Jun 30, 2027",
@@ -3896,7 +4924,11 @@
             "Germany"
           ],
           "number": "1",
-          "position": "Goalkeeper"
+          "overall_score": 70,
+          "position": "Goalkeeper",
+          "potential": 75,
+          "value": 1900000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3910,7 +4942,11 @@
             "Finland"
           ],
           "number": "32",
-          "position": "Goalkeeper"
+          "overall_score": 61,
+          "position": "Goalkeeper",
+          "potential": 69,
+          "value": 650000,
+          "yearly_wage": 44200
         },
         {
           "contract": "Jun 30, 2027",
@@ -3924,7 +4960,11 @@
             "Portugal"
           ],
           "number": "44",
-          "position": "Centre-Back"
+          "overall_score": 69,
+          "position": "Centre-Back",
+          "potential": 77,
+          "value": 2900000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2028",
@@ -3938,7 +4978,11 @@
             "Germany"
           ],
           "number": "5",
-          "position": "Centre-Back"
+          "overall_score": 70,
+          "position": "Centre-Back",
+          "potential": 78,
+          "value": 3300000,
+          "yearly_wage": 364000
         },
         {
           "contract": "Jun 30, 2027",
@@ -3952,7 +4996,11 @@
             "Angola"
           ],
           "number": "4",
-          "position": "Centre-Back"
+          "overall_score": 72,
+          "position": "Centre-Back",
+          "potential": 74,
+          "value": 2500000,
+          "yearly_wage": 468000
         },
         {
           "contract": "Jun 30, 2027",
@@ -3966,7 +5014,11 @@
             "France"
           ],
           "number": "18",
-          "position": "Centre-Back"
+          "overall_score": 69,
+          "position": "Centre-Back",
+          "potential": 74,
+          "value": 1800000,
+          "yearly_wage": 312000
         },
         {
           "contract": "Jun 30, 2028",
@@ -3980,7 +5032,11 @@
             "Chile"
           ],
           "number": "13",
-          "position": "Centre-Back"
+          "overall_score": 66,
+          "position": "Centre-Back",
+          "potential": 76,
+          "value": 1800000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2026",
@@ -3994,7 +5050,11 @@
             "Italy"
           ],
           "number": "25",
-          "position": "Left-Back"
+          "overall_score": 75,
+          "position": "Left-Back",
+          "potential": 78,
+          "value": 7000000,
+          "yearly_wage": 624000
         },
         {
           "contract": "Jun 30, 2028",
@@ -4009,7 +5069,11 @@
             "Ghana"
           ],
           "number": "3",
-          "position": "Left-Back"
+          "overall_score": 66,
+          "position": "Left-Back",
+          "potential": 68,
+          "value": 975000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2027",
@@ -4024,7 +5088,11 @@
             "Brazil"
           ],
           "number": "17",
-          "position": "Right-Back"
+          "overall_score": 69,
+          "position": "Right-Back",
+          "potential": 78,
+          "value": 3000000,
+          "yearly_wage": 312000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4039,7 +5107,11 @@
             "Kosovo"
           ],
           "number": "20",
-          "position": "Defensive Midfield"
+          "overall_score": 70,
+          "position": "Defensive Midfield",
+          "potential": 70,
+          "value": 1400000,
+          "yearly_wage": 416000
         },
         {
           "contract": "Jun 30, 2029",
@@ -4054,7 +5126,11 @@
             "Germany"
           ],
           "number": "8",
-          "position": "Defensive Midfield"
+          "overall_score": 65,
+          "position": "Defensive Midfield",
+          "potential": 72,
+          "value": 1400000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2029",
@@ -4069,7 +5145,11 @@
             "France"
           ],
           "number": "79",
-          "position": "Defensive Midfield"
+          "overall_score": 64,
+          "position": "Defensive Midfield",
+          "potential": 74,
+          "value": 1300000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2028",
@@ -4084,7 +5164,11 @@
             "Kosovo"
           ],
           "number": "10",
-          "position": "Central Midfield"
+          "overall_score": 69,
+          "position": "Central Midfield",
+          "potential": 78,
+          "value": 3100000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2027",
@@ -4098,7 +5182,11 @@
             "Mali"
           ],
           "number": "29",
-          "position": "Central Midfield"
+          "overall_score": 74,
+          "position": "Central Midfield",
+          "potential": 74,
+          "value": 3600000,
+          "yearly_wage": 624000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4126,7 +5214,11 @@
             "Spain"
           ],
           "number": "6",
-          "position": "Central Midfield"
+          "overall_score": 72,
+          "position": "Central Midfield",
+          "potential": 76,
+          "value": 3100000,
+          "yearly_wage": 416000
         },
         {
           "contract": "Jun 30, 2029",
@@ -4141,7 +5233,11 @@
             "Portugal"
           ],
           "number": "16",
-          "position": "Attacking Midfield"
+          "overall_score": 72,
+          "position": "Attacking Midfield",
+          "potential": 75,
+          "value": 3100000,
+          "yearly_wage": 468000
         },
         {
           "contract": "Jun 30, 2028",
@@ -4155,7 +5251,11 @@
             "Poland"
           ],
           "number": "36",
-          "position": "Attacking Midfield"
+          "overall_score": 67,
+          "position": "Attacking Midfield",
+          "potential": 74,
+          "value": 2000000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4169,7 +5269,11 @@
             "Italy"
           ],
           "number": "23",
-          "position": "Left Winger"
+          "overall_score": 74,
+          "position": "Left Winger",
+          "potential": 75,
+          "value": 5000000,
+          "yearly_wage": 1924000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4183,7 +5287,11 @@
             "Zambia"
           ],
           "number": "19",
-          "position": "Left Winger"
+          "overall_score": 70,
+          "position": "Left Winger",
+          "potential": 73,
+          "value": 2200000,
+          "yearly_wage": 364000
         },
         {
           "contract": "Jun 30, 2027",
@@ -4198,7 +5306,11 @@
             "Italy"
           ],
           "number": "50",
-          "position": "Right Winger"
+          "overall_score": 70,
+          "position": "Right Winger",
+          "potential": 73,
+          "value": 2200000,
+          "yearly_wage": 364000
         },
         {
           "contract": "Jun 30, 2027",
@@ -4226,7 +5338,11 @@
             "Italy"
           ],
           "number": "22",
-          "position": "Centre-Forward"
+          "overall_score": 65,
+          "position": "Centre-Forward",
+          "potential": 87,
+          "value": 2300000,
+          "yearly_wage": 364000
         },
         {
           "contract": "Jun 30, 2029",
@@ -4241,7 +5357,11 @@
             "Croatia"
           ],
           "number": "9",
-          "position": "Centre-Forward"
+          "overall_score": 70,
+          "position": "Centre-Forward",
+          "potential": 76,
+          "value": 2500000,
+          "yearly_wage": 364000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4256,7 +5376,11 @@
             "Italy"
           ],
           "number": "99",
-          "position": "Centre-Forward"
+          "overall_score": 72,
+          "position": "Centre-Forward",
+          "potential": 72,
+          "value": 2500000,
+          "yearly_wage": 2912000
         }
       ],
       "stadiumName": "Ettore Giardiniero",
@@ -4280,7 +5404,11 @@
             "Italy"
           ],
           "number": "81",
-          "position": "Goalkeeper"
+          "overall_score": 75,
+          "position": "Goalkeeper",
+          "potential": 80,
+          "value": 6500000,
+          "yearly_wage": 988000
         },
         {
           "contract": "Jun 30, 2027",
@@ -4294,7 +5422,11 @@
             "Italy"
           ],
           "number": "1",
-          "position": "Goalkeeper"
+          "overall_score": 70,
+          "position": "Goalkeeper",
+          "potential": 70,
+          "value": 800000,
+          "yearly_wage": 676000
         },
         {
           "contract": "Jun 30, 2027",
@@ -4308,7 +5440,11 @@
             "Italy"
           ],
           "number": "99",
-          "position": "Goalkeeper"
+          "overall_score": 56,
+          "position": "Goalkeeper",
+          "potential": 75,
+          "value": 325000,
+          "yearly_wage": 52000
         },
         {
           "contract": "Jun 30, 2029",
@@ -4323,7 +5459,11 @@
             "Spain"
           ],
           "number": "23",
-          "position": "Centre-Back"
+          "overall_score": 76,
+          "position": "Centre-Back",
+          "potential": 79,
+          "value": 8500000,
+          "yearly_wage": 1768000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4337,7 +5477,11 @@
             "Italy"
           ],
           "number": "35",
-          "position": "Centre-Back"
+          "overall_score": 68,
+          "position": "Centre-Back",
+          "potential": 79,
+          "value": 2500000,
+          "yearly_wage": 1196000
         },
         {
           "contract": "Jun 30, 2027",
@@ -4352,7 +5496,11 @@
             "Kosovo"
           ],
           "number": "44",
-          "position": "Centre-Back"
+          "overall_score": 74,
+          "position": "Centre-Back",
+          "potential": 74,
+          "value": 3600000,
+          "yearly_wage": 1612000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4366,7 +5514,11 @@
             "Chile"
           ],
           "number": "13",
-          "position": "Centre-Back"
+          "overall_score": 76,
+          "position": "Centre-Back",
+          "potential": 76,
+          "value": 5000000,
+          "yearly_wage": 1820000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4381,7 +5533,11 @@
             "France"
           ],
           "number": "77",
-          "position": "Centre-Back"
+          "overall_score": 70,
+          "position": "Centre-Back",
+          "potential": 73,
+          "value": 1800000,
+          "yearly_wage": 572000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4396,7 +5552,11 @@
             "Russia"
           ],
           "number": "15",
-          "position": "Centre-Back"
+          "overall_score": 73,
+          "position": "Centre-Back",
+          "potential": 78,
+          "value": 4200000,
+          "yearly_wage": 1196000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4411,7 +5571,11 @@
             "Congo"
           ],
           "number": "25",
-          "position": "Left-Back"
+          "overall_score": 73,
+          "position": "Left-Back",
+          "potential": 76,
+          "value": 4200000,
+          "yearly_wage": 1040000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4425,7 +5589,11 @@
             "Spain"
           ],
           "number": "33",
-          "position": "Left-Back"
+          "overall_score": 69,
+          "position": "Left-Back",
+          "potential": 77,
+          "value": 3000000,
+          "yearly_wage": 364000
         },
         {
           "contract": "Jun 30, 2027",
@@ -4439,7 +5607,11 @@
             "Italy"
           ],
           "number": "34",
-          "position": "Left-Back"
+          "overall_score": 77,
+          "position": "Left-Back",
+          "potential": 77,
+          "value": 7500000,
+          "yearly_wage": 1976000
         },
         {
           "contract": "Jun 30, 2027",
@@ -4453,7 +5625,11 @@
             "Norway"
           ],
           "number": "16",
-          "position": "Right-Back"
+          "overall_score": 73,
+          "position": "Right-Back",
+          "potential": 75,
+          "value": 3600000,
+          "yearly_wage": 1196000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4467,7 +5643,11 @@
             "Italy"
           ],
           "number": "4",
-          "position": "Defensive Midfield"
+          "overall_score": 72,
+          "position": "Defensive Midfield",
+          "potential": 81,
+          "value": 5000000,
+          "yearly_wage": 364000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4482,7 +5662,11 @@
             "Cameroon"
           ],
           "number": "61",
-          "position": "Defensive Midfield"
+          "overall_score": 74,
+          "position": "Defensive Midfield",
+          "potential": 74,
+          "value": 3000000,
+          "yearly_wage": 1612000
         },
         {
           "contract": "Jun 30, 2029",
@@ -4496,7 +5680,11 @@
             "Italy"
           ],
           "number": "22",
-          "position": "Central Midfield"
+          "overall_score": 75,
+          "position": "Central Midfield",
+          "potential": 83,
+          "value": 12500000,
+          "yearly_wage": 1508000
         },
         {
           "contract": "Jun 30, 2027",
@@ -4510,7 +5698,11 @@
             "Serbia"
           ],
           "number": "8",
-          "position": "Central Midfield"
+          "overall_score": 75,
+          "position": "Central Midfield",
+          "potential": 80,
+          "value": 8000000,
+          "yearly_wage": 1456000
         },
         {
           "contract": "Jun 30, 2029",
@@ -4524,7 +5716,11 @@
             "Lithuania"
           ],
           "number": "66",
-          "position": "Central Midfield"
+          "overall_score": 70,
+          "position": "Central Midfield",
+          "potential": 79,
+          "value": 3600000,
+          "yearly_wage": 780000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4538,7 +5734,11 @@
             "Türkiye"
           ],
           "number": "6",
-          "position": "Central Midfield"
+          "overall_score": 67,
+          "position": "Central Midfield",
+          "potential": 74,
+          "value": 2100000,
+          "yearly_wage": 572000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4552,7 +5752,11 @@
             "Austria"
           ],
           "number": "20",
-          "position": "Right Midfield"
+          "overall_score": 76,
+          "position": "Right Midfield",
+          "potential": 76,
+          "value": 7500000,
+          "yearly_wage": 1924000
         },
         {
           "contract": "Jun 30, 2027",
@@ -4566,7 +5770,11 @@
             "Croatia"
           ],
           "number": "10",
-          "position": "Attacking Midfield"
+          "overall_score": 80,
+          "position": "Attacking Midfield",
+          "potential": 80,
+          "value": 22500000,
+          "yearly_wage": 2444000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4581,7 +5789,11 @@
             "Nigeria"
           ],
           "number": "14",
-          "position": "Attacking Midfield"
+          "overall_score": 68,
+          "position": "Attacking Midfield",
+          "potential": 75,
+          "value": 2400000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2029",
@@ -4596,7 +5808,11 @@
             "Romania"
           ],
           "number": "83",
-          "position": "Attacking Midfield"
+          "overall_score": 59,
+          "position": "Attacking Midfield",
+          "potential": 74,
+          "value": 525000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2029",
@@ -4611,7 +5827,11 @@
             "The Gambia"
           ],
           "number": "92",
-          "position": "Left Winger"
+          "overall_score": 65,
+          "position": "Left Winger",
+          "potential": 77,
+          "value": 1700000,
+          "yearly_wage": 416000
         },
         {
           "contract": "Jun 30, 2029",
@@ -4626,7 +5846,11 @@
             "Netherlands"
           ],
           "number": "7",
-          "position": "Right Winger"
+          "overall_score": 74,
+          "position": "Right Winger",
+          "potential": 77,
+          "value": 5500000,
+          "yearly_wage": 1560000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4655,7 +5879,11 @@
             "England"
           ],
           "number": "19",
-          "position": "Centre-Forward"
+          "overall_score": 78,
+          "position": "Centre-Forward",
+          "potential": 78,
+          "value": 14500000,
+          "yearly_wage": 2340000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4670,7 +5898,11 @@
             "Spain"
           ],
           "number": "18",
-          "position": "Centre-Forward"
+          "overall_score": 76,
+          "position": "Centre-Forward",
+          "potential": 76,
+          "value": 7500000,
+          "yearly_wage": 4160000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4684,7 +5916,11 @@
             "Croatia"
           ],
           "number": "17",
-          "position": "Centre-Forward"
+          "overall_score": 70,
+          "position": "Centre-Forward",
+          "potential": 73,
+          "value": 2100000,
+          "yearly_wage": 1092000
         },
         {
           "contract": "Jun 30, 2027",
@@ -4698,7 +5934,11 @@
             "Colombia"
           ],
           "number": "91",
-          "position": "Centre-Forward"
+          "overall_score": 81,
+          "position": "Centre-Forward",
+          "potential": 81,
+          "value": 12500000,
+          "yearly_wage": 2912000
         }
       ],
       "stadiumName": "Olimpico Grande Torino",
@@ -4722,7 +5962,11 @@
             "Germany"
           ],
           "number": "40",
-          "position": "Goalkeeper"
+          "overall_score": 74,
+          "position": "Goalkeeper",
+          "potential": 78,
+          "value": 4600000,
+          "yearly_wage": 468000
         },
         {
           "contract": "Jun 30, 2029",
@@ -4736,7 +5980,11 @@
             "Romania"
           ],
           "number": "90",
-          "position": "Goalkeeper"
+          "overall_score": 71,
+          "position": "Goalkeeper",
+          "potential": 81,
+          "value": 3600000,
+          "yearly_wage": 312000
         },
         {
           "contract": "Jun 30, 2030",
@@ -4750,7 +5998,11 @@
             "Italy"
           ],
           "number": "1",
-          "position": "Goalkeeper"
+          "overall_score": 56,
+          "position": "Goalkeeper",
+          "potential": 75,
+          "value": 325000,
+          "yearly_wage": 39000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4764,7 +6016,11 @@
             "Italy"
           ],
           "number": "93",
-          "position": "Goalkeeper"
+          "overall_score": 65,
+          "position": "Goalkeeper",
+          "potential": 65,
+          "value": 80000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2027",
@@ -4779,7 +6035,11 @@
             "Cote d'Ivoire"
           ],
           "number": "28",
-          "position": "Centre-Back"
+          "overall_score": 78,
+          "position": "Centre-Back",
+          "potential": 83,
+          "value": 18500000,
+          "yearly_wage": 1040000
         },
         {
           "contract": "Jun 30, 2028",
@@ -4793,7 +6053,11 @@
             "Denmark"
           ],
           "number": "31",
-          "position": "Centre-Back"
+          "overall_score": 73,
+          "position": "Centre-Back",
+          "potential": 81,
+          "value": 6500000,
+          "yearly_wage": 624000
         },
         {
           "contract": "Jun 30, 2030",
@@ -4807,7 +6071,11 @@
             "Italy"
           ],
           "number": "13",
-          "position": "Centre-Back"
+          "overall_score": 72,
+          "position": "Centre-Back",
+          "potential": 78,
+          "value": 3400000,
+          "yearly_wage": 572000
         },
         {
           "contract": "Jun 30, 2031",
@@ -4821,7 +6089,11 @@
             "Croatia"
           ],
           "number": "22",
-          "position": "Centre-Back"
+          "overall_score": 65,
+          "position": "Centre-Back",
+          "potential": 80,
+          "value": 1600000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4836,7 +6108,11 @@
             "DR Congo"
           ],
           "number": "27",
-          "position": "Centre-Back"
+          "overall_score": 73,
+          "position": "Centre-Back",
+          "potential": 73,
+          "value": 1000000,
+          "yearly_wage": 780000
         },
         {
           "contract": "Jun 30, 2027",
@@ -4851,7 +6127,11 @@
             "England"
           ],
           "number": "33",
-          "position": "Left-Back"
+          "overall_score": 71,
+          "position": "Left-Back",
+          "potential": 73,
+          "value": 2200000,
+          "yearly_wage": 572000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4866,7 +6146,11 @@
             "France"
           ],
           "number": "11",
-          "position": "Left-Back"
+          "overall_score": 72,
+          "position": "Left-Back",
+          "potential": 72,
+          "value": 1700000,
+          "yearly_wage": 728000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4880,7 +6164,11 @@
             "Italy"
           ],
           "number": "59",
-          "position": "Right-Back"
+          "overall_score": 73,
+          "position": "Right-Back",
+          "potential": 77,
+          "value": 4100000,
+          "yearly_wage": 2444000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4895,7 +6183,11 @@
             "Nigeria"
           ],
           "number": "19",
-          "position": "Right-Back"
+          "overall_score": 71,
+          "position": "Right-Back",
+          "potential": 71,
+          "value": 1600000,
+          "yearly_wage": 624000
         },
         {
           "contract": "Jun 30, 2026",
@@ -4909,7 +6201,11 @@
             "Sweden"
           ],
           "number": "8",
-          "position": "Defensive Midfield"
+          "overall_score": 75,
+          "position": "Defensive Midfield",
+          "potential": 75,
+          "value": 4700000,
+          "yearly_wage": 936000
         },
         {
           "contract": "Jun 30, 2029",
@@ -4924,7 +6220,11 @@
             "Guinea"
           ],
           "number": "29",
-          "position": "Defensive Midfield"
+          "overall_score": 54,
+          "position": "Defensive Midfield",
+          "potential": 76,
+          "value": 325000,
+          "yearly_wage": 52000
         },
         {
           "contract": "Jun 30, 2029",
@@ -4939,7 +6239,11 @@
             "Benin"
           ],
           "number": "14",
-          "position": "Central Midfield"
+          "overall_score": 74,
+          "position": "Central Midfield",
+          "potential": 82,
+          "value": 9500000,
+          "yearly_wage": 728000
         },
         {
           "contract": "Jun 30, 2030",
@@ -4953,7 +6257,11 @@
             "Scotland"
           ],
           "number": "38",
-          "position": "Central Midfield"
+          "overall_score": 70,
+          "position": "Central Midfield",
+          "potential": 84,
+          "value": 3700000,
+          "yearly_wage": 364000
         },
         {
           "contract": "Jun 30, 2029",
@@ -4967,7 +6275,11 @@
             "Netherlands"
           ],
           "number": "32",
-          "position": "Central Midfield"
+          "overall_score": 74,
+          "position": "Central Midfield",
+          "potential": 77,
+          "value": 5500000,
+          "yearly_wage": 832000
         },
         {
           "contract": "Jun 30, 2029",
@@ -4981,7 +6293,11 @@
             "Poland"
           ],
           "number": "24",
-          "position": "Central Midfield"
+          "overall_score": 72,
+          "position": "Central Midfield",
+          "potential": 72,
+          "value": 2500000,
+          "yearly_wage": 728000
         },
         {
           "contract": "Jun 30, 2027",
@@ -4995,7 +6311,11 @@
             "Spain"
           ],
           "number": "6",
-          "position": "Central Midfield"
+          "overall_score": 71,
+          "position": "Central Midfield",
+          "potential": 71,
+          "value": 2000000,
+          "yearly_wage": 624000
         },
         {
           "contract": "Jun 30, 2030",
@@ -5009,7 +6329,11 @@
             "Colombia"
           ],
           "number": "20",
-          "position": "Left Midfield"
+          "overall_score": 63,
+          "position": "Left Midfield",
+          "potential": 78,
+          "value": 1100000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5023,7 +6347,11 @@
             "Italy"
           ],
           "number": "10",
-          "position": "Attacking Midfield"
+          "overall_score": 75,
+          "position": "Attacking Midfield",
+          "potential": 76,
+          "value": 7000000,
+          "yearly_wage": 2236000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5037,7 +6365,11 @@
             "Senegal"
           ],
           "number": "7",
-          "position": "Centre-Forward"
+          "overall_score": 69,
+          "position": "Centre-Forward",
+          "potential": 79,
+          "value": 3000000,
+          "yearly_wage": 312000
         },
         {
           "contract": "Jun 30, 2027",
@@ -5052,7 +6384,11 @@
             "Jamaica"
           ],
           "number": "9",
-          "position": "Centre-Forward"
+          "overall_score": 74,
+          "position": "Centre-Forward",
+          "potential": 74,
+          "value": 4600000,
+          "yearly_wage": 936000
         },
         {
           "contract": "Jun 30, 2029",
@@ -5066,7 +6402,11 @@
             "Poland"
           ],
           "number": "18",
-          "position": "Centre-Forward"
+          "overall_score": 72,
+          "position": "Centre-Forward",
+          "potential": 72,
+          "value": 2400000,
+          "yearly_wage": 780000
         },
         {
           "contract": "Jun 30, 2028",
@@ -5080,7 +6420,11 @@
             "Cote d'Ivoire"
           ],
           "number": "15",
-          "position": "Centre-Forward"
+          "overall_score": 69,
+          "position": "Centre-Forward",
+          "potential": 69,
+          "value": 1400000,
+          "yearly_wage": 572000
         }
       ],
       "stadiumName": "Bluenergy Stadium",
@@ -5103,7 +6447,11 @@
             "Italy"
           ],
           "number": "29",
-          "position": "Goalkeeper"
+          "overall_score": 85,
+          "position": "Goalkeeper",
+          "potential": 88,
+          "value": 55000000,
+          "yearly_wage": 3120000
         },
         {
           "contract": "Jun 30, 2028",
@@ -5117,7 +6465,11 @@
             "Italy"
           ],
           "number": "57",
-          "position": "Goalkeeper"
+          "overall_score": 76,
+          "position": "Goalkeeper",
+          "potential": 76,
+          "value": 2400000,
+          "yearly_wage": 1768000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5131,7 +6483,11 @@
             "Italy"
           ],
           "number": "31",
-          "position": "Goalkeeper"
+          "overall_score": 62,
+          "position": "Goalkeeper",
+          "potential": 62,
+          "value": 70000,
+          "yearly_wage": 416000
         },
         {
           "contract": "Jun 30, 2028",
@@ -5146,7 +6502,11 @@
             "Ghana"
           ],
           "number": "4",
-          "position": "Centre-Back"
+          "overall_score": 78,
+          "position": "Centre-Back",
+          "potential": 81,
+          "value": 16500000,
+          "yearly_wage": 2964000
         },
         {
           "contract": "Jun 30, 2028",
@@ -5160,7 +6520,11 @@
             "Italy"
           ],
           "number": "42",
-          "position": "Centre-Back"
+          "overall_score": 78,
+          "position": "Centre-Back",
+          "potential": 86,
+          "value": 29500000,
+          "yearly_wage": 2184000
         },
         {
           "contract": "Jun 30, 2028",
@@ -5174,7 +6538,11 @@
             "Nigeria"
           ],
           "number": "69",
-          "position": "Centre-Back"
+          "overall_score": 72,
+          "position": "Centre-Back",
+          "potential": 81,
+          "value": 4500000,
+          "yearly_wage": 936000
         },
         {
           "contract": "Jun 30, 2029",
@@ -5188,7 +6556,11 @@
             "Cote d'Ivoire"
           ],
           "number": "3",
-          "position": "Centre-Back"
+          "overall_score": 80,
+          "position": "Centre-Back",
+          "potential": 85,
+          "value": 29000000,
+          "yearly_wage": 2964000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5203,7 +6575,11 @@
             "Germany"
           ],
           "number": "23",
-          "position": "Centre-Back"
+          "overall_score": 78,
+          "position": "Centre-Back",
+          "potential": 78,
+          "value": 9000000,
+          "yearly_wage": 3120000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5218,7 +6594,11 @@
             "Switzerland"
           ],
           "number": "19",
-          "position": "Centre-Back"
+          "overall_score": 79,
+          "position": "Centre-Back",
+          "potential": 79,
+          "value": 11500000,
+          "yearly_wage": 3432000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5232,7 +6612,11 @@
             "Netherlands"
           ],
           "number": "15",
-          "position": "Defensive Midfield"
+          "overall_score": 81,
+          "position": "Defensive Midfield",
+          "potential": 81,
+          "value": 12000000,
+          "yearly_wage": 4056000
         },
         {
           "contract": "Jun 30, 2027",
@@ -5246,7 +6630,11 @@
             "Brazil"
           ],
           "number": "13",
-          "position": "Central Midfield"
+          "overall_score": 82,
+          "position": "Central Midfield",
+          "potential": 85,
+          "value": 40000000,
+          "yearly_wage": 4004000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5261,7 +6649,11 @@
             "England"
           ],
           "number": "6",
-          "position": "Central Midfield"
+          "overall_score": 73,
+          "position": "Central Midfield",
+          "potential": 81,
+          "value": 7000000,
+          "yearly_wage": 1456000
         },
         {
           "contract": "Jun 30, 2028",
@@ -5275,7 +6667,11 @@
             "Croatia"
           ],
           "number": "8",
-          "position": "Central Midfield"
+          "overall_score": 79,
+          "position": "Central Midfield",
+          "potential": 79,
+          "value": 17000000,
+          "yearly_wage": 3588000
         },
         {
           "contract": "Jun 30, 2029",
@@ -5289,7 +6685,11 @@
             "Italy"
           ],
           "number": "16",
-          "position": "Right Midfield"
+          "overall_score": 77,
+          "position": "Right Midfield",
+          "potential": 78,
+          "value": 12500000,
+          "yearly_wage": 2756000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5303,7 +6703,11 @@
             "Italy"
           ],
           "number": "77",
-          "position": "Right Midfield"
+          "overall_score": 79,
+          "position": "Right Midfield",
+          "potential": 79,
+          "value": 11000000,
+          "yearly_wage": 3588000
         },
         {
           "contract": "Jun 30, 2029",
@@ -5318,7 +6722,11 @@
             "Italy"
           ],
           "number": "59",
-          "position": "Left Midfield"
+          "overall_score": 77,
+          "position": "Left Midfield",
+          "potential": 79,
+          "value": 13500000,
+          "yearly_wage": 2548000
         },
         {
           "contract": "Jun 30, 2027",
@@ -5332,7 +6740,11 @@
             "Netherlands"
           ],
           "number": "5",
-          "position": "Left Midfield"
+          "overall_score": 75,
+          "position": "Left Midfield",
+          "potential": 80,
+          "value": 7500000,
+          "yearly_wage": 2340000
         },
         {
           "contract": "Jun 30, 2028",
@@ -5346,7 +6758,11 @@
             "Italy"
           ],
           "number": "47",
-          "position": "Left Midfield"
+          "overall_score": 70,
+          "position": "Left Midfield",
+          "potential": 78,
+          "value": 3600000,
+          "yearly_wage": 1196000
         },
         {
           "contract": "Jun 30, 2028",
@@ -5360,7 +6776,11 @@
             "Belgium"
           ],
           "number": "17",
-          "position": "Attacking Midfield"
+          "overall_score": 82,
+          "position": "Attacking Midfield",
+          "potential": 86,
+          "value": 43500000,
+          "yearly_wage": 3744000
         },
         {
           "contract": "Jun 30, 2029",
@@ -5375,7 +6795,11 @@
             "Germany"
           ],
           "number": "10",
-          "position": "Attacking Midfield"
+          "overall_score": 77,
+          "position": "Attacking Midfield",
+          "potential": 82,
+          "value": 16000000,
+          "yearly_wage": 2600000
         },
         {
           "contract": "Jun 30, 2029",
@@ -5389,7 +6813,11 @@
             "Ghana"
           ],
           "number": "7",
-          "position": "Left Winger"
+          "overall_score": 73,
+          "position": "Left Winger",
+          "potential": 76,
+          "value": 4200000,
+          "yearly_wage": 1924000
         },
         {
           "contract": "Jun 30, 2030",
@@ -5403,7 +6831,11 @@
             "Italy"
           ],
           "number": "18",
-          "position": "Second Striker"
+          "overall_score": 78,
+          "position": "Second Striker",
+          "potential": 81,
+          "value": 19000000,
+          "yearly_wage": 3224000
         },
         {
           "contract": "Jun 30, 2027",
@@ -5417,7 +6849,11 @@
             "Italy"
           ],
           "number": "9",
-          "position": "Centre-Forward"
+          "overall_score": 78,
+          "position": "Centre-Forward",
+          "potential": 79,
+          "value": 17000000,
+          "yearly_wage": 3380000
         },
         {
           "contract": "Jun 30, 2030",
@@ -5432,7 +6868,11 @@
             "Serbia"
           ],
           "number": "90",
-          "position": "Centre-Forward"
+          "overall_score": 76,
+          "position": "Centre-Forward",
+          "potential": 79,
+          "value": 10000000,
+          "yearly_wage": 2808000
         }
       ],
       "stadiumName": "New Balance Arena - Bergamo",
@@ -5456,7 +6896,11 @@
             "United States"
           ],
           "number": "31",
-          "position": "Goalkeeper"
+          "overall_score": 74,
+          "position": "Goalkeeper",
+          "potential": 80,
+          "value": 5500000,
+          "yearly_wage": 468000
         },
         {
           "contract": "Jun 30, 2027",
@@ -5470,7 +6914,11 @@
             "Italy"
           ],
           "number": "40",
-          "position": "Goalkeeper"
+          "overall_score": 68,
+          "position": "Goalkeeper",
+          "potential": 71,
+          "value": 1300000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2029",
@@ -5484,7 +6932,11 @@
             "Italy"
           ],
           "number": "66",
-          "position": "Goalkeeper"
+          "overall_score": 63,
+          "position": "Goalkeeper",
+          "potential": 69,
+          "value": 625000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2027",
@@ -5498,7 +6950,11 @@
             "Italy"
           ],
           "number": "64",
-          "position": "Goalkeeper"
+          "overall_score": 56,
+          "position": "Goalkeeper",
+          "potential": 68,
+          "value": 300000,
+          "yearly_wage": 52000
         },
         {
           "contract": "Jun 30, 2029",
@@ -5513,7 +6969,11 @@
             "Italy"
           ],
           "number": "39",
-          "position": "Centre-Back"
+          "overall_score": 72,
+          "position": "Centre-Back",
+          "potential": 80,
+          "value": 4900000,
+          "yearly_wage": 572000
         },
         {
           "contract": "Jun 30, 2029",
@@ -5527,7 +6987,11 @@
             "Senegal"
           ],
           "number": "3",
-          "position": "Centre-Back"
+          "overall_score": 74,
+          "position": "Centre-Back",
+          "potential": 78,
+          "value": 5500000,
+          "yearly_wage": 780000
         },
         {
           "contract": "Jun 30, 2030",
@@ -5541,7 +7005,11 @@
             "Argentina"
           ],
           "number": "37",
-          "position": "Centre-Back"
+          "overall_score": 66,
+          "position": "Centre-Back",
+          "potential": 78,
+          "value": 2000000,
+          "yearly_wage": 312000
         },
         {
           "contract": "Jun 30, 2027",
@@ -5556,7 +7024,11 @@
             "Italy"
           ],
           "number": "5",
-          "position": "Centre-Back"
+          "overall_score": 69,
+          "position": "Centre-Back",
+          "potential": 70,
+          "value": 1400000,
+          "yearly_wage": 520000
         },
         {
           "contract": "Jun 30, 2028",
@@ -5570,7 +7042,11 @@
             "Italy"
           ],
           "number": "14",
-          "position": "Left-Back"
+          "overall_score": 75,
+          "position": "Left-Back",
+          "potential": 76,
+          "value": 6000000,
+          "yearly_wage": 988000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5585,7 +7061,11 @@
             "Italy"
           ],
           "number": "29",
-          "position": "Left-Back"
+          "overall_score": 63,
+          "position": "Left-Back",
+          "potential": 68,
+          "value": 700000,
+          "yearly_wage": 312000
         },
         {
           "contract": "Jun 30, 2030",
@@ -5600,7 +7080,11 @@
             "Cameroon"
           ],
           "number": "27",
-          "position": "Right-Back"
+          "overall_score": 65,
+          "position": "Right-Back",
+          "potential": 75,
+          "value": 1400000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2027",
@@ -5614,7 +7098,11 @@
             "Italy"
           ],
           "number": "15",
-          "position": "Right-Back"
+          "overall_score": 75,
+          "position": "Right-Back",
+          "potential": 78,
+          "value": 6500000,
+          "yearly_wage": 936000
         },
         {
           "contract": "Jun 30, 2029",
@@ -5629,7 +7117,11 @@
             "Guinea"
           ],
           "number": "16",
-          "position": "Defensive Midfield"
+          "overall_score": 73,
+          "position": "Defensive Midfield",
+          "potential": 79,
+          "value": 4400000,
+          "yearly_wage": 728000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5644,7 +7136,11 @@
             "Spain"
           ],
           "number": "8",
-          "position": "Defensive Midfield"
+          "overall_score": 71,
+          "position": "Defensive Midfield",
+          "potential": 71,
+          "value": 1600000,
+          "yearly_wage": 728000
         },
         {
           "contract": "Jun 30, 2027",
@@ -5658,7 +7154,11 @@
             "Spain"
           ],
           "number": "10",
-          "position": "Central Midfield"
+          "overall_score": 76,
+          "position": "Central Midfield",
+          "potential": 81,
+          "value": 11500000,
+          "yearly_wage": 936000
         },
         {
           "contract": "Jun 30, 2030",
@@ -5672,7 +7172,11 @@
             "Denmark"
           ],
           "number": "22",
-          "position": "Central Midfield"
+          "overall_score": 72,
+          "position": "Central Midfield",
+          "potential": 77,
+          "value": 3500000,
+          "yearly_wage": 676000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5686,7 +7190,11 @@
             "Italy"
           ],
           "number": "41",
-          "position": "Central Midfield"
+          "overall_score": 75,
+          "position": "Central Midfield",
+          "potential": 79,
+          "value": 7000000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2030",
@@ -5701,7 +7209,11 @@
             "Paraguay"
           ],
           "number": "24",
-          "position": "Central Midfield"
+          "overall_score": 71,
+          "position": "Central Midfield",
+          "potential": 81,
+          "value": 3900000,
+          "yearly_wage": 520000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5716,7 +7228,11 @@
             "Italy"
           ],
           "number": "25",
-          "position": "Central Midfield"
+          "overall_score": 68,
+          "position": "Central Midfield",
+          "potential": 79,
+          "value": 2600000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5730,7 +7246,11 @@
             "Italy"
           ],
           "number": "21",
-          "position": "Attacking Midfield"
+          "overall_score": 73,
+          "position": "Attacking Midfield",
+          "potential": 79,
+          "value": 4900000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2028",
@@ -5744,7 +7264,11 @@
             "Italy"
           ],
           "number": "65",
-          "position": "Attacking Midfield"
+          "overall_score": 53,
+          "position": "Attacking Midfield",
+          "potential": 68,
+          "value": 220000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2029",
@@ -5758,7 +7282,11 @@
             "Sweden"
           ],
           "number": "17",
-          "position": "Left Winger"
+          "overall_score": 73,
+          "position": "Left Winger",
+          "potential": 79,
+          "value": 4900000,
+          "yearly_wage": 832000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5773,7 +7301,11 @@
             "Italy"
           ],
           "number": "7",
-          "position": "Right Winger"
+          "overall_score": 76,
+          "position": "Right Winger",
+          "potential": 76,
+          "value": 7500000,
+          "yearly_wage": 1560000
         },
         {
           "contract": "Jun 30, 2027",
@@ -5787,7 +7319,11 @@
             "Sweden"
           ],
           "number": "11",
-          "position": "Right Winger"
+          "overall_score": 71,
+          "position": "Right Winger",
+          "potential": 72,
+          "value": 2200000,
+          "yearly_wage": 676000
         },
         {
           "contract": "Jun 30, 2029",
@@ -5802,7 +7338,11 @@
             "Spain"
           ],
           "number": "9",
-          "position": "Centre-Forward"
+          "overall_score": 69,
+          "position": "Centre-Forward",
+          "potential": 75,
+          "value": 2200000,
+          "yearly_wage": 520000
         },
         {
           "contract": "Jun 30, 2030",
@@ -5816,7 +7356,11 @@
             "Croatia"
           ],
           "number": "20",
-          "position": "Centre-Forward"
+          "overall_score": 73,
+          "position": "Centre-Forward",
+          "potential": 78,
+          "value": 4700000,
+          "yearly_wage": 832000
         },
         {
           "contract": "Jun 30, 2030",
@@ -5831,7 +7375,11 @@
             "Cameroon"
           ],
           "number": "23",
-          "position": "Centre-Forward"
+          "overall_score": 64,
+          "position": "Centre-Forward",
+          "potential": 67,
+          "value": 800000,
+          "yearly_wage": 260000
         }
       ],
       "stadiumName": "Ennio Tardini",
@@ -5855,7 +7403,11 @@
             "Montenegro"
           ],
           "number": "49",
-          "position": "Goalkeeper"
+          "overall_score": 74,
+          "position": "Goalkeeper",
+          "potential": 76,
+          "value": 4000000,
+          "yearly_wage": 1456000
         },
         {
           "contract": "Jun 30, 2028",
@@ -5869,7 +7421,11 @@
             "Italy"
           ],
           "number": "13",
-          "position": "Goalkeeper"
+          "overall_score": 72,
+          "position": "Goalkeeper",
+          "potential": 79,
+          "value": 4000000,
+          "yearly_wage": 364000
         },
         {
           "contract": "Jun 30, 2029",
@@ -5883,7 +7439,11 @@
             "Italy"
           ],
           "number": "16",
-          "position": "Goalkeeper"
+          "overall_score": 62,
+          "position": "Goalkeeper",
+          "potential": 71,
+          "value": 775000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5897,7 +7457,11 @@
             "Italy"
           ],
           "number": "12",
-          "position": "Goalkeeper"
+          "overall_score": 66,
+          "position": "Goalkeeper",
+          "potential": 69,
+          "value": 850000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2031",
@@ -5912,7 +7476,11 @@
             "Slovenia"
           ],
           "number": "80",
-          "position": "Centre-Back"
+          "overall_score": 74,
+          "position": "Centre-Back",
+          "potential": 80,
+          "value": 6000000,
+          "yearly_wage": 780000
         },
         {
           "contract": "Jun 30, 2029",
@@ -5927,7 +7495,11 @@
             "Netherlands"
           ],
           "number": "21",
-          "position": "Centre-Back"
+          "overall_score": 73,
+          "position": "Centre-Back",
+          "potential": 77,
+          "value": 3800000,
+          "yearly_wage": 780000
         },
         {
           "contract": "Jun 30, 2029",
@@ -5942,7 +7514,11 @@
             "Portugal"
           ],
           "number": "5",
-          "position": "Centre-Back"
+          "overall_score": 71,
+          "position": "Centre-Back",
+          "potential": 73,
+          "value": 2000000,
+          "yearly_wage": 676000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5956,7 +7532,11 @@
             "Italy"
           ],
           "number": "19",
-          "position": "Centre-Back"
+          "overall_score": 70,
+          "position": "Centre-Back",
+          "potential": 70,
+          "value": 1400000,
+          "yearly_wage": 624000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5970,7 +7550,11 @@
             "Brazil"
           ],
           "number": "66",
-          "position": "Centre-Back"
+          "overall_score": 69,
+          "position": "Centre-Back",
+          "potential": 79,
+          "value": 2900000,
+          "yearly_wage": 1560000
         },
         {
           "contract": "Jun 30, 2028",
@@ -5984,7 +7568,11 @@
             "Scotland"
           ],
           "number": "3",
-          "position": "Left-Back"
+          "overall_score": 73,
+          "position": "Left-Back",
+          "potential": 78,
+          "value": 4300000,
+          "yearly_wage": 728000
         },
         {
           "contract": "Jun 30, 2026",
@@ -5999,7 +7587,11 @@
             "Cape Verde"
           ],
           "number": "23",
-          "position": "Left-Back"
+          "overall_score": 74,
+          "position": "Left-Back",
+          "potential": 74,
+          "value": 3700000,
+          "yearly_wage": 1612000
         },
         {
           "contract": "Jun 30, 2029",
@@ -6013,7 +7605,11 @@
             "Italy"
           ],
           "number": "15",
-          "position": "Left-Back"
+          "overall_score": 67,
+          "position": "Left-Back",
+          "potential": 71,
+          "value": 1400000,
+          "yearly_wage": 364000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6027,7 +7623,11 @@
             "Poland"
           ],
           "number": "6",
-          "position": "Right-Back"
+          "overall_score": 72,
+          "position": "Right-Back",
+          "potential": 76,
+          "value": 2900000,
+          "yearly_wage": 1196000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6042,7 +7642,11 @@
             "France"
           ],
           "number": "25",
-          "position": "Right-Back"
+          "overall_score": 72,
+          "position": "Right-Back",
+          "potential": 73,
+          "value": 2500000,
+          "yearly_wage": 1508000
         },
         {
           "contract": "Jun 30, 2028",
@@ -6057,7 +7661,11 @@
             "Romania"
           ],
           "number": "11",
-          "position": "Defensive Midfield"
+          "overall_score": 72,
+          "position": "Defensive Midfield",
+          "potential": 72,
+          "value": 2500000,
+          "yearly_wage": 780000
         },
         {
           "contract": "Jun 30, 2028",
@@ -6071,7 +7679,11 @@
             "Italy"
           ],
           "number": "35",
-          "position": "Defensive Midfield"
+          "overall_score": 69,
+          "position": "Defensive Midfield",
+          "potential": 77,
+          "value": 3000000,
+          "yearly_wage": 416000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6086,7 +7698,11 @@
             "Slovakia"
           ],
           "number": "18",
-          "position": "Defensive Midfield"
+          "overall_score": 77,
+          "position": "Defensive Midfield",
+          "potential": 77,
+          "value": 2100000,
+          "yearly_wage": 884000
         },
         {
           "contract": "Jun 30, 2030",
@@ -6101,7 +7717,11 @@
             "Cote d'Ivoire"
           ],
           "number": "90",
-          "position": "Central Midfield"
+          "overall_score": 75,
+          "position": "Central Midfield",
+          "potential": 79,
+          "value": 8000000,
+          "yearly_wage": 936000
         },
         {
           "contract": "Jun 30, 2027",
@@ -6115,7 +7735,11 @@
             "Norway"
           ],
           "number": "42",
-          "position": "Central Midfield"
+          "overall_score": 76,
+          "position": "Central Midfield",
+          "potential": 76,
+          "value": 8000000,
+          "yearly_wage": 1092000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6130,7 +7754,11 @@
             "DR Congo"
           ],
           "number": "40",
-          "position": "Central Midfield"
+          "overall_score": 72,
+          "position": "Central Midfield",
+          "potential": 77,
+          "value": 3600000,
+          "yearly_wage": 1300000
         },
         {
           "contract": "Jun 30, 2028",
@@ -6144,7 +7772,11 @@
             "Italy"
           ],
           "number": "44",
-          "position": "Central Midfield"
+          "overall_score": 67,
+          "position": "Central Midfield",
+          "potential": 72,
+          "value": 1500000,
+          "yearly_wage": 416000
         },
         {
           "contract": "Jun 30, 2028",
@@ -6159,7 +7791,11 @@
             "Australia"
           ],
           "number": "7",
-          "position": "Attacking Midfield"
+          "overall_score": 70,
+          "position": "Attacking Midfield",
+          "potential": 78,
+          "value": 3600000,
+          "yearly_wage": 520000
         },
         {
           "contract": "Jun 30, 2030",
@@ -6174,7 +7810,11 @@
             "Congo"
           ],
           "number": "50",
-          "position": "Attacking Midfield"
+          "overall_score": 66,
+          "position": "Attacking Midfield",
+          "potential": 81,
+          "value": 1900000,
+          "yearly_wage": 208000
         },
         {
           "contract": "Jun 30, 2027",
@@ -6189,7 +7829,11 @@
             "Guadeloupe"
           ],
           "number": "45",
-          "position": "Left Winger"
+          "overall_score": 80,
+          "position": "Left Winger",
+          "potential": 80,
+          "value": 23000000,
+          "yearly_wage": 1560000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6203,7 +7847,11 @@
             "The Gambia"
           ],
           "number": "20",
-          "position": "Left Winger"
+          "overall_score": 71,
+          "position": "Left Winger",
+          "potential": 77,
+          "value": 3000000,
+          "yearly_wage": 2236000
         },
         {
           "contract": "Jun 30, 2029",
@@ -6217,7 +7865,11 @@
             "Italy"
           ],
           "number": "10",
-          "position": "Right Winger"
+          "overall_score": 82,
+          "position": "Right Winger",
+          "potential": 82,
+          "value": 29500000,
+          "yearly_wage": 1872000
         },
         {
           "contract": "Jun 30, 2027",
@@ -6231,7 +7883,11 @@
             "Italy"
           ],
           "number": "99",
-          "position": "Centre-Forward"
+          "overall_score": 75,
+          "position": "Centre-Forward",
+          "potential": 76,
+          "value": 6500000,
+          "yearly_wage": 1144000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6246,7 +7902,11 @@
             "France"
           ],
           "number": "8",
-          "position": "Centre-Forward"
+          "overall_score": 73,
+          "position": "Centre-Forward",
+          "potential": 73,
+          "value": 3100000,
+          "yearly_wage": 1976000
         },
         {
           "contract": "Jun 30, 2027",
@@ -6260,7 +7920,11 @@
             "Italy"
           ],
           "number": "24",
-          "position": "Centre-Forward"
+          "overall_score": 68,
+          "position": "Centre-Forward",
+          "potential": 73,
+          "value": 1800000,
+          "yearly_wage": 520000
         }
       ],
       "stadiumName": "Mapei Stadium - Città del Tricolore",
@@ -6283,7 +7947,11 @@
             "Italy"
           ],
           "number": "1",
-          "position": "Goalkeeper"
+          "overall_score": 78,
+          "position": "Goalkeeper",
+          "potential": 84,
+          "value": 18000000,
+          "yearly_wage": 364000
         },
         {
           "contract": "Jun 30, 2027",
@@ -6297,7 +7965,11 @@
             "Albania"
           ],
           "number": "12",
-          "position": "Goalkeeper"
+          "overall_score": 66,
+          "position": "Goalkeeper",
+          "potential": 68,
+          "value": 775000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2027",
@@ -6311,7 +7983,11 @@
             "Italy"
           ],
           "number": "24",
-          "position": "Goalkeeper"
+          "overall_score": 59,
+          "position": "Goalkeeper",
+          "potential": 67,
+          "value": 425000,
+          "yearly_wage": 49400
         },
         {
           "contract": "Jun 30, 2026",
@@ -6325,7 +8001,11 @@
             "Italy"
           ],
           "number": "22",
-          "position": "Centre-Back"
+          "overall_score": 73,
+          "position": "Centre-Back",
+          "potential": 76,
+          "value": 3500000,
+          "yearly_wage": 2756000
         },
         {
           "contract": "Jun 30, 2030",
@@ -6339,7 +8019,11 @@
             "Uruguay"
           ],
           "number": "15",
-          "position": "Centre-Back"
+          "overall_score": 71,
+          "position": "Centre-Back",
+          "potential": 78,
+          "value": 3400000,
+          "yearly_wage": 312000
         },
         {
           "contract": "Jun 30, 2029",
@@ -6353,7 +8037,11 @@
             "Slovakia"
           ],
           "number": "33",
-          "position": "Centre-Back"
+          "overall_score": 73,
+          "position": "Centre-Back",
+          "potential": 79,
+          "value": 4600000,
+          "yearly_wage": 468000
         },
         {
           "contract": "Jun 30, 2028",
@@ -6367,7 +8055,11 @@
             "Colombia"
           ],
           "number": "26",
-          "position": "Centre-Back"
+          "overall_score": 76,
+          "position": "Centre-Back",
+          "potential": 76,
+          "value": 6000000,
+          "yearly_wage": 676000
         },
         {
           "contract": "Jun 30, 2028",
@@ -6381,7 +8073,11 @@
             "Portugal"
           ],
           "number": "32",
-          "position": "Centre-Back"
+          "overall_score": 73,
+          "position": "Centre-Back",
+          "potential": 75,
+          "value": 3100000,
+          "yearly_wage": 572000
         },
         {
           "contract": "Jun 30, 2030",
@@ -6396,7 +8092,11 @@
             "Morocco"
           ],
           "number": "3",
-          "position": "Left-Back"
+          "overall_score": 69,
+          "position": "Left-Back",
+          "potential": 76,
+          "value": 2600000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6410,7 +8110,11 @@
             "Italy"
           ],
           "number": "2",
-          "position": "Right-Back"
+          "overall_score": 75,
+          "position": "Right-Back",
+          "potential": 84,
+          "value": 12000000,
+          "yearly_wage": 1820000
         },
         {
           "contract": "Jun 30, 2030",
@@ -6424,7 +8128,11 @@
             "Italy"
           ],
           "number": "28",
-          "position": "Right-Back"
+          "overall_score": 73,
+          "position": "Right-Back",
+          "potential": 76,
+          "value": 3700000,
+          "yearly_wage": 520000
         },
         {
           "contract": "Jun 30, 2030",
@@ -6438,7 +8146,11 @@
             "Netherlands"
           ],
           "number": "18",
-          "position": "Right-Back"
+          "overall_score": 62,
+          "position": "Right-Back",
+          "potential": 75,
+          "value": 900000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6452,7 +8164,11 @@
             "Ghana"
           ],
           "number": "25",
-          "position": "Defensive Midfield"
+          "overall_score": 73,
+          "position": "Defensive Midfield",
+          "potential": 80,
+          "value": 6000000,
+          "yearly_wage": 1768000
         },
         {
           "contract": "Jun 30, 2029",
@@ -6467,7 +8183,11 @@
             "Cote d'Ivoire"
           ],
           "number": "8",
-          "position": "Central Midfield"
+          "overall_score": 73,
+          "position": "Central Midfield",
+          "potential": 76,
+          "value": 4100000,
+          "yearly_wage": 468000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6482,7 +8202,11 @@
             "Nigeria"
           ],
           "number": "90",
-          "position": "Central Midfield"
+          "overall_score": 74,
+          "position": "Central Midfield",
+          "potential": 74,
+          "value": 4500000,
+          "yearly_wage": 3276000
         },
         {
           "contract": "Jun 30, 2030",
@@ -6496,7 +8220,11 @@
             "Zambia"
           ],
           "number": "27",
-          "position": "Central Midfield"
+          "overall_score": 66,
+          "position": "Central Midfield",
+          "potential": 74,
+          "value": 1800000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2029",
@@ -6510,7 +8238,11 @@
             "Italy"
           ],
           "number": "14",
-          "position": "Central Midfield"
+          "overall_score": 70,
+          "position": "Central Midfield",
+          "potential": 70,
+          "value": 1600000,
+          "yearly_wage": 416000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6524,7 +8256,11 @@
             "Italy"
           ],
           "number": "4",
-          "position": "Central Midfield"
+          "overall_score": 73,
+          "position": "Central Midfield",
+          "potential": 73,
+          "value": 3000000,
+          "yearly_wage": 3016000
         },
         {
           "contract": "Jun 30, 2029",
@@ -6538,7 +8274,11 @@
             "Italy"
           ],
           "number": "10",
-          "position": "Attacking Midfield"
+          "overall_score": 73,
+          "position": "Attacking Midfield",
+          "potential": 76,
+          "value": 4000000,
+          "yearly_wage": 520000
         },
         {
           "contract": "Jun 30, 2027",
@@ -6552,7 +8292,11 @@
             "Italy"
           ],
           "number": "17",
-          "position": "Left Winger"
+          "overall_score": 72,
+          "position": "Left Winger",
+          "potential": 75,
+          "value": 3200000,
+          "yearly_wage": 416000
         },
         {
           "contract": "Jun 30, 2030",
@@ -6567,7 +8311,11 @@
             "Italy"
           ],
           "number": "20",
-          "position": "Left Winger"
+          "overall_score": 69,
+          "position": "Left Winger",
+          "potential": 77,
+          "value": 3000000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6581,7 +8329,11 @@
             "Italy"
           ],
           "number": "94",
-          "position": "Second Striker"
+          "overall_score": 75,
+          "position": "Second Striker",
+          "potential": 82,
+          "value": 11500000,
+          "yearly_wage": 1300000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6595,7 +8347,11 @@
             "Türkiye"
           ],
           "number": "9",
-          "position": "Centre-Forward"
+          "overall_score": 74,
+          "position": "Centre-Forward",
+          "potential": 81,
+          "value": 8500000,
+          "yearly_wage": 1248000
         },
         {
           "contract": "Jun 30, 2029",
@@ -6609,7 +8365,11 @@
             "Italy"
           ],
           "number": "29",
-          "position": "Centre-Forward"
+          "overall_score": 69,
+          "position": "Centre-Forward",
+          "potential": 71,
+          "value": 1800000,
+          "yearly_wage": 364000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6623,7 +8383,11 @@
             "Italy"
           ],
           "number": "19",
-          "position": "Centre-Forward"
+          "overall_score": 74,
+          "position": "Centre-Forward",
+          "potential": 74,
+          "value": 3600000,
+          "yearly_wage": 676000
         },
         {
           "contract": "-",
@@ -6637,7 +8401,11 @@
             "France"
           ],
           "number": "37",
-          "position": "Centre-Forward"
+          "overall_score": 62,
+          "position": "Centre-Forward",
+          "potential": 74,
+          "value": 950000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6651,7 +8419,11 @@
             "Italy"
           ],
           "number": "30",
-          "position": "Centre-Forward"
+          "overall_score": 67,
+          "position": "Centre-Forward",
+          "potential": 67,
+          "value": 350000,
+          "yearly_wage": 260000
         }
       ],
       "stadiumName": "Unipol Domus",
@@ -6675,7 +8447,11 @@
             "Italy"
           ],
           "number": "1",
-          "position": "Goalkeeper"
+          "overall_score": 79,
+          "position": "Goalkeeper",
+          "potential": 79,
+          "value": 12500000,
+          "yearly_wage": 2964000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6689,7 +8465,11 @@
             "Italy"
           ],
           "number": "16",
-          "position": "Goalkeeper"
+          "overall_score": 72,
+          "position": "Goalkeeper",
+          "potential": 72,
+          "value": 400000,
+          "yearly_wage": 312000
         },
         {
           "contract": "Jun 30, 2028",
@@ -6703,7 +8483,11 @@
             "Italy"
           ],
           "number": "69",
-          "position": "Goalkeeper"
+          "overall_score": 60,
+          "position": "Goalkeeper",
+          "potential": 72,
+          "value": 525000,
+          "yearly_wage": 36400
         },
         {
           "contract": "Jun 30, 2026",
@@ -6717,7 +8501,11 @@
             "Senegal"
           ],
           "number": "30",
-          "position": "Centre-Back"
+          "overall_score": 68,
+          "position": "Centre-Back",
+          "potential": 82,
+          "value": 2700000,
+          "yearly_wage": 416000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6731,7 +8519,11 @@
             "Italy"
           ],
           "number": "24",
-          "position": "Centre-Back"
+          "overall_score": 71,
+          "position": "Centre-Back",
+          "potential": 80,
+          "value": 3900000,
+          "yearly_wage": 1144000
         },
         {
           "contract": "Jun 30, 2030",
@@ -6745,7 +8537,11 @@
             "Italy"
           ],
           "number": "5",
-          "position": "Centre-Back"
+          "overall_score": 75,
+          "position": "Centre-Back",
+          "potential": 76,
+          "value": 5500000,
+          "yearly_wage": 676000
         },
         {
           "contract": "Jun 30, 2028",
@@ -6759,7 +8555,11 @@
             "Italy"
           ],
           "number": "6",
-          "position": "Centre-Back"
+          "overall_score": 75,
+          "position": "Centre-Back",
+          "potential": 76,
+          "value": 5500000,
+          "yearly_wage": 676000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6773,7 +8573,11 @@
             "Italy"
           ],
           "number": "15",
-          "position": "Centre-Back"
+          "overall_score": 71,
+          "position": "Centre-Back",
+          "potential": 71,
+          "value": 1200000,
+          "yearly_wage": 468000
         },
         {
           "contract": "Jun 30, 2028",
@@ -6787,7 +8591,11 @@
             "Italy"
           ],
           "number": "55",
-          "position": "Centre-Back"
+          "overall_score": 65,
+          "position": "Centre-Back",
+          "potential": 73,
+          "value": 1500000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6801,7 +8609,11 @@
             "Italy"
           ],
           "number": "23",
-          "position": "Centre-Back"
+          "overall_score": 71,
+          "position": "Centre-Back",
+          "potential": 71,
+          "value": 900000,
+          "yearly_wage": 468000
         },
         {
           "contract": "Jun 30, 2028",
@@ -6815,7 +8627,11 @@
             "Italy"
           ],
           "number": "3",
-          "position": "Left-Back"
+          "overall_score": 71,
+          "position": "Left-Back",
+          "potential": 71,
+          "value": 2000000,
+          "yearly_wage": 468000
         },
         {
           "contract": "Jun 30, 2028",
@@ -6829,7 +8645,11 @@
             "Italy"
           ],
           "number": "4",
-          "position": "Right-Back"
+          "overall_score": 71,
+          "position": "Right-Back",
+          "potential": 76,
+          "value": 2700000,
+          "yearly_wage": 364000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6843,7 +8663,11 @@
             "Italy"
           ],
           "number": "22",
-          "position": "Right-Back"
+          "overall_score": 69,
+          "position": "Right-Back",
+          "potential": 77,
+          "value": 3100000,
+          "yearly_wage": 676000
         },
         {
           "contract": "Jun 30, 2027",
@@ -6857,7 +8681,11 @@
             "Italy"
           ],
           "number": "33",
-          "position": "Defensive Midfield"
+          "overall_score": 70,
+          "position": "Defensive Midfield",
+          "potential": 70,
+          "value": 1500000,
+          "yearly_wage": 416000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6872,7 +8700,11 @@
             "DR Congo"
           ],
           "number": "38",
-          "position": "Central Midfield"
+          "overall_score": 71,
+          "position": "Central Midfield",
+          "potential": 78,
+          "value": 3800000,
+          "yearly_wage": 988000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6887,7 +8719,11 @@
             "Italy"
           ],
           "number": "32",
-          "position": "Central Midfield"
+          "overall_score": 73,
+          "position": "Central Midfield",
+          "potential": 73,
+          "value": 3300000,
+          "yearly_wage": 780000
         },
         {
           "contract": "Jun 30, 2028",
@@ -6901,7 +8737,11 @@
             "Belgium"
           ],
           "number": "27",
-          "position": "Central Midfield"
+          "overall_score": 72,
+          "position": "Central Midfield",
+          "potential": 72,
+          "value": 2300000,
+          "yearly_wage": 520000
         },
         {
           "contract": "-",
@@ -6915,7 +8755,11 @@
             "Norway"
           ],
           "number": "2",
-          "position": "Central Midfield"
+          "overall_score": 72,
+          "position": "Central Midfield",
+          "potential": 72,
+          "value": 2300000,
+          "yearly_wage": 520000
         },
         {
           "contract": "Jun 30, 2027",
@@ -6929,7 +8773,11 @@
             "Italy"
           ],
           "number": "18",
-          "position": "Central Midfield"
+          "overall_score": 72,
+          "position": "Central Midfield",
+          "potential": 75,
+          "value": 3100000,
+          "yearly_wage": 468000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6944,7 +8792,11 @@
             "Italy"
           ],
           "number": "29",
-          "position": "Central Midfield"
+          "overall_score": 71,
+          "position": "Central Midfield",
+          "potential": 72,
+          "value": 2200000,
+          "yearly_wage": 468000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6958,7 +8810,11 @@
             "Italy"
           ],
           "number": "7",
-          "position": "Right Midfield"
+          "overall_score": 73,
+          "position": "Right Midfield",
+          "potential": 73,
+          "value": 3300000,
+          "yearly_wage": 2964000
         },
         {
           "contract": "Jun 30, 2026",
@@ -6972,7 +8828,11 @@
             "Cameroon"
           ],
           "number": "14",
-          "position": "Centre-Forward"
+          "overall_score": 72,
+          "position": "Centre-Forward",
+          "potential": 76,
+          "value": 3300000,
+          "yearly_wage": 1404000
         },
         {
           "contract": "Jun 30, 2028",
@@ -6987,7 +8847,11 @@
             "Spain"
           ],
           "number": "99",
-          "position": "Centre-Forward"
+          "overall_score": 75,
+          "position": "Centre-Forward",
+          "potential": 75,
+          "value": 5500000,
+          "yearly_wage": 728000
         },
         {
           "contract": "Jun 30, 2028",
@@ -7001,7 +8865,11 @@
             "Italy"
           ],
           "number": "90",
-          "position": "Centre-Forward"
+          "overall_score": 72,
+          "position": "Centre-Forward",
+          "potential": 72,
+          "value": 2400000,
+          "yearly_wage": 572000
         },
         {
           "contract": "Jun 30, 2026",
@@ -7015,7 +8883,11 @@
             "Nigeria"
           ],
           "number": "77",
-          "position": "Centre-Forward"
+          "overall_score": 72,
+          "position": "Centre-Forward",
+          "potential": 72,
+          "value": 2500000,
+          "yearly_wage": 520000
         },
         {
           "contract": "Jun 30, 2027",
@@ -7044,7 +8916,11 @@
             "England"
           ],
           "number": "10",
-          "position": "Centre-Forward"
+          "overall_score": 75,
+          "position": "Centre-Forward",
+          "potential": 75,
+          "value": 1900000,
+          "yearly_wage": 572000
         }
       ],
       "stadiumName": "Giovanni Zini",
@@ -7067,7 +8943,11 @@
             "Croatia"
           ],
           "number": "1",
-          "position": "Goalkeeper"
+          "overall_score": 71,
+          "position": "Goalkeeper",
+          "potential": 74,
+          "value": 1800000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2028",
@@ -7081,7 +8961,11 @@
             "Italy"
           ],
           "number": "22",
-          "position": "Goalkeeper"
+          "overall_score": 71,
+          "position": "Goalkeeper",
+          "potential": 72,
+          "value": 1400000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2026",
@@ -7096,7 +8980,11 @@
             "Italy"
           ],
           "number": "12",
-          "position": "Goalkeeper"
+          "overall_score": 67,
+          "position": "Goalkeeper",
+          "potential": 67,
+          "value": 110000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2028",
@@ -7110,7 +8998,11 @@
             "Italy"
           ],
           "number": "5",
-          "position": "Centre-Back"
+          "overall_score": 72,
+          "position": "Centre-Back",
+          "potential": 75,
+          "value": 2900000,
+          "yearly_wage": 364000
         },
         {
           "contract": "Jun 30, 2030",
@@ -7124,7 +9016,11 @@
             "Bulgaria"
           ],
           "number": "2",
-          "position": "Centre-Back"
+          "overall_score": 63,
+          "position": "Centre-Back",
+          "potential": 77,
+          "value": 1100000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2029",
@@ -7139,7 +9035,11 @@
             "Cuba"
           ],
           "number": "26",
-          "position": "Centre-Back"
+          "overall_score": 61,
+          "position": "Centre-Back",
+          "potential": 76,
+          "value": 750000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2026",
@@ -7153,7 +9053,11 @@
             "Spain"
           ],
           "number": "39",
-          "position": "Centre-Back"
+          "overall_score": 75,
+          "position": "Centre-Back",
+          "potential": 75,
+          "value": 1000000,
+          "yearly_wage": 364000
         },
         {
           "contract": "Jun 30, 2026",
@@ -7167,7 +9071,11 @@
             "Italy"
           ],
           "number": "33",
-          "position": "Centre-Back"
+          "overall_score": 68,
+          "position": "Centre-Back",
+          "potential": 68,
+          "value": 1000000,
+          "yearly_wage": 312000
         },
         {
           "contract": "Jun 30, 2026",
@@ -7181,7 +9089,11 @@
             "Italy"
           ],
           "number": "4",
-          "position": "Centre-Back"
+          "overall_score": 71,
+          "position": "Centre-Back",
+          "potential": 71,
+          "value": 500000,
+          "yearly_wage": 312000
         },
         {
           "contract": "Jun 30, 2026",
@@ -7196,7 +9108,11 @@
             "Trinidad and Tobago"
           ],
           "number": "44",
-          "position": "Centre-Back"
+          "overall_score": 62,
+          "position": "Centre-Back",
+          "potential": 73,
+          "value": 825000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2026",
@@ -7211,7 +9127,11 @@
             "DR Congo"
           ],
           "number": "19",
-          "position": "Left-Back"
+          "overall_score": 72,
+          "position": "Left-Back",
+          "potential": 80,
+          "value": 5500000,
+          "yearly_wage": 2288000
         },
         {
           "contract": "Jun 30, 2026",
@@ -7225,7 +9145,11 @@
             "Romania"
           ],
           "number": "6",
-          "position": "Defensive Midfield"
+          "overall_score": 68,
+          "position": "Defensive Midfield",
+          "potential": 69,
+          "value": 1400000,
+          "yearly_wage": 312000
         },
         {
           "contract": "Jun 30, 2027",
@@ -7239,7 +9163,11 @@
             "Denmark"
           ],
           "number": "8",
-          "position": "Defensive Midfield"
+          "overall_score": 66,
+          "position": "Defensive Midfield",
+          "potential": 72,
+          "value": 1200000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2026",
@@ -7254,7 +9182,11 @@
             "Spain"
           ],
           "number": "35",
-          "position": "Central Midfield"
+          "overall_score": 73,
+          "position": "Central Midfield",
+          "potential": 76,
+          "value": 4100000,
+          "yearly_wage": 520000
         },
         {
           "contract": "Jun 30, 2026",
@@ -7268,7 +9200,11 @@
             "Nigeria"
           ],
           "number": "14",
-          "position": "Central Midfield"
+          "overall_score": 67,
+          "position": "Central Midfield",
+          "potential": 80,
+          "value": 2400000,
+          "yearly_wage": 468000
         },
         {
           "contract": "Jun 30, 2028",
@@ -7283,7 +9219,11 @@
             "Sweden"
           ],
           "number": "21",
-          "position": "Central Midfield"
+          "overall_score": 63,
+          "position": "Central Midfield",
+          "potential": 79,
+          "value": 1200000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2026",
@@ -7297,7 +9237,11 @@
             "Switzerland"
           ],
           "number": "20",
-          "position": "Central Midfield"
+          "overall_score": 74,
+          "position": "Central Midfield",
+          "potential": 74,
+          "value": 4200000,
+          "yearly_wage": 2028000
         },
         {
           "contract": "Jun 30, 2026",
@@ -7311,7 +9255,11 @@
             "Italy"
           ],
           "number": "36",
-          "position": "Central Midfield"
+          "overall_score": 68,
+          "position": "Central Midfield",
+          "potential": 73,
+          "value": 1800000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2027",
@@ -7326,7 +9274,11 @@
             "Guinea"
           ],
           "number": "15",
-          "position": "Right Midfield"
+          "overall_score": 71,
+          "position": "Right Midfield",
+          "potential": 71,
+          "value": 2000000,
+          "yearly_wage": 416000
         },
         {
           "contract": "Jun 30, 2026",
@@ -7341,7 +9293,11 @@
             "Italy"
           ],
           "number": "11",
-          "position": "Right Midfield"
+          "overall_score": 75,
+          "position": "Right Midfield",
+          "potential": 75,
+          "value": 1800000,
+          "yearly_wage": 468000
         },
         {
           "contract": "Jun 30, 2027",
@@ -7355,7 +9311,11 @@
             "Italy"
           ],
           "number": "3",
-          "position": "Left Midfield"
+          "overall_score": 71,
+          "position": "Left Midfield",
+          "potential": 78,
+          "value": 3800000,
+          "yearly_wage": 312000
         },
         {
           "contract": "Jun 30, 2026",
@@ -7369,7 +9329,11 @@
             "Brazil"
           ],
           "number": "99",
-          "position": "Attacking Midfield"
+          "overall_score": 65,
+          "position": "Attacking Midfield",
+          "potential": 80,
+          "value": 1700000,
+          "yearly_wage": 104000
         },
         {
           "contract": "Jun 30, 2030",
@@ -7384,7 +9348,11 @@
             "Italy"
           ],
           "number": "10",
-          "position": "Attacking Midfield"
+          "overall_score": 74,
+          "position": "Attacking Midfield",
+          "potential": 77,
+          "value": 5500000,
+          "yearly_wage": 520000
         },
         {
           "contract": "Jun 30, 2026",
@@ -7399,7 +9367,11 @@
             "Suriname"
           ],
           "number": "23",
-          "position": "Attacking Midfield"
+          "overall_score": 76,
+          "position": "Attacking Midfield",
+          "potential": 77,
+          "value": 9000000,
+          "yearly_wage": 832000
         },
         {
           "contract": "Jun 30, 2027",
@@ -7414,7 +9386,11 @@
             "France"
           ],
           "number": "7",
-          "position": "Right Winger"
+          "overall_score": 70,
+          "position": "Right Winger",
+          "potential": 70,
+          "value": 1700000,
+          "yearly_wage": 364000
         },
         {
           "contract": "Jun 30, 2030",
@@ -7428,7 +9404,11 @@
             "Nigeria"
           ],
           "number": "17",
-          "position": "Centre-Forward"
+          "overall_score": 75,
+          "position": "Centre-Forward",
+          "potential": 81,
+          "value": 9000000,
+          "yearly_wage": 572000
         },
         {
           "contract": "Jun 30, 2028",
@@ -7443,7 +9423,11 @@
             "Cameroon"
           ],
           "number": "9",
-          "position": "Centre-Forward"
+          "overall_score": 69,
+          "position": "Centre-Forward",
+          "potential": 76,
+          "value": 2900000,
+          "yearly_wage": 260000
         },
         {
           "contract": "Jun 30, 2029",
@@ -7458,7 +9442,11 @@
             "Serbia"
           ],
           "number": "81",
-          "position": "Centre-Forward"
+          "overall_score": 68,
+          "position": "Centre-Forward",
+          "potential": 71,
+          "value": 1600000,
+          "yearly_wage": 312000
         },
         {
           "contract": "Jun 30, 2027",
@@ -7472,7 +9460,11 @@
             "Italy"
           ],
           "number": "32",
-          "position": "Centre-Forward"
+          "overall_score": 72,
+          "position": "Centre-Forward",
+          "potential": 72,
+          "value": 1900000,
+          "yearly_wage": 520000
         }
       ],
       "stadiumName": "Cetilar® Arena",
@@ -7495,7 +9487,11 @@
             "France"
           ],
           "number": "1",
-          "position": "Goalkeeper"
+          "overall_score": 78,
+          "position": "Goalkeeper",
+          "potential": 78,
+          "value": 9500000,
+          "yearly_wage": 2704000
         },
         {
           "contract": "-",
@@ -7509,7 +9505,11 @@
             "Sweden"
           ],
           "number": "21",
-          "position": "Goalkeeper"
+          "overall_score": 73,
+          "position": "Goalkeeper",
+          "potential": 81,
+          "value": 6000000,
+          "yearly_wage": 1404000
         },
         {
           "contract": "Jun 30, 2026",
@@ -7523,7 +9523,11 @@
             "Croatia"
           ],
           "number": "44",
-          "position": "Goalkeeper"
+          "overall_score": 67,
+          "position": "Goalkeeper",
+          "potential": 73,
+          "value": 1300000,
+          "yearly_wage": 208000
         },
         {
           "dateOfBirth": "Jan 12, 2007",
@@ -7536,7 +9540,11 @@
             "Brazil"
           ],
           "number": "12",
-          "position": "Goalkeeper"
+          "overall_score": 58,
+          "position": "Goalkeeper",
+          "potential": 74,
+          "value": 450000,
+          "yearly_wage": 156000
         },
         {
           "contract": "Jun 30, 2026",
@@ -7550,7 +9558,11 @@
             "Italy"
           ],
           "number": "22",
-          "position": "Goalkeeper"
+          "overall_score": 64,
+          "position": "Goalkeeper",
+          "potential": 64,
+          "value": 60000,
+          "yearly_wage": 364000
         },
         {
           "contract": "Jun 30, 2030",
@@ -7564,7 +9576,11 @@
             "Spain"
           ],
           "number": "14",
-          "position": "Centre-Back"
+          "overall_score": 74,
+          "position": "Centre-Back",
+          "potential": 84,
+          "value": 8500000,
+          "yearly_wage": 2236000
         },
         {
           "contract": "Jun 30, 2026",
@@ -7579,7 +9595,11 @@
             "Spain"
           ],
           "number": "34",
-          "position": "Centre-Back"
+          "overall_score": 79,
+          "position": "Centre-Back",
+          "potential": 79,
+          "value": 11500000,
+          "yearly_wage": 2860000
         },
         {
           "contract": "Jun 30, 2027",
@@ -7593,7 +9613,11 @@
             "Germany"
           ],
           "number": "2",
-          "position": "Centre-Back"
+          "overall_score": 75,
+          "position": "Centre-Back",
+          "potential": 75,
+          "value": 4600000,
+          "yearly_wage": 3432000
         },
         {
           "contract": "Jun 30, 2028",
@@ -7607,7 +9631,11 @@
             "Italy"
           ],
           "number": "5",
-          "position": "Centre-Back"
+          "overall_score": 72,
+          "position": "Centre-Back",
+          "potential": 72,
+          "value": 1600000,
+          "yearly_wage": 2652000
         },
         {
           "contract": "Jun 30, 2029",
@@ -7621,7 +9649,11 @@
             "Spain"
           ],
           "number": "3",
-          "position": "Left-Back"
+          "overall_score": 74,
+          "position": "Left-Back",
+          "potential": 84,
+          "value": 9000000,
+          "yearly_wage": 2236000
         },
         {
           "contract": "Jun 30, 2026",
@@ -7635,7 +9667,11 @@
             "Spain"
           ],
           "number": "18",
-          "position": "Left-Back"
+          "overall_score": 75,
+          "position": "Left-Back",
+          "potential": 75,
+          "value": 3900000,
+          "yearly_wage": 3432000
         },
         {
           "contract": "Jun 30, 2028",
@@ -7649,7 +9685,11 @@
             "Belgium"
           ],
           "number": "77",
-          "position": "Right-Back"
+          "overall_score": 72,
+          "position": "Right-Back",
+          "potential": 78,
+          "value": 3500000,
+          "yearly_wage": 2184000
         },
         {
           "contract": "Jun 30, 2028",
@@ -7664,7 +9704,11 @@
             "Albania"
           ],
           "number": "31",
-          "position": "Right-Back"
+          "overall_score": 76,
+          "position": "Right-Back",
+          "potential": 76,
+          "value": 6500000,
+          "yearly_wage": 3640000
         },
         {
           "contract": "Jun 30, 2029",
@@ -7678,7 +9722,11 @@
             "Croatia"
           ],
           "number": "28",
-          "position": "Right-Back"
+          "overall_score": 75,
+          "position": "Right-Back",
+          "potential": 78,
+          "value": 7000000,
+          "yearly_wage": 2860000
         },
         {
           "contract": "Jun 30, 2029",
@@ -7693,7 +9741,11 @@
             "Spain"
           ],
           "number": "23",
-          "position": "Defensive Midfield"
+          "overall_score": 76,
+          "position": "Defensive Midfield",
+          "potential": 84,
+          "value": 16000000,
+          "yearly_wage": 3016000
         },
         {
           "contract": "Jun 30, 2029",
@@ -7707,7 +9759,11 @@
             "France"
           ],
           "number": "6",
-          "position": "Central Midfield"
+          "overall_score": 78,
+          "position": "Central Midfield",
+          "potential": 80,
+          "value": 17500000,
+          "yearly_wage": 3952000
         },
         {
           "contract": "Jun 30, 2029",
@@ -7722,7 +9778,11 @@
             "Portugal"
           ],
           "number": "33",
-          "position": "Central Midfield"
+          "overall_score": 76,
+          "position": "Central Midfield",
+          "potential": 80,
+          "value": 10000000,
+          "yearly_wage": 3016000
         },
         {
           "contract": "Jun 30, 2026",
@@ -7736,7 +9796,11 @@
             "Spain"
           ],
           "number": "8",
-          "position": "Central Midfield"
+          "overall_score": 76,
+          "position": "Central Midfield",
+          "potential": 76,
+          "value": 3700000,
+          "yearly_wage": 3640000
         },
         {
           "contract": "Jun 30, 2031",
@@ -7751,7 +9815,11 @@
             "Syria"
           ],
           "number": "15",
-          "position": "Central Midfield"
+          "overall_score": 60,
+          "position": "Central Midfield",
+          "potential": 77,
+          "value": 600000,
+          "yearly_wage": 312000
         },
         {
           "contract": "Jun 30, 2028",
@@ -7766,7 +9834,11 @@
             "Spain"
           ],
           "number": "10",
-          "position": "Attacking Midfield"
+          "overall_score": 82,
+          "position": "Attacking Midfield",
+          "potential": 89,
+          "value": 60500000,
+          "yearly_wage": 4264000
         },
         {
           "contract": "Jun 30, 2030",
@@ -7780,7 +9852,11 @@
             "Croatia"
           ],
           "number": "20",
-          "position": "Attacking Midfield"
+          "overall_score": 79,
+          "position": "Attacking Midfield",
+          "potential": 84,
+          "value": 27000000,
+          "yearly_wage": 4056000
         },
         {
           "contract": "Jun 30, 2030",
@@ -7794,7 +9870,11 @@
             "Spain"
           ],
           "number": "17",
-          "position": "Left Winger"
+          "overall_score": 77,
+          "position": "Left Winger",
+          "potential": 85,
+          "value": 23000000,
+          "yearly_wage": 2704000
         },
         {
           "contract": "Jun 30, 2029",
@@ -7809,7 +9889,11 @@
             "Spain"
           ],
           "number": "38",
-          "position": "Left Winger"
+          "overall_score": 76,
+          "position": "Left Winger",
+          "potential": 87,
+          "value": 16000000,
+          "yearly_wage": 2548000
         },
         {
           "contract": "Jun 30, 2030",
@@ -7824,7 +9908,11 @@
             "Ghana"
           ],
           "number": "42",
-          "position": "Right Winger"
+          "overall_score": 70,
+          "position": "Right Winger",
+          "potential": 84,
+          "value": 3800000,
+          "yearly_wage": 1456000
         },
         {
           "contract": "Jun 30, 2029",
@@ -7838,7 +9926,11 @@
             "Germany"
           ],
           "number": "19",
-          "position": "Right Winger"
+          "overall_score": 77,
+          "position": "Right Winger",
+          "potential": 78,
+          "value": 12500000,
+          "yearly_wage": 4004000
         },
         {
           "contract": "Jun 30, 2029",
@@ -7866,7 +9958,11 @@
             "Spain"
           ],
           "number": "7",
-          "position": "Centre-Forward"
+          "overall_score": 79,
+          "position": "Centre-Forward",
+          "potential": 79,
+          "value": 14000000,
+          "yearly_wage": 2912000
         }
       ],
       "stadiumName": "Giuseppe Sinigaglia",

--- a/scripts/apply-sofifa-ratings.mjs
+++ b/scripts/apply-sofifa-ratings.mjs
@@ -1,0 +1,437 @@
+#!/usr/bin/env node
+// Augment teams.json players with SoFIFA ratings, in place, by linking sofifa
+// player records to squad players *by team + name*.
+//
+// Whenever a data directory holds a `sofifa.json` next to a `teams.json`, this
+// script copies four fields onto each matched squad player:
+//   overall_score, potential, value, yearly_wage
+// `GamePlayerTemplateService::prepareTemplateRow` already honors `overall_score`
+// and `potential` when present on a player record; `value`/`yearly_wage` are
+// carried through for reference/future use. Unmatched squad players keep their
+// existing fields and fall back to the importer's market-value ability heuristic.
+//
+// Discovery: recursively scan data/ for files named `sofifa.json`; for each, the
+// target is the sibling `teams.json` in the same directory. Pass a positional
+// <dir> to restrict to one directory.
+//
+// sofifa.json shape:
+//   { league, teams: [ { team, players: [ { name, full_name, overall_score,
+//     potential, value, yearly_wage, currency }, ... ] }, ... ] }
+// teams.json shape:
+//   { id, code, name, seasonID, clubs: [ { name, players: [ { name, ... }, ... ] }, ... ] }
+//
+// Team resolution: each sofifa/teams.json name is reduced to a set of "core"
+// identifying tokens (drop club-type acronyms like RC/CD/FC/CF/Real, generic
+// descriptors, founding-year numbers and the leading "1." ordinal). A club is
+// linked to the sofifa team it shares the most tokens with, so "Inter Milan"
+// links to "Inter", "SSC Napoli" to "Napoli", and "Real Sporting de Gijón" to
+// "Sporting Gijón". See teamCoreTokens / resolveSofifaTeam.
+//
+// Player matching, scoped to the resolved sofifa team, claiming as we go so one
+// sofifa player never serves two squad players:
+//   1. exact     — squad name equals a sofifa player's `name` or `full_name`.
+//   2. token     — squad name tokens are a subset (either direction) of a sofifa
+//                  player's `name`/`full_name` tokens, unique among unclaimed.
+//   3. surname   — the squad player's last token uniquely identifies one unclaimed
+//                  sofifa player in the team (by last token of name/full_name) and
+//                  the first-name initials are compatible. Catches diminutives
+//                  (Dani↔Daniel, Nico↔Nicolás) without cross-team mislinks.
+//
+// Behaviour: report-and-write. Partial coverage is expected (a squad player may
+// simply not exist in sofifa), so unmatched players are a non-fatal warning. A
+// club that fails to resolve to a sofifa team, or an invalid rating value, is an
+// error for that club but does not abort the rest. Pass --dry-run to report
+// without writing.
+//
+// Serialization matches teams.json: object keys sorted alphabetically, 2-space
+// indent, trailing newline. The 5 top-level wrapper keys keep their insertion
+// order so the only diff is the four fields added per player.
+
+import { readFileSync, writeFileSync, readdirSync, existsSync, statSync } from "node:fs";
+import { dirname, join, resolve, basename } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const DATA_DIR = join(ROOT, "data");
+
+const argv = process.argv.slice(2);
+const DRY_RUN = argv.includes("--dry-run");
+const positional = argv.filter((a) => !a.startsWith("--"));
+const SCAN_DIR = positional[0] ? resolve(process.cwd(), positional[0]) : DATA_DIR;
+
+// The four fields we copy from a sofifa player onto a squad player.
+const RATING_FIELDS = ["overall_score", "potential", "value", "yearly_wage"];
+
+// Serialize like teams.json: alphabetical keys, 2-space indent, no trailing
+// newline (the caller appends one). Identical to scripts/apply-wc-ratings.mjs.
+function stringifySorted(value, indent = 2, depth = 0) {
+  const pad = " ".repeat(indent * depth);
+  const innerPad = " ".repeat(indent * (depth + 1));
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    if (value.length === 0) return "[]";
+    const items = value.map((v) => innerPad + stringifySorted(v, indent, depth + 1));
+    return "[\n" + items.join(",\n") + "\n" + pad + "]";
+  }
+  const keys = Object.keys(value).sort();
+  if (keys.length === 0) return "{}";
+  const items = keys.map(
+    (k) => innerPad + JSON.stringify(k) + ": " + stringifySorted(value[k], indent, depth + 1),
+  );
+  return "{\n" + items.join(",\n") + "\n" + pad + "}";
+}
+
+// Serialize the top-level wrapper preserving ITS key insertion order (id, code,
+// name, seasonID, clubs), while every nested object is sorted by stringifySorted.
+// Keeps the metadata header stable so the diff is only the per-player fields.
+function stringifyTeamsFile(data) {
+  const keys = Object.keys(data);
+  const items = keys.map(
+    (k) => "  " + JSON.stringify(k) + ": " + stringifySorted(data[k], 2, 1),
+  );
+  return "{\n" + items.join(",\n") + "\n}\n";
+}
+
+// lowercase, strip diacritics, collapse internal whitespace, trim.
+function normalizeName(raw) {
+  return String(raw ?? "")
+    .normalize("NFD")
+    .replace(/\p{Diacritic}/gu, "")
+    .toLowerCase()
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+// Normalized token set, split on whitespace, hyphens and dots.
+function tokenize(raw) {
+  return new Set(
+    normalizeName(raw)
+      .split(/[\s.\-]+/)
+      .filter(Boolean),
+  );
+}
+
+// true if every token of `a` is in `b` (a ⊆ b).
+function isSubset(a, b) {
+  for (const t of a) if (!b.has(t)) return false;
+  return true;
+}
+
+// true if either token set fully contains the other (and neither is empty).
+function tokensCompatible(a, b) {
+  if (a.size === 0 || b.size === 0) return false;
+  return isSubset(a, b) || isSubset(b, a);
+}
+
+// Club-name prefixes/suffixes that carry no identifying weight, dropped before
+// comparing team names so sofifa's "Real Sporting de Gijón" lines up with
+// teams.json's "Sporting Gijón".
+const TEAM_STOPWORDS = new Set([
+  "rc", "cd", "ud", "sd", "ad", "fc", "cf", "real", "club", "balompie", "de", "futbol",
+]);
+
+// A few clubs sofifa and teams.json spell differently; fold the variant token
+// onto a shared form so the names line up: FC Bayern München ↔ Bayern Munich,
+// Olympique Lyonnais ↔ Olympique Lyon, Lille OSC ↔ LOSC Lille.
+const TEAM_TOKEN_ALIASES = new Map([
+  ["munchen", "munich"],
+  ["lyonnais", "lyon"],
+  ["losc", "lille"],
+]);
+
+// Core identifying tokens of a team name: normalized, split on whitespace AND
+// dots (so "1. FC" and "FC St. Pauli" tokenize the same regardless of spacing),
+// with stopwords, pure-number tokens (founding years like 1909 / "05", the
+// leading "1." ordinal) dropped and aliases folded in.
+function teamCoreTokens(raw) {
+  const out = new Set();
+  for (const t of normalizeName(raw).split(/[\s.]+/)) {
+    if (!t || /^\d+$/.test(t) || TEAM_STOPWORDS.has(t)) continue;
+    out.add(TEAM_TOKEN_ALIASES.get(t) ?? t);
+  }
+  return out;
+}
+
+// Resolve a teams.json club to its sofifa team by core-token overlap: the
+// candidate sharing the most tokens wins, ties on overlap break toward the
+// fewest non-shared tokens (so "Inter Milan" prefers "Inter" over "AC Milan"
+// and "Paris FC" prefers "Paris FC" over "Paris Saint-Germain"). A genuine tie
+// is left unresolved rather than guessed.
+function resolveSofifaTeam(clubName, sofifaTeams) {
+  const clubTokens = teamCoreTokens(clubName);
+  if (clubTokens.size === 0) return null;
+  let best = null;
+  let bestOverlap = 0;
+  let bestExtra = Infinity;
+  let tied = false;
+  for (const st of sofifaTeams) {
+    if (st.tokens.size === 0) continue;
+    let overlap = 0;
+    for (const t of st.tokens) if (clubTokens.has(t)) overlap++;
+    if (overlap === 0) continue;
+    const extra = st.tokens.size + clubTokens.size - 2 * overlap;
+    if (overlap > bestOverlap || (overlap === bestOverlap && extra < bestExtra)) {
+      best = st.team;
+      bestOverlap = overlap;
+      bestExtra = extra;
+      tied = false;
+    } else if (overlap === bestOverlap && extra === bestExtra) {
+      tied = true;
+    }
+  }
+  return tied ? null : best;
+}
+
+// Mirror of GamePlayerTemplateService::resolveExplicitAbility — invalid is an
+// error here (we refuse to write junk the importer would silently drop).
+function validateAbility(raw) {
+  if (raw === null || raw === undefined || raw === "") {
+    return { ok: false, reason: "missing" };
+  }
+  const n = typeof raw === "number" ? raw : Number(raw);
+  if (!Number.isInteger(n) || n < 1 || n > 99) {
+    return { ok: false, reason: `not an integer in 1..99 (${JSON.stringify(raw)})` };
+  }
+  return { ok: true, value: n };
+}
+
+// value / yearly_wage: non-negative finite numbers (euros). Empty/null is ok and
+// copied through as-is; a non-numeric value is an error.
+function validateAmount(raw, field) {
+  if (raw === null || raw === undefined || raw === "") {
+    return { ok: true, value: raw ?? null };
+  }
+  const n = typeof raw === "number" ? raw : Number(raw);
+  if (!Number.isFinite(n) || n < 0) {
+    return { ok: false, reason: `${field} not a non-negative number (${JSON.stringify(raw)})` };
+  }
+  return { ok: true, value: n };
+}
+
+// Recursively collect every data/**/sofifa.json under `dir`.
+function findSofifaFiles(dir) {
+  const out = [];
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return out;
+  }
+  for (const entry of entries) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...findSofifaFiles(full));
+    } else if (entry.isFile() && entry.name === "sofifa.json") {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+// Build a sofifa team's player pool: one record per player, with name candidates
+// pre-normalized and a `used` flag for claiming.
+function buildPool(sofifaTeam) {
+  return sofifaTeam.players.map((p, i) => {
+    const names = [p.name, p.full_name].filter((s) => s != null && String(s).trim() !== "");
+    const tokenSets = names.map(tokenize);
+    const surnames = new Set(tokenSets.map((t) => [...t].at(-1)).filter(Boolean));
+    const initials = new Set(tokenSets.map((t) => [...t][0]?.[0]).filter(Boolean));
+    return {
+      i,
+      player: p,
+      used: false,
+      norms: names.map(normalizeName),
+      tokenSets,
+      surnames,
+      initials,
+    };
+  });
+}
+
+// Copy the four rating fields from a sofifa player onto a squad player. Returns
+// an error string if any rating value is invalid, else null.
+function applyRatings(squadPlayer, sofifaPlayer, label) {
+  const overall = validateAbility(sofifaPlayer.overall_score);
+  if (!overall.ok) return `"${label}": overall_score ${overall.reason}`;
+  const potential = validateAbility(sofifaPlayer.potential);
+  if (!potential.ok) return `"${label}": potential ${potential.reason}`;
+  if (potential.value < overall.value) {
+    return `"${label}": potential ${potential.value} < overall_score ${overall.value}`;
+  }
+  const value = validateAmount(sofifaPlayer.value, "value");
+  if (!value.ok) return `"${label}": ${value.reason}`;
+  const wage = validateAmount(sofifaPlayer.yearly_wage, "yearly_wage");
+  if (!wage.ok) return `"${label}": ${wage.reason}`;
+
+  squadPlayer.overall_score = overall.value;
+  squadPlayer.potential = potential.value;
+  squadPlayer.value = value.value;
+  squadPlayer.yearly_wage = wage.value;
+  return null;
+}
+
+// Link one club's squad to its sofifa team. Mutates squad players in place.
+// Returns { matched, unmatched: [names], errors: [msgs] }.
+function matchClub(club, sofifaTeam) {
+  const pool = buildPool(sofifaTeam);
+  const unmatched = [];
+  const errors = [];
+  let matched = 0;
+
+  const claim = (entry, squadPlayer, label) => {
+    const err = applyRatings(squadPlayer, entry.player, label);
+    if (err) {
+      errors.push(err);
+      return;
+    }
+    entry.used = true;
+    matched++;
+  };
+
+  for (const sp of club.players) {
+    const label = String(sp.name ?? "");
+    const norm = normalizeName(sp.name);
+    const tokens = tokenize(sp.name);
+
+    // Pass 1 — exact normalized name on either sofifa name candidate.
+    let cand = pool.filter((e) => !e.used && e.norms.includes(norm));
+    let uniq = [...new Set(cand.map((e) => e.i))];
+
+    // Pass 2 — partial token subset (either direction).
+    if (uniq.length !== 1) {
+      cand = pool.filter((e) => !e.used && e.tokenSets.some((t) => tokensCompatible(tokens, t)));
+      uniq = [...new Set(cand.map((e) => e.i))];
+    }
+
+    // Pass 3 — unique surname in the team with a compatible first initial.
+    if (uniq.length !== 1 && tokens.size > 0) {
+      const surname = [...tokens].at(-1);
+      const initial = [...tokens][0]?.[0];
+      cand = pool.filter(
+        (e) =>
+          !e.used &&
+          e.surnames.has(surname) &&
+          (initial ? e.initials.has(initial) : true),
+      );
+      uniq = [...new Set(cand.map((e) => e.i))];
+    }
+
+    if (uniq.length === 1) {
+      claim(pool[uniq[0]], sp, label);
+    } else {
+      unmatched.push(label);
+    }
+  }
+
+  return { matched, unmatched, errors };
+}
+
+function processPair(sofifaPath) {
+  const dir = dirname(sofifaPath);
+  const teamsPath = join(dir, "teams.json");
+  const rel = (p) => p.slice(ROOT.length + 1);
+
+  if (!existsSync(teamsPath)) {
+    console.warn(`! ${rel(sofifaPath)}: no sibling teams.json — skipped`);
+    return { skipped: true };
+  }
+
+  const sofifa = JSON.parse(readFileSync(sofifaPath, "utf8"));
+  const teams = JSON.parse(readFileSync(teamsPath, "utf8"));
+
+  // Pre-compute each sofifa team's core token set once; clubs are resolved by
+  // token overlap (see resolveSofifaTeam).
+  const sofifaTeams = (sofifa.teams ?? []).map((t) => ({
+    team: t,
+    tokens: teamCoreTokens(t.team),
+  }));
+
+  const reports = [];
+  const errors = [];
+  const unresolvedClubs = [];
+  let totalMatched = 0;
+  let totalPlayers = 0;
+
+  for (const club of teams.clubs ?? []) {
+    const sofifaTeam = resolveSofifaTeam(club.name, sofifaTeams);
+    if (!sofifaTeam) {
+      unresolvedClubs.push(`${club.name} [tokens="${[...teamCoreTokens(club.name)].join(" ")}"]`);
+      continue;
+    }
+    const { matched, unmatched, errors: clubErrors } = matchClub(club, sofifaTeam);
+    totalMatched += matched;
+    totalPlayers += club.players.length;
+    reports.push({ club: club.name, matched, total: club.players.length, unmatched });
+    for (const e of clubErrors) errors.push(`[${club.name}] ${e}`);
+  }
+
+  // Report
+  console.log(`\n${rel(teamsPath)}`);
+  for (const r of reports) {
+    console.log(`  ${r.club}: ${r.matched}/${r.total} matched`);
+  }
+  console.log(`  TOTAL: ${totalMatched}/${totalPlayers} matched`);
+
+  const allUnmatched = reports.flatMap((r) => r.unmatched.map((n) => `${r.club}: ${n}`));
+  if (allUnmatched.length) {
+    console.log(`  ${allUnmatched.length} unmatched (no sofifa rating, left as-is):`);
+    for (const u of allUnmatched) console.log(`    - ${u}`);
+  }
+  if (unresolvedClubs.length) {
+    console.warn(`  ${unresolvedClubs.length} club(s) did not resolve to a sofifa team:`);
+    for (const c of unresolvedClubs) console.warn(`    ! ${c}`);
+  }
+  if (errors.length) {
+    console.error(`  ${errors.length} rating value error(s):`);
+    for (const e of errors) console.error(`    ! ${e}`);
+  }
+
+  if (DRY_RUN) {
+    return { teamsPath, totalMatched, totalPlayers, written: false };
+  }
+
+  writeFileSync(teamsPath, stringifyTeamsFile(teams));
+  console.log(`  Wrote ${rel(teamsPath)}`);
+  return { teamsPath, totalMatched, totalPlayers, written: true };
+}
+
+function main() {
+  if (!existsSync(SCAN_DIR)) {
+    console.error(`Scan directory not found: ${SCAN_DIR}`);
+    process.exit(1);
+  }
+
+  // Allow pointing directly at a directory that contains sofifa.json, or a tree.
+  let sofifaFiles;
+  const direct = join(SCAN_DIR, "sofifa.json");
+  if (statSync(SCAN_DIR).isDirectory() && existsSync(direct)) {
+    sofifaFiles = [direct];
+  } else {
+    sofifaFiles = findSofifaFiles(SCAN_DIR).sort();
+  }
+
+  if (sofifaFiles.length === 0) {
+    console.error(`No sofifa.json found under ${SCAN_DIR}`);
+    process.exit(1);
+  }
+
+  console.log(
+    `Found ${sofifaFiles.length} sofifa.json file(s)${DRY_RUN ? " (dry run)" : ""}.`,
+  );
+
+  let wrote = 0;
+  for (const f of sofifaFiles) {
+    const res = processPair(f);
+    if (res.written) wrote++;
+  }
+
+  console.log(
+    DRY_RUN
+      ? `\nDry run complete. ${sofifaFiles.length} file(s) inspected, nothing written.`
+      : `\nDone: updated ${wrote} teams.json file(s).`,
+  );
+}
+
+main();

--- a/scripts/sofifa-scraper/manifest.json
+++ b/scripts/sofifa-scraper/manifest.json
@@ -1,0 +1,12 @@
+{
+  "manifest_version": 3,
+  "name": "SoFIFA Squad Scraper",
+  "version": "1.0.0",
+  "description": "Scrape squad data (overall, potential, value, yearly wage) from a SoFIFA team or league page into one JSON file.",
+  "permissions": ["scripting", "activeTab", "downloads"],
+  "host_permissions": ["https://sofifa.com/*"],
+  "action": {
+    "default_popup": "popup.html",
+    "default_title": "SoFIFA Squad Scraper"
+  }
+}

--- a/scripts/sofifa-scraper/popup.html
+++ b/scripts/sofifa-scraper/popup.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <style>
+    body { font: 13px/1.4 system-ui, sans-serif; width: 300px; margin: 0; padding: 14px; }
+    h1 { font-size: 14px; margin: 0 0 4px; }
+    .sub { color: #666; margin: 0 0 12px; font-size: 12px; }
+    button { width: 100%; padding: 9px; font-size: 13px; border: 0; border-radius: 6px;
+             background: #1d6fe0; color: #fff; cursor: pointer; }
+    button:disabled { background: #9bb8e0; cursor: default; }
+    #status { margin-top: 10px; font-size: 12px; color: #333; min-height: 16px; white-space: pre-wrap; }
+    .bar { height: 6px; background: #eee; border-radius: 3px; margin-top: 8px; overflow: hidden; display: none; }
+    .bar > div { height: 100%; width: 0; background: #1d6fe0; transition: width .15s; }
+    .err { color: #c0392b; }
+  </style>
+</head>
+<body>
+  <h1>SoFIFA Squad Scraper</h1>
+  <p class="sub" id="pageType">Detecting page…</p>
+  <button id="go" disabled>Scrape</button>
+  <div class="bar"><div id="fill"></div></div>
+  <div id="status"></div>
+  <script src="popup.js"></script>
+</body>
+</html>

--- a/scripts/sofifa-scraper/popup.js
+++ b/scripts/sofifa-scraper/popup.js
@@ -1,0 +1,110 @@
+const goBtn = document.getElementById("go");
+const statusEl = document.getElementById("status");
+const pageTypeEl = document.getElementById("pageType");
+const bar = document.querySelector(".bar");
+const fill = document.getElementById("fill");
+
+let currentTab = null;
+
+function setStatus(msg, isErr) {
+  statusEl.textContent = msg;
+  statusEl.className = isErr ? "err" : "";
+}
+
+function sanitize(name) {
+  return name.replace(/[\\/:*?"<>|]+/g, "_").trim() || "sofifa";
+}
+
+// Detect page type on open
+(async () => {
+  const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+  currentTab = tab;
+  const url = tab?.url || "";
+  if (/sofifa\.com\/team\//.test(url)) {
+    pageTypeEl.textContent = "Team page detected — scrapes this team.";
+    goBtn.disabled = false;
+    goBtn.textContent = "Scrape team";
+  } else if (/sofifa\.com\/league\//.test(url)) {
+    pageTypeEl.textContent = "League page detected — scrapes all teams.";
+    goBtn.disabled = false;
+    goBtn.textContent = "Scrape league";
+  } else {
+    pageTypeEl.textContent = "Open a SoFIFA team or league page.";
+    goBtn.disabled = true;
+  }
+})();
+
+// Poll page-context progress while a league scrape runs
+async function pollProgress() {
+  try {
+    const [res] = await chrome.scripting.executeScript({
+      target: { tabId: currentTab.id },
+      func: () => window.__sofifaProgress || null,
+    });
+    const p = res?.result;
+    if (p && p.total) {
+      bar.style.display = "block";
+      fill.style.width = Math.round((p.done / p.total) * 100) + "%";
+      setStatus(
+        p.current
+          ? `Fetching ${p.done + 1}/${p.total}: ${p.current}…`
+          : `Finalizing ${p.done}/${p.total}…`
+      );
+    }
+  } catch (_) {}
+}
+
+goBtn.addEventListener("click", async () => {
+  goBtn.disabled = true;
+  setStatus("Starting…");
+  bar.style.display = "none";
+  fill.style.width = "0";
+
+  const poller = setInterval(pollProgress, 400);
+
+  try {
+    const [exec] = await chrome.scripting.executeScript({
+      target: { tabId: currentTab.id },
+      files: ["scraper.js"],
+    });
+    // scraper.js defines scrapeSoFIFA(); now call it and await the result
+    const [out] = await chrome.scripting.executeScript({
+      target: { tabId: currentTab.id },
+      func: () => scrapeSoFIFA(),
+    });
+    clearInterval(poller);
+
+    const result = out?.result;
+    if (!result || !result.ok) {
+      setStatus(result?.error || "Scrape failed.", true);
+      goBtn.disabled = false;
+      return;
+    }
+
+    const data = result.data;
+    const fileBase =
+      result.kind === "league" ? data.league : data.team;
+    const json = JSON.stringify(data, null, 2);
+    const blob = new Blob([json], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+
+    await chrome.downloads.download({
+      url,
+      filename: sanitize(fileBase) + ".json",
+      saveAs: true,
+    });
+
+    const summary =
+      result.kind === "league"
+        ? `Done: ${data.team_count} teams, ${data.total_players} players.`
+        : `Done: ${data.player_count} players.`;
+    setStatus(summary);
+    fill.style.width = "100%";
+    bar.style.display = "block";
+  } catch (e) {
+    clearInterval(poller);
+    setStatus("Error: " + (e?.message || e), true);
+  } finally {
+    goBtn.disabled = false;
+  }
+});

--- a/scripts/sofifa-scraper/scraper.js
+++ b/scripts/sofifa-scraper/scraper.js
@@ -1,0 +1,137 @@
+// Injected into the sofifa.com page context. Returns the assembled dataset.
+// `mode` is "team" or "league". Progress is reported via window.postMessage
+// which popup.js listens for through chrome.scripting executeScript return polling.
+async function scrapeSoFIFA() {
+  const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+  function parseMoney(s) {
+    if (!s) return null;
+    s = s.trim().replace(/[€$£,\s]/g, "");
+    if (!s || s === "-") return null;
+    let mult = 1;
+    const last = s.slice(-1).toUpperCase();
+    if (last === "M") { mult = 1e6; s = s.slice(0, -1); }
+    else if (last === "K") { mult = 1e3; s = s.slice(0, -1); }
+    else if (last === "B") { mult = 1e9; s = s.slice(0, -1); }
+    const n = parseFloat(s);
+    return isNaN(n) ? null : Math.round(n * mult);
+  }
+
+  function detectCurrency(s) {
+    const m = (s || "").match(/[€$£]/);
+    return m ? m[0] : null;
+  }
+
+  // The team sidebar lists club-level facts as
+  // `<li><label>Transfer budget</label> €77.5M</li>`. Pull the text that
+  // follows the matching label within its <li> (works whether the value is a
+  // bare text node, an <em>, or an <a>).
+  function teamInfoValue(doc, labelText) {
+    const target = labelText.toLowerCase();
+    const label = [...doc.querySelectorAll("li label")].find(
+      (l) => l.textContent.trim().toLowerCase() === target
+    );
+    const li = label && label.closest("li");
+    if (!li) return null;
+    return li.textContent.replace(label.textContent, "").trim() || null;
+  }
+
+  // Parsed transfer budget for the team page held in `doc` (null if absent).
+  function parseTransferBudget(doc) {
+    return parseMoney(teamInfoValue(doc, "Transfer budget"));
+  }
+
+  function parsePlayers(doc) {
+    return [...doc.querySelectorAll("table tbody tr")].map((tr) => {
+      const td = tr.querySelectorAll("td");
+      if (td.length < 8) return null;
+      const link =
+        td[1].querySelector("a[data-tippy-content]") || td[1].querySelector("a");
+      const full_name = (
+        (link && link.getAttribute("data-tippy-content")) ||
+        (link ? link.innerText : td[1].innerText)
+      ).trim();
+      const name = (link ? link.innerText : td[1].innerText).trim();
+      const weekly = parseMoney(td[7].innerText);
+      return {
+        full_name,
+        name,
+        overall_score: parseInt(td[3].innerText.trim(), 10),
+        potential: parseInt(td[4].innerText.trim(), 10),
+        value: parseMoney(td[6].innerText),
+        yearly_wage: weekly == null ? null : weekly * 52,
+        currency:
+          detectCurrency(td[6].innerText) || detectCurrency(td[7].innerText),
+      };
+    }).filter((p) => p && p.name && !isNaN(p.overall_score));
+  }
+
+  const path = location.pathname;
+  const title = (document.querySelector("h1")?.innerText ||
+    document.title.split(" - ")[0]).trim();
+
+  // ---- TEAM PAGE ----
+  if (/^\/team\//.test(path)) {
+    const players = parsePlayers(document);
+    return {
+      ok: true,
+      kind: "team",
+      data: {
+        team: title,
+        url: location.origin + path,
+        scraped_at: new Date().toISOString(),
+        transfer_budget: parseTransferBudget(document),
+        player_count: players.length,
+        players,
+      },
+    };
+  }
+
+  // ---- LEAGUE PAGE ----
+  if (/^\/league\//.test(path)) {
+    const links = [...document.querySelectorAll("a[href]")]
+      .map((a) => ({ name: a.textContent.trim(), href: a.getAttribute("href") }))
+      .filter((l) => /^\/team\/\d+\//.test(l.href) && l.name);
+    const teams = [
+      ...new Map(links.map((l) => [l.href.split("?")[0], l])).values(),
+    ].map((l) => ({ name: l.name, href: l.href.split("?")[0] }));
+
+    const results = [];
+    for (let i = 0; i < teams.length; i++) {
+      const t = teams[i];
+      window.__sofifaProgress = { done: i, total: teams.length, current: t.name };
+      try {
+        const res = await fetch(t.href, { credentials: "same-origin" });
+        const html = await res.text();
+        const doc = new DOMParser().parseFromString(html, "text/html");
+        const players = parsePlayers(doc);
+        results.push({
+          team: t.name,
+          url: location.origin + t.href,
+          transfer_budget: parseTransferBudget(doc),
+          player_count: players.length,
+          players,
+        });
+      } catch (e) {
+        results.push({ team: t.name, error: String(e && e.message || e) });
+      }
+      await sleep(350); // polite rate-limiting
+    }
+    window.__sofifaProgress = { done: teams.length, total: teams.length, current: "" };
+
+    const total_players = results.reduce((s, r) => s + (r.player_count || 0), 0);
+    return {
+      ok: true,
+      kind: "league",
+      data: {
+        league: title,
+        scraped_at: new Date().toISOString(),
+        team_count: results.length,
+        total_players,
+        teams: results,
+      },
+    };
+  }
+
+  return { ok: false, error: "Not a SoFIFA team or league page." };
+}


### PR DESCRIPTION
## What

Adds `scripts/apply-sofifa-ratings.mjs`, which links scraped SoFIFA player records (`sofifa.json`) to the canonical squad data (`teams.json`) by **team + name**, copying four fields onto each matched player:

- `overall_score`, `potential` — honored by `GamePlayerTemplateService::prepareTemplateRow` when present, so hand-rated abilities replace the market-value heuristic
- `value`, `yearly_wage` — carried through for reference / future use

Applies it to ESP2 (`data/2025/ESP2/teams.json`) and commits the `sofifa.json` source so the result is reproducible.

## How matching works

Modeled on the existing `scripts/apply-wc-ratings.mjs` (reuses its normalization, serialization, and validation helpers).

- **Teams** resolve via a normalized "core" name (strips club prefixes/suffixes like `RC` / `Real` / `de Fútbol`), so `Real Sporting de Gijón` ↔ `Sporting Gijón` etc. — **22/22** clubs resolved.
- **Players** match per team in three claiming passes (no sofifa player serves two squad players):
  1. exact normalized name
  2. token-subset (either direction)
  3. unique-surname fallback with a first-initial check — recovers diminutives (Dani↔Daniel, Nico↔Nicolás) without cross-team mislinks
- **Unmatched players** are a non-fatal warning; they keep their fields and fall back to the importer's market-value ability heuristic.

The script auto-discovers any `data/**/sofifa.json` beside a `teams.json`, rewrites in place using the file's sorted-key / 2-space formatting (only the four fields are added per player; the file header is untouched), and is idempotent. Supports `--dry-run` and an optional directory arg.

## Result

**559/566** ESP2 players augmented. The 7 left unmatched are correct to skip: 5 are genuinely absent from SoFIFA, and 2 are safe declines (Ignacio↔Nacho Laquintana — initials differ; Álex Calatrava — SoFIFA lists his second surname last).

## Verification

- `node scripts/apply-sofifa-ratings.mjs --dry-run` — reports 559/566, 0 unresolved clubs
- Re-running produces a byte-identical file (idempotent)
- `teams.json` remains valid JSON; diff is only the four per-player keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)