### PR TITLE
Pay cup prize money by distance from the final

### DIFF
--- a/app/Modules/Competition/Configs/BundesligaConfig.php
+++ b/app/Modules/Competition/Configs/BundesligaConfig.php
@@ -106,7 +106,7 @@ class BundesligaConfig implements CompetitionConfig, HasSeasonGoals
         return 'season.best_goalkeeper_bundesliga';
     }
 
-    public function getKnockoutPrizeMoney(int $roundNumber): int
+    public function getKnockoutPrizeMoney(int $roundsFromFinal): int
     {
         return 0;
     }

--- a/app/Modules/Competition/Configs/ChampionsLeagueConfig.php
+++ b/app/Modules/Competition/Configs/ChampionsLeagueConfig.php
@@ -9,12 +9,13 @@ class ChampionsLeagueConfig implements CompetitionConfig
     /**
      * UCL knockout round prize money (in cents).
      */
+    /** Keyed by rounds remaining after the one won: 0 is the final. */
     private const KNOCKOUT_PRIZE_MONEY = [
-        1 => 1_100_000_000,    // €11M   — win Knockout Playoff = reach R16
-        2 => 1_250_000_000,    // €12.5M — win R16 = reach QF
-        3 => 1_500_000_000,    // €15M   — win QF = reach SF
-        4 => 1_850_000_000,    // €18.5M — win SF = reach Final
-        5 => 2_500_000_000,    // €25M   — win Final (champion)
+        0 => 2_500_000_000,    // €25M   — win Final (champion)
+        1 => 1_850_000_000,    // €18.5M — win SF = reach Final
+        2 => 1_500_000_000,    // €15M   — win QF = reach SF
+        3 => 1_250_000_000,    // €12.5M — win R16 = reach QF
+        4 => 1_100_000_000,    // €11M   — win Knockout Playoff = reach R16
     ];
 
     /**
@@ -87,9 +88,9 @@ class ChampionsLeagueConfig implements CompetitionConfig
         return 'season.best_goalkeeper';
     }
 
-    public function getKnockoutPrizeMoney(int $roundNumber): int
+    public function getKnockoutPrizeMoney(int $roundsFromFinal): int
     {
-        return self::KNOCKOUT_PRIZE_MONEY[$roundNumber] ?? 0;
+        return self::KNOCKOUT_PRIZE_MONEY[$roundsFromFinal] ?? 0;
     }
 
     public function getLeaguePhaseQualificationBonus(int $position): int

--- a/app/Modules/Competition/Configs/ConferenceLeagueConfig.php
+++ b/app/Modules/Competition/Configs/ConferenceLeagueConfig.php
@@ -9,12 +9,13 @@ class ConferenceLeagueConfig implements CompetitionConfig
     /**
      * UECL knockout round prize money (in cents).
      */
+    /** Keyed by rounds remaining after the one won: 0 is the final. */
     private const KNOCKOUT_PRIZE_MONEY = [
-        1 => 275_000_000,      // €2.75M — win Knockout Playoff = reach R16
-        2 => 310_000_000,      // €3.1M  — win R16 = reach QF
-        3 => 375_000_000,      // €3.75M — win QF = reach SF
-        4 => 460_000_000,      // €4.6M  — win SF = reach Final
-        5 => 625_000_000,      // €6.25M — win Final (champion)
+        0 => 625_000_000,      // €6.25M — win Final (champion)
+        1 => 460_000_000,      // €4.6M  — win SF = reach Final
+        2 => 375_000_000,      // €3.75M — win QF = reach SF
+        3 => 310_000_000,      // €3.1M  — win R16 = reach QF
+        4 => 275_000_000,      // €2.75M — win Knockout Playoff = reach R16
     ];
 
     public function getTvRevenue(int $position): int
@@ -49,9 +50,9 @@ class ConferenceLeagueConfig implements CompetitionConfig
         return 'season.best_goalkeeper';
     }
 
-    public function getKnockoutPrizeMoney(int $roundNumber): int
+    public function getKnockoutPrizeMoney(int $roundsFromFinal): int
     {
-        return self::KNOCKOUT_PRIZE_MONEY[$roundNumber] ?? 0;
+        return self::KNOCKOUT_PRIZE_MONEY[$roundsFromFinal] ?? 0;
     }
 
     public function getLeaguePhaseQualificationBonus(int $position): int

