### PR TITLE
Turn the league tabs into a dropdown

### DIFF
--- a/app/Http/Views/SelectTeam.php
+++ b/app/Http/Views/SelectTeam.php
@@ -9,9 +9,19 @@ use App\Models\Game;
 use App\Models\Team;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Storage;
 
 final class SelectTeam
 {
+    /**
+     * Primera Federación runs as two parallel groups. They share one entry in
+     * the league picker and one tab body below it, so the user picks a
+     * division rather than a group.
+     */
+    private const PRIMERA_RFEF_GROUPS = ['ESP3A', 'ESP3B'];
+
+    private const PRIMERA_RFEF_TAB = 'ESP3';
+
     public function __invoke(Request $request, CountryConfig $countryConfig, JobOfferService $jobOfferService)
     {
         if (Game::where('user_id', $request->user()->id)->whereNull('deleting_at')->count() >= 3) {
@@ -90,11 +100,61 @@ final class SelectTeam
 
         return view('select-team', [
             'countries' => $countries,
+            'leagues' => $this->leagueOptions($countries),
             'wcTeams' => $wcTeams,
             'wcFeaturedTeams' => $wcFeaturedTeams,
             'hasTournamentMode' => $hasTournamentMode,
             'hasCareerAccess' => $hasCareerAccess,
             'proManagerTeams' => $proManagerTeams,
         ]);
+    }
+
+    /**
+     * The league picker's options, in the order the countries were built.
+     *
+     * Shaped here rather than in the view because the labels need `__()`
+     * applied in PHP: a competition's name is a plain database string that
+     * passes straight through, but Primera Federación's combined entry is a
+     * translation key, so the two only agree on the server. Flags resolve to
+     * asset URLs for the same reason — the component renders whatever it is
+     * handed.
+     *
+     * Not cached: `$countries` is, but these labels are locale-dependent.
+     *
+     * @param  array<string, array{name: string, tiers: array<string, Competition>}>  $countries
+     * @return array<int, array{value: string, label: string, flag: string}>
+     */
+    private function leagueOptions(array $countries): array
+    {
+        $options = [];
+
+        foreach ($countries as $country) {
+            foreach ($country['tiers'] as $competition) {
+                if (in_array($competition->id, self::PRIMERA_RFEF_GROUPS, true)) {
+                    // Added when the first group is reached, which keeps the
+                    // combined entry in the position that group held.
+                    $options[self::PRIMERA_RFEF_TAB] ??= [
+                        'value' => self::PRIMERA_RFEF_TAB,
+                        'label' => __('game.primera_federacion'),
+                        'flag' => $this->flagUrl($competition->flag),
+                    ];
+
+                    continue;
+                }
+
+                $options[$competition->id] = [
+                    'value' => $competition->id,
+                    'label' => __($competition->name),
+                    'flag' => $this->flagUrl($competition->flag),
+                ];
+            }
+        }
+
+        return array_values($options);
+    }
+
+    private function flagUrl(?string $flag): string
+    {
+        return $flag ? Storage::disk('assets')->url("flags/{$flag}.svg") : '';
     }
 }

--- a/lang/en/game.php
+++ b/lang/en/game.php
@@ -243,6 +243,7 @@ return [
     'reputation_help' => 'Reputation reflects your club\'s standing in the football world. It evolves based on sustained league performance and affects budget, transfer attractiveness, and board expectations.',
     'your_competitions' => 'Your Competitions',
     'other_leagues' => 'Other Leagues',
+    'league' => 'League',
     'leagues' => 'Leagues',
     'your_leagues' => 'Your Leagues',
     'competition_role_league' => 'League',

--- a/lang/es/game.php
+++ b/lang/es/game.php
@@ -243,6 +243,7 @@ return [
     'reputation_help' => 'La reputación refleja la posición de tu club en el mundo del fútbol. Evoluciona según el rendimiento sostenido en liga y afecta a tu presupuesto, la capacidad de atraer jugadores y las expectativas de la directiva.',
     'your_competitions' => 'Tus Competiciones',
     'other_leagues' => 'Otras Ligas',
+    'league' => 'Liga',
     'leagues' => 'Ligas',
     'your_leagues' => 'Tus Ligas',
     'competition_role_league' => 'Liga',

--- a/resources/views/components/league-select.blade.php
+++ b/resources/views/components/league-select.blade.php
@@ -1,0 +1,126 @@
+@props([
+    'model',            // Alpine expression holding the selected value
+    'options',          // Alpine expression for an array of { value, label, flag }
+    'label' => null,    // Optional caption rendered above the control
+])
+
+@php
+    // Stable per-instance id so the trigger can point at its own listbox.
+    $uid = 'league-select-' . substr(md5($model . (string) $label), 0, 8);
+@endphp
+
+{{--
+    A select whose options carry a flag, which a native <select> cannot render.
+
+    $model and $options are Alpine expression names written by the caller, not
+    user data, so interpolating them is safe — the @js() rule covers PHP values,
+    and the caller passes those through @js() when it builds the options array.
+--}}
+<div
+    x-data="{
+        open: false,
+        active: 0,
+        get items() { return {{ $options }} ?? [] },
+        get selected() { return this.items.find(o => o.value === {{ $model }}) },
+        openList() {
+            this.open = true;
+            this.active = Math.max(0, this.items.findIndex(o => o.value === {{ $model }}));
+            this.$nextTick(() => this.scrollActiveIntoView());
+        },
+        close(refocus = true) {
+            this.open = false;
+            if (refocus) this.$refs.trigger.focus();
+        },
+        move(step) {
+            if (! this.open) { this.openList(); return; }
+            this.active = (this.active + step + this.items.length) % this.items.length;
+            this.scrollActiveIntoView();
+        },
+        jumpTo(index) {
+            if (! this.open) { this.openList(); }
+            this.active = index;
+            this.scrollActiveIntoView();
+        },
+        scrollActiveIntoView() {
+            this.$refs.list?.children[this.active]?.scrollIntoView({ block: 'nearest' });
+        },
+        choose(index) {
+            const option = this.items[index];
+            if (! option) return;
+            {{ $model }} = option.value;
+            this.close();
+        },
+    }"
+    class="relative mb-4"
+>
+    @if($label)
+        <span class="block mb-1 text-xs font-semibold uppercase tracking-wider text-text-muted">{{ $label }}</span>
+    @endif
+
+    <button
+        type="button"
+        x-ref="trigger"
+        role="combobox"
+        aria-haspopup="listbox"
+        :aria-expanded="open"
+        aria-controls="{{ $uid }}"
+        @click="open ? close(false) : openList()"
+        @keydown.arrow-down.prevent="move(1)"
+        @keydown.arrow-up.prevent="move(-1)"
+        @keydown.home.prevent="jumpTo(0)"
+        @keydown.end.prevent="jumpTo(items.length - 1)"
+        @keydown.enter.prevent="open ? choose(active) : openList()"
+        @keydown.space.prevent="open ? choose(active) : openList()"
+        @keydown.escape.prevent="open && close()"
+        {{ $attributes->merge(['class' => 'w-full min-h-[44px] px-3 py-2 flex items-center justify-between gap-2 rounded-lg border border-border-strong bg-surface-700 text-sm font-medium text-text-body hover:bg-surface-600 focus:outline-none focus:ring-2 focus:ring-accent-blue transition-colors']) }}
+    >
+        <span class="flex items-center gap-2 min-w-0">
+            <template x-if="selected?.flag">
+                <img class="w-5 h-4 rounded-sm shadow-sm shrink-0" :src="selected.flag" alt="">
+            </template>
+            <span class="truncate" x-text="selected?.label ?? '—'"></span>
+        </span>
+        <svg class="w-4 h-4 shrink-0 text-text-muted transition-transform duration-200" :class="open && 'rotate-180'" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/>
+        </svg>
+    </button>
+
+    <div
+        x-ref="list"
+        id="{{ $uid }}"
+        role="listbox"
+        x-show="open"
+        x-cloak
+        x-transition:enter="transition ease-out duration-150"
+        x-transition:enter-start="opacity-0 -translate-y-1"
+        x-transition:enter-end="opacity-100 translate-y-0"
+        x-transition:leave="transition ease-in duration-100"
+        x-transition:leave-start="opacity-100 translate-y-0"
+        x-transition:leave-end="opacity-0 -translate-y-1"
+        @click.outside="open = false"
+        @keydown.escape.window="open && close()"
+        class="absolute left-0 right-0 mt-1 z-30 bg-surface-800 rounded-lg shadow-xl border border-border-strong py-1 max-h-72 overflow-y-auto"
+    >
+        <template x-for="(option, index) in items" :key="option.value">
+            <button
+                type="button"
+                role="option"
+                :aria-selected="{{ $model }} === option.value"
+                @click="choose(index)"
+                @mouseenter="active = index"
+                class="w-full min-h-[44px] px-3 py-2 text-left text-sm flex items-center gap-2 transition-colors"
+                :class="{{ $model }} === option.value
+                    ? 'bg-accent-blue/10 text-accent-blue font-medium'
+                    : (active === index ? 'bg-surface-700 text-text-primary' : 'text-text-secondary')"
+            >
+                <template x-if="option.flag">
+                    <img class="w-5 h-4 rounded-sm shadow-sm shrink-0" :src="option.flag" alt="">
+                </template>
+                <span class="truncate" x-text="option.label"></span>
+                <svg x-show="{{ $model }} === option.value" x-cloak class="w-4 h-4 ml-auto text-accent-blue shrink-0" fill="currentColor" viewBox="0 0 20 20">
+                    <path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/>
+                </svg>
+            </button>
+        </template>
+    </div>
+</div>

--- a/resources/views/design-system/sections/buttons.blade.php
+++ b/resources/views/design-system/sections/buttons.blade.php
@@ -314,7 +314,7 @@
 &lt;/x-pill-button&gt;</code></pre>
         </div>
 
-        <p class="text-sm text-text-secondary mb-4">When a group grows past what one scrollable row can show, lay the pills out in a grid instead and pass <code class="text-[10px] bg-surface-700 px-1.5 py-0.5 rounded-sm text-text-body">align="start"</code> with <code class="text-[10px] bg-surface-700 px-1.5 py-0.5 rounded-sm text-text-body">w-full</code>, so leading icons line up down each column.</p>
+        <p class="text-sm text-text-secondary mb-4">A handful of pills can be laid out as a grid rather than one scrollable row — pass <code class="text-[10px] bg-surface-700 px-1.5 py-0.5 rounded-sm text-text-body">align="start"</code> with <code class="text-[10px] bg-surface-700 px-1.5 py-0.5 rounded-sm text-text-body">w-full</code> so leading icons line up down each column. Past about six options a grid costs more vertical space than it is worth on a phone; reach for <a href="#league-select" class="text-accent-blue hover:underline">League Select</a> instead, which collapses the whole set into one control.</p>
 
         <div class="bg-surface-700/30 border border-border-default rounded-xl p-6 mb-4">
             <div x-data="{ league: 'a' }" class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-2">

--- a/resources/views/design-system/sections/forms.blade.php
+++ b/resources/views/design-system/sections/forms.blade.php
@@ -75,6 +75,62 @@
         </div>
     </div>
 
+    {{-- League Select --}}
+    <div class="mb-12" id="league-select">
+        <h3 class="text-lg font-semibold text-text-primary mb-2">League Select</h3>
+        <p class="text-sm text-text-secondary mb-4">Use when the options need an icon a native <code class="text-[10px] bg-surface-700 px-1.5 py-0.5 rounded-sm text-text-body">&lt;select&gt;</code> cannot render — a flag, a crest — or when there are too many to lay out as pills. Everything else should stay on <code class="text-[10px] bg-surface-700 px-1.5 py-0.5 rounded-sm text-text-body">x-select-input</code>, which gets native keyboard and mobile pickers for free.</p>
+        <p class="text-sm text-text-secondary mb-4">Trigger is <code class="text-[10px] bg-surface-700 px-1.5 py-0.5 rounded-sm text-text-body">bg-surface-700</code>, the floating panel <code class="text-[10px] bg-surface-700 px-1.5 py-0.5 rounded-sm text-text-body">bg-surface-800</code> with a border. Options and trigger are both <code class="text-[10px] bg-surface-700 px-1.5 py-0.5 rounded-sm text-text-body">min-h-[44px]</code>. Arrow keys move, Enter selects, Escape closes and returns focus to the trigger.</p>
+
+        <div class="bg-surface-700/30 border border-border-default rounded-xl p-6 mb-3">
+            <div class="max-w-sm"
+                 x-data="{ picked: 'ESP1', demoLeagues: [
+                    { value: 'ESP1', label: 'LaLiga', flag: '' },
+                    { value: 'ENG1', label: 'Premier League', flag: '' },
+                    { value: 'ITA1', label: 'Serie A', flag: '' },
+                 ] }">
+                <x-league-select model="picked" options="demoLeagues" label="League" />
+            </div>
+        </div>
+
+        <div x-data="{ copied: false }" class="relative">
+            <button @click="navigator.clipboard.writeText($refs.code.textContent); copied = true; setTimeout(() =&gt; copied = false, 1500)"
+                    class="absolute top-2 right-2 text-xs px-2 py-1 rounded-sm bg-surface-600 text-text-secondary hover:text-text-primary">
+                <span x-text="copied ? 'Copied!' : 'Copy'"></span>
+            </button>
+            <pre class="bg-surface-700 text-text-body rounded-lg p-4 overflow-x-auto text-xs leading-relaxed"><code x-ref="code">&lt;x-league-select model="openTab" options="leagues" :label="__('game.league')" /&gt;</code></pre>
+        </div>
+
+        {{-- Props table --}}
+        <div class="overflow-x-auto mt-4">
+            <table class="w-full text-sm">
+                <thead class="text-left border-b border-border-strong">
+                    <tr class="text-text-muted">
+                        <th class="py-2 pr-4 font-medium">Prop</th>
+                        <th class="py-2 pr-4 font-medium">Type</th>
+                        <th class="py-2 font-medium">Purpose</th>
+                    </tr>
+                </thead>
+                <tbody class="text-text-secondary">
+                    <tr class="border-b border-border-default">
+                        <td class="py-2 pr-4 font-mono text-xs text-text-body">model</td>
+                        <td class="py-2 pr-4 font-mono text-xs">Alpine expr</td>
+                        <td class="py-2">The variable holding the selected value. Read and written by the component.</td>
+                    </tr>
+                    <tr class="border-b border-border-default">
+                        <td class="py-2 pr-4 font-mono text-xs text-text-body">options</td>
+                        <td class="py-2 pr-4 font-mono text-xs">Alpine expr</td>
+                        <td class="py-2">An array of <code class="text-[10px]">{ value, label, flag }</code>. Build it server-side and pass it in through <code class="text-[10px]">@@js()</code> so labels are translated in PHP.</td>
+                    </tr>
+                    <tr>
+                        <td class="py-2 pr-4 font-mono text-xs text-text-body">label</td>
+                        <td class="py-2 pr-4 font-mono text-xs">string|null</td>
+                        <td class="py-2">Optional caption above the control.</td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+
     {{-- Checkbox --}}
     <div class="mb-12">
         <h3 class="text-lg font-semibold text-text-primary mb-2">Checkbox</h3>

