### PR TITLE
Make squad morale react to under/overperformance

### DIFF
--- a/app/Modules/Match/Services/AIMatchResolver.php
+++ b/app/Modules/Match/Services/AIMatchResolver.php
@@ -7,6 +7,7 @@ use App\Models\GamePlayer;
 use App\Models\Game;
 use App\Modules\Match\DTOs\MatchEventData;
 use App\Modules\Match\Support\MatchOutcomeModel;
+use App\Modules\Match\Support\PaperStrength;
 use App\Modules\Match\Support\StoppageCalculator;
 use Illuminate\Support\Collection;
 
@@ -243,31 +244,13 @@ class AIMatchResolver
     }
 
     /**
-     * Calculate team strength from a selected XI.
-     *
-     * Simplified version of MatchSimulator::calculateTeamStrength():
-     * - No energy model (no minute-by-minute drain)
-     * - No per-player match performance variance (averages out over a season)
-     * - Fitness weight removed — its impact comes via rotation (low-fitness
-     *   players are penalized in lineup selection via effectiveScore)
+     * Paper strength of a selected XI — the ability-dominant average that feeds
+     * the outcome model. Delegates to the shared {@see PaperStrength} estimator
+     * (no energy/form/position noise; fitness enters via lineup selection).
      */
     private function calculateTeamStrength(Collection $lineup): float
     {
-        if ($lineup->count() < 7) {
-            return 0.30;
-        }
-
-        $wOverall = config('match_simulation.strength_weight_overall', 0.95);
-        $wMorale = config('match_simulation.strength_weight_morale', 0.05);
-
-        $totalStrength = 0;
-        foreach ($lineup as $player) {
-            $playerStrength = ($player->overall_score * $wOverall) +
-                              ($player->morale * $wMorale);
-            $totalStrength += $playerStrength;
-        }
-
-        return ($totalStrength / 11) / 100;
+        return PaperStrength::estimate($lineup);
     }
 
     /**

--- a/app/Modules/Match/Services/MatchNarrativeService.php
+++ b/app/Modules/Match/Services/MatchNarrativeService.php
@@ -430,9 +430,13 @@ class MatchNarrativeService
             $candidates[] = $this->candidate('mood', 8, 'injury_crisis', ['count' => $injuryCount]);
         }
 
-        if ($avgMorale < 40) {
+        // Thresholds sit inside the [50,100] morale band: the default 80 must
+        // read as neutral, not "sky-high", so `morale_high` is earned only above
+        // 85 (a winning run) and `morale_low` becomes reachable below 62 (a side
+        // slumping under the underperformance term). Neutral 62–85 stays quiet.
+        if ($avgMorale < 62) {
             $candidates[] = $this->candidate('mood', 7, 'morale_low');
-        } elseif ($avgMorale > 75) {
+        } elseif ($avgMorale > 85) {
             $candidates[] = $this->candidate('mood', 6, 'morale_high');
         }
 

--- a/app/Modules/Match/Support/PaperStrength.php
+++ b/app/Modules/Match/Support/PaperStrength.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Modules\Match\Support;
+
+/**
+ * Ability-dominant "paper" strength of a starting XI — who was favoured on paper,
+ * before a ball is kicked.
+ *
+ * This is the strength that feeds {@see MatchOutcomeModel::expectedGoals}: the
+ * average of each player's `overall_score` (weighted 0.95) and `morale` (0.05),
+ * divided by 11 and rescaled to the 0..1 rating band. It deliberately omits the
+ * match-time noise that {@see \App\Modules\Match\Services\MatchSimulator::calculateTeamStrength}
+ * layers on (per-minute energy drain, form-on-the-day, out-of-position penalties)
+ * — those describe how a match *unfolds*, not who was favoured going in.
+ *
+ * {@see \App\Modules\Match\Services\AIMatchResolver} resolves AI-vs-AI matches
+ * through this, and {@see \App\Modules\Player\Services\PlayerConditionService}
+ * recomputes it post-match to read the expected-points a squad was supposed to
+ * take — the basis of the underperformance morale term — so the paper-strength
+ * formula lives in exactly one place.
+ */
+class PaperStrength
+{
+    /** Fallback when a lineup is too thin to be a real XI (partial/empty lineups). */
+    private const MIN_LINEUP_SIZE = 7;
+
+    private const THIN_LINEUP_STRENGTH = 0.30;
+
+    /**
+     * Paper strength in the 0..1 rating band for a selected XI.
+     *
+     * Fitness weight is intentionally absent — its effect enters via lineup
+     * selection (low-fitness players are penalized when the XI is picked), not
+     * via the paper-strength average.
+     *
+     * @param  iterable<object>  $lineupPlayers  players exposing `overall_score` and `morale`
+     */
+    public static function estimate(iterable $lineupPlayers): float
+    {
+        $players = is_array($lineupPlayers) ? $lineupPlayers : iterator_to_array($lineupPlayers);
+
+        if (count($players) < self::MIN_LINEUP_SIZE) {
+            return self::THIN_LINEUP_STRENGTH;
+        }
+
+        $wOverall = config('match_simulation.strength_weight_overall', 0.95);
+        $wMorale = config('match_simulation.strength_weight_morale', 0.05);
+
+        $totalStrength = 0;
+        foreach ($players as $player) {
+            $totalStrength += ($player->overall_score * $wOverall) +
+                              ($player->morale * $wMorale);
+        }
+
+        return ($totalStrength / 11) / 100;
+    }
+}