--- a/app/Modules/Competition/Configs/DefaultLeagueConfig.php
+++ b/app/Modules/Competition/Configs/DefaultLeagueConfig.php
@@ -103,7 +103,7 @@ class DefaultLeagueConfig implements CompetitionConfig, HasSeasonGoals
         return 'season.best_goalkeeper';
     }
 
-    public function getKnockoutPrizeMoney(int $roundNumber): int
+    public function getKnockoutPrizeMoney(int $roundsFromFinal): int
     {
         return 0;
     }

--- a/app/Modules/Competition/Configs/EuropaLeagueConfig.php
+++ b/app/Modules/Competition/Configs/EuropaLeagueConfig.php
@@ -9,12 +9,13 @@ class EuropaLeagueConfig implements CompetitionConfig
     /**
      * UEL knockout round prize money (in cents).
      */
+    /** Keyed by rounds remaining after the one won: 0 is the final. */
     private const KNOCKOUT_PRIZE_MONEY = [
-        1 => 550_000_000,      // €5.5M  — win Knockout Playoff = reach R16
-        2 => 625_000_000,      // €6.25M — win R16 = reach QF
-        3 => 750_000_000,      // €7.5M  — win QF = reach SF
-        4 => 925_000_000,      // €9.25M — win SF = reach Final
-        5 => 1_250_000_000,    // €12.5M — win Final (champion)
+        0 => 1_250_000_000,    // €12.5M — win Final (champion)
+        1 => 925_000_000,      // €9.25M — win SF = reach Final
+        2 => 750_000_000,      // €7.5M  — win QF = reach SF
+        3 => 625_000_000,      // €6.25M — win R16 = reach QF
+        4 => 550_000_000,      // €5.5M  — win Knockout Playoff = reach R16
     ];
 
     public function getTvRevenue(int $position): int
@@ -49,9 +50,9 @@ class EuropaLeagueConfig implements CompetitionConfig
         return 'season.best_goalkeeper';
     }
 
-    public function getKnockoutPrizeMoney(int $roundNumber): int
+    public function getKnockoutPrizeMoney(int $roundsFromFinal): int
     {
-        return self::KNOCKOUT_PRIZE_MONEY[$roundNumber] ?? 0;
+        return self::KNOCKOUT_PRIZE_MONEY[$roundsFromFinal] ?? 0;
     }
 
     public function getLeaguePhaseQualificationBonus(int $position): int

--- a/app/Modules/Competition/Configs/KnockoutCupConfig.php
+++ b/app/Modules/Competition/Configs/KnockoutCupConfig.php
@@ -7,15 +7,21 @@ use App\Modules\Competition\Contracts\CompetitionConfig;
 class KnockoutCupConfig implements CompetitionConfig
 {
     /**
-     * Copa del Rey knockout round prize money (in cents).
+     * Domestic knockout cup prize money (in cents), keyed by how many rounds
+     * remain after the one just won: 0 is the final, 1 the semi-final, and so
+     * on back through the early rounds.
+     *
+     * Counting from the final is what lets one table serve cups of different
+     * lengths — the Copa del Rey's seven rounds and a shorter cup's five —
+     * without the early rounds of one being paid as the latter stages of another.
      */
     private const KNOCKOUT_PRIZE_MONEY = [
-        1 => 10_000_000,       // €100K - Round of 64/32
-        2 => 20_000_000,       // €200K - Round of 32/16
+        0 => 200_000_000,      // €2M   - Final
+        1 => 100_000_000,      // €1M   - Semi-finals
+        2 => 50_000_000,       // €500K - Quarter-finals
         3 => 30_000_000,       // €300K - Round of 16
-        4 => 50_000_000,       // €500K - Quarter-finals
-        5 => 100_000_000,      // €1M - Semi-finals
-        6 => 200_000_000,      // €2M - Final
+        4 => 20_000_000,       // €200K - Round of 32
+        5 => 10_000_000,       // €100K - earlier rounds
     ];
 
     public function getTvRevenue(int $position): int
@@ -38,9 +44,12 @@ class KnockoutCupConfig implements CompetitionConfig
         return 'season.best_goalkeeper';
     }
 
