### PR TITLE
Reversible club investment: backend foundation

### DIFF
--- a/app/Http/Actions/CompleteNewSeason.php
+++ b/app/Http/Actions/CompleteNewSeason.php
@@ -2,7 +2,6 @@
 
 namespace App\Http\Actions;
 
-use App\Events\SeasonStarted;
 use App\Models\ActivationEvent;
 use App\Models\Game;
 use App\Modules\Finance\Services\BudgetAllocationService;
@@ -20,39 +19,40 @@ class CompleteNewSeason
     {
         $game = Game::findOrFail($gameId);
 
-        // Ensure new-season setup is still needed
+        // The soft "board's starting plan" screen is shown once; if it's already
+        // been dismissed just bounce to the dashboard.
         if (!$game->needsNewSeasonSetup()) {
             return redirect()->route('show-game', $gameId);
         }
 
-        $finances = $game->currentFinances;
-        if (!$finances) {
-            return redirect()->route('game.new-season', $gameId)
-                ->with('error', __('messages.budget_no_projections'));
+        // The new-season screen still lets the manager set an allocation (until
+        // the Club investment page takes over editing). Honour an explicit
+        // submission — it overrides the default applied during season setup.
+        // When that screen goes read-only it posts no amounts and this no-ops,
+        // falling back to the auto-applied default (or applying one for saves
+        // created before DefaultInvestmentProcessor existed).
+        if ($request->filled(['youth_academy', 'medical', 'scouting', 'facilities', 'transfer_budget'])) {
+            $validated = $request->validate([
+                'youth_academy' => 'required|numeric|min:0',
+                'medical' => 'required|numeric|min:0',
+                'scouting' => 'required|numeric|min:0',
+                'facilities' => 'required|numeric|min:0',
+                'transfer_budget' => 'required|numeric|min:0',
+            ]);
+
+            try {
+                $this->budgetService->allocate($game, $validated);
+            } catch (\InvalidArgumentException $e) {
+                return redirect()->route('game.new-season', $gameId)
+                    ->with('error', __($e->getMessage()));
+            }
+        } elseif (!$game->currentInvestment) {
+            $this->budgetService->applyDefaultAllocation($game);
         }
 
-        $validated = $request->validate([
-            'youth_academy' => 'required|numeric|min:0',
-            'medical' => 'required|numeric|min:0',
-            'scouting' => 'required|numeric|min:0',
-            'facilities' => 'required|numeric|min:0',
-            'transfer_budget' => 'required|numeric|min:0',
-        ]);
-
-        try {
-            $this->budgetService->allocate($game, $validated);
-        } catch (\InvalidArgumentException $e) {
-            return redirect()->route('game.new-season', $gameId)
-                ->with('error', __($e->getMessage()));
-        }
-
-        // Complete new-season setup
-        $game->refresh()->setRelations([]);
         $game->completeNewSeasonSetup();
 
         $this->activationTracker->record($game->user_id, ActivationEvent::EVENT_ONBOARDING_COMPLETED, $gameId, $game->game_mode);
-
-        event(new SeasonStarted($game));
 
         return redirect()->route('show-game', $gameId)
             ->with('success', __('messages.welcome_to_team', ['team_a' => $game->team->nameWithA()]));

--- a/app/Models/GameInvestment.php
+++ b/app/Models/GameInvestment.php
@@ -21,6 +21,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  * @property int $facilities_amount
  * @property int $facilities_tier
  * @property int $transfer_budget
+ * @property array<string, int>|null $staged_downgrades
  * @property-read \App\Models\Game $game
  * @property-read float $facilities_multiplier
  * @property-read string $formatted_available_surplus
@@ -68,6 +69,7 @@ class GameInvestment extends Model
         'facilities_amount',
         'facilities_tier',
         'transfer_budget',
+        'staged_downgrades',
     ];
 
     /**
@@ -161,6 +163,7 @@ class GameInvestment extends Model
         'facilities_amount' => 'integer',
         'facilities_tier' => 'integer',
         'transfer_budget' => 'integer',
+        'staged_downgrades' => 'array',
     ];
 
     public function game(): BelongsTo
@@ -294,6 +297,31 @@ class GameInvestment extends Model
         $tiers = self::DEFAULT_TIERS_BY_REPUTATION[$reputation]
             ?? self::DEFAULT_TIERS_BY_REPUTATION['modest'];
 
+        // Reserve a share of the surplus for transfers so infrastructure can't
+        // swallow the whole budget. Without it, a club whose surplus just clears
+        // its reputation default spends it all on infrastructure and is left with
+        // almost nothing to spend — so the highest-revenue club in a division can
+        // end up with the smallest transfer budget.
+        $reserve = (float) config('finances.default_infra_transfer_reserve', 0.45);
+        $infraBudget = (int) floor($availableSurplus * (1 - $reserve));
+
+        return self::trimTiersToBudget($tiers, $infraBudget, $minTier);
+    }
+
+    /**
+     * Trim a tier selection — most expensive area first — until its total spend
+     * fits within $infraBudget, never dropping an area below $minTier. Reducing
+     * one area at a time (most expensive first) lets infra settle near the cap
+     * instead of collapsing all four tiers in a single step. Once every area
+     * sits at $minTier the floor wins: minimum infra is mandatory even if it
+     * exceeds the budget. Reused for both the reputation default and carrying
+     * last season's picks forward into a (possibly smaller) new-season surplus.
+     *
+     * @param  array<string, int>  $tiers
+     * @return array<string, int>
+     */
+    public static function trimTiersToBudget(array $tiers, int $infraBudget, int $minTier = 1): array
+    {
         $costFor = static function (string $area, int $tier): int {
             if ($tier === 0) {
                 return self::TIER_0_THRESHOLDS[$area];
@@ -301,16 +329,6 @@ class GameInvestment extends Model
 
             return self::TIER_THRESHOLDS[$area][$tier];
         };
-
-        // Reserve a share of the surplus for transfers so infrastructure can't
-        // swallow the whole budget. Without it, a club whose surplus just clears
-        // its reputation default spends it all on infrastructure and is left with
-        // almost nothing to spend — so the highest-revenue club in a division can
-        // end up with the smallest transfer budget. Reducing one area at a time
-        // (most expensive first) lets infra settle near the cap instead of
-        // collapsing all four tiers in a single step.
-        $reserve = (float) config('finances.default_infra_transfer_reserve', 0.45);
-        $infraBudget = (int) floor($availableSurplus * (1 - $reserve));
 
         while (true) {
             $totalCost = 0;
@@ -322,9 +340,6 @@ class GameInvestment extends Model
                 return $tiers;
             }
 
-            // Trim the single most expensive area still above the floor. Once
-            // every area sits at $minTier the floor wins — minimum infra is
-            // mandatory even if it exceeds the reserve-adjusted budget.
             $reduceArea = null;
             $reduceCost = -1;
             foreach ($tiers as $area => $tier) {

--- a/app/Modules/Finance/Services/BudgetAllocationService.php
+++ b/app/Modules/Finance/Services/BudgetAllocationService.php
@@ -123,4 +123,96 @@ class BudgetAllocationService
             ]
         );
     }
+
+    /**
+     * Apply the season's default investment allocation so a GameInvestment row —
+     * and therefore a transfer budget — always exists once season setup finishes.
+     * This is what lets the new-season screen stop being a blocking budget gate:
+     * the board sets a sane starting plan automatically, and the manager refines
+     * it later, reversibly, on the Club investment page.
+     *
+     * Idempotent: if the current season already has an investment row (re-entrant
+     * setup job, or the manager already adjusted their plan) it is left untouched.
+     */
+    public function applyDefaultAllocation(Game $game): GameInvestment
+    {
+        if ($existing = $game->currentInvestment) {
+            return $existing;
+        }
+
+        $finances = $game->currentFinances ?? $this->projectionService->generateProjections($game);
+        $availableSurplus = $finances->available_surplus ?? 0;
+
+        $competitionTier = (int) ($game->competition->tier ?? 1);
+        $minimumTier = GameInvestment::minimumTierForCompetitionTier($competitionTier);
+        $previousInvestment = $game->previousSeasonInvestment();
+
+        if ($previousInvestment) {
+            // Carry last season's picks forward (clamped to the new division's
+            // floor — a promoted Primera RFEF side can't keep tier-0 picks).
+            $tiers = [
+                'youth_academy' => max($minimumTier, $previousInvestment->youth_academy_tier),
+                'medical' => max($minimumTier, $previousInvestment->medical_tier),
+                'scouting' => max($minimumTier, $previousInvestment->scouting_tier),
+                'facilities' => max($minimumTier, $previousInvestment->facilities_tier),
+            ];
+
+            // Realise any downgrade the manager staged mid-season. A reduction
+            // never clawed back committed spend; it lands here, as next season's
+            // starting point.
+            foreach (($previousInvestment->staged_downgrades ?? []) as $area => $tier) {
+                if (array_key_exists($area, $tiers)) {
+                    $tiers[$area] = max($minimumTier, (int) $tier);
+                }
+            }
+
+            // Revenue can fall (relegation), so last season's spend may no longer
+            // fit. Trim to what this season's surplus can carry so the auto-applied
+            // plan never produces a negative transfer budget.
+            $tiers = GameInvestment::trimTiersToBudget($tiers, $availableSurplus, $minimumTier);
+        } else {
+            $tiers = GameInvestment::defaultTiersForReputation(
+                TeamReputation::resolveLevel($game->id, $game->team_id),
+                $availableSurplus,
+                $minimumTier,
+            );
+        }
+
+        return $this->persistTiers($game, $tiers, $availableSurplus, $competitionTier);
+    }
+
+    /**
+     * Persist a tier selection: derive per-area amounts from the competition's
+     * threshold table, set the transfer budget to whatever surplus remains, and
+     * upsert the current season's investment row.
+     *
+     * @param  array<string, int>  $tiers
+     */
+    private function persistTiers(Game $game, array $tiers, int $availableSurplus, int $competitionTier): GameInvestment
+    {
+        $thresholds = GameInvestment::thresholdsForCompetitionTier($competitionTier);
+
+        $amounts = [];
+        foreach (['youth_academy', 'medical', 'scouting', 'facilities'] as $area) {
+            $amounts[$area] = $thresholds[$area][$tiers[$area]];
+        }
+
+        $transferBudget = max(0, $availableSurplus - array_sum($amounts));
+
+        return GameInvestment::updateOrCreate(
+            ['game_id' => $game->id, 'season' => $game->season],
+            [
+                'available_surplus' => $availableSurplus,
+                'youth_academy_amount' => $amounts['youth_academy'],
+                'youth_academy_tier' => $tiers['youth_academy'],
+                'medical_amount' => $amounts['medical'],
+                'medical_tier' => $tiers['medical'],
+                'scouting_amount' => $amounts['scouting'],
+                'scouting_tier' => $tiers['scouting'],
+                'facilities_amount' => $amounts['facilities'],
+                'facilities_tier' => $tiers['facilities'],
+                'transfer_budget' => $transferBudget,
+            ],
+        );
+    }
 }

