### PR TITLE
Validate continental competition data and backfill missing countries

### DIFF
--- a/app/Console/Commands/NormalizeSeason.php
+++ b/app/Console/Commands/NormalizeSeason.php
@@ -16,6 +16,8 @@ use Illuminate\Console\Command;
  *  - sorts clubs by transfermarkt id and each club's players by player id, so a
  *    transfer shows up as a one-player add/remove instead of reshuffling the
  *    whole roster, and
+ *  - backfills a club's `country` from elsewhere in the same season folder (see
+ *    buildCountryIndex), and
  *  - re-encodes with the canonical formatter (2-space, unescaped, trailing nl).
  *
  * Idempotent: running it twice is a no-op. With `--check` it writes nothing and
@@ -47,20 +49,22 @@ class NormalizeSeason extends Command
         $this->info(($check ? 'Checking' : 'Normalizing') . " data/{$season}...");
 
         $changed = [];
+        $competitions = SeasonData::competitions($countryConfig);
+        $countries = $this->buildCountryIndex($season, $competitions, $countryConfig);
 
-        foreach (SeasonData::competitions($countryConfig) as ['code' => $code, 'type' => $type]) {
+        foreach ($competitions as ['code' => $code, 'type' => $type]) {
             $dir = "{$base}/{$code}";
 
             if ($type === 'pool') {
                 $files = array_filter(glob("{$dir}/*.json") ?: [], fn ($p) => basename($p) !== 'schedule.json');
                 foreach ($files as $file) {
-                    $this->process($file, $season, false, $check, $changed);
+                    $this->process($file, $season, $type, $countries, $check, $changed);
                 }
                 continue;
             }
 
             if ($type !== 'none') {
-                $this->process("{$dir}/teams.json", $season, true, $check, $changed);
+                $this->process("{$dir}/teams.json", $season, $type, $countries, $check, $changed);
             }
         }
 
@@ -92,10 +96,17 @@ class NormalizeSeason extends Command
      * Normalize one squad file. Records its repo-relative path in $changed when
      * its canonical form differs from disk; writes it unless in --check mode.
      *
+     * @param  array<string, string>  $countries
      * @param  array<int, string>  $changed
      */
-    private function process(string $path, string $season, bool $isTeamsFile, bool $check, array &$changed): void
-    {
+    private function process(
+        string $path,
+        string $season,
+        string $type,
+        array $countries,
+        bool $check,
+        array &$changed,
+    ): void {
         if (!file_exists($path)) {
             return;
         }
@@ -107,7 +118,7 @@ class NormalizeSeason extends Command
             return;
         }
 
-        $canonical = SeasonData::encode($this->canonicalize($data, $season, $isTeamsFile));
+        $canonical = SeasonData::encode($this->canonicalize($data, $season, $type, $countries));
 
         if ($canonical === $original) {
             return;
@@ -121,15 +132,16 @@ class NormalizeSeason extends Command
 
     /**
      * Produce the canonical structure: forced seasonID (teams files only, hoisted
-     * just after id/name), clubs sorted by transfermarkt id, players sorted by
-     * player id. All other keys and their order are preserved.
+     * just after id/name), backfilled country, clubs sorted by transfermarkt id,
+     * players sorted by player id. All other keys and their order are preserved.
      *
      * @param  array<string, mixed>  $data
+     * @param  array<string, string>  $countries
      * @return array<string, mixed>
      */
-    private function canonicalize(array $data, string $season, bool $isTeamsFile): array
+    private function canonicalize(array $data, string $season, string $type, array $countries): array
     {
-        if ($isTeamsFile) {
+        if ($type !== 'pool') {
             $data['seasonID'] = $season;
             $data = $this->hoistKeys($data, ['id', 'name', 'seasonID']);
         }
@@ -137,12 +149,130 @@ class NormalizeSeason extends Command
         if (isset($data['clubs']) && is_array($data['clubs'])) {
             $data['clubs'] = $this->sortById($data['clubs'], fn ($c) => SeasonData::resolveTransfermarktId($c));
             $data['clubs'] = array_map(fn ($club) => $this->sortPlayers($club), $data['clubs']);
-        } else {
+
+            if ($type === 'continental') {
+                $data['clubs'] = array_map(fn ($club) => $this->withCountry($club, $countries), $data['clubs']);
+            }
+        } elseif ($type === 'pool') {
             // Pool files store a single club at the top level.
+            $data = $this->withCountry($this->sortPlayers($data), $countries);
+        } else {
             $data = $this->sortPlayers($data);
         }
 
         return $data;
+    }
+
+    /**
+     * Fill in a club's `country` from the season index when the club itself
+     * doesn't declare one. Never overwrites an existing value, so a hand-curated
+     * country always wins.
+     *
+     * @param  array<string, mixed>  $club
+     * @param  array<string, string>  $countries
+     * @return array<string, mixed>
+     */
+    private function withCountry(array $club, array $countries): array
+    {
+        if (!empty($club['country'])) {
+            return $club;
+        }
+
+        $id = SeasonData::resolveTransfermarktId($club);
+        if ($id === null || !isset($countries[$id])) {
+            return $club;
+        }
+
+        $club['country'] = $countries[$id];
+
+        // Land the key where the curated files already put it — `id, name,
+        // country, pot` for a continental club, `image, name, country, ...` for
+        // a pool file — so a re-scrape of a backfilled file has no key-order
+        // churn to diff. hoistKeys skips whichever id key this shape lacks.
+        return $this->hoistKeys($club, ['id', 'image', 'name', 'country']);
+    }
+
+    /**
+     * Map every transfermarkt id in this season folder to a country, gathering
+     * from all three places one can be stated:
+     *  - a league's teams.json — the country is the competition's, from config,
+     *  - an EUR/INT pool file — its own `country` key,
+     *  - a continental participant list — its per-club `country`.
+     *
+     * The last two repair each other. The scraper emits neither for continental
+     * lists, and (before it learned to read the club page's flag) omitted it on
+     * many pool files too — leaving those clubs to seed with the pool's default
+     * `EU`. That matters: Team::country drives the Swiss draw's country
+     * protection from the second season onward, and a large bloc of clubs
+     * sharing one country makes the constraint unsatisfiable, forcing the draw
+     * to relax it for everyone.
+     *
+     * @param  array<int, array{code: string, type: string}>  $competitions
+     * @return array<string, string>
+     */
+    private function buildCountryIndex(string $season, array $competitions, CountryConfig $countryConfig): array
+    {
+        $countries = [];
+
+        foreach ($competitions as ['code' => $code, 'type' => $type]) {
+            if ($type === 'league') {
+                $country = $countryConfig->countryForCompetition($code);
+                if ($country === null) {
+                    continue;
+                }
+                foreach ($this->readClubs(base_path("data/{$season}/{$code}/teams.json")) as $club) {
+                    $id = SeasonData::resolveTransfermarktId($club);
+                    if ($id !== null) {
+                        $countries[$id] ??= $country;
+                    }
+                }
+                continue;
+            }
+
+            if ($type === 'continental') {
+                foreach ($this->readClubs(base_path("data/{$season}/{$code}/teams.json")) as $club) {
+                    $id = SeasonData::resolveTransfermarktId($club);
+                    if ($id !== null && !empty($club['country'])) {
+                        $countries[$id] ??= (string) $club['country'];
+                    }
+                }
+                continue;
+            }
+
+            if ($type === 'pool') {
+                $dir = base_path("data/{$season}/{$code}");
+                $files = array_filter(glob("{$dir}/*.json") ?: [], fn ($p) => basename($p) !== 'schedule.json');
+                foreach ($files as $file) {
+                    $data = json_decode((string) file_get_contents($file), true);
+                    if (!is_array($data) || empty($data['country'])) {
+                        continue;
+                    }
+                    $id = SeasonData::resolveTransfermarktId($data);
+                    if ($id !== null) {
+                        $countries[$id] ??= (string) $data['country'];
+                    }
+                }
+            }
+        }
+
+        return $countries;
+    }
+
+    /**
+     * Read a teams.json clubs array, or an empty list when the file is absent
+     * or unparsable — those are reported by app:validate-season, not here.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    private function readClubs(string $path): array
+    {
+        if (!file_exists($path)) {
+            return [];
+        }
+
+        $data = json_decode((string) file_get_contents($path), true);
+
+        return is_array($data) && is_array($data['clubs'] ?? null) ? $data['clubs'] : [];
     }
 
     /**

--- a/app/Console/Commands/SeedReferenceData.php
+++ b/app/Console/Commands/SeedReferenceData.php
@@ -30,6 +30,16 @@ class SeedReferenceData extends Command
     /** Base season being seeded (e.g. '2026'); governs the data/{season}/ folder. */
     private string $season;
 
+    /**
+     * Continental participants that could not be linked to a team row. Seeding
+     * continues so the operator gets a complete picture, but the command exits
+     * non-zero: a European competition short of a full league phase is silently
+     * skipped at game setup and would otherwise ship broken.
+     *
+     * @var string[]
+     */
+    private array $unlinkedContinentalClubs = [];
+
     public function handle(): int
     {
         $this->season = config('season.current');
@@ -97,6 +107,18 @@ class SeedReferenceData extends Command
         }
 
         $this->displaySummary();
+
+        if (!empty($this->unlinkedContinentalClubs)) {
+            $this->newLine();
+            $this->error('Continental participants with no squad data (they were dropped from their competition):');
+            foreach ($this->unlinkedContinentalClubs as $club) {
+                $this->line("  ✗ {$club}");
+            }
+            $this->line("Add a data/{$this->season}/EUR/{id}.json for each, then re-seed. "
+                . 'php artisan app:validate-season catches this before it reaches the database.');
+
+            return CommandAlias::FAILURE;
+        }
 
         return CommandAlias::SUCCESS;
     }
@@ -578,6 +600,7 @@ class SeedReferenceData extends Command
 
             if (!$teamId) {
                 $this->warn("  Team not found for transfermarkt_id {$transfermarktId}: {$club['name']}");
+                $this->unlinkedContinentalClubs[] = "{$competitionId}: {$club['name']} ({$transfermarktId})";
                 continue;
             }
 

--- a/app/Console/Commands/ValidateSeason.php
+++ b/app/Console/Commands/ValidateSeason.php
@@ -3,7 +3,9 @@
 namespace App\Console\Commands;
 
 use App\Modules\Competition\Services\CountryConfig;
+use App\Modules\Competition\Services\SwissDrawService;
 use App\Support\SeasonData;
+use Database\Seeders\ClubProfilesSeeder;
 use Illuminate\Console\Command;
 
 /**
@@ -18,6 +20,13 @@ use Illuminate\Console\Command;
  *
  * Mirrors the seeder's skip rules: team pools (EUR/INT) are validated as
  * per-team files, bare promotion playoffs (ESP3PO) are schedule-only.
+ *
+ * Continental competitions (UCL/UEL/UECL/UEFASUP) get extra rules, because
+ * their participant lists only *link* clubs seeded elsewhere. A participant
+ * with no squad data anywhere in the season folder is dropped with a warning by
+ * SeedReferenceData, and SeasonInitializationService then finds an incomplete
+ * league phase and skips it — leaving a competition with no fixtures at all and
+ * nothing user-visible to explain why. Catching that here is the whole point.
  *
  * Exits non-zero if any error is found so it can gate a release pipeline.
  */
@@ -34,6 +43,16 @@ class ValidateSeason extends Command
     /** @var string[] */
     private array $warnings = [];
 
+    /**
+     * Every transfermarkt id in this season folder that can supply a squad —
+     * league teams.json clubs and EUR/INT pool files — mapped to its name and
+     * country. Continental competitions only *link* clubs, so this is what
+     * their participants have to resolve against.
+     *
+     * @var array<string, array{name: string, country: string|null}>
+     */
+    private array $squadSources = [];
+
     public function handle(CountryConfig $countryConfig): int
     {
         $season = $this->argument('season');
@@ -47,16 +66,23 @@ class ValidateSeason extends Command
         $this->info("Validating data/{$season}...");
         $this->newLine();
 
-        foreach (SeasonData::competitions($countryConfig) as ['code' => $code, 'type' => $type]) {
+        $competitions = SeasonData::competitions($countryConfig);
+        $handlers = SeasonData::continentalHandlers($countryConfig);
+        $this->indexSquadSources($season, $competitions, $countryConfig);
+
+        foreach ($competitions as ['code' => $code, 'type' => $type]) {
             $dir = "{$base}/{$code}";
 
             match ($type) {
                 'league' => $this->validateLeague($code, $dir, $season),
-                'cup', 'continental' => $this->validateParticipantList($code, $dir, $season),
+                'cup' => $this->validateParticipantList($code, $dir, $season),
+                'continental' => $this->validateContinental($code, $dir, $season, $handlers[$code] ?? ''),
                 'pool' => $this->validatePool($code, $dir),
                 'none' => $this->validateScheduleOnly($code, $dir),
             };
         }
+
+        $this->warnUnprofiledClubs();
 
         foreach ($this->warnings as $warning) {
             $this->warn("  ⚠ {$warning}");
@@ -114,6 +140,130 @@ class ValidateSeason extends Command
         $this->line("  {$code}: " . count($clubs) . " clubs ✓");
     }
 
+    /**
+     * Continental participant lists get every check a cup gets, plus the ones
+     * that keep a European competition from quietly ending up empty.
+     */
+    private function validateContinental(string $code, string $dir, string $season, string $handler): void
+    {
+        $clubs = $this->loadClubs($code, "{$dir}/teams.json", $season);
+        if ($clubs === null) {
+            return;
+        }
+
+        if (!file_exists("{$dir}/schedule.json")) {
+            $this->warnings[] = "{$code}: no schedule.json (knockout/round dates) found.";
+        }
+
+        $this->validateParticipantsAreSeedable($code, $season, $clubs);
+
+        if ($handler === 'swiss_format') {
+            $this->validateSwissShape($code, $clubs);
+        }
+
+        $this->line("  {$code}: " . count($clubs) . " clubs ✓");
+    }
+
+    /**
+     * Every participant must carry a literal `id` and have squad data somewhere
+     * in this season folder.
+     *
+     * The literal-`id` rule is deliberately stricter than loadClubs(): the
+     * seeder and SetupNewGame both read `$club['id']` directly, so a club
+     * identified only by `transfermarktId` or a crest URL resolves here but is
+     * skipped there. Without squad data the seeder drops the club with a
+     * warning and the competition is left short of a full league phase, which
+     * SeasonInitializationService then skips outright — no fixtures, no error.
+     *
+     * @param  array<int, array<string, mixed>>  $clubs
+     */
+    private function validateParticipantsAreSeedable(string $code, string $season, array $clubs): void
+    {
+        $unseedable = [];
+
+        foreach ($clubs as $club) {
+            $name = $club['name'] ?? '(unnamed)';
+
+            if (empty($club['id'])) {
+                $this->errors[] = "{$code}: club '{$name}' has no literal 'id' key — "
+                    . 'the seeder links continental clubs by that field only.';
+                continue;
+            }
+
+            $id = (string) $club['id'];
+            if (!isset($this->squadSources[$id])) {
+                $unseedable[] = "{$name} ({$id})";
+            }
+        }
+
+        if (!empty($unseedable)) {
+            $this->errors[] = "{$code}: " . count($unseedable) . ' club(s) have no squad data — not in any '
+                . "league teams.json and no data/{$season}/{EUR,INT}/{id}.json: " . implode(', ', $unseedable) . '.';
+        }
+    }
+
+    /**
+     * A Swiss league phase is drawn from four equal pots, so the participant
+     * list has to be exactly that shape or SwissDrawService throws.
+     *
+     * Real seeding pots are optional — the scraper cannot read them off
+     * Transfermarkt, and SetupNewGame falls back to pots by squad market value
+     * when they are absent. A *partial* set is the dangerous case: it usually
+     * means a re-scrape overwrote hand-entered pots.
+     *
+     * @param  array<int, array<string, mixed>>  $clubs
+     */
+    private function validateSwissShape(string $code, array $clubs): void
+    {
+        $total = count($clubs);
+        $expected = SwissDrawService::LEAGUE_PHASE_TEAMS;
+
+        if ($total !== $expected) {
+            $this->errors[] = "{$code}: swiss league phase needs exactly {$expected} clubs, got {$total}.";
+        }
+
+        $potted = array_values(array_filter($clubs, fn ($club) => isset($club['pot'])));
+
+        if (count($potted) === 0) {
+            $this->warnings[] = "{$code}: no seeding pots — the draw will fall back to squad market value.";
+        } elseif (count($potted) !== $total) {
+            $this->errors[] = "{$code}: only " . count($potted) . " of {$total} clubs have a 'pot' "
+                . '(a re-scrape probably overwrote them). Give every club a pot, or none at all.';
+        } else {
+            $sizes = array_count_values(array_map(fn ($club) => (int) $club['pot'], $potted));
+            $perPot = SwissDrawService::TEAMS_PER_POT;
+            $wrong = [];
+
+            foreach (range(1, SwissDrawService::POTS) as $pot) {
+                if (($sizes[$pot] ?? 0) !== $perPot) {
+                    $wrong[] = "pot {$pot} has " . ($sizes[$pot] ?? 0);
+                }
+            }
+            foreach (array_keys($sizes) as $pot) {
+                if ($pot < 1 || $pot > SwissDrawService::POTS) {
+                    $wrong[] = "pot {$pot} is out of range";
+                }
+            }
+
+            if (!empty($wrong)) {
+                $this->errors[] = "{$code}: every pot must hold exactly {$perPot} clubs — "
+                    . implode(', ', $wrong) . '.';
+            }
+        }
+
+        $noCountry = array_values(array_filter(
+            $clubs,
+            fn ($club) => empty($club['country'])
+                && empty($this->squadSources[(string) ($club['id'] ?? '')]['country']),
+        ));
+
+        if (!empty($noCountry)) {
+            $names = array_map(fn ($club) => (string) ($club['name'] ?? '(unnamed)'), $noCountry);
+            $this->warnings[] = "{$code}: " . count($noCountry) . ' club(s) have no country, so the draw '
+                . 'cannot keep them apart from their compatriots: ' . $this->summarize($names) . '.';
+        }
+    }
+
     private function validatePool(string $code, string $dir): void
     {
         $files = array_filter(glob("{$dir}/*.json") ?: [], fn ($p) => basename($p) !== 'schedule.json');
@@ -138,6 +288,103 @@ class ValidateSeason extends Command
         }
         $this->loadSchedule($code, "{$dir}/schedule.json");
         $this->line("  {$code}: schedule only ✓");
+    }
+
+    /**
+     * Index every club in this season folder that can supply a squad: clubs in
+     * a league teams.json (country from config/countries.php) and EUR/INT pool
+     * files (country from the file itself).
+     *
+     * Built once per run and read by the continental checks. Missing files are
+     * skipped silently — they are reported by their own competition's checks,
+     * and a partial folder must not fatal here.
+     *
+     * @param  array<int, array{code: string, type: string}>  $competitions
+     */
+    private function indexSquadSources(string $season, array $competitions, CountryConfig $countryConfig): void
+    {
+        foreach ($competitions as ['code' => $code, 'type' => $type]) {
+            if ($type === 'league') {
+                $country = $countryConfig->countryForCompetition($code);
+                foreach (SeasonData::readCompetitionClubs($season, $code, $type) ?? [] as $club) {
+                    $this->squadSources[$club['id']] ??= ['name' => $club['name'], 'country' => $country];
+                }
+                continue;
+            }
+
+            if ($type === 'pool') {
+                // Read the pool files directly rather than via
+                // readCompetitionClubs: only the file itself carries the club's
+                // country, and it is the country that makes the Swiss draw able
+                // to keep compatriots apart.
+                $dir = base_path("data/{$season}/{$code}");
+                $files = array_filter(glob("{$dir}/*.json") ?: [], fn ($p) => basename($p) !== 'schedule.json');
+
+                foreach ($files as $file) {
+                    $data = json_decode((string) file_get_contents($file), true);
+                    if (!is_array($data)) {
+                        continue;
+                    }
+                    $id = SeasonData::resolveTransfermarktId($data);
+                    if ($id === null) {
+                        continue;
+                    }
+                    $this->squadSources[$id] ??= [
+                        'name' => (string) ($data['name'] ?? "({$id})"),
+                        'country' => !empty($data['country']) ? (string) $data['country'] : null,
+                    ];
+                }
+            }
+        }
+    }
+
+    /**
+     * Flag clubs with no curated entry in ClubProfilesSeeder, which silently
+     * fall back to a local-reputation, neutral-loyalty profile — wrong for a
+     * side that just qualified for Europe.
+     *
+     * Kept to a single summary line (the full list needs -v): the current data
+     * has dozens of these and a wall of warnings just trains people to ignore
+     * the validator. Names are taken from the squad-source index rather than
+     * the continental lists, because those use short forms ("Barcelona") that
+     * never match the seeded team name ("FC Barcelona").
+     */
+    private function warnUnprofiledClubs(): void
+    {
+        $profiled = array_flip(ClubProfilesSeeder::profiledClubNames());
+        $missing = [];
+
+        foreach ($this->squadSources as $source) {
+            if (!isset($profiled[$source['name']])) {
+                $missing[] = $source['name'];
+            }
+        }
+
+        if (empty($missing)) {
+            return;
+        }
+
+        sort($missing);
+        $detail = $this->output->isVerbose()
+            ? implode(', ', $missing)
+            : 'run with -v to list them';
+
+        $this->warnings[] = count($missing) . ' club(s) have no ClubProfilesSeeder entry and will be seeded '
+            . "as local-reputation clubs: {$detail}.";
+    }
+
+    /**
+     * Render a name list without letting a wholesale gap print dozens of lines.
+     *
+     * @param  array<int, string>  $names
+     */
+    private function summarize(array $names, int $limit = 5): string
+    {
+        if (count($names) <= $limit) {
+            return implode(', ', $names);
+        }
+
+        return implode(', ', array_slice($names, 0, $limit)) . ' and ' . (count($names) - $limit) . ' more';
     }
 
     /**

--- a/app/Modules/Competition/Services/SwissDrawService.php
+++ b/app/Modules/Competition/Services/SwissDrawService.php
@@ -24,7 +24,12 @@ use Illuminate\Support\Facades\Log;
  */
 class SwissDrawService
 {
-    private const TEAMS_PER_POT = 9;
+    public const POTS = 4;
+    public const TEAMS_PER_POT = 9;
+
+    /** Total clubs in a Swiss league phase — the draw needs every pot filled. */
+    public const LEAGUE_PHASE_TEAMS = self::POTS * self::TEAMS_PER_POT;
+
     private const MATCHES_PER_TEAM = 8;
     private const MATCHDAYS = 8;
 
@@ -45,7 +50,7 @@ class SwissDrawService
             $pots[$team['pot']][] = $team;
         }
 
-        foreach ([1, 2, 3, 4] as $pot) {
+        foreach (range(1, self::POTS) as $pot) {
             if (!isset($pots[$pot]) || count($pots[$pot]) !== self::TEAMS_PER_POT) {
                 throw new \InvalidArgumentException(
                     "Pot {$pot} must have exactly " . self::TEAMS_PER_POT . " teams, got " . count($pots[$pot] ?? [])
@@ -253,7 +258,7 @@ class SwissDrawService
         shuffle($shuffled);
 
         foreach ($shuffled as $team) {
-            foreach ([1, 2, 3, 4] as $pot) {
+            foreach (range(1, self::POTS) as $pot) {
                 $remaining = self::MATCHES_PER_TEAM - count($opponents[$team['id']]);
                 if ($remaining <= 0) {
                     break;

--- a/app/Modules/Season/Jobs/SetupNewGame.php
+++ b/app/Modules/Season/Jobs/SetupNewGame.php
@@ -4,6 +4,7 @@ namespace App\Modules\Season\Jobs;
 
 use App\Events\SeasonStarted;
 use App\Modules\Competition\Services\CountryConfig;
+use App\Modules\Competition\Services\SwissDrawService;
 use App\Modules\Lineup\Enums\Formation;
 use App\Modules\Lineup\Services\FormationBiasResolver;
 use App\Modules\Lineup\Services\FormationRecommender;
@@ -262,12 +263,18 @@ class SetupNewGame implements ShouldQueue, ShouldBeUnique
     private function loadTeamLookup(): Collection
     {
         return Team::whereNotNull('transfermarkt_id')
-            ->get(['id', 'transfermarkt_id'])
+            ->get(['id', 'transfermarkt_id', 'country'])
             ->keyBy('transfermarkt_id');
     }
 
     /**
      * Build Swiss pot data from JSON for all Swiss competitions (initial season only).
+     *
+     * Only publishes a competition whose participant list carries a complete,
+     * well-formed set of seeding pots. Real pots are optional data the scraper
+     * does not produce; omitting a competition here makes
+     * SeasonInitializationService fall back to assigning pots by squad market
+     * value — the same path every season after the first already uses.
      *
      * @return array<string, array<array{id: string, pot: int, country: string}>>
      */
@@ -290,6 +297,8 @@ class SetupNewGame implements ShouldQueue, ShouldBeUnique
             $clubs = $teamsData['clubs'] ?? [];
 
             $drawTeams = [];
+            $everyClubHasAPot = true;
+
             foreach ($clubs as $club) {
                 $transfermarktId = $club['id'] ?? null;
                 if (!$transfermarktId) {
@@ -301,19 +310,52 @@ class SetupNewGame implements ShouldQueue, ShouldBeUnique
                     continue;
                 }
 
+                if (!isset($club['pot'])) {
+                    $everyClubHasAPot = false;
+                }
+
                 $drawTeams[] = [
                     'id' => $team->id,
-                    'pot' => $club['pot'] ?? 4,
-                    'country' => $club['country'] ?? 'XX',
+                    'pot' => (int) ($club['pot'] ?? 0),
+                    // The seeded team row is the better country source: pool
+                    // files feed it directly, so it stays right even when a
+                    // re-scraped participant list drops the key.
+                    'country' => $club['country'] ?? $team->country ?? 'XX',
                 ];
             }
 
-            if (!empty($drawTeams)) {
+            if ($everyClubHasAPot && $this->potsAreWellFormed($drawTeams)) {
                 $potData[$competitionId] = $drawTeams;
             }
         }
 
         return $potData;
+    }
+
+    /**
+     * Whether a draw set carries the exact pot shape SwissDrawService requires:
+     * every pot from 1..POTS holding exactly TEAMS_PER_POT clubs. Anything else
+     * — a participant list scraped without pots, a partial hand-edit, or a club
+     * dropped for want of squad data — would make the draw throw, so we discard
+     * it and let the market-value fallback take over.
+     *
+     * @param  array<array{id: string, pot: int, country: string}>  $drawTeams
+     */
+    private function potsAreWellFormed(array $drawTeams): bool
+    {
+        if (count($drawTeams) !== SwissDrawService::LEAGUE_PHASE_TEAMS) {
+            return false;
+        }
+
+        $sizes = array_count_values(array_column($drawTeams, 'pot'));
+
+        foreach (range(1, SwissDrawService::POTS) as $pot) {
+            if (($sizes[$pot] ?? 0) !== SwissDrawService::TEAMS_PER_POT) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /**

--- a/app/Modules/Season/Processors/UefaQualificationProcessor.php
+++ b/app/Modules/Season/Processors/UefaQualificationProcessor.php
@@ -5,6 +5,7 @@ namespace App\Modules\Season\Processors;
 use App\Modules\Season\Contracts\SeasonProcessor;
 use App\Modules\Season\DTOs\SeasonTransitionData;
 use App\Modules\Competition\Services\CountryConfig;
+use App\Modules\Competition\Services\SwissDrawService;
 use App\Models\Competition;
 use App\Models\CompetitionEntry;
 use App\Models\CompetitionTeam;
@@ -483,7 +484,8 @@ class UefaQualificationProcessor implements SeasonProcessor
     }
 
     /**
-     * Fill remaining slots to reach 36 teams in the user's swiss_format competition.
+     * Fill remaining slots to reach a full league phase in the user's
+     * swiss_format competition.
      *
      * Only the competition the user's team participates in needs a full draw.
      * Other swiss_format competitions are never initialized (no fixtures, no standings),
@@ -519,9 +521,10 @@ class UefaQualificationProcessor implements SeasonProcessor
             ->toArray();
 
         $currentCount = count($usedTeamIds);
-        $needed = 36 - $currentCount;
+        $needed = SwissDrawService::LEAGUE_PHASE_TEAMS - $currentCount;
 
-        Log::info("[UEFA] {$userCompetitionId}: {$currentCount}/36 teams, need {$needed} fillers");
+        Log::info("[UEFA] {$userCompetitionId}: {$currentCount}/"
+            . SwissDrawService::LEAGUE_PHASE_TEAMS . " teams, need {$needed} fillers");
 
         if ($needed <= 0) {
             return;

--- a/app/Modules/Season/Services/SeasonInitializationService.php
+++ b/app/Modules/Season/Services/SeasonInitializationService.php
@@ -117,6 +117,14 @@ class SeasonInitializationService
             return;
         }
 
+        // CountryConfig::swissFormatCompetitionIds() folds in every continental
+        // competition, so UEFASUP — a two-club knockout — reaches this method
+        // whenever the user manages one of its two participants. It has no
+        // league phase to draw; its tie is created by conductCupDraws().
+        if ($competition->handler_type !== 'swiss_format') {
+            return;
+        }
+
         // Build draw teams — from explicit data or auto-assign pots by market value
         if ($teamsWithPots !== null) {
             $drawTeams = $teamsWithPots;
@@ -124,8 +132,14 @@ class SeasonInitializationService
             $drawTeams = $this->buildDrawTeamsFromGameState($gameId, $competitionId);
         }
 
-        if (count($drawTeams) < 36) {
-            Log::info("[SeasonInit] {$competitionId}: only " . count($drawTeams) . ' draw teams (need 36), skipping');
+        // Deliberately a skip rather than a throw: GameSetupStatus re-dispatches
+        // SetupNewGame while setup is incomplete, so throwing here would spin.
+        // Logged at error level because the result — a European competition with
+        // entries but no fixtures — is invisible in-game and always a data fault.
+        if (count($drawTeams) < SwissDrawService::LEAGUE_PHASE_TEAMS) {
+            Log::error("[SeasonInit] {$competitionId}: only " . count($drawTeams)
+                . ' of ' . SwissDrawService::LEAGUE_PHASE_TEAMS
+                . ' draw teams, skipping — the competition will have no fixtures');
 
             return;
         }

--- a/app/Support/SeasonData.php
+++ b/app/Support/SeasonData.php
@@ -123,6 +123,30 @@ class SeasonData
     }
 
     /**
+     * Map every continental competition that owns a season folder to its handler
+     * (e.g. `UCL => swiss_format`, `UEFASUP => knockout_cup`).
+     *
+     * Read straight from config so it works without a database — unlike
+     * CountryConfig::swissFormatCompetitionIds(), which queries `competitions`
+     * and is therefore unusable from the data-folder commands (CI runs them
+     * against an unmigrated database).
+     *
+     * @return array<string, string>
+     */
+    public static function continentalHandlers(CountryConfig $countryConfig): array
+    {
+        $handlers = [];
+
+        foreach ($countryConfig->playableCountryCodes() as $country) {
+            foreach ($countryConfig->support($country)['continental'] ?? [] as $code => $config) {
+                $handlers[$code] ??= (string) ($config['handler'] ?? '');
+            }
+        }
+
+        return $handlers;
+    }
+
+    /**
      * Read a competition's clubs as a normalized list, regardless of whether it
      * is stored as a single `teams.json` (league/cup/continental) or a folder of
      * per-team `{id}.json` files (EUR/INT pools). Returns null when the data is

--- a/database/seeders/ClubProfilesSeeder.php
+++ b/database/seeders/ClubProfilesSeeder.php
@@ -852,6 +852,20 @@ class ClubProfilesSeeder extends Seeder
         'Inter Miami CF' => 1,
     ];
 
+    /**
+     * Club names that have curated editorial data (reputation, fan loyalty,
+     * preferred formation, tactical aggression). Lookups are by exact name, so
+     * a club absent from here silently falls back to a local-reputation profile
+     * — wrong for, say, a first-time Champions League qualifier. Exposed so
+     * app:validate-season can flag the gap when a season's data is refreshed.
+     *
+     * @return array<int, string>
+     */
+    public static function profiledClubNames(): array
+    {
+        return array_keys(self::CLUB_DATA);
+    }
+
     public function run(): void
     {
         $allTeams = Team::all();

--- a/docs/season-data-refresh.md
+++ b/docs/season-data-refresh.md
@@ -66,7 +66,7 @@ add/remove line, not a reshuffled roster.
 |---------|--------------|
 | `app:scaffold-season {season}` | Create folders, bootstrap schedules from last season. |
 | `app:normalize-season {season} [--check]` | Force `seasonID`, sort clubs/players, canonical 2-space formatting. `--check` verifies without writing (the CI gate). Idempotent. |
-| `app:validate-season {season}` | Read-only completeness/correctness gate (non-zero exit on any problem). |
+| `app:validate-season {season}` | Read-only completeness/correctness gate (non-zero exit on any problem). Database-free, so CI can run it without Postgres. |
 | `app:diff-season {season} [--from=] [--format=md]` | Report signings, departures, and club movements vs a previous season. |
 | `app:seed-reference-data [--fresh] [--country=]` | Seed competitions, teams, fixtures, templates from `data/{season}/`. |
 
@@ -92,7 +92,12 @@ add/remove line, not a reshuffled roster.
      (ESP1, ESP2, ESP3A, ESP3B, ENG1, DEU1, FRA1, ITA1) — clubs + squads,
      reflecting real promotion/relegation. **Set `"seasonID": "2026"`.**
    - `data/2026/{CUP}/teams.json` participant lists (ESPCUP, ESPSUP).
-   - `data/2026/{UCL,UEL,UECL,UEFASUP}/teams.json` participant lists.
+   - `data/2026/{UCL,UEL,UECL,UEFASUP}/teams.json` participant lists. These are
+     independent of the transfer window — the draws are known before it shuts —
+     so they can go in first. Their squads cannot: every participant outside the
+     eight scraped leagues needs an `EUR` pool file (70 of 108 slots in 2025).
+     Add `pot` by hand for a true-to-life first-season draw; a re-scrape now
+     preserves it.
    - `data/2026/EUR/{id}.json` and `data/2026/INT/{id}.json` pool teams.
    - Append any new players to `data/players/player_positions_ES.json`
      (secondary positions; keyed by player id, not season-scoped).
@@ -100,8 +105,9 @@ add/remove line, not a reshuffled roster.
    `ESP3PO` (Primera RFEF playoff) is intentionally schedule-only — no
    `teams.json`; its bracket is generated per-game.
 
-4. **Normalize** (forces every `seasonID` to `2026` and sorts clubs/players so
-   re-scrapes diff cleanly — so you can skip the manual `seasonID` edits above):
+4. **Normalize** (forces every `seasonID` to `2026`, sorts clubs/players so
+   re-scrapes diff cleanly, and backfills each club's `country` — so you can skip
+   the manual `seasonID` edits above):
 
    ```bash
    php artisan app:normalize-season 2026
@@ -119,6 +125,20 @@ add/remove line, not a reshuffled roster.
    Checks every competition has the expected data, `seasonID` matches,
    transfermarkt ids resolve, and each round-robin league's schedule has exactly
    `2 × (teams − 1)` rounds (the invariant the fixture generator enforces).
+
+   European competitions get extra rules, because their participant lists only
+   *link* clubs seeded elsewhere:
+
+   - every participant needs a literal `id` and squad data somewhere in the
+     season folder — a league `teams.json` or an `EUR`/`INT` pool file. Without
+     it the seeder drops the club and the competition ends up with no fixtures
+     at all, silently;
+   - UCL/UEL/UECL need exactly 36 clubs (UEFASUP, a two-club knockout, is
+     exempt);
+   - seeding pots are optional, but all-or-nothing: give every club a `pot`
+     forming four pots of nine, or none at all. A partial set usually means a
+     re-scrape overwrote hand-entered pots. With no pots the draw seeds itself
+     by squad market value, exactly as it does from the second season onward.
 
 6. **Seed a fresh database** (wipes prior reference data and games, then seeds
    2026 and auto-generates player templates for season 2026):

--- a/scripts/transfermarkt-scraper/README.md
+++ b/scripts/transfermarkt-scraper/README.md
@@ -88,6 +88,18 @@ After scraping a supported page, click **Push to GitHub**:
 The first push creates the `season-data/{season}` branch and opens a PR; later
 pushes update the same PR. The popup links straight to it.
 
+Continental participant lists (UCL/UEL/UECL/UEFASUP) keep their `pot` values
+across a re-scrape: the extension reads the file already on the season branch
+and carries each club's pot forward by transfermarkt id. Pots are not on any
+Transfermarkt page — they are entered by hand — so a push that cannot read the
+existing file aborts rather than overwriting them. A newly drawn club arrives
+without a pot, which `app:validate-season` reports.
+
+Club squad pages also record the club's country (the flag beside its league in
+the page header, so Monaco reads as France — the federation UEFA protects on).
+Unknown labels are left out rather than guessed; add them to `COUNTRY_CODES` in
+`season-config.js`.
+
 ### Refresh every league at once
 
 **SEASON REFRESH → Refresh all leagues** drives every league in `season-config.js`

--- a/scripts/transfermarkt-scraper/background.js
+++ b/scripts/transfermarkt-scraper/background.js
@@ -391,6 +391,33 @@ async function getSettings() {
  * Commit a set of {path, content} files to the season-data branch as one commit
  * and ensure a PR is open. Returns the PR url.
  */
+/**
+ * Read the clubs already stored for a continental competition on the season
+ * branch, so their hand-entered pots survive a re-scrape. Returns null when the
+ * competition isn't continental or nothing is stored yet.
+ *
+ * Any other read failure propagates: pushing without the merge would silently
+ * wipe every pot in the file, which is worse than a failed push.
+ */
+async function previousContinentalClubs(result, pageType, season) {
+  if (pageType !== 'cup-teams') return null;
+
+  const comp = SeasonConfig.findByTmId(result.id);
+  if (!comp || comp.kind !== 'continental') return null;
+
+  const { token, repo, base } = await getSettings();
+  if (!token) throw new Error('No GitHub token set — open Settings.');
+
+  const gh = new GitHubClient(token, repo);
+  const branch = SeasonConfig.branchFor(season);
+  const path = `data/${season}/${comp.code}/teams.json`;
+
+  // The season branch doesn't exist before the first push; fall back to base.
+  const existing = (await gh.getFileJson(branch, path)) || (await gh.getFileJson(base, path));
+
+  return existing && Array.isArray(existing.clubs) ? existing.clubs : null;
+}
+
 async function pushFilesToGitHub(files, season) {
   const { token, repo, base } = await getSettings();
   if (!token) throw new Error('No GitHub token set — open Settings.');
@@ -697,9 +724,12 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
         const { season } = await getSettings();
         if (!season) throw new Error('Set a target season in Settings first.');
 
+        const previousClubs = await previousContinentalClubs(message.result, message.pageType, season);
+
         const file = SeasonConfig.repoFileForResult(message.result, message.pageType, {
           season,
           pool: message.pool,
+          previousClubs,
         });
         if (!file) {
           throw new Error('This page is not a known competition — cannot map it to a repo file.');

--- a/scripts/transfermarkt-scraper/content-club.js
+++ b/scripts/transfermarkt-scraper/content-club.js
@@ -6,11 +6,17 @@
 // {
 //   "transfermarktId": "131",
 //   "name": "FC Barcelona",
+//   "countryName": "Spain",
 //   "image": "https://tmssl.akamaized.net/images/wappen/big/131.png",
 //   "stadiumName": "Estadi Olímpic Lluís Companys",
 //   "stadiumSeats": "55926",
 //   "players": [ { "id": "74857", "name": "Marc-André ter Stegen", ... }, ... ]
 // }
+//
+// `countryName` is the raw Transfermarkt country label; season-config.js turns
+// it into the repo's two-letter `country` code at serialization time. The
+// mapping lives there because this file runs in the page context, where the
+// SeasonConfig module is not injected.
 
 (function () {
   const url = window.location.href;
@@ -35,6 +41,7 @@
   const clubInfo = {
     transfermarktId: clubId,
     name: null,
+    countryName: null,
     image: `https://tmssl.akamaized.net/images/wappen/big/${clubId}.png`,
     stadiumName: null,
     stadiumSeats: null
@@ -54,6 +61,17 @@
     if (profileHeader) {
       clubInfo.name = cleanText(profileHeader.alt);
     }
+  }
+
+  // Country - the flag beside the club's league in the header. This is the
+  // federation the club plays under (Monaco -> France), which is exactly what
+  // UEFA country protection keys on. Scoped to .data-header__club-info because
+  // player nationality flags in the squad table reuse the flaggenrahmen class.
+  // The flag is lazy-loaded (src is a base64 placeholder, the real URL sits in
+  // data-src), so the title/alt attribute is the only reliable source.
+  const clubFlag = document.querySelector('.data-header__club-info img.flaggenrahmen');
+  if (clubFlag) {
+    clubInfo.countryName = cleanText(clubFlag.getAttribute('title') || clubFlag.getAttribute('alt')) || null;
   }
 
   // Stadium info - from the data-header info box

--- a/scripts/transfermarkt-scraper/github.js
+++ b/scripts/transfermarkt-scraper/github.js
@@ -41,6 +41,23 @@
       return data;
     }
 
+    /**
+     * Read and JSON-parse a file from `branch`, or null when it does not exist
+     * there. Throws on any other failure so a caller can refuse to push rather
+     * than silently overwriting data it failed to read.
+     */
+    async getFileJson(branch, path) {
+      const file = await this.request(
+        'GET',
+        `/contents/${path.split('/').map(encodeURIComponent).join('/')}?ref=${encodeURIComponent(branch)}`,
+      );
+      if (file.notFound || !file.content) return null;
+
+      // The contents API returns base64 with embedded newlines.
+      const bytes = Uint8Array.from(atob(file.content.replace(/\n/g, '')), c => c.charCodeAt(0));
+      return JSON.parse(new TextDecoder().decode(bytes));
+    }
+
     async getRefSha(branch) {
       // Branch names (e.g. "season-data/2026") contain a slash that is part of
       // the ref path — it must not be percent-encoded.

--- a/scripts/transfermarkt-scraper/season-config.js
+++ b/scripts/transfermarkt-scraper/season-config.js
@@ -40,6 +40,50 @@
   // {id}.json files rather than a league teams.json.
   const POOLS = ['EUR', 'INT'];
 
+  // Transfermarkt country label -> the code the repo stores in `country`.
+  // ISO 3166-1 alpha-2 throughout, except that the home nations are tracked
+  // separately the way UEFA does: England is 'EN' (not 'GB') and Scotland is
+  // 'GB-SCT'. Covers the UEFA membership plus the non-European countries that
+  // show up in the INT pool. An unknown label yields no code at all — see
+  // countryCodeFor.
+  const COUNTRY_CODES = {
+    // UEFA
+    'Albania': 'AL', 'Andorra': 'AD', 'Armenia': 'AM', 'Austria': 'AT', 'Azerbaijan': 'AZ',
+    'Belarus': 'BY', 'Belgium': 'BE', 'Bosnia-Herzegovina': 'BA', 'Bulgaria': 'BG',
+    'Croatia': 'HR', 'Cyprus': 'CY', 'Czech Republic': 'CZ', 'Czechia': 'CZ',
+    'Denmark': 'DK', 'England': 'EN', 'Estonia': 'EE', 'Faroe Islands': 'FO',
+    'Finland': 'FI', 'France': 'FR', 'Georgia': 'GE', 'Germany': 'DE', 'Gibraltar': 'GI',
+    'Greece': 'GR', 'Hungary': 'HU', 'Iceland': 'IS', 'Ireland': 'IE', 'Israel': 'IL',
+    'Italy': 'IT', 'Kazakhstan': 'KZ', 'Kosovo': 'XK', 'Latvia': 'LV', 'Liechtenstein': 'LI',
+    'Lithuania': 'LT', 'Luxembourg': 'LU', 'Malta': 'MT', 'Moldova': 'MD', 'Monaco': 'MC',
+    'Montenegro': 'ME', 'Netherlands': 'NL', 'North Macedonia': 'MK', 'Northern Ireland': 'GB-NIR',
+    'Norway': 'NO', 'Poland': 'PL', 'Portugal': 'PT', 'Romania': 'RO', 'Russia': 'RU',
+    'San Marino': 'SM', 'Scotland': 'GB-SCT', 'Serbia': 'RS', 'Slovakia': 'SK',
+    'Slovenia': 'SI', 'Spain': 'ES', 'Sweden': 'SE', 'Switzerland': 'CH',
+    'Turkey': 'TR', 'Türkiye': 'TR', 'Ukraine': 'UA', 'Wales': 'GB-WLS',
+    // Non-European clubs reachable through the INT pool
+    'Algeria': 'DZ', 'Argentina': 'AR', 'Australia': 'AU', 'Brazil': 'BR', 'Canada': 'CA',
+    'Chile': 'CL', 'China': 'CN', 'Colombia': 'CO', 'Ecuador': 'EC', 'Egypt': 'EG',
+    'Japan': 'JP', 'Korea, South': 'KR', 'South Korea': 'KR', 'Mexico': 'MX',
+    'Morocco': 'MA', 'Paraguay': 'PY', 'Peru': 'PE', 'Qatar': 'QA', 'Saudi Arabia': 'SA',
+    'South Africa': 'ZA', 'Tunisia': 'TN', 'United Arab Emirates': 'AE',
+    'United States': 'US', 'Uruguay': 'UY', 'Venezuela': 'VE',
+  };
+
+  // Resolve a Transfermarkt country label to a repo code, or undefined when the
+  // label is unknown. Deliberately no fallback: writing a guessed code would
+  // seed a wrong country silently, whereas omitting it lets
+  // `php artisan app:normalize-season` backfill from the continental list and
+  // `app:validate-season` flag whatever is left.
+  function countryCodeFor(name) {
+    if (!name) return undefined;
+    const code = COUNTRY_CODES[String(name).trim()];
+    if (!code) {
+      console.warn(`[season-config] No country code for "${name}" — add it to COUNTRY_CODES.`);
+    }
+    return code;
+  }
+
   function findByTmId(tmId) {
     if (!tmId) return null;
     const upper = String(tmId).toUpperCase();
@@ -76,10 +120,29 @@
   }
 
   // Build a canonical teams.json string for a league/cup/continental result.
-  function toTeamsJson(result, comp, season) {
+  //
+  // `previousClubs` (the clubs array already on the branch) carries UEFA seeding
+  // pots forward. The scraper cannot read pots off Transfermarkt — they are
+  // entered by hand — so without this a re-scrape would destroy them with no way
+  // to reconstruct them. Clubs that dropped out lose their pot with them, and a
+  // newly drawn club arrives without one; `app:validate-season` then reports the
+  // file as partially potted, which is the right signal after a draw changes.
+  function toTeamsJson(result, comp, season, previousClubs) {
+    const pots = new Map();
+    if (comp.kind === 'continental' && Array.isArray(previousClubs)) {
+      for (const club of previousClubs) {
+        if (club && club.pot !== undefined) pots.set(resolveClubId(club), club.pot);
+      }
+    }
+
     const clubs = (result.clubs || [])
       .map(sortClubPlayers)
+      .map(club => {
+        const pot = pots.get(resolveClubId(club));
+        return pot === undefined || club.pot !== undefined ? club : { ...club, pot };
+      })
       .sort(byId(resolveClubId));
+
     return encode({
       id: result.id || comp.tmId,
       name: comp.name,
@@ -89,8 +152,22 @@
   }
 
   // Build a canonical pool {id}.json string for a single-club squad result.
+  //
+  // Translates the scraper's raw `countryName` into the repo's `country` code
+  // and drops the raw label. `country` lands right after `name`, matching the
+  // curated pool files, so re-scrapes don't churn key order.
   function toPoolJson(result) {
-    return encode(sortClubPlayers({ ...result }));
+    const { countryName, ...club } = result;
+    const country = club.country || countryCodeFor(countryName);
+    const ordered = {};
+
+    for (const [key, value] of Object.entries(club)) {
+      ordered[key] = value;
+      if (key === 'name' && country) ordered.country = country;
+    }
+    if (country && !ordered.country) ordered.country = country;
+
+    return encode(sortClubPlayers(ordered));
   }
 
   // Map a finished scrape result to the repo file it belongs in, or null when
@@ -98,7 +175,9 @@
   //
   //   { path: 'data/2026/ESP1/teams.json', content: '...' }
   //
-  // `opts.season` (required) and, for single-club pushes, `opts.pool` (EUR/INT).
+  // `opts.season` (required); for single-club pushes `opts.pool` (EUR/INT); for
+  // continental lists `opts.previousClubs` (the clubs already on the branch,
+  // whose pots are carried forward).
   function repoFileForResult(result, pageType, opts) {
     const season = String(opts.season);
 
@@ -107,7 +186,7 @@
       if (!comp) return null;
       return {
         path: `data/${season}/${comp.code}/teams.json`,
-        content: toTeamsJson(result, comp, season),
+        content: toTeamsJson(result, comp, season, opts.previousClubs),
       };
     }
 
@@ -128,7 +207,9 @@
     REPO,
     BASE_BRANCH,
     COMPETITIONS,
+    COUNTRY_CODES,
     POOLS,
+    countryCodeFor,
     findByTmId,
     toTeamsJson,
     toPoolJson,

--- a/tests/Feature/Console/NormalizeSeasonCommandTest.php
+++ b/tests/Feature/Console/NormalizeSeasonCommandTest.php
@@ -29,6 +29,36 @@ class NormalizeSeasonCommandTest extends TestCase
         return $path;
     }
 
+    /**
+     * @param  array<int, array<string, mixed>>  $clubs
+     */
+    private function writeContinental(array $clubs, string $code = 'UCL'): string
+    {
+        $dir = base_path("data/{$this->season}/{$code}");
+        File::ensureDirectoryExists($dir);
+        $path = "{$dir}/teams.json";
+        File::put($path, json_encode(['id' => $code, 'name' => $code, 'clubs' => $clubs]));
+
+        return $path;
+    }
+
+    /**
+     * @param  array<string, mixed>  $extra
+     */
+    private function writeEurPoolTeam(string $id, array $extra = []): string
+    {
+        $dir = base_path("data/{$this->season}/EUR");
+        File::ensureDirectoryExists($dir);
+        $path = "{$dir}/{$id}.json";
+        File::put($path, json_encode([
+            'image' => "https://tmssl.akamaized.net/images/wappen/big/{$id}.png",
+            'name' => "Pool Club {$id}",
+            'players' => [],
+        ] + $extra));
+
+        return $path;
+    }
+
     public function test_forces_season_id_and_sorts_clubs_and_players(): void
     {
         $path = $this->writeEsp1([
@@ -84,5 +114,72 @@ class NormalizeSeasonCommandTest extends TestCase
         $this->artisan('app:normalize-season', ['season' => $this->season, '--check' => true])
             ->expectsOutputToContain('not canonical')
             ->assertFailed();
+    }
+
+    public function test_backfills_pool_country_from_the_continental_list(): void
+    {
+        // The scraper long omitted country on pool files; without it the club
+        // seeds as 'EU' and the Swiss draw can no longer keep compatriots apart.
+        $poolPath = $this->writeEurPoolTeam('1090');
+        $this->writeContinental([['id' => '1090', 'name' => 'AZ Alkmaar', 'country' => 'NL']]);
+
+        $this->artisan('app:normalize-season', ['season' => $this->season])->assertSuccessful();
+
+        $pool = json_decode(File::get($poolPath), true);
+        $this->assertSame('NL', $pool['country']);
+        $this->assertSame(['image', 'name', 'country'], array_slice(array_keys($pool), 0, 3));
+    }
+
+    public function test_backfills_continental_country_from_the_pool_file(): void
+    {
+        $this->writeEurPoolTeam('1090', ['country' => 'NL']);
+        $path = $this->writeContinental([['id' => '1090', 'name' => 'AZ Alkmaar']]);
+
+        $this->artisan('app:normalize-season', ['season' => $this->season])->assertSuccessful();
+
+        $club = json_decode(File::get($path), true)['clubs'][0];
+        $this->assertSame('NL', $club['country']);
+        $this->assertSame(['id', 'name', 'country'], array_keys($club));
+    }
+
+    public function test_backfills_continental_country_from_the_club_league(): void
+    {
+        $this->writeEsp1([
+            'id' => 'ES1',
+            'name' => 'LaLiga',
+            'clubs' => [['transfermarktId' => '13', 'name' => 'Atlético de Madrid', 'players' => []]],
+        ]);
+        $path = $this->writeContinental([['id' => '13', 'name' => 'Atlético de Madrid']]);
+
+        $this->artisan('app:normalize-season', ['season' => $this->season])->assertSuccessful();
+
+        $this->assertSame('ES', json_decode(File::get($path), true)['clubs'][0]['country']);
+    }
+
+    public function test_never_overwrites_a_declared_country(): void
+    {
+        $this->writeEurPoolTeam('1090', ['country' => 'BE']);
+        $path = $this->writeContinental([['id' => '1090', 'name' => 'AZ Alkmaar', 'country' => 'NL']]);
+
+        $this->artisan('app:normalize-season', ['season' => $this->season])->assertSuccessful();
+
+        $this->assertSame('NL', json_decode(File::get($path), true)['clubs'][0]['country']);
+        $this->assertSame('BE', json_decode(File::get(base_path("data/{$this->season}/EUR/1090.json")), true)['country']);
+    }
+
+    public function test_leaves_an_unresolvable_country_alone_and_stays_idempotent(): void
+    {
+        $poolPath = $this->writeEurPoolTeam('1090');
+        $this->writeContinental([['id' => '1090', 'name' => 'AZ Alkmaar']]);
+
+        $this->artisan('app:normalize-season', ['season' => $this->season])->assertSuccessful();
+        $this->assertArrayNotHasKey('country', json_decode(File::get($poolPath), true));
+
+        // Nothing left to fix: a second pass is a no-op and --check is clean.
+        $this->artisan('app:normalize-season', ['season' => $this->season])
+            ->expectsOutputToContain('already canonical')
+            ->assertSuccessful();
+        $this->artisan('app:normalize-season', ['season' => $this->season, '--check' => true])
+            ->assertSuccessful();
     }
 }

--- a/tests/Feature/Console/ValidateSeasonCommandTest.php
+++ b/tests/Feature/Console/ValidateSeasonCommandTest.php
@@ -164,9 +164,14 @@ class ValidateSeasonCommandTest extends TestCase
         $clubs[0] = ['id' => '999999', 'name' => 'Ghost FC', 'country' => 'NL', 'pot' => 1];
         $this->writeContinental($clubs);
 
+        // One assertion only: PendingCommand registers a separate mock
+        // expectation per expected substring, and a single written line is
+        // routed to just the first one that matches — so two
+        // expectsOutputToContain calls can never both match the same line.
+        // "Ghost FC (999999)" is the unseedable-participant error's own
+        // "{name} ({id})" format and appears in no other message.
         $this->artisan('app:validate-season', ['season' => $this->season])
             ->expectsOutputToContain('Ghost FC (999999)')
-            ->expectsOutputToContain('have no squad data')
             ->assertFailed();
     }
 

--- a/tests/Feature/Console/ValidateSeasonCommandTest.php
+++ b/tests/Feature/Console/ValidateSeasonCommandTest.php
@@ -55,6 +55,54 @@ class ValidateSeasonCommandTest extends TestCase
         return $clubs;
     }
 
+    /**
+     * Write a continental participant list (UCL unless told otherwise).
+     *
+     * @param  array<int, array<string, mixed>>  $clubs
+     */
+    private function writeContinental(array $clubs, string $code = 'UCL'): void
+    {
+        $dir = base_path("data/{$this->season}/{$code}");
+        File::ensureDirectoryExists($dir);
+        File::put("{$dir}/teams.json", json_encode(['seasonID' => $this->season, 'clubs' => $clubs]));
+        File::put("{$dir}/schedule.json", json_encode(['league' => []]));
+    }
+
+    /** Give a continental club somewhere for its squad to come from. */
+    private function writeEurPoolTeam(string $id, string $name = 'Pool Club', ?string $country = 'NL'): void
+    {
+        $dir = base_path("data/{$this->season}/EUR");
+        File::ensureDirectoryExists($dir);
+        File::put("{$dir}/{$id}.json", json_encode(array_filter([
+            'image' => "https://tmssl.akamaized.net/images/wappen/big/{$id}.png",
+            'name' => $name,
+            'country' => $country,
+            'players' => [],
+        ], fn ($v) => $v !== null)));
+    }
+
+    /**
+     * A full 36-club Swiss field, backed by EUR pool files so the squad-source
+     * check passes and only the asserted guard can fire.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    private function seedableSwissField(bool $withPots = true): array
+    {
+        $clubs = [];
+        for ($i = 0; $i < 36; $i++) {
+            $id = (string) (500 + $i);
+            $this->writeEurPoolTeam($id, "Euro Club {$i}");
+            $club = ['id' => $id, 'name' => "Euro Club {$i}", 'country' => 'NL'];
+            if ($withPots) {
+                $club['pot'] = intdiv($i, 9) + 1;
+            }
+            $clubs[] = $club;
+        }
+
+        return $clubs;
+    }
+
     public function test_fails_when_a_competition_teams_json_is_missing(): void
     {
         File::ensureDirectoryExists(base_path("data/{$this->season}"));
@@ -107,6 +155,128 @@ class ValidateSeasonCommandTest extends TestCase
 
         $this->artisan('app:validate-season', ['season' => $this->season])
             ->expectsOutputToContain("club 'No Id Club' has no resolvable transfermarkt id")
+            ->assertFailed();
+    }
+
+    public function test_detects_continental_club_with_no_squad_data(): void
+    {
+        $clubs = $this->seedableSwissField();
+        $clubs[0] = ['id' => '999999', 'name' => 'Ghost FC', 'country' => 'NL', 'pot' => 1];
+        $this->writeContinental($clubs);
+
+        $this->artisan('app:validate-season', ['season' => $this->season])
+            ->expectsOutputToContain('Ghost FC (999999)')
+            ->expectsOutputToContain('have no squad data')
+            ->assertFailed();
+    }
+
+    public function test_accepts_a_continental_club_backed_by_an_eur_pool_file(): void
+    {
+        $this->writeContinental($this->seedableSwissField());
+
+        $this->artisan('app:validate-season', ['season' => $this->season])
+            ->doesntExpectOutputToContain('have no squad data')
+            ->assertFailed(); // ESP1 and friends are still missing from this fixture.
+    }
+
+    public function test_accepts_a_continental_club_backed_by_a_league(): void
+    {
+        // 20 ESP1 clubs with ids 100..119; point the Swiss field's first entry at one.
+        $this->writeEsp1($this->validClubs(20), $this->season);
+        $clubs = $this->seedableSwissField();
+        $clubs[0] = ['id' => '100', 'name' => 'Club 0', 'country' => 'ES', 'pot' => 1];
+        $this->writeContinental($clubs);
+
+        $this->artisan('app:validate-season', ['season' => $this->season])
+            ->doesntExpectOutputToContain('have no squad data')
+            ->assertFailed();
+    }
+
+    public function test_requires_a_literal_id_on_continental_clubs(): void
+    {
+        // The seeder reads $club['id'] directly, so a crest-only club resolves
+        // in loadClubs() but is silently dropped at seed time.
+        $clubs = $this->seedableSwissField();
+        $clubs[0] = [
+            'image' => 'https://tmssl.akamaized.net/images/wappen/big/500.png',
+            'name' => 'Crest Only FC',
+            'pot' => 1,
+        ];
+        $this->writeContinental($clubs);
+
+        $this->artisan('app:validate-season', ['season' => $this->season])
+            ->expectsOutputToContain("club 'Crest Only FC' has no literal 'id' key")
+            ->assertFailed();
+    }
+
+    public function test_detects_short_swiss_field(): void
+    {
+        $this->writeContinental(array_slice($this->seedableSwissField(), 0, 35));
+
+        $this->artisan('app:validate-season', ['season' => $this->season])
+            ->expectsOutputToContain('swiss league phase needs exactly 36 clubs, got 35')
+            ->assertFailed();
+    }
+
+    public function test_warns_but_does_not_fail_when_a_swiss_field_has_no_pots(): void
+    {
+        $this->writeContinental($this->seedableSwissField(withPots: false));
+
+        $this->artisan('app:validate-season', ['season' => $this->season])
+            ->expectsOutputToContain('no seeding pots')
+            ->doesntExpectOutputToContain('every pot must hold')
+            ->assertFailed();
+    }
+
+    public function test_detects_partially_potted_swiss_field(): void
+    {
+        $clubs = $this->seedableSwissField();
+        foreach (range(0, 15) as $i) {
+            unset($clubs[$i]['pot']);
+        }
+        $this->writeContinental($clubs);
+
+        $this->artisan('app:validate-season', ['season' => $this->season])
+            ->expectsOutputToContain('only 20 of 36 clubs have a')
+            ->assertFailed();
+    }
+
+    public function test_detects_unbalanced_pots(): void
+    {
+        $clubs = $this->seedableSwissField();
+        $clubs[35]['pot'] = 1; // pot 1 gets 10, pot 4 gets 8
+
+        $this->writeContinental($clubs);
+
+        $this->artisan('app:validate-season', ['season' => $this->season])
+            ->expectsOutputToContain('every pot must hold exactly 9 clubs')
+            ->assertFailed();
+    }
+
+    public function test_does_not_apply_the_swiss_shape_to_a_knockout_continental_cup(): void
+    {
+        // UEFASUP is a two-club knockout, not a Swiss league phase.
+        $this->writeEurPoolTeam('700', 'Winner A');
+        $this->writeEurPoolTeam('701', 'Winner B');
+        $this->writeContinental([
+            ['id' => '700', 'name' => 'Winner A', 'country' => 'EN'],
+            ['id' => '701', 'name' => 'Winner B', 'country' => 'FR'],
+        ], 'UEFASUP');
+
+        $this->artisan('app:validate-season', ['season' => $this->season])
+            ->doesntExpectOutputToContain('swiss league phase needs exactly')
+            ->assertFailed();
+    }
+
+    public function test_warns_when_a_swiss_club_has_no_country_anywhere(): void
+    {
+        $clubs = $this->seedableSwissField();
+        unset($clubs[0]['country']);
+        $this->writeEurPoolTeam($clubs[0]['id'], $clubs[0]['name'], country: null);
+        $this->writeContinental($clubs);
+
+        $this->artisan('app:validate-season', ['season' => $this->season])
+            ->expectsOutputToContain('cannot keep them apart from their compatriots')
             ->assertFailed();
     }
 }

--- a/tests/Unit/SwissPotShapeTest.php
+++ b/tests/Unit/SwissPotShapeTest.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Modules\Competition\Services\SwissDrawService;
+use App\Modules\Season\Jobs\SetupNewGame;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+
+/**
+ * Real UEFA seeding pots are optional data: the Transfermarkt scraper cannot
+ * read them off any page, so a freshly scraped participant list arrives without
+ * them and they are entered by hand afterwards.
+ *
+ * SetupNewGame must therefore treat an unusable pot set as "no pot data" and
+ * publish nothing, letting SeasonInitializationService assign pots by squad
+ * market value instead — the same path every season after the first uses. The
+ * failure this guards against is the opposite: passing a malformed set through
+ * makes SwissDrawService throw inside a queued job, and game creation dies.
+ */
+class SwissPotShapeTest extends TestCase
+{
+    private ReflectionMethod $potsAreWellFormed;
+
+    private SetupNewGame $job;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Only the pot-shape helper is exercised; the constructor args are
+        // inert here (SetupNewGame::onQueue is a plain setter).
+        $this->job = new SetupNewGame('game-id', 'team-id', 'ESP1', '2025', 'career');
+        $this->potsAreWellFormed = new ReflectionMethod(SetupNewGame::class, 'potsAreWellFormed');
+    }
+
+    /**
+     * Build a draw set from a pot => club-count map.
+     *
+     * @param  array<int, int>  $distribution
+     * @return array<int, array{id: string, pot: int, country: string}>
+     */
+    private function drawTeams(array $distribution): array
+    {
+        $teams = [];
+        foreach ($distribution as $pot => $count) {
+            for ($i = 0; $i < $count; $i++) {
+                $teams[] = ['id' => 'team-' . count($teams), 'pot' => $pot, 'country' => 'ES'];
+            }
+        }
+
+        return $teams;
+    }
+
+    /** @param array<int, array{id: string, pot: int, country: string}> $drawTeams */
+    private function isWellFormed(array $drawTeams): bool
+    {
+        return $this->potsAreWellFormed->invoke($this->job, $drawTeams);
+    }
+
+    public function test_accepts_four_full_pots(): void
+    {
+        $this->assertTrue($this->isWellFormed($this->drawTeams([1 => 9, 2 => 9, 3 => 9, 4 => 9])));
+    }
+
+    public function test_rejects_a_field_with_no_pots_at_all(): void
+    {
+        // Every club defaults to pot 0 when the scraped list carries no pots.
+        $this->assertFalse($this->isWellFormed($this->drawTeams([0 => 36])));
+    }
+
+    public function test_rejects_an_unbalanced_distribution(): void
+    {
+        $this->assertFalse($this->isWellFormed($this->drawTeams([1 => 10, 2 => 9, 3 => 9, 4 => 8])));
+    }
+
+    public function test_rejects_a_short_field(): void
+    {
+        // A club dropped for want of squad data leaves 35 — the shape the draw
+        // cannot satisfy and the reason validation guards squad sources.
+        $this->assertFalse($this->isWellFormed($this->drawTeams([1 => 9, 2 => 9, 3 => 9, 4 => 8])));
+    }
+
+    public function test_rejects_a_pot_outside_the_valid_range(): void
+    {
+        $this->assertFalse($this->isWellFormed($this->drawTeams([1 => 9, 2 => 9, 3 => 9, 4 => 9, 5 => 9])));
+    }
+
+    public function test_rejects_an_empty_field(): void
+    {
+        $this->assertFalse($this->isWellFormed([]));
+    }
+
+    public function test_pot_shape_matches_what_the_draw_service_demands(): void
+    {
+        $this->assertSame(4, SwissDrawService::POTS);
+        $this->assertSame(9, SwissDrawService::TEAMS_PER_POT);
+        $this->assertSame(36, SwissDrawService::LEAGUE_PHASE_TEAMS);
+    }
+}

--- a/tests/js/season-config.test.js
+++ b/tests/js/season-config.test.js
@@ -1,0 +1,170 @@
+/**
+ * Tests for the Transfermarkt scraper's season-config.js — the layer that turns
+ * a raw scrape into the exact JSON that lands in `data/{season}/`.
+ *
+ * Two regressions matter here. UEFA seeding pots are entered by hand (they are
+ * not on any page the scraper reads), so a continental re-scrape must carry
+ * them forward instead of overwriting them. And a club's country must never be
+ * guessed: a wrong code seeds a wrong country silently, whereas a missing one
+ * gets backfilled by `app:normalize-season` and flagged by `app:validate-season`.
+ */
+import { describe, it, expect, beforeAll, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+let SeasonConfig;
+
+beforeAll(() => {
+    // season-config.js is a plain script that attaches to the global object
+    // (it is loaded by both the popup and the MV3 service worker, not imported).
+    globalThis.self = globalThis;
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const src = readFileSync(
+        resolve(__dirname, '../../scripts/transfermarkt-scraper/season-config.js'),
+        'utf8',
+    );
+    // eslint-disable-next-line no-new-func
+    new Function(src)();
+    SeasonConfig = globalThis.SeasonConfig;
+});
+
+const UCL = { code: 'UCL', tmId: 'CL', name: 'UEFA Champions League', kind: 'continental' };
+const ESPCUP = { code: 'ESPCUP', tmId: 'CDR', name: 'Copa del Rey', kind: 'cup' };
+
+const parse = json => JSON.parse(json);
+
+describe('toTeamsJson — pot preservation on continental re-scrapes', () => {
+    const scraped = { id: 'CL', clubs: [{ id: '11', name: 'Arsenal' }, { id: '418', name: 'Real Madrid' }] };
+    const previous = [{ id: '11', name: 'Arsenal', pot: 2 }, { id: '418', name: 'Real Madrid', pot: 1 }];
+
+    it('carries pots forward by transfermarkt id', () => {
+        const clubs = parse(SeasonConfig.toTeamsJson(scraped, UCL, '2026', previous)).clubs;
+
+        expect(clubs.find(c => c.id === '11').pot).toBe(2);
+        expect(clubs.find(c => c.id === '418').pot).toBe(1);
+    });
+
+    it('leaves a newly drawn club without a pot rather than inventing one', () => {
+        const withNewcomer = { id: 'CL', clubs: [...scraped.clubs, { id: '62', name: 'SK Slavia Prague' }] };
+        const clubs = parse(SeasonConfig.toTeamsJson(withNewcomer, UCL, '2026', previous)).clubs;
+
+        expect(clubs.find(c => c.id === '62')).not.toHaveProperty('pot');
+    });
+
+    it('drops the pot of a club that is no longer a participant', () => {
+        const clubs = parse(SeasonConfig.toTeamsJson(
+            { id: 'CL', clubs: [{ id: '11', name: 'Arsenal' }] },
+            UCL,
+            '2026',
+            previous,
+        )).clubs;
+
+        expect(clubs).toHaveLength(1);
+        expect(clubs.map(c => c.id)).not.toContain('418');
+    });
+
+    it('prefers a freshly scraped pot over the stored one', () => {
+        const repotted = { id: 'CL', clubs: [{ id: '11', name: 'Arsenal', pot: 4 }] };
+        const clubs = parse(SeasonConfig.toTeamsJson(repotted, UCL, '2026', previous)).clubs;
+
+        expect(clubs[0].pot).toBe(4);
+    });
+
+    it('ignores previous clubs for a non-continental competition', () => {
+        const clubs = parse(SeasonConfig.toTeamsJson(
+            { id: 'CDR', clubs: [{ id: '11', name: 'Arsenal' }] },
+            ESPCUP,
+            '2026',
+            previous,
+        )).clubs;
+
+        expect(clubs[0]).not.toHaveProperty('pot');
+    });
+
+    it('is unchanged when there is nothing stored yet', () => {
+        expect(SeasonConfig.toTeamsJson(scraped, UCL, '2026', null))
+            .toBe(SeasonConfig.toTeamsJson(scraped, UCL, '2026'));
+    });
+});
+
+describe('countryCodeFor', () => {
+    it('maps the home nations the way the repo tracks them, not ISO', () => {
+        expect(SeasonConfig.countryCodeFor('England')).toBe('EN');
+        expect(SeasonConfig.countryCodeFor('Scotland')).toBe('GB-SCT');
+    });
+
+    it('maps ordinary UEFA members to ISO alpha-2', () => {
+        expect(SeasonConfig.countryCodeFor('Germany')).toBe('DE');
+        expect(SeasonConfig.countryCodeFor('Netherlands')).toBe('NL');
+        expect(SeasonConfig.countryCodeFor('North Macedonia')).toBe('MK');
+        expect(SeasonConfig.countryCodeFor('Kosovo')).toBe('XK');
+    });
+
+    it('accepts both spellings Transfermarkt uses for Türkiye', () => {
+        expect(SeasonConfig.countryCodeFor('Türkiye')).toBe('TR');
+        expect(SeasonConfig.countryCodeFor('Turkey')).toBe('TR');
+    });
+
+    it('returns nothing for an unknown label instead of guessing', () => {
+        expect(SeasonConfig.countryCodeFor('Atlantis')).toBeUndefined();
+        expect(SeasonConfig.countryCodeFor(null)).toBeUndefined();
+    });
+});
+
+describe('toPoolJson', () => {
+    const club = {
+        transfermarktId: '1090',
+        name: 'AZ Alkmaar',
+        countryName: 'Netherlands',
+        image: 'https://tmssl.akamaized.net/images/wappen/big/1090.png',
+        players: [{ id: '20' }, { id: '3' }],
+    };
+
+    it('translates the scraped country label into a code and drops the label', () => {
+        const out = parse(SeasonConfig.toPoolJson(club));
+
+        expect(out.country).toBe('NL');
+        expect(out).not.toHaveProperty('countryName');
+    });
+
+    it('places country immediately after name, as the curated pool files do', () => {
+        const keys = Object.keys(parse(SeasonConfig.toPoolJson(club)));
+
+        expect(keys[keys.indexOf('name') + 1]).toBe('country');
+    });
+
+    it('omits country entirely when the label is unknown', () => {
+        const out = parse(SeasonConfig.toPoolJson({ ...club, countryName: 'Atlantis' }));
+
+        expect(out).not.toHaveProperty('country');
+        expect(out).not.toHaveProperty('countryName');
+    });
+
+    it('still sorts players by id', () => {
+        expect(parse(SeasonConfig.toPoolJson(club)).players.map(p => p.id)).toEqual(['3', '20']);
+    });
+});
+
+describe('repoFileForResult', () => {
+    it('routes a continental scrape to its teams.json and forwards stored pots', () => {
+        const file = SeasonConfig.repoFileForResult(
+            { id: 'CL', clubs: [{ id: '11', name: 'Arsenal' }] },
+            'cup-teams',
+            { season: '2026', previousClubs: [{ id: '11', pot: 2 }] },
+        );
+
+        expect(file.path).toBe('data/2026/UCL/teams.json');
+        expect(parse(file.content).clubs[0].pot).toBe(2);
+    });
+
+    it('routes a single club squad into the chosen pool', () => {
+        const file = SeasonConfig.repoFileForResult(
+            { transfermarktId: '1090', name: 'AZ Alkmaar', countryName: 'Netherlands' },
+            'club',
+            { season: '2026', pool: 'EUR' },
+        );
+
+        expect(file.path).toBe('data/2026/EUR/1090.json');
+        expect(parse(file.content).country).toBe('NL');
+    });
+});


### PR DESCRIPTION
## Summary

Adds comprehensive validation for continental European competitions (UCL/UEL/UECL/UEFASUP) to catch data issues before they silently break game setup, and implements country backfilling across season data files to ensure Swiss draw seeding works correctly.

## Key Changes

**ValidateSeason command enhancements:**
- New `validateContinental()` method with stricter checks for European competitions:
  - Verifies every participant has a literal `id` field (required by the seeder)
  - Ensures all participants have squad data somewhere in the season folder (league teams.json or EUR/INT pool files)
  - For Swiss format competitions, validates the 36-club field is properly potted (4 pots of 9 clubs each)
- Builds a `$squadSources` index mapping transfermarkt IDs to their country, gathered from league teams.json and pool files
- Warns about clubs missing country data needed for Swiss draw compatriot separation
- Catches incomplete league phases that would otherwise be silently skipped at game setup

**NormalizeSeason command enhancements:**
- Implements country backfilling via new `buildCountryIndex()` and `withCountry()` methods
- Backfills missing `country` fields in continental participant lists from pool files or league teams.json
- Backfills missing `country` in pool files from continental lists or league teams.json
- Never overwrites explicitly declared countries
- Preserves key ordering (id/name/country for continental clubs, image/name/country for pool files)

**Transfermarkt scraper improvements:**
- Adds `COUNTRY_CODES` mapping for all UEFA members plus non-European INT pool countries
- New `countryCodeFor()` function translates Transfermarkt country labels to repo codes (no guessing — unknown labels yield undefined)
- Enhances `toTeamsJson()` to preserve UEFA seeding pots across re-scrapes by reading previous clubs from the season branch
- Updates `toPoolJson()` to include translated country codes
- Adds `previousContinentalClubs()` in background.js to fetch stored pots before pushing

**Supporting changes:**
- Exposes `SwissDrawService` constants (POTS, TEAMS_PER_POT, LEAGUE_PHASE_TEAMS) for validation
- Updates `SetupNewGame.buildSwissPotData()` to validate pot shape before publishing (rejects incomplete or malformed sets)
- Adds `SeasonData.continentalHandlers()` to map continental competitions to their handler type without database access
- Updates `SeasonInitializationService` to skip non-Swiss continental competitions (e.g., UEFASUP knockout)
- Tracks unlinked continental clubs in `SeedReferenceData` and exits non-zero when any are found

**Test coverage:**
- Comprehensive tests for continental validation (squad data, literal IDs, Swiss shape, pot balance, country requirements)
- Tests for country backfilling across all three sources (pool files, continental lists, league teams.json)
- Unit tests for pot shape validation in `SetupNewGame`
- JavaScript tests for pot preservation and country code mapping in the scraper

## Implementation Details

- Validation is database-free, allowing CI to run `app:validate-season` against an unmigrated database
- Country backfilling is idempotent and never overwrites hand-curated values
- Swiss pot validation prevents silent failures: a malformed pot set is rejected at setup time rather than causing SwissDrawService to throw inside a queued job
- The scraper's pot preservation ensures UEFA seeding data survives re-scrapes without manual intervention

https://claude.ai/code/session_01U39rdVTBiQutT8ZG9TX5KU