-    public function getKnockoutPrizeMoney(int $roundNumber): int
+    public function getKnockoutPrizeMoney(int $roundsFromFinal): int
     {
-        return self::KNOCKOUT_PRIZE_MONEY[$roundNumber] ?? self::KNOCKOUT_PRIZE_MONEY[1];
+        // A cup may have more preliminary rounds than the table describes;
+        // they all pay the earliest-round rate.
+        return self::KNOCKOUT_PRIZE_MONEY[$roundsFromFinal]
+            ?? self::KNOCKOUT_PRIZE_MONEY[array_key_last(self::KNOCKOUT_PRIZE_MONEY)];
     }
 
     public function getLeaguePhaseQualificationBonus(int $position): int

--- a/app/Modules/Competition/Configs/LaLiga2Config.php
+++ b/app/Modules/Competition/Configs/LaLiga2Config.php
@@ -109,7 +109,7 @@ class LaLiga2Config implements CompetitionConfig, HasSeasonGoals
         return 'season.zamora';
     }
 
-    public function getKnockoutPrizeMoney(int $roundNumber): int
+    public function getKnockoutPrizeMoney(int $roundsFromFinal): int
     {
         return 0;
     }

--- a/app/Modules/Competition/Configs/LaLigaConfig.php
+++ b/app/Modules/Competition/Configs/LaLigaConfig.php
@@ -107,7 +107,7 @@ class LaLigaConfig implements CompetitionConfig, HasSeasonGoals
         return 'season.zamora';
     }
 
-    public function getKnockoutPrizeMoney(int $roundNumber): int
+    public function getKnockoutPrizeMoney(int $roundsFromFinal): int
     {
         return 0;
     }

--- a/app/Modules/Competition/Configs/Ligue1Config.php
+++ b/app/Modules/Competition/Configs/Ligue1Config.php
@@ -106,7 +106,7 @@ class Ligue1Config implements CompetitionConfig, HasSeasonGoals
         return 'season.best_goalkeeper_ligue1';
     }
 
-    public function getKnockoutPrizeMoney(int $roundNumber): int
+    public function getKnockoutPrizeMoney(int $roundsFromFinal): int
     {
         return 0;
     }

--- a/app/Modules/Competition/Configs/PremierLeagueConfig.php
+++ b/app/Modules/Competition/Configs/PremierLeagueConfig.php
@@ -114,7 +114,7 @@ class PremierLeagueConfig implements CompetitionConfig, HasSeasonGoals
         return 'season.golden_glove';
     }
 
-    public function getKnockoutPrizeMoney(int $roundNumber): int
+    public function getKnockoutPrizeMoney(int $roundsFromFinal): int
     {
         return 0;
     }

--- a/app/Modules/Competition/Configs/PrimeraRFEFConfig.php
+++ b/app/Modules/Competition/Configs/PrimeraRFEFConfig.php
@@ -94,7 +94,7 @@ class PrimeraRFEFConfig implements CompetitionConfig, HasSeasonGoals
         return 'season.zamora';
     }
 
-    public function getKnockoutPrizeMoney(int $roundNumber): int
+    public function getKnockoutPrizeMoney(int $roundsFromFinal): int
     {
         return 0;
     }

--- a/app/Modules/Competition/Configs/PrimeraRFEFPlayoffConfig.php
+++ b/app/Modules/Competition/Configs/PrimeraRFEFPlayoffConfig.php
@@ -18,9 +18,10 @@ class PrimeraRFEFPlayoffConfig implements CompetitionConfig
      * Knockout prize money by round (in cents).
      * Round 1: Bracket semifinal. Round 2: Bracket final (promotion).
      */
+    /** Keyed by rounds remaining after the one won: 0 is the final. */
     private const KNOCKOUT_PRIZE_MONEY = [
+        0 => 100_000_000,  // €1M — winning the bracket final (promotion)
         1 => 20_000_000,   // €200K — reaching the bracket final
-        2 => 100_000_000,  // €1M — winning the bracket final (promotion)
     ];
 
     public function getTvRevenue(int $position): int
@@ -43,9 +44,9 @@ class PrimeraRFEFPlayoffConfig implements CompetitionConfig
         return 'season.best_goalkeeper';
     }
 