--- a/resources/views/select-team.blade.php
+++ b/resources/views/select-team.blade.php
@@ -5,14 +5,10 @@
             <h2 class="font-heading text-2xl lg:text-3xl font-bold uppercase tracking-wide text-text-primary">{{ __('app.new_game') }}</h2>
         </div>
 
-        @php
-            $allCompetitions = collect($countries)->flatMap(fn ($c) => collect($c['tiers']))->values();
-            $firstId = $allCompetitions->first()?->id;
-        @endphp
-
         <div x-data="{
                 mode: @js($hasCareerAccess ? 'career' : ($hasTournamentMode ? 'tournament' : 'career')),
-                openTab: '{{ $firstId }}',
+                leagues: @js($leagues),
+                openTab: @js($leagues[0]['value'] ?? null),
                 loading: false,
             }">
             <form method="post" action="{{ route('init-game') }}" @submit="loading = true" class="space-y-6">
@@ -155,37 +151,9 @@
 
                 {{-- ===================== CLUB MANAGER MODE: Club teams ===================== --}}
                 <div x-show="mode === 'career'" x-cloak x-transition:enter="transition ease-out duration-200" x-transition:enter-start="opacity-0" x-transition:enter-end="opacity-100">
-                    {{-- Competition tabs. ESP3A/ESP3B collapse into a single virtual "Primera Federación" tab keyed 'ESP3'. --}}
-                    @php
-                        $allComps = collect($countries)->flatMap(fn ($c) => collect($c['tiers']))->values();
-                        $primeraRfefComps = $allComps->whereIn('id', ['ESP3A', 'ESP3B'])->values();
-                        $tabComps = $allComps->reject(fn ($c) => in_array($c->id, ['ESP3A', 'ESP3B'], true))->values();
-                        if ($primeraRfefComps->isNotEmpty()) {
-                            $first = $primeraRfefComps->first();
-                            $esp3Index = $allComps->search(fn ($c) => $c->id === 'ESP3A');
-                            $synthetic = (object) [
-                                'id' => 'ESP3',
-                                'name' => 'game.primera_federacion',
-                                'flag' => $first->flag,
-                                'country' => $first->country,
-                            ];
-                            $tabComps->splice($esp3Index !== false ? $esp3Index : $tabComps->count(), 0, [$synthetic]);
-                        }
-                    @endphp
-                    <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-2 mb-4">
-                        @foreach($tabComps as $competition)
-                            <x-pill-button
-                                align="start"
-                                @click="openTab = '{{ $competition->id }}'"
-                                x-bind:class="openTab === '{{ $competition->id }}'
-                                    ? 'bg-accent-red text-white'
-                                    : 'bg-surface-700 text-text-secondary hover:text-text-body hover:bg-surface-600'"
-                                class="w-full gap-2">
-                                <img class="w-5 h-4 rounded-sm shadow-sm" src="{{ Storage::disk('assets')->url('flags/' . $competition->flag . '.svg') }}" alt="">
-                                <span>{{ __($competition->name) }}</span>
-                            </x-pill-button>
-                        @endforeach
-                    </div>
+                    {{-- League picker. ESP3A/ESP3B share one 'ESP3' entry, built in
+                         App\Http\Views\SelectTeam so its labels can be translated in PHP. --}}
+                    <x-league-select model="openTab" options="leagues" :label="__('game.league')" />
 
                     {{-- Team grids per competition. ESP3A/ESP3B share the 'ESP3' tab and render as group sections. --}}
                     @foreach($countries as $countryCode => $country)

