### PR TITLE
Let a country declare more than one cup winner slot

### DIFF
--- a/app/Modules/Competition/Services/CountryConfig.php
+++ b/app/Modules/Competition/Services/CountryConfig.php
@@ -253,13 +253,17 @@ class CountryConfig
     }
 
     /**
-     * Get cup winner qualification slot config for a country.
+     * Cup winner qualification slots for a country, in the order they should
+     * be applied. A country with two cups feeding two different European
+     * competitions (England: FA Cup to the Europa League, EFL Cup to the
+     * Conference League) declares the better slot first, so the second
+     * cascade sees what the first handed out.
      *
-     * @return array{cup: string, competition: string, league: string}|null
+     * @return array<int, array{cup: string, competition: string, league: string}>
      */
-    public function cupWinnerSlot(string $countryCode): ?array
+    public function cupWinnerSlots(string $countryCode): array
     {
-        return $this->get($countryCode)['cup_winner_slot'] ?? null;
+        return $this->get($countryCode)['cup_winner_slot'] ?? [];
     }
 
     /**

--- a/app/Modules/Competition/Services/CupEntryRoundService.php
+++ b/app/Modules/Competition/Services/CupEntryRoundService.php
@@ -20,7 +20,11 @@ use App\Models\Team;
  *     competition_teams row — round one when it declared none. This is the
  *     single source for a cup's shape: the FA Cup's 80 lower-league clubs
  *     in round one and its 44 league clubs in round three are a property of
- *     the data, not of engine code.
+ *     the data, not of engine code. The exception is a cup declaring an
+ *     `entry_rounds` rule: there the round on the game's own entry wins,
+ *     because DomesticCupQualificationProcessor wrote the Coppa Italia's
+ *     byes from the final table and the seed file only ever describes the
+ *     imported season.
  *  2. Supercup. When the country's supercup declares `cup_entry_round`, its
  *     field skips ahead to that round of the main cup (Spain's four Supercopa
  *     clubs join the Copa at the round of 32). A supercup club missing from
@@ -76,10 +80,22 @@ class CupEntryRoundService
         $teamIds = array_keys($current);
         $seededRound = $this->seededEntryRounds($cupId, $teamIds);
 
+        // A cup with an `entry_rounds` rule takes its rounds from this
+        // season's own field instead: DomesticCupQualificationProcessor
+        // resolved the Coppa Italia's from the final table at the close, and
+        // the data file only ever described the imported season — reading it
+        // here would pin the byes on the clubs that held them at import, on
+        // top of the clubs that hold them now. The first season is unaffected
+        // either way, since SetupNewGame copies the file's entry rounds onto
+        // the game before this runs.
+        $rule = $this->countryConfig->cupQualification($countryCode, $cupId) ?? [];
+        $fieldDecidesRounds = isset($rule['entry_rounds']);
+
         // 1. Baseline: the round the cup's data file gave each club.
         $assigned = [];
         foreach ($teamIds as $teamId) {
-            $assigned[$teamId] = min($roundCount, max(1, $seededRound[$teamId] ?? 1));
+            $declared = $fieldDecidesRounds ? $current[$teamId] : ($seededRound[$teamId] ?? 1);
+            $assigned[$teamId] = min($roundCount, max(1, $declared));
         }
 
         // 2. Supercup field skips ahead.

--- a/app/Modules/Season/Processors/DomesticCupQualificationProcessor.php
+++ b/app/Modules/Season/Processors/DomesticCupQualificationProcessor.php
@@ -5,6 +5,7 @@ namespace App\Modules\Season\Processors;
 use App\Modules\Competition\Services\CountryConfig;
 use App\Modules\Season\Contracts\SeasonProcessor;
 use App\Modules\Season\DTOs\SeasonTransitionData;
+use App\Models\Competition;
 use App\Models\CompetitionEntry;
 use App\Models\Game;
 use App\Models\GameStanding;
@@ -41,7 +42,10 @@ use Illuminate\Support\Facades\Log;
  *     after the supercup bump), and silent shortfalls are what produced
  *     the 93 broken Copa del Rey draws in production.
  *
- * Qualifiers from a playable tier are written at round 1. The supercup
+ * Qualifiers from a playable tier are written at round 1, unless the cup
+ * declares an `entry_rounds` rule — Serie A joins the Coppa at the first
+ * round proper and its top eight skip to the round of 16, and that has to be
+ * decided here, while this season's final table is still intact. The supercup
  * skip-ahead and bracket parity are applied later, at season setup, by
  * CupEntryRoundService.
  *
@@ -96,7 +100,7 @@ class DomesticCupQualificationProcessor implements SeasonProcessor
      * throw — the cup is the parity invariant and silent shortfalls are
      * what produced the 93 broken Copa del Rey draws in production.
      *
-     * @param  array{auto_qualify_tiers?: int[], top_per_group?: array<int, int>, target_size?: int}  $rule
+     * @param  array{auto_qualify_tiers?: int[], top_per_group?: array<int, int>, target_size?: int, entry_rounds?: array{league: string, default: int, byes?: array{positions: int[], round: int}}}  $rule
      * @param  string[]  $reserveTeamIdsForCountry
      */
     private function rebuildCupEntries(
@@ -111,13 +115,29 @@ class DomesticCupQualificationProcessor implements SeasonProcessor
             return;
         }
 
