### PR TITLE
Fix the season-data pipeline: weekday-preserving schedules, correct continental scrape

### DIFF
--- a/app/Console/Commands/ScaffoldSeason.php
+++ b/app/Console/Commands/ScaffoldSeason.php
@@ -12,10 +12,11 @@ use Illuminate\Console\Command;
  *
  * Creates `data/{season}/{COMP}/` for every competition declared in
  * config/countries.php and bootstraps each `schedule.json` by copying the
- * source season's calendar with every date shifted forward by the year
- * difference. Squad data (`teams.json` and EUR/INT pool files) is *not*
- * generated — those come from the scraper — so the command finishes by
- * printing a checklist of the squad files still missing for the new season.
+ * source season's calendar with every date shifted forward by the same whole
+ * number of weeks, so every fixture keeps its weekday (see `shiftDays()`).
+ * Squad data (`teams.json` and EUR/INT pool files) is *not* generated — those
+ * come from the scraper — so the command finishes by printing a checklist of
+ * the squad files still missing for the new season.
  *
  * Typical yearly use:
  *   php artisan app:scaffold-season 2026
@@ -54,7 +55,10 @@ class ScaffoldSeason extends Command
             return self::FAILURE;
         }
 
-        $this->info("Scaffolding data/{$season} from data/{$from} (shift {$yearDiff}y)...");
+        $shiftDays = $this->shiftDays((int) $from, $yearDiff);
+        $shiftWeeks = intdiv($shiftDays, 7);
+
+        $this->info("Scaffolding data/{$season} from data/{$from} (shift {$shiftDays}d = {$shiftWeeks} weeks, weekday-preserving)...");
         $this->newLine();
 
         $missing = [];
@@ -77,9 +81,9 @@ class ScaffoldSeason extends Command
                     $this->line("  {$code}: schedule.json exists (skipped; --force to overwrite)");
                 } else {
                     $data = json_decode(file_get_contents($srcSchedule), true);
-                    $shiftedData = $this->shiftDates($data, $yearDiff);
+                    $shiftedData = $this->shiftDates($data, $shiftDays);
                     file_put_contents($dstSchedule, json_encode($shiftedData, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) . "\n");
-                    $this->line("  {$code}: schedule.json shifted {$yearDiff}y → data/{$season}/{$code}/");
+                    $this->line("  {$code}: schedule.json shifted {$shiftDays}d → data/{$season}/{$code}/");
                     $shifted++;
                 }
             }
@@ -144,21 +148,43 @@ class ScaffoldSeason extends Command
     }
 
     /**
-     * Recursively shift every YYYY-MM-DD value (under any key) forward by
-     * $yearDiff years, preserving all other fields and structure.
+     * Days to move every fixture forward: the year difference rounded *up* to a
+     * whole number of weeks.
+     *
+     * Whole weeks are what keep the calendar realistic. Every date lands on the
+     * weekday it had in the source season, so leagues stay on Saturday/Sunday,
+     * Champions League nights on Tuesday/Wednesday, Europa/Conference on
+     * Thursday and the domestic cups midweek. A plain +1 year does not: 365 days
+     * is 52 weeks *plus a day*, which slides the whole season one weekday over.
+     * Rounding up rather than down also starts the new season after the old one
+     * finished (1 year → 371 days = 53 weeks).
      */