--- a/tests/Feature/SelectTeamPageTest.php
+++ b/tests/Feature/SelectTeamPageTest.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Competition;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Cache;
+use Tests\TestCase;
+
+/**
+ * The new-game page had no coverage, so a Blade or view-model mistake reached
+ * production as a 500. These pin the league picker's contract: the options it
+ * offers, and the fact that a Primera Federación group is offered once rather
+ * than twice.
+ */
+class SelectTeamPageTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // $countries is cached for an hour under a fixed key, which would leak
+        // one test's competitions into the next.
+        Cache::flush();
+    }
+
+    public function test_it_renders_with_the_league_picker(): void
+    {
+        $this->seedLeague('ESP1', 'ES');
+
+        $this->actingAs($this->user())
+            ->get(route('select-team'))
+            ->assertOk()
+            ->assertSee('league-select', escape: false)
+            ->assertSee('ESP1', escape: false);
+    }
+
+    public function test_the_two_primera_federacion_groups_share_one_option(): void
+    {
+        $this->seedLeague('ESP1', 'ES');
+        $this->seedLeague('ESP3A', 'ES');
+        $this->seedLeague('ESP3B', 'ES');
+
+        $response = $this->actingAs($this->user())->get(route('select-team'));
+
+        $response->assertOk();
+
+        $leagues = $this->pickerOptions($response->getContent());
+        $values = array_column($leagues, 'value');
+
+        $this->assertContains('ESP3', $values, 'the combined Primera Federación entry should be offered');
+        $this->assertNotContains('ESP3A', $values);
+        $this->assertNotContains('ESP3B', $values);
+        $this->assertSame(array_unique($values), $values, 'no league should be offered twice');
+    }
+
+    public function test_the_default_selection_is_an_option_the_picker_offers(): void
+    {
+        // The default used to be derived from a separate list, so it could name
+        // a league the picker had folded away.
+        $this->seedLeague('ESP3A', 'ES');
+        $this->seedLeague('ESP3B', 'ES');
+
+        $response = $this->actingAs($this->user())->get(route('select-team'));
+
+        $response->assertOk();
+
+        $values = array_column($this->pickerOptions($response->getContent()), 'value');
+        $this->assertContains($this->defaultSelection($response->getContent()), $values);
+    }
+
+    /**
+     * Pull the options back out of the page. `@js()` renders them as
+     * `JSON.parse('...')` with the quotes unicode-escaped, so the captured
+     * literal is decoded once as a JS string and then as JSON.
+     *
+     * @return array<int, array{value: string, label: string, flag: string}>
+     */
+    private function pickerOptions(string $html): array
+    {
+        preg_match("/leagues: JSON\\.parse\\('(.*?)'\\)/", $html, $m);
+        $this->assertNotEmpty($m, 'the page should hand the picker a leagues array');
+
+        return json_decode((string) json_decode('"' . $m[1] . '"'), true) ?? [];
+    }
+
+    private function defaultSelection(string $html): string
+    {
+        preg_match("/openTab: '(\\w+)'/", $html, $m);
+        $this->assertNotEmpty($m, 'the page should choose a default league');
+
+        return $m[1];
+    }
+
+    private function user(): User
+    {
+        return User::factory()->create();
+    }
+
+    private function seedLeague(string $id, string $country): void
+    {
+        $competition = Competition::factory()->league()->create([
+            'id' => $id,
+            'country' => $country,
+            'flag' => strtolower($country),
+        ]);
+
+        Team::factory()->count(2)->create(['country' => $country])
+            ->each(fn (Team $team) => $competition->teams()->attach($team, ['season' => config('season.current')]));
+    }
+}