-        // Skip when this country isn't part of the game (no entries in any
-        // playable tier). The target_size invariant below catches partial-
-        // data shortfalls — wholly absent data is a different signal.
-        $hasAnyTierEntries = CompetitionEntry::where('game_id', $game->id)
-            ->whereIn('competition_id', $playableTierCompetitions)
+        // A cup declared in config but not yet seeded has no competitions row,
+        // and competition_entries.competition_id is a foreign key. This loop
+        // runs for every country in every game, so without this guard a cup
+        // whose data hasn't landed yet would break season transitions in
+        // saves that have nothing to do with it.
+        if (!Competition::whereKey($cupId)->exists()) {
+            return;
+        }
+
+        // Skip when the game holds no field for this cup: either the country
+        // isn't part of the game at all, or the save was started before the
+        // cup's data existed. A save is never given a competition added after
+        // it began — it keeps the game it started, and its schedules come
+        // from its own base_season, which has no rounds for the cup anyway.
+        // Rebuilding the field from the playable tiers alone would be worse
+        // than leaving it empty: 18 or 20 clubs is an odd pool a round in,
+        // which ConductNextCupRoundDraw swallows and the cup silently stops.
+        // The target_size invariant below catches partial-data shortfalls;
+        // wholly absent data is a different signal.
+        $hasCupEntries = CompetitionEntry::where('game_id', $game->id)
+            ->where('competition_id', $cupId)
             ->exists();
-        if (!$hasAnyTierEntries) {
+        if (!$hasCupEntries) {
             return;
         }
 
@@ -248,6 +268,8 @@ class DomesticCupQualificationProcessor implements SeasonProcessor
                 ->delete();
         }
 
+        $leagueRounds = $this->leagueEntryRounds($game, $rule);
+
         $rows = [];
         foreach (array_keys($qualifiers) as $teamId) {
             if (isset($preservedRegional[$teamId])) {
@@ -257,7 +279,7 @@ class DomesticCupQualificationProcessor implements SeasonProcessor
                 'game_id' => $game->id,
                 'competition_id' => $cupId,
                 'team_id' => $teamId,
-                'entry_round' => 1,
+                'entry_round' => $leagueRounds[$teamId] ?? 1,
             ];
         }
 
@@ -272,6 +294,45 @@ class DomesticCupQualificationProcessor implements SeasonProcessor
         );
 
         Log::info("[DomesticCupQualification] {$cupId}: " . count($qualifiers) . ' qualifiers');