--- a/app/Modules/Finance/Services/InvestmentStateService.php
+++ b/app/Modules/Finance/Services/InvestmentStateService.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace App\Modules\Finance\Services;
+
+use App\Models\Game;
+use App\Models\GameInvestment;
+
+/**
+ * Resolves how freely the manager may change investment, and records downgrades
+ * that take effect next season.
+ *
+ * The plan is fully editable in pre-season; once the first competitive match is
+ * played the season's commitment stands. From then on the manager can invest
+ * *more* at any time (handled by InfrastructureUpgradeService, full cost), but a
+ * reduction is never clawed back — it is staged here and applied as the starting
+ * point for the next season (consumed by BudgetAllocationService::applyDefaultAllocation).
+ */
+class InvestmentStateService
+{
+    public const STATE_PRE_SEASON = 'pre_season';
+    public const STATE_LOCKED = 'locked';
+
+    private const VALID_AREAS = ['youth_academy', 'medical', 'scouting', 'facilities'];
+
+    /**
+     * PRE_SEASON = free two-way editing; LOCKED = upgrade-only, downgrades staged.
+     */
+    public function resolveState(Game $game): string
+    {
+        return $game->isInPreSeason()
+            ? self::STATE_PRE_SEASON
+            : self::STATE_LOCKED;
+    }
+
+    public function isEditableFreely(Game $game): bool
+    {
+        return $this->resolveState($game) === self::STATE_PRE_SEASON;
+    }
+
+    /**
+     * Stage a downgrade to take effect at next season's setup. Re-staging
+     * overwrites the previous request for that area.
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function stageDowngrade(Game $game, string $area, int $targetTier): GameInvestment
+    {
+        if (! in_array($area, self::VALID_AREAS, true)) {
+            throw new \InvalidArgumentException(__('messages.infrastructure_upgrade_invalid_area'));
+        }
+
+        $investment = $game->currentInvestment;
+        if (! $investment) {
+            throw new \InvalidArgumentException(__('messages.budget_no_projections'));
+        }
+
+        $minimumTier = GameInvestment::minimumTierForCompetitionTier((int) ($game->competition->tier ?? 1));
+        if ($targetTier < $minimumTier) {
+            throw new \InvalidArgumentException(__('messages.budget_minimum_tier'));
+        }
+
+        if ($targetTier >= $investment->{"{$area}_tier"}) {
+            throw new \InvalidArgumentException(__('messages.investment_downgrade_not_lower'));
+        }
+
+        $staged = $investment->staged_downgrades ?? [];
+        $staged[$area] = $targetTier;
+        $investment->update(['staged_downgrades' => $staged]);
+
+        return $investment->fresh();
+    }
+
+    /**
+     * Cancel a staged downgrade for an area, restoring "no change next season".
+     */
+    public function clearStagedDowngrade(Game $game, string $area): GameInvestment
+    {
+        $investment = $game->currentInvestment;
+        if (! $investment) {
+            throw new \InvalidArgumentException(__('messages.budget_no_projections'));
+        }
+
+        $staged = $investment->staged_downgrades ?? [];
+        unset($staged[$area]);
+        $investment->update(['staged_downgrades' => $staged === [] ? null : $staged]);
+
+        return $investment->fresh();
+    }
+}