-    public function getKnockoutPrizeMoney(int $roundNumber): int
+    public function getKnockoutPrizeMoney(int $roundsFromFinal): int
     {
-        return self::KNOCKOUT_PRIZE_MONEY[$roundNumber] ?? 0;
+        return self::KNOCKOUT_PRIZE_MONEY[$roundsFromFinal] ?? 0;
     }
 
     public function getLeaguePhaseQualificationBonus(int $position): int

--- a/app/Modules/Competition/Configs/SerieAConfig.php
+++ b/app/Modules/Competition/Configs/SerieAConfig.php
@@ -107,7 +107,7 @@ class SerieAConfig implements CompetitionConfig, HasSeasonGoals
         return 'season.best_goalkeeper_serie_a';
     }
 
-    public function getKnockoutPrizeMoney(int $roundNumber): int
+    public function getKnockoutPrizeMoney(int $roundsFromFinal): int
     {
         return 0;
     }

--- a/app/Modules/Competition/Configs/SupercupConfig.php
+++ b/app/Modules/Competition/Configs/SupercupConfig.php
@@ -15,9 +15,14 @@ use App\Modules\Competition\Contracts\CompetitionConfig;
  */
 class SupercupConfig implements CompetitionConfig
 {
+    /**
+     * Keyed by rounds remaining after the one won: 0 is the final. A final
+     * four pays a semi-final win and then the trophy; a two-club supercup
+     * plays only round one, which is its final, and is paid as one.
+     */
     private const KNOCKOUT_PRIZE_MONEY = [
-        1 => 100_000_000, // €1M — semi-final (or the final of a two-club supercup)
-        2 => 300_000_000, // €3M — winner
+        0 => 300_000_000, // €3M — winner
+        1 => 100_000_000, // €1M — semi-final
     ];
 
     public function getTvRevenue(int $position): int
@@ -40,9 +45,9 @@ class SupercupConfig implements CompetitionConfig
         return 'season.best_goalkeeper';
     }
 
-    public function getKnockoutPrizeMoney(int $roundNumber): int
+    public function getKnockoutPrizeMoney(int $roundsFromFinal): int
     {
-        return self::KNOCKOUT_PRIZE_MONEY[$roundNumber] ?? 0;
+        return self::KNOCKOUT_PRIZE_MONEY[$roundsFromFinal] ?? 0;
     }
 
     public function getLeaguePhaseQualificationBonus(int $position): int

--- a/app/Modules/Competition/Configs/UefaSuperCupConfig.php
+++ b/app/Modules/Competition/Configs/UefaSuperCupConfig.php
@@ -10,8 +10,9 @@ class UefaSuperCupConfig implements CompetitionConfig
      * UEFA Super Cup prize money (in cents). Single match: only the winner
      * of round 1 (the final) is rewarded.
      */
+    /** Keyed by rounds remaining after the one won: 0 is the final. */
     private const KNOCKOUT_PRIZE_MONEY = [
-        1 => 500_000_000, // €5M — Winner
+        0 => 500_000_000, // €5M — Winner
     ];
 
     public function getTvRevenue(int $position): int
@@ -34,9 +35,9 @@ class UefaSuperCupConfig implements CompetitionConfig
         return 'season.best_goalkeeper';
     }
 
-    public function getKnockoutPrizeMoney(int $roundNumber): int
+    public function getKnockoutPrizeMoney(int $roundsFromFinal): int
     {
-        return self::KNOCKOUT_PRIZE_MONEY[$roundNumber] ?? 0;
+        return self::KNOCKOUT_PRIZE_MONEY[$roundsFromFinal] ?? 0;
     }
 
     public function getLeaguePhaseQualificationBonus(int $position): int

--- a/app/Modules/Competition/Contracts/CompetitionConfig.php
+++ b/app/Modules/Competition/Contracts/CompetitionConfig.php
@@ -47,10 +47,17 @@ interface CompetitionConfig
     public function getStandingsZones(): array;
 
     /**
-     * Get prize money for advancing past a knockout round (in cents).
+     * Prize money for winning a knockout tie (in cents), keyed by how many
+     * rounds remain after it: 0 is the final, 1 the semi-final, and so on.
+     *
+     * Counting back from the final rather than forward from round one is what
+     * lets a config serve cups of different lengths — a round number means
+     * nothing on its own, since round 5 is the Copa del Rey's quarter-final
+     * and the Champions League final.
+     *
      * Returns 0 for competitions without knockout prize money.
      */
