### PR TITLE
Add European pool refresh batch and GitHub credential verification

### DIFF
--- a/docs/season-data-refresh.md
+++ b/docs/season-data-refresh.md
@@ -95,9 +95,11 @@ add/remove line, not a reshuffled roster.
    - `data/2026/{UCL,UEL,UECL,UEFASUP}/teams.json` participant lists. These are
      independent of the transfer window — the draws are known before it shuts —
      so they can go in first. Their squads cannot: every participant outside the
-     eight scraped leagues needs an `EUR` pool file (70 of 108 slots in 2025).
-     Add `pot` by hand for a true-to-life first-season draw; a re-scrape now
-     preserves it.
+     eight scraped leagues needs an `EUR` pool file (70 of 108 slots in 2025) —
+     **Season Refresh → Refresh European pool** derives that list from the
+     participant lists and league squads already on the branch and scrapes them
+     in one batch, so run it after both are pushed. Add `pot` by hand for a
+     true-to-life first-season draw; a re-scrape now preserves it.
    - `data/2026/EUR/{id}.json` and `data/2026/INT/{id}.json` pool teams.
    - Append any new players to `data/players/player_positions_ES.json`
      (secondary positions; keyed by player id, not season-scoped).

--- a/scripts/transfermarkt-scraper/README.md
+++ b/scripts/transfermarkt-scraper/README.md
@@ -74,6 +74,39 @@ pull request. CI then normalizes, validates, and posts a transfer diff (see
    - **PAT** — the token from step 1 (stored in `chrome.storage.local`, never committed),
    - **Target season** — e.g. `2026` (drives the `data/2026/` paths and the `season-data/2026` branch),
    - **owner/repo** and **base branch** default to `pabloroman/virtua-fc` and `main`.
+3. Click **Test GitHub connection**. It checks the values in the fields (not the
+   saved ones, so a freshly pasted token can be verified first) against the same
+   three things a push needs: the token itself, access to the repo, and a
+   Contents read of the base branch. On success it reports the repo and the
+   token's expiry date; write access is reported but cannot be proven without
+   writing.
+
+A season refresh runs the same check before it scrapes anything, so bad
+credentials cost a couple of seconds instead of a full scrape.
+
+### When a push fails on credentials
+
+`401: Bad credentials` means the token itself was rejected — GitHub never got
+as far as looking at the repo. Fine-grained PATs expire (30 days by default),
+and GitHub revokes any token it finds committed somewhere, so a token that
+worked last season is the usual cause. Generate a new one and save it.
+
+`No access to owner/repo` means the token is valid but this repository is not in
+its list — a fine-grained PAT reports a repo it cannot see as a 404, so it looks
+like a missing repo rather than a missing grant. Check the token's *Repository
+access* and that it has **Contents** and **Pull requests**.
+
+From a terminal the same check is:
+
+```bash
+curl -sS -D- -o /dev/null \
+  -H "Authorization: Bearer $GITHUB_TOKEN" \
+  -H "X-GitHub-Api-Version: 2022-11-28" \
+  https://api.github.com/repos/pabloroman/virtua-fc
+```
+
+`200` is fine (the `github-authentication-token-expiration` header gives the
+expiry), `401` is a bad token, `404` is a token without access to this repo.
 
 ### Push a single page
 

--- a/scripts/transfermarkt-scraper/README.md
+++ b/scripts/transfermarkt-scraper/README.md
@@ -144,9 +144,33 @@ Unknown labels are left out rather than guessed; add them to `COUNTRY_CODES` in
 **SEASON REFRESH → Refresh all leagues** drives every league in `season-config.js`
 (`batch: true`) for the target season — scraping each club's squad at a human
 pace — then pushes them all in **one commit + PR**. Leave a Transfermarkt tab
-open and active; **Stop** pauses cleanly between leagues. Cups, continental
-participant lists, and EUR/INT pools are pushed individually with the per-page
-button (their pages aren't part of the batch driver).
+open and active; **Stop** pauses cleanly between leagues. Cups and continental
+participant lists are pushed individually with the per-page button (their pages
+aren't part of the batch driver).
+
+### Refresh the European pool
+
+A continental participant from outside the eight scraped leagues has no squad
+until it gets a `data/{season}/EUR/{id}.json` file of its own — 70 of 2025's 108
+slots. **SEASON REFRESH → Refresh European pool** does that batch:
+
+1. reads the UCL/UEL/UECL/UEFASUP participant lists and the league `teams.json`
+   files already on the season branch,
+2. takes every participant no league covers (deduplicated — the Super Cup's two
+   clubs are also in the UCL/UEL lists),
+3. scrapes each one's squad page and pushes them all in **one commit + PR**.
+
+Run it **after** both the leagues and the participant lists are on the branch:
+the club list is derived from what is there. If a league's squads are missing it
+refuses rather than treating all ~108 participants as pool clubs; if a
+participant list is missing it works with the ones that exist and names the rest
+in the result.
+
+Every target is re-scraped, including clubs that already have a pool file — a
+pool file is last season's squad until this season overwrites it. As with the
+league driver, one unreachable club is skipped and named in the summary rather
+than sinking the run, and **Stop** pauses between clubs (nothing is pushed on a
+pause). Clubs that need the `INT` pool are still pushed one page at a time.
 
 **Expect it to take 15–25 minutes** (8 leagues × ~20 clubs, deliberately paced) and
 to drive your active tab the whole way. **Keep the popup open** to watch progress —

--- a/scripts/transfermarkt-scraper/README.md
+++ b/scripts/transfermarkt-scraper/README.md
@@ -108,6 +108,12 @@ curl -sS -D- -o /dev/null \
 `200` is fine (the `github-authentication-token-expiration` header gives the
 expiry), `401` is a bad token, `404` is a token without access to this repo.
 
+`422: Update is not a fast forward` means the branch head moved while the push
+was uploading — normally CI's `Canonicalize season {year} squad data` commit
+from your *previous* push landing a few seconds later. The push now rebuilds its
+commit on the new head and retries (up to three times), so this should no longer
+surface; if it does, something is committing to the branch continuously.
+
 ### Push a single page
 
 After scraping a supported page, click **Push to GitHub**:

--- a/scripts/transfermarkt-scraper/background.js
+++ b/scripts/transfermarkt-scraper/background.js
@@ -388,6 +388,26 @@ async function getSettings() {
 }
 
 /**
+ * Pre-flight the GitHub credentials. `overrides` lets the popup test the values
+ * currently typed into Settings before they are saved; anything it omits falls
+ * back to what is stored.
+ *
+ * Called before a season refresh starts so an expired token costs a couple of
+ * seconds instead of failing on the push at the end of a full scrape.
+ */
+async function verifyGitHub(overrides = {}) {
+  const saved = await getSettings();
+  const token = (overrides.token || saved.token || '').trim();
+  const repo = (overrides.repo || saved.repo || '').trim();
+  const base = (overrides.base || saved.base || SeasonConfig.BASE_BRANCH).trim();
+
+  if (!token) throw new Error('No GitHub token set — open Settings.');
+  if (!repo.includes('/')) throw new Error(`Repo must be "owner/name" — got "${repo}".`);
+
+  return new GitHubClient(token, repo).verify(base);
+}
+
+/**
  * Commit a set of {path, content} files to the season-data branch as one commit
  * and ensure a PR is open. Returns the PR url.
  */
@@ -485,6 +505,12 @@ async function startSeasonRefresh(tabId) {
   const { token, season } = await getSettings();
   if (!token) throw new Error('No GitHub token set — open Settings.');
   if (!season) throw new Error('Set a target season in Settings first.');
+
+  // Fail on bad credentials now rather than on the push, which only happens
+  // after every league has been scraped — tens of minutes of work thrown away
+  // by a token that expired in the meantime.
+  await updateProgress({ status: 'working', message: 'Checking GitHub credentials…', current: 0, total: 0, pageType: 'season-refresh' });
+  await verifyGitHub();
 
   const leagues = SeasonConfig.COMPETITIONS.filter(c => c.batch);
   const files = [];
@@ -741,6 +767,13 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
         sendResponse({ ok: false, error: err.message });
       }
     })();
+    return true;
+  }
+
+  if (message.action === 'testGitHub') {
+    verifyGitHub(message.settings || {})
+      .then(info => sendResponse({ ok: true, ...info }))
+      .catch(err => sendResponse({ ok: false, error: err.message }));
     return true;
   }
 

