### PR TITLE
Push a whole season in four requests instead of one per file

### DIFF
--- a/scripts/transfermarkt-scraper/README.md
+++ b/scripts/transfermarkt-scraper/README.md
@@ -108,6 +108,12 @@ curl -sS -D- -o /dev/null \
 `200` is fine (the `github-authentication-token-expiration` header gives the
 expiry), `401` is a bad token, `404` is a token without access to this repo.
 
+A push that sits on one line for minutes is not necessarily stuck: the popup now
+names each phase (uploading, creating the commit, updating the branch, opening
+the PR). If it does stall, open the service worker console
+(`chrome://extensions` → the extension's **service worker** link) — the driver
+logs there, and MV3 tears the worker down if the popup is closed while it runs.
+
 `422: Update is not a fast forward` means the branch head moved while the push
 was uploading — normally CI's `Canonicalize season {year} squad data` commit
 from your *previous* push landing a few seconds later. The push now rebuilds its

--- a/scripts/transfermarkt-scraper/background.js
+++ b/scripts/transfermarkt-scraper/background.js
@@ -446,7 +446,7 @@ async function previousContinentalClubs(result, pageType, season) {
   return existing && Array.isArray(existing.clubs) ? existing.clubs : null;
 }
 
-async function pushFilesToGitHub(files, season) {
+async function pushFilesToGitHub(files, season, onPhase = () => {}) {
   const { token, repo, base } = await getSettings();
   if (!token) throw new Error('No GitHub token set — open Settings.');
   if (files.length === 0) throw new Error('Nothing to push.');
@@ -455,8 +455,9 @@ async function pushFilesToGitHub(files, season) {
   const branch = SeasonConfig.branchFor(season);
   const message = `Season ${season} data refresh (${files.length} file${files.length === 1 ? '' : 's'})`;
 
-  await gh.commitFiles(branch, base, files, message);
+  await gh.commitFiles(branch, base, files, message, onPhase);
 
+  onPhase('Opening the pull request…');
   return gh.ensurePullRequest(
     branch,
     base,
@@ -627,9 +628,11 @@ async function startEuropeanPoolRefresh(tabId) {
     throw new Error(`Every club failed (${failed.length}) — nothing to push.`);
   }
 
-  await updateProgress({ status: 'working', message: `Pushing ${files.length} pool files to GitHub…`, current: targets.length, total: targets.length, pageType: 'euro-refresh' });
-
-  const prUrl = await pushFilesToGitHub(files, season);
+  // Each phase is also a chrome.storage write, which resets the service
+  // worker's idle timer — a long silent stretch is when MV3 tears it down, and
+  // a torn-down push looks exactly like a hang from the popup.
+  const prUrl = await pushFilesToGitHub(files, season, phase =>
+    updateProgress({ status: 'working', message: phase, current: targets.length, total: targets.length, pageType: 'euro-refresh' }));
 
   const summary = failed.length
     ? `Done — ${files.length} clubs pushed, ${failed.length} failed`
@@ -708,9 +711,8 @@ async function startSeasonRefresh(tabId) {
     throw new Error(`Every league failed (${failed.join(', ')}) — nothing to push.`);
   }
 
-  await updateProgress({ status: 'working', message: `Pushing ${files.length} files to GitHub…`, current: leagues.length, total: leagues.length, pageType: 'season-refresh' });
-
-  const prUrl = await pushFilesToGitHub(files, season);
+  const prUrl = await pushFilesToGitHub(files, season, phase =>
+    updateProgress({ status: 'working', message: phase, current: leagues.length, total: leagues.length, pageType: 'season-refresh' }));
 
   const summary = failed.length
     ? `Done — ${files.length} leagues pushed, ${failed.length} failed (${failed.join(', ')})`

--- a/scripts/transfermarkt-scraper/github.js
+++ b/scripts/transfermarkt-scraper/github.js
@@ -159,19 +159,20 @@
      *
      * @param {Array<{path: string, content: string}>} files
      */
-    async commitFiles(branch, base, files, message) {
+    async commitFiles(branch, base, files, message, onPhase = () => {}) {
       await this.ensureBranch(branch, base);
 
-      // Blobs are content-addressed and belong to no tree, so they are uploaded
-      // once and reused if the commit has to be rebuilt.
-      const tree = [];
-      for (const file of files) {
-        const blob = await this.request('POST', '/git/blobs', {
-          content: file.content,
-          encoding: 'utf-8',
-        });
-        tree.push({ path: file.path, mode: '100644', type: 'blob', sha: blob.sha });
-      }
+      // File contents go inline in the tree and GitHub writes the blobs itself,
+      // so a push costs four requests whatever its size. Creating a blob per
+      // file first cost one write request each: fine for the eight league files,
+      // but a European pool refresh pushes ~70 and that ran for minutes against
+      // GitHub's secondary rate limit on content-creating requests.
+      const tree = files.map(file => ({
+        path: file.path,
+        mode: '100644',
+        type: 'blob',
+        content: file.content,
+      }));
 
       // The branch head can move while we are uploading: CI commits the
       // normalized form of the previous push back to this same branch
@@ -184,11 +185,13 @@
         const headSha = await this.getRefSha(branch);
         const headCommit = await this.request('GET', `/git/commits/${headSha}`);
 
+        onPhase(`Uploading ${files.length} file${files.length === 1 ? '' : 's'}…`);
         const newTree = await this.request('POST', '/git/trees', {
           base_tree: headCommit.tree.sha,
           tree,
         });
 
+        onPhase('Creating the commit…');
         const commit = await this.request('POST', '/git/commits', {
           message,
           tree: newTree.sha,
@@ -196,6 +199,7 @@
         });
 
         try {
+          onPhase('Updating the branch…');
           await this.request('PATCH', `/git/refs/heads/${branch}`, {
             sha: commit.sha,
           });
@@ -208,6 +212,7 @@
                 'committing to it continuously. Let the branch settle and push again.',
             );
           }
+          onPhase(`Branch moved — rebuilding (attempt ${attempt + 1})…`);
         }
       }
     }

--- a/tests/js/github-client.test.js
+++ b/tests/js/github-client.test.js
@@ -121,7 +121,7 @@ describe('verify', () => {
  * lands mid-push.
  */
 const gitDataServer = ({ failPatchTimes = 0, patchError = null } = {}) => {
-    const state = { head: 'head1', blobs: 0, trees: [], commits: [] };
+    const state = { head: 'head1', trees: [], commits: [] };
     let remainingFailures = failPatchTimes;
     let movedHeads = 0;
 
@@ -135,10 +135,6 @@ const gitDataServer = ({ failPatchTimes = 0, patchError = null } = {}) => {
         }
         if (method === 'GET' && path.startsWith('/git/commits/')) {
             return response(200, { tree: { sha: `tree-of-${path.split('/').pop()}` } });
-        }
-        if (method === 'POST' && path === '/git/blobs') {
-            state.blobs += 1;
-            return response(201, { sha: `blob${state.blobs}` });
         }
         if (method === 'POST' && path === '/git/trees') {
             state.trees.push(body);
@@ -181,12 +177,41 @@ describe('commitFiles — a branch head that moves mid-push', () => {
         expect(state.trees[1].base_tree).toBe('tree-of-head2');
     });
 
-    it('uploads each blob once across retries', async () => {
-        const state = gitDataServer({ failPatchTimes: 2 });
+    it('carries file contents inline in the tree, in one request per attempt', async () => {
+        // One write request per file put a ~70-file European pool push against
+        // GitHub's secondary rate limit; the trees API writes the blobs itself.
+        const state = gitDataServer();
+        const files = [
+            { path: 'data/2026/EUR/11.json', content: '{"a":1}' },
+            { path: 'data/2026/EUR/418.json', content: '{"b":2}' },
+        ];
 
-        await client().commitFiles('season-data/2026', 'main', FILES, 'msg');
+        await client().commitFiles('season-data/2026', 'main', files, 'msg');
 
-        expect(state.blobs).toBe(1);
+        expect(state.trees).toHaveLength(1);
+        expect(state.trees[0].tree).toEqual([
+            { path: 'data/2026/EUR/11.json', mode: '100644', type: 'blob', content: '{"a":1}' },
+            { path: 'data/2026/EUR/418.json', mode: '100644', type: 'blob', content: '{"b":2}' },
+        ]);
+        // Four requests regardless of file count: read ref, read commit, tree, commit, ref update.
+        expect(globalThis.fetch.mock.calls.filter(([url]) => url.includes('/git/blobs'))).toHaveLength(0);
+    });
+
+    it('reports each phase so a long push is visible and the worker stays awake', async () => {
+        gitDataServer({ failPatchTimes: 1 });
+        const phases = [];
+
+        await client().commitFiles('season-data/2026', 'main', FILES, 'msg', p => phases.push(p));
+
+        expect(phases).toEqual([
+            'Uploading 1 file…',
+            'Creating the commit…',
+            'Updating the branch…',
+            'Branch moved — rebuilding (attempt 2)…',
+            'Uploading 1 file…',
+            'Creating the commit…',
+            'Updating the branch…',
+        ]);
     });
 
     it('gives up after three collisions with a message naming the branch', async () => {


### PR DESCRIPTION
The European pool refresh added in #1331 scraped its ~70 clubs and then sat on `Pushing 70 pool files to GitHub…` indefinitely.

## Cause

`commitFiles` created a blob per file before building the tree, so a push cost one write request per file:

```js
for (const file of files) {
  const blob = await this.request('POST', '/git/blobs', { content: file.content, encoding: 'utf-8' });
  tree.push({ path: file.path, mode: '100644', type: 'blob', sha: blob.sha });
}
```

Eight league files never showed it. Seventy pool files fire ~70 content-creating requests back to back, which is where GitHub's secondary rate limit sits, and the whole stretch reported no progress at all — so a slow push and a dead push looked identical from the popup.

## Changes

- **Contents go inline in the tree.** The trees API takes a `content` per entry and writes the blobs itself, so a push is four requests whatever its size: read ref, read commit, create tree, create commit, update ref.
- **Each push phase is reported** (`Uploading 70 files…`, `Creating the commit…`, `Updating the branch…`, `Opening the pull request…`, and `Branch moved — rebuilding (attempt 2)…` when the non-fast-forward retry fires). Two reasons: a long push becomes legible instead of looking hung, and every phase is a `chrome.storage` write, which resets the MV3 service worker's idle timer. A long silent stretch is exactly when the worker gets torn down, and a torn-down push is indistinguishable from a hang — the popup just keeps polling the last stored progress forever.
- README notes the phase reporting and points at the service worker console for a genuine stall.

## Tests

`tests/js/github-client.test.js` — the old "uploads each blob once" test is replaced by one asserting the tree carries inline content and `/git/blobs` is never called, plus one pinning the phase sequence across a rebuild. 34 JS tests passing across the two scraper suites.

Reload the extension at `chrome://extensions` after pulling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DUBQTcnfFLo8959LDXsYju

---
_Generated by [Claude Code](https://claude.ai/code/session_01DUBQTcnfFLo8959LDXsYju)_