### PR TITLE
Enforce release clause as forced buyout on spontaneous offers

### DIFF
--- a/app/Http/Actions/RejectTransferOffer.php
+++ b/app/Http/Actions/RejectTransferOffer.php
@@ -33,6 +33,19 @@ class RejectTransferOffer
             abort(403, 'Cannot reject offers for loaned players.');
         }
 
+        // A bid that meets the release clause is a forced buyout — the user has no
+        // veto. New clause-meeting offers are created as forced sales upstream and
+        // never reach this action, but this guards any pre-existing pending offer.
+        if ($game->release_clauses_enabled
+            && $offer->gamePlayer->hasReleaseClause()
+            && $offer->transfer_fee >= (int) $offer->gamePlayer->release_clause) {
+            return redirect()
+                ->route('game.transfers.outgoing', $gameId)
+                ->with('error', __('messages.cannot_reject_release_clause_offer', [
+                    'player' => $offer->gamePlayer->name,
+                ]));
+        }
+
         $team = $offer->offeringTeam;
 
         $this->transferService->rejectOffer($offer);

--- a/app/Modules/Match/Services/CareerActionProcessor.php
+++ b/app/Modules/Match/Services/CareerActionProcessor.php
@@ -112,7 +112,11 @@ class CareerActionProcessor
             : self::LISTED_OFFER_CHANCE_OUTSIDE_WINDOW;
         $listedOffers = $this->transferService->generateOffersForListedPlayers($game, buyerPool: $buyerPool, offerChance: $listedOfferChance);
         foreach ($listedOffers as $offer) {
-            $this->notificationService->notifyTransferOffer($game, $offer);
+            // A listed-player offer that reached the buyout is a forced sale, not a
+            // negotiable bid — announce it as a clause loss, not a routine offer.
+            $offer->triggered_release_clause
+                ? $this->notificationService->notifyPlayerLeftViaReleaseClause($game, $offer)
+                : $this->notificationService->notifyTransferOffer($game, $offer);
         }
         $mark('listed_offers');
 
@@ -120,7 +124,11 @@ class CareerActionProcessor
         if ($game->isTransferWindowOpen()) {
             $unsolicitedOffers = $this->transferService->generateUnsolicitedOffers($game, buyerPool: $buyerPool);
             foreach ($unsolicitedOffers as $offer) {
-                $this->notificationService->notifyTransferOffer($game, $offer);
+                // An unsolicited offer that reached the buyout is a forced sale, not a
+                // negotiable bid — announce it as a clause loss, not a routine offer.
+                $offer->triggered_release_clause
+                    ? $this->notificationService->notifyPlayerLeftViaReleaseClause($game, $offer)
+                    : $this->notificationService->notifyTransferOffer($game, $offer);
             }
 
             // AI clubs may (rarely) trigger the release clause on one of the

--- a/app/Modules/Transfer/Services/TransferService.php
+++ b/app/Modules/Transfer/Services/TransferService.php
@@ -892,14 +892,48 @@ class TransferService
         $desire = $this->squadNeedService->desireScore($buyerRoster, $player);
         $transferFee = $this->calculateOfferPrice($player, $desire, $offeringTeam->id);
 
-        // A club never opens above the buyout — it would just pay the clause instead.
-        if ($player->game->release_clauses_enabled && $player->hasReleaseClause()) {
-            $transferFee = min($transferFee, (int) $player->release_clause);
-        }
-
+        $game = $player->game;
         $expiryDays = $offerType === TransferOffer::TYPE_LISTED
             ? self::LISTED_OFFER_EXPIRY_DAYS
             : self::UNSOLICITED_OFFER_EXPIRY_DAYS;
+
+        // A club willing to meet (or exceed) the buyout doesn't open a negotiable
+        // bid — it pays the clause and force-buys. So when the desire-driven price
+        // reaches the clause, the spontaneous offer becomes a non-consensual forced
+        // sale, mirroring generateAIReleaseClauseTriggers: created straight at
+        // STATUS_AGREED with the clause flag set, so the user can't reject it and it
+        // completes through the normal outgoing pipeline. (The clause is below market
+        // value whenever this binds, and the buyer already cleared market-value
+        // affordability, so it can afford the buyout.)
+        if ($game->release_clauses_enabled && $player->hasReleaseClause()) {
+            $clauseCents = (int) $player->release_clause;
+
+            if ($transferFee >= $clauseCents) {
+                return DB::transaction(function () use ($game, $player, $offeringTeam, $offerType, $clauseCents, $expiryDays) {
+                    // Replicate acceptOffer's sibling-rejection so no stale pending
+                    // offer survives the forced sale.
+                    TransferOffer::where('game_player_id', $player->id)
+                        ->where('status', TransferOffer::STATUS_PENDING)
+                        ->update(['status' => TransferOffer::STATUS_REJECTED, 'resolved_at' => $game->current_date]);
+
+                    return TransferOffer::create([
+                        'id' => Str::uuid()->toString(),
+                        'game_id' => $player->game_id,
+                        'game_player_id' => $player->id,
+                        'offering_team_id' => $offeringTeam->id,
+                        'selling_team_id' => $player->team_id,
+                        'offer_type' => $offerType,
+                        'direction' => TransferOffer::DIRECTION_OUTGOING,
+                        'transfer_fee' => $clauseCents,
+                        'status' => TransferOffer::STATUS_AGREED,
+                        'triggered_release_clause' => true,
+                        'expires_at' => Carbon::parse($game->current_date)->addDays($expiryDays),
+                        'game_date' => $game->current_date,
+                        'resolved_at' => $game->current_date,
+                    ]);
+                });
+            }
+        }
 
         return TransferOffer::create([
             'id' => Str::uuid()->toString(),
@@ -909,8 +943,8 @@ class TransferService
             'offer_type' => $offerType,
             'transfer_fee' => $transferFee,
             'status' => TransferOffer::STATUS_PENDING,
-            'expires_at' => Carbon::parse($player->game->current_date)->addDays($expiryDays),
-            'game_date' => $player->game->current_date,
+            'expires_at' => Carbon::parse($game->current_date)->addDays($expiryDays),
+            'game_date' => $game->current_date,
         ]);
     }
 

