### PR TITLE
Catch and repair clubs booked twice on one date

### DIFF
--- a/app/Console/Commands/FixSeasonClashes.php
+++ b/app/Console/Commands/FixSeasonClashes.php
@@ -1,0 +1,424 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Modules\Competition\Services\CountryConfig;
+use App\Support\FixtureCalendar;
+use App\Support\SeasonData;
+use Carbon\CarbonImmutable;
+use Illuminate\Console\Command;
+
+/**
+ * Move the rounds that book a club twice on one date.
+ *
+ * `app:validate-season` reports these; this resolves them. It exists because
+ * the alternative is what happened last time — hand-editing `schedule.json`
+ * until the one clash you were looking at went away, with nothing checking
+ * whether the new date collided with something else.
+ *
+ * Only *certain* collisions are moved: two fields both fully known from the
+ * files. The possible ones depend on a draw, so a fix would be guesswork.
+ *
+ * The move policy, in order:
+ *   1. Never move a continental date. The UEFA calendar is real, and it is
+ *      shared by every country's data — shifting it to suit one league breaks
+ *      the others.
+ *   2. Prefer moving a knockout round. Cups have weeks between rounds; a
+ *      league round sits in a weekly rhythm with nine other fixtures on it.
+ *   3. Otherwise move the league round, which is what `177c77d` did by hand.
+ *
+ * A candidate date has to be free for every club in the round being moved,
+ * stay strictly between that round's neighbours, and ideally keep the
+ * competition's usual weekday. After each move the whole season is re-checked,
+ * so a fix cannot quietly create the next clash.
+ */
+class FixSeasonClashes extends Command
+{
+    protected $signature = 'app:fix-season-clashes
+                            {season : Season to repair (e.g. 2026)}
+                            {--apply : Write the moves to disk (otherwise only reported)}';
+
+    protected $description = 'Reschedule rounds that book a club for two matches on the same date';
+
+    /** How far either side of a clashing date to look for a free one. */
+    private const SEARCH_DAYS = 7;
+
+    /** Guards against a pathological data set looping forever. */
+    private const MAX_MOVES = 100;
+
+    public function handle(CountryConfig $countryConfig): int
+    {
+        $season = (string) $this->argument('season');
+
+        if (!is_dir(base_path("data/{$season}"))) {
+            $this->error("Season folder not found: " . base_path("data/{$season}"));
+
+            return self::FAILURE;
+        }
+
+        /** @var array<string, array<string, mixed>> $schedules */
+        $schedules = [];
+        $moves = [];
+        $unresolved = [];
+
+        for ($i = 0; $i < self::MAX_MOVES; $i++) {
+            $collision = $this->nextCertainCollision($season, $countryConfig, $schedules, $unresolved);
+            if ($collision === null) {
+                break;
+            }
+
+            $move = $this->planMove($season, $countryConfig, $collision, $schedules);
+            if ($move === null) {
+                $unresolved[$this->key($collision)] = $collision;
+
+                continue;
+            }
+
+            $schedules[$move['competition']] = $this->withDate(
+                $schedules[$move['competition']] ?? FixtureCalendar::schedule($season, $move['competition']) ?? [],
+                $move,
+            );
+            $moves[] = $move;
+        }
+
+        return $this->report($season, $moves, $unresolved, $schedules);
+    }
+
+    /**
+     * The next certain collision that hasn't already defeated us.
+     *
+     * @param  array<string, array<string, mixed>>  $schedules
+     * @param  array<string, array<string, mixed>>  $unresolved
+     * @return array<string, mixed>|null
+     */
+    private function nextCertainCollision(string $season, CountryConfig $countryConfig, array $schedules, array $unresolved): ?array
+    {
+        foreach (FixtureCalendar::collisions($season, $countryConfig, $schedules) as $collision) {
+            if ($collision['certain'] && !isset($unresolved[$this->key($collision)])) {
+                return $collision;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Decide which round to move and where to, or null when nothing can be.
+     *
+     * @param  array<string, mixed>  $collision
+     * @param  array<string, array<string, mixed>>  $schedules
+     * @return array{competition: string, section: string, round: int, leg: string, from: string, to: string, clubs: int}|null
+     */
+    private function planMove(string $season, CountryConfig $countryConfig, array $collision, array $schedules): ?array
+    {
+        $types = $this->competitionTypes($season, $countryConfig);
+        $bookings = FixtureCalendar::bookings($season, $countryConfig, $schedules);
+
+        $candidates = array_filter(
+            $collision['rounds'],
+            fn (array $r): bool => ($types[$r['competition']] ?? '') !== 'continental',
+        );
+
+        // Knockout rounds first: they have the slack, and moving one disturbs
+        // a single tie-round rather than a whole matchweek.
+        usort($candidates, function (array $a, array $b) use ($types): int {
+            $rank = fn (array $r): int => ($types[$r['competition']] ?? '') === 'cup' ? 0 : 1;
+
+            return [$rank($a), $a['competition']] <=> [$rank($b), $b['competition']];
+        });
+
+        foreach ($candidates as $round) {
+            $schedule = $schedules[$round['competition']]
+                ?? FixtureCalendar::schedule($season, $round['competition'])
+                ?? [];
+
+            $to = $this->findFreeDate($schedule, $round, $collision['date'], $bookings);
+            if ($to !== null) {
+                return [
+                    'competition' => $round['competition'],
+                    'section' => $this->sectionOf($schedule, $round),
+                    'round' => $round['round'],
+                    'leg' => $round['leg'],
+                    'from' => $collision['date'],
+                    'to' => $to,
+                    'clubs' => count($collision['clubs']),
+                ];
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * The nearest date that is free for every club in this round, keeps the
+     * round between its neighbours, and preferably falls on the weekday the
+     * competition usually plays.
+     *
+     * @param  array<string, mixed>  $schedule
+     * @param  array{competition: string, round: int, leg: string}  $round
+     * @param  array<string, array<string, array<int, array<string, mixed>>>>  $bookings
+     */
+    private function findFreeDate(array $schedule, array $round, string $from, array $bookings): ?string
+    {
+        $field = $this->clubsPlaying($bookings, $from, $round);
+        if ($field === []) {
+            return null;
+        }
+
+        [$after, $before] = $this->neighbours($schedule, $round, $from);
+        $preferredWeekday = $this->modalWeekday($schedule, $this->sectionOf($schedule, $round));
+        $origin = CarbonImmutable::parse($from);
+
+        $offsets = range(1, self::SEARCH_DAYS);
+        $candidates = [];
+        foreach ($offsets as $offset) {
+            foreach ([$offset, -$offset] as $signed) {
+                $candidates[] = $origin->addDays($signed);
+            }
+        }
+
+        // Nearest first, but a date on the competition's usual weekday beats a
+        // marginally nearer one — a Ligue 1 round belongs on a weekend.
+        usort($candidates, function (CarbonImmutable $a, CarbonImmutable $b) use ($origin, $preferredWeekday): int {
+            $rank = fn (CarbonImmutable $d): array => [
+                $preferredWeekday !== null && $d->dayOfWeek === $preferredWeekday ? 0 : 1,
+                abs($d->diffInDays($origin)),
+            ];
+
+            return $rank($a) <=> $rank($b);
+        });
+
+        foreach ($candidates as $candidate) {
+            $date = $candidate->toDateString();
+
+            if (($after !== null && $date <= $after) || ($before !== null && $date >= $before)) {
+                continue;
+            }
+
+            if ($this->anyBooked($bookings, $date, $field)) {
+                continue;
+            }
+
+            return $date;
+        }
+
+        return null;
+    }
+
+    /**
+     * The clubs this round has booked on the clashing date.
+     *
+     * @param  array<string, array<string, array<int, array<string, mixed>>>>  $bookings
+     * @param  array{competition: string, round: int, leg: string}  $round
+     * @return array<int, string>
+     */
+    private function clubsPlaying(array $bookings, string $date, array $round): array
+    {
+        $clubs = [];
+        foreach ($bookings[$date] ?? [] as $clubId => $entries) {
+            foreach ($entries as $entry) {
+                if ($entry['competition'] === $round['competition']
+                    && $entry['round'] === $round['round']
+                    && $entry['leg'] === $round['leg']) {
+                    $clubs[] = (string) $clubId;
+                    break;
+                }
+            }
+        }
+
+        return $clubs;
+    }
+
+    /**
+     * @param  array<string, array<string, array<int, array<string, mixed>>>>  $bookings
+     * @param  array<int, string>  $clubs
+     */
+    private function anyBooked(array $bookings, string $date, array $clubs): bool
+    {
+        foreach ($clubs as $clubId) {
+            if (!empty($bookings[$date][$clubId])) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * The dates this round has to stay between: the latest date before it and
+     * the earliest after it, within the same section of the same competition.
+     * A second leg must also stay behind its first.
+     *
+     * @param  array<string, mixed>  $schedule
+     * @param  array{round: int, leg: string}  $round
+     * @return array{0: string|null, 1: string|null}
+     */
+    private function neighbours(array $schedule, array $round, string $from): array
+    {
+        $section = $this->sectionOf($schedule, $round);
+        $after = null;
+        $before = null;
+
+        foreach ($schedule[$section] ?? [] as $entry) {
+            foreach (['date', 'first_leg_date', 'second_leg_date'] as $leg) {
+                $date = $entry[$leg] ?? null;
+                if (!$date) {
+                    continue;
+                }
+
+                $isSelf = (int) ($entry['round'] ?? 0) === $round['round'] && $leg === $round['leg'];
+                if ($isSelf) {
+                    continue;
+                }
+
+                $sameRound = (int) ($entry['round'] ?? 0) === $round['round'];
+                $isEarlier = $sameRound ? $leg === 'first_leg_date' : (int) ($entry['round'] ?? 0) < $round['round'];
+
+                if ($isEarlier) {
+                    $after = $after === null ? $date : max($after, $date);
+                } else {
+                    $before = $before === null ? $date : min($before, $date);
+                }
+            }
+        }
+
+        return [$after, $before];
+    }
+
+    /**
+     * The weekday a competition's section usually plays on, so a moved round
+     * lands back in its rhythm rather than on whichever day was free first.
+     *
+     * @param  array<string, mixed>  $schedule
+     */
+    private function modalWeekday(array $schedule, string $section): ?int
+    {
+        $counts = [];
+        foreach ($schedule[$section] ?? [] as $entry) {
+            foreach (['date', 'first_leg_date', 'second_leg_date'] as $leg) {
+                if (!empty($entry[$leg])) {
+                    $day = CarbonImmutable::parse($entry[$leg])->dayOfWeek;
+                    $counts[$day] = ($counts[$day] ?? 0) + 1;
+                }
+            }
+        }
+
+        if ($counts === []) {
+            return null;
+        }
+
+        arsort($counts);
+
+        return (int) array_key_first($counts);
+    }
+
+    /**
+     * @param  array<string, mixed>  $schedule
+     * @param  array{round: int, leg: string}  $round
+     */
+    private function sectionOf(array $schedule, array $round): string
+    {
+        foreach (['league', 'knockout'] as $section) {
+            foreach ($schedule[$section] ?? [] as $entry) {
+                if ((int) ($entry['round'] ?? 0) === $round['round'] && isset($entry[$round['leg']])) {
+                    return $section;
+                }
+            }
+        }
+
+        return 'knockout';
+    }
+
+    /**
+     * @param  array<string, mixed>  $schedule
+     * @param  array{section: string, round: int, leg: string, to: string}  $move
+     * @return array<string, mixed>
+     */
+    private function withDate(array $schedule, array $move): array
+    {
+        foreach ($schedule[$move['section']] ?? [] as $index => $entry) {
+            if ((int) ($entry['round'] ?? 0) === $move['round'] && isset($entry[$move['leg']])) {
+                $schedule[$move['section']][$index][$move['leg']] = $move['to'];
+                break;
+            }
+        }
+
+        return $schedule;
+    }
+
+    /**
+     * Competition code => the type SeasonData assigned it, so the move policy
+     * can tell a cup from a league from an untouchable continental calendar.
+     *
+     * @return array<string, string>
+     */
+    private function competitionTypes(string $season, CountryConfig $countryConfig): array
+    {
+        return array_column(SeasonData::competitions($countryConfig, $season), 'type', 'code');
+    }
+
+    /** @param  array<string, mixed>  $collision */
+    private function key(array $collision): string
+    {
+        return $collision['date'] . '|' . implode('|', array_map(
+            fn (array $r): string => "{$r['competition']}#{$r['round']}#{$r['leg']}",
+            $collision['rounds'],
+        ));
+    }
+
+    /**
+     * @param  array<int, array{competition: string, round: int, leg: string, from: string, to: string, clubs: int}>  $moves
+     * @param  array<string, array<string, mixed>>  $unresolved
+     * @param  array<string, array<string, mixed>>  $schedules
+     */
+    private function report(string $season, array $moves, array $unresolved, array $schedules): int
+    {
+        if ($moves === [] && $unresolved === []) {
+            $this->info("No club is booked twice on one date in data/{$season}.");
+
+            return self::SUCCESS;
+        }
+
+        if ($moves !== []) {
+            $this->info(($this->option('apply') ? 'Applied' : 'Proposed') . ' ' . count($moves) . ' move(s):');
+            $this->table(
+                ['competition', 'round', 'leg', 'from', 'to', 'clubs freed'],
+                array_map(fn (array $m): array => [
+                    $m['competition'],
+                    $m['round'],
+                    $m['leg'] === 'second_leg_date' ? '2nd' : ($m['leg'] === 'first_leg_date' ? '1st' : '—'),
+                    $m['from'],
+                    $m['to'],
+                    $m['clubs'],
+                ], $moves),
+            );
+        }
+
+        foreach ($unresolved as $collision) {
+            $rounds = implode(' and ', array_map(
+                fn (array $r): string => "{$r['competition']} round {$r['round']}",
+                $collision['rounds'],
+            ));
+            $this->warn("  ⚠ {$collision['date']}: {$rounds} — no free date within "
+                . self::SEARCH_DAYS . ' days that keeps the round between its neighbours. Move it by hand.');
+        }
+
+        if (!$this->option('apply')) {
+            $this->newLine();
+            $this->line('Re-run with --apply to write these to data/' . $season . '.');
+
+            return $unresolved === [] ? self::SUCCESS : self::FAILURE;
+        }
+
+        foreach ($schedules as $code => $schedule) {
+            $path = base_path("data/{$season}/{$code}/schedule.json");
+            file_put_contents($path, json_encode(
+                $schedule,
+                JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR,
+            ) . "\n");
+            $this->line("  wrote data/{$season}/{$code}/schedule.json");
+        }
+
+        return $unresolved === [] ? self::SUCCESS : self::FAILURE;
+    }
+}

--- a/app/Console/Commands/ValidateSeason.php
+++ b/app/Console/Commands/ValidateSeason.php
@@ -4,6 +4,7 @@ namespace App\Console\Commands;
 
 use App\Modules\Competition\Services\CountryConfig;
 use App\Modules\Competition\Services\SwissDrawService;
+use App\Support\FixtureCalendar;
 use App\Support\SeasonData;
 use Database\Seeders\ClubProfilesSeeder;
 use Illuminate\Console\Command;
@@ -95,6 +96,7 @@ class ValidateSeason extends Command
         }
 
         $this->validateSquadNumbers($season, $competitions);
+        $this->validateNoFixtureClashes($season, $countryConfig);
         $this->warnUnprofiledClubs();
 
         foreach ($this->warnings as $warning) {
@@ -588,6 +590,47 @@ class ValidateSeason extends Command
 
         $this->warnings[] = count($missing) . ' club(s) have no ClubProfilesSeeder entry and will be seeded '
             . "as local-reputation clubs: {$detail}.";
+    }
+
+    /**
+     * No club may be booked for two matches on one date.
+     *
+     * Nothing catches this at runtime: MatchdayService collects every unplayed
+     * match on the earliest date and the orchestrator takes the first as the
+     * user's, so the second is simulated in the same batch, same legs, same
+     * fitness, silently. It is the bug `177c77d` fixed by hand after it
+     * reached production.
+     *
+     * Errors only where both fields are known from the files — a league round
+     * books its whole division, a Swiss matchday all 36, a cup's opening round
+     * whoever declares that entry round. Everything downstream of a draw is a
+     * superset, so it warns instead. See App\Support\FixtureCalendar for what
+     * is deliberately not modelled.
+     */
+    private function validateNoFixtureClashes(string $season, CountryConfig $countryConfig): void
+    {
+        foreach (FixtureCalendar::collisions($season, $countryConfig) as $collision) {
+            $rounds = implode(' and ', array_map(
+                fn (array $r): string => $r['competition'] . ' round ' . $r['round']
+                    . ($r['leg'] === 'second_leg_date' ? ' (2nd leg)' : ''),
+                $collision['rounds'],
+            ));
+
+            $clubs = $this->summarize($collision['clubs']);
+            $count = count($collision['clubs']);
+
+            if ($collision['certain']) {
+                $this->errors[] = "{$collision['date']}: {$rounds} are both on this date, so "
+                    . "{$count} club(s) are booked twice — {$clubs}.";
+
+                continue;
+            }
+
+            $reachable = min($collision['slots'], $count);
+            $this->warnings[] = "{$collision['date']}: {$rounds} share this date. Up to {$reachable} "
+                . "of the {$count} club(s) in both could be booked twice — {$clubs}. Which of them "
+                . 'reach the round depends on the draw.';
+        }
     }
 
     /**

--- a/app/Support/FixtureCalendar.php
+++ b/app/Support/FixtureCalendar.php
@@ -1,0 +1,330 @@
+<?php
+
+namespace App\Support;
+
+use App\Modules\Competition\Services\CountryConfig;
+
+/**
+ * Reads a season folder as a calendar of "which clubs are booked on which
+ * date", so a club scheduled twice on one day can be found before the data is
+ * ever seeded.
+ *
+ * This is the bug class `177c77d` fixed by hand: ESP1 and ENG1 both had a
+ * midweek round on 2025-09-24, which is matchday 1 of the Europa League and
+ * the Conference League, so every Spanish or English club in either was booked
+ * twice that day. Nothing catches it at runtime — MatchdayService collects
+ * every unplayed match on the earliest date and the orchestrator takes the
+ * first as the user's, so the second is simulated in the same batch on the
+ * same legs, with no warning anywhere.
+ *
+ * Database-free by construction: the season-data workflow runs the validator
+ * against an unmigrated database, so everything here comes from `data/**` and
+ * `config/countries.php`.
+ *
+ * How confidently a booking is known splits three ways, and only the first is
+ * worth failing a build over:
+ *
+ *  - CERTAIN. A round-robin league round pairs every club exactly once, and a
+ *    Swiss league phase plays all 36 on every matchday, so the whole
+ *    `teams.json` is booked on that date. A domestic cup's *opening* round is
+ *    equally certain: its field is whoever declares that entry round.
+ *  - POSSIBLE. From a cup's second round on, the field is last round's winners
+ *    — decided by a draw at runtime, not by the file. Continental knockout
+ *    rounds are seeded from league-phase standings, so not even their first
+ *    round is known. The file gives a superset, so a shared date is a risk
+ *    rather than a fact.
+ *  - UNKNOWABLE, and deliberately not modelled: a supercup from season 2 on
+ *    (its field is last season's champion and cup winner), promotion playoffs
+ *    (ESP3PO has no `teams.json` at all), the Coppa Italia's byes once they
+ *    are re-derived from a final table, and pre-season friendlies (dates live
+ *    in PreseasonOpponentService, and the opponent is the user's choice).
+ *    Catching those needs a simulated save, not a data gate.
+ */
+class FixtureCalendar
+{
+    /**
+     * Every booking this season folder declares, keyed by date then club id.
+     *
+     * `$scheduleOverrides` replaces a competition's schedule.json with an
+     * in-memory one, keyed by competition code, so app:fix-season-clashes can
+     * try a move and re-check without writing to disk.
+     *
+     * @param  array<string, array<string, mixed>>  $scheduleOverrides
+     * @return array<string, array<string, array<int, array{competition: string, round: int, name: string, leg: string, certain: bool, slots: int, club: string}>>>
+     */
+    public static function bookings(
+        string $season,
+        CountryConfig $countryConfig,
+        array $scheduleOverrides = [],
+    ): array
+    {
+        $bookings = [];
+
+        foreach (SeasonData::competitions($countryConfig, $season) as ['code' => $code, 'type' => $type]) {
+            // Pools hold no fixtures, and a bare playoff has a schedule but no
+            // teams.json to say who turns up for it.
+            if (!in_array($type, ['league', 'cup', 'continental'], true)) {
+                continue;
+            }
+
+            $clubs = SeasonData::readCompetitionClubs($season, $code, $type);
+            $schedule = $scheduleOverrides[$code] ?? self::schedule($season, $code);
+            if (empty($clubs) || $schedule === null) {
+                continue;
+            }
+
+            $skipAhead = self::supercupSkipAhead($season, $code, $countryConfig);
+            $slots = self::knockoutSlots($clubs, $schedule, $skipAhead);
+
+            foreach (self::rounds($schedule, $type) as $round) {
+                foreach (self::fieldFor($clubs, $round, $skipAhead) as $club) {
+                    foreach ($round['dates'] as $leg => $date) {
+                        $bookings[$date][$club['id']][] = [
+                            'competition' => $code,
+                            'round' => $round['round'],
+                            'name' => $round['name'],
+                            'leg' => $leg,
+                            'certain' => $round['certain'],
+                            'slots' => $round['section'] === 'league'
+                                ? count($clubs)
+                                : ($slots[$round['round']] ?? count($clubs)),
+                            'club' => $club['name'],
+                        ];
+                    }
+                }
+            }
+        }
+
+        return $bookings;
+    }
+
+    /**
+     * Clubs booked twice on one date, grouped into the collision that caused
+     * it — one league round meeting one cup round is a single scheduling
+     * mistake however many clubs it catches, and reporting it per club buries
+     * the signal.
+     *
+     * A collision is `certain` when at least two of its bookings are: two
+     * fields that are both fully known cannot avoid each other.
+     *
+     * @param  array<string, array<string, mixed>>  $scheduleOverrides
+     * @return array<int, array{date: string, certain: bool, rounds: array<int, array{competition: string, round: int, name: string, leg: string, certain: bool, slots: int}>, slots: int, clubs: array<int, string>}>
+     */
+    public static function collisions(
+        string $season,
+        CountryConfig $countryConfig,
+        array $scheduleOverrides = [],
+    ): array
+    {
+        $collisions = [];
+
+        foreach (self::bookings($season, $countryConfig, $scheduleOverrides) as $date => $clubs) {
+            foreach ($clubs as $entries) {
+                if (count($entries) < 2) {
+                    continue;
+                }
+
+                // Key on the rounds involved so every club caught by the same
+                // pair of rounds folds into one collision.
+                $key = $date . '|' . implode('|', array_map(
+                    fn (array $e): string => "{$e['competition']}#{$e['round']}#{$e['leg']}",
+                    $entries,
+                ));
+
+                $collisions[$key] ??= [
+                    'date' => $date,
+                    'certain' => count(array_filter($entries, fn (array $e): bool => $e['certain'])) >= 2,
+                    'rounds' => array_map(
+                        fn (array $e): array => array_diff_key($e, ['club' => null]),
+                        $entries,
+                    ),
+                    // The narrowest round bounds the damage: a cup final and a
+                    // league round share a date, but only two clubs can be in
+                    // both however many could have got there.
+                    'slots' => min(array_column($entries, 'slots')),
+                    'clubs' => [],
+                ];
+                $collisions[$key]['clubs'][] = $entries[0]['club'];
+            }
+        }
+
+        // Certain collisions first, then chronologically: the ones that have
+        // to be fixed lead the report.
+        uasort($collisions, function (array $a, array $b): int {
+            return [$b['certain'], $a['date']] <=> [$a['certain'], $b['date']];
+        });
+
+        return array_values($collisions);
+    }
+
+    /**
+     * Read a competition's schedule.json, or null when it has none.
+     *
+     * @return array<string, mixed>|null
+     */
+    public static function schedule(string $season, string $code): ?array
+    {
+        $path = base_path("data/{$season}/{$code}/schedule.json");
+        if (!file_exists($path)) {
+            return null;
+        }
+
+        $data = json_decode((string) file_get_contents($path), true);
+
+        return is_array($data) ? $data : null;
+    }
+
+    /**
+     * Flatten a schedule into rounds carrying every date they occupy — a
+     * league round is one date, a knockout round may be two legs on two.
+     *
+     * A knockout round is only `certain` when it is a domestic cup's opening
+     * round, where the declared field is exactly who turns up. Later rounds
+     * are last round's winners, and a continental knockout is seeded from
+     * league-phase standings, so neither is known from the file.
+     *
+     * @param  array<string, mixed>  $schedule
+     * @return array<int, array{section: string, round: int, name: string, dates: array<string, string>, certain: bool}>
+     */
+    public static function rounds(array $schedule, string $type = 'cup'): array
+    {
+        $out = [];
+        $openingRound = self::openingKnockoutRound($schedule);
+
+        foreach (['league', 'knockout'] as $section) {
+            foreach ($schedule[$section] ?? [] as $round) {
+                if (!is_array($round)) {
+                    continue;
+                }
+
+                $dates = [];
+                foreach (['date', 'first_leg_date', 'second_leg_date'] as $key) {
+                    if (!empty($round[$key])) {
+                        $dates[$key] = (string) $round[$key];
+                    }
+                }
+
+                if ($dates === []) {
+                    continue;
+                }
+
+                $number = (int) ($round['round'] ?? 0);
+
+                $out[] = [
+                    'section' => $section,
+                    'round' => $number,
+                    'name' => (string) ($round['name'] ?? ''),
+                    'dates' => $dates,
+                    'certain' => $section === 'league'
+                        || ($type === 'cup' && $number === $openingRound),
+                ];
+            }
+        }
+
+        return $out;
+    }
+
+    /**
+     * The lowest knockout round in a schedule — the one a cup's declared field
+     * actually turns up for.
+     *
+     * @param  array<string, mixed>  $schedule
+     */
+    private static function openingKnockoutRound(array $schedule): ?int
+    {
+        $rounds = array_map(
+            fn (array $r): int => (int) ($r['round'] ?? 0),
+            array_filter($schedule['knockout'] ?? [], 'is_array'),
+        );
+
+        return $rounds === [] ? null : min($rounds);
+    }
+
+    /**
+     * How many clubs each knockout round actually fields, by walking the
+     * halvings: a round starts with the last one's winners plus whoever enters
+     * at it. The same arithmetic validateBracketParity uses, for the same
+     * reason — it is the only way to know that a final is two clubs and not
+     * the eighty that could have reached it.
+     *
+     * @param  array<int, array{id: string, entryRound: int}>  $clubs
+     * @param  array<string, mixed>  $schedule
+     * @param  array<string, int>  $skipAhead
+     * @return array<int, int>
+     */
+    private static function knockoutSlots(array $clubs, array $schedule, array $skipAhead): array
+    {
+        $entrants = [];
+        foreach ($clubs as $club) {
+            $round = $skipAhead[$club['id']] ?? $club['entryRound'];
+            $entrants[$round] = ($entrants[$round] ?? 0) + 1;
+        }
+
+        $rounds = array_map(
+            fn (array $r): int => (int) ($r['round'] ?? 0),
+            array_filter($schedule['knockout'] ?? [], 'is_array'),
+        );
+        sort($rounds);
+
+        $slots = [];
+        $survivors = 0;
+        foreach ($rounds as $round) {
+            $field = $survivors + ($entrants[$round] ?? 0);
+            $slots[$round] = $field;
+            $survivors = intdiv($field, 2);
+        }
+
+        return $slots;
+    }
+
+    /**
+     * Which clubs a round books. A league round or Swiss matchday books
+     * everyone; a knockout round books whoever could still be alive for it,
+     * which from the file is everyone who entered at or before it.
+     *
+     * @param  array<int, array{id: string, name: string, entryRound: int}>  $clubs
+     * @param  array{section: string, round: int}  $round
+     * @param  array<string, int>  $skipAhead
+     * @return array<int, array{id: string, name: string}>
+     */
+    private static function fieldFor(array $clubs, array $round, array $skipAhead): array
+    {
+        if ($round['section'] === 'league') {
+            return $clubs;
+        }
+
+        return array_values(array_filter(
+            $clubs,
+            fn (array $club): bool => ($skipAhead[$club['id']] ?? $club['entryRound']) <= $round['round'],
+        ));
+    }
+
+    /**
+     * Where a country's supercup field joins its main cup. Spain's four
+     * Supercopa clubs skip to the Copa's round of 32, so they are not in its
+     * opening round at all — CupEntryRoundService applies the same bump at
+     * season setup, and without it a correctly built cup reads as a clash.
+     *
+     * @return array<string, int> club id => the round it really enters at
+     */
+    private static function supercupSkipAhead(string $season, string $cupCode, CountryConfig $countryConfig): array
+    {
+        foreach ($countryConfig->allCountryCodes() as $countryCode) {
+            $supercup = $countryConfig->supercup($countryCode, $season);
+            if (($supercup['cup'] ?? null) !== $cupCode) {
+                continue;
+            }
+
+            $skipToRound = (int) ($supercup['cup_entry_round'] ?? 0);
+            if ($skipToRound < 2) {
+                return [];
+            }
+
+            $field = SeasonData::readCompetitionClubs($season, $supercup['competition'], 'cup') ?? [];
+
+            return array_fill_keys(array_column($field, 'id'), $skipToRound);
+        }
+
+        return [];
+    }
+}

--- a/app/Support/SeasonData.php
+++ b/app/Support/SeasonData.php
@@ -160,11 +160,12 @@ class SeasonData
      * absent. Bare playoffs ('none') always return null (no squads).
      *
      * Each club is `['id' => transfermarktId, 'name' => string,
+     * 'entryRound' => int,
      * 'players' => array<string id, string name>,
      * 'numbers' => array<string id, int shirt>,
      * 'positions' => array<string id, string position>]`.
      *
-     * @return array<int, array{id: string, name: string, players: array<string, string>, numbers: array<string, int>, positions: array<string, string>}>|null
+     * @return array<int, array{id: string, name: string, entryRound: int, players: array<string, string>, numbers: array<string, int>, positions: array<string, string>}>|null
      */
     public static function readCompetitionClubs(string $season, string $code, string $type): ?array
     {
@@ -203,14 +204,15 @@ class SeasonData
     }
 
     /**
-     * Normalize a single club entry to {id, name, players[id => name],
-     * numbers[id => shirt], positions[id => position]}. Shirt numbers and
-     * positions are kept in their own maps so a squad-file consumer can check
-     * them without every consumer having to care: a player missing either is
-     * simply absent from that map.
+     * Normalize a single club entry to {id, name, entryRound, players[id =>
+     * name], numbers[id => shirt], positions[id => position]}. Shirt numbers
+     * and positions are kept in their own maps so a squad-file consumer can
+     * check them without every consumer having to care: a player missing
+     * either is simply absent from that map. `entryRound` is the cup round the
+     * club joins at, defaulting to 1 the way CupEntryRoundService reads it.
      *
      * @param  array<string, mixed>  $club
-     * @return array{id: string, name: string, players: array<string, string>, numbers: array<string, int>, positions: array<string, string>}|null
+     * @return array{id: string, name: string, entryRound: int, players: array<string, string>, numbers: array<string, int>, positions: array<string, string>}|null
      */
     private static function club(array $club): ?array
     {
@@ -242,6 +244,7 @@ class SeasonData
         return [
             'id' => $id,
             'name' => (string) ($club['name'] ?? "({$id})"),
+            'entryRound' => max(1, (int) ($club['entryRound'] ?? 1)),
             'players' => $players,
             'numbers' => $numbers,
             'positions' => $positions,

--- a/docs/season-data-refresh.md
+++ b/docs/season-data-refresh.md
@@ -256,6 +256,42 @@ between is. Runtime callers need none either: a save is never handed a
 competition added after it began, because the season processors skip a cup with
 no `competitions` row and one the game holds no field for.
 
+## Fixture clashes
+
+`app:validate-season` also checks that no club is booked for two matches on one
+date. It is a real failure mode, not a theoretical one: ESP1 and ENG1 once had a
+midweek round on the same day as Europa League matchday 1, and every Spanish or
+English club in that competition was scheduled twice. Nothing catches it at
+runtime — the matchday service collects every unplayed match on the earliest
+date and the orchestrator takes the first as the user's, so the second is
+simulated in the same batch, same legs, silently.
+
+The check errors only where both fields are known from the files: a league round
+books its whole division, a Swiss matchday all 36, a cup's opening round whoever
+declares that entry round. Anything downstream of a draw is a superset, so it
+warns instead and names how many of the overlapping clubs can actually reach
+that round — a cup final shares a date with two clubs, not with everyone who
+might have got there.
+
+To repair what it finds:
+
+```bash
+php artisan app:fix-season-clashes 2026            # propose moves
+php artisan app:fix-season-clashes 2026 --apply    # write them
+```
+
+It moves the certain clashes only, never touches a continental date (the UEFA
+calendar is real and shared by every country's data), prefers moving a knockout
+round over a league matchweek, keeps the round between its neighbours and on the
+competition's usual weekday, and re-checks the whole season after each move so a
+fix cannot create the next clash. Anything it cannot solve within a week either
+side is reported for you to move by hand.
+
+Deliberately not modelled, because a data gate cannot know them: a supercup from
+season 2 on (its field is last season's champion and cup winner), promotion
+playoffs, the Coppa Italia's byes once re-derived from a final table, and
+pre-season friendlies (the opponent is the user's choice).
+
 ## Notes & caveats
 
 - **Games are pinned to the season they were created in.** `games.base_season`

--- a/tests/Feature/Console/FixSeasonClashesCommandTest.php
+++ b/tests/Feature/Console/FixSeasonClashesCommandTest.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace Tests\Feature\Console;
+
+use Illuminate\Support\Facades\File;
+use Tests\TestCase;
+
+class FixSeasonClashesCommandTest extends TestCase
+{
+    // A throwaway season disjoint from the years ValidateSeasonCommandTest
+    // (2096) and ScaffoldSeasonCommandTest (2098/2099) use: all three write to
+    // the shared base_path('data') tree, so under `test --parallel` they would
+    // otherwise race, one tearDown deleting another's freshly written files.
+    private string $season = '2097';
+
+    protected function tearDown(): void
+    {
+        File::deleteDirectory(base_path("data/{$this->season}"));
+        parent::tearDown();
+    }
+
+    public function test_it_moves_a_cup_round_off_a_league_date(): void
+    {
+        $this->writeSeason(cupRound1: $this->weekOfSeason(3));
+
+        $this->artisan('app:fix-season-clashes', ['season' => $this->season, '--apply' => true])
+            ->assertSuccessful();
+
+        // The league keeps its matchweek; the cup is the one that gives way.
+        $this->assertSame($this->weekOfSeason(3), $this->leagueDate(3));
+        $this->assertNotSame($this->weekOfSeason(3), $this->cupDate(1));
+    }
+
+    public function test_the_moved_round_does_not_land_on_another_booked_date(): void
+    {
+        $this->writeSeason(cupRound1: $this->weekOfSeason(3));
+
+        $this->artisan('app:fix-season-clashes', ['season' => $this->season, '--apply' => true]);
+
+        // Every league date is taken by the same clubs, so the only free days
+        // are the ones between matchweeks.
+        $leagueDates = array_map(fn (int $w): string => $this->weekOfSeason($w), range(1, 6));
+        $this->assertNotContains($this->cupDate(1), $leagueDates);
+    }
+
+    public function test_it_leaves_the_season_validating(): void
+    {
+        $this->writeSeason(cupRound1: $this->weekOfSeason(3));
+
+        $this->artisan('app:fix-season-clashes', ['season' => $this->season, '--apply' => true]);
+
+        $this->artisan('app:validate-season', ['season' => $this->season])
+            ->doesntExpectOutputToContain('are booked twice');
+    }
+
+    public function test_a_dry_run_changes_nothing_on_disk(): void
+    {
+        $this->writeSeason(cupRound1: $this->weekOfSeason(3));
+
+        $this->artisan('app:fix-season-clashes', ['season' => $this->season])
+            ->expectsOutputToContain('Re-run with --apply');
+
+        $this->assertSame($this->weekOfSeason(3), $this->cupDate(1));
+    }
+
+    public function test_a_clean_season_reports_nothing_to_do(): void
+    {
+        $this->writeSeason(cupRound1: $this->dayOfSeason(3));
+
+        $this->artisan('app:fix-season-clashes', ['season' => $this->season])
+            ->expectsOutputToContain('No club is booked twice')
+            ->assertSuccessful();
+    }
+
+    public function test_it_writes_the_canonical_encoding(): void
+    {
+        $this->writeSeason(cupRound1: $this->weekOfSeason(3));
+
+        $this->artisan('app:fix-season-clashes', ['season' => $this->season, '--apply' => true]);
+
+        // app:normalize-season must be a no-op afterwards, or every fix would
+        // land as a whole-file reformat in the diff.
+        $path = base_path("data/{$this->season}/ESPCUP/schedule.json");
+        $written = File::get($path);
+        $canonical = json_encode(
+            json_decode($written, true),
+            JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE,
+        ) . "\n";
+
+        $this->assertSame($canonical, $written);
+    }
+
+    /**
+     * A four-club league running weekly, plus a one-round cup whose field is
+     * the same four clubs.
+     */
+    private function writeSeason(string $cupRound1): void
+    {
+        $clubs = [];
+        for ($i = 0; $i < 4; $i++) {
+            $clubs[] = ['id' => (string) (200 + $i), 'name' => "Club {$i}"];
+        }
+
+        $leagueDir = base_path("data/{$this->season}/ESP1");
+        File::ensureDirectoryExists($leagueDir);
+        File::put("{$leagueDir}/teams.json", json_encode(['seasonID' => $this->season, 'clubs' => $clubs]));
+        $league = [];
+        for ($round = 1; $round <= 6; $round++) {
+            $league[] = ['round' => $round, 'date' => $this->weekOfSeason($round)];
+        }
+        File::put("{$leagueDir}/schedule.json", json_encode(['league' => $league]));
+
+        $cupDir = base_path("data/{$this->season}/ESPCUP");
+        File::ensureDirectoryExists($cupDir);
+        File::put("{$cupDir}/teams.json", json_encode(['seasonID' => $this->season, 'clubs' => $clubs]));
+        File::put("{$cupDir}/schedule.json", json_encode([
+            'knockout' => [['round' => 1, 'name' => 'cup.first_round', 'date' => $cupRound1]],
+        ]));
+    }
+
+    private function leagueDate(int $round): string
+    {
+        $schedule = json_decode(File::get(base_path("data/{$this->season}/ESP1/schedule.json")), true);
+
+        return $schedule['league'][$round - 1]['date'];
+    }
+
+    private function cupDate(int $round): string
+    {
+        $schedule = json_decode(File::get(base_path("data/{$this->season}/ESPCUP/schedule.json")), true);
+
+        return $schedule['knockout'][$round - 1]['date'];
+    }
+
+    private function weekOfSeason(int $week): string
+    {
+        return date('Y-m-d', strtotime("{$this->season}-08-01 +" . ($week - 1) . ' weeks'));
+    }
+
+    private function dayOfSeason(int $days): string
+    {
+        return date('Y-m-d', strtotime("{$this->season}-08-01 +{$days} days"));
+    }
+}

--- a/tests/Feature/Console/ValidateSeasonCommandTest.php
+++ b/tests/Feature/Console/ValidateSeasonCommandTest.php
@@ -40,9 +40,43 @@ class ValidateSeasonCommandTest extends TestCase
         $rounds = $leagueRounds ?? 2 * (count($clubs) - 1);
         $league = [];
         for ($i = 1; $i <= $rounds; $i++) {
-            $league[] = ['round' => $i, 'date' => sprintf('%s-08-%02d', $this->season, min($i, 28))];
+            // One round a week, all distinct: rounds sharing a date would book
+            // every club twice and trip the fixture-clash check.
+            $league[] = ['round' => $i, 'date' => $this->weekOfSeason($i)];
         }
         File::put("{$dir}/schedule.json", json_encode(['league' => $league]));
+    }
+
+    /** A day offset from the start of the throwaway season, as YYYY-MM-DD. */
+    private function dayOfSeason(int $days): string
+    {
+        return date('Y-m-d', strtotime("{$this->season}-08-01 +{$days} days"));
+    }
+
+    /** The nth weekly matchday of the throwaway season, as YYYY-MM-DD. */
+    private function weekOfSeason(int $week): string
+    {
+        return date('Y-m-d', strtotime("{$this->season}-08-01 +" . ($week - 1) . ' weeks'));
+    }
+
+    /**
+     * Write a knockout competition: a participant list plus one round per
+     * supplied date.
+     *
+     * @param  array<int, array<string, mixed>>  $clubs
+     * @param  array<int, string>  $dates
+     */
+    private function writeCup(string $code, array $clubs, array $dates): void
+    {
+        $dir = base_path("data/{$this->season}/{$code}");
+        File::ensureDirectoryExists($dir);
+        File::put("{$dir}/teams.json", json_encode(['seasonID' => $this->season, 'clubs' => $clubs]));
+
+        $knockout = [];
+        foreach (array_values($dates) as $index => $date) {
+            $knockout[] = ['round' => $index + 1, 'name' => 'cup.first_round', 'date' => $date];
+        }
+        File::put("{$dir}/schedule.json", json_encode(['knockout' => $knockout]));
     }
 
     /** @return array<int, array<string, string>> */
@@ -311,6 +345,82 @@ class ValidateSeasonCommandTest extends TestCase
         $this->artisan('app:validate-season', ['season' => $this->season])
             ->doesntExpectOutputToContain('swiss league phase needs exactly')
             ->assertFailed();
+    }
+
+    // =========================================
+    // Fixture clashes — a club booked twice on one date
+    // =========================================
+
+    public function test_errors_when_a_cups_opening_round_shares_a_date_with_a_league_round(): void
+    {
+        // Exactly the shape that reached production: a league round and a cup
+        // round the whole division enters, on one day.
+        $clubs = $this->validClubs(4);
+        $this->writeEsp1($clubs, $this->season);
+        $this->writeCup('ESPCUP', $clubs, [$this->weekOfSeason(2)]);
+
+        $this->artisan('app:validate-season', ['season' => $this->season])
+            ->expectsOutputToContain('are both on this date, so 4 club(s) are booked twice')
+            ->assertFailed();
+    }
+
+    public function test_a_later_cup_round_only_warns_because_the_draw_decides_it(): void
+    {
+        $clubs = $this->validClubs(20);
+        $this->writeEsp1($clubs, $this->season);
+        // Round 1 sits midweek, clear of every league date. Round 2 lands on
+        // one — but it is last round's winners, so the file cannot say who is
+        // actually there.
+        $this->writeCup('ESPCUP', $clubs, [$this->dayOfSeason(3), $this->weekOfSeason(5)]);
+
+        $this->artisan('app:validate-season', ['season' => $this->season])
+            ->expectsOutputToContain('could be booked twice')
+            ->doesntExpectOutputToContain('are booked twice');
+    }
+
+    public function test_a_round_whose_two_legs_share_a_date_is_reported(): void
+    {
+        $clubs = $this->validClubs(4);
+        $this->writeEsp1($clubs, $this->season);
+
+        $dir = base_path("data/{$this->season}/ESPCUP");
+        File::ensureDirectoryExists($dir);
+        File::put("{$dir}/teams.json", json_encode(['seasonID' => $this->season, 'clubs' => $clubs]));
+        File::put("{$dir}/schedule.json", json_encode(['knockout' => [[
+            'round' => 1,
+            'name' => 'cup.semi_finals',
+            'first_leg_date' => $this->weekOfSeason(20),
+            'second_leg_date' => $this->weekOfSeason(20),
+        ]]]));
+
+        $this->artisan('app:validate-season', ['season' => $this->season])
+            ->expectsOutputToContain('booked twice')
+            ->assertFailed();
+    }
+
+    public function test_a_season_whose_dates_are_all_distinct_reports_no_clash(): void
+    {
+        $clubs = $this->validClubs(4);
+        $this->writeEsp1($clubs, $this->season);
+        $this->writeCup('ESPCUP', $clubs, [$this->weekOfSeason(20)]);
+
+        $this->artisan('app:validate-season', ['season' => $this->season])
+            ->doesntExpectOutputToContain('booked twice');
+    }
+
+    public function test_the_supercup_field_is_not_counted_in_the_cup_round_it_skips(): void
+    {
+        // Spain's four Supercopa clubs join the Copa at the round of 32, so a
+        // Copa opening round on a league date must not implicate them.
+        config(['countries.ES.supercup.cup_entry_round' => 2]);
+
+        $clubs = $this->validClubs(4);
+        $this->writeEsp1($clubs, $this->season);
+        $this->writeCup('ESPCUP', $clubs, [$this->weekOfSeason(2), $this->weekOfSeason(30)]);
+        $this->writeCup('ESPSUP', $clubs, [$this->weekOfSeason(40)]);
+
+        $this->artisan('app:validate-season', ['season' => $this->season])
+            ->doesntExpectOutputToContain('are booked twice');
     }
 
     public function test_detects_duplicate_squad_numbers_within_a_club(): void


### PR DESCRIPTION
**Merge this before #1347** — it is the only one of the three that gates it.

## Why

`177c77d` fixed this by hand: ESP1 and ENG1 both had a midweek round 6 on **2025-09-24**, which is matchday 1 of both the Europa League and the Conference League, so every Spanish or English club in either was scheduled for two matches that day. It was found by eye, and nothing stopped the next one.

Nothing catches it at runtime either. `MatchdayService::getNextMatchBatch()` collects every unplayed match on the earliest date and `MatchdayOrchestrator.php:183` takes `->first()` as the user's match — so the second is simulated in the same batch, same legs, same fitness, silently.

**The 2026 calendars in #1347 bring it straight back.** Running this gate against that branch:

```
✗ 2026-09-23: UCL round 1 and ENGLC round 1 are both on this date, so 5 club(s)
  are booked twice — Arsenal FC, Liverpool FC, Manchester City, Aston Villa,
  Manchester United.
✗ 2026-12-19: FRA1 round 15 and FRACUP round 1 are both on this date, so 18
  club(s) are booked twice — the whole of Ligue 1.
```

plus 12 warnings, including the Coupe de France final on Ligue 1 matchday 33 and the Coppa Italia final on Serie A matchday 36. `data/2025` is clean and stays clean.

## What

**`app:validate-season` gains a whole-season pass.** It errors only where both fields are known from the files — a league round books its whole division, a Swiss matchday all 36 (the draw shuffles opponents, never whether you play), a cup's opening round whoever declares that entry round. Anything downstream of a draw is a superset, so it warns instead, and says how many of the overlapping clubs can actually reach that round:

> Up to **2** of the 18 club(s) in both could be booked twice

A cup final shares a date with two clubs, not with the eighty that might have got there. That number comes from the same halving walk `validateBracketParity` already does.

Deliberately **not** modelled, and named as such in the docblock rather than half-checked: a supercup from season 2 on (its field is last season's champion and cup winner), promotion playoffs (`ESP3PO` has no `teams.json` at all), the Coppa Italia's byes once re-derived from a final table, and pre-season friendlies (the opponent is the user's choice). Those need a simulated save, not a data gate.

Database-free by construction — the `season-data` workflow runs it against an unmigrated database.

**`app:fix-season-clashes {season} [--apply]`** repairs what the gate finds. Certain clashes only. It never moves a continental date (the UEFA calendar is real and shared by every country's data), prefers moving a knockout round over a league matchweek, keeps the round between its neighbours and on its competition's usual weekday, and re-checks the whole season after each move — the greedy re-check is the whole reason to write a tool rather than hand-edit again.

Against #1347's data it proposes two moves and both are sensible:

| competition | round | from | to |
|---|---|---|---|
| ENGLC | 1 | 2026-09-23 | 2026-09-16 |
| FRACUP | 1 | 2026-12-19 | 2026-12-20 |

The EFL Cup keeps its Wednesday a week earlier; the Coupe moves a day.

## Note on the test fixture

`writeEsp1` put every league round past the 28th on one date, which is itself a clash. It now runs weekly like a real calendar. No assertion depended on the old dates.

## Verification

PHPStan clean · 1310 tests pass (11 new) · `app:validate-season 2025` still passes with no new findings · applied against #1347's data, `app:validate-season 2026` then passes and `app:normalize-season 2026` reports the files already canonical, so a fix lands as two changed dates rather than a whole-file reformat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B9964iVM9oLHCo74xyWTF9

---
_Generated by [Claude Code](https://claude.ai/code/session_01B9964iVM9oLHCo74xyWTF9)_