### PR TITLE
Fix exploding scorelines (13-0, 21-0, 0-15) in user-played matches

### DIFF
--- a/app/Modules/Match/Services/MatchSimulator.php
+++ b/app/Modules/Match/Services/MatchSimulator.php
@@ -285,45 +285,14 @@ class MatchSimulator
             return $output;
         }
 
-        $events = $result->events;
-        $toRemove = [];
-
-        foreach ([[$homeTeamId, $awayTeamId, $result->homeScore], [$awayTeamId, $homeTeamId, $result->awayScore]] as [$teamId, $opponentId, $score]) {
-            $surplus = $score - $cap;
-            if ($surplus <= 0) {
-                continue;
-            }
-
-            $surplusGoals = $events
-                ->filter(fn (MatchEventData $e) => ($e->type === 'goal' && $e->teamId === $teamId)
-                    || ($e->type === 'own_goal' && $e->teamId === $opponentId))
-                ->sortByDesc('minute')
-                ->take($surplus);
-
-            foreach ($surplusGoals as $goal) {
-                $toRemove[spl_object_id($goal)] = true;
-
-                if ($goal->type === 'goal') {
-                    $assist = $events->first(fn (MatchEventData $e) => $e->type === 'assist'
-                        && $e->teamId === $goal->teamId
-                        && $e->minute === $goal->minute
-                        && ! isset($toRemove[spl_object_id($e)]));
-                    if ($assist !== null) {
-                        $toRemove[spl_object_id($assist)] = true;
-                    }
-                }
-            }
-        }
-
-        $cappedEvents = $events
-            ->reject(fn (MatchEventData $e) => isset($toRemove[spl_object_id($e)]))
-            ->values();
+        $events = $this->trimGoalsToTarget($result->events, $homeTeamId, $awayTeamId, $cap);
+        $events = $this->trimGoalsToTarget($events, $awayTeamId, $homeTeamId, $cap);
 
         return new MatchSimulationOutput(
             new MatchResult(
                 min($result->homeScore, $cap),
                 min($result->awayScore, $cap),
-                $cappedEvents,
+                $events,
                 $result->homePossession,
                 $result->awayPossession,
                 $result->homeXG,
@@ -331,6 +300,53 @@ class MatchSimulator
             ),
             $output->performances,
         );