--- a/lang/en/messages.php
+++ b/lang/en/messages.php
@@ -9,6 +9,7 @@ return [
     'player_unlisted' => ':player removed from the transfer list.',
     'cannot_sell_same_window' => 'Cannot sell :player — they were signed recently and can\'t be transferred yet.',
     'offer_rejected' => ':team_de offer rejected.',
+    'cannot_reject_release_clause_offer' => 'You can\'t reject this offer — it meets :player\'s release clause, so the sale is mandatory.',
     'offer_accepted_sale' => ':player sold :team_a for :fee.',
     'offer_accepted_pre_contract' => 'Deal agreed! :player will sign for :team for :fee when the :window window opens.',
     'offer_accepted_intra_window' => 'Deal agreed! :player will leave for :team for :fee after the next match.',

--- a/lang/es/messages.php
+++ b/lang/es/messages.php
@@ -9,6 +9,7 @@ return [
     'player_unlisted' => ':player retirado de la lista de fichajes.',
     'cannot_sell_same_window' => 'No se puede vender a :player — fue fichado recientemente y aún no puede ser traspasado.',
     'offer_rejected' => 'Oferta :team_de rechazada.',
+    'cannot_reject_release_clause_offer' => 'No puedes rechazar esta oferta — alcanza la cláusula de rescisión de :player, así que la venta es obligatoria.',
     'offer_accepted_sale' => ':player vendido :team_a por :fee.',
     'offer_accepted_pre_contract' => '¡Acuerdo cerrado! :player fichará por :team por :fee cuando abra la ventana de :window.',
     'offer_accepted_intra_window' => '¡Acuerdo cerrado! :player se marchará :team_a por :fee tras el próximo partido.',

--- a/tests/Feature/RejectReleaseClauseOfferTest.php
+++ b/tests/Feature/RejectReleaseClauseOfferTest.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Competition;
+use App\Models\Game;
+use App\Models\GamePlayer;
+use App\Models\Team;
+use App\Models\TransferOffer;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Defensive guard on RejectTransferOffer: a pending offer that meets the player's
+ * release clause is a forced buyout the user can't veto. New clause-meeting offers
+ * are created as forced sales upstream, but this protects any pre-existing pending
+ * offer sitting at the clause value.
+ */
+class RejectReleaseClauseOfferTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const CLAUSE = 50_000_000_00; // €50M
+
+    private User $user;
+    private Game $game;
+    private Team $userTeam;
+    private Team $buyer;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = User::factory()->create();
+        $this->userTeam = Team::factory()->create();
+        $this->buyer = Team::factory()->create();
+        Competition::factory()->league()->create(['id' => 'ESP1', 'name' => 'LaLiga']);
+
+        $this->game = Game::factory()->create([
+            'user_id' => $this->user->id,
+            'team_id' => $this->userTeam->id,
+            'competition_id' => 'ESP1',
+            'current_date' => '2025-08-01',
+            'release_clauses_enabled' => true,
+        ]);
+    }
+
+    public function test_cannot_reject_a_pending_offer_that_meets_the_clause(): void
+    {
+        $offer = $this->offer(self::CLAUSE);
+
+        $response = $this->actingAs($this->user)->post(
+            route('game.transfers.reject', [$this->game->id, $offer->id]),
+        );
+
+        $response->assertRedirect(route('game.transfers.outgoing', $this->game->id));
+        $response->assertSessionHas('error');
+        $this->assertSame(TransferOffer::STATUS_PENDING, $offer->fresh()->status);
+    }
+
+    public function test_can_still_reject_an_offer_below_the_clause(): void
+    {
+        $offer = $this->offer(self::CLAUSE - 1_00);
+
+        $this->actingAs($this->user)->post(
+            route('game.transfers.reject', [$this->game->id, $offer->id]),
+        );
+
+        $this->assertSame(TransferOffer::STATUS_REJECTED, $offer->fresh()->status);
+    }
+
+    private function offer(int $transferFeeCents): TransferOffer
+    {
+        $player = GamePlayer::factory()->forGame($this->game)->forTeam($this->userTeam)->create([
+            'release_clause' => self::CLAUSE,
+            'market_value_cents' => self::CLAUSE,
+        ]);
+
+        return TransferOffer::create([
+            'game_id' => $this->game->id,
+            'game_player_id' => $player->id,
+            'offering_team_id' => $this->buyer->id,
+            'selling_team_id' => $this->userTeam->id,
+            'offer_type' => TransferOffer::TYPE_UNSOLICITED,
+            'direction' => TransferOffer::DIRECTION_OUTGOING,
+            'transfer_fee' => $transferFeeCents,
+            'status' => TransferOffer::STATUS_PENDING,
+            'expires_at' => '2025-08-31',
+            'game_date' => '2025-08-01',
+        ]);
+    }
+}

