### PR TITLE
Read European fields off the participants page, not the fixture list

### DIFF
--- a/docs/season-data-refresh.md
+++ b/docs/season-data-refresh.md
@@ -95,8 +95,8 @@ add/remove line, not a reshuffled roster.
    - `data/2026/{CUP}/teams.json` participant lists (ESPCUP, ESPSUP).
    - `data/2026/{UCL,UEL,UECL,UEFASUP}/teams.json` participant lists. These are
      independent of the transfer window — the draws are known before it shuts —
-     so they can go in first. Scrape UCL/UEL/UECL from the **league-phase table**
-     (`/tabelle/pokalwettbewerb/...`), not the fixture list: the fixture list
+     so they can go in first. Scrape them from the **participants page**
+     (`/teilnehmer/pokalwettbewerb/...`), not the fixture list: the fixture list
      spans qualifying, so it returns every club knocked out on the way in too.
      Their squads cannot go in first: every participant outside the eight
      scraped leagues needs an `EUR` pool file (70 of 108 slots in 2025) —

--- a/scripts/transfermarkt-scraper/README.md
+++ b/scripts/transfermarkt-scraper/README.md
@@ -134,12 +134,13 @@ Which page a participant list comes from depends on the competition's shape:
 
 | Competition | Page |
 |---|---|
-| UCL / UEL / UECL | the **league-phase table** — `/tabelle/pokalwettbewerb/{CL\|EL\|UCOL}/saison_id/{year}` |
-| Copa del Rey, Supercopa, UEFA Super Cup | the **full fixture list** — `/gesamtspielplan/pokalwettbewerb/{id}/saison_id/{year}` |
+| UCL / UEL / UECL / UEFA Super Cup | the **participants page** — `/teilnehmer/pokalwettbewerb/{CL\|EL\|UCOL\|USC}/saison_id/{year}` |
+| Copa del Rey, Supercopa | the **full fixture list** — `/gesamtspielplan/pokalwettbewerb/{id}/saison_id/{year}` |
 
-Use the table for the Swiss competitions, never the fixture list: the fixture
-list spans qualifying rounds, so it hands back every club knocked out on the way
-in as well as the 36 in the league phase.
+Use the participants page for the European competitions, never the fixture list:
+the fixture list spans the qualifying rounds, so it hands back every club knocked
+out on the way in as well as the 36 in the league phase (and, for the Super Cup,
+the winners of past editions alongside this year's two finalists).
 
 Competitions with a fixed shape are checked before anything is written — 36
 clubs for UCL/UEL/UECL, 4 for the Supercopa, 2 for the Super Cup. On a mismatch

--- a/scripts/transfermarkt-scraper/content-cup-teams.js
+++ b/scripts/transfermarkt-scraper/content-cup-teams.js
@@ -2,23 +2,21 @@
 // competition from Transfermarkt.
 //
 // Two page shapes, because "who is in this competition" means different things
-// for a Swiss league phase than for a knockout bracket:
+// for a European league phase than for a domestic knockout:
 //
-//   Swiss (UCL/UEL/UECL) → the league-phase table
-//     https://www.transfermarkt.com/{slug}/tabelle/pokalwettbewerb/{id}/saison_id/{year}
-//     One row per participant, exactly 36 of them, and qualifying rounds are not
-//     on the page at all.
+//   Continental (UCL/UEL/UECL/UEFASUP) → the participants page
+//     https://www.transfermarkt.com/{slug}/teilnehmer/pokalwettbewerb/{id}/saison_id/{year}
+//     A `table.items` with one club per row — the league-phase field exactly
+//     (36 for the Swiss competitions, 2 for the Super Cup).
 //
-//   Knockout (Copa del Rey, Supercopa, UEFA Super Cup) → the full fixture list
+//   Domestic cups (Copa del Rey, Supercopa) → the full fixture list
 //     https://www.transfermarkt.com/{slug}/gesamtspielplan/pokalwettbewerb/{id}/saison_id/{year}
-//     There is no table to read; the clubs have to come off the fixtures.
+//     Every club that plays a tie, which for these is what we want.
 //
-// The fixture page must NOT be scraped by querying the whole document: it also
-// carries sidebars, nav and related-club widgets whose `/verein/` links are not
-// participants at all (that is how the 2026 Super Cup — a single two-club tie —
-// ended up with seven clubs). Both branches therefore stay inside the page's
-// content tables, and neither falls back to a document-wide query: an empty
-// result makes background.js throw, which is what we want if the markup moves.
+// Do not read a European field off the fixture list: it spans the qualifying
+// rounds, so it hands back every club knocked out on the way in as well. That is
+// how the 2026 refresh produced 37/41/41 clubs for UCL/UEL/UECL against a
+// 36-team league phase, and seven for the Super Cup's single two-club tie.
 //
 // Output format (identical for both shapes):
 // {
@@ -41,7 +39,7 @@
   const seasonMatch = url.match(/saison_id\/(\d{4})/);
   const seasonId = seasonMatch ? seasonMatch[1] : '';
 
-  const isLeaguePhaseTable = /\/tabelle\/pokalwettbewerb\//i.test(url);
+  const isParticipantsPage = /\/teilnehmer\/pokalwettbewerb\//i.test(url);
 
   const clubs = [];
   const seenIds = new Set();
@@ -54,6 +52,7 @@
     const clubId = idMatch[1];
     if (seenIds.has(clubId)) return;
 
+    // Transfermarkt ships trailing whitespace in some names ("FC Ararat-Armenia ").
     const name = link.textContent.trim();
 
     // Skip empty or very short names (likely icons/navigation)
@@ -63,20 +62,18 @@
     clubs.push({ id: clubId, name });
   };
 