+    }
+
+    /**
+     * Trim a team's scoring events down to at most `$target` goals so the
+     * headline score stays consistent with the events (MatchResultProcessor
+     * counts player goals/assists from the events, independently of the score
+     * field). A goal credits `$teamId` when it is that team's `goal` (scored
+     * penalties are tagged `goal` events) or the opponent's `own_goal`. The
+     * latest-minute surplus goals are dropped along with the assist tied to each
+     * (own goals carry no assist). Returns the collection unchanged when the
+     * team is already within `$target`.
+     *
+     * @param  Collection<MatchEventData>  $events
+     * @return Collection<MatchEventData>
+     */
+    private function trimGoalsToTarget(Collection $events, string $teamId, string $opponentId, int $target): Collection
+    {
+        $crediting = $events
+            ->filter(fn (MatchEventData $e) => ($e->type === 'goal' && $e->teamId === $teamId)
+                || ($e->type === 'own_goal' && $e->teamId === $opponentId))
+            ->sortByDesc('minute')
+            ->values();
+
+        $surplus = $crediting->count() - $target;
+        if ($surplus <= 0) {
+            return $events;
+        }
+
+        $toRemove = [];
+
+        foreach ($crediting->take($surplus) as $goal) {
+            $toRemove[spl_object_id($goal)] = true;
+
+            if ($goal->type === 'goal') {
+                $assist = $events->first(fn (MatchEventData $e) => $e->type === 'assist'
+                    && $e->teamId === $goal->teamId
+                    && $e->minute === $goal->minute
+                    && ! isset($toRemove[spl_object_id($e)]));
+                if ($assist !== null) {
+                    $toRemove[spl_object_id($assist)] = true;
+                }
+            }
+        }
+
+        return $events
+            ->reject(fn (MatchEventData $e) => isset($toRemove[spl_object_id($e)]))
+            ->values();
     }
 
     /**
@@ -2492,7 +2508,10 @@ class MatchSimulator
             ->merge($this->generateGoalEventsInRange($homeScore2, $homeTeam->id, $awayTeam->id, $homePlayers2, $awayPlayers2, $splitMinute + 1, $toMinute))
             ->merge($this->generateGoalEventsInRange($awayScore2, $awayTeam->id, $homeTeam->id, $awayPlayers2, $homePlayers2, $splitMinute + 1, $toMinute));
 
-        // Combine scores and apply cap
+        // Combine scores and apply cap. Trim the goal events to the capped score
+        // too — the two periods generate events for the uncapped sample, so
+        // without this the events would outnumber the capped score and credit
+        // phantom goals to player stats (the score field and events must agree).
         $homeScore = $homeScore1 + $homeScore2;
         $awayScore = $awayScore1 + $awayScore2;
 
@@ -2500,6 +2519,8 @@ class MatchSimulator
         if ($maxGoalsCap > 0) {
             $homeScore = min($homeScore, $maxGoalsCap);
             $awayScore = min($awayScore, $maxGoalsCap);
+            $goalEvents = $this->trimGoalsToTarget($goalEvents, $homeTeam->id, $awayTeam->id, $homeScore);
+            $goalEvents = $this->trimGoalsToTarget($goalEvents, $awayTeam->id, $homeTeam->id, $awayScore);
         }
 
         return [$homeScore, $awayScore, $goalEvents];

--- a/app/Modules/Match/Services/MatchSimulator.php
+++ b/app/Modules/Match/Services/MatchSimulator.php
@@ -218,8 +218,8 @@ class MatchSimulator
             default => false,
         };
 
-        if ($aiSubsActive) {
-            return $this->simulateWithAISubstitutions(
+        $output = $aiSubsActive
+            ? $this->simulateWithAISubstitutions(
                 $homeTeam, $awayTeam,
                 $homePlayers, $awayPlayers,
                 $homeFormation, $awayFormation,
@@ -232,28 +232,104 @@ class MatchSimulator
                 $matchSeed,
                 $userTeamId,
                 $regulationEnd,
+            )
+            : $this->simulateRemainder(
+                $homeTeam, $awayTeam,
+                $homePlayers, $awayPlayers,
+                $homeFormation, $awayFormation,
+                $homeMentality, $awayMentality,
+                fromMinute: 0,
+                game: $game,
+                homePlayingStyle: $homePlayingStyle,
+                awayPlayingStyle: $awayPlayingStyle,
+                homePressing: $homePressing,
+                awayPressing: $awayPressing,
+                homeDefLine: $homeDefLine,
+                awayDefLine: $awayDefLine,
+                homeBenchPlayers: $homeBenchPlayers,
+                awayBenchPlayers: $awayBenchPlayers,
+                matchSeed: $matchSeed,
+                neutralVenue: $neutralVenue,
+                toMinute: $regulationEnd,
+                userTeamId: $userTeamId,
             );
+
+        // Final safety net: hard-cap the regulation match TOTAL at max_goals_cap.
+        // The per-period cap inside each simulation period bounds a single
+        // period, not the multi-period sum (substitution windows, red-card
+        // splits), so without this a runaway xG could still stack into a blow-out.
+        // With the strength-ratio clamp in place this almost never binds. Applied
+        // only here in simulate() — the unambiguous full-match-from-minute-0 entry
+        // point; resimulation and extra-time run simulateRemainder/
+        // simulateExtraTime directly and are bounded by the ratio clamp.
+        return $this->capMatchTotal($output, $homeTeam->id, $awayTeam->id);
+    }
+
+    /**
+     * Hard-cap each team's match total at max_goals_cap, trimming the surplus
+     * scoring events so the headline score and the goal/assist events stay
+     * consistent (MatchResultProcessor counts player goals/assists from the
+     * events independently of the score field).
+     *
+     * A goal credits a team when it is that team's `goal` (scored penalties are
+     * `goal` events) or the opponent's `own_goal`. Surplus goals are removed
+     * latest-minute first, along with the assist tied to each removed goal (own
+     * goals carry no assist). A cap of 0 (or scores already within it) is a no-op.
+     */
+    private function capMatchTotal(MatchSimulationOutput $output, string $homeTeamId, string $awayTeamId): MatchSimulationOutput
+    {
+        $cap = (int) config('match_simulation.max_goals_cap', 0);
+        $result = $output->result;
+
+        if ($cap <= 0 || ($result->homeScore <= $cap && $result->awayScore <= $cap)) {
+            return $output;
         }
 
-        return $this->simulateRemainder(
-            $homeTeam, $awayTeam,
-            $homePlayers, $awayPlayers,
-            $homeFormation, $awayFormation,
-            $homeMentality, $awayMentality,
-            fromMinute: 0,
-            game: $game,
-            homePlayingStyle: $homePlayingStyle,
-            awayPlayingStyle: $awayPlayingStyle,
-            homePressing: $homePressing,
-            awayPressing: $awayPressing,
-            homeDefLine: $homeDefLine,
-            awayDefLine: $awayDefLine,
-            homeBenchPlayers: $homeBenchPlayers,
-            awayBenchPlayers: $awayBenchPlayers,
-            matchSeed: $matchSeed,
-            neutralVenue: $neutralVenue,
-            toMinute: $regulationEnd,
-            userTeamId: $userTeamId,
+        $events = $result->events;
+        $toRemove = [];
+
+        foreach ([[$homeTeamId, $awayTeamId, $result->homeScore], [$awayTeamId, $homeTeamId, $result->awayScore]] as [$teamId, $opponentId, $score]) {
+            $surplus = $score - $cap;
+            if ($surplus <= 0) {
+                continue;
+            }
+
+            $surplusGoals = $events
+                ->filter(fn (MatchEventData $e) => ($e->type === 'goal' && $e->teamId === $teamId)
+                    || ($e->type === 'own_goal' && $e->teamId === $opponentId))
+                ->sortByDesc('minute')
+                ->take($surplus);
+
+            foreach ($surplusGoals as $goal) {
+                $toRemove[spl_object_id($goal)] = true;
+
+                if ($goal->type === 'goal') {
+                    $assist = $events->first(fn (MatchEventData $e) => $e->type === 'assist'
+                        && $e->teamId === $goal->teamId
+                        && $e->minute === $goal->minute
+                        && ! isset($toRemove[spl_object_id($e)]));
+                    if ($assist !== null) {
+                        $toRemove[spl_object_id($assist)] = true;
+                    }
+                }
+            }
+        }
+
+        $cappedEvents = $events
+            ->reject(fn (MatchEventData $e) => isset($toRemove[spl_object_id($e)]))
+            ->values();
+
+        return new MatchSimulationOutput(
+            new MatchResult(
+                min($result->homeScore, $cap),
+                min($result->awayScore, $cap),
+                $cappedEvents,
+                $result->homePossession,
+                $result->awayPossession,
+                $result->homeXG,
+                $result->awayXG,
+            ),
+            $output->performances,
         );
     }
 
@@ -1787,7 +1863,13 @@ class MatchSimulator
         $skillDominance = config('match_simulation.skill_dominance', 2.0);
         $homeAdvantageGoals = $neutralVenue ? 0.0 : config('match_simulation.home_advantage_goals', 0.15);
 
-        $strengthRatio = $awayStrength > 0 ? $homeStrength / $awayStrength : 1.0;
+        // Bound the ratio before exponentiation. Match-time strength (eroded by
+        // form/energy/out-of-position) can fall far below the static band the
+        // strength floor was calibrated on, exploding the raw ratio; the clamp
+        // caps xG at the source. See MatchOutcomeModel::clampStrengthRatio.
+        $strengthRatio = $awayStrength > 0
+            ? MatchOutcomeModel::clampStrengthRatio($homeStrength / $awayStrength)
+            : 1.0;
 
         $homeXG = (pow($strengthRatio, $skillDominance) * $baseGoals + $homeAdvantageGoals)
             * $homeFormation->attackModifier()
@@ -1830,6 +1912,10 @@ class MatchSimulator
         float $effectiveMinute,
         float $strengthRatio = 1.0,
     ): array {
+        // Use the same bounded ratio the xG formula uses, so the defensive
+        // attenuation below can't be driven by a runaway match-time ratio.
+        $strengthRatio = MatchOutcomeModel::clampStrengthRatio($strengthRatio);
+
         $preHomeXG = $homeXG;
         $preAwayXG = $awayXG;
 

--- a/app/Modules/Match/Support/MatchOutcomeModel.php
+++ b/app/Modules/Match/Support/MatchOutcomeModel.php
@@ -59,11 +59,40 @@ class MatchOutcomeModel
             return [$baseGoals + $homeAdvantage, $baseGoals * 0.5];
         }
 