--- a/tests/Feature/ReleaseClauseSpontaneousOfferTest.php
+++ b/tests/Feature/ReleaseClauseSpontaneousOfferTest.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Competition;
+use App\Models\Game;
+use App\Models\GamePlayer;
+use App\Models\Team;
+use App\Models\TransferOffer;
+use App\Models\User;
+use App\Modules\Transfer\Services\TransferService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use ReflectionMethod;
+use Tests\TestCase;
+
+/**
+ * A spontaneous incoming offer (unsolicited or listed) whose desire-driven price
+ * reaches the player's release clause is a forced buyout, not a negotiable bid:
+ * createOffer must produce it straight at STATUS_AGREED with the clause flag set,
+ * so the user can't reject it and it completes through the normal outgoing
+ * pipeline — mirroring generateAIReleaseClauseTriggers. Below the clause it stays
+ * a normal, rejectable PENDING offer. Guards the bug where such an offer arrived
+ * PENDING and could be rejected.
+ */
+class ReleaseClauseSpontaneousOfferTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const MV = 10_000_000_00; // €10M
+
+    private TransferService $transferService;
+    private Game $game;
+    private Team $userTeam;
+    private Team $buyer;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->transferService = app(TransferService::class);
+
+        $user = User::factory()->create();
+        $this->userTeam = Team::factory()->create();
+        $this->buyer = Team::factory()->create();
+        Competition::factory()->league()->create(['id' => 'ESP1', 'name' => 'LaLiga']);
+
+        $this->game = Game::factory()->create([
+            'user_id' => $user->id,
+            'team_id' => $this->userTeam->id,
+            'competition_id' => 'ESP1',
+            'current_date' => '2025-08-01',
+            'release_clauses_enabled' => true,
+        ]);
+
+        // A small squad for the buyer so calculateOfferPrice has a roster to read.
+        GamePlayer::factory()->forGame($this->game)->forTeam($this->buyer)->count(3)->create([
+            'position' => 'Centre-Forward',
+            'overall_score' => 60,
+        ]);
+    }
+
+    public function test_offer_meeting_the_clause_is_a_forced_agreed_sale(): void
+    {
+        // Clause of €1 — any plausible offer price clears it, so the cap binds and
+        // the spontaneous offer becomes a forced sale.
+        $clause = 1_00;
+        $player = $this->userPlayer(['release_clause' => $clause]);
+
+        $offer = $this->createOffer($player, TransferOffer::TYPE_UNSOLICITED);
+
+        $this->assertSame(TransferOffer::STATUS_AGREED, $offer->status);
+        $this->assertTrue((bool) $offer->triggered_release_clause);
+        $this->assertSame($clause, (int) $offer->transfer_fee);
+        $this->assertSame(TransferOffer::DIRECTION_OUTGOING, $offer->direction);
+        $this->assertSame($this->userTeam->id, $offer->selling_team_id);
+        $this->assertSame($this->buyer->id, $offer->offering_team_id);
+        $this->assertNotNull($offer->resolved_at);
+    }
+
+    public function test_offer_below_the_clause_stays_a_normal_rejectable_offer(): void
+    {
+        // Clause far above any opening price — the cap never binds.
+        $player = $this->userPlayer(['release_clause' => 1_000_000_000_00]);
+
+        $offer = $this->createOffer($player, TransferOffer::TYPE_UNSOLICITED);
+
+        $this->assertSame(TransferOffer::STATUS_PENDING, $offer->status);
+        $this->assertFalse((bool) $offer->triggered_release_clause);
+        $this->assertLessThan((int) $player->release_clause, (int) $offer->transfer_fee);
+    }
+
+    public function test_forced_sale_rejects_sibling_pending_offers(): void
+    {
+        $player = $this->userPlayer(['release_clause' => 1_00]);
+
+        $otherBuyer = Team::factory()->create();
+        $stale = TransferOffer::create([
+            'game_id' => $this->game->id,
+            'game_player_id' => $player->id,
+            'offering_team_id' => $otherBuyer->id,
+            'selling_team_id' => $this->userTeam->id,
+            'offer_type' => TransferOffer::TYPE_UNSOLICITED,
+            'direction' => TransferOffer::DIRECTION_OUTGOING,
+            'transfer_fee' => self::MV,
+            'status' => TransferOffer::STATUS_PENDING,
+            'expires_at' => '2025-08-31',
+            'game_date' => '2025-08-01',
+        ]);
+
+        $this->createOffer($player, TransferOffer::TYPE_UNSOLICITED);
+
+        $this->assertSame(TransferOffer::STATUS_REJECTED, $stale->fresh()->status);
+    }
+
+    public function test_feature_disabled_never_forces_a_sale(): void
+    {
+        $this->game->update(['release_clauses_enabled' => false]);
+        $player = $this->userPlayer(['release_clause' => 1_00]);
+
+        $offer = $this->createOffer($player, TransferOffer::TYPE_UNSOLICITED);
+
+        $this->assertSame(TransferOffer::STATUS_PENDING, $offer->status);
+        $this->assertFalse((bool) $offer->triggered_release_clause);
+    }
+
+    private function userPlayer(array $overrides = []): GamePlayer
+    {
+        return GamePlayer::factory()->forGame($this->game)->forTeam($this->userTeam)->create(array_merge([
+            'position' => 'Central Midfield',
+            'overall_score' => 80,
+            'market_value_cents' => self::MV,
+        ], $overrides));
+    }
+
+    private function createOffer(GamePlayer $player, string $offerType): TransferOffer
+    {
+        $method = new ReflectionMethod($this->transferService, 'createOffer');
+        $method->setAccessible(true);
+
+        return $method->invoke($this->transferService, $player, $this->buyer, $offerType);
+    }
+}


