### PR TITLE
Remove pre-season banner from game dashboard

### DIFF
--- a/app/Http/Views/ShowGame.php
+++ b/app/Http/Views/ShowGame.php
@@ -209,16 +209,9 @@ class ShowGame
             }
         }
 
-        // Add pre-season data
+        // Add pre-season flag (hides the standings/cup-path card on the dashboard).
         if ($game->isInPreSeason()) {
-            $firstCompetitiveMatch = GameMatch::where('game_id', $game->id)
-                ->where('competition_id', '!=', 'PRESEASON')
-                ->where('played', false)
-                ->orderBy('scheduled_date')
-                ->first();
-
             $viewData['isPreSeason'] = true;
-            $viewData['seasonStartDate'] = $firstCompetitiveMatch?->scheduled_date;
         }
 
         return view('game', $viewData);

--- a/lang/en/game.php
+++ b/lang/en/game.php
@@ -547,8 +547,6 @@ return [
     // Pre-season
     'pre_season' => 'Pre-Season',
     'pre_season_friendly' => 'Friendly',
-    'pre_season_banner_title' => 'Pre-Season',
-    'pre_season_banner_desc' => 'Season starts :date. Use this time to set up your squad, play friendlies and sign players.',
     'pre_season_ready' => 'Pre-season set. Good luck this season!',
     // Pre-season opponent selection screen
     'preseason_setup_title' => 'Plan Your Pre-Season',

--- a/lang/es/game.php
+++ b/lang/es/game.php
@@ -547,8 +547,6 @@ return [
     // Pre-season
     'pre_season' => 'Pretemporada',
     'pre_season_friendly' => 'Amistoso',
-    'pre_season_banner_title' => 'Pretemporada',
-    'pre_season_banner_desc' => 'La temporada comienza el :date. Aprovecha para configurar tu plantilla, jugar amistosos y fichar jugadores.',
     'pre_season_ready' => 'Pretemporada lista. ¡Buena suerte esta temporada!',
     // Pantalla de selección de rivales de pretemporada
     'preseason_setup_title' => 'Planifica tu Pretemporada',

--- a/resources/views/game.blade.php
+++ b/resources/views/game.blade.php
@@ -23,20 +23,6 @@
             </x-status-banner>
         @endif
 
-        {{-- Pre-Season Banner --}}
-        @if(!empty($isPreSeason))
-        <x-status-banner color="blue"
-            :title="__('game.pre_season_banner_title')"
-            :description="__('game.pre_season_banner_desc', ['date' => isset($seasonStartDate) ? $seasonStartDate->locale(app()->getLocale())->translatedFormat('d M Y') : ''])"
-            class="mt-6">
-            <x-slot name="icon">
-                <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
-                </svg>
-            </x-slot>
-        </x-status-banner>
-        @endif
-
         @if($nextMatch)
         <div class="mt-6 grid grid-cols-1 md:grid-cols-3 gap-4 md:gap-8">
             {{-- Left Column (2/3) - Main Content --}}

--- a/tests/Feature/PreSeasonTest.php
+++ b/tests/Feature/PreSeasonTest.php
@@ -280,6 +280,5 @@ class PreSeasonTest extends TestCase
 
         $response->assertOk();
         $response->assertViewHas('isPreSeason', true);
-        $response->assertViewHas('seasonStartDate');
     }
 }


### PR DESCRIPTION
The banner pointed users to set up their squad and play friendlies, but
pre-season matches are now configurable, so the prompt no longer serves a
purpose. Drops the banner markup, its translation keys, and the now-unused
seasonStartDate view data while keeping the isPreSeason flag that still
hides the standings card.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018xkMr3gTFcyxi6vurHMKLR