### PR TITLE
Suppress misdated and phantom injury notifications across match-less gaps

### DIFF
--- a/app/Modules/Notification/Listeners/SendMatchNotifications.php
+++ b/app/Modules/Notification/Listeners/SendMatchNotifications.php
@@ -81,6 +81,17 @@ class SendMatchNotifications
 
     private function notifyInjury(MatchFinalized $event, GamePlayer $player, MatchEvent $matchEvent): void
     {
+        // MatchResultProcessor only *applies* an injury when it would cost the player
+        // at least one fixture (getMatchesMissed > 0); a knock that heals entirely
+        // within a match-less gap — e.g. between the last pre-season game and the
+        // first league game — leaves injury_until null. This listener runs after that,
+        // so an absent injury_until means the injury was deemed cosmetic. Suppress the
+        // alert to match: otherwise the user sees a phantom "injured" notification with
+        // no real absence and no corresponding recovery (which is keyed off injury_until).
+        if (! $player->isInjured($event->match->scheduled_date)) {
+            return;
+        }
+
         $injuryType = $matchEvent->metadata['injury_type'] ?? 'Unknown injury';
         $weeksOut = $matchEvent->metadata['weeks_out'] ?? 2;
 

--- a/app/Modules/Notification/Services/NotificationService.php
+++ b/app/Modules/Notification/Services/NotificationService.php
@@ -31,7 +31,8 @@ class NotificationService
         ?string $message = null,
         string $priority = GameNotification::PRIORITY_INFO,
         array $metadata = [],
-        ?string $icon = null
+        ?string $icon = null,
+        ?Carbon $gameDate = null
     ): GameNotification {
         return GameNotification::create([
             'id' => Str::uuid()->toString(),
@@ -42,7 +43,12 @@ class NotificationService
             'icon' => $icon ?? $this->getDefaultIcon($type),
             'priority' => $priority,
             'metadata' => $metadata,
-            'game_date' => $game->current_date,
+            // Defaults to current_date, but callers may pass the date the event
+            // actually occurred. current_date is forward-looking (the next match),
+            // so for events detected on date-advance — e.g. an injury recovery that
+            // fell in the gap before the next match — stamping current_date would
+            // misdate them. See notifyRecovery().
+            'game_date' => $gameDate ?? $game->current_date,
         ]);
     }
 
@@ -221,8 +227,16 @@ class NotificationService
 
     /**
      * Create a player recovered notification.
+     *
+     * @param  Carbon|null  $recoveredOn  The date the player actually returned (their
+     *                                    former injury_until). Recovery is detected on
+     *                                    date-advance, so current_date — the next match —
+     *                                    can be days later than the real return date
+     *                                    (notably across the pre-season → season gap).
+     *                                    Stamp the true date so it stays consistent with
+     *                                    the "out until X" date shown on the injury notice.
      */
-    public function notifyRecovery(Game $game, GamePlayer $player): GameNotification
+    public function notifyRecovery(Game $game, GamePlayer $player, ?Carbon $recoveredOn = null): GameNotification
     {
         return $this->create(
             game: $game,
@@ -233,6 +247,7 @@ class NotificationService
             metadata: [
                 'player_id' => $player->id,
             ],
+            gameDate: $recoveredOn,
         );
     }
 

--- a/app/Modules/Squad/Listeners/CheckRecoveredPlayers.php
+++ b/app/Modules/Squad/Listeners/CheckRecoveredPlayers.php
@@ -42,10 +42,17 @@ class CheckRecoveredPlayers
             ->toArray();
 
         foreach ($recoveredPlayers as $player) {
+            // Capture the return date before clearInjury() wipes it. current_date is
+            // forward-looking (the next match), which can be days past the real return
+            // date — e.g. across the pre-season → first-league-match gap — so the
+            // recovery notice must be dated to injury_until to stay consistent with the
+            // "out until X" date the injury notice promised.
+            $recoveredOn = $player->injury_until?->copy();
+
             $this->eligibilityService->clearInjury($player);
 
             if (! in_array($player->id, $recentNotificationPlayerIds)) {
-                $this->notificationService->notifyRecovery($game, $player);
+                $this->notificationService->notifyRecovery($game, $player, $recoveredOn);
             }
         }
     }

