### PR TITLE
Fix resim opponent-sub filter to use phase-aware absolute minutes

### DIFF
--- a/app/Modules/Lineup/Services/SubstitutionService.php
+++ b/app/Modules/Lineup/Services/SubstitutionService.php
@@ -211,13 +211,28 @@ class SubstitutionService
         // and is not updated by subsequent resimulations. Filtering by minute ensures
         // the reconstructed lineup matches the actual state at $minute — any sub events
         // at minute > $minute will be reverted by doResimulate() anyway.
-        $opponentSubEventsQuery = MatchEvent::where('game_match_id', $match->id)
+        //
+        // Order by phase tuple, not raw minute: a stoppage-time sub (e.g. 90+2',
+        // stored as minute=90 with stoppage held separately) is ambiguous by minute
+        // alone. When $minute is given, filter in PHP on the absolute (phase-aware)
+        // minute for the same reason the red-card filter above does — a raw
+        // `minute <= $minute` would misclassify stoppage-time subs.
+        $opponentSubEvents = MatchEvent::where('game_match_id', $match->id)
             ->where('team_id', $opponentTeamId)
-            ->where('event_type', 'substitution');
+            ->where('event_type', 'substitution')
+            ->orderedChronologically()
+            ->get();
         if ($minute !== null) {
-            $opponentSubEventsQuery->where('minute', '<=', $minute);
+            $stoppage = StoppageDurations::fromMatch($match);
+            $opponentSubEvents = $opponentSubEvents
+                ->filter(fn (MatchEvent $e) => MinuteCoordinates::toAbsoluteWith(
+                    $e->phase,
+                    $e->minute,
+                    $e->stoppage_minute,
+                    $stoppage,
+                ) <= $minute)
+                ->values();
         }
-        $opponentSubEvents = $opponentSubEventsQuery->orderBy('minute')->get();
 
         // Track subbed-out players explicitly so they are excluded from the bench.
         // Without this, a starter who was subbed out ends up back on the bench


### PR DESCRIPTION
## What

`SubstitutionService::loadTeamsForResimulation()` reconstructs the opponent's lineup at a given minute by reading their substitution events from `match_events`. It filtered those events with a raw `where('minute', '<=', $minute)` and ordered them with `orderBy('minute')`.

In the phase-aware schema, a stoppage-time sub (e.g. 90+2') is stored as `minute=90` with the stoppage offset carried separately in `stoppage_minute`. So the raw filter **misclassifies stoppage-time subs** — silently including or excluding them at the boundary — and the raw ordering can place them ahead of earlier regulation events.

## Fix

Mirror the red-card filter already living in this same service (landed via #1230):

- Order by the phase tuple via `orderedChronologically()` instead of raw `minute`.
- When a `$minute` bound is given, filter in PHP on the **absolute** (phase-aware) minute via `MinuteCoordinates::toAbsoluteWith()`.

## Notes

- Cherry-picked from a stale phase-aware cleanup branch. That branch fixed both the red-card filter *and* this resim filter, but the red-card half already landed independently on `main` (#1230) — so only this remaining half is applied here.
- Written in main's existing inline style to match the red-card filter directly above it. The `MinuteCoordinates` / `StoppageDurations` imports were already present.
- Single-file change, no migration or dependency on any other in-flight work. `php -l` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)