### PR TITLE
Communicate the 2026/27 data refresh: landing banner and save vintage

### DIFF
--- a/app/Http/Views/Dashboard.php
+++ b/app/Http/Views/Dashboard.php
@@ -25,6 +25,11 @@ class Dashboard
             'user' => $request->user(),
             'games' => $games,
             'canCreateGame' => $games->count() < $maxGames,
+            // Only users who already have a career from an older data season
+            // need telling that saves keep the squads they started with.
+            'hasLegacySaves' => $games->contains(
+                fn (Game $game) => ! $game->isTournamentMode() && $game->isFromPastBaseSeason()
+            ),
             'gameCount' => $games->count(),
             'maxGames' => $maxGames,
         ]);

--- a/app/Models/Game.php
+++ b/app/Models/Game.php
@@ -779,11 +779,30 @@ class Game extends Model
     }
 
     /**
+     * Format a season year for compact display: "2025" → "25/26".
+     * Derived from formatSeason() so the two cannot drift apart.
+     */
+    public static function formatSeasonShort(string $season): string
+    {
+        return substr(self::formatSeason($season), 2);
+    }
+
+    /**
      * Get the season formatted for display (e.g. "2025/26").
      */
     public function getFormattedSeasonAttribute(): string
     {
         return self::formatSeason($this->season);
+    }
+
+    /**
+     * Whether this save was created from an older reference-data season than
+     * the one currently seeded — its squads predate the latest data refresh.
+     * Saves cannot be migrated to newer data, so this is fixed for their life.
+     */
+    public function isFromPastBaseSeason(): bool
+    {
+        return (int) $this->base_season < (int) config('season.current');
     }
 
     // ==========================================

--- a/landing/public/index-en.html
+++ b/landing/public/index-en.html
@@ -54,6 +54,16 @@
 </head>
 <body class="min-h-screen bg-surface-900 font-sans text-white antialiased">
 
+    <!-- Season announcement -->
+    <div class="bg-accent-gold/10 border-b border-accent-gold/20">
+        <div class="max-w-7xl mx-auto px-6 py-2.5 flex items-center justify-center gap-2.5">
+            <span class="hidden sm:block w-2 h-2 bg-accent-gold rounded-full shrink-0"></span>
+            <p class="text-xs font-semibold text-accent-gold uppercase tracking-wider text-center">
+                Squads and competitions updated for the 2026/27 season
+            </p>
+        </div>
+    </div>
+
     <!-- Nav -->
     <nav class="max-w-7xl mx-auto px-6 py-6 flex items-center justify-between">
         <div class="-skew-x-12 bg-accent-red px-3 sm:px-4 py-1">
@@ -243,7 +253,7 @@
                             <div class="w-10 h-10 bg-accent-blue/20 flex items-center justify-center mb-4 mr-4 rounded-lg">
                                 <svg class="w-5 h-5 text-accent-blue" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M4 7v10c0 2.21 3.582 4 8 4s8-1.79 8-4V7M4 7c0 2.21 3.582 4 8 4s8-1.79 8-4M4 7c0-2.21 3.582-4 8-4s8 1.79 8 4m0 5c0 2.21-3.582 4-8 4s-8-1.79-8-4"/></svg>
                             </div>
-                            <h3 class="font-heading text-xl font-semibold mb-2">Real 2025/26 Data</h3>
+                            <h3 class="font-heading text-xl font-semibold mb-2">Real 2026/27 Data</h3>
                         </div>
                         <p class="text-sm text-slate-400 leading-relaxed">346 real teams and 8,145 players from 43 European and international countries. Ratings from real market values. Realistic development over time.</p>
                     </div>

--- a/landing/public/index.html
+++ b/landing/public/index.html
@@ -54,6 +54,16 @@
 </head>
 <body class="min-h-screen bg-surface-900 font-sans text-white antialiased">
 
+    <!-- Season announcement -->
+    <div class="bg-accent-gold/10 border-b border-accent-gold/20">
+        <div class="max-w-7xl mx-auto px-6 py-2.5 flex items-center justify-center gap-2.5">
+            <span class="hidden sm:block w-2 h-2 bg-accent-gold rounded-full shrink-0"></span>
+            <p class="text-xs font-semibold text-accent-gold uppercase tracking-wider text-center">
+                Plantillas y competiciones actualizadas a la temporada 2026/27
+            </p>
+        </div>
+    </div>
+
     <!-- Nav -->
     <nav class="max-w-7xl mx-auto px-6 py-6 flex items-center justify-between">
         <div class="-skew-x-12 bg-accent-red px-3 sm:px-4 py-1">
