### PR TITLE
Distribution-derived per-competition match strength floor

### DIFF
--- a/app/Console/Commands/DiagnoseStrengthRealism.php
+++ b/app/Console/Commands/DiagnoseStrengthRealism.php
@@ -1,0 +1,708 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\CompetitionEntry;
+use App\Models\Game;
+use App\Models\GamePlayer;
+use App\Models\Team;
+use App\Modules\Match\Services\CompetitionStrengthFloorResolver;
+use App\Modules\Match\Support\MatchOutcomeModel;
+use Illuminate\Console\Command;
+use Illuminate\Support\Collection;
+
+/**
+ * Measure whether squad-strength differences translate into realistic match and
+ * season outcomes — i.e. does the better/higher-reputation team reliably prevail
+ * over a 38-game season, or has the flattened overall-score distribution turned
+ * results into coin flips?
+ *
+ * Read-only. It computes each team's strength with the SAME definition the match
+ * engine uses (mean of the best XI's `overall·0.95 + morale·0.05`, /100) and
+ * drives the SAME outcome math (xG power-law + Dixon-Coles) via the shared
+ * {@see MatchOutcomeModel}, so the numbers reflect production behaviour, not a
+ * re-implementation.
+ *
+ * Note: the AI-vs-AI league (the tables forming around the user) is resolved by
+ * AIMatchResolver, which omits per-player "form on the day" variance — so AI
+ * league realism is governed ONLY by strength ratios + skill_dominance +
+ * Dixon-Coles. The analytical sections model that exactly. `--std-dev` lets you
+ * additionally approximate the user's own MatchSimulator matches, which DO carry
+ * per-player variance.
+ *
+ * The `--floor`, `--skill-dominance` and `--std-dev` flags preview tuning levers
+ * without touching config or code, turning this into the calibration instrument
+ * for the data-driven mitigation pass (favoured lever: the strength-floor
+ * rescale `(rating - floor)/(100 - floor)`, previewed via `--floor`).
+ */
+class DiagnoseStrengthRealism extends Command
+{
+    protected $signature = 'app:diagnose-strength-realism
+        {game? : Game id (defaults to the most recently created game)}
+        {--league= : Competition code, e.g. ESP1 (defaults to the game\'s own league)}
+        {--runs=2000 : Number of Monte-Carlo seasons for the distribution section}
+        {--floor= : Preview the strength-floor rescale: strength = (rating - floor)/(100 - floor)}
+        {--auto-floor : Derive & apply the league floor via the production CompetitionStrengthFloorResolver}
+        {--skill-dominance= : Preview a different skill_dominance exponent}
+        {--std-dev= : Add per-match team form noise (models user MatchSimulator matches; AI league uses none)}
+        {--neutral : Ignore home advantage in every matchup}
+        {--json= : Also write the full metric set as JSON to this path}';
+
+    protected $description = 'Measure whether squad-strength differences yield realistic match/season outcomes (read-only).';
+
+    /**
+     * Real top-flight reference bands used purely for a ✓/⚠ sanity flag. These
+     * are loose realism targets (≈ La Liga over a 20-team, 38-game season), not
+     * hard rules — the point is to see whether simulated spread/correlation land
+     * in a plausible neighbourhood, not to hit an exact number.
+     */
+    private const BENCHMARK_CHAMPION_PTS = [82, 95];
+
+    private const BENCHMARK_LAST_PTS = [18, 32];
+
+    private const BENCHMARK_SPREAD = [50, 72];
+
+    private const BENCHMARK_MIN_SPEARMAN = 0.70;
+
+    private bool $neutral = false;
+
+    private ?float $skillDominance = null;
+
+    private ?float $stdDev = null;
+
+    public function handle(): int
+    {
+        $game = $this->resolveGame();
+        if (! $game) {
+            return self::FAILURE;
+        }
+
+        $league = (string) ($this->option('league') ?: $game->competition_id);
+        $this->neutral = (bool) $this->option('neutral');
+        $this->skillDominance = $this->option('skill-dominance') !== null
+            ? (float) $this->option('skill-dominance') : null;
+        $this->stdDev = $this->option('std-dev') !== null
+            ? (float) $this->option('std-dev') : null;
+        $floor = $this->option('floor') !== null ? (float) $this->option('floor') : null;
+        if ($this->option('auto-floor')) {
+            // Mirror production: the floor the live engine would use for this league.
+            $floor = (new CompetitionStrengthFloorResolver)->leagueFloor($game, $league);
+        }
+        $runs = max(1, (int) $this->option('runs'));
+
+        $teamIds = CompetitionEntry::query()
+            ->where('game_id', $game->id)
+            ->where('competition_id', $league)
+            ->pluck('team_id')
+            ->all();
+
+        if (count($teamIds) < 4) {
+            $this->error("League {$league} has only " . count($teamIds) . ' team(s) in game ' . $game->id . ' — need at least 4.');
+
+            return self::FAILURE;
+        }
+
+        $names = Team::query()->whereIn('id', $teamIds)->pluck('name', 'id')->all();
+        $playersByTeam = GamePlayer::query()
+            ->where('game_id', $game->id)
+            ->whereIn('team_id', $teamIds)
+            ->with('matchState')
+            ->get(['id', 'game_id', 'team_id', 'overall_score', 'position'])
+            ->groupBy('team_id');
+
+        // Per-team rating (0..100 weighted XI mean) and engine strength (0..1).
+        $rating = [];
+        $strength = [];
+        foreach ($teamIds as $tid) {
+            $xi = $this->bestEleven($playersByTeam->get($tid, collect()));
+            $rating[$tid] = $this->weightedRating($xi);
+            $strength[$tid] = $this->toStrength($rating[$tid], $xi->count(), $floor);
+        }
+
+        // Rank teams by strength descending → strengthRank[teamId] = 1..n.
+        $ranked = $teamIds;
+        usort($ranked, fn ($a, $b) => $strength[$b] <=> $strength[$a]);
+        $strengthRank = [];
+        foreach ($ranked as $idx => $tid) {
+            $strengthRank[$tid] = $idx + 1;
+        }
+
+        $this->printContext($game, $league, count($teamIds), $floor, $runs);
+        $this->sectionInputSpread($ranked, $names, $rating, $strength);
+
+        // Precompute the analytical outcome for every ordered fixture once. With
+        // no form noise the matrices are reused for both the expected-points
+        // table and the Monte-Carlo sampling, keeping the whole run cheap.
+        [$probs, $matrices] = $this->precomputeFixtures($teamIds, $strength);
+
+        $this->sectionPairwise($ranked, $names, $strength, $probs);
+        $xTable = $this->sectionExpectedTable($teamIds, $names, $strengthRank, $probs);
+        $mc = $this->sectionMonteCarlo($teamIds, $names, $strength, $strengthRank, $matrices, $runs);
+        $this->sectionVerdict($mc);
+
+        if ($this->option('json')) {
+            $this->dumpJson($game, $league, $floor, $runs, $names, $strengthRank, $rating, $strength, $xTable, $mc);
+        }
+
+        return self::SUCCESS;
+    }
+
+    private function resolveGame(): ?Game
+    {
+        $gameId = $this->argument('game');
+        if ($gameId) {
+            $game = Game::find($gameId);
+            if (! $game) {
+                $this->error("Game {$gameId} not found.");
+
+                return null;
+            }
+
+            return $game;
+        }
+
+        $game = Game::query()->orderByDesc('created_at')->first();
+        if (! $game) {
+            $this->error('No games exist. Seed a game first or pass a game id.');
+
+            return null;
+        }
+
+        return $game;
+    }
+
+    /**
+     * Best XI in a 4-3-3 shape, by overall_score — mirrors
+     * AIMatchResolver::selectRotatedXI (minus transient injury/fitness rotation,
+     * which is irrelevant for a structural squad-strength snapshot).
+     *
+     * @param  Collection<int, GamePlayer>  $players
+     * @return Collection<int, GamePlayer>
+     */
+    private function bestEleven(Collection $players): Collection
+    {
+        if ($players->count() <= 11) {
+            return $players->values();
+        }
+
+        $score = fn (GamePlayer $p): float => (float) $p->overall_score;
+        $grouped = $players->groupBy('position_group');
+        $requirements = ['Goalkeeper' => 1, 'Defender' => 4, 'Midfielder' => 3, 'Forward' => 3];
+
+        $selected = collect();
+        foreach ($requirements as $group => $count) {
+            $selected = $selected->merge(
+                ($grouped->get($group) ?? collect())->sortByDesc($score)->take($count)
+            );
+        }
+
+        if ($selected->count() < 11) {
+            $ids = $selected->pluck('id')->all();
+            $selected = $selected->merge(
+                $players->reject(fn ($p) => in_array($p->id, $ids, true))
+                    ->sortByDesc($score)
+                    ->take(11 - $selected->count())
+            );
+        }
+
+        return $selected->values();
+    }
+
+    /**
+     * Weighted XI mean on the 0..100 scale: overall·0.95 + morale·0.05, summed
+     * over the XI and divided by the full squad size of 11 (so a short XI scores
+     * lower) — identical to the engine's calculateTeamStrength before /100.
+     *
+     * @param  Collection<int, GamePlayer>  $xi
+     */
+    private function weightedRating(Collection $xi): float
+    {
+        if ($xi->isEmpty()) {
+            return 0.0;
+        }
+
+        $wOverall = (float) config('match_simulation.strength_weight_overall', 0.95);
+        $wMorale = (float) config('match_simulation.strength_weight_morale', 0.05);
+
+        $sum = 0.0;
+        foreach ($xi as $p) {
+            $sum += ($p->overall_score * $wOverall) + ($p->morale * $wMorale);
+        }
+
+        return $sum / 11.0;
+    }
+
+    /**
+     * Convert a 0..100 rating to the engine's normalized strength. Without
+     * --floor this is the production `rating/100` (zero baseline). With --floor
+     * it previews the rescale `(rating - floor)/(100 - floor)`, which re-expands
+     * the ratio between teams because no real squad rates below ~50.
+     */
+    private function toStrength(float $rating, int $xiCount, ?float $floor): float
+    {
+        if ($xiCount < 7) {
+            return 0.30; // matches the engine's depleted-lineup fallback
+        }
+
+        // Same rescale the production engines apply (floor 0/null = no-op).
+        return MatchOutcomeModel::applyFloor($rating / 100.0, $floor ?? 0.0);
+    }
+
+    /**
+     * Build P(W/D/L) and the score matrix for every ordered fixture.
+     *
+     * @param  array<int, string>  $teamIds
+     * @param  array<string, float>  $strength
+     * @return array{0: array<string, array<string, array{home: float, draw: float, away: float, homeGoals: float, awayGoals: float}>>, 1: array<string, array<string, array<int, array{0: int, 1: int, 2: float}>>>}
+     */
+    private function precomputeFixtures(array $teamIds, array $strength): array
+    {
+        $probs = [];
+        $matrices = [];
+        $overrides = $this->overrides();
+
+        foreach ($teamIds as $home) {
+            foreach ($teamIds as $away) {
+                if ($home === $away) {
+                    continue;
+                }
+                [$hxg, $axg] = MatchOutcomeModel::expectedGoals($strength[$home], $strength[$away], $this->neutral, $overrides);
+                $matrix = MatchOutcomeModel::scoreProbabilityMatrix($hxg, $axg);
+                $matrices[$home][$away] = $matrix;
+                $probs[$home][$away] = MatchOutcomeModel::outcomeProbabilities($matrix);
+            }
+        }
+
+        return [$probs, $matrices];
+    }
+
+    /** @return array{skill_dominance?: float} */
+    private function overrides(): array
+    {
+        return $this->skillDominance !== null ? ['skill_dominance' => $this->skillDominance] : [];
+    }
+
+    private function printContext(Game $game, string $league, int $teams, ?float $floor, int $runs): void
+    {
+        $dom = $this->skillDominance ?? (float) config('match_simulation.skill_dominance', 2.4);
+        $this->line('');
+        $this->info('=== Squad-strength realism diagnostic ===');
+        $this->line("game: {$game->id}   league: {$league}   teams: {$teams}   season: {$game->season}");
+        $this->line("skill_dominance: {$dom}" . ($this->skillDominance !== null ? ' (override)' : '')
+            . '   base_goals: ' . config('match_simulation.base_goals')
+            . '   home_advantage: ' . ($this->neutral ? '0 (neutral)' : config('match_simulation.home_advantage_goals')));
+        $this->line('strength floor: ' . ($floor === null ? 'none (rating/100)' : "{$floor}  →  (rating-{$floor})/(100-{$floor})")
+            . '   form noise (std-dev): ' . ($this->stdDev === null ? 'none — AI league path' : $this->stdDev . ' (user-match approximation)'));
+        $this->line("monte-carlo seasons: {$runs}");
+    }
+
+    /**
+     * @param  array<int, string>  $ranked
+     * @param  array<string, string>  $names
+     * @param  array<string, float>  $rating
+     * @param  array<string, float>  $strength
+     */
+    private function sectionInputSpread(array $ranked, array $names, array $rating, array $strength): void
+    {
+        $this->line('');
+        $this->info('— 1. Input spread (how different are the squads?) —');
+
+        $rows = [];
+        foreach ($ranked as $idx => $tid) {
+            $rows[] = [
+                $idx + 1,
+                $this->shortName($names[$tid] ?? $tid),
+                number_format($rating[$tid], 1),
+                number_format($strength[$tid], 3),
+            ];
+        }
+        $this->table(['#', 'Team', 'XI rating', 'Strength'], $rows);
+
+        $strengths = array_values($strength);
+        $top = max($strengths);
+        $bottom = min($strengths);
+        $mean = array_sum($strengths) / count($strengths);
+        $variance = 0.0;
+        foreach ($strengths as $s) {
+            $variance += ($s - $mean) ** 2;
+        }
+        $cov = $mean > 0 ? sqrt($variance / count($strengths)) / $mean : 0.0;
+        $ratio = $bottom > 0 ? $top / $bottom : INF;
+
+        $this->line(sprintf(
+            '  top strength %.3f  /  bottom strength %.3f  →  top:bottom ratio %.3f',
+            $top, $bottom, $ratio
+        ));
+        $this->line(sprintf('  coefficient of variation: %.1f%%   (xG gap of top vs bottom scales as ratio^(2·skill_dominance))', $cov * 100));
+        $this->line('  ↳ the closer this ratio is to 1.000, the more every match tends toward a coin flip.');
+    }
+
+    /**
+     * @param  array<int, string>  $ranked
+     * @param  array<string, string>  $names
+     * @param  array<string, float>  $strength
+     * @param  array<string, array<string, array{home: float, draw: float, away: float, homeGoals: float, awayGoals: float}>>  $probs
+     */
+    private function sectionPairwise(array $ranked, array $names, array $strength, array $probs): void
+    {
+        $this->line('');
+        $this->info('— 2. Pairwise win probabilities (analytical, exact) —');
+
+        $n = count($ranked);
+        $mid = intdiv($n, 2);
+        $matchups = [
+            ['Strongest (H) v Weakest (A)', $ranked[0], $ranked[$n - 1]],
+            ['Weakest (H) v Strongest (A)', $ranked[$n - 1], $ranked[0]],
+            ['1st (H) v 2nd (A)', $ranked[0], $ranked[1]],
+            ['Mid (H) v Mid+1 (A)', $ranked[$mid - 1], $ranked[$mid]],
+            ['2nd-last (H) v 3rd-last (A)', $ranked[$n - 2], $ranked[$n - 3]],
+        ];
+
+        $rows = [];
+        foreach ($matchups as [$label, $home, $away]) {
+            $o = $probs[$home][$away];
+            $rows[] = [
+                $label,
+                $this->shortName($names[$home] ?? $home) . ' v ' . $this->shortName($names[$away] ?? $away),
+                sprintf('%.2f–%.2f', $o['homeGoals'], $o['awayGoals']),
+                sprintf('%.0f%%', $o['home'] * 100),
+                sprintf('%.0f%%', $o['draw'] * 100),
+                sprintf('%.0f%%', $o['away'] * 100),
+            ];
+        }
+        $this->table(['Matchup', 'Teams', 'xG', 'Home win', 'Draw', 'Away win'], $rows);
+        $this->line('  ↳ a healthy league shows the top team strongly favoured vs the bottom and near-even games only between true peers.');
+    }
+
+    /**
+     * Deterministic expected-points table: each team's mean points if every
+     * fixture paid out its probability-weighted result. Over a 20-team double
+     * round-robin this is directly comparable to a real 38-game points total.
+     *
+     * @param  array<int, string>  $teamIds
+     * @param  array<string, string>  $names
+     * @param  array<string, int>  $strengthRank
+     * @param  array<string, array<string, array{home: float, draw: float, away: float, homeGoals: float, awayGoals: float}>>  $probs
+     * @return array<int, array{team: string, name: string, xpts: float, strengthRank: int}>
+     */
+    private function sectionExpectedTable(array $teamIds, array $names, array $strengthRank, array $probs): array
+    {
+        $this->line('');
+        $this->info('— 3. Expected points table (analytical, no variance) —');
+
+        $xpts = array_fill_keys($teamIds, 0.0);
+        foreach ($teamIds as $home) {
+            foreach ($teamIds as $away) {
+                if ($home === $away) {
+                    continue;
+                }
+                $o = $probs[$home][$away];
+                $xpts[$home] += 3 * $o['home'] + $o['draw'];
+                $xpts[$away] += 3 * $o['away'] + $o['draw'];
+            }
+        }
+
+        $order = $teamIds;
+        usort($order, fn ($a, $b) => $xpts[$b] <=> $xpts[$a]);
+
+        $table = [];
+        $rows = [];
+        foreach ($order as $idx => $tid) {
+            $pos = $idx + 1;
+            $delta = $strengthRank[$tid] - $pos;
+            $rows[] = [
+                $pos,
+                $this->shortName($names[$tid] ?? $tid),
+                number_format($xpts[$tid], 1),
+                $strengthRank[$tid],
+                $delta === 0 ? '·' : sprintf('%+d', $delta),
+            ];
+            $table[] = ['team' => $tid, 'name' => $names[$tid] ?? $tid, 'xpts' => $xpts[$tid], 'strengthRank' => $strengthRank[$tid]];
+        }
+        $this->table(['#', 'Team', 'xPts', 'Str rank', 'Δ'], $rows);
+
+        $champion = $xpts[$order[0]];
+        $last = $xpts[$order[count($order) - 1]];
+        $this->line(sprintf(
+            '  champion xPts %.1f   last xPts %.1f   1st–last gap %.1f   (Δ column = strength rank minus finishing position; · = as expected)',
+            $champion, $last, $champion - $last
+        ));
+
+        return $table;
+    }
+
+    /**
+     * Monte-Carlo the season `runs` times, sampling every fixture's scoreline
+     * from its distribution, to expose the spread and predictability a player
+     * actually experiences across seasons.
+     *
+     * @param  array<int, string>  $teamIds
+     * @param  array<string, string>  $names
+     * @param  array<string, float>  $strength
+     * @param  array<string, int>  $strengthRank
+     * @param  array<string, array<string, array<int, array{0: int, 1: int, 2: float}>>>  $matrices
+     * @return array<string, mixed>
+     */
+    private function sectionMonteCarlo(array $teamIds, array $names, array $strength, array $strengthRank, array $matrices, int $runs): array
+    {
+        $this->line('');
+        $this->info("— 4. Season distribution over {$runs} Monte-Carlo seasons —");
+
+        $strongestId = array_search(1, $strengthRank, true);
+        $n = count($teamIds);
+
+        $titleCount = array_fill_keys($teamIds, 0);
+        $championPts = [];
+        $lastPts = [];
+        $spreads = [];
+        $spearmans = [];
+        $strongestOutsideTop4 = 0;
+        $overrides = $this->overrides();
+
+        $bar = $this->output->createProgressBar($runs);
+        $bar->start();
+
+        for ($r = 0; $r < $runs; $r++) {
+            $pts = array_fill_keys($teamIds, 0);
+
+            foreach ($teamIds as $home) {
+                foreach ($teamIds as $away) {
+                    if ($home === $away) {
+                        continue;
+                    }
+
+                    if ($this->stdDev === null) {
+                        [$hg, $ag] = MatchOutcomeModel::sampleScore($matrices[$home][$away]);
+                    } else {
+                        // Per-match form noise (user-match approximation): perturb
+                        // each team's strength by a Gaussian whose sd is shrunk by
+                        // √11 — the central-limit spread of 11 iid per-player rolls.
+                        $hs = $strength[$home] * $this->noiseFactor();
+                        $as = $strength[$away] * $this->noiseFactor();
+                        [$hxg, $axg] = MatchOutcomeModel::expectedGoals($hs, $as, $this->neutral, $overrides);
+                        [$hg, $ag] = MatchOutcomeModel::sampleScoreline($hxg, $axg);
+                    }
+
+                    if ($hg > $ag) {
+                        $pts[$home] += 3;
+                    } elseif ($hg < $ag) {
+                        $pts[$away] += 3;
+                    } else {
+                        $pts[$home] += 1;
+                        $pts[$away] += 1;
+                    }
+                }
+            }
+
+            // Final order: points desc, ties broken by strength (a stand-in for
+            // goal difference) so positions are deterministic.
+            $order = $teamIds;
+            usort($order, fn ($a, $b) => ($pts[$b] <=> $pts[$a]) ?: ($strength[$b] <=> $strength[$a]));
+
+            $position = [];
+            foreach ($order as $idx => $tid) {
+                $position[$tid] = $idx + 1;
+            }
+
+            $titleCount[$order[0]]++;
+            $championPts[] = $pts[$order[0]];
+            $lastPts[] = $pts[$order[$n - 1]];
+            $spreads[] = $pts[$order[0]] - $pts[$order[$n - 1]];
+            $spearmans[] = $this->spearman($strengthRank, $position, $teamIds);
+            if ($position[$strongestId] > 4) {
+                $strongestOutsideTop4++;
+            }
+
+            $bar->advance();
+        }
+
+        $bar->finish();
+        $this->line('');
+
+        $strongestTitlePct = 100.0 * $titleCount[$strongestId] / $runs;
+        $strongestOutsidePct = 100.0 * $strongestOutsideTop4 / $runs;
+
+        $metrics = [
+            'spearman_mean' => $this->mean($spearmans),
+            'spearman_p10' => $this->percentile($spearmans, 10),
+            'spearman_p90' => $this->percentile($spearmans, 90),
+            'champion_pts_mean' => $this->mean($championPts),
+            'champion_pts_p10' => $this->percentile($championPts, 10),
+            'champion_pts_p90' => $this->percentile($championPts, 90),
+            'last_pts_mean' => $this->mean($lastPts),
+            'spread_mean' => $this->mean($spreads),
+            'strongest_title_pct' => $strongestTitlePct,
+            'strongest_outside_top4_pct' => $strongestOutsidePct,
+            'strongest_team' => $names[$strongestId] ?? $strongestId,
+        ];
+
+        $this->table(['Metric', 'Value', 'What it tells you'], [
+            ['Strength→position correlation (ρ)', sprintf('%.2f  [p10 %.2f … p90 %.2f]', $metrics['spearman_mean'], $metrics['spearman_p10'], $metrics['spearman_p90']), 'Higher = stronger teams finish higher. ~0 = coin flip.'],
+            ['Champion points', sprintf('%.0f  [p10 %.0f … p90 %.0f]', $metrics['champion_pts_mean'], $metrics['champion_pts_p10'], $metrics['champion_pts_p90']), 'How dominant the winner is.'],
+            ['Last-place points', sprintf('%.0f', $metrics['last_pts_mean']), 'How adrift the worst team is.'],
+            ['1st–last points gap', sprintf('%.0f', $metrics['spread_mean']), 'Overall table stretch.'],
+            ['Strongest team wins title', sprintf('%.0f%%', $metrics['strongest_title_pct']), 'Does the best squad usually win?'],
+            ['Strongest team finishes 5th+', sprintf('%.0f%%', $metrics['strongest_outside_top4_pct']), 'How often the best squad is squeezed out of the top 4.'],
+        ]);
+
+        return $metrics;
+    }
+
+    /**
+     * @param  array<string, mixed>  $mc
+     */
+    private function sectionVerdict(array $mc): void
+    {
+        $this->line('');
+        $this->info('— 5. Verdict vs top-flight reference bands —');
+
+        $rows = [
+            $this->verdictRow('Champion points', $mc['champion_pts_mean'], self::BENCHMARK_CHAMPION_PTS),
+            $this->verdictRow('Last-place points', $mc['last_pts_mean'], self::BENCHMARK_LAST_PTS),
+            $this->verdictRow('1st–last gap', $mc['spread_mean'], self::BENCHMARK_SPREAD),
+            $this->verdictRowMin('Strength→position ρ', $mc['spearman_mean'], self::BENCHMARK_MIN_SPEARMAN),
+        ];
+        $this->table(['Metric', 'Simulated', 'Reference', 'Flag'], $rows);
+        $this->line('  Bands are loose realism targets (≈ La Liga), not hard rules. ⚠ on the gap/ρ rows is the signature of strength flattening.');
+        $this->line('  ↳ Re-run with --floor=45 or --floor=50 to preview how the strength-floor rescale widens the spread and lifts ρ.');
+    }
+
+    /**
+     * @param  array{0: int, 1: int}  $band
+     * @return array<int, string>
+     */
+    private function verdictRow(string $label, float $value, array $band): array
+    {
+        $ok = $value >= $band[0] && $value <= $band[1];
+
+        return [$label, number_format($value, 1), "{$band[0]}–{$band[1]}", $ok ? '✓' : '⚠'];
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function verdictRowMin(string $label, float $value, float $min): array
+    {
+        return [$label, number_format($value, 2), "≥ {$min}", $value >= $min ? '✓' : '⚠'];
+    }
+
+    /**
+     * Spearman rank correlation. Both inputs are dense distinct ranks (1..n), so
+     * the exact form ρ = 1 − 6Σd² / (n(n²−1)) applies with no tie correction.
+     *
+     * @param  array<string, int>  $rankA
+     * @param  array<string, int>  $rankB
+     * @param  array<int, string>  $ids
+     */
+    private function spearman(array $rankA, array $rankB, array $ids): float
+    {
+        $n = count($ids);
+        if ($n < 2) {
+            return 0.0;
+        }
+
+        $d2 = 0;
+        foreach ($ids as $id) {
+            $d = $rankA[$id] - $rankB[$id];
+            $d2 += $d * $d;
+        }
+
+        return 1.0 - (6.0 * $d2) / ($n * ($n * $n - 1));
+    }
+
+    /**
+     * One Gaussian form factor centred on 1.0, sd = stdDev/√11, clamped loosely.
+     * Box-Muller; consumes two mt_rand() calls.
+     */
+    private function noiseFactor(): float
+    {
+        $u1 = max(1e-9, mt_rand() / mt_getrandmax());
+        $u2 = mt_rand() / mt_getrandmax();
+        $z = sqrt(-2 * log($u1)) * cos(2 * M_PI * $u2);
+        $sd = $this->stdDev / sqrt(11.0);
+
+        return max(0.85, min(1.15, 1.0 + $z * $sd));
+    }
+
+    /**
+     * @param  array<int, float|int>  $values
+     */
+    private function mean(array $values): float
+    {
+        return $values === [] ? 0.0 : array_sum($values) / count($values);
+    }
+
+    /**
+     * @param  array<int, float|int>  $values
+     */
+    private function percentile(array $values, float $p): float
+    {
+        if ($values === []) {
+            return 0.0;
+        }
+        sort($values);
+        $idx = ($p / 100) * (count($values) - 1);
+        $lo = (int) floor($idx);
+        $hi = (int) ceil($idx);
+        if ($lo === $hi) {
+            return (float) $values[$lo];
+        }
+        $frac = $idx - $lo;
+
+        return $values[$lo] * (1 - $frac) + $values[$hi] * $frac;
+    }
+
+    private function shortName(string $name): string
+    {
+        return mb_strlen($name) > 22 ? mb_substr($name, 0, 21) . '…' : $name;
+    }
+
+    /**
+     * @param  array<string, string>  $names
+     * @param  array<string, int>  $strengthRank
+     * @param  array<string, float>  $rating
+     * @param  array<string, float>  $strength
+     * @param  array<int, array{team: string, name: string, xpts: float, strengthRank: int}>  $xTable
+     * @param  array<string, mixed>  $mc
+     */
+    private function dumpJson(Game $game, string $league, ?float $floor, int $runs, array $names, array $strengthRank, array $rating, array $strength, array $xTable, array $mc): void
+    {
+        $path = (string) $this->option('json');
+
+        $teams = [];
+        foreach ($strengthRank as $tid => $rank) {
+            $teams[] = [
+                'team_id' => $tid,
+                'name' => $names[$tid] ?? $tid,
+                'strength_rank' => $rank,
+                'rating' => round($rating[$tid], 2),
+                'strength' => round($strength[$tid], 4),
+            ];
+        }
+
+        $payload = [
+            'game_id' => $game->id,
+            'league' => $league,
+            'season' => $game->season,
+            'config' => [
+                'skill_dominance' => $this->skillDominance ?? (float) config('match_simulation.skill_dominance', 2.4),
+                'floor' => $floor,
+                'std_dev' => $this->stdDev,
+                'neutral' => $this->neutral,
+                'runs' => $runs,
+            ],
+            'teams' => $teams,
+            'expected_table' => array_map(fn ($r) => [
+                'team_id' => $r['team'],
+                'name' => $r['name'],
+                'xpts' => round($r['xpts'], 2),
+                'strength_rank' => $r['strengthRank'],
+            ], $xTable),
+            'monte_carlo' => $mc,
+        ];
+
+        file_put_contents($path, json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE));
+        $this->line('');
+        $this->line("JSON written to {$path}");
+    }
+}

--- a/app/Models/Competition.php
+++ b/app/Models/Competition.php
@@ -122,6 +122,20 @@ class Competition extends Model
     }
 
     /**
+     * Whether this is a domestic round-robin league (ESP1, ENG1, …) as opposed
+     * to a cup or a continental competition. Unlike isLeague(), this EXCLUDES
+     * the continental Swiss/group formats. Used to decide whether a match's
+     * strength normalization should use that league's own rating band (domestic
+     * league) or the global cross-band scale (cups, Europe, World Cup).
+     */
+    public function isDomesticLeague(): bool
+    {
+        return in_array($this->handler_type, ['league', 'league_with_playoff'], true)
+            && $this->role === self::ROLE_LEAGUE
+            && $this->scope === self::SCOPE_DOMESTIC;
+    }
+
+    /**
      * Whether this is a domestic tier league (tier >= 1).
      * Replaces the old ROLE_PRIMARY / ROLE_FOREIGN distinction.
      */

--- a/app/Modules/Match/Services/AIMatchResolver.php
+++ b/app/Modules/Match/Services/AIMatchResolver.php
@@ -6,6 +6,7 @@ use App\Models\GameMatch;
 use App\Models\GamePlayer;
 use App\Models\Game;
 use App\Modules\Match\DTOs\MatchEventData;
+use App\Modules\Match\Support\MatchOutcomeModel;
 use App\Modules\Match\Support\StoppageCalculator;
 use Illuminate\Support\Collection;
 
@@ -28,11 +29,8 @@ class AIMatchResolver
 {
     public function __construct(
         private readonly StoppageCalculator $stoppageCalculator = new StoppageCalculator,
+        private readonly CompetitionStrengthFloorResolver $floorResolver = new CompetitionStrengthFloorResolver,
     ) {}
-
-    private const DIXON_COLES_MAX_GOALS = 8;
-
-    private const FACTORIALS = [1, 1, 2, 6, 24, 120, 720, 5040, 40320];
 
     // Position weights for goal scoring (matches MatchSimulator)
     private const GOAL_SCORING_WEIGHTS = [
@@ -135,10 +133,18 @@ class AIMatchResolver
         $homeStrength = $this->calculateTeamStrength($homeXI);
         $awayStrength = $this->calculateTeamStrength($awayXI);
 
-        // Generate scoreline
+        // Rescale both strengths by this competition's strength floor (domestic
+        // league → its own rating band, cups/continental → global cross-band
+        // floor) so AI league tables reflect quality instead of being coin flips.
+        $floor = $this->floorResolver->floorForMatch($game, $match);
+        $homeStrength = MatchOutcomeModel::applyFloor($homeStrength, $floor);
+        $awayStrength = MatchOutcomeModel::applyFloor($awayStrength, $floor);
+
+        // Generate scoreline — same xG formula and Dixon-Coles distribution the
+        // full MatchSimulator uses, via the shared MatchOutcomeModel.
         $neutralVenue = $match->isNeutralVenue();
-        [$homeXG, $awayXG] = $this->calculateExpectedGoals($homeStrength, $awayStrength, $neutralVenue);
-        [$homeScore, $awayScore] = $this->dixonColesRandom($homeXG, $awayXG);
+        [$homeXG, $awayXG] = MatchOutcomeModel::expectedGoals($homeStrength, $awayStrength, $neutralVenue);
+        [$homeScore, $awayScore] = MatchOutcomeModel::sampleScoreline($homeXG, $awayXG);
 
         // Cap goals
         $maxGoals = (int) config('match_simulation.max_goals_cap', 6);
@@ -277,97 +283,6 @@ class AIMatchResolver
         }
 
         return ($totalStrength / 11) / 100;
-    }
-
-    /**
-     * Calculate expected goals using the same ratio-based formula as MatchSimulator.
-     */
-    private function calculateExpectedGoals(float $homeStrength, float $awayStrength, bool $neutralVenue): array
-    {
-        $baseGoals = (float) config('match_simulation.base_goals', 1.2);
-        $skillDominance = (float) config('match_simulation.skill_dominance', 2.3);
-        $homeAdvantage = $neutralVenue ? 0.0 : (float) config('match_simulation.home_advantage_goals', 0.20);
-
-        if ($awayStrength <= 0) {
-            return [$baseGoals + $homeAdvantage, $baseGoals * 0.5];
-        }
-
-        $strengthRatio = $homeStrength / $awayStrength;
-        $homeXG = pow($strengthRatio, $skillDominance) * $baseGoals + $homeAdvantage;
-        $awayXG = pow(1.0 / $strengthRatio, $skillDominance) * $baseGoals;
-
-        return [$homeXG, $awayXG];
-    }
-
-    /**
-     * Dixon-Coles correlated Poisson sampling (identical to MatchSimulator).
-     */
-    private function dixonColesRandom(float $homeXG, float $awayXG): array
-    {
-        $rho = (float) config('match_simulation.dixon_coles_rho', -0.13);
-        $concentration = (float) config('match_simulation.score_concentration', 1.0);
-
-        $probabilities = [];
-
-        for ($i = 0; $i <= self::DIXON_COLES_MAX_GOALS; $i++) {
-            $pHome = $this->poissonPmf($i, $homeXG);
-            for ($j = 0; $j <= self::DIXON_COLES_MAX_GOALS; $j++) {
-                $pAway = $this->poissonPmf($j, $awayXG);
-                $tau = $this->dixonColesTau($i, $j, $homeXG, $awayXG, $rho);
-                $probabilities[] = [$i, $j, $pHome * $pAway * $tau];
-            }
-        }
-
-        if ($concentration !== 1.0) {
-            foreach ($probabilities as &$entry) {
-                $entry[2] = $entry[2] ** $concentration;
-            }
-            unset($entry);
-        }
-
-        $cumulative = 0.0;
-        foreach ($probabilities as &$entry) {
-            $cumulative += $entry[2];
-            $entry[2] = $cumulative;
-        }
-        unset($entry);
-
-        $rand = (mt_rand() / mt_getrandmax()) * $cumulative;
-
-        foreach ($probabilities as [$home, $away, $cum]) {
-            if ($rand <= $cum) {
-                return [$home, $away];
-            }
-        }
-
-        return [0, 0];
-    }
-
-    private function poissonPmf(int $k, float $lambda): float
-    {
-        if ($lambda <= 0) {
-            return $k === 0 ? 1.0 : 0.0;
-        }
-
-        return exp(-$lambda) * pow($lambda, $k) / self::FACTORIALS[$k];
-    }
-
-    private function dixonColesTau(int $homeGoals, int $awayGoals, float $homeXG, float $awayXG, float $rho): float
-    {
-        if ($homeGoals === 0 && $awayGoals === 0) {
-            return 1.0 - $homeXG * $awayXG * $rho;
-        }
-        if ($homeGoals === 1 && $awayGoals === 0) {
-            return 1.0 + $awayXG * $rho;
-        }
-        if ($homeGoals === 0 && $awayGoals === 1) {
-            return 1.0 + $homeXG * $rho;
-        }
-        if ($homeGoals === 1 && $awayGoals === 1) {
-            return 1.0 - $rho;
-        }
-
-        return 1.0;
     }
 
     /**

--- a/app/Modules/Match/Services/CompetitionStrengthFloorResolver.php
+++ b/app/Modules/Match/Services/CompetitionStrengthFloorResolver.php
@@ -1,0 +1,213 @@
+<?php
+
+namespace App\Modules\Match\Services;
+
+use App\Models\Competition;
+use App\Models\Game;
+use App\Models\GameMatch;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Resolves the strength FLOOR used to rescale team strengths for a match
+ * (see {@see \App\Modules\Match\Support\MatchOutcomeModel::applyFloor()}).
+ *
+ * Why this exists: team strength is `mean(rating)/100` on a zero-baseline 0..100
+ * scale, but no real squad rates below ~50, so the bottom half is dead weight
+ * that squashes every strength ratio toward 1.0 and makes matches coin flips.
+ * Subtracting a floor re-expands the ratios. The catch is that the right floor
+ * is league-specific: a league whose ratings sit in a high, narrow band (the
+ * cash-rich, egalitarian Premier League: 76.7→88) needs a much larger floor
+ * than one with a low, wide band (La Liga: 72.5→91.7). So the floor is DERIVED
+ * from each competition's own rating distribution rather than hard-coded.
+ *
+ * One global knob drives it: `strength_ratio_target` (R). For a league with
+ * rating band [bottom, top], the floor that makes the strongest/weakest strength
+ * ratio equal R is `F = (R·bottom − top)/(R − 1)`. The same R yields ≈16 for
+ * La Liga and ≈44 for the Premier League — matching what the realism diagnostic
+ * found by hand.
+ *
+ * Match classification:
+ *  - DOMESTIC LEAGUE match → that league's own derived floor.
+ *  - Everything else (domestic cups, continental, World Cup, pre-season) →
+ *    a GLOBAL floor pooled across all domestic leagues in the game. That band
+ *    is very wide, so the global floor collapses toward 0 — i.e. cross-band
+ *    fixtures fall back to the raw, globally-consistent overalls, preserving the
+ *    genuine quality gap (a richer league's team really is stronger in Europe).
+ *
+ * Floors are memoized per (game, competition) for the lifetime of the instance,
+ * so resolving every fixture in a matchday batch costs at most one windowed
+ * query per league.
+ */
+class CompetitionStrengthFloorResolver
+{
+    private const MIN_TEAMS = 6;
+
+    /** @var array<string, float> "gameId|competitionId" => resolved match floor */
+    private array $matchFloorCache = [];
+
+    /** @var array<string, float> "gameId|competitionId" => domestic-league floor */
+    private array $leagueFloorCache = [];
+
+    /** @var array<string, float> "gameId" => global floor */
+    private array $globalFloorCache = [];
+
+    /** @var array<string, bool> competitionId => is domestic league */
+    private array $domesticLeagueCache = [];
+
+    /**
+     * The strength floor for a specific match, chosen by its competition type.
+     * Returns 0.0 (an exact no-op in applyFloor) when the feature is disabled.
+     */
+    public function floorForMatch(Game $game, GameMatch $match): float
+    {
+        if (! config('match_simulation.strength_floor_enabled', true)) {
+            return 0.0;
+        }
+
+        $competitionId = $match->competition_id;
+        $key = $game->id . '|' . $competitionId;
+
+        if (array_key_exists($key, $this->matchFloorCache)) {
+            return $this->matchFloorCache[$key];
+        }
+
+        $floor = $this->isDomesticLeague($competitionId)
+            ? $this->leagueFloor($game, $competitionId)
+            : $this->globalFloor($game);
+
+        return $this->matchFloorCache[$key] = $floor;
+    }
+
+    /**
+     * Floor derived from a single domestic league's own rating band.
+     */
+    public function leagueFloor(Game $game, string $competitionId): float
+    {
+        $key = $game->id . '|' . $competitionId;
+        if (array_key_exists($key, $this->leagueFloorCache)) {
+            return $this->leagueFloorCache[$key];
+        }
+
+        $ratings = $this->teamRatings($game->id, [$competitionId]);
+
+        return $this->leagueFloorCache[$key] = $this->deriveFloor($ratings);
+    }
+
+    /**
+     * Floor derived from the pooled rating band of every domestic league in the
+     * game — the cross-band reference for cups and continental competitions.
+     */
+    public function globalFloor(Game $game): float
+    {
+        if (array_key_exists($game->id, $this->globalFloorCache)) {
+            return $this->globalFloorCache[$game->id];
+        }
+
+        $leagueIds = $this->domesticLeagueIds($game->id);
+        $ratings = $leagueIds === [] ? [] : $this->teamRatings($game->id, $leagueIds);
+
+        return $this->globalFloorCache[$game->id] = $this->deriveFloor($ratings);
+    }
+
+    /**
+     * Solve for the floor that makes the band's top:bottom strength ratio equal
+     * the configured target R, then clamp it strictly below the weakest team so
+     * every squad keeps a positive rescaled strength. A degenerate band (too few
+     * teams, or a broken low outlier that drives the floor negative) returns 0.0,
+     * gracefully disabling the rescale rather than producing a wild floor.
+     *
+     * @param  array<int, float>  $ratings  per-team mean top-N overall_score
+     */
+    private function deriveFloor(array $ratings): float
+    {
+        if (count($ratings) < self::MIN_TEAMS) {
+            return 0.0;
+        }
+
+        $bottom = min($ratings);
+        $top = max($ratings);
+
+        $target = (float) config('match_simulation.strength_ratio_target', 1.34);
+        $margin = (float) config('match_simulation.strength_floor_margin', 3.0);
+
+        if ($target <= 1.0 || $top <= $bottom) {
+            return 0.0;
+        }
+
+        $floor = ($target * $bottom - $top) / ($target - 1.0);
+        $floor = min($floor, $bottom - $margin);
+
+        return max(0.0, $floor);
+    }
+
+    /**
+     * Per-team mean of the top-N `overall_score` for every team entered in the
+     * given competition(s) of this game. Reuses the windowed-query pattern from
+     * SyntheticLeagueResolver::loadTeamStrengths, scoped via competition_entries.
+     *
+     * @param  array<int, string>  $competitionIds
+     * @return array<int, float>  one mean rating per team
+     */
+    private function teamRatings(string $gameId, array $competitionIds): array
+    {
+        if ($competitionIds === []) {
+            return [];
+        }
+
+        $topN = (int) config('match_simulation.strength_floor_top_n', 11);
+        $placeholders = implode(',', array_fill(0, count($competitionIds), '?'));
+        $bindings = array_merge([$gameId], $competitionIds, [$gameId, $topN]);
+
+        $rows = DB::select(<<<SQL
+            SELECT AVG(overall_score)::float AS rating
+            FROM (
+                SELECT
+                    gp.team_id,
+                    gp.overall_score,
+                    ROW_NUMBER() OVER (PARTITION BY gp.team_id ORDER BY gp.overall_score DESC) AS rn
+                FROM game_players gp
+                WHERE gp.game_id = ?
+                  AND gp.team_id IN (
+                      SELECT team_id FROM competition_entries
+                      WHERE competition_id IN ({$placeholders}) AND game_id = ?
+                  )
+                  AND gp.overall_score IS NOT NULL
+            ) ranked
+            WHERE rn <= ?
+            GROUP BY team_id
+        SQL, $bindings);
+
+        return array_map(static fn ($row) => (float) $row->rating, $rows);
+    }
+
+    private function isDomesticLeague(string $competitionId): bool
+    {
+        if (array_key_exists($competitionId, $this->domesticLeagueCache)) {
+            return $this->domesticLeagueCache[$competitionId];
+        }
+
+        $competition = Competition::find($competitionId);
+
+        return $this->domesticLeagueCache[$competitionId] = (bool) $competition?->isDomesticLeague();
+    }
+
+    /**
+     * Codes of every domestic league that has entries in this game.
+     *
+     * @return array<int, string>
+     */
+    private function domesticLeagueIds(string $gameId): array
+    {
+        return Competition::query()
+            ->whereIn('handler_type', ['league', 'league_with_playoff'])
+            ->where('role', Competition::ROLE_LEAGUE)
+            ->where('scope', Competition::SCOPE_DOMESTIC)
+            ->whereIn('id', function ($query) use ($gameId) {
+                $query->select('competition_id')
+                    ->from('competition_entries')
+                    ->where('game_id', $gameId);
+            })
+            ->pluck('id')
+            ->all();
+    }
+}

--- a/app/Modules/Match/Services/FullMatchSimulationService.php
+++ b/app/Modules/Match/Services/FullMatchSimulationService.php
@@ -28,6 +28,7 @@ class FullMatchSimulationService
         private readonly NotificationService $notificationService,
         private readonly AIMatchResolver $aiMatchResolver = new AIMatchResolver,
         private readonly StoppageCalculator $stoppageCalculator = new StoppageCalculator,
+        private readonly CompetitionStrengthFloorResolver $floorResolver = new CompetitionStrengthFloorResolver,
     ) {}
 
     /**
@@ -165,6 +166,10 @@ class FullMatchSimulationService
         // both teams, same as if the user had clicked "Skip to end" from
         // minute 0. Tactics stay intact above.
         $simulatorUserTeamId = ($isUserMatch && ! $fastForward) ? $game->team_id : null;
+
+        // Rescale team strengths by this competition's distribution-derived floor
+        // (domestic league) or the global cross-band floor (cups/continental).
+        $this->matchSimulator->setStrengthFloor($this->floorResolver->floorForMatch($game, $match));
 
         $output = $this->matchSimulator->simulate(
             $match->homeTeam,

--- a/app/Modules/Match/Services/MatchResimulationService.php
+++ b/app/Modules/Match/Services/MatchResimulationService.php
@@ -31,6 +31,7 @@ class MatchResimulationService
         private readonly EligibilityService $eligibilityService,
         private readonly MatchEventRepository $matchEventRepository,
         private readonly MatchRatingCalculator $ratingCalculator,
+        private readonly CompetitionStrengthFloorResolver $floorResolver = new CompetitionStrengthFloorResolver,
     ) {}
 
     /**
@@ -271,6 +272,10 @@ class MatchResimulationService
         // via getMatchPerformance() when first called.
         $cachedPerformances = Cache::get("match_performances:{$match->id}", []);
         $this->matchSimulator->seedPerformance($cachedPerformances);
+
+        // Match the strength floor the initial simulation used, so the resimulated
+        // remainder stays consistent with the played first half.
+        $this->matchSimulator->setStrengthFloor($this->floorResolver->floorForMatch($game, $match));
 
         $regulationEnd = $stoppage->regulationEnd();
 
@@ -554,6 +559,9 @@ class MatchResimulationService
             // roll naturally on first call to getMatchPerformance().
             $etSeedPerformances = Cache::get("match_performances:{$match->id}", []);
             $this->matchSimulator->seedPerformance($etSeedPerformances);
+
+            // Keep the same strength floor as the rest of the match.
+            $this->matchSimulator->setStrengthFloor($this->floorResolver->floorForMatch($game, $match));
 
             $remainderResult = $this->matchSimulator->simulateExtraTime(
                 $match->homeTeam,

--- a/app/Modules/Match/Services/MatchSimulator.php
+++ b/app/Modules/Match/Services/MatchSimulator.php
@@ -20,6 +20,7 @@ use App\Support\PositionMapper;
 use App\Support\PositionSlotMapper;
 use App\Modules\Player\Services\InjuryService;
 use App\Modules\Match\Services\EnergyCalculator;
+use App\Modules\Match\Support\MatchOutcomeModel;
 use App\Modules\Match\Support\StoppageDurations;
 
 class MatchSimulator
@@ -58,6 +59,21 @@ class MatchSimulator
         private readonly InjuryService $injuryService = new InjuryService,
         private readonly AISubstitutionService $aiSubstitutionService = new AISubstitutionService,
     ) {}
+
+    /**
+     * Per-match strength floor (0..100 rating units) applied in
+     * calculateTeamStrength to re-expand the home/away strength ratio. 0.0 is a
+     * no-op. Resolved per match by the caller (CompetitionStrengthFloorResolver)
+     * and set before simulating, because the resim entry points
+     * (simulateRemainder / simulateExtraTime) bypass simulate(); a setter keeps
+     * every entry path consistent without threading it through their signatures.
+     */
+    private float $strengthFloor = 0.0;
+
+    public function setStrengthFloor(float $floor): void
+    {
+        $this->strengthFloor = $floor;
+    }
 
     /**
      * Match performance cache - stores per-player performance modifiers for the current match.
@@ -1362,7 +1378,11 @@ class MatchSimulator
         // Divide by full squad size (11) so that having fewer players
         // naturally reduces team strength — a red card's impact emerges
         // from the missing player's contribution to the sum.
-        return ($totalStrength / 11) / 100;
+        //
+        // Rescale against the per-match strength floor so the home/away ratio
+        // reflects relative quality rather than where the league's rating band
+        // sits on the 0..100 scale. Floor 0.0 leaves this unchanged.
+        return MatchOutcomeModel::applyFloor(($totalStrength / 11) / 100, $this->strengthFloor);
     }
 
     /**

--- a/app/Modules/Match/Support/MatchOutcomeModel.php
+++ b/app/Modules/Match/Support/MatchOutcomeModel.php
@@ -1,0 +1,244 @@
+<?php
+
+namespace App\Modules\Match\Support;
+
+/**
+ * Pure, stateless model of a match outcome: the ratio-based expected-goals
+ * formula plus the Dixon-Coles correlated-Poisson scoreline distribution.
+ *
+ * This is the SHARED source of the simulation's outcome math. {@see AIMatchResolver}
+ * resolves AI-vs-AI matches through these methods, so any season-realism
+ * diagnostic that calls them is exercising the exact production formula rather
+ * than a copy. {@see MatchSimulator} still carries its own equivalent
+ * implementation (it threads per-minute match fractions and tactical modifiers
+ * through the same shape) and can adopt this helper in a later pass.
+ *
+ * Beyond sampling a scoreline (what the resolver needs), this helper exposes
+ * `outcomeProbabilities()` — the analytical P(win)/P(draw)/P(loss) collapse of
+ * the score matrix — which neither resolver nor simulator computed before. That
+ * is what lets a diagnostic read win probabilities and expected league points
+ * straight from the model, with no Monte-Carlo noise.
+ */
+class MatchOutcomeModel
+{
+    /** Score matrix is evaluated for 0..MAX_GOALS per team before capping. */
+    private const MAX_GOALS = 8;
+
+    /** Precomputed factorials for the Poisson PMF, indices 0..MAX_GOALS. */
+    private const FACTORIALS = [1, 1, 2, 6, 24, 120, 720, 5040, 40320];
+
+    /**
+     * Expected goals for each side from the ratio-based power formula:
+     *
+     *   homeXG = (homeStr/awayStr) ^ skill_dominance × base_goals + home_advantage
+     *   awayXG = (awayStr/homeStr) ^ skill_dominance × base_goals
+     *
+     * The stronger team is always favoured; the exponent controls how sharply a
+     * strength ratio widens the xG gap. `$overrides` lets callers preview a
+     * different `skill_dominance` / `base_goals` / `home_advantage_goals` without
+     * mutating config (used by the strength-realism diagnostic).
+     *
+     * @param  array{skill_dominance?: float, base_goals?: float, home_advantage_goals?: float}  $overrides
+     * @return array{0: float, 1: float}  [homeXG, awayXG]
+     */
+    public static function expectedGoals(
+        float $homeStrength,
+        float $awayStrength,
+        bool $neutralVenue = false,
+        array $overrides = [],
+    ): array {
+        $baseGoals = $overrides['base_goals'] ?? (float) config('match_simulation.base_goals', 1.4);
+        $skillDominance = $overrides['skill_dominance'] ?? (float) config('match_simulation.skill_dominance', 2.4);
+        $homeAdvantage = $neutralVenue
+            ? 0.0
+            : ($overrides['home_advantage_goals'] ?? (float) config('match_simulation.home_advantage_goals', 0.20));
+
+        // Degenerate opponent (no players / zero strength): give the present side
+        // a base attack plus home edge, the empty side a token half-base.
+        if ($awayStrength <= 0) {
+            return [$baseGoals + $homeAdvantage, $baseGoals * 0.5];
+        }
+
+        $strengthRatio = $homeStrength / $awayStrength;
+        $homeXG = pow($strengthRatio, $skillDominance) * $baseGoals + $homeAdvantage;
+        $awayXG = pow(1.0 / $strengthRatio, $skillDominance) * $baseGoals;
+
+        return [$homeXG, $awayXG];
+    }
+
+    /**
+     * Rescale a team strength against a baseline floor on the 0..100 rating
+     * scale, where `rating = strength * 100`:
+     *
+     *   strength' = (rating - floor) / (100 - floor)
+     *
+     * This re-expands the ratio between teams whose ratings sit in a high,
+     * narrow band. No real squad rates below ~50, so the bottom of the 0..100
+     * strength scale is dead weight that squashes every ratio toward 1.0 and
+     * makes matches coin flips; subtracting a floor stretches the relative gaps
+     * back out. Apply the SAME floor to both teams in a match before forming
+     * their strength ratio.
+     *
+     * A floor of 0 (or an out-of-range floor) is an exact no-op, so callers that
+     * don't resolve a floor keep the original behaviour.
+     */
+    public static function applyFloor(float $strength, float $floor): float
+    {
+        if ($floor <= 0.0 || $floor >= 100.0) {
+            return $strength;
+        }
+
+        $rescaled = ($strength * 100.0 - $floor) / (100.0 - $floor);
+
+        // Keep strictly positive so the home/away ratio stays finite even for a
+        // squad rated at or below the floor (e.g. a heavily depleted XI).
+        return max(0.02, $rescaled);
+    }
+
+    /**
+     * Build the normalized Dixon-Coles scoreline probability matrix.
+     *
+     * Each entry is [homeGoals, awayGoals, probability] with probabilities
+     * summing to 1.0. Independent Poisson is corrected by the Dixon-Coles `tau`
+     * factor for low scores and then sharpened by `score_concentration` (an
+     * inverse-temperature power transform) before renormalization.
+     *
+     * @return array<int, array{0: int, 1: int, 2: float}>
+     */
+    public static function scoreProbabilityMatrix(float $homeXG, float $awayXG): array
+    {
+        $rho = (float) config('match_simulation.dixon_coles_rho', -0.13);
+        $concentration = (float) config('match_simulation.score_concentration', 1.0);
+
+        $matrix = [];
+        $total = 0.0;
+
+        for ($i = 0; $i <= self::MAX_GOALS; $i++) {
+            $pHome = self::poissonPmf($i, $homeXG);
+            for ($j = 0; $j <= self::MAX_GOALS; $j++) {
+                $pAway = self::poissonPmf($j, $awayXG);
+                $tau = self::dixonColesTau($i, $j, $homeXG, $awayXG, $rho);
+                $p = $pHome * $pAway * $tau;
+
+                if ($concentration !== 1.0) {
+                    $p = $p ** $concentration;
+                }
+
+                $matrix[] = [$i, $j, $p];
+                $total += $p;
+            }
+        }
+
+        if ($total > 0.0) {
+            foreach ($matrix as &$entry) {
+                $entry[2] /= $total;
+            }
+            unset($entry);
+        }
+
+        return $matrix;
+    }
+
+    /**
+     * Collapse a (normalized) score matrix into analytical outcome probabilities
+     * and expected goals for each side.
+     *
+     * @param  array<int, array{0: int, 1: int, 2: float}>  $matrix
+     * @return array{home: float, draw: float, away: float, homeGoals: float, awayGoals: float}
+     */
+    public static function outcomeProbabilities(array $matrix): array
+    {
+        $home = 0.0;
+        $draw = 0.0;
+        $away = 0.0;
+        $homeGoals = 0.0;
+        $awayGoals = 0.0;
+
+        foreach ($matrix as [$i, $j, $p]) {
+            if ($i > $j) {
+                $home += $p;
+            } elseif ($i === $j) {
+                $draw += $p;
+            } else {
+                $away += $p;
+            }
+            $homeGoals += $i * $p;
+            $awayGoals += $j * $p;
+        }
+
+        return [
+            'home' => $home,
+            'draw' => $draw,
+            'away' => $away,
+            'homeGoals' => $homeGoals,
+            'awayGoals' => $awayGoals,
+        ];
+    }
+
+    /**
+     * Draw a scoreline from a (normalized) score matrix. Consumes exactly one
+     * mt_rand() call — the same random-stream footprint as the resolver's
+     * previous inline sampler, so seeded runs stay reproducible.
+     *
+     * @param  array<int, array{0: int, 1: int, 2: float}>  $matrix
+     * @return array{0: int, 1: int}  [homeGoals, awayGoals]
+     */
+    public static function sampleScore(array $matrix): array
+    {
+        $rand = mt_rand() / mt_getrandmax();
+
+        $cumulative = 0.0;
+        foreach ($matrix as [$home, $away, $p]) {
+            $cumulative += $p;
+            if ($rand <= $cumulative) {
+                return [$home, $away];
+            }
+        }
+
+        return [0, 0];
+    }
+
+    /**
+     * Convenience: build the matrix and sample a scoreline in one call.
+     *
+     * @return array{0: int, 1: int}  [homeGoals, awayGoals]
+     */
+    public static function sampleScoreline(float $homeXG, float $awayXG): array
+    {
+        return self::sampleScore(self::scoreProbabilityMatrix($homeXG, $awayXG));
+    }
+
+    /**
+     * Poisson probability mass function: P(X = k) given expected value lambda.
+     */
+    private static function poissonPmf(int $k, float $lambda): float
+    {
+        if ($lambda <= 0) {
+            return $k === 0 ? 1.0 : 0.0;
+        }
+
+        return exp(-$lambda) * pow($lambda, $k) / self::FACTORIALS[$k];
+    }
+
+    /**
+     * Dixon-Coles tau correction. Only adjusts the four low-scoring outcomes
+     * (0-0, 1-0, 0-1, 1-1); tau = 1 everywhere else.
+     */
+    private static function dixonColesTau(int $homeGoals, int $awayGoals, float $homeXG, float $awayXG, float $rho): float
+    {
+        if ($homeGoals === 0 && $awayGoals === 0) {
+            return 1.0 - $homeXG * $awayXG * $rho;
+        }
+        if ($homeGoals === 1 && $awayGoals === 0) {
+            return 1.0 + $awayXG * $rho;
+        }
+        if ($homeGoals === 0 && $awayGoals === 1) {
+            return 1.0 + $homeXG * $rho;
+        }
+        if ($homeGoals === 1 && $awayGoals === 1) {
+            return 1.0 - $rho;
+        }
+
+        return 1.0;
+    }
+}

