### PR TITLE
Fix over-aggressive AI withdrawal in transfer counter-offers

### DIFF
--- a/app/Modules/Transfer/Services/ScoutingService.php
+++ b/app/Modules/Transfer/Services/ScoutingService.php
@@ -631,21 +631,37 @@ class ScoutingService
     }
 
     /**
-     * Counter-offer willingness premium curve, applied to market value:
-     *   desire 0.0 → 0.95× MV  (no need: rejects premium counters, settles just below market)
-     *   desire 1.0 → 1.50× MV  (clear need/upgrade: pays a real premium)
+     * Counter-offer willingness premium curve, applied to market value. Desire is
+     * driven by SquadNeedService::desireScore, whose upgrade term scales with how
+     * much the player improves *the buyer's* squad — so a clear upgrade gets chased
+     * harder (relative quality, not raw rating):
+     *   desire 0.0 → 0.95× MV  (no need: only a small premium over market)
+     *   desire 1.0 → 1.60× MV  (clear need/upgrade: pays a real premium)
+     * The resulting willingness is then floored at the club's own current bid (and
+     * at market value when affordable) — see evaluateCounterOffer.
      */
     private const COUNTER_PREMIUM_FLOOR = 0.95;
-    private const COUNTER_PREMIUM_CEIL = 1.50;
+    private const COUNTER_PREMIUM_CEIL = 1.60;
 
     /** Reproducible ±band variance on the premium, seeded from the offer uuid. */
-    private const COUNTER_PREMIUM_JITTER = 0.05;
-
-    /** Below this desire, the buyer won't floor its willingness at its current bid. */
-    private const COUNTER_FLOOR_DESIRE_THRESHOLD = 0.40;
+    private const COUNTER_PREMIUM_JITTER = 0.10;
 
     /** A club won't spend more than this fraction of its squad value on one player. */
     private const COUNTER_SQUAD_VALUE_RATIO = 0.25;
+
+    /** Asks at or below this fraction of max willingness are accepted outright. */
+    private const COUNTER_ACCEPT_RATIO = 0.95;
+
+    /** Base walk-away multiple: asks beyond this fraction of max willingness are rejected. */
+    private const COUNTER_REJECT_RATIO = 1.15;
+
+    /**
+     * Reproducible one-sided spread added on top of the walk-away multiple, seeded per
+     * offer (0..this, never negative). Keeps the exact threshold from being reverse-
+     * engineered while never dipping below the base ratio, so the bid floor's guarantee
+     * (the club never withdraws below paying a little over its own bid) always holds.
+     */
+    private const COUNTER_REJECT_JITTER = 0.10;
 
     /**
      * Evaluate the user's counter-offer from the AI buyer's perspective.
@@ -654,12 +670,16 @@ class ScoutingService
      * The AI club evaluates whether to accept, counter, or walk away.
      *
      * The buyer's max willingness is market_value × a premium that scales with
-     * how badly it wants the player (SquadNeedService::desireScore), clamped by
-     * an affordability ceiling. A club that needs the player and is upgrading
-     * pays a real premium; a deep-squad club with no need won't be talked up to
-     * (or even back up to) market value — so a countered offer no longer always
-     * beats market. This is the buyer-side counterpart to calculateAskingPrice's
-     * seller-side reluctance model; keep the two axes separate.
+     * how badly it wants the player (SquadNeedService::desireScore), clamped by an
+     * affordability ceiling. A club that needs the player and is upgrading pays a
+     * real premium. Crucially, a club that has already tabled a bid has revealed it
+     * values the player at — and can afford — at least that bid, so willingness is
+     * always floored at its own current bid (and at market value when the squad-value
+     * ceiling can afford it). The buyer therefore never withdraws rather than
+     * negotiate modestly up from its own anchor; only a genuinely cash-constrained
+     * club (ceiling below market value) settles below market. This is the buyer-side
+     * counterpart to calculateAskingPrice's seller-side reluctance model; keep the
+     * two axes separate.
      *
      * @return array{result: string, counter_amount: int|null}
      */
@@ -682,23 +702,40 @@ class ScoutingService
         $premium += $this->squadNeedService->jitter($offer->id, self::COUNTER_PREMIUM_JITTER);
         $premium = max(self::COUNTER_PREMIUM_FLOOR - self::COUNTER_PREMIUM_JITTER, $premium);
 
