### PR TITLE
Recompute season wage projection at transfer-window close

### DIFF
--- a/app/Modules/Finance/Listeners/RecomputeWageProjectionOnWindowClose.php
+++ b/app/Modules/Finance/Listeners/RecomputeWageProjectionOnWindowClose.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Modules\Finance\Listeners;
+
+use App\Modules\Finance\Services\BudgetProjectionService;
+use App\Modules\Match\Events\GameDateAdvanced;
+use App\Modules\Transfer\Enums\TransferWindowType;
+
+/**
+ * Restates the season wage projection the moment a transfer window closes.
+ *
+ * The season-start projection sums every squad member's annual wage once, in
+ * pre-season, and never moves it — so after a window's ins and outs the
+ * "projected salaries" line on the finances page stays frozen at its July value
+ * (#1191 / #689). Recomputing once at window close (Sep 1 for summer, Feb 1 for
+ * winter) folds the window's net squad change into the projection wholesale,
+ * without per-transfer proration bookkeeping. The actual wage bill is still
+ * reconciled independently at season-end settlement; this only keeps the
+ * in-season forecast honest.
+ */
+class RecomputeWageProjectionOnWindowClose
+{
+    public function __construct(
+        private readonly BudgetProjectionService $budgetProjectionService,
+    ) {}
+
+    public function handle(GameDateAdvanced $event): void
+    {
+        // Detect boundary crossing: previousDate was inside a window, newDate is
+        // outside — mirrors ProcessTransferWindowClose so both fire on the same
+        // matchday the window shuts.
+        $previousWindow = TransferWindowType::fromDate($event->previousDate);
+        $newWindow = TransferWindowType::fromDate($event->newDate);
+
+        if (! $previousWindow || $newWindow !== null) {
+            return;
+        }
+
+        $this->budgetProjectionService->recomputeWageProjection($event->game);
+    }
+}

--- a/app/Modules/Finance/Services/BudgetProjectionService.php
+++ b/app/Modules/Finance/Services/BudgetProjectionService.php
@@ -3,7 +3,6 @@
 namespace App\Modules\Finance\Services;
 
 use App\Models\BudgetLoan;
-use App\Models\ClubProfile;
 use App\Models\Competition;
 use App\Models\FinancialTransaction;
 use App\Models\Game;
@@ -17,7 +16,6 @@ use App\Modules\Squad\Services\SquadService;
 use App\Modules\Stadium\Services\MatchAttendanceService;
 use App\Modules\Stadium\Services\NamingRightsService;
 use App\Modules\Stadium\Services\SeasonTicketPricingService;
-use App\Modules\Finance\Services\StadiumLoanService;
 use Carbon\Carbon;
 
 class BudgetProjectionService
@@ -29,6 +27,7 @@ class BudgetProjectionService
         private readonly StadiumLoanService $stadiumLoanService,
         private readonly NamingRightsService $namingRightsService,
     ) {}