--- a/config/match_simulation.php
+++ b/config/match_simulation.php
@@ -71,6 +71,47 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Strength Floor (Distribution-Derived Rescale)
+    |--------------------------------------------------------------------------
+    |
+    | Team strength is mean(rating)/100 on a zero-baseline 0..100 scale. Because
+    | no real squad rates below ~50, the bottom half of that scale is dead weight
+    | that squashes the home/away strength RATIO toward 1.0 — making matches coin
+    | flips and league tables too flat (champions on ~72 pts, the best squad
+    | winning the title only ~25% of seasons). Subtracting a floor re-expands the
+    | ratios:  strength = (rating - floor) / (100 - floor).
+    |
+    | The correct floor is league-specific because leagues sit on different parts
+    | of the scale: the cash-rich, egalitarian Premier League band is high and
+    | narrow (76.7→88) while La Liga is lower and wide (72.5→91.7). So the floor
+    | is DERIVED per competition from its own rating band rather than hard-coded
+    | (see CompetitionStrengthFloorResolver). Domestic-league matches use their
+    | league's floor; cups/continental matches use a global cross-band floor that
+    | collapses toward 0 (raw overalls), preserving genuine cross-league gaps.
+    |
+    | strength_ratio_target (R): the single tuning knob. It is the top:bottom
+    | strength ratio each league is stretched to. The per-league floor solving
+    | for it is F = (R·bottom - top)/(R - 1). Higher R → bigger floors → more
+    | table spread / fewer upsets.
+    |
+    |   1.25 = gentle — leagues stay fairly tight
+    |   1.34 = default — champion ~85, strongest team wins title ~45% (La Liga
+    |          floor ≈16, Premier League floor ≈44)
+    |   1.45 = aggressive — top teams pull clear, relegation strugglers crushed
+    |
+    | strength_floor_margin: keeps the derived floor at least this far below the
+    |   weakest team's rating, so its rescaled strength stays positive.
+    | strength_floor_top_n: squad depth (best-N overall_score) used to define a
+    |   team's rating for the band — matches the best-XI the engine fields.
+    |
+    */
+    'strength_floor_enabled' => true,
+    'strength_ratio_target' => 1.34,
+    'strength_floor_margin' => 3.0,
+    'strength_floor_top_n' => 11,
+
+    /*
+    |--------------------------------------------------------------------------
     | Match Performance Variance (Randomness)
     |--------------------------------------------------------------------------
     |

--- a/docs/game-systems/match-simulation.md
+++ b/docs/game-systems/match-simulation.md
@@ -22,6 +22,16 @@ The stronger team is always favored regardless of venue — home advantage is a 
 
 All base values and exponents are configurable in `config/match_simulation.php`.
 
+### Strength floor (distribution-derived rescale)
+
+Because outcomes depend on the strength **ratio** (`ratio ^ skill_dominance`) and strength is `mean(rating)/100` on a zero-baseline scale, leagues whose ratings cluster in a high, narrow band (e.g. the cash-rich, egalitarian Premier League) produce ratios near 1.0 — making matches coin flips and tables too flat. To correct this, each team's strength is rescaled by a per-match **floor** before the ratio is formed:
+
+```
+strength = (rating - floor) / (100 - floor)
+```
+
+The floor is **derived per competition** from its own rating band (`CompetitionStrengthFloorResolver`) so a high-narrow league gets a large floor and a low-wide league a small one, from a single global knob `strength_ratio_target` (R): `floor = (R·bottom - top)/(R - 1)`. Domestic-league matches use their league's floor; cups and continental matches use a global cross-band floor (which collapses toward 0, i.e. raw globally-consistent overalls, preserving genuine cross-league quality gaps). The rescale lives in `MatchOutcomeModel::applyFloor()` (a floor of 0 is a no-op) and is applied in both the full `MatchSimulator` path (via `setStrengthFloor()`, set by `FullMatchSimulationService`/`MatchResimulationService`) and the lightweight `AIMatchResolver`. Set `strength_floor_enabled => false` to disable. The `app:diagnose-strength-realism` command measures the effect and `--auto-floor` previews the production-derived floor.
+
 ## Formation & Mentality
 
 Each formation has attack and defense modifiers (multiplicative on xG). A team's attack modifier scales their own xG; their defense modifier scales the opponent's. Available formations and their modifiers are defined in `Formation` enum.
@@ -114,6 +124,8 @@ Cup competitions (`knockout_cup`), Swiss-format competitions (`swiss_format`, `g
 | File | Purpose |
 |------|---------|
 | `app/Modules/Match/Services/MatchSimulator.php` | Core simulation: xG, strength, events, extra time, penalties |
+| `app/Modules/Match/Support/MatchOutcomeModel.php` | Shared xG + Dixon-Coles math and the strength-floor rescale |
+| `app/Modules/Match/Services/CompetitionStrengthFloorResolver.php` | Per-competition / global strength floor from the rating band |
 | `app/Modules/Match/Services/EnergyCalculator.php` | Energy drain and effectiveness calculations |
 | `app/Modules/Match/Services/SyntheticLeagueResolver.php` | Lazy Poisson simulation of non-user flat leagues |
 | `app/Modules/Player/Services/PlayerConditionService.php` | Between-match recovery and energy updates |

--- a/tests/Feature/CompetitionStrengthFloorResolverTest.php
+++ b/tests/Feature/CompetitionStrengthFloorResolverTest.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Competition;
+use App\Models\CompetitionEntry;
+use App\Models\Game;
+use App\Models\GameMatch;
+use App\Models\GamePlayer;
+use App\Models\Team;
+use App\Modules\Match\Services\CompetitionStrengthFloorResolver;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class CompetitionStrengthFloorResolverTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function makeGame(): Game
+    {
+        $userTeam = Team::factory()->create();
+
+        return Game::factory()->create([
+            'team_id' => $userTeam->id,
+            'season' => '2025',
+        ]);
+    }
+
+    /**
+     * Add a team to a competition with 11 players all at the given overall, so
+     * the team's top-11 mean rating equals that overall exactly.
+     */
+    private function addTeam(Game $game, string $competitionId, int $overall): Team
+    {
+        $team = Team::factory()->create();
+        CompetitionEntry::create([
+            'game_id' => $game->id,
+            'competition_id' => $competitionId,
+            'team_id' => $team->id,
+        ]);
+        GamePlayer::factory()->forGame($game)->forTeam($team)->count(11)->create([
+            'overall_score' => $overall,
+            'position' => 'Central Midfield',
+        ]);
+
+        return $team;
+    }
+
+    private function matchIn(string $competitionId): GameMatch
+    {
+        $match = new GameMatch;
+        $match->competition_id = $competitionId;
+
+        return $match;
+    }
+
+    public function test_league_floor_matches_the_ratio_target_formula(): void
+    {
+        config(['match_simulation.strength_ratio_target' => 1.34]);
+        $game = $this->makeGame();
+        Competition::factory()->league()->create(['id' => 'TSTA', 'season' => '2025']);
+
+        foreach ([70, 74, 78, 82, 86, 90] as $overall) {
+            $this->addTeam($game, 'TSTA', $overall);
+        }
+
+        // F = (R*bottom - top)/(R-1) = (1.34*70 - 90)/0.34 ≈ 11.18
+        $floor = (new CompetitionStrengthFloorResolver)->leagueFloor($game, 'TSTA');
+
+        $this->assertEqualsWithDelta(11.18, $floor, 0.3);
+    }
+
+    public function test_fewer_than_minimum_teams_disables_the_floor(): void
+    {
+        $game = $this->makeGame();
+        Competition::factory()->league()->create(['id' => 'TSTA', 'season' => '2025']);
+
+        foreach ([70, 78, 84, 90] as $overall) { // only 4 teams (< MIN_TEAMS)
+            $this->addTeam($game, 'TSTA', $overall);
+        }
+
+        $this->assertSame(0.0, (new CompetitionStrengthFloorResolver)->leagueFloor($game, 'TSTA'));
+    }
+
+    public function test_cup_match_uses_global_floor_below_a_high_narrow_league_floor(): void
+    {
+        config(['match_simulation.strength_ratio_target' => 1.34]);
+        $game = $this->makeGame();
+
+        // High, narrow domestic league → a high floor.
+        Competition::factory()->league()->create(['id' => 'TSTA', 'season' => '2025']);
+        foreach ([82, 84, 86, 88, 89, 90] as $overall) {
+            $this->addTeam($game, 'TSTA', $overall);
+        }
+        // A second, much weaker domestic league widens the global pool.
+        Competition::factory()->league()->create(['id' => 'TSTB', 'season' => '2025']);
+        foreach ([60, 62, 64, 66, 68, 70] as $overall) {
+            $this->addTeam($game, 'TSTB', $overall);
+        }
+        // A domestic cup.
+        Competition::factory()->knockoutCup()->create(['id' => 'TSTCUP', 'season' => '2025']);
+
+        $resolver = new CompetitionStrengthFloorResolver;
+        $leagueFloor = $resolver->floorForMatch($game, $this->matchIn('TSTA'));
+        $cupFloor = $resolver->floorForMatch($game, $this->matchIn('TSTCUP'));
+
+        $this->assertGreaterThan(40.0, $leagueFloor, 'high narrow league should get a large floor');
+        $this->assertSame($resolver->leagueFloor($game, 'TSTA'), $leagueFloor, 'league match uses its own league floor');
+        $this->assertLessThan($leagueFloor, $cupFloor, 'cup match uses the lower global cross-band floor');
+        $this->assertSame($resolver->globalFloor($game), $cupFloor);
+    }
+
+    public function test_disabled_flag_returns_zero(): void
+    {
+        config(['match_simulation.strength_floor_enabled' => false]);
+        $game = $this->makeGame();
+        Competition::factory()->league()->create(['id' => 'TSTA', 'season' => '2025']);
+        foreach ([70, 74, 78, 82, 86, 90] as $overall) {
+            $this->addTeam($game, 'TSTA', $overall);
+        }
+
+        $this->assertSame(0.0, (new CompetitionStrengthFloorResolver)->floorForMatch($game, $this->matchIn('TSTA')));
+    }
+
+    public function test_is_domestic_league_classification(): void
+    {
+        $league = new Competition([
+            'handler_type' => 'league',
+            'role' => Competition::ROLE_LEAGUE,
+            'scope' => Competition::SCOPE_DOMESTIC,
+        ]);
+        $this->assertTrue($league->isDomesticLeague());
+
+        $cup = new Competition([
+            'handler_type' => 'knockout_cup',
+            'role' => Competition::ROLE_DOMESTIC_CUP,
+            'scope' => Competition::SCOPE_DOMESTIC,
+        ]);
+        $this->assertFalse($cup->isDomesticLeague());
+
+        // Continental Swiss is a "league" handler but NOT a domestic league.
+        $continental = new Competition([
+            'handler_type' => 'swiss_format',
+            'role' => Competition::ROLE_EUROPEAN,
+            'scope' => Competition::SCOPE_CONTINENTAL,
+        ]);
+        $this->assertFalse($continental->isDomesticLeague());
+    }
+}