--- a/scripts/transfermarkt-scraper/background.js
+++ b/scripts/transfermarkt-scraper/background.js
@@ -56,22 +56,30 @@ async function navigateAndWait(tabId, url) {
 }
 
 /**
- * Scrape players from the current page
+ * Scrape a club's full record (name, country, stadium, squad) from its kader
+ * page. A league scrape keeps only the players; a pool file needs all of it.
  */
-async function scrapePlayersFromTab(tabId) {
-  console.log('[TM Scraper] Scraping players from tab:', tabId);
+async function scrapeClubFromTab(tabId) {
   try {
     const results = await chrome.scripting.executeScript({
       target: { tabId },
       files: ['content-club.js']
     });
-    const players = results?.[0]?.result?.players || [];
-    console.log('[TM Scraper] Found', players.length, 'players');
-    return players;
+    return results?.[0]?.result || null;
   } catch (err) {
-    console.error('[TM Scraper] Error scraping players:', err);
-    return [];
+    console.error('[TM Scraper] Error scraping club:', err);
+    return null;
   }
+}
+
+/**
+ * Scrape players from the current page
+ */
+async function scrapePlayersFromTab(tabId) {
+  console.log('[TM Scraper] Scraping players from tab:', tabId);
+  const players = (await scrapeClubFromTab(tabId))?.players || [];
+  console.log('[TM Scraper] Found', players.length, 'players');
+  return players;
 }
 
 /**
@@ -496,6 +504,148 @@ async function scrapeLeagueSquads(tabId, stadiumsUrl, onClub) {
 }
 
 /**
+ * Work out which clubs still need a `data/{season}/EUR/{id}.json` squad file,
+ * from what is already on the season branch: the continental participant lists
+ * minus every club a batch league's teams.json already covers.
+ *
+ * Refuses to run when a league's squads are missing. Without them no
+ * participant looks covered and the run would scrape all ~108 clubs, writing
+ * pool files for clubs that belong to a league.
+ */
+async function europeanPoolTargets(season) {
+  const { token, repo, base } = await getSettings();
+  const gh = new GitHubClient(token, repo);
+  const branch = SeasonConfig.branchFor(season);
+
+  // The season branch is where scraped data lands; base only matters before the
+  // first push of a given file.
+  const readList = async code => {
+    const path = `data/${season}/${code}/teams.json`;
+    const file = (await gh.getFileJson(branch, path)) || (await gh.getFileJson(base, path));
+    return file && Array.isArray(file.clubs) ? { code, clubs: file.clubs } : null;
+  };
+
+  const leagues = [];
+  const missingLeagues = [];
+  for (const comp of SeasonConfig.COMPETITIONS.filter(c => c.batch)) {
+    const list = await readList(comp.code);
+    if (list) leagues.push(list);
+    else missingLeagues.push(comp.code);
+  }
+  if (missingLeagues.length > 0) {
+    throw new Error(
+      `No squads on ${branch} for ${missingLeagues.join(', ')} — run "Refresh all leagues" first, ` +
+        'or every participant would be scraped as a pool club.',
+    );
+  }
+
+  const continental = [];
+  const missingLists = [];
+  for (const comp of SeasonConfig.COMPETITIONS.filter(c => c.kind === 'continental')) {
+    const list = await readList(comp.code);
+    if (list) continental.push(list);
+    else missingLists.push(comp.code);
+  }
+  if (continental.length === 0) {
+    throw new Error(
+      `No continental participant lists on ${branch} — scrape and push the UCL/UEL/UECL/UEFASUP ` +
+        'fixtures pages first.',
+    );
+  }
+
+  return { targets: SeasonConfig.poolTargets(continental, leagues), missingLists };
+}
+
+/**
+ * Scrape a squad for every continental participant that needs a pool file and
+ * push them to the season-data branch in one commit + PR.
+ */
+async function startEuropeanPoolRefresh(tabId) {
+  refreshAborted = false;
+
+  const { token, season } = await getSettings();
+  if (!token) throw new Error('No GitHub token set — open Settings.');
+  if (!season) throw new Error('Set a target season in Settings first.');
+
+  await updateProgress({ status: 'working', message: 'Checking GitHub credentials…', current: 0, total: 0, pageType: 'euro-refresh' });
+  await verifyGitHub();
+
+  await updateProgress({ status: 'working', message: 'Reading participant lists…', current: 0, total: 0, pageType: 'euro-refresh' });
+  const { targets, missingLists } = await europeanPoolTargets(season);
+
+  if (targets.length === 0) {
+    await updateProgress({
+      status: 'ready',
+      message: 'Nothing to do — every participant already has a squad',
+      current: 0,
+      total: 0,
+      pageType: 'euro-refresh',
+      result: { files: 0, failed: [], missingLists },
+    });
+    return;
+  }
+
+  const files = [];
+  const failed = [];
+
+  for (let i = 0; i < targets.length; i++) {
+    if (refreshAborted) {
+      await updateProgress({ status: 'paused', message: `Paused — ${i}/${targets.length} clubs (nothing pushed)`, current: i, total: targets.length, pageType: 'euro-refresh' });
+      return;
+    }
+
+    const club = targets[i];
+    await updateProgress({
+      status: 'working',
+      message: `${club.name} (${club.competitions.join(', ')})`,
+      current: i + 1,
+      total: targets.length,
+      pageType: 'euro-refresh',
+    });
+
+    // One unreachable club must not discard the squads already scraped in this
+    // run, exactly as a failed league does not in startSeasonRefresh.
+    try {
+      await navigateAndWait(tabId, buildKaderUrl(club.id, season));
+      const result = await scrapeClubFromTab(tabId);
+      if (!result || (result.players || []).length === 0) {
+        throw new Error('no players found on the squad page');
+      }
+
+      const file = SeasonConfig.repoFileForResult(result, 'club', { season, pool: 'EUR' });
+      if (!file) throw new Error('scrape did not map to a repo file');
+      files.push(file);
+    } catch (err) {
+      failed.push(`${club.name} (${club.id})`);
+      console.error(`[TM Scraper] ${club.name} (${club.id}) failed:`, err);
+    }
+
+    if (i < targets.length - 1) await sleep(800);
+  }
+
+  if (files.length === 0) {
+    throw new Error(`Every club failed (${failed.length}) — nothing to push.`);
+  }
+
+  await updateProgress({ status: 'working', message: `Pushing ${files.length} pool files to GitHub…`, current: targets.length, total: targets.length, pageType: 'euro-refresh' });
+
+  const prUrl = await pushFilesToGitHub(files, season);
+
+  const summary = failed.length
+    ? `Done — ${files.length} clubs pushed, ${failed.length} failed`
+    : `Done — ${files.length} clubs pushed`;
+
+  await updateProgress({
+    status: 'ready',
+    message: summary,
+    current: targets.length,
+    total: targets.length,
+    pageType: 'euro-refresh',
+    result: { prUrl, files: files.length, failed, missingLists },
+  });
+}
+
+/**
  * Drive every batch-enabled league for the target season, scrape its full
  * squad, and push them all to the season-data branch in one commit + PR.
  */
@@ -783,6 +933,17 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
         if (err.message === 'aborted') return;
         console.error('[TM Scraper] Season refresh failed:', err);
         updateProgress({ status: 'error', message: err.message, pageType: 'season-refresh' });
+      });
+    sendResponse({ started: true });
+    return true;
+  }
+
+  if (message.action === 'startEuroRefresh') {
+    startEuropeanPoolRefresh(message.tabId)
+      .catch(err => {
+        if (err.message === 'aborted') return;
+        console.error('[TM Scraper] European pool refresh failed:', err);
+        updateProgress({ status: 'error', message: err.message, pageType: 'euro-refresh' });
       });
     sendResponse({ started: true });
     return true;

--- a/scripts/transfermarkt-scraper/github.js
+++ b/scripts/transfermarkt-scraper/github.js
@@ -42,6 +42,63 @@
     }
 
     /**
+     * Check the credentials before a scrape commits to them. Exercises the
+     * same three things a push needs — the token itself, access to the repo,
+     * and a Contents read of the base branch (`commitFiles`' first call) —
+     * and throws naming whichever failed.
+     *
+     * Write access cannot be proven without writing; `canWrite` reports what
+     * the repo endpoint says about it, so the caller can warn rather than
+     * refuse.
+     */
+    async verify(base) {
+      // Not routed through request(): that maps 404 to { notFound } and drops
+      // the response headers, and both matter here. A fine-grained PAT gets a
+      // 404 (not a 403) for a repo it was never granted, and GitHub reports a
+      // PAT's expiry in a header.
+      const res = await fetch(`${API}/repos/${this.owner}/${this.name}`, {
+        headers: {
+          'Authorization': `Bearer ${this.token}`,
+          'Accept': 'application/vnd.github+json',
+          'X-GitHub-Api-Version': '2022-11-28',
+        },
+      });
+      const data = await res.json().catch(() => ({}));
+
+      if (res.status === 401) {
+        throw new Error(
+          'Bad credentials — the token is invalid, expired or revoked. ' +
+            'Fine-grained PATs expire (30 days by default); generate a new one and save it again.',
+        );
+      }
+      if (res.status === 404) {
+        throw new Error(
+          `No access to ${this.owner}/${this.name}. The token is valid, so either the ` +
+            'owner/repo is wrong or the PAT does not list this repository — a fine-grained ' +
+            'token reports a repo it cannot see as "not found".',
+        );
+      }
+      if (!res.ok) {
+        throw new Error(`GitHub GET /repos/${this.owner}/${this.name} → ${res.status}: ${data.message || res.statusText}`);
+      }
+
+      const ref = await this.request('GET', `/git/ref/heads/${base}`);
+      if (ref.notFound) {
+        throw new Error(
+          `Base branch "${base}" is not readable — it does not exist, or the token is ` +
+            'missing the Contents permission.',
+        );
+      }
+
+      return {
+        repo: data.full_name || `${this.owner}/${this.name}`,
+        // Absent for token types that do not report it (a non-expiring PAT).
+        expiresAt: res.headers.get('github-authentication-token-expiration') || null,
+        canWrite: !data.permissions || data.permissions.push === true,
+      };
+    }
+
+    /**
      * Read and JSON-parse a file from `branch`, or null when it does not exist
      * there. Throws on any other failure so a caller can refuse to push rather
      * than silently overwriting data it failed to read.

--- a/scripts/transfermarkt-scraper/github.js
+++ b/scripts/transfermarkt-scraper/github.js
@@ -7,6 +7,17 @@
 (function (global) {
   const API = 'https://api.github.com';
 
+  // How many times to rebuild a commit onto a moved branch head before giving
+  // up. Three covers CI landing its normalize commit mid-push; more than that
+  // means something is pushing continuously and retrying will not help.
+  const COMMIT_ATTEMPTS = 3;
+
+  // GitHub rejects a ref update whose commit is not a descendant of the current
+  // head with a 422 rather than a conflict status.
+  function isNotFastForward(err) {
+    return err.status === 422 && /fast forward/i.test(err.message);
+  }
+
   class GitHubClient {
     /**
      * @param {string} token  Fine-grained PAT scoped to the repo, with
@@ -36,7 +47,9 @@
       const data = await res.json().catch(() => ({}));
       if (!res.ok) {
         const detail = data && data.message ? data.message : res.statusText;
-        throw new Error(`GitHub ${method} ${path} → ${res.status}: ${detail}`);
+        const err = new Error(`GitHub ${method} ${path} → ${res.status}: ${detail}`);
+        err.status = res.status;
+        throw err;
       }
       return data;
     }
@@ -147,10 +160,10 @@
      * @param {Array<{path: string, content: string}>} files
      */
     async commitFiles(branch, base, files, message) {
-      const headSha = await this.ensureBranch(branch, base);
-      const headCommit = await this.request('GET', `/git/commits/${headSha}`);
-      const baseTree = headCommit.tree.sha;
+      await this.ensureBranch(branch, base);
 
+      // Blobs are content-addressed and belong to no tree, so they are uploaded
+      // once and reused if the commit has to be rebuilt.
       const tree = [];
       for (const file of files) {
         const blob = await this.request('POST', '/git/blobs', {
@@ -160,22 +173,43 @@
         tree.push({ path: file.path, mode: '100644', type: 'blob', sha: blob.sha });
       }
 
-      const newTree = await this.request('POST', '/git/trees', {
-        base_tree: baseTree,
-        tree,
-      });
+      // The branch head can move while we are uploading: CI commits the
+      // normalized form of the previous push back to this same branch
+      // (.github/workflows/season-data.yml), which lands seconds after a push
+      // and makes the ref update a non-fast-forward. Rebuild the commit on the
+      // new head and try again — every file here is written whole, so rebasing
+      // onto a newer tree cannot conflict; the other files come from
+      // `base_tree`, and CI simply re-normalizes what we overwrite.
+      for (let attempt = 1; ; attempt++) {
+        const headSha = await this.getRefSha(branch);
+        const headCommit = await this.request('GET', `/git/commits/${headSha}`);
 
-      const commit = await this.request('POST', '/git/commits', {
-        message,
-        tree: newTree.sha,
-        parents: [headSha],
-      });
+        const newTree = await this.request('POST', '/git/trees', {
+          base_tree: headCommit.tree.sha,
+          tree,
+        });
 
-      await this.request('PATCH', `/git/refs/heads/${branch}`, {
-        sha: commit.sha,
-      });
+        const commit = await this.request('POST', '/git/commits', {
+          message,
+          tree: newTree.sha,
+          parents: [headSha],
+        });
 
-      return commit.sha;
+        try {
+          await this.request('PATCH', `/git/refs/heads/${branch}`, {
+            sha: commit.sha,
+          });
+          return commit.sha;
+        } catch (err) {
+          if (!isNotFastForward(err)) throw err;
+          if (attempt >= COMMIT_ATTEMPTS) {
+            throw new Error(
+              `"${branch}" moved under the push ${COMMIT_ATTEMPTS} times in a row — something is ` +
+                'committing to it continuously. Let the branch settle and push again.',
+            );
+          }
+        }
+      }
     }
 
     /**

--- a/scripts/transfermarkt-scraper/popup.html
+++ b/scripts/transfermarkt-scraper/popup.html
@@ -240,7 +240,9 @@
         <input id="ghRepo" class="tf-input" type="text" placeholder="owner/repo">
         <input id="ghBaseBranch" class="tf-input" type="text" placeholder="Base branch (main)">
         <button class="btn btn-secondary" id="saveSettingsBtn">Save settings</button>
+        <button class="btn btn-secondary" id="testSettingsBtn">Test GitHub connection</button>
         <span id="settingsStatus" style="font-size: 11px; color: #718096;"></span>
+        <div id="testResult" style="display:none; font-size: 11px; line-height: 1.5;"></div>
       </div>
     </details>
 

--- a/scripts/transfermarkt-scraper/popup.html
+++ b/scripts/transfermarkt-scraper/popup.html
@@ -289,7 +289,9 @@
     <div class="section-title">SEASON REFRESH</div>
     <p style="font-size: 11px; color: #718096; margin-bottom: 10px; line-height: 1.5;">
       Scrapes every league for the target season and pushes them to the
-      <code>season-data</code> branch in one commit + PR.
+      <code>season-data</code> branch in one commit + PR. <strong>European pool</strong>
+      then scrapes every UCL/UEL/UECL/UEFASUP participant that no league covers,
+      into <code>EUR/</code> — run it after the leagues and the participant lists.
     </p>
 
     <div class="status-bar">
@@ -303,6 +305,7 @@
 
     <div class="btn-row" style="margin-top: 10px">
       <button class="btn btn-primary" id="refreshStartBtn">Refresh all leagues</button>
+      <button class="btn btn-secondary" id="euroStartBtn">Refresh European pool</button>
       <button class="btn btn-warning" id="refreshStopBtn" disabled>Stop</button>
     </div>
     <div id="refreshResult" class="info" style="display:none"></div>

--- a/scripts/transfermarkt-scraper/popup.js
+++ b/scripts/transfermarkt-scraper/popup.js
@@ -529,7 +529,9 @@ const ghSeasonEl = document.getElementById('ghSeason');
 const ghRepoEl = document.getElementById('ghRepo');
 const ghBaseEl = document.getElementById('ghBaseBranch');
 const saveSettingsBtn = document.getElementById('saveSettingsBtn');
+const testSettingsBtn = document.getElementById('testSettingsBtn');
 const settingsStatus = document.getElementById('settingsStatus');
+const testResult = document.getElementById('testResult');
 
 async function loadSettings() {
   const s = await chrome.storage.local.get(['ghToken', 'ghSeason', 'ghRepo', 'ghBaseBranch']);
@@ -553,6 +555,49 @@ saveSettingsBtn.addEventListener('click', async () => {
   });
   settingsStatus.textContent = 'Saved ✓';
   setTimeout(() => { settingsStatus.textContent = ''; }, 2000);
+});
+
+function setTestResult(color, html) {
+  testResult.style.display = 'block';
+  testResult.style.color = color;
+  testResult.innerHTML = html;
+}
+
+// Checks the values currently in the fields rather than the saved ones, so a
+// freshly pasted token can be verified before it replaces a working one.
+testSettingsBtn.addEventListener('click', async () => {
+  testSettingsBtn.disabled = true;
+  setTestResult('#718096', 'Checking…');
+
+  try {
+    const resp = await chrome.runtime.sendMessage({
+      action: 'testGitHub',
+      settings: {
+        token: ghTokenEl.value.trim(),
+        repo: ghRepoEl.value.trim(),
+        base: ghBaseEl.value.trim(),
+      },
+    });
+
+    if (!resp) {
+      throw new Error('Background worker did not respond — reload the extension at chrome://extensions.');
+    }
+    if (!resp.ok) {
+      setTestResult('#fc8181', resp.error);
+      return;
+    }
+
+    const expiry = resp.expiresAt ? ` · token expires ${resp.expiresAt}` : '';
+    const warning = resp.canWrite
+      ? ''
+      : '<br><span style="color:#f6ad55">Read-only access reported — the push will fail. '
+        + 'Grant Contents and Pull requests: Read and write.</span>';
+    setTestResult('#68d391', `Connected to <strong>${resp.repo}</strong>${expiry}${warning}`);
+  } catch (err) {
+    setTestResult('#fc8181', err.message);
+  } finally {
+    testSettingsBtn.disabled = false;
+  }
 });
 
 loadSettings();

--- a/scripts/transfermarkt-scraper/popup.js
+++ b/scripts/transfermarkt-scraper/popup.js
@@ -657,6 +657,7 @@ pushBtn.addEventListener('click', async () => {
 // =========================================================================
 
 const refreshStartBtn = document.getElementById('refreshStartBtn');
+const euroStartBtn = document.getElementById('euroStartBtn');
 const refreshStopBtn = document.getElementById('refreshStopBtn');
 const refreshStatusDot = document.getElementById('refreshStatusDot');
 const refreshStatusText = document.getElementById('refreshStatusText');
@@ -667,17 +668,28 @@ const refreshResult = document.getElementById('refreshResult');
 
 let refreshPollingInterval = null;
 
+// Both drivers report through the same panel; only one can run at a time.
+const REFRESH_UNITS = { 'season-refresh': 'leagues', 'euro-refresh': 'clubs' };
+
+const isRefreshProgress = progress => !!progress && progress.pageType in REFRESH_UNITS;
+
 function setRefreshStatus(state, message) {
   refreshStatusDot.className = 'status-dot ' + state;
   refreshStatusText.textContent = message;
 }
 
-function setRefreshProgress(current, total) {
+function setRefreshRunning(running) {
+  refreshStartBtn.disabled = running;
+  euroStartBtn.disabled = running;
+  refreshStopBtn.disabled = !running;
+}
+
+function setRefreshProgress(current, total, unit) {
   if (total === 0) return;
   const pct = ((current / total) * 100).toFixed(0);
   refreshProgressBar.style.display = 'block';
   refreshProgressFill.style.width = pct + '%';
-  refreshCountBadge.textContent = `${current}/${total} leagues`;
+  refreshCountBadge.textContent = `${current}/${total} ${unit}`;
   refreshCountBadge.style.display = 'inline-block';
 }
 
@@ -693,28 +705,29 @@ function startRefreshPolling() {
     } catch {
       return;
     }
-    if (!progress || progress.pageType !== 'season-refresh') return;
+    if (!isRefreshProgress(progress)) return;
 
+    const unit = REFRESH_UNITS[progress.pageType];
     setRefreshStatus(progress.status, progress.message);
-    if (progress.total > 0) setRefreshProgress(progress.current, progress.total);
+    if (progress.total > 0) setRefreshProgress(progress.current, progress.total, unit);
 
     if (progress.status === 'ready') {
       stopRefreshPolling();
-      refreshStartBtn.disabled = false;
-      refreshStopBtn.disabled = true;
+      setRefreshRunning(false);
       if (progress.result && progress.result.prUrl) {
         const skipped = progress.result.failed || [];
+        const missing = progress.result.missingLists || [];
         refreshResult.style.display = 'block';
-        refreshResult.innerHTML = `Pushed ${progress.result.files} leagues — <a href="${progress.result.prUrl}" target="_blank">open PR ↗</a>`
-          + (skipped.length ? `<br>Skipped: ${skipped.join(', ')}` : '');
+        refreshResult.innerHTML = `Pushed ${progress.result.files} ${unit} — <a href="${progress.result.prUrl}" target="_blank">open PR ↗</a>`
+          + (skipped.length ? `<br>Skipped: ${skipped.join(', ')}` : '')
+          + (missing.length ? `<br>No participant list yet for: ${missing.join(', ')}` : '');
       }
       chrome.runtime.sendMessage({ action: 'clearProgress' });
     }
 
     if (progress.status === 'paused' || progress.status === 'error') {
       stopRefreshPolling();
-      refreshStartBtn.disabled = false;
-      refreshStopBtn.disabled = true;
+      setRefreshRunning(false);
     }
   }, 500);
 }
@@ -728,18 +741,18 @@ function stopRefreshPolling() {
 
 async function checkRefreshProgress() {
   const progress = await chrome.runtime.sendMessage({ action: 'getProgress' });
-  if (progress && progress.pageType === 'season-refresh' && progress.status === 'working') {
+  if (isRefreshProgress(progress) && progress.status === 'working') {
     setRefreshStatus('working', progress.message);
-    if (progress.total > 0) setRefreshProgress(progress.current, progress.total);
-    refreshStartBtn.disabled = true;
-    refreshStopBtn.disabled = false;
+    if (progress.total > 0) setRefreshProgress(progress.current, progress.total, REFRESH_UNITS[progress.pageType]);
+    setRefreshRunning(true);
     startRefreshPolling();
   }
 }
 
 checkRefreshProgress();
 
-refreshStartBtn.addEventListener('click', async () => {
+// Both drivers need saved settings and an active Transfermarkt tab to navigate.
+async function startRefreshDriver(action) {
   const { ghToken, ghSeason } = await chrome.storage.local.get(['ghToken', 'ghSeason']);
   if (!ghToken || !ghSeason) {
     setRefreshStatus('error', 'Set GitHub token + season in Settings first');
@@ -758,8 +771,7 @@ refreshStartBtn.addEventListener('click', async () => {
   }
 
   refreshResult.style.display = 'none';
-  refreshStartBtn.disabled = true;
-  refreshStopBtn.disabled = false;
+  setRefreshRunning(true);
   setRefreshStatus('working', 'Starting…');
 
   // A silent handshake failure used to leave the panel stuck on "Starting…"
@@ -767,17 +779,19 @@ refreshStartBtn.addEventListener('click', async () => {
   // running a stale build without this action) and nothing reset the buttons.
   try {
     await chrome.runtime.sendMessage({ action: 'clearProgress' });
-    const response = await chrome.runtime.sendMessage({ action: 'startSeasonRefresh', tabId: tab.id });
+    const response = await chrome.runtime.sendMessage({ action, tabId: tab.id });
     if (!response || !response.started) {
       throw new Error('Background worker did not respond — reload the extension at chrome://extensions.');
     }
     startRefreshPolling();
   } catch (err) {
     setRefreshStatus('error', err.message);
-    refreshStartBtn.disabled = false;
-    refreshStopBtn.disabled = true;
+    setRefreshRunning(false);
   }
-});
+}
+
+refreshStartBtn.addEventListener('click', () => startRefreshDriver('startSeasonRefresh'));
+euroStartBtn.addEventListener('click', () => startRefreshDriver('startEuroRefresh'));
 
 refreshStopBtn.addEventListener('click', async () => {
   refreshStopBtn.disabled = true;

--- a/scripts/transfermarkt-scraper/season-config.js
+++ b/scripts/transfermarkt-scraper/season-config.js
@@ -170,6 +170,48 @@
     return encode(sortClubPlayers(ordered));
   }
 
+  // The continental participants that need their own EUR pool file: the ones no
+  // league teams.json in the same season folder already supplies a squad for.
+  //
+  // Mirrors `app:validate-season`'s seedable-participant rule — a participant is
+  // seedable when some league or pool file in the season folder carries its
+  // squad — with one deliberate difference: EUR/INT files already on the branch
+  // do not count as covered. A pool file is last season's squad until this
+  // season re-scrapes it, so a refresh rebuilds all of them.
+  //
+  // Deduplicated by club id: the UEFA Super Cup's two participants also appear
+  // in the UCL and UEL lists.
+  //
+  // @param {Array<{code: string, clubs: Array}>} continentalLists
+  // @param {Array<{clubs: Array}>} leagueLists
+  // @returns {Array<{id: string, name: string, competitions: string[]}>} by id
+  function poolTargets(continentalLists, leagueLists) {
+    const covered = new Set();
+    for (const league of leagueLists) {
+      for (const club of league.clubs || []) {
+        const id = resolveClubId(club);
+        if (id) covered.add(id);
+      }
+    }
+
+    const targets = new Map();
+    for (const list of continentalLists) {
+      for (const club of list.clubs || []) {
+        const id = resolveClubId(club);
+        if (!id || covered.has(id)) continue;
+
+        const seen = targets.get(id);
+        if (seen) {
+          if (!seen.competitions.includes(list.code)) seen.competitions.push(list.code);
+          continue;
+        }
+        targets.set(id, { id, name: club.name || id, competitions: [list.code] });
+      }
+    }
+
+    return [...targets.values()].sort(byId(target => target.id));
+  }
+
   // Map a finished scrape result to the repo file it belongs in, or null when
   // the competition is not in the registry.
   //
@@ -211,6 +253,8 @@
     POOLS,
     countryCodeFor,
     findByTmId,
+    resolveClubId,
+    poolTargets,
     toTeamsJson,
     toPoolJson,
     repoFileForResult,

--- a/tests/js/github-client.test.js
+++ b/tests/js/github-client.test.js
@@ -1,0 +1,114 @@
+/**
+ * Tests for the Transfermarkt scraper's github.js — specifically `verify()`,
+ * the pre-flight the season refresh runs before it starts scraping.
+ *
+ * The failure it exists to prevent is silent and expensive: an expired PAT used
+ * to surface only on the push at the *end* of a full-season scrape, as a raw
+ * "GET /git/ref/heads/season-data/2026 → 401: Bad credentials". So what matters
+ * here is that each way the credentials can be wrong maps to a message naming
+ * the actual cause — a fine-grained PAT reports a repo it was never granted as
+ * a 404, which reads nothing like a permissions problem unless we say so.
+ */
+import { describe, it, expect, beforeAll, beforeEach, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+let GitHubClient;
+
+beforeAll(() => {
+    // github.js is a plain script that attaches to the global object (it is
+    // loaded via importScripts in the MV3 service worker, not imported).
+    globalThis.self = globalThis;
+    const src = readFileSync(
+        resolve(__dirname, '../../scripts/transfermarkt-scraper/github.js'),
+        'utf8',
+    );
+    // eslint-disable-next-line no-new-func
+    new Function(src)();
+    GitHubClient = globalThis.GitHubClient;
+});
+
+const response = (status, body = {}, headers = {}) => ({
+    status,
+    ok: status >= 200 && status < 300,
+    statusText: `status ${status}`,
+    json: async () => body,
+    headers: { get: name => headers[name] ?? null },
+});
+
+const REPO = { full_name: 'pabloroman/virtua-fc', permissions: { push: true } };
+const REF = { object: { sha: 'abc123' } };
+
+let fetchMock;
+
+beforeEach(() => {
+    fetchMock = vi.fn();
+    globalThis.fetch = fetchMock;
+});
+
+const client = () => new GitHubClient('github_pat_x', 'pabloroman/virtua-fc');
+
+describe('verify', () => {
+    it('reports an expired or revoked token as a credentials problem', async () => {
+        fetchMock.mockResolvedValueOnce(response(401, { message: 'Bad credentials' }));
+
+        await expect(client().verify('main')).rejects.toThrow(/Bad credentials — the token is invalid, expired or revoked/);
+    });
+
+    it('reads a 404 on the repo as missing access, not a missing repo', async () => {
+        fetchMock.mockResolvedValueOnce(response(404, { message: 'Not Found' }));
+
+        // A fine-grained PAT that does not list the repository gets a 404 here,
+        // so the message has to point at the token's repository selection.
+        await expect(client().verify('main')).rejects.toThrow(/does not list this repository/);
+    });
+
+    it('fails when the base branch cannot be read', async () => {
+        fetchMock
+            .mockResolvedValueOnce(response(200, REPO))
+            .mockResolvedValueOnce(response(404, { message: 'Not Found' }));
+
+        await expect(client().verify('main')).rejects.toThrow(/Base branch "main" is not readable/);
+    });
+
+    it('returns the repo and token expiry once both calls succeed', async () => {
+        fetchMock
+            .mockResolvedValueOnce(response(200, REPO, {
+                'github-authentication-token-expiration': '2026-10-01 12:00:00 UTC',
+            }))
+            .mockResolvedValueOnce(response(200, REF));
+
+        await expect(client().verify('main')).resolves.toEqual({
+            repo: 'pabloroman/virtua-fc',
+            expiresAt: '2026-10-01 12:00:00 UTC',
+            canWrite: true,
+        });
+    });
+
+    it('checks the base branch ref, which is the first call a push makes', async () => {
+        fetchMock
+            .mockResolvedValueOnce(response(200, REPO))
+            .mockResolvedValueOnce(response(200, REF));
+
+        await client().verify('main');
+
+        expect(fetchMock.mock.calls[0][0]).toBe('https://api.github.com/repos/pabloroman/virtua-fc');
+        expect(fetchMock.mock.calls[1][0]).toBe('https://api.github.com/repos/pabloroman/virtua-fc/git/ref/heads/main');
+    });
+
+    it('flags a read-only token instead of failing — write access cannot be proven without writing', async () => {
+        fetchMock
+            .mockResolvedValueOnce(response(200, { ...REPO, permissions: { push: false } }))
+            .mockResolvedValueOnce(response(200, REF));
+
+        await expect(client().verify('main')).resolves.toMatchObject({ canWrite: false });
+    });
+
+    it('assumes write access when the repo endpoint reports no permissions block', async () => {
+        fetchMock
+            .mockResolvedValueOnce(response(200, { full_name: 'pabloroman/virtua-fc' }))
+            .mockResolvedValueOnce(response(200, REF));
+
+        await expect(client().verify('main')).resolves.toMatchObject({ canWrite: true, expiresAt: null });
+    });
+});

--- a/tests/js/github-client.test.js
+++ b/tests/js/github-client.test.js
@@ -112,3 +112,94 @@ describe('verify', () => {
         await expect(client().verify('main')).resolves.toMatchObject({ canWrite: true, expiresAt: null });
     });
 });
+
+/**
+ * A stand-in for the Git Data endpoints `commitFiles` drives, so the retry can
+ * be tested as a sequence rather than as a fixed list of canned responses.
+ * `failPatchTimes` makes the ref update fail as a non-fast-forward that many
+ * times, moving the head each time — what CI's normalize commit does when it
+ * lands mid-push.
+ */
+const gitDataServer = ({ failPatchTimes = 0, patchError = null } = {}) => {
+    const state = { head: 'head1', blobs: 0, trees: [], commits: [] };
+    let remainingFailures = failPatchTimes;
+    let movedHeads = 0;
+
+    globalThis.fetch = vi.fn(async (url, init = {}) => {
+        const method = init.method || 'GET';
+        const path = url.replace('https://api.github.com/repos/pabloroman/virtua-fc', '');
+        const body = init.body ? JSON.parse(init.body) : null;
+
+        if (method === 'GET' && path.startsWith('/git/ref/heads/')) {
+            return response(200, { object: { sha: state.head } });
+        }
+        if (method === 'GET' && path.startsWith('/git/commits/')) {
+            return response(200, { tree: { sha: `tree-of-${path.split('/').pop()}` } });
+        }
+        if (method === 'POST' && path === '/git/blobs') {
+            state.blobs += 1;
+            return response(201, { sha: `blob${state.blobs}` });
+        }
+        if (method === 'POST' && path === '/git/trees') {
+            state.trees.push(body);
+            return response(201, { sha: `tree${state.trees.length}` });
+        }
+        if (method === 'POST' && path === '/git/commits') {
+            state.commits.push(body);
+            return response(201, { sha: `commit${state.commits.length}` });
+        }
+        if (method === 'PATCH' && path.startsWith('/git/refs/heads/')) {
+            if (patchError) return response(patchError, { message: 'nope' });
+            if (remainingFailures > 0) {
+                remainingFailures -= 1;
+                movedHeads += 1;
+                state.head = `head${movedHeads + 1}`;
+                return response(422, { message: 'Update is not a fast forward' });
+            }
+            state.head = body.sha;
+            return response(200, { object: { sha: body.sha } });
+        }
+        throw new Error(`unexpected ${method} ${path}`);
+    });
+
+    return state;
+};
+
+const FILES = [{ path: 'data/2026/UCL/teams.json', content: '{}' }];
+
+describe('commitFiles — a branch head that moves mid-push', () => {
+    it('rebuilds the commit on the new head and pushes it', async () => {
+        const state = gitDataServer({ failPatchTimes: 1 });
+
+        await expect(client().commitFiles('season-data/2026', 'main', FILES, 'msg')).resolves.toBe('commit2');
+
+        // The second attempt parents off the head CI moved to, and takes its
+        // base tree from there — so CI's commit survives instead of being
+        // reverted by the retry.
+        expect(state.commits[0].parents).toEqual(['head1']);
+        expect(state.commits[1].parents).toEqual(['head2']);
+        expect(state.trees[1].base_tree).toBe('tree-of-head2');
+    });
+
+    it('uploads each blob once across retries', async () => {
+        const state = gitDataServer({ failPatchTimes: 2 });
+
+        await client().commitFiles('season-data/2026', 'main', FILES, 'msg');
+
+        expect(state.blobs).toBe(1);
+    });
+
+    it('gives up after three collisions with a message naming the branch', async () => {
+        gitDataServer({ failPatchTimes: 3 });
+
+        await expect(client().commitFiles('season-data/2026', 'main', FILES, 'msg'))
+            .rejects.toThrow(/"season-data\/2026" moved under the push 3 times in a row/);
+    });
+
+    it('does not retry a failure that is not a fast-forward conflict', async () => {
+        const state = gitDataServer({ patchError: 403 });
+
+        await expect(client().commitFiles('season-data/2026', 'main', FILES, 'msg')).rejects.toThrow(/403/);
+        expect(state.commits).toHaveLength(1);
+    });
+});

--- a/tests/js/season-config.test.js
+++ b/tests/js/season-config.test.js
@@ -168,3 +168,77 @@ describe('repoFileForResult', () => {
         expect(parse(file.content).country).toBe('NL');
     });
 });