--- a/app/Modules/Season/Jobs/SetupNewGame.php
+++ b/app/Modules/Season/Jobs/SetupNewGame.php
@@ -2,6 +2,7 @@
 
 namespace App\Modules\Season\Jobs;
 
+use App\Events\SeasonStarted;
 use App\Modules\Competition\Services\CountryConfig;
 use App\Modules\Lineup\Enums\Formation;
 use App\Modules\Lineup\Services\FormationBiasResolver;
@@ -171,6 +172,14 @@ class SetupNewGame implements ShouldQueue, ShouldBeUnique
         // Notify the user that the summer transfer window is open
         if (in_array($this->gameMode, [Game::MODE_CAREER, Game::MODE_CAREER_PRO], true)) {
             app(NotificationService::class)->notifyTransferWindowOpen($game->refresh(), 'summer');
+
+            // A season starts here for new games (season transitions fire this
+            // from ProcessSeasonTransition). The default investment was applied
+            // during the setup pipeline, so listeners that read it (academy
+            // intake) see a populated row. Fired after setup_completed_at, so a
+            // crash-recovery re-run short-circuits at the isSetupComplete() guard
+            // and never double-fires.
+            event(new SeasonStarted($game));
         }
     }
 

--- a/app/Modules/Season/Processors/DefaultInvestmentProcessor.php
+++ b/app/Modules/Season/Processors/DefaultInvestmentProcessor.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Modules\Season\Processors;
+
+use App\Modules\Finance\Services\BudgetAllocationService;
+use App\Modules\Season\Contracts\SeasonProcessor;
+use App\Modules\Season\DTOs\SeasonTransitionData;
+use App\Models\Game;
+
+/**
+ * Auto-applies the season's default investment allocation so a GameInvestment
+ * row (and a transfer budget) exists the moment setup finishes — for both the
+ * initial season and every transition. This is what lets the new-season screen
+ * stop being a blocking budget gate: the board sets a sane starting plan and the
+ * manager refines it later, reversibly, on the Club investment page.
+ *
+ * Runs after BudgetProjectionProcessor (107), which generates the finances the
+ * default sizing reads, and before NewSeasonResetProcessor (110). Unlike the
+ * reset processor it runs for the initial season too — every season needs a
+ * starting allocation.
+ */
+class DefaultInvestmentProcessor implements SeasonProcessor
+{
+    public function __construct(
+        private readonly BudgetAllocationService $budgetService,
+    ) {}
+
+    public function priority(): int
+    {
+        return 109;
+    }
+
+    public function process(Game $game, SeasonTransitionData $data): SeasonTransitionData
+    {
+        $this->budgetService->applyDefaultAllocation($game);
+
+        return $data;
+    }
+}