--- a/tests/Unit/MatchOutcomeModelApplyFloorTest.php
+++ b/tests/Unit/MatchOutcomeModelApplyFloorTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Modules\Match\Support\MatchOutcomeModel;
+use PHPUnit\Framework\TestCase;
+
+class MatchOutcomeModelApplyFloorTest extends TestCase
+{
+    public function test_zero_floor_is_a_no_op(): void
+    {
+        $this->assertSame(0.80, MatchOutcomeModel::applyFloor(0.80, 0.0));
+        $this->assertSame(0.55, MatchOutcomeModel::applyFloor(0.55, 0.0));
+    }
+
+    public function test_out_of_range_floor_is_a_no_op(): void
+    {
+        $this->assertSame(0.80, MatchOutcomeModel::applyFloor(0.80, -5.0));
+        $this->assertSame(0.80, MatchOutcomeModel::applyFloor(0.80, 100.0));
+        $this->assertSame(0.80, MatchOutcomeModel::applyFloor(0.80, 120.0));
+    }
+
+    public function test_rescale_matches_formula(): void
+    {
+        // rating 80, floor 50 → (80-50)/(100-50) = 0.60
+        $this->assertEqualsWithDelta(0.60, MatchOutcomeModel::applyFloor(0.80, 50.0), 1e-9);
+        // rating 64, floor 50 → (64-50)/(100-50) = 0.28
+        $this->assertEqualsWithDelta(0.28, MatchOutcomeModel::applyFloor(0.64, 50.0), 1e-9);
+    }
+
+    public function test_floor_widens_the_ratio_between_two_teams(): void
+    {
+        $strong = 0.80; // rating 80
+        $weak = 0.64;   // rating 64
+
+        $rawRatio = $strong / $weak; // 1.25
+        $flooredStrong = MatchOutcomeModel::applyFloor($strong, 50.0); // 0.60
+        $flooredWeak = MatchOutcomeModel::applyFloor($weak, 50.0);     // 0.28
+        $flooredRatio = $flooredStrong / $flooredWeak;                 // ~2.14
+
+        $this->assertGreaterThan($rawRatio, $flooredRatio);
+        $this->assertEqualsWithDelta(2.142857, $flooredRatio, 1e-4);
+    }
+
+    public function test_strength_at_or_below_floor_is_clamped_positive(): void
+    {
+        // rating 40, floor 50 → negative pre-clamp; must stay strictly positive
+        $result = MatchOutcomeModel::applyFloor(0.40, 50.0);
+        $this->assertGreaterThan(0.0, $result);
+        $this->assertSame(0.02, $result);
+    }
+}