### PR DESCRIPTION
## Summary

When a spontaneous transfer offer (unsolicited or listed) reaches a player's release clause, it becomes a non-negotiable forced buyout rather than a rejectable bid. This PR implements that mechanic: offers meeting the clause are created directly in `STATUS_AGREED` with the `triggered_release_clause` flag set, mirroring the existing AI release clause trigger behavior. It also adds defensive guards to prevent users from rejecting clause-meeting offers that may already exist as pending bids.

## Key Changes

- **TransferService.createOffer()**: When an offer's desire-driven price reaches the release clause, create it as a forced sale (`STATUS_AGREED`, `triggered_release_clause=true`, `resolved_at` set) instead of a negotiable `PENDING` bid. Reject any sibling pending offers on the same player to prevent stale competing bids. The forced sale completes through the normal outgoing pipeline without user intervention.

- **RejectTransferOffer action**: Added a guard to prevent rejection of any pending offer that meets the player's release clause, protecting against pre-existing pending offers that should be treated as forced buyouts.

- **CareerActionProcessor**: Updated notification routing for listed and unsolicited offers—those with `triggered_release_clause=true` now notify via `notifyPlayerLeftViaReleaseClause()` (clause loss) instead of `notifyTransferOffer()` (routine offer).

- **Localization**: Added `cannot_reject_release_clause_offer` message key in English and Spanish.

## Implementation Details

- The forced-sale logic is wrapped in a database transaction to ensure atomicity when rejecting sibling offers.
- The clause cap only applies when `release_clauses_enabled=true` on the game; below that threshold or with the feature disabled, offers remain normal `PENDING` bids.
- Clause-meeting offers are resolved immediately (`resolved_at = current_date`) and bypass the normal expiry window, preventing them from lingering as open bids.

## Tests

Two new feature test suites validate the behavior:
- `ReleaseClauseSpontaneousOfferTest`: Verifies forced-sale creation, sibling rejection, and feature-flag behavior.
- `RejectReleaseClauseOfferTest`: Confirms the rejection guard blocks clause-meeting offers while allowing below-clause rejections.

https://claude.ai/code/session_011T7wVkwX5cNhkWjuNLECb7