-    public function getKnockoutPrizeMoney(int $roundNumber): int;
+    public function getKnockoutPrizeMoney(int $roundsFromFinal): int;
 
     /**
      * Get the bonus paid to a team for qualifying out of the league phase,

--- a/app/Modules/Match/Listeners/AwardCupPrizeMoney.php
+++ b/app/Modules/Match/Listeners/AwardCupPrizeMoney.php
@@ -3,6 +3,7 @@
 namespace App\Modules\Match\Listeners;
 
 use App\Modules\Match\Events\CupTieResolved;
+use App\Modules\Competition\Services\LeagueFixtureGenerator;
 use App\Models\FinancialTransaction;
 
 class AwardCupPrizeMoney
@@ -18,7 +19,18 @@ class AwardCupPrizeMoney
             return;
         }
 
-        $amount = $competition->getConfig()->getKnockoutPrizeMoney($event->cupTie->round_number);
+        // Prize tables are written from the final backwards, because a round
+        // number means nothing on its own: round 5 is the Copa's quarter-final
+        // and the Champions League final. Count back from the last round the
+        // cup's schedule declares instead.
+        $finalRound = LeagueFixtureGenerator::finalKnockoutRound($competition->id, $event->game->base_season);
+        if ($finalRound === null) {
+            return;
+        }
+
+        $roundsFromFinal = $finalRound - $event->cupTie->round_number;
+
+        $amount = $competition->getConfig()->getKnockoutPrizeMoney($roundsFromFinal);
 
         if ($amount <= 0) {
             return;

--- a/tests/Feature/AwardCupPrizeMoneyTest.php
+++ b/tests/Feature/AwardCupPrizeMoneyTest.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Competition;
+use App\Models\CupTie;
+use App\Models\FinancialTransaction;
+use App\Models\Game;
+use App\Models\GameMatch;
+use App\Models\Team;
+use App\Models\User;
+use App\Modules\Match\Events\CupTieResolved;
+use App\Modules\Match\Listeners\AwardCupPrizeMoney;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Prize money is keyed on how many rounds remain after the tie just won, not
+ * on the round's own number — a number that means nothing on its own, since
+ * round 5 is the Copa del Rey's quarter-final and the Champions League final.
+ */
+class AwardCupPrizeMoneyTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Game $game;
+    private Team $userTeam;
+    private Team $opponent;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Competition::factory()->league()->create(['id' => 'ESP1', 'country' => 'ES', 'tier' => 1]);
+
+        $this->userTeam = Team::factory()->create(['country' => 'ES']);
+        $this->opponent = Team::factory()->create(['country' => 'ES']);
+
+        $this->game = Game::factory()->create([
+            'user_id' => User::factory()->create()->id,
+            'team_id' => $this->userTeam->id,
+            'competition_id' => 'ESP1',
+            'season' => '2025',
+            'base_season' => '2025',
+        ]);
+    }
+
+    public function test_winning_the_copa_del_rey_pays_the_final_prize_not_the_first_round_one(): void
+    {
+        // The Copa's final is round 7. Keyed on the raw round number against a
+        // six-entry table, it fell through to the opening round's €100K.
+        $this->assertSame(200_000_000, $this->awardFor('ESPCUP', roundNumber: 7));
+    }
+
+    public function test_copa_rounds_are_paid_by_their_distance_from_the_final(): void
+    {
+        $this->assertSame(100_000_000, $this->awardFor('ESPCUP', roundNumber: 6)); // semi-final
+        $this->assertSame(50_000_000, $this->awardFor('ESPCUP', roundNumber: 5));  // quarter-final
+        $this->assertSame(30_000_000, $this->awardFor('ESPCUP', roundNumber: 4));  // round of 16
+        $this->assertSame(20_000_000, $this->awardFor('ESPCUP', roundNumber: 3));  // round of 32
+    }
+
+    public function test_rounds_earlier_than_the_table_pay_the_opening_round_rate(): void
+    {
+        // The Copa opens with two rounds beyond the table's five entries.
+        $this->assertSame(10_000_000, $this->awardFor('ESPCUP', roundNumber: 2));
+        $this->assertSame(10_000_000, $this->awardFor('ESPCUP', roundNumber: 1));
+    }
+
+    public function test_champions_league_payouts_are_unchanged(): void
+    {
+        // Regression guard: the UCL's table already ended on its final round,
+        // so counting from the end must leave every figure where it was.
+        $this->assertSame(2_500_000_000, $this->awardFor('UCL', roundNumber: 5)); // final
+        $this->assertSame(1_850_000_000, $this->awardFor('UCL', roundNumber: 4)); // semi-final
+        $this->assertSame(1_100_000_000, $this->awardFor('UCL', roundNumber: 1)); // knockout playoff
+    }
+
+    public function test_nothing_is_paid_when_the_user_is_not_the_winner(): void
+    {
+        $this->assertSame(0, $this->awardFor('ESPCUP', roundNumber: 7, winner: $this->opponent));
+    }
+
+    /**
+     * Resolve one cup tie and return what the user's club was paid, in cents.
+     */
+    private function awardFor(string $competitionId, int $roundNumber, ?Team $winner = null): int
+    {
+        $winner ??= $this->userTeam;
+
+        $competition = Competition::firstOrCreate(
+            ['id' => $competitionId],
+            [
+                'name' => $competitionId,
+                'country' => 'ES',
+                'type' => 'cup',
+                'role' => Competition::ROLE_DOMESTIC_CUP,
+                'handler_type' => 'knockout_cup',
+                'season' => $this->game->base_season,
+                'tier' => 0,
+            ],
+        );
+
+        $tie = CupTie::create([
+            'game_id' => $this->game->id,
+            'competition_id' => $competitionId,
+            'round_number' => $roundNumber,
+            'home_team_id' => $winner->id,
+            'away_team_id' => $this->opponent->id,
+            'winner_id' => $winner->id,
+            'completed' => true,
+        ]);
+
+        $match = GameMatch::factory()->create([
+            'game_id' => $this->game->id,
+            'competition_id' => $competitionId,
+            'home_team_id' => $winner->id,
+            'away_team_id' => $this->opponent->id,
+            'round_number' => $roundNumber,
+        ]);
+
+        FinancialTransaction::where('game_id', $this->game->id)->delete();
+
+        (new AwardCupPrizeMoney())->handle(
+            new CupTieResolved($tie, $winner->id, $match, $this->game, $competition),
+        );
+
+        return (int) FinancialTransaction::where('game_id', $this->game->id)
+            ->where('category', FinancialTransaction::CATEGORY_CUP_BONUS)
+            ->sum('amount');
+    }
+}