### PR DESCRIPTION
## Problem

Flattening the player **overall-score** distribution (the value→overall calibration) compressed squad-strength **ratios**. The match engine separates teams by `ratio ^ skill_dominance` over `strength = mean(rating)/100` — a zero-baseline scale whose bottom half is dead weight (no real squad rates below ~50) — so those ratios collapse toward 1.0 and league tables become coin flips.

Measured on a real game world (read-only `app:diagnose-strength-realism`):

| League | bottom XI | top XI | strength→position ρ | champion pts | strongest wins title |
|---|---|---|---|---|---|
| La Liga | 72.5 | 91.7 | 0.65–0.72 | ~80 | 51% |
| Premier League | 76.7 | 88.0 | **0.65** | **~72** | **23%** |

The strongest squad winning the Premier League title only ~23% of seasons (and finishing 5th-or-worse ~29%) is the "coin flip" — quality stops predicting the table over a 38-game season.

## Fix

Rescale each team's strength by a per-match **floor** before the ratio is formed:

```
strength = (rating - floor) / (100 - floor)
```

The correct floor is league-specific (a high, narrow band like the Premier League needs a much larger floor than a low, wide one like La Liga), so it's **derived per competition** from its own rating band via a single knob, `strength_ratio_target` (R):

```
floor = (R · bottom - top) / (R - 1)
```