--- a/app/Modules/Season/Services/SeasonSetupPipeline.php
+++ b/app/Modules/Season/Services/SeasonSetupPipeline.php
@@ -7,6 +7,7 @@ use App\Modules\Season\Contracts\SeasonProcessor;
 use App\Modules\Season\DTOs\SeasonTransitionData;
 use App\Modules\Season\Processors\BudgetProjectionProcessor;
 use App\Modules\Season\Processors\ContinentalAndCupInitProcessor;
+use App\Modules\Season\Processors\DefaultInvestmentProcessor;
 use App\Modules\Season\Processors\GenerateNamingRightsOffersProcessor;
 use App\Modules\Season\Processors\LeagueFixtureProcessor;
 use App\Modules\Season\Processors\NewSeasonResetProcessor;
@@ -38,6 +39,7 @@ class SeasonSetupPipeline
         LeagueFixtureProcessor $fixtureGeneration,
         StandingsResetProcessor $standingsReset,
         BudgetProjectionProcessor $budgetProjection,
+        DefaultInvestmentProcessor $defaultInvestment,
         ContinentalAndCupInitProcessor $competitionInitialization,
         UefaSuperCupQualificationProcessor $uefaSuperCup,
         SquadRegistrationEnforcementProcessor $squadRegistration,