+    }
+
+    /**
+     * Where a cup's `entry_rounds` rule puts each club of a playable league:
+     * a round they all join at, and a later one for the finishing positions
+     * that earn a bye. The Coppa Italia's twelve non-seeded Serie A clubs
+     * enter at the first round proper and its top eight skip to the round of
+     * 16 — both halves are needed, since sending only the byes forward would
+     * drop the other twelve to round 1 and leave the field unable to halve.
+     *
+     * It has to run here, at the close, while the final table is still
+     * readable: by the time CupEntryRoundService assigns rounds at setup,
+     * the standings have rolled over.
+     *
+     * @param  array{entry_rounds?: array{league: string, default: int, byes?: array{positions: int[], round: int}}}  $rule
+     * @return array<string, int>
+     */
+    private function leagueEntryRounds(Game $game, array $rule): array
+    {
+        $entryRounds = $rule['entry_rounds'] ?? null;
+        if (!$entryRounds) {
+            return [];
+        }
+
+        $ranked = $this->rankedTeams($game, $entryRounds['league']);
+
+        $rounds = [];
+        foreach ($ranked as $teamId) {
+            $rounds[$teamId] = $entryRounds['default'];
+        }
+
+        foreach ($entryRounds['byes']['positions'] ?? [] as $position) {
+            $teamId = $ranked[$position - 1] ?? null;
+            if ($teamId !== null) {
+                $rounds[$teamId] = $entryRounds['byes']['round'];
+            }
+        }
+
+        return $rounds;
     }
 
     /**

--- a/app/Modules/Season/Processors/SupercupQualificationProcessor.php
+++ b/app/Modules/Season/Processors/SupercupQualificationProcessor.php
@@ -8,6 +8,7 @@ use App\Modules\Competition\Services\CountryConfig;
 use App\Modules\Competition\Services\LeagueFixtureGenerator;
 use App\Models\CupTie;
 use App\Models\Game;
+use App\Models\Competition;
 use App\Models\CompetitionEntry;
 use App\Models\GameStanding;
 use App\Models\SimulatedSeason;
@@ -81,13 +82,24 @@ class SupercupQualificationProcessor implements SeasonProcessor
         $size = $this->countryConfig->supercupSize($countryCode);
         $cupFinalRound = LeagueFixtureGenerator::finalKnockoutRound($cupId, $game->base_season);
 
-        // Skip when this country isn't part of the game (no top-league
-        // entries). The 4-qualifier guard below catches partial-data bugs
-        // — wholly absent data is a different signal and shouldn't trip it.
-        $hasLeague = CompetitionEntry::where('game_id', $game->id)
-            ->where('competition_id', $leagueId)
+        // A supercup declared in config but not yet seeded has no
+        // competitions row, and competition_entries.competition_id is a
+        // foreign key — inserting its field would fail outright.
+        if (!Competition::whereKey($supercupId)->exists()) {
+            return;
+        }
+
+        // Skip when the game holds no supercup field: either the country
+        // isn't part of the game, or the save was started before the
+        // supercup's data existed. A save is never given a competition added
+        // after it began. The field is replaced wholesale below every season,
+        // so on a live save this is always non-empty. The 4-qualifier guard
+        // further down catches partial-data bugs — wholly absent data is a
+        // different signal and shouldn't trip it.
+        $hasSupercupEntries = CompetitionEntry::where('game_id', $game->id)
+            ->where('competition_id', $supercupId)
             ->exists();
-        if (!$hasLeague) {
+        if (!$hasSupercupEntries) {
             return;
         }
 

--- a/app/Modules/Season/Processors/UefaQualificationProcessor.php
+++ b/app/Modules/Season/Processors/UefaQualificationProcessor.php
@@ -12,6 +12,7 @@ use App\Models\CompetitionEntry;
 use App\Models\CompetitionTeam;
 use App\Models\CupTie;
 use App\Models\Game;
+use App\Models\GamePlayer;
 use App\Models\GameStanding;
 use App\Models\SimulatedSeason;
 use App\Models\Team;
@@ -26,12 +27,21 @@ use Illuminate\Support\Facades\Log;
  * Qualification slots are defined in config/countries.php under
  * each country's 'continental_slots' and 'cup_winner_slot' keys.
  *
- * Cup winner cascade rules:
- * - If cup winner is NOT already qualified via league position, they get the UEL slot.
- * - If cup winner already qualifies for UCL or UEL via league, the UEL cup spot
- *   cascades to the next non-qualified team in standings.
- * - If cup winner qualifies for UECL via league, they get upgraded to UEL and
- *   the UECL spot cascades to the next non-qualified team.
+ * A country may declare more than one cup winner slot — England's FA Cup pays
+ * a Europa League place and its EFL Cup a Conference League one. They are
+ * applied in declaration order, best competition first, so a later cascade
+ * sees what an earlier one handed out.
+ *
+ * Cup winner cascade rules, per slot:
+ * - If the cup winner is NOT already qualified via league position, they take
+ *   the cup's slot.
+ * - If the cup winner already holds a place at least as good as the cup's, the
+ *   cup's slot cascades to the next non-qualified team in the standings.
+ * - If the cup winner holds a lesser place, they are upgraded to the cup's
+ *   competition and the place they vacate cascades in the same way.
+ * - If there is no cup winner at all — a country the user doesn't manage never
+ *   has its cups drawn — the slot cascades to the next non-qualified team, so
+ *   the country still sends its full contingent.
  *
  * European holder rules:
  * - The defending UCL winner auto-qualifies for next season's UCL.
@@ -123,19 +133,20 @@ class UefaQualificationProcessor implements SeasonProcessor
             }
         }
 
-        // Handle cup winner slot
-        $cupWinnerConfig = $this->countryConfig->cupWinnerSlot($countryCode);
-        if ($cupWinnerConfig && !empty($standings)) {
-            $this->applyCupWinnerCascade(
-                $game->id,
-                $countryCode,
-                $cupWinnerConfig,
-                $qualifications,
-                $standings,
-                $slots,
-                $data,
-                $userCountry,
-            );
+        // Handle cup winner slots, best competition first so a later cascade
+        // sees what an earlier one handed out.
+        if (!empty($standings)) {
+            foreach ($this->countryConfig->cupWinnerSlots($countryCode) as $cupWinnerConfig) {
+                $this->applyCupWinnerCascade(
+                    $game->id,
+                    $countryCode,
+                    $cupWinnerConfig,
+                    $qualifications,
+                    $standings,
+                    $data,
+                    $userCountry,
+                );
+            }
         }
 
         // Write all qualifications to competition_entries
@@ -153,7 +164,6 @@ class UefaQualificationProcessor implements SeasonProcessor
         array $cupWinnerConfig,
         array &$qualifications,
         array $standings,
-        array $slots,
         SeasonTransitionData $data,
         string $userCountry,
     ): void {
@@ -169,23 +179,32 @@ class UefaQualificationProcessor implements SeasonProcessor
             ]);
         }
 
+        $targetCompetition = $cupWinnerConfig['competition'];
+
+        // No winner to reward — the cup wasn't played out (a country the user
+        // doesn't manage never has its cups drawn), or it was abandoned. The
+        // slot still belongs to the country, so it falls to the next team in
+        // the table rather than going unused.
         if (!$cupWinnerId) {
+            $nextTeam = $this->getNextNonQualifiedTeam($standings, $qualifications);
+            if ($nextTeam) {
+                $qualifications[$nextTeam] = $targetCompetition;
+            }
+
             return;
         }
-
-        $targetCompetition = $cupWinnerConfig['competition']; // UEL
 
         $existingQualification = $qualifications[$cupWinnerId] ?? null;
 
         if (!$existingQualification) {
-            // Cup winner is NOT already qualified — give them the UEL spot
+            // Cup winner is NOT already qualified — give them the cup's spot
             $qualifications[$cupWinnerId] = $targetCompetition;
             if ($isUserCountry) {
                 $data->setMetadata('cupWinnerCascade', 'direct');
             }
-        } elseif ($existingQualification === 'UCL' || $existingQualification === $targetCompetition) {
-            // Cup winner already in UCL or UEL — cascade the cup's UEL spot
-            // to the next non-qualified team
+        } elseif ($this->europeanRank($existingQualification) >= $this->europeanRank($targetCompetition)) {
+            // Cup winner already holds a place at least as good as the cup's
+            // — the cup's spot cascades to the next non-qualified team.
             $nextTeam = $this->getNextNonQualifiedTeam($standings, $qualifications);
             if ($nextTeam) {
                 $qualifications[$nextTeam] = $targetCompetition;
@@ -193,19 +212,40 @@ class UefaQualificationProcessor implements SeasonProcessor
             if ($isUserCountry) {
                 $data->setMetadata('cupWinnerCascade', "cascade_from_{$existingQualification}");
             }
-        } elseif ($existingQualification === 'UECL') {
-            // Cup winner was in UECL via league — upgrade them to UEL
+        } else {
+            // Cup winner held a lesser place (UECL via the league, say, when
+            // the cup pays a UEL berth) — upgrade them, then cascade the spot
+            // they vacated. Assign first, so the vacated spot can't come
+            // straight back to them.
             $qualifications[$cupWinnerId] = $targetCompetition;
 
-            // Cascade the now-vacant UECL spot to the next non-qualified team
             $nextTeam = $this->getNextNonQualifiedTeam($standings, $qualifications);
             if ($nextTeam) {
-                $qualifications[$nextTeam] = 'UECL';
+                $qualifications[$nextTeam] = $existingQualification;
             }
             if ($isUserCountry) {
-                $data->setMetadata('cupWinnerCascade', 'uecl_upgrade');
+                $data->setMetadata(
+                    'cupWinnerCascade',
+                    $existingQualification === 'UECL' ? 'uecl_upgrade' : "upgrade_from_{$existingQualification}",
+                );
             }
         }
+    }
+
+    /**
+     * Ranks the European competitions so the cascade can compare a team's
+     * existing place against the one a cup is offering, whichever cup it is.
+     * England's EFL Cup pays a Conference League berth, so "already qualified
+     * for something better" is not the same test as "already in the UCL".
+     */
+    private function europeanRank(string $competitionId): int
+    {
+        return match ($competitionId) {
+            'UCL' => 3,
+            'UEL' => 2,
+            'UECL' => 1,
+            default => 0,
+        };
     }
 
     /**
@@ -249,6 +289,12 @@ class UefaQualificationProcessor implements SeasonProcessor
     /**
      * Find the domestic cup winner from the final cup tie. The final is the
      * last round of the cup's schedule.json for the game's base season.
+     *
+     * A ghost team — a lower-division cup entrant with no squad — can win a
+     * cup outright, and the deeper a country's ghost field the likelier it
+     * is (England's FA Cup is 44 ghosts in 64). It cannot then take a place
+     * in a 36-team Swiss league phase, so a winner registered in no playable
+     * league counts as no winner and its slot cascades to the league table.
      */
     private function getCupWinner(string $gameId, string $countryCode, string $cupId): ?string
     {
@@ -265,7 +311,25 @@ class UefaQualificationProcessor implements SeasonProcessor
             ->where('completed', true)
             ->first();
 
-        return $finalTie?->winner_id;
+        $winnerId = $finalTie?->winner_id;
+
+        if ($winnerId === null || !$this->hasSquad($gameId, $winnerId)) {
+            return null;
+        }
+
+        return $winnerId;
+    }
+
+    /**
+     * Whether a team has any players in this game. A ghost has none, which is
+     * the same test MatchSimulator uses when it forbids a squad-less side
+     * from scoring.
+     */
+    private function hasSquad(string $gameId, string $teamId): bool
+    {
+        return GamePlayer::where('game_id', $gameId)
+            ->where('team_id', $teamId)
+            ->exists();
     }
 
     /**

--- a/config/countries.php
+++ b/config/countries.php
@@ -223,10 +223,14 @@ return [
             ],
         ],
 
+        // Cup winner slots, applied in order, best competition first: a
+        // later cascade sees what an earlier one handed out.
         'cup_winner_slot' => [
-            'cup' => 'ESPCUP',
-            'competition' => 'UEL',
-            'league' => 'ESP1',
+            [
+                'cup' => 'ESPCUP',
+                'competition' => 'UEL',
+                'league' => 'ESP1',
+            ],
         ],
 
         'continental_competitions' => [
@@ -304,7 +308,7 @@ return [
             ],
         ],
 
-        'cup_winner_slot' => null,
+        'cup_winner_slot' => [],
 
         'continental_competitions' => [
             'UCL' => [
@@ -362,7 +366,7 @@ return [
             ],
         ],
 
-        'cup_winner_slot' => null,
+        'cup_winner_slot' => [],
 
         'continental_competitions' => [
             'UCL' => [
@@ -420,7 +424,7 @@ return [
             ],
         ],
 
-        'cup_winner_slot' => null,
+        'cup_winner_slot' => [],
 
         'continental_competitions' => [
             'UCL' => [
@@ -478,7 +482,7 @@ return [
             ],
         ],
 
-        'cup_winner_slot' => null,
+        'cup_winner_slot' => [],
 
         'continental_competitions' => [
             'UCL' => [

--- a/tests/Feature/CupEntryRoundServiceTest.php
+++ b/tests/Feature/CupEntryRoundServiceTest.php
@@ -124,6 +124,44 @@ class CupEntryRoundServiceTest extends TestCase
         $this->assertSame(20, $this->countAtRound('ESPCUP', 3));
     }
 
+    /**
+     * The Coppa Italia's eight byes belong to the previous season's top
+     * eight, so they are decided at the close and written onto the cup
+     * entry. Resetting them to the data file — which only ever described
+     * the imported season — would pin them on the wrong clubs forever.
+     */
+    public function test_a_cup_with_an_entry_rounds_rule_keeps_the_round_this_seasons_field_assigned(): void
+    {
+        config(['countries.ES.supercup' => null]);
+        config(['countries.ES.cup_qualification.ESPCUP.entry_rounds' => [
+            'league' => 'ESP1',
+            'default' => 1,
+            'byes' => ['positions' => [1, 2], 'round' => 3],
+        ]]);
+
+        $topFlight = $this->teamsIn('ESP1', 4);
+        $this->enter('ESPCUP', $topFlight);
+        // The data file gave the byes to the last two clubs; this season's
+        // table gave them to the first two.
+        $this->seedRounds('ESPCUP', array_slice($topFlight, 0, 2), 1);
+        $this->seedRounds('ESPCUP', array_slice($topFlight, 2), 3);
+        CompetitionEntry::where('game_id', $this->game->id)
+            ->where('competition_id', 'ESPCUP')
+            ->whereIn('team_id', [$topFlight[0]->id, $topFlight[1]->id])
+            ->update(['entry_round' => 3]);
+
+        $this->service()->assignEntryRounds($this->game->id, 'ES');
+
+        $rounds = $this->rounds('ESPCUP');
+        $this->assertSame(3, $rounds[$topFlight[0]->id]);
+        $this->assertSame(3, $rounds[$topFlight[1]->id]);
+        // The regression this guards: honouring the file as well as the
+        // field would leave six clubs with a bye meant for four.
+        $this->assertSame(1, $rounds[$topFlight[2]->id], 'a club the file seeded at round 3 loses the bye it no longer holds');
+        $this->assertSame(1, $rounds[$topFlight[3]->id]);
+        $this->assertSame(2, $this->countAtRound('ESPCUP', 3));
+    }
+
     public function test_a_declared_round_beyond_the_final_is_clamped_to_it(): void
     {
         config(['countries.ES.supercup' => null]);

--- a/tests/Feature/DomesticCupQualificationTest.php
+++ b/tests/Feature/DomesticCupQualificationTest.php
@@ -60,6 +60,18 @@ class DomesticCupQualificationTest extends TestCase
         $this->createLeague('ESP2', 22);
         $this->createLeague('ESP3A', 20);
         $this->createLeague('ESP3B', 20);
+
+        // Every save the processor rebuilds already holds a cup field,
+        // copied from its season's data when the game was created; a save
+        // with none predates the cup and is deliberately left alone. Seed
+        // the champion's entry so these rule-level tests describe a live
+        // cup — it qualifies through tier 1 anyway, so no count moves.
+        CompetitionEntry::create([
+            'game_id' => $this->game->id,
+            'competition_id' => 'ESPCUP',
+            'team_id' => $this->teamsByCompetition['ESP1'][0]->id,
+            'entry_round' => 1,
+        ]);
     }
 
     public function test_base_case_qualifies_all_tier_1_and_2_plus_top_5_per_primera_rfef_group(): void