--- a/tests/Feature/Notification/InjuryNotificationGuardTest.php
+++ b/tests/Feature/Notification/InjuryNotificationGuardTest.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace Tests\Feature\Notification;
+
+use App\Models\Competition;
+use App\Models\Game;
+use App\Models\GameMatch;
+use App\Models\GameNotification;
+use App\Models\GamePlayer;
+use App\Models\MatchEvent;
+use App\Models\Team;
+use App\Models\User;
+use App\Modules\Match\Events\MatchFinalized;
+use App\Modules\Notification\Listeners\SendMatchNotifications;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * The user's own match notifies injuries via SendMatchNotifications (the deferred
+ * path), separately from MatchResultProcessor which actually applies the injury.
+ * MatchResultProcessor skips "cosmetic" injuries that overlap no fixtures, leaving
+ * injury_until null; the notification must follow suit so the user never sees a
+ * phantom injury alert for an absence that never happens.
+ */
+class InjuryNotificationGuardTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Game $game;
+    private Team $team;
+    private GameMatch $match;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $user = User::factory()->create();
+        $this->team = Team::factory()->create();
+
+        Competition::factory()->league()->create(['id' => 'ESP1', 'name' => 'LaLiga']);
+
+        $this->game = Game::factory()->create([
+            'user_id' => $user->id,
+            'team_id' => $this->team->id,
+            'competition_id' => 'ESP1',
+            'current_date' => '2025-08-17',
+        ]);
+
+        $this->match = GameMatch::factory()
+            ->forGame($this->game)
+            ->forCompetition(Competition::find('ESP1'))
+            ->scheduledOn('2025-07-22')
+            ->played(1, 0)
+            ->create(['home_team_id' => $this->team->id]);
+    }
+
+    public function test_cosmetic_injury_with_no_missed_matches_is_not_notified(): void
+    {
+        // Injured during the match but never sidelined for a fixture — injury_until
+        // stays null because MatchResultProcessor's guard skipped applying it.
+        $player = $this->makePlayerWithInjuryEvent(injuryUntil: null);
+
+        $this->dispatchFinalized();
+
+        $this->assertDatabaseMissing('game_notifications', [
+            'game_id' => $this->game->id,
+            'type' => GameNotification::TYPE_PLAYER_INJURED,
+        ]);
+    }
+
+    public function test_real_injury_that_sidelines_the_player_is_notified(): void
+    {
+        $player = $this->makePlayerWithInjuryEvent(injuryUntil: '2025-08-05');
+
+        $this->dispatchFinalized();
+
+        $notification = GameNotification::where('game_id', $this->game->id)
+            ->where('type', GameNotification::TYPE_PLAYER_INJURED)
+            ->first();
+
+        $this->assertNotNull($notification);
+        $this->assertSame($player->id, $notification->metadata['player_id']);
+    }
+
+    private function makePlayerWithInjuryEvent(?string $injuryUntil): GamePlayer
+    {
+        $player = GamePlayer::factory()
+            ->forGame($this->game)
+            ->forTeam($this->team)
+            ->create([
+                'name' => 'Kylian Mbappé',
+                'injury_until' => $injuryUntil,
+                'injury_type' => $injuryUntil ? 'Muscle strain' : null,
+            ]);
+
+        MatchEvent::create([
+            'game_id' => $this->game->id,
+            'game_match_id' => $this->match->id,
+            'game_player_id' => $player->id,
+            'team_id' => $this->team->id,
+            'minute' => 37,
+            'event_type' => MatchEvent::TYPE_INJURY,
+            'metadata' => ['injury_type' => 'Muscle strain', 'weeks_out' => 2],
+        ]);
+
+        return $player;
+    }
+
+    private function dispatchFinalized(): void
+    {
+        $event = new MatchFinalized($this->match->fresh(), $this->game->fresh(), Competition::find('ESP1'));
+
+        app(SendMatchNotifications::class)->handle($event);
+    }
+}