--- a/app/Modules/Player/Services/PlayerConditionService.php
+++ b/app/Modules/Player/Services/PlayerConditionService.php
@@ -5,6 +5,8 @@ namespace App\Modules\Player\Services;
 use App\Models\GamePlayer;
 use App\Models\GamePlayerMatchState;
 use App\Modules\Match\Services\EnergyCalculator;
+use App\Modules\Match\Support\MatchOutcomeModel;
+use App\Modules\Match\Support\PaperStrength;
 use App\Modules\Player\PlayerAge;
 use Carbon\Carbon;
 
@@ -32,6 +34,24 @@ class PlayerConditionService
     // Morale bounds
     private const MAX_MORALE = 100;
     private const MIN_MORALE = 50;
+
+    // Underperformance/overperformance morale, keyed on the expected-points delta
+    // (actual − expected league points, expected derived from the sim's pre-match
+    // win probability). Dropping points you were favoured to take erodes morale
+    // beyond the flat loss penalty; stealing points you weren't favoured to take
+    // lifts it beyond the flat win bonus. Both scale with severity and stack on
+    // the normal result change, so a heavy favourite's collapse bites hard while
+    // an underdog's expected defeat barely registers.
+    private const UNDERPERFORMANCE_POINTS_THRESHOLD = 1.0; // expected pts dropped before it bites
+    private const UNDERPERFORMANCE_SPAN = 1.5;              // delta beyond threshold ⇒ full penalty
+    private const UNDERPERFORMANCE_MAX_PENALTY = 5;         // cap (heavy-favourite collapse)
+    private const OVERPERFORMANCE_POINTS_THRESHOLD = 1.0;  // expected pts gained above expectation before it lifts
+    private const OVERPERFORMANCE_SPAN = 1.5;
+    private const OVERPERFORMANCE_MAX_BONUS = 4;            // cap (underdog giant-killing)
+
+    // A lineup below this many players isn't a real XI (partial/empty lineups in
+    // tests or abandoned matches) — skip the expectation term for that match.
+    private const MIN_LINEUP_FOR_EXPECTATION = 7;
 
     /**
      * Batch-update fitness and morale for all players across all matches in a matchday.
@@ -62,9 +82,14 @@ class PlayerConditionService
             $homeWon = $match->home_score > $match->away_score;
             $awayWon = $match->away_score > $match->home_score;
 
-            $players = collect()
-                ->merge($allPlayersByTeam->get($match->home_team_id, collect()))
-                ->merge($allPlayersByTeam->get($match->away_team_id, collect()));
+            $homePlayers = $allPlayersByTeam->get($match->home_team_id, collect());
+            $awayPlayers = $allPlayersByTeam->get($match->away_team_id, collect());
+
+            // Expected-points delta per side (actual − expected). Computed once per
+            // match from the paper strength of each XI, before the player loop.
+            [$homeDelta, $awayDelta] = $this->expectedPointsDeltas($match, $homePlayers, $awayPlayers);
+
+            $players = collect()->merge($homePlayers)->merge($awayPlayers);
 
             foreach ($players as $player) {
                 if (isset($updates[$player->id])) {
@@ -81,7 +106,8 @@ class PlayerConditionService
                     $isInLineup,
                     $isHome ? $homeWon : $awayWon,
                     $isHome ? $awayWon : $homeWon,
-                    $eventsByPlayer[$player->id] ?? []
+                    $eventsByPlayer[$player->id] ?? [],
+                    $isHome ? $homeDelta : $awayDelta,
                 );
 
                 // Sidelined players are allowed below MIN_FITNESS so a long
@@ -105,6 +131,65 @@ class PlayerConditionService
     private function bulkUpdateConditions(array $updates): void
     {
         GamePlayerMatchState::bulkSetValues($updates);
+    }
+
+    /**
+     * Expected-points delta (actual − expected) for each side of a match.
+     *
+     * Recomputes the pre-match expectation from the paper strength of each XI —
+     * the same math the sim used to produce the result — so morale can react to
+     * a favourite dropping points it was supposed to take (negative delta) or an
+     * underdog stealing points it wasn't (positive delta).
+     *
+     * Returns [0.0, 0.0] when there is nothing to weigh — an unscored match (e.g.
+     * the user's deferred match while an AI batch updates conditions) or a lineup
+     * too thin to be a real XI — leaving the flat result change as the only
+     * morale driver.
+     *
+     * @return array{0: float, 1: float}  [homeDelta, awayDelta]
+     */
+    private function expectedPointsDeltas($match, $homePlayers, $awayPlayers): array
+    {
+        if ($match->home_score === null || $match->away_score === null) {
+            return [0.0, 0.0];
+        }
+
+        $homeXI = $homePlayers->whereIn('id', $match->home_lineup ?? []);
+        $awayXI = $awayPlayers->whereIn('id', $match->away_lineup ?? []);
+
+        if ($homeXI->count() < self::MIN_LINEUP_FOR_EXPECTATION
+            || $awayXI->count() < self::MIN_LINEUP_FOR_EXPECTATION) {
+            return [0.0, 0.0];
+        }
+
+        [$homeXG, $awayXG] = MatchOutcomeModel::expectedGoals(
+            PaperStrength::estimate($homeXI),
+            PaperStrength::estimate($awayXI),
+            $match->isNeutralVenue(),
+        );
+        $probs = MatchOutcomeModel::outcomeProbabilities(
+            MatchOutcomeModel::scoreProbabilityMatrix($homeXG, $awayXG),
+        );
+
+        $homeExpectedPts = 3 * $probs['home'] + $probs['draw'];
+        $awayExpectedPts = 3 * $probs['away'] + $probs['draw'];
+
+        $homeActualPts = $this->actualPoints($match->home_score, $match->away_score);
+        $awayActualPts = $this->actualPoints($match->away_score, $match->home_score);
+
+        return [$homeActualPts - $homeExpectedPts, $awayActualPts - $awayExpectedPts];
+    }
+
+    /**
+     * League points a side earned from its own vs the opponent's score (3/1/0).
+     */
+    private function actualPoints(int $forScore, int $againstScore): int
+    {
+        return match (true) {
+            $forScore > $againstScore => 3,
+            $forScore === $againstScore => 1,
+            default => 0,
+        };
     }
 
     /**
@@ -204,7 +289,8 @@ class PlayerConditionService
         bool $playedMatch,
         bool $teamWon,
         bool $teamLost,
-        array $playerEvents
+        array $playerEvents,
+        float $teamPointsDelta = 0.0
     ): int {
         $change = 0;
 
@@ -218,6 +304,13 @@ class PlayerConditionService
         } else {
             $change += (int) (rand(self::MORALE_DRAW[0], self::MORALE_DRAW[1]) * $resultMultiplier);
         }
+
+        // Under/overperformance vs the pre-match expectation, keyed on the
+        // expected-points delta. A favourite that drops points it was supposed
+        // to take loses morale beyond the flat penalty; an underdog that steals
+        // points gains beyond the flat bonus. Shares the same result multiplier
+        // so bench players feel it at half.
+        $change += self::underperformanceMoraleDelta($teamPointsDelta, $resultMultiplier);
 
         // Individual event impacts (only for players who participated)
         if ($playedMatch) {
@@ -243,6 +336,40 @@ class PlayerConditionService
         }
 
         return $change;
+    }
+
+    /**
+     * Morale change from a result relative to its pre-match expectation, keyed on
+     * the expected-points delta (actual − expected league points).
+     *
+     * Deterministic and severity-scaled: a favourite dropping points it was
+     * favoured to take erodes morale beyond the flat loss penalty, and an
+     * underdog stealing points lifts it beyond the flat win bonus, while a result
+     * that merely matched expectation returns 0. An expected defeat (small
+     * negative delta below the threshold) barely registers. `$resultMultiplier`
+     * scales the same way the flat result does (1.0 played, 0.5 bench).
+     *
+     * Static so the shape can be unit-tested directly, without the random
+     * flat-result noise around it.
+     */
+    public static function underperformanceMoraleDelta(float $teamPointsDelta, float $resultMultiplier = 1.0): int
+    {
+        $dropped = -$teamPointsDelta; // >0 when the side finished below expectation
+        $gained = $teamPointsDelta;   // >0 when the side finished above expectation
+
+        if ($dropped > self::UNDERPERFORMANCE_POINTS_THRESHOLD) {
+            $severity = min(1.0, ($dropped - self::UNDERPERFORMANCE_POINTS_THRESHOLD) / self::UNDERPERFORMANCE_SPAN);
+
+            return -(int) round($severity * self::UNDERPERFORMANCE_MAX_PENALTY * $resultMultiplier);
+        }
+
+        if ($gained > self::OVERPERFORMANCE_POINTS_THRESHOLD) {
+            $severity = min(1.0, ($gained - self::OVERPERFORMANCE_POINTS_THRESHOLD) / self::OVERPERFORMANCE_SPAN);
+
+            return (int) round($severity * self::OVERPERFORMANCE_MAX_BONUS * $resultMultiplier);
+        }
+
+        return 0;
     }
 
     /**

--- a/tests/Unit/MatchNarrativeMoodTest.php
+++ b/tests/Unit/MatchNarrativeMoodTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\Game;
+use App\Models\GamePlayer;
+use App\Models\Team;
+use App\Modules\Match\Services\MatchNarrativeService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use ReflectionMethod;
+use Tests\TestCase;
+
+/**
+ * Guards the retuned mood thresholds. Morale is clamped to [50,100] (default 80),
+ * so the narrative signals only make sense inside that band: `morale_high` must
+ * be earned (a winning run), not read off the default, and `morale_low` must be
+ * reachable (a slumping side). The cut-offs are `> 85` and `< 62`, with a quiet
+ * 62–85 neutral zone that the default 80 sits in.
+ */
+class MatchNarrativeMoodTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** Reflect the private mood selector and return just the candidate keys. */
+    private function moodKeys(Game $game): array
+    {
+        $service = new MatchNarrativeService();
+        $method = new ReflectionMethod($service, 'moodCandidates');
+        $method->setAccessible(true);
+
+        return array_map(fn ($c) => $c['key'], $method->invoke($service, $game));
+    }
+
+    /**
+     * Seed a squad whose average morale is the given value, with fitness pinned
+     * to the neutral band (55–80) so no fitness signal interferes.
+     */
+    private function seedGame(int $morale): Game
+    {
+        $team = Team::factory()->create();
+        $game = Game::factory()->forTeam($team)->create(['current_date' => '2025-10-01']);
+
+        GamePlayer::factory()->count(11)->forGame($game)->forTeam($team)->create([
+            'morale' => $morale,
+            'fitness' => 70,
+        ]);
+
+        return $game;
+    }
+
+    public function test_slumping_squad_surfaces_morale_low(): void
+    {
+        $keys = $this->moodKeys($this->seedGame(55));
+
+        $this->assertContains('morale_low', $keys);
+        $this->assertNotContains('morale_high', $keys);
+    }
+
+    public function test_default_morale_sits_in_the_neutral_zone(): void
+    {
+        $keys = $this->moodKeys($this->seedGame(80));
+
+        $this->assertNotContains('morale_low', $keys);
+        $this->assertNotContains('morale_high', $keys);
+    }
+
+    public function test_high_morale_only_above_eighty_five(): void
+    {
+        // Just above the old threshold but inside the new neutral zone: no signal.
+        $this->assertNotContains('morale_high', $this->moodKeys($this->seedGame(80)));
+
+        // Clearly above the new cut-off: earned.
+        $keys = $this->moodKeys($this->seedGame(90));
+        $this->assertContains('morale_high', $keys);
+        $this->assertNotContains('morale_low', $keys);
+    }
+}