@@ -412,6 +424,77 @@ class DomesticCupQualificationTest extends TestCase
         }
         $this->assertSame(1, $rounds[$earlyGhost->id]);
         $this->assertSame(2, $rounds[$lateGhost->id], 'a ghost keeps its seeded entry round');
+    }
+
+    /**
+     * A cup can place a whole league at one round and hand its best
+     * finishers a bye to a later one — Serie A joins the Coppa at the first
+     * round proper, its top eight at the round of 16. It has to be settled
+     * here, at the close, because by the time entry rounds are assigned at
+     * setup the table this reads has already rolled over.
+     */
+    public function test_an_entry_rounds_rule_places_a_league_and_its_bye_holders(): void
+    {
+        config(['countries.ES.cup_qualification.ESPCUP.entry_rounds' => [
+            'league' => 'ESP1',
+            'default' => 2,
+            'byes' => ['positions' => [1, 2, 3], 'round' => 3],
+        ]]);
+
+        $this->runProcessor();
+
+        $rounds = CompetitionEntry::where('game_id', $this->game->id)
+            ->where('competition_id', 'ESPCUP')
+            ->pluck('entry_round', 'team_id')
+            ->all();
+
+        foreach (array_slice($this->teamsByCompetition['ESP1'], 0, 3) as $team) {
+            $this->assertSame(3, (int) $rounds[$team->id], "ESP1 top-3 team {$team->id} should get the bye");
+        }
+        foreach (array_slice($this->teamsByCompetition['ESP1'], 3) as $team) {
+            $this->assertSame(2, (int) $rounds[$team->id], "ESP1 team {$team->id} outside the top 3 takes the league's default round");
+        }
+        foreach ($this->teamsByCompetition['ESP2'] as $team) {
+            $this->assertSame(1, (int) $rounds[$team->id], 'a league the rule does not name is unaffected');
+        }
+    }
+
+    public function test_without_an_entry_rounds_rule_every_qualifier_enters_at_round_one(): void
+    {
+        $this->runProcessor();
+
+        $this->assertSame(
+            [1],
+            CompetitionEntry::where('game_id', $this->game->id)
+                ->where('competition_id', 'ESPCUP')
+                ->distinct()
+                ->pluck('entry_round')
+                ->all(),
+        );
+    }
+
+    /**
+     * A save started before a cup existed holds no field for it, and is never
+     * given one: its schedules come from its own base_season, which has no
+     * rounds for the cup. Rebuilding from the playable tiers would be worse
+     * than leaving it empty — 20 clubs is an odd pool a round in, which
+     * ConductNextCupRoundDraw swallows and the cup silently stops.
+     */
+    public function test_a_save_holding_no_cup_field_is_left_alone(): void
+    {
+        CompetitionEntry::where('game_id', $this->game->id)
+            ->where('competition_id', 'ESPCUP')
+            ->delete();
+
+        $this->runProcessor();
+
+        $this->assertSame(
+            0,
+            CompetitionEntry::where('game_id', $this->game->id)
+                ->where('competition_id', 'ESPCUP')
+                ->count(),
+            'a save that predates the cup must not be handed a field',
+        );
     }
 
     private function runProcessor(): void