-  if (isLeaguePhaseTable) {
-    // One participant per standings row. Taking the row's *first* named club
-    // link keeps the crest link (whose text is empty) and any trailing links
-    // out, and means a row can never contribute two clubs.
-    document.querySelectorAll('.responsive-table table tbody tr').forEach(row => {
-      const before = clubs.length;
-      for (const link of row.querySelectorAll('a[href*="/verein/"]')) {
-        addClub(link);
-        if (clubs.length > before) break;
-      }
+  if (isParticipantsPage) {
+    // One participant per row of `table.items`. The name lives in the row's
+    // `hauptlink` cell; the other club link in the row wraps only the crest
+    // image, so reading the hauptlink directly keeps the row to one club and
+    // never depends on link order.
+    document.querySelectorAll('table.items tbody tr').forEach(row => {
+      const link = row.querySelector('td.hauptlink a[href*="/verein/"]');
+      if (link) addClub(link);
     });
   } else {
-    // Fixture tables only — never the whole document.
-    document.querySelectorAll('.responsive-table a[href*="/verein/"]').forEach(addClub);
+    // Get all club links from the page
+    document.querySelectorAll('a[href*="/verein/"]').forEach(addClub);
   }
 
   // Sort clubs alphabetically by name

--- a/scripts/transfermarkt-scraper/popup.js
+++ b/scripts/transfermarkt-scraper/popup.js
@@ -28,9 +28,9 @@ function detectPageType(url) {
   if (/\/stadien\/wettbewerb\/[A-Z0-9]+/i.test(url)) {
     return 'competition-stadiums';
   }
-  // Participant list for a cup / continental competition: the league-phase
-  // table for the Swiss competitions, the full fixture list for knockouts.
-  if (/\/(gesamtspielplan|tabelle)\/pokalwettbewerb\/[A-Z0-9]+/i.test(url)) {
+  // Participant list for a cup / continental competition: the participants page
+  // for the European competitions, the full fixture list for the domestic cups.
+  if (/\/(gesamtspielplan|teilnehmer)\/pokalwettbewerb\/[A-Z0-9]+/i.test(url)) {
     return 'cup-teams';
   }
   // League fixtures page (wettbewerb)
@@ -210,7 +210,7 @@ scrapeBtn.addEventListener('click', async () => {
     }
 
     if (pageType === 'competition') {
-      throw new Error('Please navigate to a stadiums (/stadien/), fixtures (/gesamtspielplan/) or league-phase table (/tabelle/) page.');
+      throw new Error('Please navigate to a stadiums (/stadien/), fixtures (/gesamtspielplan/) or participants (/teilnehmer/) page.');
     }
 
     // Handle redirect from spielplan to kader page


### PR DESCRIPTION
The continental scrape landed on /tabelle/ with a selector guessed at rather than checked: transfermarkt.com is unreachable from the sandbox this was written in, so nothing verified it against real markup.

The right page is /teilnehmer/pokalwettbewerb/{id}/saison_id/{year}, and it is a straightforward table.items with one club per row: the name in the row's hauptlink cell, the id in that link's /verein/{id}. Reading the hauptlink directly keeps a row to one club and drops the "first named link in the row" heuristic — the row's other club link wraps only the crest image.

Checked against the real thing: the Europa League participants page for 2026 lists exactly 36 clubs, and all 36 are already in data/2026/UEL/teams.json. That file's extra five — Atlético (13), Tottenham (148), Sevilla (368), Aston Villa (405), Chelsea (631) — are precisely the clubs the fixture list adds by spanning the qualifying rounds. So the participants page is the league-phase field, with no filtering needed. The Super Cup moves there too, which is what actually fixes its seven clubs.

Also revert the fixture branch to its original document-wide query. It had been scoped to .responsive-table on the theory that sidebar links caused the Super Cup's seven; the 2025 data says otherwise — the same page type produced a correct 116-club Copa del Rey and a correct 4-club Supercopa — and an unverified selector there risks breaking the Copa del Rey scrape for no gain.

Verified by running the content script in Chromium at the real URL against the markup from that page: 36 clubs, ids and names matching row for row, trailing whitespace trimmed ("FC Ararat-Armenia "), and four club links planted in nav/sidebar/footer correctly ignored. Not committed as a test — vitest runs environment: 'node' here and adding jsdom was declined; the club-count guard in season-config.js stays the CI safety net.


Claude-Session: https://claude.ai/code/session_01JiCkDr1ZeddgiRSsW1wqXn