### PR DESCRIPTION
Independent of #1348 and #1349 — merge in any order.

## Why

The team-selection leagues were a grid of pills, which was itself yesterday's fix (#1344) for a horizontally scrolling row that hid choices behind a swipe. A grid buys headroom rather than solving it: #1347 adds two more countries, and on a phone the pills already push the team list below the fold before a single club is visible.

## What

A native `<select>` can't render the flags, so this is a listbox — `resources/views/components/league-select.blade.php`:

- Trigger on `bg-surface-700`, floating panel on `bg-surface-800` with a border (never `surface-800` for an interactive element on the page background; the panel floats and has a border, which is what every documented dropdown does).
- `min-h-[44px]` on the trigger **and** every option row.
- The keyboard handling `tactical-select` never had: arrows move, Home/End jump, Enter selects, Escape closes and returns focus to the trigger, `role="listbox"`/`role="option"` with `aria-expanded` and `aria-selected`.
- Option rows are the ones `other-leagues-menu.blade.php:35–43` already uses, down to the `w-5 h-4 rounded-sm shadow-sm` flag sizing.

The panels below are **untouched** — the only contract is the `openTab` string.

## Options move into the view model

`$tabComps` was built in a Blade `@php` block as a mixed collection: real `Competition` models plus one anonymous `stdClass` for the synthetic ESP3 entry that folds ESP3A and ESP3B together. Only `id`/`name`/`flag`/`country` were safe on every element — `shortName()` would have fatalled on the synthetic one.