--- a/tests/Unit/PlayerConditionServiceTest.php
+++ b/tests/Unit/PlayerConditionServiceTest.php
@@ -345,4 +345,194 @@ class PlayerConditionServiceTest extends TestCase
         // Weekly matches should allow near-full recovery (stabilize 90-100)
         $this->assertGreaterThan(85, $fitness, 'Weekly schedule should maintain high fitness');
     }
+
+    // -------------------------------------------------------
+    // Underperformance / overperformance morale term
+    // -------------------------------------------------------
+
+    public function test_underperformance_morale_delta_shape(): void
+    {
+        // Favourite that loses (dropped ≈ 2.4 expected pts) takes the near-full penalty.
+        $this->assertSame(-5, PlayerConditionService::underperformanceMoraleDelta(-2.4));
+        // Even match lost (dropped ≈ 1.4) — a small bite just past the threshold.
+        $this->assertSame(-1, PlayerConditionService::underperformanceMoraleDelta(-1.4));
+        // Underdog losing as expected (dropped 0.6, below threshold) — nothing.
+        $this->assertSame(0, PlayerConditionService::underperformanceMoraleDelta(-0.6));
+        // Exactly at the threshold does not fire (strict comparison).
+        $this->assertSame(0, PlayerConditionService::underperformanceMoraleDelta(-1.0));
+        // A result that matched expectation is neutral.
+        $this->assertSame(0, PlayerConditionService::underperformanceMoraleDelta(0.0));
+        // Favourite winning as expected (gained 0.6) earns no surge.
+        $this->assertSame(0, PlayerConditionService::underperformanceMoraleDelta(0.6));
+        // Underdog upset win (gained ≈ 2.4) earns the near-full surge.
+        $this->assertSame(4, PlayerConditionService::underperformanceMoraleDelta(2.4));
+        // Bench players feel it at half.
+        $this->assertSame(-2, PlayerConditionService::underperformanceMoraleDelta(-2.4, 0.5));
+        // Severity is capped — an extreme delta can't exceed the max penalty.
+        $this->assertSame(-5, PlayerConditionService::underperformanceMoraleDelta(-6.0));
+    }
+
+    public function test_strong_favourite_losing_drops_morale_beyond_flat_loss(): void
+    {
+        $game = Game::factory()->create(['current_date' => '2025-10-01']);
+        $strong = Team::factory()->create();
+        $weak = Team::factory()->create();
+
+        $strongSquad = $this->createSquad($game, $strong, overall: 90, morale: 80);
+        $weakSquad = $this->createSquad($game, $weak, overall: 40, morale: 80);
+
+        // Heavy favourite (home) loses 0-1: it dropped points it was expected to
+        // take, so its squad morale should fall below what the flat loss alone
+        // (max −4 → 76) could produce — the underperformance term (−5) stacks on.
+        $match = GameMatch::factory()->create([
+            'game_id' => $game->id,
+            'home_team_id' => $strong->id,
+            'away_team_id' => $weak->id,
+            'home_lineup' => $strongSquad->pluck('id')->all(),
+            'away_lineup' => $weakSquad->pluck('id')->all(),
+            'home_score' => 0,
+            'away_score' => 1,
+        ]);
+
+        $this->service->batchUpdateAfterMatchday(
+            collect([$match]),
+            [['matchId' => $match->id, 'events' => []]],
+            collect([$strong->id => $strongSquad, $weak->id => $weakSquad]),
+            [$strong->id => 7, $weak->id => 7],
+            $this->currentDate,
+        );
+
+        $avgMorale = $this->squadAverageMorale($strongSquad);
+        $this->assertLessThan(75, $avgMorale,
+            'A favourite collapsing should drop morale past the flat loss penalty');
+    }
+
+    public function test_underdog_upset_win_lifts_morale_beyond_flat_win(): void
+    {
+        $game = Game::factory()->create(['current_date' => '2025-10-01']);
+        $strong = Team::factory()->create();
+        $weak = Team::factory()->create();
+
+        // Seed at 65 so the win bonus + surge stays clear of the 100 clamp.
+        $strongSquad = $this->createSquad($game, $strong, overall: 90, morale: 65);
+        $weakSquad = $this->createSquad($game, $weak, overall: 40, morale: 65);
+
+        // Underdog (away) wins 1-0: it took points it wasn't expected to, so its
+        // morale rises above what the flat win alone (~+6 avg → ~71) yields.
+        $match = GameMatch::factory()->create([
+            'game_id' => $game->id,
+            'home_team_id' => $strong->id,
+            'away_team_id' => $weak->id,
+            'home_lineup' => $strongSquad->pluck('id')->all(),
+            'away_lineup' => $weakSquad->pluck('id')->all(),
+            'home_score' => 0,
+            'away_score' => 1,
+        ]);
+
+        $this->service->batchUpdateAfterMatchday(
+            collect([$match]),
+            [['matchId' => $match->id, 'events' => []]],
+            collect([$strong->id => $strongSquad, $weak->id => $weakSquad]),
+            [$strong->id => 7, $weak->id => 7],
+            $this->currentDate,
+        );
+
+        $avgMorale = $this->squadAverageMorale($weakSquad);
+        $this->assertGreaterThan(72, $avgMorale,
+            'An underdog upset should lift morale past the flat win bonus');
+    }
+
+    public function test_incomplete_lineups_skip_underperformance_term(): void
+    {
+        $game = Game::factory()->create(['current_date' => '2025-10-01']);
+        $strong = Team::factory()->create();
+        $weak = Team::factory()->create();
+
+        $strongSquad = $this->createSquad($game, $strong, overall: 90, morale: 80);
+        $weakSquad = $this->createSquad($game, $weak, overall: 40, morale: 80);
+
+        // Empty lineups (an abandoned/unset match): no XI to compute expectation
+        // from, so the term must NOT fire — morale stays in the flat-only band and
+        // never dips into the favourite-collapse range (~72).
+        $match = GameMatch::factory()->create([
+            'game_id' => $game->id,
+            'home_team_id' => $strong->id,
+            'away_team_id' => $weak->id,
+            'home_lineup' => [],
+            'away_lineup' => [],
+            'home_score' => 0,
+            'away_score' => 1,
+        ]);
+
+        $this->service->batchUpdateAfterMatchday(
+            collect([$match]),
+            [['matchId' => $match->id, 'events' => []]],
+            collect([$strong->id => $strongSquad, $weak->id => $weakSquad]),
+            [$strong->id => 7, $weak->id => 7],
+            $this->currentDate,
+        );
+
+        $avgMorale = $this->squadAverageMorale($strongSquad);
+        $this->assertGreaterThanOrEqual(75, $avgMorale,
+            'Incomplete lineups should apply no underperformance term');
+    }
+
+    public function test_unscored_match_applies_no_underperformance_term(): void
+    {
+        $game = Game::factory()->create(['current_date' => '2025-10-01']);
+        $strong = Team::factory()->create();
+        $weak = Team::factory()->create();
+
+        $strongSquad = $this->createSquad($game, $strong, overall: 90, morale: 80);
+        $weakSquad = $this->createSquad($game, $weak, overall: 40, morale: 80);
+
+        // A full XI on both sides but no score yet — the user's deferred match
+        // while an AI batch updates conditions. There is no result to weigh, so
+        // the term must be skipped (and must not blow up on null scores); the
+        // squad only sees the flat draw nudge and stays near its starting morale.
+        $match = GameMatch::factory()->create([
+            'game_id' => $game->id,
+            'home_team_id' => $strong->id,
+            'away_team_id' => $weak->id,
+            'home_lineup' => $strongSquad->pluck('id')->all(),
+            'away_lineup' => $weakSquad->pluck('id')->all(),
+            'home_score' => null,
+            'away_score' => null,
+        ]);
+
+        $this->service->batchUpdateAfterMatchday(
+            collect([$match]),
+            [['matchId' => $match->id, 'events' => []]],
+            collect([$strong->id => $strongSquad, $weak->id => $weakSquad]),
+            [$strong->id => 7, $weak->id => 7],
+            $this->currentDate,
+        );
+
+        $avgMorale = $this->squadAverageMorale($strongSquad);
+        $this->assertGreaterThanOrEqual(78, $avgMorale,
+            'An unscored match should apply no underperformance term');
+    }
+
+    /**
+     * Create a full XI's worth of players on a team with a fixed overall/morale.
+     *
+     * @return \Illuminate\Support\Collection<int, GamePlayer>
+     */
+    private function createSquad(Game $game, Team $team, int $overall, int $morale, int $count = 11): \Illuminate\Support\Collection
+    {
+        return collect(range(1, $count))->map(fn () => GamePlayer::factory()
+            ->forGame($game)
+            ->forTeam($team)
+            ->create([
+                'position' => 'Central Midfield',
+                'fitness' => 100,
+                'morale' => $morale,
+                'overall_score' => $overall,
+            ]));
+    }
+
+    private function squadAverageMorale(\Illuminate\Support\Collection $squad): float
+    {
+        return (float) $squad->avg(fn (GamePlayer $p) => $p->fresh()->morale);
+    }
 }