--- a/tests/Feature/SupercupQualificationTest.php
+++ b/tests/Feature/SupercupQualificationTest.php
@@ -81,6 +81,16 @@ class SupercupQualificationTest extends TestCase
                 'points' => max(0, (25 - $position) * 3 + 5),
             ]);
         }
+
+        // As on a real save: the supercup field exists from game setup and
+        // is replaced wholesale every season. A save holding no field
+        // predates the competition and is skipped, so seed one club.
+        CompetitionEntry::create([
+            'game_id' => $this->game->id,
+            'competition_id' => 'ESPSUP',
+            'team_id' => $this->league[1]->id,
+            'entry_round' => 1,
+        ]);
     }
 
     public function test_no_overlap_qualifies_both_cup_finalists_plus_league_top_2(): void

--- a/tests/Feature/UefaQualificationTest.php
+++ b/tests/Feature/UefaQualificationTest.php
@@ -166,8 +166,11 @@ class UefaQualificationTest extends TestCase
             ->where('competition_id', 'UEL')
             ->count();
 
-        // ES=1, EN=1, DE=2, IT=1, FR=1 = 6 qualified teams (no fillers)
-        $this->assertEquals(6, $uelCount, "UEL should only have qualified teams (no fillers), got {$uelCount}");
+        // ES=2, EN=1, DE=2, IT=1, FR=1 = 7 qualified teams (no fillers).
+        // Spain fields one more club than its league positions alone would
+        // give: no Copa was played here, so its unclaimed cup place cascades
+        // down the table instead of going unused.
+        $this->assertEquals(7, $uelCount, "UEL should only have qualified teams (no fillers), got {$uelCount}");
     }
 
     public function test_uel_winner_qualifies_for_ucl(): void
