### PR TITLE
Fix auto-lineup parking tired/lower-rated MCDs in MC slots

### DIFF
--- a/app/Http/Actions/GetAutoLineup.php
+++ b/app/Http/Actions/GetAutoLineup.php
@@ -29,7 +29,10 @@ class GetAutoLineup
         $matchDate = $match->scheduled_date;
         $competitionId = $match->competition_id;
 
-        // Get auto-selected lineup for the formation
+        // Get auto-selected lineup for the formation. Pass the user's
+        // configured rotation policy so tired starters are penalised the
+        // same way fast-mode prep does — otherwise this button would rank
+        // purely by raw overall_score.
         $requireEnrollment = $game->requiresSquadEnrollment();
         $autoLineup = $this->lineupService->autoSelectLineup(
             $gameId,
@@ -38,6 +41,7 @@ class GetAutoLineup
             $competitionId,
             $formation,
             $requireEnrollment,
+            $game->tactics?->default_rotation_policy,
         );
 
         return response()->json([

--- a/app/Http/Views/ShowLineup.php
+++ b/app/Http/Views/ShowLineup.php
@@ -71,8 +71,18 @@ class ShowLineup
         $currentMentality = $this->lineupService->getMentality($match, $game->team_id);
         $currentMentality = $currentMentality ?? $defaultMentality;
 
-        // Get auto-selected lineup for quick select (using current formation)
-        $autoLineup = $this->lineupService->autoSelectLineup($gameId, $game->team_id, $matchDate, $competitionId, $formationEnum, $requireEnrollment);
+        // Get auto-selected lineup for quick select (using current formation).
+        // Pass the user's configured rotation policy so the "Auto Select"
+        // button penalises tired players the same way fast-mode prep does.
+        $autoLineup = $this->lineupService->autoSelectLineup(
+            $gameId,
+            $game->team_id,
+            $matchDate,
+            $competitionId,
+            $formationEnum,
+            $requireEnrollment,
+            $game->tactics?->default_rotation_policy,
+        );
 
         // If still no lineup (first match ever), use auto lineup
         if (empty($currentLineup)) {

--- a/app/Modules/Lineup/Services/FormationRecommender.php
+++ b/app/Modules/Lineup/Services/FormationRecommender.php
@@ -15,13 +15,17 @@ class FormationRecommender
      *                         specific slots (e.g. user drag-drops). These
      *                         slots are locked for the rest of the algorithm.
      *   Pass 1 — Primary:     place players whose PRIMARY matches a slot (compat 100).
-     *   Pass 2 — Secondary:   for still-empty slots, place unused players whose
-     *                         SECONDARY matches (compat 100).
      *   Pass 3 — Swap:        for still-empty slots, move a primary-pass assignee
      *                         to the empty slot via his secondary, freeing his
      *                         original slot for a less versatile unused player.
      *   Pass 4 — Weighted:    best-available fallback for slots that no natural
-     *                         fit can cover.
+     *                         fit can cover. Players whose secondary makes them
+     *                         compat-100 for the slot still benefit from that
+     *                         compat in the weighted score, but compete head-to-
+     *                         head with compat-80 primaries instead of pre-empting
+     *                         them — keeps a tired specialist (e.g. DM whose
+     *                         secondary is CM) from automatically beating a
+     *                         fresher player whose primary is a good fit.
      *   Pass 6 — Improve:     after all slots are filled, swap any placed player
      *                         for a higher-rated bench player who is a natural
      *                         (compat 100) fit for that slot — catches cases
@@ -129,7 +133,7 @@ class FormationRecommender
 
         // Result map keyed by slot id. The `pass` field tracks how each
         // assignment happened so Pass 3 can identify genuine primary
-        // assignees (valid swap donors) vs secondary/manual/fallback fillers.
+        // assignees (valid swap donors) vs manual/fallback fillers.
         $assigned = [];
         foreach ($slots as $slot) {
             $assigned[$slot['id']] = [
@@ -144,7 +148,6 @@ class FormationRecommender
 
         $this->applyManualPins($manualAssignments, $sortedPlayers, $assigned, $usedPlayerIds);
         $this->fillByPrimary($sortedSlots, $sortedPlayers, $assigned, $usedPlayerIds);
-        $this->fillBySecondary($sortedSlots, $sortedPlayers, $assigned, $usedPlayerIds);
         $this->trySwapFill($sortedSlots, $sortedPlayers, $assigned, $usedPlayerIds);
         $this->fillByWeighted($sortedSlots, $sortedPlayers, $assigned, $usedPlayerIds);
         $this->fillByForceAssignment($sortedSlots, $sortedPlayers, $assigned, $usedPlayerIds);
@@ -219,39 +222,14 @@ class FormationRecommender
     }
 
     /**
-     * Pass 2 — fill still-empty slots with unused players whose SECONDARY
-     * position gives compatibility 100 for that slot.
-     */
-    private function fillBySecondary(array $sortedSlots, array $sortedPlayers, array &$assigned, array &$usedPlayerIds): void
-    {
-        foreach ($sortedSlots as $slot) {
-            if ($assigned[$slot['id']]['player'] !== null) {
-                continue;
-            }
-            foreach ($sortedPlayers as $player) {
-                if (in_array($player['id'], $usedPlayerIds, true)) {
-                    continue;
-                }
-                foreach ($player['secondary_positions'] ?? [] as $secondary) {
-                    if (PositionSlotMapper::getCompatibilityScore($secondary, $slot['label']) === 100) {
-                        $this->assignPlayer($assigned, $slot, $player, 100, 'secondary');
-                        $usedPlayerIds[] = $player['id'];
-                        continue 3; // next slot
-                    }
-                }
-            }
-        }
-    }
-
-    /**
      * Pass 3 — for still-empty slots, see if an already-assigned primary-pass
      * player can move here via one of his secondaries, freeing his original
      * slot for a less versatile unused player whose primary fits there.
      *
-     * Only Pass-1 assignees are considered as donors. Pass-0 (manual),
-     * Pass-2 (secondary), and Pass-4 (fallback) assignees are deliberately
-     * excluded — moving them would either override user intent or fail to
-     * open up any new primary slot.
+     * Only Pass-1 assignees are considered as donors. Pass-0 (manual) and
+     * Pass-4 (fallback) assignees are deliberately excluded — moving them
+     * would either override user intent or fail to open up any new primary
+     * slot.
      */
     private function trySwapFill(array $sortedSlots, array $sortedPlayers, array &$assigned, array &$usedPlayerIds): void
     {

--- a/app/Modules/Lineup/Services/LineupService.php
+++ b/app/Modules/Lineup/Services/LineupService.php
@@ -183,6 +183,13 @@ class LineupService
     /**
      * Auto-select best XI by overall_score, respecting formation requirements.
      * Returns array of player IDs.
+     *
+     * Applies a rotation policy (defaulting to Balanced) so the fatigue
+     * penalty in selectBestXI keeps tired starters from beating fresher
+     * subs of the same rating. Without this, the manual "Auto Select"
+     * button on the lineup screen would rank purely by raw overall_score
+     * and pick burned-out players over rested ones — every automated
+     * lineup path already does this, this one was the outlier.
      */
     public function autoSelectLineup(
         string $gameId,
@@ -191,10 +198,12 @@ class LineupService
         string $competitionId,
         ?Formation $formation = null,
         bool $requireEnrollment = false,
+        ?RotationPolicy $rotationPolicy = null,
     ): array {
         return $this->selectBestXI(
             $this->getAvailablePlayers($gameId, $teamId, $matchDate, $competitionId, $requireEnrollment),
-            $formation
+            $formation,
+            $rotationPolicy ?? RotationPolicy::Balanced,
         )->pluck('id')->toArray();
     }
 

--- a/tests/Unit/FormationRecommenderTest.php
+++ b/tests/Unit/FormationRecommenderTest.php
@@ -195,8 +195,9 @@ class FormationRecommenderTest extends TestCase
 
     public function test_secondary_fill_prefers_unused_player_over_swap(): void
     {
-        // If Pass 2 can fill an empty slot with an unused player via his
-        // secondary, we should not trigger a swap.
+        // When the only unused candidate for an empty slot fits via a
+        // secondary position, the weighted fallback (Pass 4) must still
+        // pick him at compat 100 — we do not need to trigger a swap.
         $players = collect([
             $this->player('gk', 'Goalkeeper'),
             $this->player('lb', 'Left-Back'),
@@ -459,9 +460,9 @@ class FormationRecommenderTest extends TestCase
         // Squad that fits 4-3-3 perfectly. 4-4-2 is also a clean fit because:
         //   - The wingers cover LM and RM via primary (LB/LW/RB/RW are all
         //     natural-fit 100 for the wide-mid slots in PositionSlotMapper).
-        //   - cm3 carries a `Second Striker` secondary, so Pass 2 fills the
-        //     spare CF slot at compat 100 once cm1 and cm2 have taken the
-        //     two CM slots.
+        //   - cm3 carries a `Second Striker` secondary, so the weighted
+        //     fallback (Pass 4) fills the spare CF slot at compat 100 once
+        //     cm1 and cm2 have taken the two CM slots.
         // Both formations end at score 103 mechanically, so the unbiased run
         // settles on the initial 4-3-3 candidate; a moderate 4-4-2 bias is
         // enough to push it ahead.
@@ -484,6 +485,86 @@ class FormationRecommenderTest extends TestCase
 
         $this->assertSame(Formation::F_4_3_3, $unbiased, 'Sanity check — fixture should pick 4-3-3 without bias');
         $this->assertSame(Formation::F_4_4_2, $biased, 'Bias should flip the choice when 4-4-2 is also supported');
+    }
+
+    public function test_fresh_mp_without_cm_secondary_beats_tired_mcd_with_cm_secondary(): void
+    {
+        // User-reported bug: in a 4-3-3 with 3 CM slots, the auto-lineup
+        // always parks defensive midfielders (with "Central Midfield" as a
+        // secondary) into the central slots even when fresher attacking
+        // midfielders are available. The fresh MP here doesn't have CM in
+        // his secondaries, but his weighted score (rating × compat=80 via
+        // primary) must still beat a tired MCD's (lowered rating × compat=100
+        // via secondary).
+        //
+        // Ratings here are pre-adjusted as if LineupService had already
+        // applied the fitness penalty before passing the pool to the
+        // recommender — that mirrors the autoSelectLineup path post-fix.
+        $players = collect([
+            $this->player('gk', 'Goalkeeper', 75),
+            $this->player('lb', 'Left-Back', 75),
+            $this->player('cb1', 'Centre-Back', 75),
+            $this->player('cb2', 'Centre-Back', 75),
+            $this->player('rb', 'Right-Back', 75),
+            $this->player('lw', 'Left Winger', 75),
+            $this->player('cf', 'Centre-Forward', 75),
+            $this->player('rw', 'Right Winger', 75),
+            // One natural CM at full freshness.
+            $this->player('mcFresh', 'Central Midfield', 80),
+            // Two MCDs with CM secondary, but their ratings are heavily
+            // penalised by fatigue (raw 85, effective ~60 each).
+            $this->player('mcdTired1', 'Defensive Midfield', 60, ['Central Midfield']),
+            $this->player('mcdTired2', 'Defensive Midfield', 58, ['Central Midfield']),
+            // Fresh attacking mid with NO Central Midfield secondary.
+            $this->player('mpFresh', 'Attacking Midfield', 78),
+        ]);
+
+        $bestXI = $this->recommender->bestXIFor(Formation::F_4_3_3, $players);
+        $map = $this->slotMap($bestXI);
+
+        // F_4_3_3 CM slots are ids 5, 6, 7.
+        $cmAssignments = [$map[5], $map[6], $map[7]];
+
+        $this->assertContains('mcFresh', $cmAssignments, 'Natural CM still fills a midfield slot');
+        $this->assertContains('mpFresh', $cmAssignments, 'Fresh MP must reach a CM slot ahead of a tired MCD');
+        $this->assertNotContains(
+            'mcdTired2',
+            $cmAssignments,
+            'Lower-rated tired MCD must not displace the fresh MP',
+        );
+    }
+
+    public function test_high_rated_mcd_with_cm_secondary_still_beats_lower_rated_fresh_mp(): void
+    {
+        // Counter-test: when the MCD is clearly the better player even after
+        // the compat-80-vs-100 tradeoff, the weighted formula should still
+        // prefer him. We keep this case green so the fix doesn't overshoot
+        // into "secondary positions are worthless" territory.
+        //
+        // Weighted score = (rating × 0.7) + (compat × 0.3).
+        //   mcdStar  (rating 88, compat 100 via secondary) → 61.6 + 30 = 91.6
+        //   mpAvg    (rating 78, compat 80  via primary)   → 54.6 + 24 = 78.6
+        $players = collect([
+            $this->player('gk', 'Goalkeeper', 75),
+            $this->player('lb', 'Left-Back', 75),
+            $this->player('cb1', 'Centre-Back', 75),
+            $this->player('cb2', 'Centre-Back', 75),
+            $this->player('rb', 'Right-Back', 75),
+            $this->player('lw', 'Left Winger', 75),
+            $this->player('cf', 'Centre-Forward', 75),
+            $this->player('rw', 'Right Winger', 75),
+            $this->player('mcOk', 'Central Midfield', 80),
+            $this->player('mcdStar', 'Defensive Midfield', 88, ['Central Midfield']),
+            $this->player('mpAvg', 'Attacking Midfield', 78),
+            $this->player('extraDef', 'Centre-Back', 60),
+        ]);
+
+        $bestXI = $this->recommender->bestXIFor(Formation::F_4_3_3, $players);
+        $map = $this->slotMap($bestXI);
+
+        $cmAssignments = [$map[5], $map[6], $map[7]];
+        $this->assertContains('mcOk', $cmAssignments);
+        $this->assertContains('mcdStar', $cmAssignments, 'Higher-rated MCD with CM secondary still earns the slot');
     }
 
     public function test_getBestFormation_overrides_bias_when_squad_cannot_support_it(): void


### PR DESCRIPTION
## Summary

User report: *"Hay un patrón que se repite y es en las posiciones de MC (que pueden jugar MCD, MC y MP) no sé por qué la alineación automática siempre tira por los MCD, aunque estén más cansados y/o tengan menos media."*

The **Auto Select** button on the lineup screen kept parking defensive midfielders into central midfield slots even when fresher or higher-rated MCs/MPs were available. Two compounding bugs:

- **`LineupService::autoSelectLineup` ignored fatigue.** Every other automated lineup path (`ensureTeamLineup` for player + AI teams) passes a `RotationPolicy` so tired players get an effective-rating penalty. This one entry skipped it, so the recommender saw raw `overall_score` and ranked a tired MCD (fitness 30, rating 85) the same as a fresh one. Now passes the user's configured `$game->tactics->default_rotation_policy`, defaulting to `Balanced`.

- **`FormationRecommender` Pass 2 (`fillBySecondary`) pre-empted the weighted fallback.** Any unused player whose secondary position gave compat=100 for an empty slot was placed before Pass 4 even ran. In practice MCDs commonly carry `"Central Midfield"` in `secondary_positions` while MPs often don't — so an MCD with CM secondary would automatically beat a higher-rated MP whose primary was only compat=80 for CM. Removed Pass 2. Pass 4's weighted formula `(effective * 0.7) + (compat * 0.3)` already takes the max of primary and secondary compat via `getPlayerCompatibilityScore`, so a player who used to win via Pass 2 keeps the compat-100 edge in the weighted score — but now competes head-to-head with compat-80 primaries instead of pre-empting them.

Pass 3 (swap) and Pass 6 (improve-by-rating) are unaffected: the former ignored Pass 2 assignees as donors anyway, and the latter only filters out manual pins.

## Test plan

- [x] Added `test_fresh_mp_without_cm_secondary_beats_tired_mcd_with_cm_secondary` — fresh MP wins a CM slot over two tired MCDs even though both MCDs carry CM as a secondary.
- [x] Added `test_high_rated_mcd_with_cm_secondary_still_beats_lower_rated_fresh_mp` — guards the inverse: when the MCD is clearly the better player, Pass 4 keeps preferring him.
- [x] Existing `test_secondary_fill_prefers_unused_player_over_swap` and `test_getBestFormation_respects_bias_when_squad_supports_it` still pass (verified by re-tracing — both behaviours now happen via Pass 4 with the same end result). Comments updated.
- [ ] Manual check on the lineup screen: tire your MCDs, click **Auto Select**, confirm fresher MCs/MPs land in the central slots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N7hT4B5Yo5FYfjFieR374u

---
_Generated by [Claude Code](https://claude.ai/code/session_01N7hT4B5Yo5FYfjFieR374u)_