- **Domestic-league** matches use their league's own floor.
- **Cups / continental** matches use a global cross-band floor (collapses toward 0 → raw, globally-consistent overalls, preserving genuine cross-league quality gaps for European competitions).
- A floor of **0 is an exact no-op**, so this is backward-compatible and gated by `strength_floor_enabled`.

This is **decoupled from the wage/valuation calibration** — it does not touch `competence_floor`.

## Result (R = 1.34)

The resolver auto-derives **≈28 for La Liga** and **≈48 for the Premier League** from one knob, and both leagues land every realism metric in band:

| League | derived floor | ρ | champion pts | 1st–last gap | strongest wins title |
|---|---|---|---|---|---|
| La Liga | 28 | 0.83 | 89 | 60 | 60% |
| Premier League | 48 | 0.89 | 85 | 61 | 42% |

**Tournaments** are intentionally left on the global (≈0) floor: the national-team band is the *widest* of any competition (raw ratio 1.33 vs La Liga 1.26), so the World Cup is already realistic at raw overalls (favourites separated from the field, level among themselves) and a league-style floor would make it unrealistically deterministic.

## What's in here

- `MatchOutcomeModel::applyFloor()` — the rescale, single source of truth (also where the shared xG + Dixon-Coles math now lives; `AIMatchResolver` delegates to it).
- `CompetitionStrengthFloorResolver` — per-competition / global floor from the rating band; `Competition::isDomesticLeague()` classifies the match.
- Wired into `MatchSimulator` (via `setStrengthFloor()`, set by `FullMatchSimulationService` + `MatchResimulationService`) and `AIMatchResolver`.
- `config/match_simulation.php` knobs (`strength_floor_enabled`, `strength_ratio_target`, `strength_floor_margin`, `strength_floor_top_n`) + docs.
- `app:diagnose-strength-realism` — read-only realism diagnostic; `--auto-floor` previews the production-derived floor.
- Unit + feature tests (rescale math, formula, domestic/cup routing).

## Test plan

- `php artisan test tests/Unit/MatchOutcomeModelApplyFloorTest.php tests/Feature/CompetitionStrengthFloorResolverTest.php` — 10 pass.
- `php artisan app:diagnose-strength-realism <game> --league=ESP1 --auto-floor` and `--league=ENG1 --auto-floor` — all four verdict metrics ✓ for both.
- Backward-compat: `strength_floor_enabled=false` reproduces the pre-change (flat) numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)