### PR TITLE
Add defensive fatigue mechanic to break down parked buses late

### DIFF
--- a/app/Console/Commands/SimulateMatch.php
+++ b/app/Console/Commands/SimulateMatch.php
@@ -143,7 +143,7 @@ class SimulateMatch extends Command
                 $formation,
                 $homeMentality,
                 $awayMentality
-            );
+            )->result;
 
             // Track results
             if ($result->homeScore > $result->awayScore) {

--- a/app/Modules/Match/Services/MatchSimulator.php
+++ b/app/Modules/Match/Services/MatchSimulator.php
@@ -1932,13 +1932,16 @@ class MatchSimulator
         // Attenuate defensive effect based on the attacker's quality advantage.
         // When a team is much stronger, opponent's defensive tactics are less
         // effective — quality prevails through possession, individual skill,
-        // and forcing defensive errors over 90 minutes.
+        // and forcing defensive errors over 90 minutes. Defensive fatigue adds a
+        // time dimension on top: a sustained shell tires and cracks late, so the
+        // stronger side breaks it down further as the match wears on.
         $damping = (float) config('match_simulation.defensive_quality_damping', 1.2);
 
         if ($preHomeXG > 0) {
             $homeReduction = $homeXG / $preHomeXG;
             if ($homeReduction < 1.0 && $strengthRatio > 1.0) {
                 $attenuation = 1.0 / pow($strengthRatio, $damping);
+                $attenuation *= 1.0 - $this->defensiveFatigueErosion($effectiveMinute, $strengthRatio);
                 $homeXG = $preHomeXG * (1.0 - (1.0 - $homeReduction) * $attenuation);
             }
         }
@@ -1948,11 +1951,58 @@ class MatchSimulator
             $inverseRatio = $strengthRatio > 0 ? 1.0 / $strengthRatio : 1.0;
             if ($awayReduction < 1.0 && $inverseRatio > 1.0) {
                 $attenuation = 1.0 / pow($inverseRatio, $damping);
+                $attenuation *= 1.0 - $this->defensiveFatigueErosion($effectiveMinute, $inverseRatio);
                 $awayXG = $preAwayXG * (1.0 - (1.0 - $awayReduction) * $attenuation);
             }
         }
 
         return [$homeXG, $awayXG];
+    }
+
+    /**
+     * Defensive fatigue: the extra fraction of an opponent's defensive xG
+     * suppression that a *sustained* shell surrenders as the match wears on. A
+     * parked bus tires and makes late mistakes, so the attacking side breaks it
+     * down in the closing stages. Returns 0 before `ramp_start_minute`, then
+     * ramps linearly to `max_erosion` by minute 90 (mirroring the High-Press
+     * fade in {@see PressingIntensity::opponentXGModifier()}).
+     *
+     * When `pressure_scaled` is on, the shell tires faster the bigger the quality
+     * edge it is absorbing — `$edge` is the attacking side's strength ratio over
+     * the defender (> 1.0), reaching full effect at `full_pressure_edge`. The
+     * result is folded into the quality-damping attenuation, so it only ever
+     * lifts the stronger side's xG and never applies in evenly-matched games.
+     *
+     * @param  float  $effectiveMinute  Midpoint minute of the simulated segment
+     * @param  float  $edge  Attacking side's strength ratio over the defender (> 1.0)
+     * @return float  Erosion fraction in [0, 1]
+     */
+    private function defensiveFatigueErosion(float $effectiveMinute, float $edge): float
+    {
+        $config = config('match_simulation.defensive_fatigue', []);
+
+        if (! ($config['enabled'] ?? false)) {
+            return 0.0;
+        }
+
+        $rampStart = (float) ($config['ramp_start_minute'] ?? 60);
+        if ($effectiveMinute <= $rampStart) {
+            return 0.0;
+        }
+
+        $rampRange = 90.0 - $rampStart;
+        $progress = $rampRange > 0 ? min(1.0, ($effectiveMinute - $rampStart) / $rampRange) : 1.0;
+        $erosion = (float) ($config['max_erosion'] ?? 0.0) * $progress;
+
+        if ($config['pressure_scaled'] ?? false) {
+            $fullPressureEdge = (float) ($config['full_pressure_edge'] ?? 0.30);
+            $pressure = $fullPressureEdge > 0
+                ? min(1.0, max(0.0, $edge - 1.0) / $fullPressureEdge)
+                : 1.0;
+            $erosion *= $pressure;
+        }
+
+        return min(1.0, max(0.0, $erosion));
     }
 
     /**

--- a/config/match_simulation.php
+++ b/config/match_simulation.php
@@ -64,16 +64,16 @@ return [
     |   keeps a realistic spread (champion ~85, strongest squad wins ~45%); verify
     |   with `php artisan app:diagnose-strength-realism`.
     |
-    | Example (base_goals 1.4, D 10, neutral):
-    |   gap  4 pts → supremacy 0.4 → xG 1.6 vs 1.2  (slight edge, frequent draws)
-    |   gap 12 pts → supremacy 1.2 → xG 2.0 vs 0.8  (clear favourite — pulls clear)
-    |   gap 20 pts → supremacy 2.0 → xG 2.4 vs 0.4  (rout)
+    | Example (base_goals 1.5, D 8.5, neutral):
+    |   gap  4 pts → supremacy 0.47 → xG 1.74 vs 1.27  (slight edge, frequent draws)
+    |   gap 12 pts → supremacy 1.41 → xG 2.21 vs 0.79  (clear favourite — pulls clear)
+    |   gap 20 pts → supremacy 2.35 → xG 2.68 vs 0.32  (rout)
     |
     */