-        $strengthRatio = $homeStrength / $awayStrength;
+        $strengthRatio = self::clampStrengthRatio($homeStrength / $awayStrength);
         $homeXG = pow($strengthRatio, $skillDominance) * $baseGoals + $homeAdvantage;
         $awayXG = pow(1.0 / $strengthRatio, $skillDominance) * $baseGoals;
 
         return [$homeXG, $awayXG];
+    }
+
+    /**
+     * Bound a home/away strength ratio before it is raised to `skill_dominance`.
+     *
+     * The xG power formula has no inherent ceiling: a ratio of 13 at exponent 2.4
+     * is ~700× base goals. The strength FLOOR is calibrated on STATIC top-11
+     * overall_score (so the static league ratio tops out near R≈1.34), but the
+     * full MatchSimulator feeds it MATCH-TIME strength — overall × form × energy ×
+     * out-of-position penalty — which can erode far below the static band the
+     * floor was derived from. As a side nears the floor, applyFloor() collapses
+     * its rescaled strength toward the 0.02 clamp while the opponent stays high,
+     * exploding the ratio and producing 13-0 / 21-0 blowouts. Clamping the ratio
+     * symmetrically to `[1/max, max]` caps xG at the source.
+     *
+     * `max_strength_ratio` ≤ 1.0 (e.g. 0) disables the clamp — a no-op escape
+     * hatch mirroring the floor's own convention. The clamp never binds on static
+     * AI-vs-AI matches (ratio ≈ R), so the league-table realism of the floor is
+     * preserved.
+     */
+    public static function clampStrengthRatio(float $ratio): float
+    {
+        $max = (float) config('match_simulation.max_strength_ratio', 2.2);
+
+        if ($max <= 1.0) {
+            return $ratio;
+        }
+
+        return min($max, max(1.0 / $max, $ratio));
     }
 
     /**

--- a/config/match_simulation.php
+++ b/config/match_simulation.php
@@ -69,6 +69,21 @@ return [
     'home_advantage_goals' => 0.20,     // fixed home xG bonus
     'defensive_quality_damping' => 0.6, // how much quality advantage erodes defensive tactics (0=none, higher=more erosion)
 
+    // Hard ceiling on the home/away strength ratio BEFORE it is raised to
+    // skill_dominance. The xG formula is unbounded — a ratio of 13 at exponent
+    // 2.4 is ~700× base goals. The strength floor (below) is calibrated on
+    // STATIC top-11 overall_score, so the static league ratio tops out near
+    // R≈1.34. But the live simulator applies that floor to MATCH-TIME strength
+    // (overall × form × energy × out-of-position penalty), which can erode far
+    // below the static band; as a side nears the floor its rescaled strength
+    // collapses toward applyFloor()'s 0.02 clamp and the ratio explodes,
+    // producing 13-0 / 21-0 blowouts. Clamping symmetrically to [1/max, max]
+    // caps xG at the source. 2.2 → worst case ≈ 2.2^2.4 × 1.4 ≈ 8.4 xG (a
+    // once-a-decade scoreline), while leaving genuine single-match maulings room
+    // above the static R. The clamp never binds on static AI-vs-AI matches, so
+    // the floor's league-table realism is untouched. 0 (or ≤ 1.0) disables it.
+    'max_strength_ratio' => 2.2,
+
     /*
     |--------------------------------------------------------------------------
     | Strength Floor (Distribution-Derived Rescale)

--- a/docs/game-systems/match-simulation.md
+++ b/docs/game-systems/match-simulation.md
@@ -32,6 +32,10 @@ strength = (rating - floor) / (100 - floor)
 
 The floor is **derived per competition** from its own rating band (`CompetitionStrengthFloorResolver`) so a high-narrow league gets a large floor and a low-wide league a small one, from a single global knob `strength_ratio_target` (R): `floor = (R·bottom - top)/(R - 1)`. Domestic-league matches use their league's floor; cups and continental matches use a global cross-band floor (which collapses toward 0, i.e. raw globally-consistent overalls, preserving genuine cross-league quality gaps). The rescale lives in `MatchOutcomeModel::applyFloor()` (a floor of 0 is a no-op) and is applied in both the full `MatchSimulator` path (via `setStrengthFloor()`, set by `FullMatchSimulationService`/`MatchResimulationService`) and the lightweight `AIMatchResolver`. Set `strength_floor_enabled => false` to disable. The `app:diagnose-strength-realism` command measures the effect and `--auto-floor` previews the production-derived floor.
 
+### Strength-ratio clamp (blow-out guard)
+
+The floor is calibrated on **static** top-11 `overall_score`, so the static league ratio tops out near R (~1.34). But the full simulator applies the floor to **match-time** strength — `overall × form × energy × out-of-position penalty` — which can erode far below that static band. As a side nears the floor, `applyFloor()` collapses its rescaled strength toward the `0.02` clamp while the opponent stays high, so the raw ratio explodes (e.g. 2.5×–25×) and `ratio ^ skill_dominance` produces enormous xG. (AI-vs-AI matches don't show this: `AIMatchResolver` uses static strength.) To bound it, the home/away ratio is clamped symmetrically to `[1/max, max]` via `MatchOutcomeModel::clampStrengthRatio()` **before** exponentiation — in `expectedGoals()`, `calculateBaseExpectedGoals()`, and `applyTacticalModifiers()`. The knob is `max_strength_ratio` (default 2.2; `0`/`≤1.0` disables it as a rollback escape hatch). It never binds on static AI-vs-AI matches, so the floor's league-table realism is preserved.
+
 ## Formation & Mentality
 
 Each formation has attack and defense modifiers (multiplicative on xG). A team's attack modifier scales their own xG; their defense modifier scales the opponent's. Available formations and their modifiers are defined in `Formation` enum.
@@ -77,7 +81,7 @@ Each player gets a random "form on the day" modifier using a normal distribution
 
 ## Score Generation
 
-Scores are Poisson-distributed from the final xG, capped at a maximum per team to prevent unrealistic scorelines.
+Scores are Poisson-distributed from the final xG, capped at `max_goals_cap` per team to prevent unrealistic scorelines. That cap is applied **per simulation period** (each substitution window, red-card split, etc.); because a match spans several periods, `simulate()` also enforces `max_goals_cap` on the match **total** as a final safety net (`MatchSimulator::capMatchTotal()`), trimming the surplus scoring events so the headline score stays consistent with the goal/assist events. With the strength-ratio clamp in place this total cap almost never binds.
 
 ## Match Events
 

--- a/landing/public/index.html
+++ b/landing/public/index.html
@@ -85,14 +85,14 @@
             </p>
 
             <!-- Inline waitlist -->
-            <form id="waitlist-form" class="mt-8 flex flex-col sm:flex-row gap-3 max-w-xl">
+            <form id="waitlist-form" class="mt-8 flex flex-col sm:flex-row gap-3 max-w-3xl">
                 <input
                     type="text"
                     id="name"
                     name="name"
                     required
                     placeholder="Tu nombre"
-                    class="sm:w-40 px-4 py-3 rounded-md bg-white/10 border border-white/20 text-white placeholder-slate-500 focus:outline-hidden focus:ring-2 focus:ring-accent-blue focus:border-transparent transition text-sm"
+                    class="sm:w-48 px-4 py-3 rounded-md bg-white/10 border border-white/20 text-white placeholder-slate-500 focus:outline-hidden focus:ring-2 focus:ring-accent-blue focus:border-transparent transition text-sm"
                 >
                 <input
                     type="email"

--- a/tests/Feature/MatchStrengthRatioBlowoutGuardTest.php
+++ b/tests/Feature/MatchStrengthRatioBlowoutGuardTest.php
@@ -1,0 +1,140 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Game;
+use App\Models\Team;
+use App\Modules\Match\Services\MatchSimulator;
+use App\Modules\Match\Support\MatchOutcomeModel;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use Tests\Traits\CreatesLineups;
+
+/**
+ * Guards against the exploding scorelines (13-0, 21-0, 0-15) that the
+ * distribution-derived strength floor introduced (#1281).
+ *
+ * The floor is calibrated on STATIC top-11 overall_score, but the live
+ * simulator applies it to MATCH-TIME strength (eroded by form, energy and
+ * out-of-position penalties), which can fall far below the static band the
+ * floor was derived from. As a side nears the floor, applyFloor() collapses its
+ * rescaled strength toward the 0.02 clamp while the opponent stays high, so the
+ * home/away ratio explodes and `ratio^skill_dominance` produces enormous xG.
+ *
+ * The fix bounds the ratio before exponentiation (max_strength_ratio) and
+ * hard-caps the match total (max_goals_cap) with event-consistent trimming.
+ * Pre-fix, the multi-period scenario below blows past max_goals_cap; post-fix it
+ * stays within it, and the headline score always matches the scoring events.
+ */
+class MatchStrengthRatioBlowoutGuardTest extends TestCase
+{
+    use RefreshDatabase;
+    use CreatesLineups;
+
+    private MatchSimulator $simulator;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->simulator = new MatchSimulator;
+    }
+
+    public function test_expected_goals_ratio_is_clamped_before_exponentiation(): void
+    {
+        config([
+            'match_simulation.max_strength_ratio' => 2.2,
+            'match_simulation.skill_dominance' => 2.4,
+            'match_simulation.base_goals' => 1.4,
+        ]);
+
+        // Raw ratio = 0.80 / 0.05 = 16, which unclamped would be 16^2.4 ≈ 775×
+        // base goals (~1085 xG). Clamped to 2.2 it must match a 2.2× ratio.
+        [$homeXG, $awayXG] = MatchOutcomeModel::expectedGoals(0.80, 0.05, neutralVenue: true);
+
+        $this->assertEqualsWithDelta(pow(2.2, 2.4) * 1.4, $homeXG, 1e-6);
+        $this->assertEqualsWithDelta(pow(1.0 / 2.2, 2.4) * 1.4, $awayXG, 1e-6);
+        $this->assertLessThan(10.0, $homeXG);
+    }
+
+    public function test_clamp_protects_a_weak_home_side_symmetrically(): void
+    {
+        config([
+            'match_simulation.max_strength_ratio' => 2.2,
+            'match_simulation.skill_dominance' => 2.4,
+            'match_simulation.base_goals' => 1.4,
+        ]);
+
+        // Home is the weak side now: ratio 1/16 clamps up to 1/2.2.
+        [$homeXG, $awayXG] = MatchOutcomeModel::expectedGoals(0.05, 0.80, neutralVenue: true);
+
+        $this->assertEqualsWithDelta(pow(2.2, 2.4) * 1.4, $awayXG, 1e-6);
+        $this->assertEqualsWithDelta(pow(1.0 / 2.2, 2.4) * 1.4, $homeXG, 1e-6);
+    }
+
+    public function test_max_strength_ratio_zero_disables_the_clamp(): void
+    {
+        config([
+            'match_simulation.max_strength_ratio' => 0,
+            'match_simulation.skill_dominance' => 2.4,
+            'match_simulation.base_goals' => 1.4,
+        ]);
+
+        // With the clamp disabled the raw 16× ratio comes through, restoring the
+        // pre-fix (unbounded) behaviour as a rollback escape hatch.
+        [$homeXG] = MatchOutcomeModel::expectedGoals(0.80, 0.05, neutralVenue: true);
+
+        $this->assertEqualsWithDelta(pow(16.0, 2.4) * 1.4, $homeXG, 1e-3);
+        $this->assertGreaterThan(100.0, $homeXG);
+    }
+
+    public function test_full_match_total_never_exceeds_cap_for_extreme_mismatch(): void
+    {
+        $cap = (int) config('match_simulation.max_goals_cap', 6);
+        $this->assertGreaterThan(0, $cap, 'This guard test requires max_goals_cap > 0');
+
+        $game = Game::factory()->create(['current_date' => '2025-10-01']);
+        $homeTeam = Team::factory()->create();
+        $awayTeam = Team::factory()->create();
+
+        // Strong fresh home vs a much weaker away. A high floor stands in for the
+        // match-time strength erosion (form/energy/out-of-position) that pushes a
+        // side toward the floor in real matches — it is what explodes the ratio.
+        $homePlayers = $this->createLineup($game, $homeTeam, 11, 88);
+        $awayPlayers = $this->createLineup($game, $awayTeam, 11, 70);
+        $homeBench = $this->createBenchPlayers($game, $homeTeam, 7, 85);
+        $awayBench = $this->createBenchPlayers($game, $awayTeam, 7, 66);
+
+        // Benches enable AI substitution windows → multiple simulation periods.
+        // Pre-fix each period caps at max_goals_cap but the TOTAL stacks past it.
+        $this->simulator->setStrengthFloor(60.0);
+
+        for ($i = 0; $i < 30; $i++) {
+            $output = $this->simulator->simulate(
+                $homeTeam, $awayTeam,
+                $homePlayers, $awayPlayers,
+                game: $game,
+                homeBenchPlayers: $homeBench,
+                awayBenchPlayers: $awayBench,
+            );
+
+            $result = $output->result;
+
+            $this->assertLessThanOrEqual($cap, $result->homeScore, "home total exceeded cap (iter {$i})");
+            $this->assertLessThanOrEqual($cap, $result->awayScore, "away total exceeded cap (iter {$i})");
+
+            // Score must stay consistent with the events after trimming: a team's
+            // score = its own goals + the opponent's own goals.
+            $homeScoringEvents = $result->events
+                ->filter(fn ($e) => ($e->type === 'goal' && $e->teamId === $homeTeam->id)
+                    || ($e->type === 'own_goal' && $e->teamId === $awayTeam->id))
+                ->count();
+            $awayScoringEvents = $result->events
+                ->filter(fn ($e) => ($e->type === 'goal' && $e->teamId === $awayTeam->id)
+                    || ($e->type === 'own_goal' && $e->teamId === $homeTeam->id))
+                ->count();
+
+            $this->assertSame($result->homeScore, $homeScoringEvents, "home score/event mismatch (iter {$i})");
+            $this->assertSame($result->awayScore, $awayScoringEvents, "away score/event mismatch (iter {$i})");
+        }
+    }
+}