-        $maxWillingness = min($squadValueCeiling, (int) ($marketValue * $premium));
+        $desiredWillingness = (int) ($marketValue * $premium);
 
-        // Only floor at the club's current bid when it genuinely wants the
-        // player. This lets a low-desire buyer settle below its own (possibly
-        // pre-change) opening bid rather than being forced above market.
-        if ($desire >= self::COUNTER_FLOOR_DESIRE_THRESHOLD) {
-            $maxWillingness = max($maxWillingness, $offer->transfer_fee);
+        // A club that already tabled a bid has revealed it can afford that bid, so
+        // the affordability ceiling must never cut willingness below a bid the club
+        // itself made.
+        $affordabilityCeiling = max($squadValueCeiling, $offer->transfer_fee);
+
+        $maxWillingness = min($affordabilityCeiling, $desiredWillingness);
+
+        // Always floor willingness at the club's own anchor — never withdraw rather
+        // than negotiate modestly up from a bid already on the table. Reach up to
+        // market value only when the squad-value ceiling can actually afford it, so a
+        // genuinely cash-poor club still settles below market.
+        $maxWillingness = max($maxWillingness, $offer->transfer_fee);
+        if ($affordabilityCeiling >= $marketValue) {
+            $maxWillingness = max($maxWillingness, $marketValue);
         }
 
-        if ($userAskingPrice <= (int) ($maxWillingness * 0.95)) {
+        if ($userAskingPrice <= (int) ($maxWillingness * self::COUNTER_ACCEPT_RATIO)) {
             return [
                 'result' => 'accepted',
                 'counter_amount' => null,
             ];
         }
 
-        if ($userAskingPrice <= (int) ($maxWillingness * 1.15)) {
+        // The walk-away point carries a reproducible per-offer wobble so the exact
+        // threshold can't be reverse-engineered. The wobble is one-sided (abs): it
+        // only ever makes the buyer *more* generous, never below the base ratio — so
+        // the bid floor above still guarantees a modest over-bid counter is
+        // negotiated, not refused, regardless of the offer's seed.
+        $rejectRatio = self::COUNTER_REJECT_RATIO
+            + abs($this->squadNeedService->jitter($offer->id . 'reject', self::COUNTER_REJECT_JITTER));
+
+        if ($userAskingPrice <= (int) ($maxWillingness * $rejectRatio)) {
             // Counter with midpoint of user's ask and AI's current bid
             $counterAmount = (int) (($userAskingPrice + $offer->transfer_fee) / 2);
             $counterAmount = Money::roundPrice($counterAmount);

--- a/tests/Feature/CounterOfferDesireTest.php
+++ b/tests/Feature/CounterOfferDesireTest.php
@@ -17,10 +17,12 @@ use Tests\TestCase;
 
 /**
  * Covers the desire-driven AI buyer behaviour for a player the user is selling:
- * a club that needs the player pays a premium; a deep-squad club with no need
- * won't be talked above (or even up to) market value. This is the regression
- * the player-facing complaint described — a countered offer no longer always
- * beats market value.
+ * a club that needs the player pays a real premium above market; a deep-squad
+ * club with no need won't be talked into a premium. Because a club that has
+ * tabled a bid has revealed it can afford that bid, willingness is floored at the
+ * club's own bid (and at market value when the squad-value ceiling can afford it):
+ * the buyer never withdraws rather than negotiate modestly up from its own anchor.
+ * Only a genuinely cash-constrained club settles below market.
  */
 class CounterOfferDesireTest extends TestCase
 {
@@ -97,14 +99,16 @@ class CounterOfferDesireTest extends TestCase
 
     public function test_low_need_deep_squad_buyer_rejects_above_market_counter(): void
     {
-        // Deep at midfield (8) and the target wouldn't improve them →
-        // desire ≈ 0.08, willingness ≈ 0.99× MV (just below market). A clearly
-        // above-market ask (1.3× MV) is still rejected: no need, no premium.
+        // Deep at midfield (8) and the target wouldn't improve them → desire ≈ 0.08,
+        // no premium. The club is solvent (€80M squad) and bid below market, so its
+        // willingness floors at market value (≈ €10M) — but it still refuses to be
+        // pushed to a clear premium. A 1.5× MV ask is well beyond the (jittered)
+        // walk-away point and is rejected.
         $player = $this->target(overall: 50);
         $buyer = $this->buyer('Central Midfield', 70, 8, 10_000_000_00);
         $offer = $this->offer($player, $buyer, 9_000_000_00); // opened below market
 
-        $result = $this->scoutingService->evaluateCounterOffer($offer, 13_000_000_00, $this->game);
+        $result = $this->scoutingService->evaluateCounterOffer($offer, 15_000_000_00, $this->game);
 
         $this->assertSame('rejected', $result['result']);
     }
@@ -135,6 +139,43 @@ class CounterOfferDesireTest extends TestCase
         $result = $this->scoutingService->evaluateCounterOffer($offer, 10_000_000_00, $this->game);
 
         $this->assertSame('rejected', $result['result']);
+    }
+
+    public function test_low_desire_solvent_buyer_that_bid_at_market_counters_modest_over_bid(): void
+    {
+        // The player-facing complaint: a club bids at market value, the user counters
+        // ~10% higher (still below the player's real value), and the AI walks away.
+        // Here the buyer is deep at the position with no upgrade (desire ≈ 0.08) and a
+        // cheap squad, so its affordability ceiling (0.25 × €20M = €5M) sits below its
+        // own €10M bid. Old behaviour: no bid floor for low desire → willingness
+        // collapses to €5M → any counter is rejected. New behaviour: the ceiling can't
+        // cut below a bid the club already made and willingness floors at the bid, so a
+        // modest over-bid is negotiated, not refused.
+        $player = $this->target(overall: 60);
+        $buyer = $this->buyer('Central Midfield', 75, 8, 2_500_000_00); // €20M squad
+        $offer = $this->offer($player, $buyer, 10_000_000_00); // bid == market value
+
+        $result = $this->scoutingService->evaluateCounterOffer($offer, 11_000_000_00, $this->game);
+
+        $this->assertSame('countered', $result['result']);
+        $this->assertGreaterThan($offer->transfer_fee, $result['counter_amount']);
+    }
+
+    public function test_buyer_never_withdraws_below_its_own_bid(): void
+    {
+        // A low-desire buyer that opened *above* market (€12M bid vs €10M MV). Its
+        // desire-driven willingness (≈ market) and cheap-squad ceiling both sit below
+        // the bid, so old behaviour would reject any counter. The bid floor guarantees
+        // the club engages on a small over-bid rather than withdrawing from its own
+        // anchor — the outcome is accept or counter, never reject.
+        $player = $this->target(overall: 60);
+        $buyer = $this->buyer('Central Midfield', 75, 8, 2_500_000_00); // €20M squad
+        $offer = $this->offer($player, $buyer, 12_000_000_00); // bid above market value
+
+        $result = $this->scoutingService->evaluateCounterOffer($offer, 12_500_000_00, $this->game);
+
+        $this->assertContains($result['result'], ['accepted', 'countered']);
+        $this->assertNotSame('rejected', $result['result']);
     }
 
     public function test_opening_price_is_below_market_for_a_low_desire_buyer(): void

--- a/tests/Feature/CounterOfferTest.php
+++ b/tests/Feature/CounterOfferTest.php
@@ -80,8 +80,8 @@ class CounterOfferTest extends TestCase
         // Buyer squad: 10 forwards (€100M total), ZERO midfielders. For the
         // midfield target above this is a high-need, clear-upgrade signing, so
         // SquadNeedService::desireScore ≈ 0.93 and the buyer's max willingness
-        // lands near 1.45× market value (≈ €14.5M, within the ±5% premium jitter
-        // band [€14.0M, €15.0M]). The €25M squad-value clamp (0.25 × €100M) does
+        // lands near 1.55× market value (≈ €15.5M, within the ±10% premium jitter
+        // band [€14.5M, €16.5M]). The €25M squad-value clamp (0.25 × €100M) does
         // not bind.
         for ($i = 0; $i < 10; $i++) {
             GamePlayer::factory()->create([
@@ -122,8 +122,8 @@ class CounterOfferTest extends TestCase
 
     public function test_counter_accepted_when_asking_within_willingness(): void
     {
-        // High-need buyer: max willingness ≈ €14–15M. 95% of the low end
-        // (€14.0M) = €13.3M, so an above-market ask of €12M is comfortably
+        // High-need buyer: max willingness ≈ €14.5–16.5M. 95% of the low end
+        // (€14.5M) = €13.8M, so an above-market ask of €12M is comfortably
         // accepted regardless of the premium jitter.
         $this->actingAs($this->user)->postJson(
             route('game.negotiate.counter-offer', [$this->game->id, $this->offer->id]),
@@ -141,8 +141,9 @@ class CounterOfferTest extends TestCase
 
     public function test_counter_rejected_when_asking_far_above_willingness(): void
     {
-        // Buyer max willingness ≈ €14–15M. 115% of the high end (€15M) = €17.3M.
-        // Ask for €30M → far above any plausible willingness → rejected.
+        // Buyer max willingness ≈ €14.5–16.5M. Even at the highest jittered
+        // walk-away point (1.25 × €16.5M ≈ €20.6M), an ask of €30M is far above
+        // any plausible willingness → rejected.
         $this->actingAs($this->user)->postJson(
             route('game.negotiate.counter-offer', [$this->game->id, $this->offer->id]),
             ['action' => 'start']
@@ -162,10 +163,10 @@ class CounterOfferTest extends TestCase
 
     public function test_counter_results_in_ai_counter_when_moderately_above(): void
     {
-        // Max willingness ≈ €14–15M. €15M sits robustly in the counter band for
-        // the whole jitter range: above 95% of the high end (€14.3M) so it is
-        // not auto-accepted, and at/below 115% of the low end (€16.1M) so it is
-        // not rejected → the buyer counters with a raised bid.
+        // Max willingness ≈ €14.5–16.5M. €16M sits robustly in the counter band for
+        // the whole jitter range: above 95% of the high end (≈ €15.7M) so it is not
+        // auto-accepted, and at/below the lowest walk-away point (1.15 × €14.5M ≈
+        // €16.7M) so it is not rejected → the buyer counters with a raised bid.
         $this->actingAs($this->user)->postJson(
             route('game.negotiate.counter-offer', [$this->game->id, $this->offer->id]),
             ['action' => 'start']
@@ -173,7 +174,7 @@ class CounterOfferTest extends TestCase
 
         $response = $this->actingAs($this->user)->postJson(
             route('game.negotiate.counter-offer', [$this->game->id, $this->offer->id]),
-            ['action' => 'counter', 'bid' => 15_000_000] // €15M
+            ['action' => 'counter', 'bid' => 16_000_000] // €16M
         );
 
         $response->assertOk();


### PR DESCRIPTION
When an AI club bid for the user's player and the user countered slightly
above the bid — still below the player's market value and release clause —
the AI often withdrew rather than negotiate. Two flaws combined in
ScoutingService::evaluateCounterOffer: the squad-value affordability ceiling
could cut the buyer's max willingness below a bid it had already tabled, and
the floor-at-current-bid only applied when desire >= 0.40, so a low-desire
buyer's willingness collapsed below its own opening bid. Any legal counter
(which must exceed the current bid) then exceeded the 1.15x walk-away
threshold and the deal died.

A club that has tabled bid X has revealed it values the player at — and can
afford — at least X. Willingness is now always floored at the current bid,
and at market value when the squad-value ceiling can afford it; the ceiling
can no longer cut below a bid the club already made. The buyer therefore
never withdraws rather than negotiate modestly up from its own anchor; only
a genuinely cash-constrained club settles below market.

Better players are chased harder via the existing desire/upgrade premium
(ceiling raised 1.50 -> 1.60), routed through relative quality (improvement
over the buyer's squad) rather than raw rating. The walk-away point carries a
reproducible, one-sided per-offer wobble so the exact threshold can't be
reverse-engineered, while never dipping below the base ratio so the bid-floor
guarantee holds.

Adds regression tests for the screenshot case (low-desire solvent buyer that
bid at market counters a modest over-bid) and the bid-floor invariant (buyer
never withdraws below its own bid); recalibrates existing band-math comments.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TbQcitE7nQerEvbjSiP97L