-    private function shiftDates(mixed $value, int $yearDiff): mixed
+    private function shiftDays(int $from, int $yearDiff): int
+    {
+        // Anchored on 1 August of the source season — a football season's
+        // start — so any leap day inside the span is counted.
+        $anchor = Carbon::parse("{$from}-08-01");
+        $days = (int) $anchor->diffInDays($anchor->copy()->addYears($yearDiff));
+
+        return (int) ceil($days / 7) * 7;
+    }
+
+    /**
+     * Recursively shift every YYYY-MM-DD value (under any key) forward by
+     * $shiftDays days, preserving all other fields and structure.
+     */
+    private function shiftDates(mixed $value, int $shiftDays): mixed
     {
         if (is_array($value)) {
             $out = [];
             foreach ($value as $k => $v) {
-                $out[$k] = $this->shiftDates($v, $yearDiff);
+                $out[$k] = $this->shiftDates($v, $shiftDays);
             }
             return $out;
         }
 
         if (is_string($value) && preg_match('/^\d{4}-\d{2}-\d{2}$/', $value)) {
-            return Carbon::parse($value)->addYears($yearDiff)->format('Y-m-d');
+            return Carbon::parse($value)->addDays($shiftDays)->format('Y-m-d');
         }
 
         return $value;

--- a/app/Console/Commands/ValidateSeason.php
+++ b/app/Console/Commands/ValidateSeason.php
@@ -27,6 +27,8 @@ use Illuminate\Console\Command;
  * SeedReferenceData, and SeasonInitializationService then finds an incomplete
  * league phase and skips it — leaving a competition with no fixtures at all and
  * nothing user-visible to explain why. Catching that here is the whole point.
+ * Their shape is checked too: a Swiss league phase is exactly 36 clubs and no
+ * club appears in two of them, a continental knockout is exactly two.
  *
  * Exits non-zero if any error is found so it can gate a release pipeline.
  */
@@ -42,6 +44,16 @@ class ValidateSeason extends Command
 
     /** @var string[] */
     private array $warnings = [];
+
+    /**
+     * Transfermarkt id -> the Swiss competition that already claimed it. A club
+     * plays in exactly one of UCL/UEL/UECL, so a second claim is a data error.
+     * The Super Cup is deliberately absent: its two finalists legitimately also
+     * play in that season's Champions or Europa League.
+     *
+     * @var array<string, string>
+     */
+    private array $swissEntrants = [];
 
     /**
      * Every transfermarkt id in this season folder that can supply a squad —
@@ -155,13 +167,57 @@ class ValidateSeason extends Command
             $this->warnings[] = "{$code}: no schedule.json (knockout/round dates) found.";
         }
 
+        $errorsBefore = count($this->errors);
+
         $this->validateParticipantsAreSeedable($code, $season, $clubs);
 
         if ($handler === 'swiss_format') {
             $this->validateSwissShape($code, $clubs);
+            $this->validateNoRepeatEntrants($code, $clubs);
         }
 
-        $this->line("  {$code}: " . count($clubs) . " clubs ✓");
+        // A continental knockout is the one-off Super Cup: prior UCL winner v
+        // prior UEL winner, a single tie. On the initial season those two rows
+        // *are* the finalists (UefaSuperCupQualificationProcessor leaves seed
+        // data alone), so any other count produces a draw that cannot be made.
+        if ($handler === 'knockout_cup') {
+            $total = count($clubs);
+            if ($total !== 2) {
+                $this->errors[] = "{$code}: a continental knockout is a single two-club tie, got {$total} clubs.";
+            }
+        }
+
+        if (count($this->errors) === $errorsBefore) {
+            $this->line("  {$code}: " . count($clubs) . " clubs ✓");
+        }
+    }
+
+    /**
+     * A club plays in exactly one of the Swiss competitions. Two claims mean the
+     * participant lists were read off a page that spans more than one — a
+     * fixture list including qualifying rounds puts a club knocked out of the
+     * Champions League into both it and the Europa League.
+     *
+     * @param  array<int, array<string, mixed>>  $clubs
+     */
+    private function validateNoRepeatEntrants(string $code, array $clubs): void
+    {
+        foreach ($clubs as $club) {
+            if (empty($club['id'])) {
+                continue;   // already reported by validateParticipantsAreSeedable
+            }
+
+            $id = (string) $club['id'];
+            $name = $club['name'] ?? '(unnamed)';
+
+            if (isset($this->swissEntrants[$id])) {
+                $this->errors[] = "{$code}: '{$name}' ({$id}) is also a {$this->swissEntrants[$id]} "
+                    . 'entrant — a club plays in one European competition per season.';
+                continue;
+            }
+
+            $this->swissEntrants[$id] = $code;
+        }
     }
 
     /**

--- a/docs/season-data-refresh.md
+++ b/docs/season-data-refresh.md
@@ -95,8 +95,11 @@ add/remove line, not a reshuffled roster.
    - `data/2026/{CUP}/teams.json` participant lists (ESPCUP, ESPSUP).
    - `data/2026/{UCL,UEL,UECL,UEFASUP}/teams.json` participant lists. These are
      independent of the transfer window — the draws are known before it shuts —
-     so they can go in first. Their squads cannot: every participant outside the
-     eight scraped leagues needs an `EUR` pool file (70 of 108 slots in 2025) —
+     so they can go in first. Scrape UCL/UEL/UECL from the **league-phase table**
+     (`/tabelle/pokalwettbewerb/...`), not the fixture list: the fixture list
+     spans qualifying, so it returns every club knocked out on the way in too.
+     Their squads cannot go in first: every participant outside the eight
+     scraped leagues needs an `EUR` pool file (70 of 108 slots in 2025) —
      **Season Refresh → Refresh European pool** derives that list from the
      participant lists and league squads already on the branch and scrapes them
      in one batch, so run it after both are pushed. Add `pot` by hand for a

--- a/docs/season-data-refresh.md
+++ b/docs/season-data-refresh.md
@@ -64,7 +64,7 @@ add/remove line, not a reshuffled roster.
 
 | Command | What it does |
 |---------|--------------|
-| `app:scaffold-season {season}` | Create folders, bootstrap schedules from last season. |
+| `app:scaffold-season {season}` | Create folders, bootstrap schedules from last season (dates shifted by whole weeks, so weekdays hold). |
 | `app:normalize-season {season} [--check]` | Force `seasonID`, sort clubs/players, canonical 2-space formatting. `--check` verifies without writing (the CI gate). Idempotent. |
 | `app:validate-season {season}` | Read-only completeness/correctness gate (non-zero exit on any problem). Database-free, so CI can run it without Postgres. |
 | `app:diff-season {season} [--from=] [--format=md]` | Report signings, departures, and club movements vs a previous season. |
@@ -77,7 +77,8 @@ add/remove line, not a reshuffled roster.
    `2025` so the engine keeps using `data/2025/` until the new season is ready.)
 
 2. **Scaffold the data folder** (creates dirs, bootstraps `schedule.json` for
-   every competition by shifting last season's dates forward one year):
+   every competition by shifting last season's dates forward a whole number of
+   weeks):
 
    ```bash
    php artisan app:scaffold-season 2026
@@ -163,8 +164,12 @@ add/remove line, not a reshuffled roster.
   competition id, so flipping the base season re-points it for everyone. Do not
   re-seed an active production DB mid-season — a live game would then compute a
   negative year offset for its fixtures.
-- **Year boundary.** A league season spans Aug → Jun; the scaffolder shifts each
-  absolute date by one year, preserving the crossover (Aug 2026 → May 2027).
+- **Year boundary.** A league season spans Aug → Jun; the scaffolder shifts every
+  absolute date by the same whole number of weeks — a year rounded up, so 371
+  days (53 weeks) for a one-year bump. That preserves the crossover (Aug 2026 →
+  May 2027) *and* every fixture's weekday, so leagues stay on Saturday/Sunday,
+  European nights on Tuesday–Thursday and the cups midweek. A plain +1 year would
+  not: 365 days is 52 weeks plus a day, sliding the whole season one weekday over.
 - **World Cup (WC2026) is out of scope.** It is a fixed real-world tournament
   under `data/2025/WC2026/` with its own commands and is intentionally *not*
   tied to the career base season.

--- a/scripts/transfermarkt-scraper/README.md
+++ b/scripts/transfermarkt-scraper/README.md
@@ -124,11 +124,28 @@ surface; if it does, something is committing to the branch continuously.
 
 After scraping a supported page, click **Push to GitHub**:
 
-- **League** (stadiums) and **cup/continental** (fixtures) pages → written to
+- **League** (stadiums) and **cup/continental** participant pages → written to
   `data/{season}/{CODE}/teams.json` (the repo code is resolved from the
   Transfermarkt competition id via `season-config.js`).
 - **Single club squad** pages → written to `data/{season}/{EUR|INT}/{id}.json`;
   pick the pool from the selector that appears.
+
+Which page a participant list comes from depends on the competition's shape:
+
+| Competition | Page |
+|---|---|
+| UCL / UEL / UECL | the **league-phase table** — `/tabelle/pokalwettbewerb/{CL\|EL\|UCOL}/saison_id/{year}` |
+| Copa del Rey, Supercopa, UEFA Super Cup | the **full fixture list** — `/gesamtspielplan/pokalwettbewerb/{id}/saison_id/{year}` |
+
+Use the table for the Swiss competitions, never the fixture list: the fixture
+list spans qualifying rounds, so it hands back every club knocked out on the way
+in as well as the 36 in the league phase.
+
+Competitions with a fixed shape are checked before anything is written — 36
+clubs for UCL/UEL/UECL, 4 for the Supercopa, 2 for the Super Cup. On a mismatch
+the push is refused and the popup says what it got; you are almost certainly on
+the wrong page for that competition. Competitions whose field genuinely varies
+by season (the Copa del Rey fielded 116 clubs in 2025) carry no such count.
 
 The first push creates the `season-data/{season}` branch and opens a PR; later
 pushes update the same PR. The popup links straight to it.

--- a/scripts/transfermarkt-scraper/content-cup-teams.js
+++ b/scripts/transfermarkt-scraper/content-cup-teams.js
@@ -1,8 +1,26 @@
-// content-cup-teams.js — Extracts participating teams from a Transfermarkt cup/tournament fixtures page.
+// content-cup-teams.js — Extracts the participating clubs of a cup / continental
+// competition from Transfermarkt.
 //
-// Target URL pattern: https://www.transfermarkt.com/{competition}/gesamtspielplan/pokalwettbewerb/{id}/saison_id/{year}
+// Two page shapes, because "who is in this competition" means different things
+// for a Swiss league phase than for a knockout bracket:
 //
-// Output format:
+//   Swiss (UCL/UEL/UECL) → the league-phase table
+//     https://www.transfermarkt.com/{slug}/tabelle/pokalwettbewerb/{id}/saison_id/{year}
+//     One row per participant, exactly 36 of them, and qualifying rounds are not
+//     on the page at all.
+//
+//   Knockout (Copa del Rey, Supercopa, UEFA Super Cup) → the full fixture list
+//     https://www.transfermarkt.com/{slug}/gesamtspielplan/pokalwettbewerb/{id}/saison_id/{year}
+//     There is no table to read; the clubs have to come off the fixtures.
+//
+// The fixture page must NOT be scraped by querying the whole document: it also
+// carries sidebars, nav and related-club widgets whose `/verein/` links are not
+// participants at all (that is how the 2026 Super Cup — a single two-club tie —
+// ended up with seven clubs). Both branches therefore stay inside the page's
+// content tables, and neither falls back to a document-wide query: an empty
+// result makes background.js throw, which is what we want if the markup moves.
+//
+// Output format (identical for both shapes):
 // {
 //   "id": "CL",
 //   "seasonId": "2025",
@@ -23,14 +41,12 @@
   const seasonMatch = url.match(/saison_id\/(\d{4})/);
   const seasonId = seasonMatch ? seasonMatch[1] : '';
 
-  // Find all unique clubs from the fixture tables
+  const isLeaguePhaseTable = /\/tabelle\/pokalwettbewerb\//i.test(url);
+
   const clubs = [];
   const seenIds = new Set();
 
-  // Get all club links from the page
-  const clubLinks = document.querySelectorAll('a[href*="/verein/"]');
-
-  clubLinks.forEach(link => {
+  const addClub = link => {
     const href = link.getAttribute('href') || '';
     const idMatch = href.match(/\/verein\/(\d+)/);
     if (!idMatch) return;
@@ -38,18 +54,30 @@
     const clubId = idMatch[1];
     if (seenIds.has(clubId)) return;
 
-    // Get the club name from the link text
-    let name = link.textContent.trim();
+    const name = link.textContent.trim();
 
     // Skip empty or very short names (likely icons/navigation)
     if (!name || name.length < 2) return;
 
     seenIds.add(clubId);
-    clubs.push({
-      id: clubId,
-      name: name
+    clubs.push({ id: clubId, name });
+  };
+
+  if (isLeaguePhaseTable) {
+    // One participant per standings row. Taking the row's *first* named club
+    // link keeps the crest link (whose text is empty) and any trailing links
+    // out, and means a row can never contribute two clubs.
+    document.querySelectorAll('.responsive-table table tbody tr').forEach(row => {
+      const before = clubs.length;
+      for (const link of row.querySelectorAll('a[href*="/verein/"]')) {
+        addClub(link);
+        if (clubs.length > before) break;
+      }
     });
-  });
+  } else {
+    // Fixture tables only — never the whole document.
+    document.querySelectorAll('.responsive-table a[href*="/verein/"]').forEach(addClub);
+  }
 
   // Sort clubs alphabetically by name
   clubs.sort((a, b) => a.name.localeCompare(b.name));

--- a/scripts/transfermarkt-scraper/popup.js
+++ b/scripts/transfermarkt-scraper/popup.js
@@ -28,8 +28,9 @@ function detectPageType(url) {
   if (/\/stadien\/wettbewerb\/[A-Z0-9]+/i.test(url)) {
     return 'competition-stadiums';
   }
-  // Cup fixtures page (pokalwettbewerb)
-  if (/\/gesamtspielplan\/pokalwettbewerb\/[A-Z0-9]+/i.test(url)) {
+  // Participant list for a cup / continental competition: the league-phase
+  // table for the Swiss competitions, the full fixture list for knockouts.
+  if (/\/(gesamtspielplan|tabelle)\/pokalwettbewerb\/[A-Z0-9]+/i.test(url)) {
     return 'cup-teams';
   }
   // League fixtures page (wettbewerb)
@@ -209,7 +210,7 @@ scrapeBtn.addEventListener('click', async () => {
     }
 
     if (pageType === 'competition') {
-      throw new Error('Please navigate to stadiums (/stadien/) or fixtures (/gesamtspielplan/) page.');
+      throw new Error('Please navigate to a stadiums (/stadien/), fixtures (/gesamtspielplan/) or league-phase table (/tabelle/) page.');
     }
 
     // Handle redirect from spielplan to kader page

--- a/scripts/transfermarkt-scraper/season-config.js
+++ b/scripts/transfermarkt-scraper/season-config.js
@@ -19,6 +19,13 @@
   // `batch: true` means "Refresh all leagues" drives it automatically (only the
   // fully-understood stadiums-scrape leagues); cups/continental are pushed
   // one-page-at-a-time via the per-page "Push to GitHub" button.
+  //
+  // `expectedClubs` is set only where the engine has a *structural* requirement
+  // — a Swiss league phase is four pots of nine, the Super Cup is one tie, the
+  // Supercopa is a final four — and it is enforced on push (see assertClubCount).
+  // Competitions whose entry list genuinely varies by season (the Copa del Rey
+  // fielded 116 clubs in 2025) carry no count; the leagues are checked against
+  // their schedule by `php artisan app:validate-season` instead.
   const COMPETITIONS = [
     { code: 'ESP1',    tmId: 'ES1',     name: 'LaLiga',                          kind: 'league',      batch: true },
     { code: 'ESP2',    tmId: 'ES2',     name: 'LaLiga2',                         kind: 'league',      batch: true },
@@ -29,11 +36,11 @@
     { code: 'FRA1',    tmId: 'FR1',     name: 'Ligue 1',                         kind: 'league',      batch: true },
     { code: 'ITA1',    tmId: 'IT1',     name: 'Serie A',                         kind: 'league',      batch: true },
     { code: 'ESPCUP',  tmId: 'CDR',     name: 'Copa del Rey',                    kind: 'cup',         batch: false },
-    { code: 'ESPSUP',  tmId: 'SUC',     name: 'Supercopa de España',            kind: 'cup',         batch: false },
-    { code: 'UCL',     tmId: 'CL',      name: 'UEFA Champions League',           kind: 'continental', batch: false },
-    { code: 'UEL',     tmId: 'EL',      name: 'UEFA Europa League',              kind: 'continental', batch: false },
-    { code: 'UECL',    tmId: 'UCOL',    name: 'UEFA Europa Conference League',   kind: 'continental', batch: false },
-    { code: 'UEFASUP', tmId: 'USC',     name: 'UEFA Super Cup',                  kind: 'continental', batch: false },
+    { code: 'ESPSUP',  tmId: 'SUC',     name: 'Supercopa de España',            kind: 'cup',         batch: false, expectedClubs: 4 },
+    { code: 'UCL',     tmId: 'CL',      name: 'UEFA Champions League',           kind: 'continental', batch: false, expectedClubs: 36 },
+    { code: 'UEL',     tmId: 'EL',      name: 'UEFA Europa League',              kind: 'continental', batch: false, expectedClubs: 36 },
+    { code: 'UECL',    tmId: 'UCOL',    name: 'UEFA Europa Conference League',   kind: 'continental', batch: false, expectedClubs: 36 },
+    { code: 'UEFASUP', tmId: 'USC',     name: 'UEFA Super Cup',                  kind: 'continental', batch: false, expectedClubs: 2 },
   ];
 
   // Pool folders for single-club (squad page) pushes — these store per-team
@@ -117,6 +124,26 @@
   // normalize step is a no-op on what we push.
   function encode(obj) {
     return JSON.stringify(obj, null, 2) + '\n';
+  }
+
+  // Refuse to write a participant list whose size cannot be right.
+  //
+  // The scraper reads a page, and a page can change shape or spill clubs that
+  // are not participants: the 2026 refresh pushed 37/41/41 clubs for
+  // UCL/UEL/UECL (qualifying rounds harvested off the fixture page) and 7 for
+  // the two-club Super Cup (sidebar links). Both sailed into a PR and one of
+  // them passed `app:validate-season` outright. Failing the push is far cheaper
+  // than discovering it in CI — or not discovering it.
+  function assertClubCount(clubs, comp) {
+    if (comp.expectedClubs === undefined) return;
+
+    const actual = Array.isArray(clubs) ? clubs.length : 0;
+    if (actual !== comp.expectedClubs) {
+      throw new Error(
+        `${comp.code} needs exactly ${comp.expectedClubs} clubs, this page gave ${actual}. ` +
+        'Nothing was pushed — check you are on the right page for this competition.'
+      );
+    }
   }
 
   // Build a canonical teams.json string for a league/cup/continental result.
@@ -213,7 +240,9 @@
   }
 
   // Map a finished scrape result to the repo file it belongs in, or null when
-  // the competition is not in the registry.
+  // the competition is not in the registry. Throws when the participant count
+  // is structurally impossible for the competition (see assertClubCount) —
+  // background.js's pushScrape handler surfaces the message in the popup.
   //
   //   { path: 'data/2026/ESP1/teams.json', content: '...' }
   //
@@ -226,6 +255,7 @@
     if (pageType === 'competition-stadiums' || pageType === 'cup-teams') {
       const comp = findByTmId(result.id);
       if (!comp) return null;
+      assertClubCount(result.clubs, comp);
       return {
         path: `data/${season}/${comp.code}/teams.json`,
         content: toTeamsJson(result, comp, season, opts.previousClubs),
@@ -255,6 +285,7 @@
     findByTmId,
     resolveClubId,
     poolTargets,
+    assertClubCount,
     toTeamsJson,
     toPoolJson,
     repoFileForResult,

--- a/tests/Feature/Console/ScaffoldSeasonCommandTest.php
+++ b/tests/Feature/Console/ScaffoldSeasonCommandTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature\Console;
 
+use Carbon\Carbon;
 use Illuminate\Support\Facades\File;
 use Tests\TestCase;
 
@@ -23,7 +24,7 @@ class ScaffoldSeasonCommandTest extends TestCase
         parent::tearDown();
     }
 
-    public function test_shifts_schedule_dates_forward_one_year(): void
+    public function test_shifts_schedule_dates_forward_a_whole_number_of_weeks(): void
     {
         $srcDir = base_path("data/{$this->from}/ESP1");
         File::ensureDirectoryExists($srcDir);
@@ -47,16 +48,51 @@ class ScaffoldSeasonCommandTest extends TestCase
         $this->artisan('app:scaffold-season', ['season' => $this->to, '--from' => $this->from])
             ->assertSuccessful();
 
+        // A year rounded up to whole weeks: 371 days, so every date keeps its
+        // weekday (league rounds on Sunday here, the cup rounds midweek).
         $league = json_decode(File::get(base_path("data/{$this->to}/ESP1/schedule.json")), true);
-        $this->assertSame('2099-08-17', $league['league'][0]['date']);
-        $this->assertSame('2100-05-24', $league['league'][1]['date']);
+        $this->assertSame('2099-08-23', $league['league'][0]['date']);
+        $this->assertSame('2100-05-30', $league['league'][1]['date']);
 
         $knockout = json_decode(File::get(base_path("data/{$this->to}/ESPCUP/schedule.json")), true);
-        $this->assertSame('2099-10-29', $knockout['knockout'][0]['date']);
+        $this->assertSame('2099-11-04', $knockout['knockout'][0]['date']);
         // Two-legged dates and sibling fields (name) are preserved + shifted.
         $this->assertSame('cup.semi_final', $knockout['knockout'][1]['name']);
-        $this->assertSame('2100-02-04', $knockout['knockout'][1]['first_leg_date']);
-        $this->assertSame('2100-02-25', $knockout['knockout'][1]['second_leg_date']);
+        $this->assertSame('2100-02-10', $knockout['knockout'][1]['first_leg_date']);
+        $this->assertSame('2100-03-03', $knockout['knockout'][1]['second_leg_date']);
+    }
+
+    public function test_every_shifted_date_keeps_its_weekday(): void
+    {
+        // The invariant behind the whole-week shift: national leagues stay on
+        // the weekend and European nights / cups stay midweek.
+        $srcDir = base_path("data/{$this->from}/ESP1");
+        File::ensureDirectoryExists($srcDir);
+        $source = [
+            'league' => [
+                ['round' => 1, 'date' => '2098-08-15'],   // Fri
+                ['round' => 2, 'date' => '2098-08-16'],   // Sat
+                ['round' => 3, 'date' => '2098-08-17'],   // Sun
+                ['round' => 4, 'date' => '2098-12-29'],   // Mon
+                ['round' => 5, 'date' => '2099-02-24'],   // Tue
+                ['round' => 6, 'date' => '2099-03-04'],   // Wed
+                ['round' => 7, 'date' => '2099-03-12'],   // Thu
+            ],
+        ];
+        File::put("{$srcDir}/schedule.json", json_encode($source));
+
+        $this->artisan('app:scaffold-season', ['season' => $this->to, '--from' => $this->from])
+            ->assertSuccessful();
+
+        $shifted = json_decode(File::get(base_path("data/{$this->to}/ESP1/schedule.json")), true);
+
+        foreach ($source['league'] as $i => $round) {
+            $this->assertSame(
+                Carbon::parse($round['date'])->dayOfWeek,
+                Carbon::parse($shifted['league'][$i]['date'])->dayOfWeek,
+                "Round {$round['round']} changed weekday: {$round['date']} → {$shifted['league'][$i]['date']}",
+            );
+        }
     }
 
     public function test_reports_missing_squad_data_and_does_not_invent_teams_json(): void

--- a/tests/Feature/Console/ValidateSeasonCommandTest.php
+++ b/tests/Feature/Console/ValidateSeasonCommandTest.php
@@ -214,6 +214,46 @@ class ValidateSeasonCommandTest extends TestCase
             ->assertFailed();
     }
 
+    public function test_detects_a_club_entered_in_two_swiss_competitions(): void
+    {
+        // A club knocked out of Champions League qualifying drops into the
+        // Europa League, so a fixture-page scrape lists it under both.
+        $ucl = $this->seedableSwissField();
+        $uel = $this->seedableSwissField();
+        $uel[0] = $ucl[0];
+
+        $this->writeContinental($ucl);
+        $this->writeContinental($uel, 'UEL');
+
+        $this->artisan('app:validate-season', ['season' => $this->season])
+            ->expectsOutputToContain('is also a UCL entrant')
+            ->assertFailed();
+    }
+
+    public function test_allows_a_super_cup_finalist_to_also_play_in_the_champions_league(): void
+    {
+        // The Super Cup is contested by the prior season's UCL and UEL winners,
+        // who are in that season's European competitions too — not a duplicate.
+        $ucl = $this->seedableSwissField();
+        $this->writeContinental($ucl);
+        $this->writeContinental([$ucl[0], $ucl[1]], 'UEFASUP');
+
+        $this->artisan('app:validate-season', ['season' => $this->season])
+            ->doesntExpectOutputToContain('entrant')
+            ->assertFailed(); // ESP1 and friends are still missing from this fixture.
+    }
+
+    public function test_detects_a_continental_knockout_that_is_not_a_two_club_tie(): void
+    {
+        // The 2026 refresh scraped seven clubs onto the Super Cup — a single
+        // tie — and nothing checked it, because only swiss_format had a shape.
+        $this->writeContinental(array_slice($this->seedableSwissField(), 0, 7), 'UEFASUP');
+
+        $this->artisan('app:validate-season', ['season' => $this->season])
+            ->expectsOutputToContain('single two-club tie, got 7 clubs')
+            ->assertFailed();
+    }
+
     public function test_detects_short_swiss_field(): void
     {
         $this->writeContinental(array_slice($this->seedableSwissField(), 0, 35));

--- a/tests/js/season-config.test.js
+++ b/tests/js/season-config.test.js
@@ -33,6 +33,10 @@ const ESPCUP = { code: 'ESPCUP', tmId: 'CDR', name: 'Copa del Rey', kind: 'cup' 
 
 const parse = json => JSON.parse(json);
 
+// A well-formed Swiss league phase: 36 clubs, Arsenal (11) among them.
+const leaguePhase = (size = 36) =>
+    Array.from({ length: size }, (_, i) => ({ id: String(i + 11), name: `Club ${i + 11}` }));
+
 describe('toTeamsJson — pot preservation on continental re-scrapes', () => {
     const scraped = { id: 'CL', clubs: [{ id: '11', name: 'Arsenal' }, { id: '418', name: 'Real Madrid' }] };
     const previous = [{ id: '11', name: 'Arsenal', pot: 2 }, { id: '418', name: 'Real Madrid', pot: 1 }];
@@ -148,13 +152,13 @@ describe('toPoolJson', () => {
 describe('repoFileForResult', () => {
     it('routes a continental scrape to its teams.json and forwards stored pots', () => {
         const file = SeasonConfig.repoFileForResult(
-            { id: 'CL', clubs: [{ id: '11', name: 'Arsenal' }] },
+            { id: 'CL', clubs: leaguePhase() },
             'cup-teams',
             { season: '2026', previousClubs: [{ id: '11', pot: 2 }] },
         );
 
         expect(file.path).toBe('data/2026/UCL/teams.json');
-        expect(parse(file.content).clubs[0].pot).toBe(2);
+        expect(parse(file.content).clubs.find(c => c.id === '11').pot).toBe(2);
     });
 
     it('routes a single club squad into the chosen pool', () => {
@@ -240,5 +244,41 @@ describe('poolTargets — clubs that still need an EUR pool file', () => {
         const targets = SeasonConfig.poolTargets([ucl([{ name: 'Mystery FC' }])], []);
 
         expect(targets).toEqual([]);
+    });
+});
+
+describe('assertClubCount — structural guard on participant lists', () => {
+    // The 2026 refresh pushed 37/41/41 clubs for UCL/UEL/UECL (qualifying rounds
+    // harvested off the fixture page) and 7 for the two-club Super Cup (sidebar
+    // links). Only the first three were caught, and only later, by CI.
+    it('accepts a Swiss league phase of exactly 36', () => {
+        const file = SeasonConfig.repoFileForResult(
+            { id: 'CL', clubs: leaguePhase() }, 'cup-teams', { season: '2026' },
+        );
+
+        expect(file.path).toBe('data/2026/UCL/teams.json');
+    });
+
+    it('refuses the push when a Swiss league phase is the wrong size', () => {
+        expect(() => SeasonConfig.repoFileForResult(
+            { id: 'CL', clubs: leaguePhase(37) }, 'cup-teams', { season: '2026' },
+        )).toThrow(/UCL needs exactly 36 clubs, this page gave 37/);
+    });
+
+    it('holds the Super Cup to its two finalists', () => {
+        expect(() => SeasonConfig.repoFileForResult(
+            { id: 'USC', clubs: leaguePhase(7) }, 'cup-teams', { season: '2026' },
+        )).toThrow(/UEFASUP needs exactly 2 clubs, this page gave 7/);
+
+        expect(SeasonConfig.repoFileForResult(
+            { id: 'USC', clubs: leaguePhase(2) }, 'cup-teams', { season: '2026' },
+        ).path).toBe('data/2026/UEFASUP/teams.json');
+    });
+
+    it('leaves competitions with a season-varying entry list alone', () => {
+        // The Copa del Rey fielded 116 clubs in 2025; there is no right number.
+        expect(SeasonConfig.repoFileForResult(
+            { id: 'CDR', clubs: leaguePhase(116) }, 'cup-teams', { season: '2026' },
+        ).path).toBe('data/2026/ESPCUP/teams.json');
     });
 });


### PR DESCRIPTION
Two bugs found while getting the 2026 refresh (#1330) through its pipeline. Code only — the 2026 data itself stays in #1330, which needs a re-scrape once this is merged.

## 1. `app:scaffold-season` shifted schedules by a calendar year

It bootstrapped a new season's `schedule.json` with `Carbon::addYears()`. 365 days is 52 weeks **plus a day**, so every fixture slid one weekday over: LaLiga's Sunday rounds became Mondays, Champions League nights became Thursdays, the domestic cups drifted off midweek. Nothing downstream notices — the dates are still valid — so the calendar just quietly reads wrong.

Now shifts by a whole number of weeks, computed once per run and applied uniformly, so weekdays *and* the gaps between rounds both survive the copy. Rounded up rather than down (a year → 371 days = 53 weeks) so the new season starts after the old one finished.

## 2. The scraper harvested every club link on the page

`content-cup-teams.js` ran on the *gesamtspielplan* (full fixture list) page and did `document.querySelectorAll('a[href*="/verein/"]')`. That leaks twice:

- the fixture list spans qualifying rounds, so clubs knocked out on the way in came along — hence 37/41/41 clubs for UCL/UEL/UECL against a 36-team league phase;
- a document-wide query also picks up sidebar and nav links, which is how the UEFA Super Cup — a single two-club tie — ended up with **seven** clubs.

The Swiss competitions now scrape the **league-phase table** (`/tabelle/pokalwettbewerb/`), which is 36 rows by construction: no qualifying entrants, no round-heading parsing. Knockouts keep the fixture list (they have no table) but both branches stay inside the page's content tables, and neither falls back to a document-wide query — an empty result makes the scrape throw, which beats silently reimporting this.

Backed by a structural count guard in `season-config.js`: 36 for UCL/UEL/UECL, 4 for the Supercopa, 2 for the Super Cup, nothing for competitions whose field varies by season (the Copa del Rey fielded 116 clubs in 2025). A mismatch refuses the push instead of opening a PR for CI to catch.

## 3. `app:validate-season` let both of those through

- Only `swiss_format` had a shape check, so the Super Cup's 7 clubs **passed validation outright**. A continental knockout is now required to be exactly two — and `UefaSuperCupQualificationProcessor` treats that file as the two finalists on an initial season, so 7 would have produced a draw that can't be made.
- Nothing noticed that 7 clubs sat in two Swiss competitions at once (AC Milan, Atlético and Aston Villa in UCL+UEL; Roma in UCL+UECL; Chelsea, Crystal Palace and Olympiacos in UEL+UECL). The Super Cup is exempt — its finalists legitimately play in that season's UCL/UEL too.
- It also printed `37 clubs ✓` for a competition that had just failed.

## Verification

- `npm test` — 82 passing, including new guard cases (36 accepted, 37 refused, Super Cup held to 2, Copa del Rey unconstrained).
- `php artisan test --filter="ScaffoldSeasonCommandTest|ValidateSeasonCommandTest"` — 23 passing, including a weekday-preservation assertion across Fri–Thu source dates and the three new validation rules.
- `./vendor/bin/phpstan analyse` clean.
- `php artisan app:validate-season 2025` still exits 0 — the stricter rules don't break the season currently on `main`.

The DOM extractors have no unit test: vitest runs `environment: 'node'` with no jsdom, and a stubbed DOM would only prove the stub matches the selector, not that either matches Transfermarkt's markup. The count guard is the real safety net.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JiCkDr1ZeddgiRSsW1wqXn