### PR DESCRIPTION
## Problem

A user reported wildly lopsided results in matches they play — *"igual que gano 13–0 o 21-0 pierdo alguno 1-13 o 0-15"* — while AI-vs-AI matches in the same league looked normal.

## Root cause

The regression was introduced by #1281 (`3e861170`, the distribution-derived per-competition **strength floor**).

The floor rescales team strength as `(rating − floor) / (100 − floor)` before the home/away **strength ratio** is formed, and that ratio drives expected goals via `xG = (homeStr/awayStr)^skill_dominance × base_goals` (`skill_dominance` = 2.4). **The ratio was never clamped.**

The floor is calibrated on **static** top-11 `overall_score` (`CompetitionStrengthFloorResolver`), so by construction the static top-vs-bottom league ratio after rescaling is only ~1.34 — and on static strength everything looks fine (which is why `DiagnoseStrengthRealism`, which also uses static overalls, validated #1281 as healthy).

But `MatchSimulator::calculateTeamStrength` applies the floor to **match-time** strength:

```
overall × form-on-the-day × out-of-position penalty (×0.75) × energy/fatigue modifier
```

A fatigued / rotated / out-of-position / red-carded side's effective rating drops **far below** the static band the floor was derived from. As that side's strength approaches the floor, `applyFloor()` collapses its rescaled strength toward the `0.02` clamp while the opponent stays high — so the ratio explodes (2.5×–25×) and `ratio^2.4 × 1.4` yields 13–100+ xG. `max_goals_cap = 6` is applied **per simulation period only**, never to the match total, so regulation periods + red-card splits + extra time stack into 13-0 / 21-0 / 0-15.

**Why only the user's matches:** AI-vs-AI runs through `AIMatchResolver`, which uses *static* `overall_score` (no fatigue/form/position) **and** caps the match total at 6. The full fatigue-aware `MatchSimulator` is where the explosion lives.

## Fix

**1. Clamp the strength ratio before exponentiation** (the precise root-cause fix). New knob `match_simulation.max_strength_ratio` (default **2.2**; `0`/`≤1.0` disables it as a rollback escape hatch). `MatchOutcomeModel::clampStrengthRatio()` clamps symmetrically to `[1/max, max]` and is called everywhere the ratio feeds the power formula:

- `MatchOutcomeModel::expectedGoals()` — also covers the `AIMatchResolver` path
- `MatchSimulator::calculateBaseExpectedGoals()` — covers regulation, red-card split, and extra time (all route through it)
- `MatchSimulator::applyTacticalModifiers()` — keeps the possession / defensive-damping ratio consistent with the xG ratio

The clamp **never binds on static AI-vs-AI matches** (ratio ≈ 1.34 ≪ 2.2), so #1281's league-table realism is fully preserved — only the runaway match-time ratios are bounded. Worst case is now `2.2^2.4 × 1.4 ≈ 8.4` xG.

**2. Match-total backstop.** `MatchSimulator::capMatchTotal()` enforces `max_goals_cap` on the full match in `simulate()` (the unambiguous full-match-from-minute-0 entry point; resim / extra-time paths run `simulateRemainder`/`simulateExtraTime` directly and are bounded by the ratio clamp). It trims the surplus latest-minute goal + assist events so the headline score stays consistent with the events that `MatchResultProcessor` uses for player stats.

## Tests

`tests/Feature/MatchStrengthRatioBlowoutGuardTest.php`:
- ratio clamped before exponentiation (raw 16× → bounded to a 2.2× ratio)
- `max_strength_ratio = 0` is a no-op (rollback escape hatch)
- symmetric clamp protects a weak *home* side too
- full-match guard: an extreme multi-period mismatch never exceeds `max_goals_cap`, and the headline score always equals the scoring events (goals + opponent own-goals)

## Notes

- No user-facing strings — no i18n changes.
- Docs updated in `docs/game-systems/match-simulation.md` (ratio-clamp subsection + match-total cap note).

🤖 Generated with [Claude Code](https://claude.com/claude-code)