+
+/**
+ * poolTargets decides which continental participants get scraped into EUR/.
+ *
+ * Both directions cost real work if wrong: a club wrongly included is a
+ * redundant pool file (and a needless page load in a run that already takes
+ * minutes), while a club wrongly excluded has no squad at all — the seeder drops
+ * it, SeasonInitializationService then skips the whole league phase, and the
+ * competition ends up with no fixtures and nothing said about it in-game.
+ */
+describe('poolTargets — clubs that still need an EUR pool file', () => {
+    const league = clubs => ({ code: 'ESP1', clubs });
+    const ucl = clubs => ({ code: 'UCL', clubs });
+
+    it('keeps participants no league covers', () => {
+        const targets = SeasonConfig.poolTargets(
+            [ucl([{ id: '418', name: 'Real Madrid' }, { id: '10482', name: 'Kairat Almaty' }])],
+            [league([{ transfermarktId: '418', name: 'Real Madrid' }])],
+        );
+
+        expect(targets).toEqual([{ id: '10482', name: 'Kairat Almaty', competitions: ['UCL'] }]);
+    });
+
+    it('matches league clubs on transfermarktId, which is the key league files use', () => {
+        // Continental lists carry `id`; league teams.json carries
+        // `transfermarktId`. Comparing the raw keys would cover nothing.
+        const targets = SeasonConfig.poolTargets(
+            [ucl([{ id: '11', name: 'Arsenal' }])],
+            [league([{ transfermarktId: '11', name: 'Arsenal' }])],
+        );
+
+        expect(targets).toEqual([]);
+    });
+
+    it('falls back to the crest url for a club with no id fields', () => {
+        const targets = SeasonConfig.poolTargets(
+            [ucl([{ id: '11', name: 'Arsenal' }])],
+            [league([{ name: 'Arsenal', image: 'https://tmssl.akamaized.net/images/wappen/big/11.png' }])],
+        );
+
+        expect(targets).toEqual([]);
+    });
+
+    it('lists a club once, naming every competition it plays in', () => {
+        // The Super Cup's two participants are also in the UCL and UEL lists;
+        // scraping the same squad twice would push two identical files.
+        const targets = SeasonConfig.poolTargets(
+            [
+                ucl([{ id: '10482', name: 'Kairat Almaty' }]),
+                { code: 'UEFASUP', clubs: [{ id: '10482', name: 'Kairat Almaty' }] },
+            ],
+            [],
+        );
+
+        expect(targets).toEqual([
+            { id: '10482', name: 'Kairat Almaty', competitions: ['UCL', 'UEFASUP'] },
+        ]);
+    });
+
+    it('orders by club id so a re-run walks the same sequence', () => {
+        const targets = SeasonConfig.poolTargets(
+            [ucl([{ id: '10482', name: 'Kairat' }, { id: '294', name: 'Slavia' }, { id: '1090', name: 'Pafos' }])],
+            [],
+        );
+
+        expect(targets.map(t => t.id)).toEqual(['294', '1090', '10482']);
+    });
+
+    it('skips entries with no resolvable id rather than scraping a bad url', () => {
+        const targets = SeasonConfig.poolTargets([ucl([{ name: 'Mystery FC' }])], []);
+
+        expect(targets).toEqual([]);
+    });
+});


