### PR TITLE
Clear the baked-in supercup bump from cup entry rounds

### DIFF
--- a/app/Modules/Season/Services/SeasonInitializationService.php
+++ b/app/Modules/Season/Services/SeasonInitializationService.php
@@ -209,9 +209,10 @@ class SeasonInitializationService
     /**
      * Conduct cup draws for every knockout cup this game participates in
      * — the country's domestic cups and supercup, plus continental
-     * knockouts (UEFASUP). Entry rounds are settled first (tier rules,
-     * supercup skip-ahead, European entrants, parity) so round 1 is drawn
-     * from the right field.
+     * knockouts (UEFASUP). Entry rounds are settled first — the round each
+     * club's data file declared, then the supercup skip-ahead — so round 1
+     * is drawn from the right field. Parity is not adjusted here; it comes
+     * from the cup's own size (see cup_qualification.target_size).
      */
     public function conductCupDraws(string $gameId, string $countryCode): void
     {

--- a/config/countries.php
+++ b/config/countries.php
@@ -137,8 +137,10 @@ return [
         // pool) are left untouched, so regional qualifiers keep their cup
         // place and the entry round their data file gave them.
         //
-        // Whatever these rules produce, CupEntryRoundService balances the
-        // bracket at season setup so every round has an even field.
+        // Nothing balances the bracket afterwards: every round is even
+        // because target_size below leaves exactly as many clubs in round
+        // one as the supercup field takes out of it, and CupEntryRoundService
+        // only applies declared rounds and that skip-ahead.
         'cup_qualification' => [
             'ESPCUP' => [
                 'auto_qualify_tiers' => [1, 2],

--- a/database/migrations/2026_09_05_000002_reset_baked_in_supercup_cup_entry_rounds.php
+++ b/database/migrations/2026_09_05_000002_reset_baked_in_supercup_cup_entry_rounds.php
@@ -1,0 +1,65 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Clears the supercup skip-ahead that the seeder used to bake into
+ * competition_teams.entry_round.
+ *
+ * That column now holds only what a cup's teams.json declares; the
+ * per-game skip-ahead is derived each season by CupEntryRoundService.
+ * Databases seeded before that change still carry cup_entry_round on the
+ * clubs that happened to be in the supercup the season the data was
+ * scraped, and CupEntryRoundService reads the column as its baseline —
+ * so those clubs stay parked at the round of 32 while the season's real
+ * supercup field is bumped there as well.
+ *
+ * Round one then loses more clubs than the cup's size budgeted for. With
+ * three of Spain's four 2025 Supercopa clubs re-qualifying, five clubs
+ * sat at round 3 instead of four and the Copa's first round was drawn
+ * from 111 teams — an odd pool, which fails the draw and takes the whole
+ * season transition down with it (OddCupDrawPoolException).
+ *
+ * Reverses the old rule exactly: a cup row is reset only when it sits at
+ * the country's cup_entry_round *and* the club was in that same season's
+ * supercup field, which is the only way the old seeder ever wrote it.
+ * A round a data file declares itself is left alone.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        foreach (config('countries', []) as $country) {
+            $supercup = $country['supercup'] ?? null;
+            $cupId = $supercup['cup'] ?? null;
+            $supercupId = $supercup['competition'] ?? null;
+            $bumpRound = (int) ($supercup['cup_entry_round'] ?? 0);
+
+            if ($cupId === null || $supercupId === null || $bumpRound <= 1) {
+                continue;
+            }
+
+            $supercupTeamsBySeason = DB::table('competition_teams')
+                ->where('competition_id', $supercupId)
+                ->get(['season', 'team_id'])
+                ->groupBy('season');
+
+            foreach ($supercupTeamsBySeason as $season => $rows) {
+                DB::table('competition_teams')
+                    ->where('competition_id', $cupId)
+                    ->where('season', $season)
+                    ->where('entry_round', $bumpRound)
+                    ->whereIn('team_id', $rows->pluck('team_id')->all())
+                    ->update(['entry_round' => 1]);
+            }
+        }
+    }
+
+    public function down(): void
+    {
+        // Intentionally left empty — the rounds this clears were derived
+        // state that no longer belongs in the column, so re-baking them
+        // would only reintroduce the bug.
+    }
+};

--- a/tests/Feature/ResetBakedInSupercupCupEntryRoundsTest.php
+++ b/tests/Feature/ResetBakedInSupercupCupEntryRoundsTest.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Competition;
+use App\Models\Team;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+/**
+ * The seeder used to bake the supercup skip-ahead into
+ * competition_teams.entry_round. CupEntryRoundService now reads that column
+ * as the round a cup's data file declared, so a database still carrying the
+ * baked bump parks last season's supercup clubs at the round of 32 on top of
+ * this season's field — five clubs where the cup budgeted for four, and a
+ * first round drawn from an odd pool.
+ *
+ * The repair migration undoes the old rule without touching a round a data
+ * file declares for itself.
+ */
+class ResetBakedInSupercupCupEntryRoundsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Competition::factory()->knockoutCup()->create(['id' => 'ESPCUP', 'country' => 'ES']);
+        Competition::factory()->knockoutCup()->create(['id' => 'ESPSUP', 'country' => 'ES']);
+    }
+
+    public function test_it_clears_the_baked_supercup_bump_from_the_cup(): void
+    {
+        $supercupClubs = $this->teams(4);
+        $this->seedRounds('ESPSUP', $supercupClubs, 1);
+        // The old seeder wrote the country's cup_entry_round on exactly the
+        // clubs that were in that season's supercup.
+        $this->seedRounds('ESPCUP', $supercupClubs, 3);
+        $this->seedRounds('ESPCUP', $this->teams(112), 1);
+
+        $this->migration()->up();
+
+        $this->assertSame(116, $this->countAtRound('ESPCUP', 1));
+        $this->assertSame(0, $this->countAtRound('ESPCUP', 3));
+    }
+
+    public function test_it_leaves_a_round_the_data_file_declares_alone(): void
+    {
+        // An FA Cup-shaped field: league clubs join at round 3 because their
+        // teams.json says so, not because they are in a supercup.
+        $leagueClubs = $this->teams(44);
+        $this->seedRounds('ESPCUP', $leagueClubs, 3);
+        $this->seedRounds('ESPCUP', $this->teams(80), 1);
+        $this->seedRounds('ESPSUP', $this->teams(4), 1);
+
+        $this->migration()->up();
+
+        $this->assertSame(44, $this->countAtRound('ESPCUP', 3));
+        $this->assertSame(80, $this->countAtRound('ESPCUP', 1));
+    }
+
+    public function test_it_matches_the_supercup_field_of_the_same_season(): void
+    {
+        // A club bumped in 2025 that only reached the supercup in 2026 keeps
+        // its 2025 round: the old seeder could not have written it there.
+        $club = $this->teams(1);
+        $this->seedRounds('ESPSUP', $club, 1, '2026');
+        $this->seedRounds('ESPCUP', $club, 3, '2025');
+
+        $this->migration()->up();
+
+        $this->assertSame(3, $this->countAtRound('ESPCUP', 3, '2025'));
+    }
+
+    private function migration(): Migration
+    {
+        return require database_path(
+            'migrations/2026_09_05_000002_reset_baked_in_supercup_cup_entry_rounds.php'
+        );
+    }
+
+    /**
+     * @return Team[]
+     */
+    private function teams(int $count): array
+    {
+        $teams = [];
+        for ($i = 0; $i < $count; $i++) {
+            $teams[] = Team::factory()->create(['country' => 'ES']);
+        }
+
+        return $teams;
+    }
+
+    /**
+     * The round a cup's data file gave each club, as the seeder records it.
+     *
+     * @param  Team[]  $teams
+     */
+    private function seedRounds(string $competitionId, array $teams, int $entryRound, string $season = '2025'): void
+    {
+        DB::table('competition_teams')->insert(array_map(fn (Team $team) => [
+            'competition_id' => $competitionId,
+            'team_id' => $team->id,
+            'season' => $season,
+            'entry_round' => $entryRound,
+        ], $teams));
+    }
+
+    private function countAtRound(string $competitionId, int $entryRound, string $season = '2025'): int
+    {
+        return DB::table('competition_teams')
+            ->where('competition_id', $competitionId)
+            ->where('season', $season)
+            ->where('entry_round', $entryRound)
+            ->count();
+    }
+}

