### PR TITLE
Fix blank squad numbers and club names re-spelled upstream

### DIFF
--- a/app/Console/Commands/SeedReferenceData.php
+++ b/app/Console/Commands/SeedReferenceData.php
@@ -5,7 +5,9 @@ namespace App\Console\Commands;
 use App\Modules\Competition\Services\CountryConfig;
 use App\Modules\Stadium\UefaCategory;
 use App\Models\User;
+use App\Support\ClubNames;
 use App\Support\Money;
+use App\Support\SeasonData;
 use App\Support\TeamColors;
 use Carbon\Carbon;
 use Database\Seeders\ClubProfilesSeeder;
@@ -548,8 +550,8 @@ class SeedReferenceData extends Command
                 DB::table('teams')->insert([
                     'id' => $teamId,
                     'transfermarkt_id' => $transfermarktId,
-                    'name' => $data['name'] ?? "Unknown ({$transfermarktId})",
-                    'slug' => Str::slug($data['name'] ?? "unknown-{$transfermarktId}"),
+                    'name' => ClubNames::canonical($data['name'] ?? "Unknown ({$transfermarktId})"),
+                    'slug' => Str::slug(ClubNames::canonical($data['name'] ?? "unknown-{$transfermarktId}")),
                     'country' => $teamCountry,
                     'image' => $data['image'] ?? null,
                     'stadium_name' => $data['stadiumName'] ?? null,
@@ -711,7 +713,8 @@ class SeedReferenceData extends Command
                 ->where('transfermarkt_id', $transfermarktId)
                 ->first();
 
-            $colors = TeamColors::get($club['name']);
+            $name = ClubNames::canonical($club['name']);
+            $colors = TeamColors::get($name);
 
             if ($existingTeam) {
                 $teamId = $existingTeam->id;
@@ -741,8 +744,8 @@ class SeedReferenceData extends Command
                 DB::table('teams')->insert([
                     'id' => $teamId,
                     'transfermarkt_id' => $transfermarktId,
-                    'name' => $club['name'],
-                    'slug' => Str::slug($club['name']),
+                    'name' => $name,
+                    'slug' => Str::slug($name),
                     'country' => $country,
                     'image' => $club['image'] ?? null,
                     'stadium_name' => $club['stadiumName'] ?? null,
@@ -798,8 +801,12 @@ class SeedReferenceData extends Command
             ->keyBy(fn ($team) => (string) $team->transfermarkt_id);
 
         foreach ($clubs as $club) {
-            $name = trim((string) ($club['name'] ?? ''));
-            $transfermarktId = isset($club['id']) && (string) $club['id'] !== '' ? (string) $club['id'] : null;
+            $name = ClubNames::canonical(trim((string) ($club['name'] ?? '')));
+            // Same id resolution the season validator uses, so a cup list
+            // composed from a league stadiums scrape (which writes
+            // `transfermarktId`, not `id`) seeds instead of silently
+            // warning past every club.
+            $transfermarktId = SeasonData::resolveTransfermarktId($club);
 
             if ($name === '' || $transfermarktId === null) {
                 $this->warn("  Skipping cup club without a name or transfermarkt id in {$competitionId}: " . ($name ?: '(unnamed)'));

--- a/app/Modules/Season/Services/GamePlayerTemplateService.php
+++ b/app/Modules/Season/Services/GamePlayerTemplateService.php
@@ -514,7 +514,12 @@ class GamePlayerTemplateService
             'loan_from_transfermarkt_id' => isset($playerData['loan']['from']['id'])
                 ? (string) $playerData['loan']['from']['id']
                 : null,
-            'number' => isset($playerData['number']) ? (int) $playerData['number'] : null,
+            // A squad file states an unknown shirt as "" (or omits it). That has
+            // to land as NULL, not 0: the partial unique index on
+            // (season, team_id, number) covers every non-null value, so casting
+            // blanks to 0 makes two shirtless team-mates collide and
+            // insertOrIgnore silently drops one. Mirrors SeasonData's guard.
+            'number' => ($playerData['number'] ?? '') === '' ? null : (int) $playerData['number'],
             'position' => $position ?? 'Unknown',
             'secondary_positions' => json_encode($secondaryPositions),
             'market_value' => $playerData['marketValue'] ?? null,

--- a/app/Support/ClubNames.php
+++ b/app/Support/ClubNames.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Support;
+
+/**
+ * Canonical club names.
+ *
+ * The Transfermarkt scrape occasionally re-spells a club between season
+ * refreshes ("Athletic Club" → "Athletic Bilbao", "RC Celta" → "Celta de
+ * Vigo"). Teams are matched by transfermarkt_id, so a re-spelling never
+ * creates a duplicate row — but every name-keyed lookup in the codebase
+ * (club profiles, kit colours, regional player origins, academy nationality
+ * bias) silently misses, and the club quietly loses its curated data.
+ *
+ * Everything that turns scraped club data into a team name goes through
+ * canonical() so that only one spelling per club ever reaches the database.
+ */
+class ClubNames
+{
+    /**
+     * Scrape spelling → the name the game uses. Both directions of a rename
+     * appear here when the upstream data has flip-flopped, so an existing row
+     * seeded under the old spelling and a fresh scrape converge on the same
+     * canonical name.
+     */
+    private const CANONICAL = [
+        'Athletic Bilbao' => 'Athletic Club',
+        'Celta de Vigo' => 'RC Celta',
+        'Deportivo de A Coruña' => 'Deportivo A Coruña',
+        'Panathinaikos' => 'Panathinaikos FC',
+        'CS Universitatea Craiova' => 'Universitatea Craiova',
+    ];
+
+    public static function canonical(string $name): string
+    {
+        return self::CANONICAL[$name] ?? $name;
+    }
+
+    /**
+     * Scrape spellings that resolve to a canonical name. Exposed so
+     * app:validate-season doesn't report a renamed club as unprofiled.
+     *
+     * @return array<int, string>
+     */
+    public static function aliases(): array
+    {
+        return array_keys(self::CANONICAL);
+    }
+}

--- a/app/Support/TeamColors/LaLiga2.php
+++ b/app/Support/TeamColors/LaLiga2.php
@@ -7,7 +7,7 @@ final class LaLiga2 implements TeamColorProvider
     public static function teams(): array
     {
         return [
-            'Deportivo de A Coruña' => [
+            'Deportivo A Coruña' => [
                 'pattern' => 'stripes',
                 'primary' => 'blue-600',
                 'secondary' => 'white',

--- a/config/commercial.php
+++ b/config/commercial.php
@@ -275,7 +275,7 @@ return [
         940  => ['sponsor' => 'Abanca',            'clean_name' => 'Balaídos'],            // RC Celta
 
         // ── Spain — Segunda ──────────────────────────────────────────────
-        897  => ['sponsor' => 'Abanca',            'clean_name' => 'Riazor'],              // Deportivo de A Coruña
+        897  => ['sponsor' => 'Abanca',            'clean_name' => 'Riazor'],              // Deportivo A Coruña
         142  => ['sponsor' => 'Ibercaja',          'clean_name' => 'La Romareda'],         // Real Zaragoza
         993  => ['sponsor' => 'Bahrain Victorious', 'clean_name' => 'Nuevo Arcángel'],     // Córdoba CF
         2502 => ['sponsor' => 'SkyFi',             'clean_name' => 'Castalia'],            // CD Castellón

--- a/database/migrations/2026_09_03_000001_canonicalize_renamed_club_names.php
+++ b/database/migrations/2026_09_03_000001_canonicalize_renamed_club_names.php
@@ -1,0 +1,48 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Align rows seeded before the 2026 data refresh with the canonical names
+     * in App\Support\ClubNames. Keyed by transfermarkt_id (stable identifier)
+     * rather than name, so this is safe to re-run and independent of whichever
+     * spelling the row currently holds.
+     *
+     * Athletic Club (621) and RC Celta (940) already have their own rename
+     * migrations; these are the two that were still on an old spelling.
+     */
+    private const RENAMES = [
+        897 => ['Deportivo A Coruña', 'deportivo-a-coruna'],
+        40812 => ['Universitatea Craiova', 'universitatea-craiova'],
+    ];
+
+    private const PREVIOUS = [
+        897 => ['Deportivo de A Coruña', 'deportivo-de-a-coruna'],
+        40812 => ['CS Universitatea Craiova', 'cs-universitatea-craiova'],
+    ];
+
+    public function up(): void
+    {
+        $this->apply(self::RENAMES);
+    }
+
+    public function down(): void
+    {
+        $this->apply(self::PREVIOUS);
+    }
+
+    /**
+     * @param  array<int, array{0: string, 1: string}>  $names
+     */
+    private function apply(array $names): void
+    {
+        foreach ($names as $transfermarktId => [$name, $slug]) {
+            DB::table('teams')
+                ->where('transfermarkt_id', $transfermarktId)
+                ->update(['name' => $name, 'slug' => $slug]);
+        }
+    }
+};

--- a/database/seeders/ClubProfilesSeeder.php
+++ b/database/seeders/ClubProfilesSeeder.php
@@ -4,6 +4,7 @@ namespace Database\Seeders;
 
 use App\Models\ClubProfile;
 use App\Models\Team;
+use App\Support\ClubNames;
 use Illuminate\Database\Seeder;
 
 class ClubProfilesSeeder extends Seeder
@@ -12,7 +13,9 @@ class ClubProfilesSeeder extends Seeder
      * Club profiles with reputation level.
      * Commercial revenue is now calculated algorithmically from stadium_seats × config rate.
      *
-     * Names must match the database exactly (seeded from Transfermarkt JSON data).
+     * Names must match the database exactly (seeded from Transfermarkt JSON
+     * data). When a club is re-spelled upstream, keep the canonical name here
+     * and register the variant in App\Support\ClubNames.
      */
     private const CLUB_DATA = [
         // =============================================
@@ -52,7 +55,7 @@ class ClubProfilesSeeder extends Seeder
         // =============================================
 
         // Established (historic clubs) - Objetivo: Playoff ascenso
-        'Deportivo de A Coruña' => ClubProfile::REPUTATION_ESTABLISHED,
+        'Deportivo A Coruña' => ClubProfile::REPUTATION_ESTABLISHED,
         'Málaga CF' => ClubProfile::REPUTATION_ESTABLISHED,
         'Sporting Gijón' => ClubProfile::REPUTATION_ESTABLISHED,
         'UD Las Palmas' => ClubProfile::REPUTATION_ESTABLISHED,
@@ -863,7 +866,7 @@ class ClubProfilesSeeder extends Seeder
      */
     public static function profiledClubNames(): array
     {
-        return array_keys(self::CLUB_DATA);
+        return array_merge(array_keys(self::CLUB_DATA), ClubNames::aliases());
     }
 
     public function run(): void

--- a/tests/Unit/GamePlayerTemplateSquadNumberTest.php
+++ b/tests/Unit/GamePlayerTemplateSquadNumberTest.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Modules\Season\Services\GamePlayerTemplateService;
+use ReflectionMethod;
+use Tests\TestCase;
+
+/**
+ * game_player_templates carries a partial unique index on
+ * (season, team_id, number) WHERE number IS NOT NULL. A squad file states an
+ * unknown shirt as "" (or omits the key), so a blank must reach the row as
+ * NULL — casting it to 0 puts two shirtless team-mates on the same "number"
+ * and SetupNewGame's insertOrIgnore silently drops one of them.
+ */
+class GamePlayerTemplateSquadNumberTest extends TestCase
+{
+    private ReflectionMethod $prepareTemplateRow;
+
+    private GamePlayerTemplateService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->service = app(GamePlayerTemplateService::class);
+        $this->prepareTemplateRow = new ReflectionMethod(GamePlayerTemplateService::class, 'prepareTemplateRow');
+    }
+
+    /**
+     * @param  array<string, mixed>  $playerData
+     * @return array<string, mixed>|null
+     */
+    private function prepare(array $playerData): ?array
+    {
+        return $this->prepareTemplateRow->invoke(
+            $this->service,
+            '2025',          // season
+            'team-uuid',     // teamId
+            null,            // clubCountry
+            $playerData,     // playerData
+            0,               // minimumWage
+        );
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     * @return array<string, mixed>
+     */
+    private function basePlayer(array $overrides = []): array
+    {
+        return array_merge([
+            'id' => '999999',
+            'name' => 'Test Player',
+            'dateOfBirth' => '2000-01-01',
+            'position' => 'Central Midfield',
+        ], $overrides);
+    }
+
+    public function test_empty_string_number_becomes_null(): void
+    {
+        $row = $this->prepare($this->basePlayer(['number' => '']));
+
+        $this->assertNull($row['number']);
+    }
+
+    public function test_missing_number_becomes_null(): void
+    {
+        $row = $this->prepare($this->basePlayer());
+
+        $this->assertNull($row['number']);
+    }
+
+    public function test_null_number_becomes_null(): void
+    {
+        $row = $this->prepare($this->basePlayer(['number' => null]));
+
+        $this->assertNull($row['number']);
+    }
+
+    /**
+     * Two blanks in one club is the case the index used to reject: both rows
+     * must be NULL, which the partial index excludes.
+     */
+    public function test_two_blank_shirts_in_one_club_do_not_collide(): void
+    {
+        $first = $this->prepare($this->basePlayer(['id' => '1', 'number' => '']));
+        $second = $this->prepare($this->basePlayer(['id' => '2', 'number' => '']));
+
+        $this->assertNull($first['number']);
+        $this->assertNull($second['number']);
+    }
+
+    public function test_real_numbers_are_still_cast_to_int(): void
+    {
+        $this->assertSame(9, $this->prepare($this->basePlayer(['number' => '9']))['number']);
+        $this->assertSame(7, $this->prepare($this->basePlayer(['number' => '07']))['number']);
+        $this->assertSame(23, $this->prepare($this->basePlayer(['number' => 23]))['number']);
+    }
+}


### PR DESCRIPTION
**3 of 7** splitting `season-data/2026`. Based on #1342.

Two unrelated bugs found during the refresh. Both are fixes for season 2025 as it stands — worth merging on their own merit, not because 2026 needs them. One commit each.

## Blank squad number lands as `NULL`, not shirt 0

A squad file states an unknown shirt as `""` or omits it, and `(int) "" === 0`. The partial unique index on `(season, team_id, number)` covers every non-null value, so two shirtless team-mates both landed on 0, collided, and `insertOrIgnore` silently dropped one — leaving `SetupNewGame` to FK-fail on the missing player's match-state row.

## Canonical club names

Transfermarkt occasionally re-spells a club between refreshes ("Athletic Club" → "Athletic Bilbao", "Deportivo de A Coruña" → "Deportivo A Coruña"). Teams are matched by `transfermarkt_id`, so a re-spelling never duplicates a row — but every name-keyed lookup misses: club profile, kit colours, regional player origins, academy nationality bias. The club quietly loses its curated data and nothing reports it.

Every path that turns scraped club data into a team name now goes through `ClubNames::canonical()`, and the two rows still on an old spelling are aligned by `transfermarkt_id` — safe to re-run, independent of whichever spelling the row currently holds. Athletic Club and RC Celta already have their own rename migrations.

**This commit is atomic on purpose.** The migration renames rows by id; the seeder, club-profile and kit-colour maps are keyed by name. Split them and Deportivo loses its profile and kit in between.

Also: cup clubs now resolve their id the way the validator does, so a cup list composed from a league stadiums scrape (which writes `transfermarktId`, not `id`) seeds instead of warning past every club.

## Blast radius

Two `teams` rows renamed, keyed by a stable id, reversible via `down()`:

| `transfermarkt_id` | from | to |
|---|---|---|
| 897 | Deportivo de A Coruña | Deportivo A Coruña |
| 40812 | CS Universitatea Craiova | Universitatea Craiova |

**Before deploying:** confirm those are the only rows on an old spelling in production.

The shirt-number fix takes effect on template regeneration, so it changes newly created games, not existing saves.

## Verification

`./vendor/bin/phpstan analyse` clean · 1287 tests pass (5 new) · `migrate --pretend` emits exactly the two updates · `app:validate-season 2025` passes and its unprofiled count drops 32 → 31 as the Craiova alias is recognised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B9964iVM9oLHCo74xyWTF9

---
_Generated by [Claude Code](https://claude.ai/code/session_01B9964iVM9oLHCo74xyWTF9)_