-    'base_goals' => 1.4,                // per-team xG when evenly matched (~2.8 total)
-    'goal_supremacy_scale' => 10.0,     // rating points per goal of home-minus-away supremacy
+    'base_goals' => 1.5,                // per-team xG when evenly matched (~3.0 total)
+    'goal_supremacy_scale' => 8.5,      // rating points per goal of home-minus-away supremacy
     'home_advantage_goals' => 0.20,     // fixed home xG bonus
-    'defensive_quality_damping' => 0.6, // how much quality advantage erodes defensive tactics (0=none, higher=more erosion)
+    'defensive_quality_damping' => 1.0, // how much quality advantage erodes defensive tactics (0=none, higher=more erosion)
 
     /*
     |--------------------------------------------------------------------------
@@ -144,7 +144,7 @@ return [
     |
     */
     'dixon_coles_rho' => -0.05,         // goal correlation: 0 = independent Poisson, -0.13 = realistic
-    'score_concentration' => 1.4,       // 1.0 = standard, >1 = results cluster closer to xG mode
+    'score_concentration' => 1.2,       // 1.0 = standard, >1 = results cluster closer to xG mode
 
     /*
     |--------------------------------------------------------------------------
@@ -338,6 +338,42 @@ return [
         'direct_vs_deep' => 1.08,                        // Direct own xG bonus vs opponent Deep line (long balls bypass deep block)
         'high_line_high_press_synergy' => 1.06,          // Own xG bonus when using both High Line + High Press (coordinated pressing)
         'attacking_high_line_vulnerability' => 1.04,     // Opponent own xG bonus vs team using Attacking mentality + High Line (general exposure)
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Defensive Fatigue (Time × Pressure)
+    |--------------------------------------------------------------------------
+    |
+    | A sustained defensive shell tires. As a match wears on, a defending side
+    | under pressure loses concentration and makes late defensive mistakes, so a
+    | parked bus tends to crack in the closing stages. This adds a TIME dimension
+    | to `defensive_quality_damping`: past `ramp_start_minute`, an additional
+    | fraction of the opponent's defensive xG suppression is undone, ramping
+    | linearly to `max_erosion` at minute 90. It only ever *lifts* the attacking
+    | side's xG (a tiring shell concedes more, it never starts attacking) and only
+    | applies where a quality edge already lets the stronger side break the block,
+    | so evenly-matched games stay tight and low-scoring.
+    |
+    | This is what turns a raw quality advantage into late goals against packed
+    | defences — the realism reason a much stronger side eventually pulls away
+    | rather than being held to a 0-0 by a team that simply defends for 90'.
+    |
+    | ramp_start_minute: shell holds firm until this minute (no erosion before it).
+    | max_erosion: at minute 90, up to this fraction of the surviving defensive
+    |   suppression is undone (0 = fatigue off, 1 = the shell fully cracks).
+    | pressure_scaled: when true, the shell tires faster the bigger the quality
+    |   edge it is absorbing; when false, time is the only factor.
+    | full_pressure_edge: the attacker's strength-ratio surplus (e.g. 0.30 = a
+    |   30%-stronger side) at which pressure scaling reaches its full effect.
+    |
+    */
+    'defensive_fatigue' => [
+        'enabled' => true,
+        'ramp_start_minute' => 60,
+        'max_erosion' => 0.5,
+        'pressure_scaled' => true,
+        'full_pressure_edge' => 0.30,
     ],
 
     /*

--- a/tests/Unit/GoalScoringBalanceTest.php
+++ b/tests/Unit/GoalScoringBalanceTest.php
@@ -1,0 +1,236 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Modules\Lineup\Enums\DefensiveLineHeight;
+use App\Modules\Lineup\Enums\Formation;
+use App\Modules\Lineup\Enums\Mentality;
+use App\Modules\Lineup\Enums\PlayingStyle;
+use App\Modules\Lineup\Enums\PressingIntensity;
+use App\Modules\Match\Services\MatchSimulator;
+use App\Modules\Match\Support\MatchOutcomeModel;
+use ReflectionMethod;
+use Tests\TestCase;
+
+/**
+ * Guards the goal-scoring calibration (issue #1313 / [L15]): a clearly dominant
+ * squad must convert its quality edge into goals — averaging well over two per
+ * game and producing regular blowouts — while evenly-matched games stay tight
+ * and no scoreline explodes (the #1283/#1304 guardrail). Also verifies the
+ * defensive-fatigue mechanic: a sustained shell cracks late.
+ *
+ * These exercise the production outcome math directly (the private xG pipeline
+ * and the shared {@see MatchOutcomeModel}) with fixed strengths, so they are
+ * fast and deterministic in xG without seeding a database or running full
+ * minute-by-minute matches.
+ */
+class GoalScoringBalanceTest extends TestCase
+{
+    /** A dominant squad's effective strength (~90-rated best XI). */
+    private const STRONG = 0.89;
+
+    /** A clearly weaker squad's effective strength (~70-rated best XI). */
+    private const WEAK = 0.70;
+
+    private MatchSimulator $simulator;
+
+    private ReflectionMethod $calculateBaseExpectedGoals;
+
+    private ReflectionMethod $applyTacticalModifiers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->simulator = new MatchSimulator;
+        $this->calculateBaseExpectedGoals = new ReflectionMethod(MatchSimulator::class, 'calculateBaseExpectedGoals');
+        $this->applyTacticalModifiers = new ReflectionMethod(MatchSimulator::class, 'applyTacticalModifiers');
+    }
+
+    public function test_dominant_squad_scores_freely_and_produces_blowouts(): void
+    {
+        // A dominant side against a weaker opponent playing straightforwardly.
+        [$homeXG, $awayXG] = $this->fullMatchXg(
+            Mentality::BALANCED, Mentality::BALANCED,
+            PlayingStyle::BALANCED, PlayingStyle::BALANCED,
+            PressingIntensity::STANDARD, PressingIntensity::STANDARD,
+            DefensiveLineHeight::NORMAL, DefensiveLineHeight::NORMAL,
+        );
+
+        $stats = $this->sampleMany($homeXG, $awayXG);
+
+        // Core acceptance criterion: a dominant squad averages > 2.3 GF/game.
+        $this->assertGreaterThan(2.3, $stats['avgHome'],
+            "Dominant squad should average > 2.3 GF/game, got {$stats['avgHome']}");
+
+        // Result variety: clear blowouts (3+ margin) happen regularly.
+        $this->assertGreaterThan(0.10, $stats['blowoutRate'],
+            "Blowouts (3+ margin) should occur regularly, got rate {$stats['blowoutRate']}");
+
+        // Guardrail against the #1283/#1304 exploding-scoreline class.
+        $this->assertLessThan(6.0, $stats['avgTotal'],
+            "Average total goals should stay realistic, got {$stats['avgTotal']}");
+        $this->assertLessThanOrEqual(14, $stats['maxTotal'],
+            "No single scoreline should explode, got max total {$stats['maxTotal']}");
+    }
+
+    public function test_dominant_squad_still_breaks_down_a_parked_bus(): void
+    {
+        // The exact complaint: a much stronger side vs a full defensive shell.
+        // Quality damping + defensive fatigue must keep it scoring rather than
+        // being held to a 0-0.
+        [$homeXG, $awayXG] = $this->fullMatchXg(
+            Mentality::BALANCED, Mentality::DEFENSIVE,
+            PlayingStyle::BALANCED, PlayingStyle::COUNTER_ATTACK,
+            PressingIntensity::STANDARD, PressingIntensity::LOW_BLOCK,
+            DefensiveLineHeight::NORMAL, DefensiveLineHeight::DEEP,
+        );
+
+        $stats = $this->sampleMany($homeXG, $awayXG);
+
+        $this->assertGreaterThan(1.5, $stats['avgHome'],
+            "A dominant squad should break a parked bus for > 1.5 GF/game, got {$stats['avgHome']}");
+        $this->assertGreaterThan(0.05, $stats['blowoutRate'],
+            "Blowouts vs a parked bus should still happen, got rate {$stats['blowoutRate']}");
+    }
+
+    public function test_defensive_shell_concedes_more_late_than_early(): void
+    {
+        // Identical inputs; only the match minute differs. A tiring shell should
+        // concede more in the closing stages.
+        $early = $this->attackerXgAgainstShell(20.0);
+        $late = $this->attackerXgAgainstShell(85.0);
+
+        $this->assertGreaterThan($early, $late,
+            "A tiring defensive shell should concede more late ({$late}) than early ({$early})");
+    }
+
+    public function test_defensive_fatigue_does_not_fire_in_evenly_matched_games(): void
+    {
+        // Equal strengths: the quality-damping branch (and therefore fatigue)
+        // must not engage, so an evenly-matched defensive game stays tight
+        // regardless of the minute.
+        $early = $this->attackerXgAgainstShell(20.0, self::WEAK, self::WEAK);
+        $late = $this->attackerXgAgainstShell(85.0, self::WEAK, self::WEAK);
+
+        $this->assertEqualsWithDelta($early, $late, 0.0001,
+            'Fatigue should not inflate scoring in an evenly-matched game');
+    }
+
+    /**
+     * Full-match xG for the strong (home) side vs the weak (away) side, summed
+     * over an early and a late period exactly as the engine scales xG by match
+     * fraction — so the late period picks up the defensive-fatigue ramp.
+     *
+     * @return array{0: float, 1: float} [homeXG, awayXG]
+     */
+    private function fullMatchXg(
+        Mentality $homeMentality,
+        Mentality $awayMentality,
+        PlayingStyle $homeStyle,
+        PlayingStyle $awayStyle,
+        PressingIntensity $homePress,
+        PressingIntensity $awayPress,
+        DefensiveLineHeight $homeLine,
+        DefensiveLineHeight $awayLine,
+    ): array {
+        $baseGoals = (float) config('match_simulation.base_goals', 1.5);
+        $strengthRatio = self::STRONG / self::WEAK;
+
+        // Two 45' periods; each contributes its fraction of the full match.
+        $fraction = 45.0 / 93.0;
+        $homeXG = 0.0;
+        $awayXG = 0.0;
+
+        foreach ([22.5, 67.5] as $effectiveMinute) {
+            [$h, $a] = $this->calculateBaseExpectedGoals->invoke(
+                $this->simulator,
+                self::STRONG, self::WEAK,
+                Formation::F_4_3_3, Formation::F_4_3_3,
+                $homeMentality, $awayMentality,
+                $baseGoals, $fraction,
+                false,
+            );
+
+            [$h, $a] = $this->applyTacticalModifiers->invoke(
+                $this->simulator,
+                $h, $a,
+                $homeStyle, $awayStyle,
+                $homePress, $awayPress,
+                $homeLine, $awayLine,
+                $homeMentality, $awayMentality,
+                $effectiveMinute,
+                $strengthRatio,
+            );
+
+            $homeXG += $h;
+            $awayXG += $a;
+        }
+
+        return [$homeXG, $awayXG];
+    }
+
+    /**
+     * Sample many scorelines from the shared outcome model and aggregate the
+     * stats the acceptance criteria care about.
+     *
+     * @return array{avgHome: float, avgTotal: float, blowoutRate: float, maxTotal: int}
+     */
+    private function sampleMany(float $homeXG, float $awayXG, int $runs = 5000): array
+    {
+        $homeGoals = 0;
+        $totalGoals = 0;
+        $blowouts = 0;
+        $maxTotal = 0;
+
+        for ($i = 0; $i < $runs; $i++) {
+            [$h, $a] = MatchOutcomeModel::sampleScoreline($homeXG, $awayXG);
+            $homeGoals += $h;
+            $totalGoals += $h + $a;
+            $maxTotal = max($maxTotal, $h + $a);
+            if ($h - $a >= 3) {
+                $blowouts++;
+            }
+        }
+
+        return [
+            'avgHome' => $homeGoals / $runs,
+            'avgTotal' => $totalGoals / $runs,
+            'blowoutRate' => $blowouts / $runs,
+            'maxTotal' => $maxTotal,
+        ];
+    }
+
+    /**
+     * Home (attacker) xG for a single late/early period against a full defensive
+     * shell, at a given minute. Used to isolate the fatigue ramp.
+     */
+    private function attackerXgAgainstShell(
+        float $effectiveMinute,
+        float $homeStrength = self::STRONG,
+        float $awayStrength = self::WEAK,
+    ): float {
+        $strengthRatio = $awayStrength > 0 ? $homeStrength / $awayStrength : 1.0;
+
+        [$h, $a] = $this->calculateBaseExpectedGoals->invoke(
+            $this->simulator,
+            $homeStrength, $awayStrength,
+            Formation::F_4_3_3, Formation::F_4_3_3,
+            Mentality::BALANCED, Mentality::DEFENSIVE,
+            (float) config('match_simulation.base_goals', 1.5), 45.0 / 93.0,
+            false,
+        );
+
+        [$homeXG] = $this->applyTacticalModifiers->invoke(
+            $this->simulator,
+            $h, $a,
+            PlayingStyle::BALANCED, PlayingStyle::COUNTER_ATTACK,
+            PressingIntensity::STANDARD, PressingIntensity::LOW_BLOCK,
+            DefensiveLineHeight::NORMAL, DefensiveLineHeight::DEEP,
+            Mentality::BALANCED, Mentality::DEFENSIVE,
+            $effectiveMinute,
+            $strengthRatio,
+        );
+
+        return $homeXG;
+    }
+}


