### PR TITLE
Let a country or cup declare the season it arrives in

### DIFF
--- a/app/Console/Commands/DiffSeason.php
+++ b/app/Console/Commands/DiffSeason.php
@@ -50,7 +50,7 @@ class DiffSeason extends Command
         }
 
         $sections = [];
-        foreach (SeasonData::competitions($countryConfig) as ['code' => $code, 'type' => $type]) {
+        foreach (SeasonData::competitions($countryConfig, $season) as ['code' => $code, 'type' => $type]) {
             if ($type === 'none') {
                 continue;
             }

--- a/app/Console/Commands/NormalizeSeason.php
+++ b/app/Console/Commands/NormalizeSeason.php
@@ -49,7 +49,7 @@ class NormalizeSeason extends Command
         $this->info(($check ? 'Checking' : 'Normalizing') . " data/{$season}...");
 
         $changed = [];
-        $competitions = SeasonData::competitions($countryConfig);
+        $competitions = SeasonData::competitions($countryConfig, $season);
         $countries = $this->buildCountryIndex($season, $competitions, $countryConfig);
 
         foreach ($competitions as ['code' => $code, 'type' => $type]) {

--- a/app/Console/Commands/RefreshPlayerTemplates.php
+++ b/app/Console/Commands/RefreshPlayerTemplates.php
@@ -20,7 +20,7 @@ class RefreshPlayerTemplates extends Command
         $season = $this->option('season') ?: config('season.current');
         $countryFilter = $this->option('country');
 
-        $countryCodes = $countryConfig->playableCountryCodes();
+        $countryCodes = $countryConfig->playableCountryCodes($season);
 
         if ($countryFilter) {
             $countryFilter = strtoupper($countryFilter);

--- a/app/Console/Commands/ScaffoldSeason.php
+++ b/app/Console/Commands/ScaffoldSeason.php
@@ -64,7 +64,7 @@ class ScaffoldSeason extends Command
         $missing = [];
         $shifted = 0;
 
-        foreach ($this->competitions($countryConfig) as $code => $needs) {
+        foreach ($this->competitions($countryConfig, $season) as $code => $needs) {
             $srcDir = "{$fromBase}/{$code}";
             $dstDir = base_path("data/{$season}/{$code}");
 
@@ -131,7 +131,7 @@ class ScaffoldSeason extends Command
      *
      * @return array<string, string>
      */
-    private function competitions(CountryConfig $countryConfig): array
+    private function competitions(CountryConfig $countryConfig, string $season): array
     {
         $needsByType = [
             'league' => 'teams',
@@ -142,7 +142,7 @@ class ScaffoldSeason extends Command
         ];
 
         $out = [];
-        foreach (SeasonData::competitions($countryConfig) as ['code' => $code, 'type' => $type]) {
+        foreach (SeasonData::competitions($countryConfig, $season) as ['code' => $code, 'type' => $type]) {
             $out[$code] = $needsByType[$type];
         }
 

--- a/app/Console/Commands/SeedReferenceData.php
+++ b/app/Console/Commands/SeedReferenceData.php
@@ -56,7 +56,7 @@ class SeedReferenceData extends Command
         }
 
         $countryConfig = app(CountryConfig::class);
-        $countryCodes = $countryConfig->playableCountryCodes();
+        $countryCodes = $countryConfig->playableCountryCodes($this->season);
 
         if ($countryFilter) {
             $countryFilter = strtoupper($countryFilter);
@@ -192,9 +192,9 @@ class SeedReferenceData extends Command
 
         // Step 2: Seed domestic cups — supercup first so main cup can look up
         // supercup teams for entry_round calculation
-        $cupIds = array_keys($config['domestic_cups'] ?? []);
+        $cupIds = $countryConfig->domesticCupIds($countryCode, $this->season);
         $this->line("  Step 2/4: Seeding " . count($cupIds) . " domestic cup(s)...");
-        $supercupConfig = $countryConfig->supercup($countryCode);
+        $supercupConfig = $countryConfig->supercup($countryCode, $this->season);
         if ($supercupConfig) {
             $supercupId = $supercupConfig['competition'];
             $cupIds = array_values(array_diff($cupIds, [$supercupId]));
@@ -217,7 +217,7 @@ class SeedReferenceData extends Command
 
         // Step 3: Seed transfer pool (foreign leagues + EUR pool)
         $support = $countryConfig->support($countryCode);
-        $transferPool = $support['transfer_pool'] ?? [];
+        $transferPool = $countryConfig->transferPool($countryCode, $this->season);
         $this->line("  Step 3/4: Seeding " . count($transferPool) . " transfer pool competition(s)...");
         foreach ($transferPool as $code => $poolConfig) {
             $poolCountry = $poolConfig['country'] ?? 'EU';

--- a/app/Console/Commands/ValidateSeason.php
+++ b/app/Console/Commands/ValidateSeason.php
@@ -78,8 +78,8 @@ class ValidateSeason extends Command
         $this->info("Validating data/{$season}...");
         $this->newLine();
 
-        $competitions = SeasonData::competitions($countryConfig);
-        $handlers = SeasonData::continentalHandlers($countryConfig);
+        $competitions = SeasonData::competitions($countryConfig, $season);
+        $handlers = SeasonData::continentalHandlers($countryConfig, $season);
         $this->indexSquadSources($season, $competitions, $countryConfig);
 
         foreach ($competitions as ['code' => $code, 'type' => $type]) {

--- a/app/Modules/Competition/Services/CountryConfig.php
+++ b/app/Modules/Competition/Services/CountryConfig.php
@@ -20,14 +20,46 @@ class CountryConfig
     /**
      * Get all playable country codes (countries with tiers, excluding test).
      *
+     * A country or a cup added for a future season declares `from_season`, and
+     * is invisible until that season. Without it, declaring one here would make
+     * every earlier season invalid the moment the config landed: the seeder and
+     * app:validate-season enumerate competitions from this file and demand a
+     * `data/{season}/{CODE}/` folder for each, so a season that predates the
+     * addition could no longer be seeded or validated — and the release could
+     * only be undone by reverting the merge, rather than by moving GAME_SEASON
+     * back.
+     *
+     * Defaults to the season the game is currently seeded for. Runtime callers
+     * do not need to pass one: a competition absent from a save is skipped on
+     * its missing `competitions` row or its empty field, not on this.
+     *
      * @return string[]
      */
-    public function playableCountryCodes(): array
+    public function playableCountryCodes(?string $season = null): array
     {
         return collect($this->allCountries())
-            ->filter(fn (array $config) => !empty($config['tiers']) && empty($config['tournament']))
+            ->filter(fn (array $config) => !empty($config['tiers'])
+                && empty($config['tournament'])
+                && $this->availableIn($config, $season))
             ->keys()
             ->all();
+    }
+
+    /**
+     * Whether a config block — a country, a domestic cup — exists yet in the
+     * given season. A block with no `from_season` has always existed.
+     *
+     * @param  array<string, mixed>  $config
+     */
+    private function availableIn(array $config, ?string $season = null): bool
+    {
+        $fromSeason = $config['from_season'] ?? null;
+
+        if ($fromSeason === null) {
+            return true;
+        }
+
+        return (string) ($season ?? config('season.current')) >= (string) $fromSeason;
     }
 
     /**
@@ -267,13 +299,23 @@ class CountryConfig
     }
 
     /**
-     * Get supercup config for a country.
+     * Get supercup config for a country. Null while the cup it is contested
+     * between has not arrived yet — a supercup is drawn from its country's main
+     * cup and its league, so it cannot exist before the cup does.
      *
      * @return array{competition: string, cup: string, league: string, teams?: int, cup_entry_round?: int}|null
      */
-    public function supercup(string $countryCode): ?array
+    public function supercup(string $countryCode, ?string $season = null): ?array
     {
-        return $this->get($countryCode)['supercup'] ?? null;
+        $supercup = $this->get($countryCode)['supercup'] ?? null;
+
+        if ($supercup === null) {
+            return null;
+        }
+
+        return in_array($supercup['competition'], $this->domesticCupIds($countryCode, $season), true)
+            ? $supercup
+            : null;
     }
 
     /**
@@ -281,19 +323,25 @@ class CountryConfig
      * finalists plus the league's top two), 2 for a champions-v-cup-winner
      * one-off. Defaults to the final four, the shape ESPSUP always had.
      */
-    public function supercupSize(string $countryCode): int
+    public function supercupSize(string $countryCode, ?string $season = null): int
     {
-        return (int) ($this->supercup($countryCode)['teams'] ?? 4);
+        return (int) ($this->supercup($countryCode, $season)['teams'] ?? 4);
     }
 
     /**
-     * Get domestic cup IDs for a country.
+     * Get domestic cup IDs for a country, excluding any not yet introduced in
+     * the given season. See playableCountryCodes() for why `from_season` exists.
      *
      * @return string[]
      */
-    public function domesticCupIds(string $countryCode): array
+    public function domesticCupIds(string $countryCode, ?string $season = null): array
     {
-        return array_keys($this->get($countryCode)['domestic_cups'] ?? []);
+        $cups = $this->get($countryCode)['domestic_cups'] ?? [];
+
+        return array_keys(array_filter(
+            $cups,
+            fn (array $cup) => $this->availableIn($cup, $season),
+        ));
     }
 
     /**
@@ -432,13 +480,28 @@ class CountryConfig
     }
 
     /**
+     * A country's transfer-pool competitions, excluding any not yet introduced
+     * in the given season. See playableCountryCodes() for why `from_season`
+     * exists.
+     *
+     * @return array<string, array{role?: string, handler?: string, country?: string, from_season?: string}>
+     */
+    public function transferPool(string $countryCode, ?string $season = null): array
+    {
+        return array_filter(
+            $this->support($countryCode)['transfer_pool'] ?? [],
+            fn (array $pool) => $this->availableIn($pool, $season),
+        );
+    }
+
+    /**
      * Get transfer pool competition IDs for a country.
      *
      * @return string[]
      */
-    public function transferPoolIds(string $countryCode): array
+    public function transferPoolIds(string $countryCode, ?string $season = null): array
     {
-        return array_keys($this->support($countryCode)['transfer_pool'] ?? []);
+        return array_keys($this->transferPool($countryCode, $season));
     }
 
     /**

--- a/app/Support/SeasonData.php
+++ b/app/Support/SeasonData.php
@@ -85,9 +85,13 @@ class SeasonData
      * Order and de-duplication match the seeder's traversal so every consumer
      * sees the same competition set.
      *
+     * Competitions a country or a cup declares `from_season` for are excluded
+     * until that season, so an earlier season folder stays valid after a new
+     * country's config lands.
+     *
      * @return array<int, array{code: string, type: string}>
      */
-    public static function competitions(CountryConfig $countryConfig): array
+    public static function competitions(CountryConfig $countryConfig, ?string $season = null): array
     {
         $out = [];
         $seen = [];
@@ -100,17 +104,20 @@ class SeasonData
             $out[] = ['code' => $code, 'type' => $type];
         };
 
-        foreach ($countryConfig->playableCountryCodes() as $country) {
+        foreach ($countryConfig->playableCountryCodes($season) as $country) {
             foreach ($countryConfig->flattenedTiers($country) as $tier) {
                 $add($tier['competition'], 'league');
             }
             foreach ($countryConfig->promotionPlayoffIds($country) as $playoffId) {
                 $add($playoffId, 'none');
             }
-            foreach ($countryConfig->domesticCupIds($country) as $cupId) {
+            foreach ($countryConfig->domesticCupIds($country, $season) as $cupId) {
                 $add($cupId, 'cup');
             }
-            $transferPool = $countryConfig->support($country)['transfer_pool'] ?? [];
+            // A transfer-pool league can also postdate the season being read:
+            // every country lists every other country's top flight, so a new
+            // one appears in eight blocks at once and each needs the same gate.
+            $transferPool = $countryConfig->transferPool($country, $season);
             foreach ($transferPool as $code => $poolConfig) {
                 $add($code, ($poolConfig['role'] ?? 'league') === 'team_pool' ? 'pool' : 'league');
             }
@@ -133,11 +140,11 @@ class SeasonData
      *
      * @return array<string, string>
      */
-    public static function continentalHandlers(CountryConfig $countryConfig): array
+    public static function continentalHandlers(CountryConfig $countryConfig, ?string $season = null): array
     {
         $handlers = [];
 
-        foreach ($countryConfig->playableCountryCodes() as $country) {
+        foreach ($countryConfig->playableCountryCodes($season) as $country) {
             foreach ($countryConfig->support($country)['continental'] ?? [] as $code => $config) {
                 $handlers[$code] ??= (string) ($config['handler'] ?? '');
             }

--- a/docs/season-data-refresh.md
+++ b/docs/season-data-refresh.md
@@ -228,6 +228,34 @@ existing save, whose competition membership is its own `competition_entries`.
 Verify afterwards by taking an existing save through a cup draw and a season
 transition, not just by loading its squad.
 
+## Introducing a country or a cup in a future season
+
+`config/countries.php` is enumerated by `app:seed-reference-data` and
+`app:validate-season`, both of which demand a `data/{season}/{CODE}/` folder for
+every competition they find. So adding one unconditionally invalidates every
+earlier season the moment the config lands: that season can no longer be seeded
+or validated, and the release can only be undone by reverting the merge.
+
+Declare `from_season` instead, on the country block, the `domestic_cups` entry
+or the `support.transfer_pool` entry:
+
+```php
+'PT' => [
+    'name' => 'Portugal',
+    'from_season' => '2026',
+    // ...
+],
+```
+
+The competition is then invisible to the seeder and the validator until that
+season, so 2025 keeps working while 2026's data sits on `main` unused, and
+`GAME_SEASON` stays a switch you can move in both directions.
+
+A supercup needs no key of its own — it is hidden while the cup it is contested
+between is. Runtime callers need none either: a save is never handed a
+competition added after it began, because the season processors skip a cup with
+no `competitions` row and one the game holds no field for.
+
 ## Notes & caveats
 
 - **Games are pinned to the season they were created in.** `games.base_season`

--- a/tests/Feature/SeasonAvailabilityTest.php
+++ b/tests/Feature/SeasonAvailabilityTest.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Modules\Competition\Services\CountryConfig;
+use App\Support\SeasonData;
+use Tests\TestCase;
+
+/**
+ * A country or competition added for a future season is invisible until that
+ * season arrives.
+ *
+ * Without this, declaring one makes every earlier season invalid the moment the
+ * config lands: the seeder and app:validate-season enumerate competitions from
+ * config/countries.php and demand a data/{season}/{CODE}/ folder for each, so a
+ * season that predates the addition can no longer be seeded or validated. The
+ * gate is what keeps GAME_SEASON a reversible switch rather than a one-way door.
+ */
+class SeasonAvailabilityTest extends TestCase
+{
+    private CountryConfig $countryConfig;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->countryConfig = app(CountryConfig::class);
+    }
+
+    public function test_a_country_is_hidden_before_the_season_it_is_introduced_in(): void
+    {
+        config(['countries.XT' => [
+            'name' => 'Testland',
+            'from_season' => '2030',
+            'tiers' => [1 => ['competition' => 'XT1', 'teams' => 18, 'handler' => 'league']],
+        ]]);
+
+        $this->assertNotContains('XT', $this->countryConfig->playableCountryCodes('2029'));
+        $this->assertContains('XT', $this->countryConfig->playableCountryCodes('2030'));
+        $this->assertContains('XT', $this->countryConfig->playableCountryCodes('2031'));
+    }
+
+    public function test_a_country_without_a_from_season_has_always_existed(): void
+    {
+        $this->assertContains('ES', $this->countryConfig->playableCountryCodes('2025'));
+        $this->assertContains('ES', $this->countryConfig->playableCountryCodes('1998'));
+    }
+
+    public function test_a_cup_is_hidden_before_the_season_it_is_introduced_in(): void
+    {
+        config(['countries.ES.domestic_cups.XTCUP' => [
+            'handler' => 'knockout_cup',
+            'from_season' => '2030',
+        ]]);
+
+        $this->assertNotContains('XTCUP', $this->countryConfig->domesticCupIds('ES', '2029'));
+        $this->assertContains('XTCUP', $this->countryConfig->domesticCupIds('ES', '2030'));
+        $this->assertContains('ESPCUP', $this->countryConfig->domesticCupIds('ES', '2029'));
+    }
+
+    public function test_a_supercup_is_hidden_while_its_cup_is(): void
+    {
+        config(['countries.ES.domestic_cups.ESPSUP.from_season' => '2030']);
+
+        $this->assertNull($this->countryConfig->supercup('ES', '2029'));
+        $this->assertNotNull($this->countryConfig->supercup('ES', '2030'));
+    }
+
+    public function test_a_transfer_pool_league_is_hidden_before_its_season(): void
+    {
+        config(['countries.ES.support.transfer_pool.XT1' => [
+            'role' => 'league',
+            'handler' => 'league',
+            'country' => 'XT',
+            'from_season' => '2030',
+        ]]);
+
+        $this->assertNotContains('XT1', $this->countryConfig->transferPoolIds('ES', '2029'));
+        $this->assertContains('XT1', $this->countryConfig->transferPoolIds('ES', '2030'));
+    }
+
+    public function test_the_competition_list_a_season_folder_owns_respects_the_gate(): void
+    {
+        config(['countries.ES.domestic_cups.XTCUP' => [
+            'handler' => 'knockout_cup',
+            'from_season' => '2030',
+        ]]);
+
+        $codesFor = fn (string $season): array => array_column(
+            SeasonData::competitions($this->countryConfig, $season),
+            'code',
+        );
+
+        $this->assertNotContains('XTCUP', $codesFor('2029'));
+        $this->assertContains('XTCUP', $codesFor('2030'));
+        $this->assertContains('ESPCUP', $codesFor('2029'));
+    }
+
+    public function test_the_gate_defaults_to_the_season_the_game_is_seeded_for(): void
+    {
+        config([
+            'season.current' => '2029',
+            'countries.ES.domestic_cups.XTCUP' => [
+                'handler' => 'knockout_cup',
+                'from_season' => '2030',
+            ],
+        ]);
+
+        $this->assertNotContains('XTCUP', $this->countryConfig->domesticCupIds('ES'));
+
+        config(['season.current' => '2030']);
+
+        $this->assertContains('XTCUP', $this->countryConfig->domesticCupIds('ES'));
+    }
+}


### PR DESCRIPTION
**6 of 7** splitting `season-data/2026`. Based on #1345. **This is the one that makes the release reversible.**

## The problem it solves

`app:seed-reference-data` and `app:validate-season` both enumerate competitions from `config/countries.php` and demand a `data/{season}/{CODE}/` folder for each. So declaring a new country or cup invalidates every earlier season the moment the config lands.

Measured on the original `season-data/2026` branch:

```
$ php artisan app:validate-season 2025
Validation FAILED:
  ✗ POR1: teams.json missing at data/2025/POR1/teams.json.
  ✗ NED1: teams.json missing at data/2025/NED1/teams.json.
  ✗ ENGCUP: ...          (15 errors in total)
```

Production would keep running — live saves are fine and the country picker degrades cleanly — but reference data could no longer be rebuilt, CI could no longer validate a 2025 data touch, and **there would be no way back except reverting the merge.**

## The fix

An optional `from_season` key on a country block, a `domestic_cups` entry or a `support.transfer_pool` entry, and the enumeration is gated on it. A block without one has always existed, so nothing currently declared moves.

The gate is confined to the **data layer** — the only place that reads the config to decide what must exist on disk. Runtime callers need nothing: a save is never handed a competition added after it began, because PR 5's processors already skip a cup with no `competitions` row and one the game holds no field for. A supercup needs no key of its own; it is hidden while the cup it is contested between is.

`playableCountryCodes()`, `domesticCupIds()`, `supercup()` and the new `transferPool()` take an optional season defaulting to `config('season.current')`. `SeedReferenceData`, `RefreshPlayerTemplates`, `ValidateSeason`, `NormalizeSeason`, `DiffSeason` and `ScaffoldSeason` pass theirs explicitly.

## What it buys

- `app:validate-season 2025` and `app:seed-reference-data` keep working after PR 7.
- **The season flip becomes an environment change, not a merge.** `GAME_SEASON` is already read from env, so rolling 2026 back becomes editing one variable and redeploying.
- PR 7 becomes safe to merge on its own schedule, decoupled from the day you want players to see 2026.

## Blast radius

None today — nothing currently in `config/countries.php` declares `from_season`.

## Verification

`./vendor/bin/phpstan analyse` clean · 1299 tests pass (7 new, in `SeasonAvailabilityTest`) · `app:validate-season 2025` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B9964iVM9oLHCo74xyWTF9

---
_Generated by [Claude Code](https://claude.ai/code/session_01B9964iVM9oLHCo74xyWTF9)_