+
     /**
      * UEFA / RFEF solidarity funds by competition tier (in cents).
      * Segunda receives the full €1M pool; Primera RFEF gets a trimmed €250K share
@@ -36,7 +35,7 @@ class BudgetProjectionService
      */
     private const SOLIDARITY_FUNDS_BY_TIER = [
         2 => 100_000_000, // €1M — Segunda
-        3 =>  25_000_000, // €250K — Primera RFEF
+        3 => 25_000_000, // €250K — Primera RFEF
     ];
 
     /**
@@ -46,7 +45,7 @@ class BudgetProjectionService
     private const MINIMUM_TRANSFER_BUDGET_BY_TIER = [
         1 => 100_000_000, // €1M — La Liga
         2 => 100_000_000, // €1M — Segunda
-        3 =>  20_000_000, // €200K — Primera RFEF
+        3 => 20_000_000, // €200K — Primera RFEF
     ];
 
     private const MINIMUM_TRANSFER_BUDGET_DEFAULT = 100_000_000; // €1M in cents
@@ -121,7 +120,7 @@ class BudgetProjectionService
         // that would swamp it. Computed on pre-subsidy revenue so a public subsidy
         // top-up never inflates the overhead it is meant to cover.
         $reputation = TeamReputation::resolveLevel($game->id, $team->id);
-        $opexRatio = (float) config('finances.opex_revenue_ratio.' . $reputation, 0.13);
+        $opexRatio = (float) config('finances.opex_revenue_ratio.'.$reputation, 0.13);
         $projectedOperatingExpenses = (int) round($projectedTotalRevenue * $opexRatio);
 
         // Calculate projected surplus
@@ -388,6 +387,41 @@ class BudgetProjectionService
     }
 
     /**
+     * Restate the persisted wage projection against the CURRENT squad, then move
+     * projected surplus by the same delta so the revenue − wages − opex invariant
+     * (and the available_surplus derived from it) stays intact. Called once when a
+     * transfer window closes (see RecomputeWageProjectionOnWindowClose) so the
+     * season budget reflects the window's net ins and outs instead of staying
+     * frozen at its season-start squad (#1191).
+     *
+     * Stateless and idempotent: the bill is recomputed wholesale from the current
+     * squad via calculateProjectedWages (which already excludes loaned-in players
+     * and counts loaned-out ones), so sales, purchases and free-agent signings are
+     * reflected uniformly with no per-transfer bookkeeping. A second run finds a
+     * zero delta and no-ops. No-op too when there is no finances row yet. The
+     * actual wage bill is reconciled independently at season-end settlement; this
+     * only keeps the in-season forecast honest.
+     */
+    public function recomputeWageProjection(Game $game): void
+    {
+        $finances = $game->currentFinances;
+        if (! $finances) {
+            return;
+        }
+
+        $newWages = $this->calculateProjectedWages($game);
+        $delta = $newWages - (int) $finances->projected_wages;
+        if ($delta === 0) {
+            return;
+        }
+
+        $finances->projected_wages = $newWages;
+        // Surplus = revenue − wages − opex, so it moves opposite the wage bill.
+        $finances->projected_surplus = (int) $finances->projected_surplus - $delta;
+        $finances->save();
+    }
+
+    /**
      * Trailing player-trading allowance in cents — the smoothed net player-
      * trading result (sales − purchases) over the last few COMPLETED seasons,
      * floored at zero (net buyers earn nothing, but pay no penalty) and capped
@@ -476,7 +510,7 @@ class BudgetProjectionService
             ->where('season', $previousSeason)
             ->first();
 
-        if (!$previousFinances || $previousFinances->actual_surplus === 0 && $previousFinances->actual_total_revenue === 0) {
+        if (! $previousFinances || $previousFinances->actual_surplus === 0 && $previousFinances->actual_total_revenue === 0) {
             return 0;
         }
 

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,39 +2,44 @@
 
 namespace App\Providers;
 
-use App\Http\View\Composers\TacticalGuideComposer;
 use App\Events\SeasonCompleted;
 use App\Events\SeasonStarted;
 use App\Events\TournamentCompleted;
 use App\Events\TournamentEnded;
+use App\Http\View\Composers\TacticalGuideComposer;
 use App\Modules\Academy\Listeners\GenerateInitialAcademyBatch;
+use App\Modules\Competition\Services\CompetitionHandlerResolver;
+use App\Modules\Finance\Listeners\ActivateCompletedStadiumProjects;
+use App\Modules\Finance\Listeners\RecomputeWageProjectionOnWindowClose;
 use App\Modules\Match\Events\CupTieResolved;
 use App\Modules\Match\Events\GameDateAdvanced;
 use App\Modules\Match\Events\LeaguePhaseCompleted;
 use App\Modules\Match\Events\MatchFinalized;
-use App\Modules\Match\Handlers\PreSeasonHandler;
 use App\Modules\Match\Handlers\GroupStageCupHandler;
 use App\Modules\Match\Handlers\KnockoutCupHandler;
 use App\Modules\Match\Handlers\LeagueHandler;
 use App\Modules\Match\Handlers\LeagueWithPlayoffHandler;
+use App\Modules\Match\Handlers\PreSeasonHandler;
 use App\Modules\Match\Handlers\SwissFormatHandler;
 use App\Modules\Match\Listeners\AwardCupPrizeMoney;
 use App\Modules\Match\Listeners\AwardLeaguePhaseBonus;
 use App\Modules\Match\Listeners\ConductNextCupRoundDraw;
 use App\Modules\Match\Listeners\EnsureMatchAttendance;
+use App\Modules\Match\Listeners\UpdateGoalkeeperStats;
+use App\Modules\Match\Listeners\UpdateLeagueStandings;
+use App\Modules\Match\Listeners\UpdateManagerStats;
 use App\Modules\Notification\Listeners\NotifyTransferWindowClosed;
 use App\Modules\Notification\Listeners\NotifyTransferWindowClosing;
 use App\Modules\Notification\Listeners\NotifyTransferWindowOpen;
 use App\Modules\Notification\Listeners\NotifyUnenrolledPlayersBeforeWindowClose;
-use App\Modules\Notification\Listeners\SendCupTieNotifications;
 use App\Modules\Notification\Listeners\SendCompetitionProgressNotifications;
+use App\Modules\Notification\Listeners\SendCupTieNotifications;
 use App\Modules\Notification\Listeners\SendMatchNotifications;
-use App\Modules\Match\Listeners\UpdateGoalkeeperStats;
-use App\Modules\Match\Listeners\UpdateLeagueStandings;
-use App\Modules\Match\Listeners\UpdateManagerStats;
 use App\Modules\Report\Listeners\CreateTournamentSnapshot;
 use App\Modules\Season\Listeners\GrantCareerAccessToChampion;
+use App\Modules\Season\Listeners\RecordSeasonCompleted;
 use App\Modules\Season\Listeners\RecordTournamentCompletedActivation;
+use App\Modules\Season\Listeners\SimulateOtherLeagues;
 use App\Modules\Season\Listeners\SoftDeleteCompletedTournamentGame;
 use App\Modules\Squad\Listeners\CheckRecoveredPlayers;
 use App\Modules\Squad\Listeners\EnforceSquadRegistration;
@@ -44,20 +49,17 @@ use App\Modules\Transfer\Listeners\CompleteAgreedTransfersOnWindowOpen;
 use App\Modules\Transfer\Listeners\ProcessTransferWindowClose;
 use App\Modules\Transfer\Listeners\RollAIContractRenewals;
 use App\Modules\Transfer\Listeners\RollSalaryUnhappiness;
-use App\Modules\Finance\Listeners\ActivateCompletedStadiumProjects;
-use App\Modules\Season\Listeners\RecordSeasonCompleted;
-use App\Modules\Season\Listeners\SimulateOtherLeagues;
-use App\Modules\Competition\Services\CompetitionHandlerResolver;
 use Illuminate\Cache\RateLimiting\Limit;
 use Illuminate\Http\Request;
 use Illuminate\Queue\Events\JobFailed;
-use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\Facades\View;
+use Illuminate\Support\Number;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -74,7 +76,7 @@ class AppServiceProvider extends ServiceProvider
 
         // Register competition handler resolver as singleton
         $this->app->singleton(CompetitionHandlerResolver::class, function ($app) {
-            $resolver = new CompetitionHandlerResolver();
+            $resolver = new CompetitionHandlerResolver;
 
             // Register handlers
             $resolver->register($app->make(LeagueHandler::class));
@@ -97,7 +99,7 @@ class AppServiceProvider extends ServiceProvider
             return $user->is_admin;
         });
 
-        \Illuminate\Support\Number::useLocale(config('app.locale'));
+        Number::useLocale(config('app.locale'));
 
         // Static reference data for the tactical-guide modal — composed lazily
         // so view actions that include the partial don't rebuild it on every
@@ -149,6 +151,7 @@ class AppServiceProvider extends ServiceProvider
         Event::listen(GameDateAdvanced::class, NotifyTransferWindowClosing::class);
         Event::listen(GameDateAdvanced::class, NotifyUnenrolledPlayersBeforeWindowClose::class);
         Event::listen(GameDateAdvanced::class, ProcessTransferWindowClose::class);
+        Event::listen(GameDateAdvanced::class, RecomputeWageProjectionOnWindowClose::class);
         Event::listen(GameDateAdvanced::class, NotifyTransferWindowClosed::class);
         Event::listen(GameDateAdvanced::class, EnforceSquadRegistration::class);
         Event::listen(GameDateAdvanced::class, RollSalaryUnhappiness::class);

--- a/tests/Unit/BudgetProjectionServiceTest.php
+++ b/tests/Unit/BudgetProjectionServiceTest.php
@@ -7,6 +7,7 @@ use App\Models\ClubProfile;
 use App\Models\Competition;
 use App\Models\Game;
 use App\Models\GameFinances;
+use App\Models\GamePlayer;
 use App\Models\Team;
 use App\Modules\Finance\Services\BudgetProjectionService;
 use App\Modules\Finance\Services\StadiumLoanService;
@@ -30,11 +31,17 @@ class BudgetProjectionServiceTest extends TestCase
     use RefreshDatabase;
 
     private const PREV_SEASON = 2025;
+
     private const CUR_SEASON = '2026';
+
     private const ACTUAL_SURPLUS = 10_000_000_00;
+
     private const CARRIED_SURPLUS = 2_000_000_00;
+
     private const ACTUAL_COMMERCIAL_REVENUE = 50_000_000_00;
+
     private const ACTUAL_TOTAL_REVENUE = 200_000_000_00;
+
     private const LOAN_REPAYMENT = 5_000_000_00;
 
     public function test_fresh_club_skips_carry_overs_and_uses_stadium_commercial_baseline(): void
@@ -212,6 +219,74 @@ class BudgetProjectionServiceTest extends TestCase
         $expected = (int) round($preSubsidyRevenue * config('finances.opex_revenue_ratio.local'));
 
         $this->assertSame($expected, $finances->projected_operating_expenses);
+    }
+
+    public function test_recompute_restates_projected_wages_from_the_current_squad(): void
+    {
+        [$service, $game, $team] = $this->buildScenario();
+
+        $finances = GameFinances::create([
+            'game_id' => $game->id,
+            'season' => (int) $game->season,
+            'projected_wages' => 50_000_000_00,
+            'projected_surplus' => 10_000_000_00,
+        ]);
+
+        // Current squad totals €30M/yr — €20M below the €50M season-start
+        // snapshot, as if a high earner left during the window.
+        GamePlayer::factory()->forGame($game)->forTeam($team)->create(['annual_wage' => 20_000_000_00]);
+        GamePlayer::factory()->forGame($game)->forTeam($team)->create(['annual_wage' => 10_000_000_00]);
+
+        $service->recomputeWageProjection($game);
+
+        $finances->refresh();
+        $this->assertSame(30_000_000_00, $finances->projected_wages);
+        // The €20M wage saving lifts projected surplus by the same amount.
+        $this->assertSame(10_000_000_00 + 20_000_000_00, $finances->projected_surplus);
+    }
+
+    public function test_recompute_is_idempotent_and_tracks_a_later_sale(): void
+    {
+        [$service, $game, $team] = $this->buildScenario();
+
+        $finances = GameFinances::create([
+            'game_id' => $game->id,
+            'season' => (int) $game->season,
+            'projected_wages' => 30_000_000_00,
+            'projected_surplus' => 10_000_000_00,
+        ]);
+
+        GamePlayer::factory()->forGame($game)->forTeam($team)->create(['annual_wage' => 20_000_000_00]);
+        $leaver = GamePlayer::factory()->forGame($game)->forTeam($team)->create(['annual_wage' => 10_000_000_00]);
+
+        // First run already matches the seeded snapshot exactly → no-op.
+        $service->recomputeWageProjection($game);
+        $finances->refresh();
+        $this->assertSame(30_000_000_00, $finances->projected_wages);
+        $this->assertSame(10_000_000_00, $finances->projected_surplus);
+
+        // Sell the €10M earner to another club, then recompute again.
+        $leaver->update(['team_id' => Team::factory()->create()->id]);
+        $service->recomputeWageProjection($game);
+        $finances->refresh();
+        $this->assertSame(20_000_000_00, $finances->projected_wages);
+        $this->assertSame(20_000_000_00, $finances->projected_surplus);
+    }
+
+    public function test_recompute_is_a_no_op_without_a_current_finances_row(): void
+    {
+        [$service, $game, $team] = $this->buildScenario();
+
+        GamePlayer::factory()->forGame($game)->forTeam($team)->create(['annual_wage' => 20_000_000_00]);
+
+        // buildScenario only seeds the PREVIOUS season's finances, so there is no
+        // current-season row — the recompute must not create or touch anything.
+        $service->recomputeWageProjection($game);
+
+        $this->assertDatabaseMissing('game_finances', [
+            'game_id' => $game->id,
+            'season' => (int) $game->season,
+        ]);
     }
 
     /**

--- a/tests/Unit/RecomputeWageProjectionOnWindowCloseTest.php
+++ b/tests/Unit/RecomputeWageProjectionOnWindowCloseTest.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\Competition;
+use App\Models\Game;
+use App\Models\GameFinances;
+use App\Models\GamePlayer;
+use App\Models\Team;
+use App\Modules\Finance\Listeners\RecomputeWageProjectionOnWindowClose;
+use App\Modules\Match\Events\GameDateAdvanced;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * The season wage projection is frozen at its pre-season squad. This listener
+ * restates it once when a transfer window closes so the finances page reflects
+ * the window's net ins and outs (#1191 / #689). It mirrors
+ * ProcessTransferWindowClose's boundary detection: fire only when current_date
+ * crosses OUT of a window.
+ */
+class RecomputeWageProjectionOnWindowCloseTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_recomputes_the_wage_projection_when_the_winter_window_closes(): void
+    {
+        [$game, $finances] = $this->buildGameWithFrozenProjection(
+            projectedWages: 50_000_000_00,
+            projectedSurplus: 10_000_000_00,
+            currentSquadWage: 30_000_000_00,
+        );
+
+        // Jan 31 (winter window open) → Feb 1 (closed): the close boundary.
+        $this->handle($game, Carbon::create(2026, 1, 31), Carbon::create(2026, 2, 1));
+
+        $finances->refresh();
+        $this->assertSame(30_000_000_00, $finances->projected_wages);
+        $this->assertSame(10_000_000_00 + 20_000_000_00, $finances->projected_surplus);
+    }
+
+    public function test_does_not_recompute_when_a_window_opens(): void
+    {
+        [$game, $finances] = $this->buildGameWithFrozenProjection(
+            projectedWages: 50_000_000_00,
+            projectedSurplus: 10_000_000_00,
+            currentSquadWage: 30_000_000_00,
+        );
+
+        // Jun 30 (closed) → Jul 1 (summer window open): an OPEN boundary, not a
+        // close — the projection must stay frozen.
+        $this->handle($game, Carbon::create(2026, 6, 30), Carbon::create(2026, 7, 1));
+
+        $finances->refresh();
+        $this->assertSame(50_000_000_00, $finances->projected_wages);
+        $this->assertSame(10_000_000_00, $finances->projected_surplus);
+    }
+
+    public function test_does_not_recompute_while_the_window_stays_open(): void
+    {
+        [$game, $finances] = $this->buildGameWithFrozenProjection(
+            projectedWages: 50_000_000_00,
+            projectedSurplus: 10_000_000_00,
+            currentSquadWage: 30_000_000_00,
+        );
+
+        // Jan 10 → Jan 20: both inside the winter window, no boundary crossed.
+        $this->handle($game, Carbon::create(2026, 1, 10), Carbon::create(2026, 1, 20));
+
+        $finances->refresh();
+        $this->assertSame(50_000_000_00, $finances->projected_wages);
+        $this->assertSame(10_000_000_00, $finances->projected_surplus);
+    }
+
+    private function handle(Game $game, Carbon $previousDate, Carbon $newDate): void
+    {
+        // Resolve through the container so the real BudgetProjectionService is
+        // wired; recomputeWageProjection only touches the squad + finances row,
+        // so its other (mocked-elsewhere) collaborators are never called.
+        app(RecomputeWageProjectionOnWindowClose::class)
+            ->handle(new GameDateAdvanced($game, $previousDate, $newDate));
+    }
+
+    /**
+     * @return array{0: Game, 1: GameFinances}
+     */
+    private function buildGameWithFrozenProjection(int $projectedWages, int $projectedSurplus, int $currentSquadWage): array
+    {
+        $team = Team::factory()->create();
+        $competition = Competition::factory()->league()->create();
+        $game = Game::factory()
+            ->forTeam($team)
+            ->inCompetition($competition->id)
+            ->create(['season' => 2026]);
+
+        $finances = GameFinances::create([
+            'game_id' => $game->id,
+            'season' => (int) $game->season,
+            'projected_wages' => $projectedWages,
+            'projected_surplus' => $projectedSurplus,
+        ]);
+
+        // A single current-squad player carrying the whole live wage bill.
+        GamePlayer::factory()->forGame($game)->forTeam($team)->create(['annual_wage' => $currentSquadWage]);
+
+        return [$game, $finances];
+    }
+}