It now lives in `SelectTeam::leagueOptions()`, because the labels only agree there: a competition's name is a plain database string that passes through `__()` untranslated, while Primera Federación's combined entry *is* a translation key. Not cached alongside `$countries` — those labels follow the locale. `$countries` keeps its shape, so no cache-key bump is needed.

## Two latent bugs fixed on the way

- `openTab: '{{ $firstId }}'` was raw Blade interpolation into `x-data`, which CLAUDE.md forbids. Now `@js()`.
- `$firstId` was derived from a *separate* list from the tabs, so had `ESP3A` ever sorted first, the page would have opened on a tab that no longer exists.

## Design system

`buttons.blade.php:317–325` documented the grid-of-pills as the answer to this exact problem, with select-team as its only consumer. It now scopes that to small groups and points at the new component past about six options. `league-select` gets its own section with a live demo and a props table — `tactical-select` never had one, so this closes that gap too.

One new key in both locales: `game.league`.

## Verification

PHPStan clean · 1302 tests pass · `npm run build` clean.

The page had **no test at all**, so a Blade mistake reached production as a 500 — which is exactly what happened while writing this (a literal `@js()` in the design-system prose, which Blade executed). It has three now: the render, the folded Primera Federación entry, and that the default selection is a league the picker actually offers.

Worth a look in the browser at 375px in both themes, and a keyboard-only pass — those I couldn't check from here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B9964iVM9oLHCo74xyWTF9

---
_Generated by [Claude Code](https://claude.ai/code/session_01B9964iVM9oLHCo74xyWTF9)_