@@ -54,6 +56,7 @@ class SeasonSetupPipeline
             $fixtureGeneration,
             $standingsReset,
             $budgetProjection,
+            $defaultInvestment,
             $competitionInitialization,
             $uefaSuperCup,
             $squadRegistration,

--- a/database/migrations/2026_06_17_000000_add_staged_downgrades_to_game_investments.php
+++ b/database/migrations/2026_06_17_000000_add_staged_downgrades_to_game_investments.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('game_investments', function (Blueprint $table) {
+            // Per-area tier reductions staged to take effect at next season's
+            // setup. A mid-season downgrade never claws back committed spend, so
+            // a requested reduction is parked here and consumed when the next
+            // season's default allocation is computed. Shape: {"scouting": 1}.
+            $table->json('staged_downgrades')->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('game_investments', function (Blueprint $table) {
+            $table->dropColumn('staged_downgrades');
+        });
+    }
+};

--- a/lang/en/messages.php
+++ b/lang/en/messages.php
@@ -86,6 +86,7 @@ return [
     'infrastructure_upgrade_not_higher' => 'Target tier must be higher than current tier.',
     'infrastructure_upgrade_max_tier' => 'Maximum tier is 4.',
     'infrastructure_upgrade_insufficient_budget' => 'Insufficient transfer budget. Upgrade costs :cost.',
+    'investment_downgrade_not_lower' => 'Choose a tier lower than the current one.',
 
     // Onboarding
     'welcome_to_team' => 'Welcome :team_a! Your season awaits.',

--- a/lang/es/messages.php
+++ b/lang/es/messages.php
@@ -86,6 +86,7 @@ return [
     'infrastructure_upgrade_not_higher' => 'El nivel objetivo debe ser superior al actual.',
     'infrastructure_upgrade_max_tier' => 'El nivel máximo es 4.',
     'infrastructure_upgrade_insufficient_budget' => 'Presupuesto de fichajes insuficiente. La mejora cuesta :cost.',
+    'investment_downgrade_not_lower' => 'Elige un nivel inferior al actual.',
 
     // Onboarding
     'welcome_to_team' => '¡Bienvenido :team_a! Tu temporada te espera.',


### PR DESCRIPTION
## What

Backend foundation for reversible club investment — the season-start budget allocation stops being a blocking, irreversible gate.

- **Auto-applied default**: `DefaultInvestmentProcessor` (priority 109) applies a sane default allocation during season setup (reputation defaults for new games; last season's tiers carried forward + staged downgrades, trimmed to fit surplus, for transitions), so a `GameInvestment` row and transfer budget always exist once setup finishes.
- **`SeasonStarted` decoupled**: fires from the setup paths only (added to `SetupNewGame`; already fired by `ProcessSeasonTransition`), fixing a latent season-2+ double-fire that generated the academy batch twice.
- **`CompleteNewSeason` slimmed + bridged**: no longer owns allocation, but honours an explicit season-start submission when present (interim) and otherwise relies on the auto-applied default.
- **Reversibility groundwork**: nullable `staged_downgrades` JSON column + `InvestmentStateService` (resolve editing state; stage/clear next-season downgrades). In-season upgrades reuse the existing full-cost `InfrastructureUpgradeService` unchanged (full cost any time — early investment is better value, no proration).

## Interim (resolved in the follow-up UI step)

The new-season screen still shows the old sliders and submits amounts; the `CompleteNewSeason` bridge honours them so selections aren't lost. When the read-only "starting plan" screen + the new Club investment page land, that screen posts no amounts and the bridge no-ops (then gets removed).

## Verify

- `php artisan migrate` (adds `staged_downgrades`).
- New career game → setup finishes → a `GameInvestment` row exists with reputation-default tiers; season starts; the academy notification fires once.
- Season transition (`app:simulate-season`) → new season's investment carries forward and reflects any staged downgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)