### PR DESCRIPTION
Winning the Copa del Rey pays €100K. KnockoutCupConfig's table is keyed by round number and stops at 6, the Copa's final is round 7, and the lookup falls back to KNOCKOUT_PRIZE_MONEY[1] — so lifting the trophy pays the opening-round rate. The whole table is shifted for the same reason: the semi-final collects the €2M meant for the final, the quarter-final the €1M meant for the semi.

A round number means nothing on its own. Round 5 is the Copa's quarter-final and the Champions League final, so no table keyed by it can serve both. Key on how many rounds remain after the tie just won instead: 0 is the final, 1 the semi-final, and so on back through the early rounds. AwardCupPrizeMoney takes the last round from the cup's own schedule.json, which is where the final has been defined since #1338 removed cup_final_round from config.

Every other config's table already ended exactly on its cup's final round — the Champions League's five knockout rounds, the Super Cup's one, the Primera RFEF playoff's two — so reversing their keys is behaviour- preserving, and the new test asserts the UCL figures are untouched. KnockoutCupConfig keeps a fallback, now to the earliest entry rather than the first key, because a cup may open with more preliminary rounds than the table describes; the Copa's two do.

This also fixes the two-club supercup that SupercupConfig's own comment flagged: it plays one round, which is its final, and was being paid the semi-final's €1M rather than the winner's €3M.

There were no tests over cup prize money at all, which is how the Copa went a whole competition unpaid. There are now.


Claude-Session: https://claude.ai/code/session_01Dj9FmnYtMv1HbuM4DxGyJF