### PR DESCRIPTION
Closes #1191. Alternative to #1290 — a lighter approach to the same bug, for comparison.

## Problem

`projected_wages` on `GameFinances` is a snapshot summed once at season start (every squad member's annual wage) and never recalculated. After mid-season ins/outs, the "projected salaries" line on the finances page stays frozen at its July value (reported in #689).

Worth noting up front: this is a **forecast/display** inaccuracy, not a money-correctness one. The *actual* wage bill is computed independently at season-end settlement (`SeasonSettlementProcessor::calculateActualWages`, prorated by months present), and any difference vs. the projection flows into next season's budget via `variance` → carried surplus/debt. No money is lost today by the stale projection — only the in-season forecast is wrong.

## Fix

Restate the wage projection **wholesale once, when a transfer window closes** (Sep 1 for summer, Feb 1 for winter), via a `GameDateAdvanced` listener that mirrors `ProcessTransferWindowClose`'s boundary detection.

- **`BudgetProjectionService::recomputeWageProjection()`** — recomputes the bill from the current squad using the existing, loan-aware `calculateProjectedWages()`, then moves `projected_surplus` by the same delta so the `revenue − wages − opex` invariant (and the `available_surplus` derived from it) stays intact. Stateless and idempotent: a second run finds a zero delta and no-ops; no-op too when there's no finances row.
- **`RecomputeWageProjectionOnWindowClose`** — fires only on the close boundary (previous date in a window, new date out). Registered after `ProcessTransferWindowClose`.
- **No view/blade/i18n changes** — the finances page already reads the persisted fields, so it reflects the recompute automatically.

## How this differs from #1290

| | #1290 | This PR |
|---|---|---|
| Trigger | every individual transfer (3 mirrored hook sites + loan carve-out) | one listener at window close |
| Coupling | `BudgetProjectionService` injected into `TransferCompletionService` (Transfer→Finance direct) | via the canonical `GameDateAdvanced` event seam |
| Proration | `annual_wage × matchdays_remaining / total` + a per-transfer `GameMatch` query | none — wholesale recompute of current squad |
| State | incremental deltas that must stay mirrored across sale/buy/free-agent | stateless, idempotent snapshot refresh |
| Size | +159 / −2 | ~small |

### Trade-off
Between a mid-window sale and the window close, the projected-salaries line stays at its prior value; it updates when the window settles. This is intentional — the window is the period of flux — and matches the maintainer's preferred direction. Scope is wages only (revenue/position rework is explicitly out of scope per #1191 / M2).

## Tests

- `BudgetProjectionServiceTest` — recompute restates wages from the current squad and moves surplus inversely; idempotent + tracks a later sale; no-op without a current finances row.
- `RecomputeWageProjectionOnWindowCloseTest` — recomputes on the winter-close boundary; no-op on a window-open boundary and on an in-window advance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YHM2BACofJZVMxh3zzC933)_