### PR TITLE
Recalculate projected salaries on mid-season transfers

### DIFF
--- a/app/Modules/Finance/Services/BudgetProjectionService.php
+++ b/app/Modules/Finance/Services/BudgetProjectionService.php
@@ -388,6 +388,75 @@ class BudgetProjectionService
     }
 
     /**
+     * Fold a mid-season squad change into the projected wage bill — and, to keep
+     * the surplus invariant intact, the projected surplus. Only the UNPLAYED
+     * slice of the player's annual wage moves (see remainingSeasonWageFraction):
+     * the matchdays already played were paid regardless of the move.
+     *
+     * A departure (permanent sale) lowers projected wages and lifts surplus; an
+     * arrival (purchase / free-agent signing) does the reverse. The season-start
+     * projection sums every squad wage for the WHOLE season, so without this the
+     * salaries line stays frozen at its July value all year (#1191).
+     *
+     * No-op when there is no finances row yet, the wage is zero, or the season's
+     * matchdays are spent (the prorated slice rounds to zero). Loans are
+     * intentionally left out: their wage stays on the projection (mirroring
+     * calculateProjectedWages, which still counts loaned-out players) until the
+     * loan salary-split rules land.
+     */
+    public function adjustProjectedWagesForSquadChange(Game $game, int $annualWage, bool $isArrival): void
+    {
+        $finances = $game->currentFinances;
+        if (! $finances || $annualWage === 0) {
+            return;
+        }
+
+        $proratedWage = (int) round($annualWage * $this->remainingSeasonWageFraction($game));
+        if ($proratedWage === 0) {
+            return;
+        }
+
+        $delta = $isArrival ? $proratedWage : -$proratedWage;
+
+        $finances->projected_wages = max(0, (int) $finances->projected_wages + $delta);
+        // Surplus = revenue − wages − opex, so it moves opposite to the wage bill.
+        $finances->projected_surplus = (int) $finances->projected_surplus - $delta;
+        $finances->save();
+    }
+
+    /**
+     * Season-progress fraction of an annual wage still owed after today — the
+     * share of the campaign NOT yet played, measured in the managed team's own
+     * league matchdays (total fixtures vs. those still unplayed). This naturally
+     * tracks the division's matchday count and matches the acceptance criterion
+     * `matchdays_remaining_in_season / total_matchdays_in_season`.
+     *
+     * `current_date` is forward-looking (the next match to play), so an unplayed
+     * fixture is one whose wage slice the club would still have paid — exactly
+     * the slice that shifts to the other club on a move. Returns 0 once the
+     * league fixtures are exhausted (or before they exist), making the caller's
+     * adjustment a no-op at those edges.
+     */
+    private function remainingSeasonWageFraction(Game $game): float
+    {
+        $counts = GameMatch::where('game_id', $game->id)
+            ->where('competition_id', $game->competition_id)
+            ->where(function ($q) use ($game) {
+                $q->where('home_team_id', $game->team_id)
+                    ->orWhere('away_team_id', $game->team_id);
+            })
+            ->selectRaw('COUNT(*) AS total, SUM(CASE WHEN played THEN 0 ELSE 1 END) AS remaining')
+            ->first();
+
+        $total = (int) ($counts->total ?? 0);
+        if ($total === 0) {
+            return 0.0;
+        }
+
+        return (int) ($counts->remaining ?? 0) / $total;
+    }
+
+    /**
      * Trailing player-trading allowance in cents — the smoothed net player-
      * trading result (sales − purchases) over the last few COMPLETED seasons,
      * floored at zero (net buyers earn nothing, but pay no penalty) and capped

--- a/app/Modules/Transfer/Services/TransferCompletionService.php
+++ b/app/Modules/Transfer/Services/TransferCompletionService.php
@@ -12,6 +12,7 @@ use App\Models\ShortlistedPlayer;
 use App\Models\TransferListing;
 use App\Models\TransferOffer;
 use App\Models\UserSquadCareerRecord;
+use App\Modules\Finance\Services\BudgetProjectionService;
 use App\Modules\Notification\Services\NotificationService;
 use App\Modules\Player\PlayerAge;
 use App\Modules\Squad\Services\SquadNumberService;
@@ -31,6 +32,7 @@ class TransferCompletionService
         private readonly SquadNumberService $squadNumberService,
         private readonly ContractService $contractService,
         private readonly NotificationService $notificationService,
+        private readonly BudgetProjectionService $budgetProjectionService,
     ) {}
     /**
      * Complete an outgoing transfer (user's player sold to AI team).
@@ -114,10 +116,15 @@ class TransferCompletionService
         // Remove from shortlist to free up scouting slot
         ShortlistedPlayer::removeForPlayer($game->id, $player->id);
 
-        // Player has left user's club permanently — drop career record.
-        // Loans preserve ownership so the record is left intact.
+        // Player has left user's club permanently — drop career record and
+        // shed the unplayed slice of their wage from the season projection.
+        // Loans preserve ownership (and their wage stays on the books), so both
+        // are left intact.
         if (! $isLoan) {
             UserSquadCareerRecord::where('game_player_id', $player->id)->delete();
+            $this->budgetProjectionService->adjustProjectedWagesForSquadChange(
+                $game, (int) $player->annual_wage, isArrival: false,
+            );
         }
     }
 
@@ -290,6 +297,12 @@ class TransferCompletionService
         // Remove from shortlist to free up scouting slot
         ShortlistedPlayer::removeForPlayer($game->id, $player->id);
 
+        // Add the unplayed slice of the incoming player's (just-set) wage to the
+        // season projection — the buy-side mirror of the sale adjustment.
+        $this->budgetProjectionService->adjustProjectedWagesForSquadChange(
+            $game, (int) $player->annual_wage, isArrival: true,
+        );
+
         return true;
     }
 
@@ -343,6 +356,11 @@ class TransferCompletionService
         );
 
         ShortlistedPlayer::removeForPlayer($game->id, $player->id);
+
+        // Add the unplayed slice of the new signing's wage to the projection.
+        $this->budgetProjectionService->adjustProjectedWagesForSquadChange(
+            $game, (int) $player->annual_wage, isArrival: true,
+        );
     }
 
     /**

--- a/tests/Unit/BudgetProjectionServiceTest.php
+++ b/tests/Unit/BudgetProjectionServiceTest.php
@@ -7,6 +7,7 @@ use App\Models\ClubProfile;
 use App\Models\Competition;
 use App\Models\Game;
 use App\Models\GameFinances;
+use App\Models\GameMatch;
 use App\Models\Team;
 use App\Modules\Finance\Services\BudgetProjectionService;
 use App\Modules\Finance\Services\StadiumLoanService;
@@ -212,6 +213,75 @@ class BudgetProjectionServiceTest extends TestCase
         $expected = (int) round($preSubsidyRevenue * config('finances.opex_revenue_ratio.local'));
 
         $this->assertSame($expected, $finances->projected_operating_expenses);
+    }
+
+    public function test_mid_season_sale_sheds_the_prorated_remaining_wage_from_the_projection(): void
+    {
+        [$service, $game] = $this->buildScenario();
+
+        // 10 league matchdays, 4 already played → 6/10 of the season unplayed.
+        $finances = $this->seedCurrentSeasonProjection($game, wages: 100_000_00, surplus: 30_000_00);
+        $this->seedLeagueMatchdays($game, total: 10, played: 4);
+
+        // Selling a €5M/yr earner at this point removes 6/10 of his wage.
+        $service->adjustProjectedWagesForSquadChange($game, 5_000_000_00, isArrival: false);
+
+        $expectedDelta = (int) round(5_000_000_00 * 0.6);
+        $finances->refresh();
+        $this->assertSame(100_000_00 - $expectedDelta, $finances->projected_wages);
+        // Surplus moves opposite to the wage bill: a wage cut lifts it.
+        $this->assertSame(30_000_00 + $expectedDelta, $finances->projected_surplus);
+    }
+
+    public function test_mid_season_purchase_adds_the_prorated_remaining_wage_to_the_projection(): void
+    {
+        [$service, $game] = $this->buildScenario();
+
+        $finances = $this->seedCurrentSeasonProjection($game, wages: 100_000_00, surplus: 30_000_00);
+        $this->seedLeagueMatchdays($game, total: 10, played: 4);
+
+        $service->adjustProjectedWagesForSquadChange($game, 5_000_000_00, isArrival: true);
+
+        $expectedDelta = (int) round(5_000_000_00 * 0.6);
+        $finances->refresh();
+        $this->assertSame(100_000_00 + $expectedDelta, $finances->projected_wages);
+        $this->assertSame(30_000_00 - $expectedDelta, $finances->projected_surplus);
+    }
+
+    public function test_adjustment_is_a_no_op_once_the_season_matchdays_are_spent(): void
+    {
+        [$service, $game] = $this->buildScenario();
+
+        $finances = $this->seedCurrentSeasonProjection($game, wages: 100_000_00, surplus: 30_000_00);
+        $this->seedLeagueMatchdays($game, total: 10, played: 10);
+
+        $service->adjustProjectedWagesForSquadChange($game, 5_000_000_00, isArrival: false);
+
+        $finances->refresh();
+        $this->assertSame(100_000_00, $finances->projected_wages);
+        $this->assertSame(30_000_00, $finances->projected_surplus);
+    }
+
+    private function seedCurrentSeasonProjection(Game $game, int $wages, int $surplus): GameFinances
+    {
+        return GameFinances::create([
+            'game_id' => $game->id,
+            'season' => (int) $game->season,
+            'projected_wages' => $wages,
+            'projected_surplus' => $surplus,
+        ]);
+    }
+
+    private function seedLeagueMatchdays(Game $game, int $total, int $played): void
+    {
+        for ($round = 1; $round <= $total; $round++) {
+            GameMatch::factory()
+                ->forGame($game)
+                ->forCompetition($game->competition)
+                ->inRound($round)
+                ->between($game->team, Team::factory()->create())
+                ->create(['played' => $round <= $played]);
+        }
     }
 
     /**

--- a/tests/Unit/BudgetProjectionServiceTest.php
+++ b/tests/Unit/BudgetProjectionServiceTest.php
@@ -220,7 +220,7 @@ class BudgetProjectionServiceTest extends TestCase
         [$service, $game] = $this->buildScenario();
 
         // 10 league matchdays, 4 already played → 6/10 of the season unplayed.
-        $finances = $this->seedCurrentSeasonProjection($game, wages: 100_000_00, surplus: 30_000_00);
+        $finances = $this->seedCurrentSeasonProjection($game, wages: 50_000_000_00, surplus: 10_000_000_00);
         $this->seedLeagueMatchdays($game, total: 10, played: 4);
 
         // Selling a €5M/yr earner at this point removes 6/10 of his wage.
@@ -228,38 +228,38 @@ class BudgetProjectionServiceTest extends TestCase
 
         $expectedDelta = (int) round(5_000_000_00 * 0.6);
         $finances->refresh();
-        $this->assertSame(100_000_00 - $expectedDelta, $finances->projected_wages);
+        $this->assertSame(50_000_000_00 - $expectedDelta, $finances->projected_wages);
         // Surplus moves opposite to the wage bill: a wage cut lifts it.
-        $this->assertSame(30_000_00 + $expectedDelta, $finances->projected_surplus);
+        $this->assertSame(10_000_000_00 + $expectedDelta, $finances->projected_surplus);
     }
 
     public function test_mid_season_purchase_adds_the_prorated_remaining_wage_to_the_projection(): void
     {
         [$service, $game] = $this->buildScenario();
 
-        $finances = $this->seedCurrentSeasonProjection($game, wages: 100_000_00, surplus: 30_000_00);
+        $finances = $this->seedCurrentSeasonProjection($game, wages: 50_000_000_00, surplus: 10_000_000_00);
         $this->seedLeagueMatchdays($game, total: 10, played: 4);
 
         $service->adjustProjectedWagesForSquadChange($game, 5_000_000_00, isArrival: true);
 
         $expectedDelta = (int) round(5_000_000_00 * 0.6);
         $finances->refresh();
-        $this->assertSame(100_000_00 + $expectedDelta, $finances->projected_wages);
-        $this->assertSame(30_000_00 - $expectedDelta, $finances->projected_surplus);
+        $this->assertSame(50_000_000_00 + $expectedDelta, $finances->projected_wages);
+        $this->assertSame(10_000_000_00 - $expectedDelta, $finances->projected_surplus);
     }
 
     public function test_adjustment_is_a_no_op_once_the_season_matchdays_are_spent(): void
     {
         [$service, $game] = $this->buildScenario();
 
-        $finances = $this->seedCurrentSeasonProjection($game, wages: 100_000_00, surplus: 30_000_00);
+        $finances = $this->seedCurrentSeasonProjection($game, wages: 50_000_000_00, surplus: 10_000_000_00);
         $this->seedLeagueMatchdays($game, total: 10, played: 10);
 
         $service->adjustProjectedWagesForSquadChange($game, 5_000_000_00, isArrival: false);
 
         $finances->refresh();
-        $this->assertSame(100_000_00, $finances->projected_wages);
-        $this->assertSame(30_000_00, $finances->projected_surplus);
+        $this->assertSame(50_000_000_00, $finances->projected_wages);
+        $this->assertSame(10_000_000_00, $finances->projected_surplus);
     }
 
     private function seedCurrentSeasonProjection(Game $game, int $wages, int $surplus): GameFinances


### PR DESCRIPTION
Closes #1191

## Problem

Projected salaries (`projected_wages` on `GameFinances`) were computed **once** at season start — the sum of every squad member's annual wage — and never recalculated when a player joined or left mid-season. The salaries line stayed frozen at its July value all year, showing a wrong financial figure that affects strategic decisions (originally reported in #689).

## Fix

- **`BudgetProjectionService::adjustProjectedWagesForSquadChange()`** — folds a mid-season squad change into the projected wage bill, moving only the *unplayed* slice of the wage: `annual_wage × matchdays_remaining / total_matchdays`. Projected surplus moves opposite to keep the `revenue − wages − opex` invariant intact (same pattern as `refreshTicketingProjection`).
- **`remainingSeasonWageFraction()`** — derives the proration fraction from the managed team's own league fixtures (total vs. still unplayed), matching the acceptance criterion exactly.
- **`TransferCompletionService`** — hooks the adjustment into the three genuine mid-season squad changes:
  - `completeOutgoingTransfer` (permanent sale) → sheds the prorated wage
  - `completeIncomingTransfer` (purchase) → adds the prorated wage
  - `completeFreeAgentSigning` (free-agent signing) → adds the prorated wage

## Design notes

- **Loans are intentionally out of scope** (the issue's loan bullet depends on C1/C2a). `calculateProjectedWages` still counts loaned-out players' full wage, so leaving loans untouched keeps the projection consistent.
- **Pre-contract (Bosman) transfers need no hook**: they resolve at the season boundary, where the proration fraction is ~0 and the projection is regenerated from scratch.
- **`BudgetAllocationService` untouched**: `available_surplus` derives from `projected_surplus`, so it updates automatically.
- **No double counting in the season-setup pipeline**: if the projection runs first, the player isn't on the squad yet and the delta adds them; if completion runs first, there's no finances row yet (no-op) and `generateProjections` counts them. Correct in both orderings.

## Acceptance criteria

- [x] On a sale, projected salaries decrease by `seller_salary × (matchdays_remaining / total_matchdays)`
- [x] Mirrored on the buy side: incoming player adds the prorated salary
- [ ] Loan transfers — deferred (depends on C1/C2a)
- [x] Unit test: sell a player mid-season; assert projected salary delta matches the expected proration (plus buy-side and end-of-season no-op cases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