### PR DESCRIPTION
## Why

The season-mode dashboard news feed could print *"confidence is sky-high in the dressing room"* right next to *"7th — 6 places off the season target."* That contradiction is a **symptom**: squad morale never reacted to results *relative to expectation*. A prior iteration merged/de-duplicated the feed's redundant lines; this closes the *contradiction* at the root — a team that keeps losing matches it was favoured to win now has lower morale, so the feed just reports reality.

This is a game-dynamics change (it improves the sim broadly, for **every team**), not a UI patch.

## What

- **`PaperStrength`** (new) — shared XI "paper" strength estimator (`overall·0.95 + morale·0.05`, /11, `<7 ⇒ 0.30`), extracted from `AIMatchResolver::calculateTeamStrength`, which now delegates to it.
- **`PlayerConditionService`** — `batchUpdateAfterMatchday` recomputes each match's **expected-points delta** once (paper strength → `MatchOutcomeModel::expectedGoals` → `scoreProbabilityMatrix` → `outcomeProbabilities` → `3·P(win)+P(draw)`) and threads the player's-team delta into `calculateMoraleChange`. A new **symmetric term** — `public static underperformanceMoraleDelta()` — applies up to **−5** for a heavy favourite's collapse and **+4** for an underdog upset, sharing the flat result's played/bench multiplier. Two guards return `[0,0]` (no term): incomplete lineups (`<7`) and **unscored matches** (the user's deferred match reaches condition-update during an AI batch with full lineups but null scores).
- **`MatchNarrativeService::moodCandidates`** — retune the mood thresholds so the signals are *earned* inside the clamped `[50,100]` morale band: `morale_high` `>75 → >85`, `morale_low` `<40` (previously unreachable) `→ <62`. Neutral 62–85; the default 80 sits quiet.

## Design decisions

| Decision | Choice |
|---|---|
| Signal | Expected-**points** delta (morale follows results + the expectation of results) |
| Upset bonus | **Symmetric** — underdogs that overperform get a morale surge |
| Scope | **All teams** — AI giants that slump genuinely weaken (morale feeds 5% of strength) |
| Accumulation | **Morale-as-accumulator** — no window/schema; a slump compounds, a one-off shock recovers |
| Visibility | **Threshold retune** (not lowering `MIN_MORALE`, which would ripple into `DispositionService`/strength) |

## Safety

The feedback loop is negative/bounded: underperform → morale ↓ → strength ↓ → expectation ↓ → future delta smaller → *less* penalty. Floored at `MIN_MORALE`, ceilinged at `MAX_MORALE`. No spiral.

## Tests

- **Unit** — exact shape of `underperformanceMoraleDelta` (favourite loss −5, even loss −1, underdog loss 0, underdog win +4, bench half, cap).
- **Integration** — strong XI losing drops squad-avg morale past the flat loss penalty; underdog upset lifts it past the flat win bonus.
- **Guards** — incomplete lineups and unscored matches apply no term (keeps existing condition/suspension tests green).
- **Narrative** — `moodCandidates` surfaces `morale_low` at avg 55 and `morale_high` only above 85.

## Calibration (follow-up)

The `<62` / `>85` thresholds and the term constants are starting values. To calibrate, simulate a season and read the actual morale distribution — confirm morale spreads across the low/neutral/high zones, and tune `UNDERPERFORMANCE_MAX_PENALTY` / thresholds if a zone stays empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)