### PR DESCRIPTION
## Summary

Implements a defensive fatigue system that allows dominant sides to break down packed defences in the closing stages of matches. A sustained defensive shell tires and makes late mistakes, so the attacking side's xG suppression is progressively eroded from minute 60 onwards, ramping linearly to full effect by minute 90. This adds a time dimension to the existing quality-damping mechanic and ensures that much stronger teams eventually pull away rather than being held to 0-0 draws by teams that simply park the bus.

## Key Changes

- **New `defensiveFatigueErosion()` method** in `MatchSimulator`: Calculates the fraction of defensive xG suppression that a tiring shell surrenders as the match wears on. Returns 0 before `ramp_start_minute` (default 60), then ramps linearly to `max_erosion` (default 0.5) by minute 90. When `pressure_scaled` is enabled, the shell tires faster the bigger the quality edge it is absorbing, reaching full effect at `full_pressure_edge` (default 0.30 strength-ratio surplus).

- **Updated `applyTacticalModifiers()`**: Integrates defensive fatigue into the quality-damping attenuation calculation. The erosion is only applied where a quality edge already lets the stronger side break the block, so evenly-matched games remain tight and low-scoring regardless of match minute.

- **Config tuning** (`config/match_simulation.php`):
  - `base_goals`: 1.4 → 1.5 (per-team xG when evenly matched, ~3.0 total)
  - `goal_supremacy_scale`: 10.0 → 8.5 (rating points per goal of supremacy)
  - `defensive_quality_damping`: 0.6 → 1.0 (stronger quality erosion of defensive tactics)
  - `score_concentration`: 1.4 → 1.2 (results cluster slightly less tightly to xG mode)
  - New `defensive_fatigue` config block with `enabled`, `ramp_start_minute`, `max_erosion`, `pressure_scaled`, and `full_pressure_edge` settings

- **Comprehensive test suite** (`GoalScoringBalanceTest`): Guards the goal-scoring calibration with three acceptance criteria:
  - Dominant squads average > 2.3 GF/game and produce regular blowouts (3+ margin)
  - Dominant squads still break down parked buses for > 1.5 GF/game
  - Defensive shells concede more in closing stages (late > early) due to fatigue
  - Fatigue does not fire in evenly-matched games (quality-damping branch not engaged)

- **Minor fix** in `SimulateMatch` command: Added `.result` accessor to match outcome object.

## Implementation Details

The fatigue mechanic is folded into the existing quality-damping attenuation, so it:
- Only ever *lifts* the attacking side's xG (a tiring shell concedes more, never starts attacking)
- Only applies where a quality edge already lets the stronger side break the block
- Scales with both time (minute) and pressure (quality edge) when enabled
- Mirrors the High-Press fade pattern used elsewhere in the engine

This ensures realistic late-game breakdowns of defensive blocks while preserving tight, low-scoring matches between evenly-matched sides.

https://claude.ai/code/session_011rKaGVnK7PyF46n3bFxdoH