### PR DESCRIPTION
## Summary

Adds a new batch scraper for continental competition participants that need individual squad files, plus pre-flight credential verification to catch token/repo issues before a long scrape begins.

## Key Changes

**European Pool Refresh (`startEuropeanPoolRefresh`)**
- New batch driver to scrape `data/{season}/EUR/{id}.json` files for continental participants not covered by league squads
- Reads UCL/UEL/UECL/UEFASUP participant lists and league `teams.json` files from the season branch
- Deduplicates clubs appearing in multiple competitions (e.g., Super Cup participants also in UCL/UEL)
- Refuses to run if any league's squads are missing (would treat all ~108 participants as pool clubs)
- Pushes all scraped files in one commit + PR, with per-club error handling matching the season refresh pattern

**GitHub Credential Verification (`verifyGitHub`)**
- New pre-flight check that exercises the same three operations a push needs: token validation, repo access, and base branch read
- Runs before season/pool refreshes start, catching expired/revoked tokens in seconds rather than after a full scrape
- Distinguishes between token problems (401), missing repo access (404 on fine-grained PATs), and missing base branch
- Reports token expiry date and write access status (read-only tokens are flagged but don't block)
- Callable from the Settings panel to test values before saving them

**Refactored Club Scraping**
- Renamed `scrapePlayersFromTab` internals to `scrapeClubFromTab` to reflect that it now returns the full club record (name, country, stadium, squad)
- `scrapePlayersFromTab` now calls `scrapeClubFromTab` and extracts just the players array
- Enables pool refresh to access club metadata alongside squad data

**UI Updates**
- Added "Test GitHub connection" button in Settings to verify credentials before saving
- Added "Refresh European pool" button in the Season Refresh panel
- Both refresh drivers (season and pool) report through the same progress panel; only one can run at a time
- Progress badge now shows unit name ("leagues" vs "clubs") based on which driver is active
- Result display shows missing participant lists alongside failed clubs

**GitHub Client Enhancements**
- `commitFiles` now retries up to 3 times when the branch head moves mid-push (non-fast-forward conflict)
- Rebuilds the commit on the new head each retry, preserving CI's normalize commits that land during the push
- Blobs are uploaded once and reused across retries (content-addressed)
- Gives up after 3 collisions with a clear message naming the branch

**Tests**
- Added comprehensive test suite for `GitHubClient.verify()` covering token expiry, repo access, base branch reads, and permission detection
- Added tests for `commitFiles` retry logic with moving branch heads
- Added `SeasonConfig.poolTargets()` tests covering deduplication, league matching, and edge cases

## Implementation Details

- `europeanPoolTargets()` reads from both the season branch and base branch (fallback) to handle the first push of a file
- Pool targets are sorted by club ID for deterministic re-run ordering
- Club ID resolution falls back to extracting from crest image URLs when `id`/`transfermarktId` fields are absent
- The `verifyGitHub` function accepts an `overrides` parameter so the Settings panel can test unsaved values
- Error messages name the specific failure (token, repo, branch) rather than generic "credentials failed"

https://claude.ai/code/session_01DUBQTcnfFLo8959LDXsYju