@@ -607,13 +610,30 @@ class UefaQualificationTest extends TestCase
                 $team = Team::find($teamId);
                 $slots = $this->countryConfig->continentalSlots($team->country);
                 $qualifyingTeamIds = [];
+                $allDeclaredPositions = [];
                 foreach ($slots as $leagueId => $allocations) {
                     foreach ($allocations as $continentalId => $positions) {
+                        $allDeclaredPositions = array_merge($allDeclaredPositions, $positions);
                         if ($continentalId === $competitionId) {
                             foreach ($positions as $pos) {
                                 $qualifyingTeamIds[] = $this->teamsByCountry[$team->country][$pos - 1]->id ?? null;
                             }
                         }
+                    }
+                }
+
+                // A cup place whose cup wasn't played cascades to the next
+                // teams in the table — a legitimate qualification, not a
+                // filler. One extra position is reachable per cup slot.
+                $cupSlots = $this->countryConfig->cupWinnerSlots($team->country);
+                $cupSlotsForThisCompetition = array_filter(
+                    $cupSlots,
+                    fn (array $slot) => $slot['competition'] === $competitionId,
+                );
+                if (!empty($cupSlotsForThisCompetition) && !empty($allDeclaredPositions)) {
+                    $deepest = max($allDeclaredPositions);
+                    for ($pos = $deepest + 1; $pos <= $deepest + count($cupSlots); $pos++) {
+                        $qualifyingTeamIds[] = $this->teamsByCountry[$team->country][$pos - 1]->id ?? null;
                     }
                 }
 