--- a/tests/Feature/Squad/CheckRecoveredPlayersTest.php
+++ b/tests/Feature/Squad/CheckRecoveredPlayersTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Tests\Feature\Squad;
+
+use App\Models\Competition;
+use App\Models\Game;
+use App\Models\GameNotification;
+use App\Models\GamePlayer;
+use App\Models\Team;
+use App\Models\User;
+use App\Modules\Match\Events\GameDateAdvanced;
+use App\Modules\Squad\Listeners\CheckRecoveredPlayers;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class CheckRecoveredPlayersTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+    private Team $team;
+    private Game $game;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = User::factory()->create();
+        $this->team = Team::factory()->create();
+
+        Competition::factory()->league()->create([
+            'id' => 'ESP1',
+            'name' => 'LaLiga',
+        ]);
+
+        $this->game = Game::factory()->create([
+            'user_id' => $this->user->id,
+            'team_id' => $this->team->id,
+            'competition_id' => 'ESP1',
+            'season' => '2025',
+            // Forward-looking: the next match the user is about to play (first
+            // league match), days after the actual return date below.
+            'current_date' => '2025-08-17',
+        ]);
+    }
+
+    public function test_recovery_notification_is_dated_to_the_return_date_not_the_next_match(): void
+    {
+        // Player returns Aug 5, but the next match isn't until Aug 17 — the dead
+        // gap between the last pre-season game and the first league game.
+        $player = GamePlayer::factory()
+            ->forGame($this->game)
+            ->forTeam($this->team)
+            ->create([
+                'name' => 'Kylian Mbappé',
+                'injury_until' => '2025-08-05',
+                'injury_type' => 'Muscle strain',
+            ]);
+
+        $this->dispatchAdvanceTo('2025-07-30', '2025-08-17');
+
+        $notification = GameNotification::where('game_id', $this->game->id)
+            ->where('type', GameNotification::TYPE_PLAYER_RECOVERED)
+            ->first();
+
+        $this->assertNotNull($notification);
+        // Dated to the actual return date, not the forward-looking current_date,
+        // so it stays consistent with the "out until 5 Aug" injury notice.
+        $this->assertSame('2025-08-05', $notification->game_date->toDateString());
+        $this->assertSame($player->id, $notification->metadata['player_id']);
+
+        // And the injury is actually cleared.
+        $this->assertNull($player->refresh()->injury_until);
+    }
+
+    private function dispatchAdvanceTo(string $previous, string $new): void
+    {
+        $event = new GameDateAdvanced(
+            $this->game,
+            Carbon::parse($previous),
+            Carbon::parse($new),
+        );
+
+        app(CheckRecoveredPlayers::class)->handle($event);
+    }
+}


### PR DESCRIPTION
## Problem

A player injury reported during a pre-season match showed a recovery notification dated **12 days later** than the promised return date — the gap between the last pre-season match and the first league match, where `current_date` jumps forward with no intermediate matches.

Digging in surfaced **two distinct bugs** in the injury → recovery notification flow.

### 1. Recovery notice dated to the wrong day
Recovery is detected lazily on `GameDateAdvanced`, and `NotificationService::create()` stamped `game_date = current_date`. But `current_date` is **forward-looking** (it points at the *next* match). After the last pre-season match it jumps straight to the first league match, so a recovery that logically happened on the return date got dated days later. Invisible mid-season (matches are days apart), glaring across the pre-season → season gap.

### 2. Phantom injury notice with no real absence
`MatchResultProcessor` only **applies** an injury when it would cost the player at least one fixture (`getMatchesMissed > 0`), leaving `injury_until` null otherwise. But the user's *own* match notifies through `SendMatchNotifications` (a `MatchFinalized` listener), which had **no such guard** and fired off the raw match event. A knock that healed entirely within a match-less gap produced an "injured" alert with no absence — and no recovery to close it (recovery is keyed off `injury_until`).

| Path | Applies injury (guarded) | Notifies |
|---|---|---|
| AI matches | `MatchResultProcessor` ✓ | same place — guarded ✓ |
| Training | `MatchdayOrchestrator` ✓ | same place — guarded ✓ |
| **User's own match** | `MatchResultProcessor` ✓ | `SendMatchNotifications` — **no guard** ✗ |

## Fix

- **`NotificationService`** — `create()` accepts an optional `$gameDate`; `notifyRecovery()` stamps the player's actual return date.
- **`CheckRecoveredPlayers`** — captures `injury_until` before `clearInjury()` wipes it, and passes it through.
- **`SendMatchNotifications`** — keys the injury alert off the real injury state. Since `MatchResultProcessor` runs (and applies/skips the injury) during `advance()`, `injury_until` is authoritative by the time `MatchFinalized` fires — so the listener suppresses the alert exactly when the injury was skipped.

## Net behavior
- **Injury + recovery both in a match-less gap** → injury never applied → **no injury alert, no recovery alert**.
- **Injury overlaps real fixtures** → both alerts shown, recovery dated to the **true return date**.

## Tests
- `CheckRecoveredPlayersTest` — recovery notification is dated to the return date, not the next-match date.
- `InjuryNotificationGuardTest` — a cosmetic injury (no `injury_until`) is not notified; a real one is.

No schema or translation changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)