@@ -243,7 +253,7 @@
                             <div class="w-10 h-10 bg-accent-blue/20 flex items-center justify-center mb-4 mr-4 rounded-lg">
                                 <svg class="w-5 h-5 text-accent-blue" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M4 7v10c0 2.21 3.582 4 8 4s8-1.79 8-4V7M4 7c0 2.21 3.582 4 8 4s8-1.79 8-4M4 7c0-2.21 3.582-4 8-4s8 1.79 8 4m0 5c0 2.21-3.582 4-8 4s-8-1.79-8-4"/></svg>
                             </div>
-                            <h3 class="font-heading text-xl font-semibold mb-2">Datos Reales 2025/26</h3>
+                            <h3 class="font-heading text-xl font-semibold mb-2">Datos Reales 2026/27</h3>
                         </div>
                         <p class="text-sm text-slate-400 leading-relaxed">346 equipos y 8.145 jugadores de 43 países de Europa y el mundo. Habilidades basadas en valor de mercado. Desarrollo realista cada temporada.</p>
                     </div>

--- a/lang/en/game.php
+++ b/lang/en/game.php
@@ -415,6 +415,7 @@ return [
     // Game modes
     'mode_all' => 'All',
     'mode_career' => 'Club Manager',
+    'mode_with_season' => ':mode - :season',
     'mode_career_desc' => 'Take charge of one club. Build a long-term project.',
     'mode_career_pro' => 'Pro Manager',
     'mode_career_pro_desc' => 'Build your manager career from the ground up.',
@@ -422,6 +423,7 @@ return [
     'mode_tournament' => 'National team',
     'mode_tournament_desc' => 'Take a nation to the World Cup.',
     'mode_tournament_badge' => 'World Cup',
+    'legacy_saves_notice' => 'Saved careers keep the squads they started with. To play with :season data, start a new career.',
     'wc2026_name' => 'World Cup 2026',
     'career_unlock_hint' => 'Win the World Cup to unlock',
     'b_team_not_playable' => 'B teams are not playable',

--- a/lang/es/game.php
+++ b/lang/es/game.php
@@ -415,6 +415,7 @@ return [
     // Game modes
     'mode_all' => 'Todos',
     'mode_career' => 'Club Manager',
+    'mode_with_season' => ':mode - :season',
     'mode_career_desc' => 'Toma el mando de un club. Construye un proyecto a largo plazo.',
     'mode_career_pro' => 'Pro Manager',
     'mode_career_pro_desc' => 'Forja tu carrera de entrenador desde abajo.',
@@ -422,6 +423,7 @@ return [
     'mode_tournament' => 'Selección nacional',
     'mode_tournament_desc' => 'Lleva a una selección al Mundial.',
     'mode_tournament_badge' => 'Copa del Mundo',
+    'legacy_saves_notice' => 'Las partidas guardadas mantienen las plantillas con las que empezaron. Para jugar con los datos :season, empieza una partida nueva.',
     'wc2026_name' => 'Copa del Mundo 2026',
     'career_unlock_hint' => 'Gana el Mundial para desbloquearlo',
     'b_team_not_playable' => 'Las filiales no son jugables',

--- a/resources/views/components/game-mode-badge.blade.php
+++ b/resources/views/components/game-mode-badge.blade.php
@@ -1,0 +1,29 @@
+@props(['game'])
+
+@php
+    $label = match (true) {
+        $game->isTournamentMode() => __('game.mode_tournament_badge'),
+        $game->isProManagerMode() => __('game.mode_career_pro'),
+        $game->isCareerMode() => __('game.mode_career'),
+        default => null,
+    };
+
+    // Career saves are pinned to the reference-data season they were created
+    // from, so a save started before a data refresh stays distinguishable from
+    // one started after it. The World Cup is a fixed real-world tournament —
+    // a data vintage says nothing about it, so it keeps a bare mode label.
+    $showSeason = $label !== null && ! $game->isTournamentMode();
+@endphp
+
+@if($label)
+    <span {{ $attributes->merge(['class' => 'inline-flex items-center rounded-full bg-accent-gold/10 px-2.5 py-0.5 text-xs font-medium text-accent-gold ring-1 ring-inset ring-amber-600/20']) }}>
+        @if($showSeason)
+            {{ __('game.mode_with_season', [
+                'mode' => $label,
+                'season' => \App\Models\Game::formatSeasonShort($game->base_season),
+            ]) }}
+        @else
+            {{ $label }}
+        @endif
+    </span>
+@endif

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -16,6 +16,12 @@
                     <a href="{{ route('select-team') }}" class="inline-flex items-center justify-center px-4 py-2 min-h-[44px] sm:min-h-0 text-sm bg-surface-700 border border-border-strong font-semibold text-text-body shadow-xs hover:bg-surface-600 hover:text-text-primary rounded-lg focus:outline-hidden focus:ring-2 focus:ring-accent-blue focus:ring-offset-2 focus:ring-offset-surface-900 transition ease-in-out duration-150">+ {{ __('app.new_game') }}</a>
                 @endif
             </div>
+
+            @if($hasLegacySaves)
+                <p class="mt-3 text-sm text-text-secondary">
+                    {{ __('game.legacy_saves_notice', ['season' => \App\Models\Game::formatSeason(config('season.current'))]) }}
+                </p>
+            @endif
         </div>
 
         @if($errors->has('limit'))
@@ -37,25 +43,9 @@
                         @endif
                         <h3 class="text-xl font-semibold leading-tight text-text-primary">{{ $game->team->name }}</h3>
                         <dl class="flex flex-col justify-between">
-                            @if($game->isTournamentMode())
-                                <dd class="mb-1">
-                                    <span class="inline-flex items-center rounded-full bg-accent-gold/10 px-2.5 py-0.5 text-xs font-medium text-accent-gold ring-1 ring-inset ring-amber-600/20">
-                                        {{ __('game.mode_tournament_badge') }}
-                                    </span>
-                                </dd>
-                            @elseif($game->isProManagerMode())
                             <dd class="mb-1">
-                                <span class="inline-flex items-center rounded-full bg-accent-gold/10 px-2.5 py-0.5 text-xs font-medium text-accent-gold ring-1 ring-inset ring-amber-600/20">
-                                    {{ __('game.mode_career_pro') }}
-                                </span>
+                                <x-game-mode-badge :game="$game" />
                             </dd>
-                            @elseif($game->isCareerMode())
-                            <dd class="mb-1">
-                                <span class="inline-flex items-center rounded-full bg-accent-gold/10 px-2.5 py-0.5 text-xs font-medium text-accent-gold ring-1 ring-inset ring-amber-600/20">
-                                    {{ __('game.mode_career') }}
-                                </span>
-                            </dd>
-                            @endif
 
                             <hr class="pt-4 mt-4 border-t border-border-default">
 

--- a/tests/Feature/DashboardSaveVintageTest.php
+++ b/tests/Feature/DashboardSaveVintageTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Game;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Saves cannot be migrated to a newer reference-data season, so the dashboard
+ * has to make the distinction visible: each career card carries the season it
+ * was created from, and users who still hold one from a past season are told
+ * that starting a new career is the only way onto the new data.
+ */
+class DashboardSaveVintageTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const NOTICE = 'keep the squads they started with';
+
+    /** @param array<int, array{0: string, 1: string}> $saves [base_season, game_mode] */
+    private function dashboardFor(array $saves): string
+    {
+        $user = User::factory()->create();
+
+        foreach ($saves as [$baseSeason, $mode]) {
+            Game::factory()->create([
+                'user_id' => $user->id,
+                'base_season' => $baseSeason,
+                'season' => $baseSeason,
+                'game_mode' => $mode,
+            ]);
+        }
+
+        return $this->actingAs($user)->get('/dashboard')->getContent();
+    }
+
+    public function test_each_career_card_shows_the_season_it_was_created_from(): void
+    {
+        config(['season.current' => '2026']);
+
+        $html = $this->dashboardFor([
+            ['2025', Game::MODE_CAREER],
+            ['2026', Game::MODE_CAREER],
+        ]);
+
+        $this->assertStringContainsString('Club Manager - 25/26', $html);
+        $this->assertStringContainsString('Club Manager - 26/27', $html);
+    }
+
+    public function test_a_save_from_a_past_season_earns_the_notice(): void
+    {
+        config(['season.current' => '2026']);
+
+        $html = $this->dashboardFor([['2025', Game::MODE_CAREER]]);
+
+        $this->assertStringContainsString(self::NOTICE, $html);
+        // Names the season currently seeded, not a hardcoded year.
+        $this->assertStringContainsString('2026/27', $html);
+    }
+
+    public function test_no_notice_when_every_save_is_on_the_current_season(): void
+    {
+        config(['season.current' => '2026']);
+
+        $html = $this->dashboardFor([['2026', Game::MODE_CAREER]]);
+
+        $this->assertStringNotContainsString(self::NOTICE, $html);
+    }
+
+    public function test_world_cup_saves_carry_no_season_and_raise_no_notice(): void
+    {
+        config(['season.current' => '2026']);
+
+        $html = $this->dashboardFor([['2025', Game::MODE_TOURNAMENT]]);
+
+        $this->assertStringContainsString('World Cup', $html);
+        $this->assertStringNotContainsString('World Cup - ', $html);
+        $this->assertStringNotContainsString(self::NOTICE, $html);
+    }
+}


### PR DESCRIPTION
Two ways of telling players about the 2026/27 refresh: one outward-facing on the landing page, one in-app for people who already have careers that can't be migrated to it.

## Landing page

Both `landing/public/index.html` and `landing/public/index-en.html`:

- **Announcement bar** above the nav: *"Plantillas y competiciones actualizadas a la temporada 2026/27"* / *"Squads and competitions updated for the 2026/27 season"*.
- **Feature card heading**: "Datos Reales 2025/26" → "2026/27" (and "Real 2025/26 Data" → "Real 2026/27 Data").

The bar uses `accent-gold`: red is already the logo and the primary CTA, green is the hero's "en desarrollo activo" pill, so gold is the only accent left that reads as new information. It reuses the hero pill's dot-plus-uppercase-label idiom, with the dot hidden below `sm` so the copy gets full width on a phone.

## Dashboard

Saves cannot be migrated to newer reference data — a career keeps the squads it was seeded with for life. Nothing said so, so after a refresh an old save looks like a new one that failed to update.

- **Each career card's mode badge carries the season the save was created from** — `Club Manager - 25/26`, read from `base_season`. It renders on every card rather than only on old ones, so it reads as a coordinate rather than a warning, and a mixed dashboard explains itself.
- **Users holding at least one save from a past season get a muted line** saying those saves keep their original squads and that a new career is the way onto the new data. Accounts with no such save never see it — they have no reason to know the constraint exists.

The badge shows `base_season`, not the season being played. That's what makes it identify an old save at all: a pre-refresh career that has completed a season would otherwise be indistinguishable from a new one. The known cost is that a long-running career shows the season it started from next to an in-game date from a later one — accepted deliberately.

World Cup saves are excluded from both. They're pinned to a fixed real-world tournament, so a data vintage says nothing about them and "start a new career for the new data" isn't advice that applies.

Also folds the card's three near-identical mode spans into one component. The existing `x-mode-badge` is untouched — the leaderboard renders it from `manager_stats` rows, which have no `base_season` to show.

Both the badge and the line are inert until `GAME_SEASON` flips to 2026, so this can merge ahead of the release without changing anything visible.

## Not done, deliberately

- **The landing page's marketing figures are unchanged** (346 equipos, 8.145 jugadores, 43 países). They don't reconcile to the data files on any basis I could reproduce — 245 clubs with squads plus 48 World Cup sides is 293, and the cup-only participants don't close the gap — so they come from a seeded database and should be recomputed from the 2026 seed rather than guessed at.
- **No `GAME_SEASON` bump.** `data/2026/` is still on the open data-refresh PR; flipping the base season before that merges would point the seeder and every base-season lookup at a folder that isn't on `main`.

## Verification

The dashboard work is covered by `DashboardSaveVintageTest`, which renders the real dashboard for mixed, current-only and World Cup saves. Full suite 1249 passed, Larastan clean.

**The landing page has not been checked visually** — `cdn.tailwindcss.com` is blocked by egress policy in the environment this was built in, so screenshots rendered as unstyled HTML. Verified structurally only: the bar sits in the same position in both files, `accent-gold` is defined in each page's inline Tailwind config, and no `2025/26` strings remain under `landing/public/`. Worth an eyeball via `cd landing && npm run dev` before deploying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WUuDXK2BECRfCLPM49HxPy