--- a/tests/Feature/ResetBakedInSupercupCupEntryRoundsTest.php
+++ b/tests/Feature/ResetBakedInSupercupCupEntryRoundsTest.php
@@ -72,7 +72,7 @@ class ResetBakedInSupercupCupEntryRoundsTest extends TestCase
 
         $this->migration()->up();
 
-        $this->assertSame(3, $this->countAtRound('ESPCUP', 3, '2025'));
+        $this->assertSame(3, $this->roundOf('ESPCUP', $club[0], '2025'));
     }
 
     private function migration(): Migration
@@ -108,6 +108,15 @@ class ResetBakedInSupercupCupEntryRoundsTest extends TestCase
             'season' => $season,
             'entry_round' => $entryRound,
         ], $teams));
+    }
+
+    private function roundOf(string $competitionId, Team $team, string $season = '2025'): int
+    {
+        return (int) DB::table('competition_teams')
+            ->where('competition_id', $competitionId)
+            ->where('team_id', $team->id)
+            ->where('season', $season)
+            ->value('entry_round');
     }
 
     private function countAtRound(string $competitionId, int $entryRound, string $season = '2025'): int


### PR DESCRIPTION
Season transitions were dying on the Copa del Rey draw:

  Cannot draw ESPCUP round 1: pool has 111 teams (odd).

competition_teams.entry_round used to carry the supercup skip-ahead:
the seeder wrote the country's cup_entry_round on whichever clubs were
in the supercup the season the data was scraped. #1338 made that column
hold only what a cup's teams.json declares and moved the skip-ahead to
CupEntryRoundService, which derives it per game per season — but it
reads the same column as its baseline, so a database seeded before that
change still parks the 2025 Supercopa clubs at the round of 32 while
this season's field is bumped there as well.

Three of the four 2025 clubs re-qualified, so five sat at round 3 where
the Copa's 116-club field budgets for four, and round one was drawn from
111. The draw refuses an odd pool rather than dropping a club, which
takes the whole transition down with it.

Repair the column instead of waiting on an app:seed-reference-data
rerun. The migration reverses the old rule exactly — a cup row is reset
only where it sits at the country's cup_entry_round and the club was in
that same season's supercup field, the only way the old seeder ever
wrote it — so a round a data file declares for itself is untouched.
Stuck games recover on their own: the entry rounds are recomputed from
the repaired baseline when the transition is re-dispatched.

Also correct two comments that still promised a bracket-balancing step
CupEntryRoundService no longer has; the parity comes from target_size.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0124MR5gnD1K4ebZPJzZmnkj