### PR TITLE
Fixes #1230 Fix substitution wrongly blocked by a not-yet-revealed red card

### DIFF
--- a/app/Modules/Lineup/Services/SubstitutionService.php
+++ b/app/Modules/Lineup/Services/SubstitutionService.php
@@ -7,6 +7,8 @@ use App\Models\GameMatch;
 use App\Models\GamePlayer;
 use App\Models\MatchEvent;
 use App\Models\PlayerSuspension;
+use App\Modules\Match\Support\MinuteCoordinates;
+use App\Modules\Match\Support\StoppageDurations;
 
 class SubstitutionService
 {
@@ -66,12 +68,30 @@ class SubstitutionService
         // Pre-load all suspended player IDs for this competition (single query)
         $suspendedPlayerIds = PlayerSuspension::suspendedPlayerIdsForCompetition($match->game_id, $match->competition_id);
 
-        // Pre-load red-carded player IDs up to this minute (single query instead of N)
+        // Pre-load red-carded player IDs that have ALREADY occurred by this
+        // minute (single query instead of N). The submission `$minute` is an
+        // absolute clock minute (the live UI's currentMinute), but
+        // MatchEvent.minute is the phase-relative base minute (1-45, 46-90, …)
+        // with stoppage held separately in stoppage_minute — the two systems
+        // differ by the accumulated stoppage offset. Comparing the raw column
+        // against the absolute minute counts a not-yet-revealed red card as
+        // already shown: a 50' second-half red is absolute minute 50+fhs, so a
+        // sub at absolute 51 would wrongly see it and block with "sent off"
+        // (#1230). Convert each red to its absolute minute the same way the
+        // live feed does (MatchResimulationService::formatMatchEvents) so the
+        // server's notion of "elapsed" matches what the user has actually seen.
         $playerOutIds = array_column($newSubstitutions, 'playerOutId');
+        $stoppage = StoppageDurations::fromMatch($match);
         $redCardedPlayerIds = MatchEvent::where('game_match_id', $match->id)
             ->whereIn('game_player_id', $playerOutIds)
             ->where('event_type', 'red_card')
-            ->where('minute', '<=', $minute)
+            ->get(['game_player_id', 'phase', 'minute', 'stoppage_minute'])
+            ->filter(fn (MatchEvent $e) => MinuteCoordinates::toAbsoluteWith(
+                $e->phase,
+                $e->minute,
+                $e->stoppage_minute,
+                $stoppage,
+            ) <= $minute)
             ->pluck('game_player_id')
             ->all();
 

--- a/tests/Unit/SubstitutionRedCardMinuteTest.php
+++ b/tests/Unit/SubstitutionRedCardMinuteTest.php
@@ -1,0 +1,157 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\Game;
+use App\Models\GameMatch;
+use App\Models\GamePlayer;
+use App\Models\MatchEvent;
+use App\Models\Team;
+use App\Modules\Lineup\Services\SubstitutionService;
+use App\Modules\Match\Enums\MatchPhase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use Tests\Traits\CreatesLineups;
+
+/**
+ * Regression for #1230: a substitution was wrongly blocked as "player sent
+ * off" when the red card was pre-simulated but not yet revealed in the live
+ * feed.
+ *
+ * The validator compared the persisted MatchEvent.minute (phase-relative base
+ * minute) against the submission minute (absolute clock minute). The two
+ * coordinate systems differ by the accumulated stoppage offset, so a second-
+ * half red at base minute 50 (absolute 50 + first_half_stoppage) was treated
+ * as already elapsed by a sub made at an earlier absolute minute.
+ */
+class SubstitutionRedCardMinuteTest extends TestCase
+{
+    use RefreshDatabase;
+    use CreatesLineups;
+
+    private SubstitutionService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = new SubstitutionService;
+    }
+
+    /**
+     * Build a match where the user's team is home, with a configurable
+     * first-half stoppage, a red card recorded for one starter, and a bench
+     * player available to bring on.
+     *
+     * @return array{0: Game, 1: GameMatch, 2: GamePlayer, 3: GamePlayer}
+     */
+    private function makeScenario(MatchPhase $redPhase, int $redBaseMinute, int $firstHalfStoppage): array
+    {
+        $team = Team::factory()->create();
+        $opponent = Team::factory()->create();
+        $game = Game::factory()->forTeam($team)->create(['current_date' => '2025-10-01']);
+
+        $lineup = $this->createLineup($game, $team, 11, 75);
+
+        $match = GameMatch::factory()
+            ->forGame($game)
+            ->between($team, $opponent)
+            ->create([
+                'first_half_stoppage' => $firstHalfStoppage,
+                'second_half_stoppage' => 3,
+                'home_lineup' => $lineup->pluck('id')->all(),
+            ]);
+
+        $sentOff = $lineup[7]; // Defensive Midfield starter
+
+        MatchEvent::create([
+            'game_id' => $game->id,
+            'game_match_id' => $match->id,
+            'team_id' => $team->id,
+            'game_player_id' => $sentOff->id,
+            'event_type' => 'red_card',
+            'phase' => $redPhase,
+            'minute' => $redBaseMinute,
+            'stoppage_minute' => null,
+        ]);
+
+        $bench = GamePlayer::factory()
+            ->forGame($game)
+            ->forTeam($team)
+            ->create([
+                'position' => 'Defensive Midfield',
+                'number' => 99,
+                'injury_until' => null,
+            ]);
+
+        return [$game, $match, $sentOff, $bench];
+    }
+
+    private function sub(GamePlayer $out, GamePlayer $in): array
+    {
+        return [['playerOutId' => $out->id, 'playerInId' => $in->id]];
+    }
+
+    public function test_second_half_red_is_not_counted_before_its_absolute_minute(): void
+    {
+        // Red at base minute 50 + 3' first-half stoppage = absolute minute 53.
+        [$game, $match, $sentOff, $bench] = $this->makeScenario(MatchPhase::SECOND_HALF, 50, 3);
+
+        // Sub at absolute minute 51 — the red (absolute 53) has not been
+        // revealed yet, so it must NOT block the substitution.
+        $this->service->validateBatchSubstitution(
+            $match,
+            $game,
+            $this->sub($sentOff, $bench),
+            51,
+            [],
+        );
+
+        // No exception thrown == the sub is allowed.
+        $this->addToAssertionCount(1);
+    }
+
+    public function test_second_half_red_blocks_at_or_after_its_absolute_minute(): void
+    {
+        [$game, $match, $sentOff, $bench] = $this->makeScenario(MatchPhase::SECOND_HALF, 50, 3);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('game.sub_error_player_sent_off');
+
+        // Sub at absolute minute 55 (>= 53) — the red is now elapsed, block it.
+        $this->service->validateBatchSubstitution(
+            $match,
+            $game,
+            $this->sub($sentOff, $bench),
+            55,
+            [],
+        );
+    }
+
+    public function test_first_half_red_still_blocks_correctly(): void
+    {
+        // First-half phase has no stoppage offset, so base == absolute.
+        [$game, $match, $sentOff, $bench] = $this->makeScenario(MatchPhase::FIRST_HALF, 30, 3);
+
+        // Before the red: allowed.
+        $this->service->validateBatchSubstitution(
+            $match,
+            $game,
+            $this->sub($sentOff, $bench),
+            29,
+            [],
+        );
+        $this->addToAssertionCount(1);
+
+        // At/after the red: blocked.
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('game.sub_error_player_sent_off');
+
+        $this->service->validateBatchSubstitution(
+            $match,
+            $game,
+            $this->sub($sentOff, $bench),
+            31,
+            [],
+        );
+    }
+}


### PR DESCRIPTION
The live match is fully pre-simulated and then revealed minute by minute. Substitution validation compared the persisted MatchEvent.minute (the phase-relative base minute: 1-45, 46-90, with stoppage held separately in stoppage_minute) against the submission minute, which is an absolute clock minute (the live UI's currentMinute). The two coordinate systems differ by the accumulated stoppage offset, so a second-half red at base minute 50 has absolute minute 50 + first_half_stoppage. A substitution made at an earlier absolute minute then saw the red as already elapsed and blocked it as "player sent off", even though the red had not yet been revealed in the feed.

Convert each red card to its absolute minute via MinuteCoordinates the same way the live feed does (MatchResimulationService::formatMatchEvents), so the server's notion of "elapsed" matches what the user has actually seen. Still a single query; the absolute filter runs in memory over the tiny red-card set.

Adds unit coverage for the second-half offset case and a first-half regression guard.

Fixes #1230