### PR TITLE
Fix contracted players showing as free in the market

### DIFF
--- a/app/Modules/Season/Services/GamePlayerTemplateService.php
+++ b/app/Modules/Season/Services/GamePlayerTemplateService.php
@@ -459,13 +459,17 @@ class GamePlayerTemplateService
 
         $age = (int) $dateOfBirth->diffInYears($referenceDate);
         $marketValueCents = Money::parseMarketValue($playerData['marketValue'] ?? null);
-        // Transfermarkt occasionally lists fringe / youth squad players with
-        // no quoted value — floor those at €100K so they still get a usable
-        // ability baseline and a non-zero transfer price.
-        $marketValueForOverall = $marketValueCents > 0 ? $marketValueCents : 10_000_000;
+        // Transfermarkt occasionally lists fringe / youth squad players with no
+        // quoted value. Floor those at €100K so they get a usable ability
+        // baseline, a non-zero transfer price, and don't render as "Free" in the
+        // market. Flooring the persisted value (not just an ability-only local)
+        // keeps stored market value, wage, release clause and tier consistent.
+        if ($marketValueCents <= 0) {
+            $marketValueCents = 10_000_000; // €100K, matches PlayerGeneratorService floor
+        }
         $position = $playerData['position'] ?? null;
         $overallScore = $this->resolveExplicitAbility($playerData['overall_score'] ?? null)
-            ?? $this->valuationService->marketValueToOverallScore($marketValueForOverall, $age, $position);
+            ?? $this->valuationService->marketValueToOverallScore($marketValueCents, $age, $position);
         $annualWage = $this->contractService->calculateAnnualWageForPlayer($overallScore, $marketValueCents, $minimumWage, $age, $position);
 
         $explicitPotential = $this->resolveExplicitPotential($playerData['potential'] ?? null, $overallScore);

--- a/database/migrations/2026_06_21_000000_backfill_zero_market_values.php
+++ b/database/migrations/2026_06_21_000000_backfill_zero_market_values.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        // Contracted (team_id) players whose template carried no quoted market
+        // value were persisted at 0 cents and render as "Free" / "€ 0" in the
+        // transfer market and scouting screens. Floor them at €100K to match the
+        // corrected template generation (GamePlayerTemplateService). National-team
+        // (tournament / World Cup) squads are excluded — their 0 values are set
+        // intentionally and have no transfer market.
+        //
+        // tier needs no update: €100K is below PlayerTierService::TIER_2_MIN (€1M),
+        // so these rows are already tier 1, which is what a raw 0 produced too.
+        DB::table('game_players')
+            ->where('market_value_cents', '<=', 0)
+            ->whereNotNull('team_id')
+            ->whereNotIn('team_id', function ($query) {
+                $query->select('id')->from('teams')->where('type', 'national');
+            })
+            ->update(['market_value_cents' => 10_000_000]);
+    }
+
+    public function down(): void
+    {
+        // No-op: the original 0 values were a bug and are not recoverable.
+    }
+};

--- a/tests/Unit/GamePlayerTemplateMarketValueFloorTest.php
+++ b/tests/Unit/GamePlayerTemplateMarketValueFloorTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Modules\Season\Services\GamePlayerTemplateService;
+use ReflectionMethod;
+use Tests\TestCase;
+
+class GamePlayerTemplateMarketValueFloorTest extends TestCase
+{
+    private ReflectionMethod $prepareTemplateRow;
+
+    private GamePlayerTemplateService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->service = app(GamePlayerTemplateService::class);
+        $this->prepareTemplateRow = new ReflectionMethod(GamePlayerTemplateService::class, 'prepareTemplateRow');
+    }
+
+    /**
+     * @param  array<string, mixed>  $playerData
+     * @return array<string, mixed>|null
+     */
+    private function prepare(array $playerData, ?string $clubCountry = null): ?array
+    {
+        return $this->prepareTemplateRow->invoke(
+            $this->service,
+            '2025',          // season
+            'team-uuid',     // teamId
+            $clubCountry,    // clubCountry
+            $playerData,     // playerData
+            0,               // minimumWage
+        );
+    }
+
+    private function basePlayer(array $overrides = []): array
+    {
+        return array_merge([
+            'id' => '999999',
+            'name' => 'Test Player',
+            'dateOfBirth' => '2000-01-01',
+            'position' => 'Central Midfield',
+        ], $overrides);
+    }
+
+    public function test_missing_market_value_is_floored_to_100k(): void
+    {
+        // No 'marketValue' key at all → parseMarketValue(null) === 0.
+        $row = $this->prepare($this->basePlayer());
+
+        $this->assertSame(10_000_000, $row['market_value_cents']);
+        $this->assertSame(1, $row['tier']);
+    }
+
+    public function test_dash_market_value_is_floored_to_100k(): void
+    {
+        $row = $this->prepare($this->basePlayer(['marketValue' => '-']));
+
+        $this->assertSame(10_000_000, $row['market_value_cents']);
+        $this->assertSame(1, $row['tier']);
+    }
+
+    public function test_floored_value_yields_a_release_clause_for_es_clubs(): void
+    {
+        // With the old bug (0 cents) an ES club's clause was null; flooring to
+        // €100K must produce a non-zero mandatory clause.
+        $row = $this->prepare($this->basePlayer(), clubCountry: 'ES');
+
+        $this->assertNotNull($row['release_clause']);
+        $this->assertGreaterThan(0, $row['release_clause']);
+    }
+
+    public function test_quoted_market_value_is_preserved(): void
+    {
+        $row = $this->prepare($this->basePlayer(['marketValue' => '€5.00m']));
+
+        $this->assertSame(5_000_000_00, $row['market_value_cents']);
+    }
+}


### PR DESCRIPTION
Players whose source data carried no quoted market value were persisted
with market_value_cents = 0 and rendered as "Free" / "€ 0" in the
transfer-market and scouting screens, even though they belong to a club.

In GamePlayerTemplateService::prepareTemplateRow the intended €100K floor
was applied only to a throwaway local used for the ability baseline; the
value persisted into market_value_cents (and downstream wage, release
clause, tier) kept the raw 0. Only Primera RFEF had a fallback, so top
divisions left fringe players at €0.

Floor the persisted market_value_cents at €100K when the source value is
missing, so stored value, overall score, wage, release clause and tier
stay consistent. Add a backfill migration for existing games (excluding
national-team / tournament squads, whose 0 values are intentional) and a
unit test covering the floor.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0186dmV3QVm119yEyHKQKPLh