@@ -684,6 +704,37 @@ class UefaQualificationTest extends TestCase
         );
     }
 
+    public function test_a_squadless_ghost_winning_a_cup_does_not_enter_europe(): void
+    {
+        // A lower-division cup entrant: a team row with no players, the way
+        // SeedReferenceData creates one. It can win the Copa outright — most
+        // of its 116-club field is squad-less — but it has no side to put in
+        // a 36-team Swiss league phase.
+        $ghost = Team::factory()->create(['country' => 'ES']);
+        $this->createCupFinal('ESPCUP', $ghost->id);
+
+        $processor = app(UefaQualificationProcessor::class);
+        $processor->process($this->game, $this->makeTransitionData());
+
+        $this->assertFalse(
+            CompetitionEntry::where('game_id', $this->game->id)
+                ->where('competition_id', 'UEL')
+                ->where('team_id', $ghost->id)
+                ->exists(),
+            'A squad-less cup winner must not take a European place'
+        );
+
+        // The place still belongs to Spain and falls to the table.
+        $nextTeam = $this->teamsByCountry['ES'][7];
+        $this->assertTrue(
+            CompetitionEntry::where('game_id', $this->game->id)
+                ->where('competition_id', 'UEL')
+                ->where('team_id', $nextTeam->id)
+                ->exists(),
+            "The ghost's UEL place should cascade to the next team in the table"
+        );
+    }
+
     // =========================================
     // Transition metadata logging
     // =========================================
@@ -718,9 +769,11 @@ class UefaQualificationTest extends TestCase
         $this->assertNotNull($qualifications, 'UEFA qualifications metadata should be set');
         $this->assertArrayHasKey('ES', $qualifications);
 
-        // Spain should have positions 1-7 qualified
+        // Positions 1-7 from the table, plus position 8 taking the Copa
+        // place: no final was played here, so the cup's slot cascades down
+        // the table rather than going unused.
         $esQualifications = $qualifications['ES'];
-        $this->assertCount(7, $esQualifications);
+        $this->assertCount(8, $esQualifications);
     }
 
     public function test_processor_logs_cascade_when_cup_winner_already_in_ucl(): void


### PR DESCRIPTION
**5 of 7** splitting `season-data/2026`. Based on #1344. **This is the one with real behaviour changes — worth the closest read of the seven.**

Prepares the season pipelines for countries whose cups the data does not carry yet. Spain's config is reshaped but semantically identical; `EN`/`DE`/`IT`/`FR` stay at no cup slot until PR 7.

## Mechanism

`cup_winner_slot` becomes an ordered list rather than a single map, applied best competition first so a later cascade sees what an earlier one handed out — England's FA Cup pays a Europa League place and its EFL Cup a Conference League one. The cascade compares European competitions by rank instead of naming UCL and UEL, since "already qualified for something better" is not the same test when the cup on offer is a UECL place.

The cup and supercup qualification processors gain the guards that make a newly declared competition safe: skip when it has no `competitions` row (`competition_entries.competition_id` is a foreign key), and skip when the game holds no field for it, because a save is never given a competition added after it began. Rebuilding from the playable tiers instead would leave an odd pool a round in — which `ConductNextCupRoundDraw` swallows and the cup silently stops.

A cup may also declare an `entry_rounds` rule placing a whole league at one round and its best finishers at a later one. It has to be resolved at the close, while the final table is still readable, because the data file only ever describes the imported season. **No cup declares one yet** — dormant until PR 7.

## Blast radius — two changes reach existing saves

Both are fixes, but neither is a no-op. Worth its own deploy window.

1. **A squad-less ghost can no longer win a European place.** Most of the Copa's 116-club field has no players; such a club can win the cup outright and then cannot field a side in a 36-team Swiss league phase. A winner registered in no playable league now counts as no winner.
2. **A cup that was never drawn no longer leaves its European place unused.** That is every cup outside the country the user manages. The place belongs to the country either way, so it now falls to the next team in the table.

Two existing assertions move as a result — Spain now fields 8 European qualifiers rather than 7 in a save where no Copa was played, and the UEL count in `test_uel_only_filled_when_user_participates` goes 6 → 7. Both are updated with the reason inline.

## Note on the tests

Six tests on the original branch assert PR 7's config (England's two cups, a single-tier country's cup rebuild, the EFL Cup's prize table) and cannot pass here. They ship with PR 7. This PR keeps the mechanism tests and adds a ghost-winner test written against the Copa — which is where the guard actually earns its place.

## Verification

`./vendor/bin/phpstan analyse` clean · 1292 tests pass (5 new).

One caveat: the first full-suite run had a single failure in `RedCardSimulationTest::test_losing_higher_rated_player_has_larger_impact` (2.19875 vs 2.21625). It is an unseeded Monte Carlo comparison, this PR touches no match-simulation code, it passed 5/5 in isolation, and the suite was green on re-run. Pre-existing flake — but it will bite CI occasionally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B9964iVM9oLHCo74xyWTF9

---
_Generated by [Claude Code](https://claude.ai/code/session_01B9964iVM9oLHCo74xyWTF9)_