### PR TITLE
Give squad-less cup entrants a chance

### DIFF
--- a/app/Models/MatchEvent.php
+++ b/app/Models/MatchEvent.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Ramsey\Uuid\Uuid;
 
 /**
  * @property string $id
@@ -124,6 +125,15 @@ class MatchEvent extends Model
     public const TYPE_PENALTY_MISSED = 'penalty_missed';
     public const TYPE_SUBSTITUTION = 'substitution';
 
+    /**
+     * The scorer of a goal by a side with no squad — a cup ghost. Nobody on the
+     * pitch can be credited, but the event still has to exist: the score is
+     * recomputed from events, so a goal without one vanishes the moment the
+     * match is re-simulated. This id references no `game_players` row, which is
+     * why `match_events` carries no foreign key on `game_player_id`.
+     */
+    public const UNATTRIBUTED_PLAYER_ID = Uuid::NIL;
+
     public function game(): BelongsTo
     {
         return $this->belongsTo(Game::class);
@@ -153,6 +163,14 @@ class MatchEvent extends Model
     }
 
     /**
+     * Whether this event has no scorer — a goal by a squad-less cup entrant.
+     */
+    public function isUnattributed(): bool
+    {
+        return $this->game_player_id === self::UNATTRIBUTED_PLAYER_ID;
+    }
+
+    /**
      * Check if this event is a card.
      */
     public function isCard(): bool
@@ -161,11 +179,16 @@ class MatchEvent extends Model
     }
 
     /**
-     * Get the player name via relationship.
+     * Get the player name via relationship. An unattributed goal reads as the
+     * club that scored it, since there is no player to name.
      */
     public function getPlayerNameAttribute(): string
     {
-        return $this->gamePlayer->name;
+        if ($this->isUnattributed()) {
+            return $this->team->name;
+        }
+
+        return $this->gamePlayer?->name ?? '';
     }
 
     /**

--- a/app/Modules/Competition/Services/CompetitionViewService.php
+++ b/app/Modules/Competition/Services/CompetitionViewService.php
@@ -127,6 +127,9 @@ class CompetitionViewService
         // cumulative tally rather than splitting into one row per former club.
         $scorerRows = MatchEvent::where('match_events.game_id', $gameId)
             ->where('match_events.event_type', MatchEvent::TYPE_GOAL)
+            // A squad-less cup entrant's goals share one sentinel scorer, so
+            // they would aggregate into a phantom leader and eat a top-ten slot.
+            ->where('match_events.game_player_id', '!=', MatchEvent::UNATTRIBUTED_PLAYER_ID)
             ->join('game_matches', 'game_matches.id', '=', 'match_events.game_match_id')
             ->where('game_matches.competition_id', $competitionId)
             ->selectRaw('match_events.game_player_id, COUNT(*) as goals')

--- a/app/Modules/Match/DTOs/MatchEventData.php
+++ b/app/Modules/Match/DTOs/MatchEventData.php
@@ -2,6 +2,8 @@
 
 namespace App\Modules\Match\DTOs;
 
+use App\Models\MatchEvent;
+
 /**
  * Data transfer object for a single match event.
  */
@@ -21,6 +23,15 @@ readonly class MatchEventData
     public static function goal(string $teamId, string $gamePlayerId, int $minute): self
     {
         return new self($teamId, $gamePlayerId, $minute, 'goal');
+    }
+
+    /**
+     * Create a goal nobody can be credited with — a squad-less cup entrant's
+     * goal. It is an ordinary goal for `$teamId`; only the scorer is missing.
+     */
+    public static function unattributedGoal(string $teamId, int $minute): self
+    {
+        return new self($teamId, MatchEvent::UNATTRIBUTED_PLAYER_ID, $minute, 'goal');
     }
 
     /**

--- a/app/Modules/Match/Services/AIMatchResolver.php
+++ b/app/Modules/Match/Services/AIMatchResolver.php
@@ -3,6 +3,8 @@
 namespace App\Modules\Match\Services;
 
 use App\Models\GameMatch;
+use App\Models\MatchEvent;
+use App\Models\Team;
 use App\Models\GamePlayer;
 use App\Models\Game;
 use App\Modules\Match\DTOs\MatchEventData;
@@ -130,8 +132,8 @@ class AIMatchResolver
         }
 
         // Calculate team strengths from the selected XI
-        $homeStrength = $this->calculateTeamStrength($homeXI);
-        $awayStrength = $this->calculateTeamStrength($awayXI);
+        $homeStrength = $this->calculateTeamStrength($homeXI, $match->homeTeam);
+        $awayStrength = $this->calculateTeamStrength($awayXI, $match->awayTeam);
 
         // Generate scoreline — same difference-based xG formula and Dixon-Coles
         // distribution the full MatchSimulator uses, via the shared MatchOutcomeModel.
@@ -248,9 +250,9 @@ class AIMatchResolver
      * the outcome model. Delegates to the shared {@see PaperStrength} estimator
      * (no energy/form/position noise; fitness enters via lineup selection).
      */
-    private function calculateTeamStrength(Collection $lineup): float
+    private function calculateTeamStrength(Collection $lineup, ?Team $team = null): float
     {
-        return PaperStrength::estimate($lineup);
+        return PaperStrength::estimate($lineup, $team?->clubProfile?->reputation_level);
     }
 
     /**
@@ -288,6 +290,16 @@ class AIMatchResolver
         $ownGoalChance = (float) config('match_simulation.own_goal_chance', 1.0);
         $assistChance = (float) config('match_simulation.assist_chance', 60.0);
         $goalCounts = [];
+
+        // A squad-less cup entrant has nobody to credit a goal to, so its goals
+        // are unattributed — the same treatment MatchSimulator gives them. They
+        // still have to be events: this resolver used to keep the scoreline and
+        // drop the goals, leaving a score no event could account for.
+        if ($lineup->isEmpty()) {
+            $this->generateUnattributedGoalEvents($events, $teamId, $goals);
+
+            return;
+        }
 
         for ($i = 0; $i < $goals; $i++) {
             // Extend slightly past 90 so AI matches can have stoppage-time
@@ -332,6 +344,22 @@ class AIMatchResolver
                     ];
                 }
             }
+        }
+    }
+
+    /**
+     * A squad-less side's goals — real events for its own team, with no scorer.
+     */
+    private function generateUnattributedGoalEvents(array &$events, string $teamId, int $goals): void
+    {
+        for ($i = 0; $i < $goals; $i++) {
+            $events[] = [
+                'team_id' => $teamId,
+                'game_player_id' => MatchEvent::UNATTRIBUTED_PLAYER_ID,
+                'minute' => mt_rand(1, 95),
+                'event_type' => 'goal',
+                'metadata' => null,
+            ];
         }
     }
 

--- a/app/Modules/Match/Services/MatchResimulationService.php
+++ b/app/Modules/Match/Services/MatchResimulationService.php
@@ -793,6 +793,16 @@ class MatchResimulationService
             return;
         }
 
+        // A squad-less side's goals share one sentinel scorer with no record.
+        $playerIds = array_values(array_filter(
+            $playerIds,
+            fn ($id) => $id !== MatchEvent::UNATTRIBUTED_PLAYER_ID,
+        ));
+
+        if (empty($playerIds)) {
+            return;
+        }
+
         // Count each stat type per player from all remaining events
         $statCounts = MatchEvent::where('game_id', $gameId)
             ->whereIn('game_player_id', $playerIds)
@@ -909,6 +919,11 @@ class MatchResimulationService
         foreach ($events as $event) {
             $playerId = $event->gamePlayerId;
             $type = $event->type;
+
+            // A squad-less side's goal has no scorer whose record to touch.
+            if ($playerId === MatchEvent::UNATTRIBUTED_PLAYER_ID) {
+                continue;
+            }
 
             if (! isset($statIncrements[$playerId])) {
                 $statIncrements[$playerId] = [];
@@ -1068,9 +1083,22 @@ class MatchResimulationService
             $stoppage,
         );
 
+        // A squad-less cup entrant's goal has no scorer, so it reads as the club
+        // that scored it — the same substitution the live-match JS makes for a
+        // goal it has to synthesise. Team names are resolved only when such an
+        // event is present, so an ordinary match costs no extra query.
+        $clubNames = $events->contains(fn ($e) => $e->isUnattributed())
+            ? $firstEvent->gameMatch->loadMissing(['homeTeam', 'awayTeam'])
+            : null;
+        $clubName = fn ($e) => $clubNames === null ? '' : ($e->team_id === $clubNames->home_team_id
+            ? $clubNames->homeTeam->name
+            : $clubNames->awayTeam->name);
+
         $formatted = $events
             ->filter(fn ($e) => $e->event_type !== 'assist')
-            ->map(function ($e) use ($playerInNames, $absoluteMinute) {
+            ->map(function ($e) use ($playerInNames, $absoluteMinute, $clubName) {
+                $isUnattributed = $e->isUnattributed();
+
                 $data = [
                     'minute' => $absoluteMinute($e),
                     'baseMinute' => $e->minute,
@@ -1078,9 +1106,11 @@ class MatchResimulationService
                     'phase' => $e->phase->value,
                     'displayMinute' => $e->displayMinute(),
                     'type' => $e->event_type,
-                    'playerName' => $e->gamePlayer->name ?? '',
+                    'playerName' => $isUnattributed ? $clubName($e) : ($e->gamePlayer->name ?? ''),
                     'teamId' => $e->team_id,
-                    'gamePlayerId' => $e->game_player_id,
+                    // Null, not the sentinel: the frontend already treats a goal
+                    // without a player id as one nobody scored.
+                    'gamePlayerId' => $isUnattributed ? null : $e->game_player_id,
                     'metadata' => $e->metadata,
                 ];
 

--- a/app/Modules/Match/Services/MatchResultProcessor.php
+++ b/app/Modules/Match/Services/MatchResultProcessor.php
@@ -388,6 +388,11 @@ class MatchResultProcessor
                 $playerId = $eventData['game_player_id'];
                 $type = $eventData['event_type'];
 
+                // A squad-less side's goal has no scorer whose record to touch.
+                if ($playerId === MatchEvent::UNATTRIBUTED_PLAYER_ID) {
+                    continue;
+                }
+
                 if (! isset($statIncrements[$playerId])) {
                     $statIncrements[$playerId] = [];
                 }

--- a/app/Modules/Match/Services/MatchSimulator.php
+++ b/app/Modules/Match/Services/MatchSimulator.php
@@ -13,6 +13,7 @@ use App\Modules\Lineup\Enums\PressingIntensity;
 use App\Modules\Lineup\Services\SubstitutionService;
 use App\Models\Game;
 use App\Models\GamePlayer;
+use App\Models\MatchEvent;
 use App\Models\Team;
 use Carbon\Carbon;
 use Illuminate\Support\Collection;
@@ -20,6 +21,7 @@ use App\Support\PositionMapper;
 use App\Support\PositionSlotMapper;
 use App\Modules\Player\Services\InjuryService;
 use App\Modules\Match\Services\EnergyCalculator;
+use App\Modules\Match\Support\GhostStrength;
 use App\Modules\Match\Support\MatchOutcomeModel;
 use App\Modules\Match\Support\StoppageDurations;
 
@@ -1128,6 +1130,14 @@ class MatchSimulator
                 return $event;
             }
 
+            // An unattributed goal has no scorer to be unavailable. Falling
+            // through would hand it to a player on the wrong side, or drop it
+            // when no candidate is found — and a dropped goal is the failure
+            // this whole path exists to avoid.
+            if ($event->gamePlayerId === MatchEvent::UNATTRIBUTED_PLAYER_ID) {
+                return $event;
+            }
+
             $needsReassignment = false;
             $playerId = $event->gamePlayerId;
 
@@ -1311,11 +1321,18 @@ class MatchSimulator
      * @param  int  $fromMinute  Start of the simulation period (for energy averaging)
      * @param  array<string, int>  $playerEntryMinutes  Map of player ID to minute they entered the match
      */
-    private function calculateTeamStrength(Collection $lineup, int $fromMinute = 0, array $playerEntryMinutes = [], float $tacticalDrainMultiplier = 1.0, ?Carbon $currentDate = null, array $playerSlotMap = []): float
+    private function calculateTeamStrength(Collection $lineup, int $fromMinute = 0, array $playerEntryMinutes = [], float $tacticalDrainMultiplier = 1.0, ?Carbon $currentDate = null, array $playerSlotMap = [], ?Team $team = null): float
     {
+        if ($lineup->isEmpty()) {
+            // A squad-less cup entrant. Its standing stands in for an XI, so a
+            // second-tier club is a harder night than a non-league one.
+            return GhostStrength::forTeam($team);
+        }
+
         if ($lineup->count() < 7) {
-            // Fallback for severely depleted lineup - reflects amateur/semi-pro level
-            return 0.30;
+            // A real club that could not field a side, which is a different
+            // thing: it keeps the flat amateur rating.
+            return GhostStrength::thinLineup();
         }
 
         // Calculate effective attributes with match performance modifier
@@ -1381,6 +1398,14 @@ class MatchSimulator
      */
     private function calculateGoalkeeperModifier(Collection $lineup): float
     {
+        // A squad-less side is not a team that picked a centre-back in goal —
+        // it has no XI at all, and its whole standard is already priced into
+        // the strength gap. Charging it again doubled the opponent's xG on top
+        // of a 30-point rating advantage, which is what made these ties 6-0.
+        if ($lineup->isEmpty()) {
+            return 1.0;
+        }
+
         $hasNaturalGK = $lineup->contains(fn ($player) => $player->position === 'Goalkeeper');
 
         if ($hasNaturalGK) {
@@ -2078,8 +2103,8 @@ class MatchSimulator
         $currentDate = $game?->current_date ?? now();
 
         // Preliminary strength calculation (used for card bias and as final strength if no injury sub)
-        $homeStrength = $this->calculateTeamStrength($homePlayers, $fromMinute, $homeEntryMinutes, $homeTacticalDrain, $currentDate, $this->homePlayerSlotMap);
-        $awayStrength = $this->calculateTeamStrength($awayPlayers, $fromMinute, $awayEntryMinutes, $awayTacticalDrain, $currentDate, $this->awayPlayerSlotMap);
+        $homeStrength = $this->calculateTeamStrength($homePlayers, $fromMinute, $homeEntryMinutes, $homeTacticalDrain, $currentDate, $this->homePlayerSlotMap, $homeTeam);
+        $awayStrength = $this->calculateTeamStrength($awayPlayers, $fromMinute, $awayEntryMinutes, $awayTacticalDrain, $currentDate, $this->awayPlayerSlotMap, $awayTeam);
 
         [$homeExpectedGoals, $awayExpectedGoals] = $this->calculateBaseExpectedGoals(
             $homeStrength, $awayStrength,
@@ -2119,17 +2144,6 @@ class MatchSimulator
         $awayExpectedGoals *= $this->possessionXGModifier($possession['away']);
 
         [$homeScore, $awayScore] = $this->dixonColesRandom($homeExpectedGoals, $awayExpectedGoals);
-
-        // A team with no players cannot score — force their goals to 0.
-        // This prevents phantom goals that have no events, which would be
-        // lost during resimulation (subs/tactical changes) and cause
-        // incorrect extra time triggers in cup matches.
-        if ($homePlayers->isEmpty()) {
-            $homeScore = 0;
-        }
-        if ($awayPlayers->isEmpty()) {
-            $awayScore = 0;
-        }
 
         if ($homePlayers->isNotEmpty() && $awayPlayers->isNotEmpty()) {
             // Generate cards first using the initial Poisson score for goal-difference bias
@@ -2191,8 +2205,8 @@ class MatchSimulator
 
             // Recalculate strength and goals with updated lineup if an injury sub occurred
             if ($lineupChanged) {
-                $homeStrength = $this->calculateTeamStrength($homePlayers, $fromMinute, $homeEntryMinutes, $homeTacticalDrain, $currentDate, $this->homePlayerSlotMap);
-                $awayStrength = $this->calculateTeamStrength($awayPlayers, $fromMinute, $awayEntryMinutes, $awayTacticalDrain, $currentDate, $this->awayPlayerSlotMap);
+                $homeStrength = $this->calculateTeamStrength($homePlayers, $fromMinute, $homeEntryMinutes, $homeTacticalDrain, $currentDate, $this->homePlayerSlotMap, $homeTeam);
+                $awayStrength = $this->calculateTeamStrength($awayPlayers, $fromMinute, $awayEntryMinutes, $awayTacticalDrain, $currentDate, $this->awayPlayerSlotMap, $awayTeam);
 
                 [$homeExpectedGoals, $awayExpectedGoals] = $this->calculateBaseExpectedGoals(
                     $homeStrength, $awayStrength,
@@ -2269,15 +2283,14 @@ class MatchSimulator
             $events = $this->reassignEventsFromUnavailablePlayers(
                 $events, $homePlayers, $awayPlayers, $homeTeam->id, $awayTeam->id
             );
-        } elseif ($homePlayers->isNotEmpty() || $awayPlayers->isNotEmpty()) {
-            // One team has no players (e.g. lower-division cup opponent).
-            // Generate goal events only for the team with players so that
-            // goals are backed by events and survive resimulation.
-            [$homeScore, $awayScore, $goalEvents] = $this->generateSingleTeamGoalEvents(
+        } else {
+            // At least one side has no players (a lower-division cup opponent).
+            // Both scorelines still get events — a squad-less side's without a
+            // scorer — so nothing is lost to a resimulation.
+            $events = $events->merge($this->generateGoalEventsWithoutBothSquads(
                 $homeTeam, $awayTeam, $homePlayers, $awayPlayers,
                 $homeScore, $awayScore, $fromMinute + 1, $toMinute,
-            );
-            $events = $events->merge($goalEvents)->sortBy('minute')->values();
+            ))->sortBy('minute')->values();
         }
 
         $possession = $this->calculatePossession(
@@ -2410,8 +2423,8 @@ class MatchSimulator
         $fraction2 = max(0, $toMinute - $splitMinute) / 93;
         $effectiveMinute2 = $splitMinute + ($toMinute - $splitMinute) / 2;
 
-        $homeStrength2 = $this->calculateTeamStrength($homePlayers2, $splitMinute, $homeEntryMinutes, $homeTacticalDrain, $currentDate, $this->homePlayerSlotMap);
-        $awayStrength2 = $this->calculateTeamStrength($awayPlayers2, $splitMinute, $awayEntryMinutes, $awayTacticalDrain, $currentDate, $this->awayPlayerSlotMap);
+        $homeStrength2 = $this->calculateTeamStrength($homePlayers2, $splitMinute, $homeEntryMinutes, $homeTacticalDrain, $currentDate, $this->homePlayerSlotMap, $homeTeam);
+        $awayStrength2 = $this->calculateTeamStrength($awayPlayers2, $splitMinute, $awayEntryMinutes, $awayTacticalDrain, $currentDate, $this->awayPlayerSlotMap, $awayTeam);
 
         [$homeXG2, $awayXG2] = $this->calculateBaseExpectedGoals(
             $homeStrength2, $awayStrength2,
@@ -2553,11 +2566,22 @@ class MatchSimulator
     }
 
     /**
-     * Generate goal events when only one team has players (the other squad is empty).
+     * Goal events for a tie where at least one side has no squad.
      *
-     * @return array{0: int, 1: int, 2: Collection<MatchEventData>} [homeScore, awayScore, goalEvents]
+     * A side with players scores through them as usual. A squad-less one — a
+     * cup ghost — has nobody to credit, so its goals are unattributed: an
+     * ordinary goal for its own team whose scorer is
+     * {@see MatchEvent::UNATTRIBUTED_PLAYER_ID}.
+     *
+     * They have to be events like any other. The score is recomputed from
+     * events, so a goal without one disappears when a half-time change
+     * re-simulates the match, and takes a cup tie's extra-time trigger with it.
+     *
+     * @param  Collection<GamePlayer>  $homePlayers
+     * @param  Collection<GamePlayer>  $awayPlayers
+     * @return Collection<MatchEventData>
      */
-    private function generateSingleTeamGoalEvents(
+    private function generateGoalEventsWithoutBothSquads(
         Team $homeTeam,
         Team $awayTeam,
         Collection $homePlayers,
@@ -2566,19 +2590,41 @@ class MatchSimulator
         int $awayScore,
         int $minMinute,
         int $maxMinute,
-    ): array {
-        $homeHasPlayers = $homePlayers->isNotEmpty();
-        $scoringPlayers = $homeHasPlayers ? $homePlayers : $awayPlayers;
-        $scoringTeamId = $homeHasPlayers ? $homeTeam->id : $awayTeam->id;
-        $concedingTeamId = $homeHasPlayers ? $awayTeam->id : $homeTeam->id;
-        $goalCount = $homeHasPlayers ? $homeScore : $awayScore;
+    ): Collection {
+        $side = fn (int $goalCount, string $teamId, string $opponentTeamId, Collection $players, Collection $opponents) => $players->isEmpty()
+            ? $this->generateUnattributedGoalEvents($goalCount, $teamId, $minMinute, $maxMinute)
+            : $this->generateGoalEventsInRange(
+                $goalCount, $teamId, $opponentTeamId, $players, $opponents, $minMinute, $maxMinute,
+            );
 
-        $events = $this->generateGoalEventsInRange(
-            $goalCount, $scoringTeamId, $concedingTeamId,
-            $scoringPlayers, collect(), $minMinute, $maxMinute,
-        );
+        return $side($homeScore, $homeTeam->id, $awayTeam->id, $homePlayers, $awayPlayers)
+            ->merge($side($awayScore, $awayTeam->id, $homeTeam->id, $awayPlayers, $homePlayers))
+            ->sortBy('minute')
+            ->values();
+    }
 
-        return [$homeScore, $awayScore, $events];
+    /**
+     * A squad-less side's goals — real events for its own team, with no scorer.
+     *
+     * @return Collection<MatchEventData>
+     */
+    private function generateUnattributedGoalEvents(
+        int $goalCount,
+        string $teamId,
+        int $minMinute,
+        int $maxMinute,
+    ): Collection {
+        $events = collect();
+        $usedMinutes = [];
+
+        for ($i = 0; $i < $goalCount; $i++) {
+            $minute = $this->generateUniqueMinuteInRange($usedMinutes, $minMinute, $maxMinute);
+            $usedMinutes[] = $minute;
+
+            $events->push(MatchEventData::unattributedGoal($teamId, $minute));
+        }
+
+        return $events;
     }
 
     /**
@@ -2923,8 +2969,8 @@ class MatchSimulator
         $currentDate = $homePlayers->first()?->game?->current_date ?? now();
 
         // Ratio-based xG — energy already accounts for fatigue
-        $homeStrength = $this->calculateTeamStrength($homePlayers, $fromMinute, $homeEntryMinutes, $homeTacticalDrain, $currentDate, $this->homePlayerSlotMap);
-        $awayStrength = $this->calculateTeamStrength($awayPlayers, $fromMinute, $awayEntryMinutes, $awayTacticalDrain, $currentDate, $this->awayPlayerSlotMap);
+        $homeStrength = $this->calculateTeamStrength($homePlayers, $fromMinute, $homeEntryMinutes, $homeTacticalDrain, $currentDate, $this->homePlayerSlotMap, $homeTeam);
+        $awayStrength = $this->calculateTeamStrength($awayPlayers, $fromMinute, $awayEntryMinutes, $awayTacticalDrain, $currentDate, $this->awayPlayerSlotMap, $awayTeam);
 
         $baseGoals = config('match_simulation.base_goals', 1.3);
 
@@ -2968,14 +3014,6 @@ class MatchSimulator
 
         [$homeScore, $awayScore] = $this->dixonColesRandom($homeExpectedGoals, $awayExpectedGoals);
 
-        // A team with no players cannot score — force their goals to 0.
-        if ($homePlayers->isEmpty()) {
-            $homeScore = 0;
-        }
-        if ($awayPlayers->isEmpty()) {
-            $awayScore = 0;
-        }
-
         // Generate goal events in range [fromMinute+1, extraTimeEnd].
         // extraTimeEnd = 120 + regulation stoppage + ET headroom, so events
         // can land anywhere from the start of ET first half through ET
@@ -3008,13 +3046,12 @@ class MatchSimulator
             $events = $this->reassignEventsFromUnavailablePlayers(
                 $events, $homePlayers, $awayPlayers, $homeTeam->id, $awayTeam->id
             );
-        } elseif ($homePlayers->isNotEmpty() || $awayPlayers->isNotEmpty()) {
-            // One team has no players — generate events only for the team with players.
-            [$homeScore, $awayScore, $goalEvents] = $this->generateSingleTeamGoalEvents(
+        } else {
+            // At least one side has no players — see simulateRemainder().
+            $events = $events->merge($this->generateGoalEventsWithoutBothSquads(
                 $homeTeam, $awayTeam, $homePlayers, $awayPlayers,
                 $homeScore, $awayScore, $minMinute, $maxMinute,
-            );
-            $events = $events->merge($goalEvents)->sortBy('minute')->values();
+            ))->sortBy('minute')->values();
         }
 
         $possession = $this->calculatePossession(

--- a/app/Modules/Match/Services/MatchSummaryPresenter.php
+++ b/app/Modules/Match/Services/MatchSummaryPresenter.php
@@ -81,8 +81,14 @@ class MatchSummaryPresenter
             return $event->team_id;
         };
 
+        // A squad-less cup entrant's goal has no scorer, so it is listed under
+        // the club that scored it.
+        $scorerName = fn (MatchEvent $e) => $e->isUnattributed()
+            ? ($e->team_id === $match->home_team_id ? $match->homeTeam->name : $match->awayTeam->name)
+            : ($e->gamePlayer?->name ?? '—');
+
         $format = fn ($events) => $events
-            ->groupBy(fn (MatchEvent $e) => $e->gamePlayer?->name ?? '—')
+            ->groupBy($scorerName)
             ->map(function ($playerEvents, $name) {
                 $minutes = $playerEvents
                     ->map(function (MatchEvent $e) {

--- a/app/Modules/Match/Services/MvpCalculator.php
+++ b/app/Modules/Match/Services/MvpCalculator.php
@@ -2,6 +2,7 @@
 
 namespace App\Modules\Match\Services;
 
+use App\Models\MatchEvent;
 use Illuminate\Support\Collection;
 
 /**
@@ -182,7 +183,8 @@ class MvpCalculator
                 $matchLength = 120;
             }
 
-            if (! $playerId) {
+            // A squad-less side's goal names no player to rate.
+            if (! $playerId || $playerId === MatchEvent::UNATTRIBUTED_PLAYER_ID) {
                 continue;
             }
 

--- a/app/Modules/Match/Support/GhostStrength.php
+++ b/app/Modules/Match/Support/GhostStrength.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Modules\Match\Support;
+
+use App\Models\ClubProfile;
+use App\Models\Team;
+
+/**
+ * How good a squad-less cup entrant is.
+ *
+ * A ghost is a `Team` row with a name, a crest and no players — the way a cup
+ * fields a whole pyramid without seeding a roster per club. Its matches are
+ * resolved from a stand-in strength, because there is no XI to average.
+ *
+ * That stand-in used to be one hardcoded number for every ghost in the game, so
+ * a regional amateur side and a second-tier club with 30,000 seats were exactly
+ * as hard to beat. Reputation separates them: `ClubProfilesSeeder` writes a
+ * profile for every team, curated where the club is notable and
+ * local-by-default where it is not, so the tier is already in the database and
+ * costs no new data.
+ *
+ * The band is deliberately narrow. A ghost should be beatable by any
+ * professional side on nearly every occasion — the point is that "nearly" stops
+ * meaning "always".
+ */
+class GhostStrength
+{
+    /**
+     * Paper strength for a squad-less side, in the same 0..1 band a real XI
+     * averages into.
+     */
+    public static function forTeam(?Team $team): float
+    {
+        return self::forReputation($team?->clubProfile?->reputation_level);
+    }
+
+    public static function forReputation(?string $reputationLevel): float
+    {
+        $band = config('match_simulation.ghost_strength', []);
+        $default = (float) ($band['default'] ?? 0.30);
+
+        if ($reputationLevel === null) {
+            return $default;
+        }
+
+        return (float) ($band[$reputationLevel] ?? $default);
+    }
+
+    /**
+     * The floor a thin-but-not-empty lineup falls back to. A side with four
+     * players is not a ghost — it is a real club that could not field a team —
+     * so it keeps the flat amateur rating rather than borrowing a reputation
+     * it has not earned on the pitch.
+     */
+    public static function thinLineup(): float
+    {
+        return (float) (config('match_simulation.ghost_strength.default') ?? 0.30);
+    }
+
+    /**
+     * Reputation levels in the order they are ranked, so a caller can reason
+     * about the band without reaching into config.
+     *
+     * @return array<int, string>
+     */
+    public static function levels(): array
+    {
+        return ClubProfile::REPUTATION_TIERS;
+    }
+}

--- a/app/Modules/Match/Support/PaperStrength.php
+++ b/app/Modules/Match/Support/PaperStrength.php
@@ -24,8 +24,6 @@ class PaperStrength
     /** Fallback when a lineup is too thin to be a real XI (partial/empty lineups). */
     private const MIN_LINEUP_SIZE = 7;
 
-    private const THIN_LINEUP_STRENGTH = 0.30;
-
     /**
      * Paper strength in the 0..1 rating band for a selected XI.
      *
@@ -33,14 +31,24 @@ class PaperStrength
      * selection (low-fitness players are penalized when the XI is picked), not
      * via the paper-strength average.
      *
+     * A squad-less cup entrant has no XI to average, so it falls back to
+     * {@see GhostStrength}, which reads its standing from the club profile
+     * every team carries. Pass `$reputationLevel` when the caller knows whose
+     * lineup this is; without it a ghost gets the flat amateur rating, which
+     * is the same answer for the overwhelming majority of them.
+     *
      * @param  iterable<object>  $lineupPlayers  players exposing `overall_score` and `morale`
      */
-    public static function estimate(iterable $lineupPlayers): float
+    public static function estimate(iterable $lineupPlayers, ?string $reputationLevel = null): float
     {
         $players = is_array($lineupPlayers) ? $lineupPlayers : iterator_to_array($lineupPlayers);
 
+        if ($players === []) {
+            return GhostStrength::forReputation($reputationLevel);
+        }
+
         if (count($players) < self::MIN_LINEUP_SIZE) {
-            return self::THIN_LINEUP_STRENGTH;
+            return GhostStrength::thinLineup();
         }
 
         $wOverall = config('match_simulation.strength_weight_overall', 0.95);

--- a/app/Modules/Report/Services/TournamentSnapshotService.php
+++ b/app/Modules/Report/Services/TournamentSnapshotService.php
@@ -171,8 +171,12 @@ class TournamentSnapshotService
             ];
         }
 
-        $finalGoalEvents = $data['finalGoalEvents']->map(function ($event) {
-            $playerName = $event->gamePlayer?->name ?? '?';
+        $finalGoalEvents = $data['finalGoalEvents']->map(function ($event) use ($teams) {
+            // A squad-less cup entrant's goal has no scorer, so it reads as the
+            // club that scored it.
+            $playerName = $event->isUnattributed()
+                ? ($teams[$event->team_id]['name'] ?? '?')
+                : ($event->gamePlayer?->name ?? '?');
             $isOwnGoal = $event->event_type === \App\Models\MatchEvent::TYPE_OWN_GOAL;
 
             return [

--- a/app/Modules/Season/Processors/UefaQualificationProcessor.php
+++ b/app/Modules/Season/Processors/UefaQualificationProcessor.php
@@ -322,8 +322,8 @@ class UefaQualificationProcessor implements SeasonProcessor
 
     /**
      * Whether a team has any players in this game. A ghost has none, which is
-     * the same test MatchSimulator uses when it forbids a squad-less side
-     * from scoring.
+     * the same test MatchSimulator uses to decide that a side has no XI to
+     * resolve a match through.
      */
     private function hasSquad(string $gameId, string $teamId): bool
     {

--- a/config/match_simulation.php
+++ b/config/match_simulation.php
@@ -154,6 +154,33 @@ return [
     | Probabilities for various match events.
     |
     */
+    /*
+    |--------------------------------------------------------------------------
+    | Ghost teams (squad-less cup entrants)
+    |--------------------------------------------------------------------------
+    |
+    | A cup fields the whole pyramid by seeding lower-division clubs as teams
+    | with no players, so their matches are resolved from the strength below
+    | rather than from an XI. Keyed by ClubProfile reputation, which every team
+    | already has — curated where the club is notable, local by default — so a
+    | Championship side in the FA Cup is a harder night than a non-league one.
+    |
+    | `default` also serves a real club too depleted to field seven players: it
+    | is a genuine XI that fell apart, not a club of this standing.
+    |
+    | Raising these narrows the gap and makes upsets more common. A professional
+    | side should still win the overwhelming majority of these ties.
+    |
+    */
+    'ghost_strength' => [
+        'default' => 0.30,
+        'local' => 0.30,
+        'modest' => 0.34,
+        'established' => 0.38,
+        'continental' => 0.42,
+        'elite' => 0.46,
+    ],
+
     'own_goal_chance' => 1.0,           // % chance per goal is an own goal
     'assist_chance' => 60.0,            // % chance a goal has an assist
     'yellow_cards_per_team' => 1.6,     // Average yellow cards per team per match

--- a/database/migrations/2026_09_06_000001_drop_game_player_foreign_key_from_match_events.php
+++ b/database/migrations/2026_09_06_000001_drop_game_player_foreign_key_from_match_events.php
@@ -1,0 +1,47 @@
+<?php
+
+use App\Models\MatchEvent;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Let a match event name a scorer who is nobody.
+ *
+ * A squad-less cup entrant — a ghost — can score, and its goal has to be a real
+ * `match_events` row: the score is recomputed from events, so a goal without one
+ * disappears when the match is re-simulated. There is no player to credit, so
+ * the row carries `MatchEvent::UNATTRIBUTED_PLAYER_ID`, which references no
+ * `game_players` row. The foreign key has to go for that to insert.
+ *
+ * The column stays NOT NULL, so a genuinely missing scorer still fails loudly;
+ * exactly one known value is exempt.
+ *
+ * Losing `ON DELETE CASCADE` costs nothing in practice. The only place the
+ * application deletes a `GamePlayer` is `PlayerRetirementProcessor` (priority
+ * 40), and `SeasonArchiveProcessor` (priority 25) has already deleted the game's
+ * match events earlier in the same closing pipeline. `SeedWorldCupData` deletes
+ * its match events explicitly.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('match_events', function (Blueprint $table) {
+            $table->dropForeign(['game_player_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        // The rows the constraint cannot describe have to go before it comes back.
+        DB::table('match_events')
+            ->where('game_player_id', MatchEvent::UNATTRIBUTED_PLAYER_ID)
+            ->delete();
+
+        Schema::table('match_events', function (Blueprint $table) {
+            $table->foreign('game_player_id')->references('id')->on('game_players')->onDelete('cascade');
+        });
+    }
+};

--- a/docs/game-systems/domestic-cups.md
+++ b/docs/game-systems/domestic-cups.md
@@ -11,7 +11,7 @@ Only the top flight of most countries is playable, but a real cup runs through t
 A **ghost team** is a `Team` row with a name, a country, an optional crest and stadium, and no players. It only ever appears in cup competitions:
 
 - Ghosts are created by the reference-data seeder from a cup's `teams.json`, keyed by Transfermarkt `id` like every other club: the id supplies the crest, links the club to its league row when it has one, and keeps a ghost the same club across seasons. The seeder refuses an id that resolves to a club of another country, which is how a mistyped id would otherwise drag a foreign club into the cup.
-- Matches involving a ghost are resolved from a default strength. In AI-only ties a ghost can win; in the user's own match a ghost cannot score, so an upset only ever comes on penalties.
+- Matches involving a ghost are resolved from a stand-in strength, read from the reputation on its club profile, so a second-tier side is a harder night than a village one. It has no XI to credit a goal to, so its goals are unattributed: ordinary goal events for its own team whose scorer is `MatchEvent::UNATTRIBUTED_PLAYER_ID`, listed under the club's name. An upset is rare but it no longer has to come on penalties. See `match-simulation.md`.
 - Ghosts are excluded from the transfer market, job offers, pre-season friendlies and every other flow that needs a squad, because they are only registered in cup competitions (`Team::scopeTransferMarketEligible`).
 
 Spain's Copa del Rey already used this shape for its regional entrants; a country whose only playable tier is the top flight extends it to whole divisions.

--- a/docs/game-systems/match-simulation.md
+++ b/docs/game-systems/match-simulation.md
@@ -112,6 +112,41 @@ At season close, `FinalizeOtherLeaguesProcessor` (priority 74, in `SeasonClosing
 
 Cup competitions (`knockout_cup`), Swiss-format competitions (`swiss_format`, `group_stage_cup`), and the World Cup are not handled by the resolver — they keep their existing path.
 
+## Squad-less cup entrants
+
+A cup fields the whole pyramid by seeding lower-division clubs as teams with no
+players. There is no XI to average, so their strength comes from
+`GhostStrength`, keyed by the reputation every team already carries from
+`ClubProfilesSeeder` — curated where the club is notable, local by default. A
+second-tier side in the FA Cup is a harder night than a non-league one, without
+any new data.
+
+They were previously charged twice for having no squad: once through the rating
+gap, then again through the missing-goalkeeper penalty, which doubled the
+opponent's xG on top of it. A top-flight side faced 8.87 xG and won these ties
+about 6-0. The penalty now applies only to a side that picked an outfielder in
+goal, which is what it was for.
+
+A ghost can score, which it could not before. It has nobody to credit a goal to,
+so its goals are **unattributed**: ordinary `goal` events for its own team whose
+`game_player_id` is `MatchEvent::UNATTRIBUTED_PLAYER_ID`, a constant that
+references no player row. That sentinel is why `match_events` carries no foreign
+key on `game_player_id`; the column stays `NOT NULL`, so a genuinely missing
+scorer still fails loudly and exactly one known value is exempt. Wherever a
+scorer's name would appear — the match summary, the live feed, a tournament
+report — the club's name appears instead.
+
+The event has to exist at all because the score is recomputed from events: a goal
+without one disappears when a half-time change re-simulates the match, and takes
+a cup tie's extra-time trigger with it. That constraint is what the old
+zero-forcing guard was protecting. `AIMatchResolver` resolves these goals the
+same way; it used to count them in the scoreline and then drop them, having no
+player to attach them to.
+
+Upsets land in the low single digits of percent, rising with the ghost's
+standing. Tune them through `config/match_simulation.php`'s `ghost_strength`
+band: raising a tier narrows the gap and makes upsets more common.
+
 ## Key Files
 
 | File | Purpose |

--- a/resources/js/modules/match-summary-generator.js
+++ b/resources/js/modules/match-summary-generator.js
@@ -78,7 +78,9 @@ function countTrailingStreak(formArray, predicate) {
 function detectHatTrick(allEvents) {
     const tally = {};
     for (const e of allEvents) {
-        if (e.type === 'goal' && e.playerName) {
+        // A goal with no player id was scored by a squad-less side and carries
+        // the club's name, not a player's — nobody scored a hat-trick there.
+        if (e.type === 'goal' && e.playerName && e.gamePlayerId) {
             if (!tally[e.playerName]) {
                 tally[e.playerName] = { count: 0, teamId: e.teamId };
             }

--- a/resources/views/tournament-end.blade.php
+++ b/resources/views/tournament-end.blade.php
@@ -36,7 +36,10 @@ $homeGoals = collect();
 $awayGoals = collect();
 if ($finalMatch && $finalGoalEvents->isNotEmpty()) {
     foreach ($finalGoalEvents as $event) {
-        $playerName = $event->gamePlayer?->name ?? '?';
+        // A squad-less cup entrant's goal has no scorer, so it reads as the club.
+        $playerName = $event->isUnattributed()
+            ? ($event->team_id === $finalMatch->home_team_id ? $finalMatch->homeTeam->name : $finalMatch->awayTeam->name)
+            : ($event->gamePlayer?->name ?? '?');
         $isOwnGoal = $event->event_type === \App\Models\MatchEvent::TYPE_OWN_GOAL;
 
         // For own goals, the scoring team is the OPPOSITE of the event's team

--- a/tests/Feature/Console/DiffSeasonCommandTest.php
+++ b/tests/Feature/Console/DiffSeasonCommandTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature\Console;
 
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\File;
+use Tests\Support\ThrowawaySeasons;
 use Tests\TestCase;
 
 class DiffSeasonCommandTest extends TestCase
@@ -12,8 +13,8 @@ class DiffSeasonCommandTest extends TestCase
     // write to the shared base_path('data') tree (Scaffold 2098/2099, Normalize
     // 2097, Validate 2096): under `test --parallel` they run in separate
     // processes but share the same data/ folder, so overlapping years race.
-    private string $from = '2094';
-    private string $season = '2095';
+    private string $from = ThrowawaySeasons::DIFF_FROM;
+    private string $season = ThrowawaySeasons::DIFF_TO;
 
     protected function tearDown(): void
     {

--- a/tests/Feature/Console/FixSeasonClashesCommandTest.php
+++ b/tests/Feature/Console/FixSeasonClashesCommandTest.php
@@ -3,15 +3,12 @@
 namespace Tests\Feature\Console;
 
 use Illuminate\Support\Facades\File;
+use Tests\Support\ThrowawaySeasons;
 use Tests\TestCase;
 
 class FixSeasonClashesCommandTest extends TestCase
 {
-    // A throwaway season disjoint from the years ValidateSeasonCommandTest
-    // (2096) and ScaffoldSeasonCommandTest (2098/2099) use: all three write to
-    // the shared base_path('data') tree, so under `test --parallel` they would
-    // otherwise race, one tearDown deleting another's freshly written files.
-    private string $season = '2097';
+    private string $season = ThrowawaySeasons::FIX_CLASHES;
 
     protected function tearDown(): void
     {

--- a/tests/Feature/Console/NormalizeSeasonCommandTest.php
+++ b/tests/Feature/Console/NormalizeSeasonCommandTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature\Console;
 
 use Illuminate\Support\Facades\File;
+use Tests\Support\ThrowawaySeasons;
 use Tests\TestCase;
 
 class NormalizeSeasonCommandTest extends TestCase
@@ -11,7 +12,7 @@ class NormalizeSeasonCommandTest extends TestCase
     // write to the shared base_path('data') tree (Scaffold 2098/2099, Diff
     // 2094/2095, Validate 2096): under `test --parallel` they run in separate
     // processes but share the same data/ folder, so overlapping years race.
-    private string $season = '2097';
+    private string $season = ThrowawaySeasons::NORMALIZE;
 
     protected function tearDown(): void
     {

--- a/tests/Feature/Console/ScaffoldSeasonCommandTest.php
+++ b/tests/Feature/Console/ScaffoldSeasonCommandTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature\Console;
 
 use Carbon\Carbon;
 use Illuminate\Support\Facades\File;
+use Tests\Support\ThrowawaySeasons;
 use Tests\TestCase;
 
 class ScaffoldSeasonCommandTest extends TestCase
@@ -13,9 +14,9 @@ class ScaffoldSeasonCommandTest extends TestCase
     // Diff 2094/2095, Validate 2096): every class writes to the shared
     // base_path('data') tree, so under `test --parallel` they must stay on
     // disjoint years or they race on the same folder.
-    private string $from = '2098';
+    private string $from = ThrowawaySeasons::SCAFFOLD_FROM;
 
-    private string $to = '2099';
+    private string $to = ThrowawaySeasons::SCAFFOLD_TO;
 
     protected function tearDown(): void
     {

--- a/tests/Feature/Console/ValidateSeasonCommandTest.php
+++ b/tests/Feature/Console/ValidateSeasonCommandTest.php
@@ -3,16 +3,12 @@
 namespace Tests\Feature\Console;
 
 use Illuminate\Support\Facades\File;
+use Tests\Support\ThrowawaySeasons;
 use Tests\TestCase;
 
 class ValidateSeasonCommandTest extends TestCase
 {
-    // Throwaway season kept clear of any real data/{season} folder AND of the
-    // years ScaffoldSeasonCommandTest uses (2098/2099): both classes write to
-    // the shared base_path('data') tree, so under `test --parallel` they must
-    // not touch the same folder or they race (one's tearDown deletes the
-    // other's freshly-written files). Disjoint years keep them isolated.
-    private string $season = '2096';
+    private string $season = ThrowawaySeasons::VALIDATE;
 
     protected function tearDown(): void
     {

--- a/tests/Feature/SquadlessCupEntrantGoalsTest.php
+++ b/tests/Feature/SquadlessCupEntrantGoalsTest.php
@@ -1,0 +1,180 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Competition;
+use App\Models\Game;
+use App\Models\GameMatch;
+use App\Models\GamePlayer;
+use App\Models\MatchEvent;
+use App\Models\Team;
+use App\Models\User;
+use App\Modules\Match\DTOs\MatchEventData;
+use App\Modules\Match\Services\AIMatchResolver;
+use App\Modules\Match\Services\MatchEventRepository;
+use App\Modules\Match\Services\MatchSimulator;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use Tests\Traits\CreatesLineups;
+
+/**
+ * A ghost — a cup entrant seeded with no squad — can score, and its goals are
+ * unattributed: ordinary goal events for its own team whose scorer is
+ * `MatchEvent::UNATTRIBUTED_PLAYER_ID`, an id that references no player row.
+ *
+ * That is only possible because `match_events` has no foreign key on
+ * `game_player_id` any more, and only a test that actually writes the row
+ * proves it. The rest of the model is covered by EmptySquadSimulationTest,
+ * which never touches the database.
+ */
+class SquadlessCupEntrantGoalsTest extends TestCase
+{
+    use RefreshDatabase;
+    use CreatesLineups;
+
+    private Game $game;
+    private Team $leagueTeam;
+    private Team $ghost;
+    private Competition $competition;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $user = User::factory()->create();
+        $this->leagueTeam = Team::factory()->create(['name' => 'League Club']);
+        $this->ghost = Team::factory()->create(['name' => 'Village Rovers']);
+
+        $this->competition = Competition::factory()->league()->create([
+            'id' => 'ESP1',
+            'name' => 'LaLiga',
+        ]);
+
+        $this->game = Game::factory()->create([
+            'user_id' => $user->id,
+            'team_id' => $this->leagueTeam->id,
+            'competition_id' => $this->competition->id,
+            'season' => '2024',
+            'current_date' => '2024-08-15',
+        ]);
+    }
+
+    public function test_a_ghosts_goal_persists_without_a_player_row(): void
+    {
+        $match = $this->createMatch();
+
+        $repository = new MatchEventRepository;
+        $repository->bulkInsert(
+            collect([MatchEventData::unattributedGoal($this->ghost->id, 34)]),
+            $this->game->id,
+            $match->id,
+        );
+
+        $event = MatchEvent::where('game_match_id', $match->id)->sole();
+
+        $this->assertSame(MatchEvent::TYPE_GOAL, $event->event_type);
+        $this->assertSame($this->ghost->id, $event->team_id);
+        $this->assertTrue($event->isUnattributed());
+        $this->assertNull($event->gamePlayer, 'the sentinel references no player row');
+        $this->assertSame('Village Rovers', $event->player_name, 'it reads as the club that scored it');
+    }
+
+    public function test_a_squadless_side_is_never_left_with_a_goal_no_event_explains(): void
+    {
+        $players = $this->createLineup($this->game, $this->leagueTeam, 11, 75);
+        $simulator = new MatchSimulator;
+        $match = $this->createMatch();
+        $repository = new MatchEventRepository;
+
+        // Enough runs that the ghost scores in some of them.
+        for ($i = 0; $i < 40; $i++) {
+            $output = $simulator->simulate($this->leagueTeam, $this->ghost, $players, collect());
+
+            MatchEvent::where('game_match_id', $match->id)->delete();
+            $repository->bulkInsert($output->result->events, $this->game->id, $match->id);
+
+            $match->update([
+                'home_score' => $output->result->homeScore,
+                'away_score' => $output->result->awayScore,
+            ]);
+
+            $this->assertScoreMatchesEvents($match->fresh());
+        }
+    }
+
+    public function test_the_ai_resolver_backs_a_ghosts_scoreline_with_events(): void
+    {
+        $this->createLineup($this->game, $this->leagueTeam, 11, 75);
+
+        $allPlayers = GamePlayer::where('game_id', $this->game->id)->get()->groupBy('team_id');
+        $resolver = new AIMatchResolver;
+
+        $scoredAtLeastOnce = false;
+
+        for ($i = 0; $i < 40; $i++) {
+            $match = $this->createMatch();
+            $result = $resolver->resolveMatches(collect([$match]), $allPlayers, $this->game)[0];
+
+            $ghostGoals = collect($result['events'])->filter(
+                fn (array $e) => $e['event_type'] === 'goal' && $e['team_id'] === $this->ghost->id,
+            );
+
+            $this->assertCount($result['awayScore'], $ghostGoals, "iteration {$i}");
+            $this->assertTrue(
+                $ghostGoals->every(fn (array $e) => $e['game_player_id'] === MatchEvent::UNATTRIBUTED_PLAYER_ID),
+                "a squad-less side has no scorer to credit (iteration {$i})",
+            );
+            $this->assertCount(
+                0,
+                collect($result['events'])->filter(fn (array $e) => $e['event_type'] === 'own_goal'),
+                "no own goal is invented to explain a ghost's goals (iteration {$i})",
+            );
+
+            $scoredAtLeastOnce = $scoredAtLeastOnce || $result['awayScore'] > 0;
+        }
+
+        $this->assertTrue($scoredAtLeastOnce, 'a ghost should score at least once in 40 AI-resolved ties');
+    }
+
+    private function createMatch(): GameMatch
+    {
+        return GameMatch::factory()->create([
+            'game_id' => $this->game->id,
+            'competition_id' => $this->competition->id,
+            'round_number' => 1,
+            'home_team_id' => $this->leagueTeam->id,
+            'away_team_id' => $this->ghost->id,
+            'scheduled_date' => Carbon::parse('2024-08-16'),
+            'played' => true,
+            'home_score' => 0,
+            'away_score' => 0,
+            'first_half_stoppage' => 1,
+            'second_half_stoppage' => 3,
+        ]);
+    }
+
+    /**
+     * The invariant everything here exists to protect: every goal on the
+     * scoreboard has an event, on the right side.
+     */
+    private function assertScoreMatchesEvents(GameMatch $match): void
+    {
+        $tally = ['home' => 0, 'away' => 0];
+
+        $events = MatchEvent::where('game_match_id', $match->id)
+            ->whereIn('event_type', [MatchEvent::TYPE_GOAL, MatchEvent::TYPE_OWN_GOAL])
+            ->get();
+
+        foreach ($events as $event) {
+            $forHome = $event->event_type === MatchEvent::TYPE_GOAL
+                ? $event->team_id === $match->home_team_id
+                : $event->team_id !== $match->home_team_id;
+
+            $tally[$forHome ? 'home' : 'away']++;
+        }
+
+        $this->assertSame((int) $match->home_score, $tally['home'], 'home score is not backed by events');
+        $this->assertSame((int) $match->away_score, $tally['away'], 'away score is not backed by events');
+    }
+}

--- a/tests/Support/ThrowawaySeasons.php
+++ b/tests/Support/ThrowawaySeasons.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Tests\Support;
+
+/**
+ * The season folders the console tests write into.
+ *
+ * Every one of these commands reads and writes the real `base_path('data')`
+ * tree, and each test deletes its own folder in `tearDown()`. Under
+ * `php artisan test --parallel` they run at the same time, so two tests
+ * sharing a year means one deletes the other's fixtures mid-run — a failure
+ * that only shows up in parallel, names an innocent test, and passes on a
+ * re-run.
+ *
+ * That happened: FixSeasonClashesCommandTest was added on 2097, which
+ * NormalizeSeasonCommandTest already held. Each file documented its own year
+ * in a comment, which is not somewhere you look before picking one. They live
+ * here instead, so the whole allocation is in front of you the moment you add
+ * to it.
+ *
+ * Pick from 2092 downward when you need another, and keep well clear of any
+ * season the app might really seed.
+ */
+final class ThrowawaySeasons
+{
+    public const FIX_CLASHES = '2093';
+
+    public const DIFF_FROM = '2094';
+
+    public const DIFF_TO = '2095';
+
+    public const VALIDATE = '2096';
+
+    public const NORMALIZE = '2097';
+
+    public const SCAFFOLD_FROM = '2098';
+
+    public const SCAFFOLD_TO = '2099';
+}

--- a/tests/Unit/EmptySquadSimulationTest.php
+++ b/tests/Unit/EmptySquadSimulationTest.php
@@ -3,12 +3,26 @@
 namespace Tests\Unit;
 
 use App\Models\Game;
+use App\Models\MatchEvent;
 use App\Models\Team;
+use App\Modules\Match\DTOs\MatchEventData;
 use App\Modules\Match\Services\MatchSimulator;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Collection;
 use Tests\TestCase;
 use Tests\Traits\CreatesLineups;
 
+/**
+ * A ghost — a cup entrant with no squad — used to be forbidden from scoring, so
+ * the only upset available was a 0-0 and a shootout, at odds of roughly one in
+ * eight thousand. It can score now. Its goals are unattributed: ordinary goal
+ * events for its own team, carrying a sentinel scorer, never charged to a real
+ * player of the side it beat.
+ *
+ * What must not change: the scoreline and the events always agree. A goal
+ * without an event vanishes when a half-time change re-simulates the match, and
+ * takes the extra-time trigger of a cup tie with it.
+ */
 class EmptySquadSimulationTest extends TestCase
 {
     use RefreshDatabase;
@@ -22,42 +36,53 @@ class EmptySquadSimulationTest extends TestCase
         $this->simulator = new MatchSimulator;
     }
 
-    public function test_empty_away_squad_always_scores_zero(): void
+    public function test_every_goal_a_squadless_side_scores_has_an_event(): void
     {
         $game = Game::factory()->create(['current_date' => '2025-10-01']);
         $homeTeam = Team::factory()->create();
         $awayTeam = Team::factory()->create();
         $homePlayers = $this->createLineup($game, $homeTeam, 11, 75);
-        $awayPlayers = collect(); // Empty squad
 
-        // Run 20 simulations to verify the empty team never scores
-        for ($i = 0; $i < 20; $i++) {
-            $output = $this->simulator->simulate(
-                $homeTeam, $awayTeam,
-                $homePlayers, $awayPlayers,
-            );
+        for ($i = 0; $i < 60; $i++) {
+            $output = $this->simulator->simulate($homeTeam, $awayTeam, $homePlayers, collect());
 
-            $this->assertEquals(0, $output->result->awayScore, "Empty squad should never score (iteration {$i})");
-            $this->assertGreaterThanOrEqual(0, $output->result->homeScore);
+            $this->assertUnattributedGoals($output->result->events, $awayTeam, $output->result->awayScore, $i);
+            $this->assertNoOwnGoals($output->result->events, $i);
         }
     }
 
-    public function test_empty_home_squad_always_scores_zero(): void
+    public function test_a_squadless_side_scores_sometimes_but_rarely(): void
     {
         $game = Game::factory()->create(['current_date' => '2025-10-01']);
         $homeTeam = Team::factory()->create();
         $awayTeam = Team::factory()->create();
-        $homePlayers = collect(); // Empty squad
-        $awayPlayers = $this->createLineup($game, $awayTeam, 11, 75);
+        $homePlayers = $this->createLineup($game, $homeTeam, 11, 75);
+
+        $runs = 400;
+        $scored = 0;
+        for ($i = 0; $i < $runs; $i++) {
+            $output = (new MatchSimulator)->simulate($homeTeam, $awayTeam, $homePlayers, collect());
+            $scored += $output->result->awayScore > 0 ? 1 : 0;
+        }
+
+        $rate = $scored / $runs;
+        $this->assertGreaterThan(0.0, $rate, 'a ghost that can never score has no upset in it');
+        $this->assertLessThan(0.35, $rate, 'a ghost scoring this often stops being an upset');
+    }
+
+    public function test_two_squadless_sides_still_back_their_goals_with_events(): void
+    {
+        $homeTeam = Team::factory()->create();
+        $awayTeam = Team::factory()->create();
 
         for ($i = 0; $i < 20; $i++) {
-            $output = $this->simulator->simulate(
-                $homeTeam, $awayTeam,
-                $homePlayers, $awayPlayers,
-            );
+            $output = $this->simulator->simulate($homeTeam, $awayTeam, collect(), collect());
 
-            $this->assertEquals(0, $output->result->homeScore, "Empty squad should never score (iteration {$i})");
-            $this->assertGreaterThanOrEqual(0, $output->result->awayScore);
+            // Neither side has a player, so every goal on the board is one
+            // nobody is credited with — on both sides.
+            $this->assertUnattributedGoals($output->result->events, $homeTeam, $output->result->homeScore, $i);
+            $this->assertUnattributedGoals($output->result->events, $awayTeam, $output->result->awayScore, $i);
+            $this->assertNoOwnGoals($output->result->events, $i);
         }
     }
 
@@ -78,10 +103,17 @@ class EmptySquadSimulationTest extends TestCase
             );
 
             if ($output->result->homeScore > 0) {
-                // Verify goal events exist for every home goal
-                $goalEvents = $output->result->events->filter(fn ($e) => $e->type === 'goal');
-                $this->assertEquals($output->result->homeScore, $goalEvents->count(),
+                // The side with players scores through them, with a real scorer
+                // on every goal.
+                $goalEvents = $output->result->events
+                    ->filter(fn (MatchEventData $e) => $e->type === 'goal' && $e->teamId === $homeTeam->id);
+
+                $this->assertCount($output->result->homeScore, $goalEvents,
                     'Each home goal should have a corresponding event');
+                $this->assertTrue(
+                    $goalEvents->every(fn (MatchEventData $e) => $homePlayers->contains('id', $e->gamePlayerId)),
+                    'a side with an XI credits its goals to its own players',
+                );
                 $foundGoalEvents = true;
                 break;
             }
@@ -90,7 +122,7 @@ class EmptySquadSimulationTest extends TestCase
         $this->assertTrue($foundGoalEvents, 'Home team should score in at least one of 50 simulations');
     }
 
-    public function test_empty_squad_extra_time_scores_zero(): void
+    public function test_extra_time_backs_a_squadless_sides_goals_with_events(): void
     {
         $game = Game::factory()->create(['current_date' => '2025-10-01']);
         $homeTeam = Team::factory()->create();
@@ -104,11 +136,12 @@ class EmptySquadSimulationTest extends TestCase
                 $homePlayers, $awayPlayers,
             );
 
-            $this->assertEquals(0, $result->awayScore, "Empty squad should never score in ET (iteration {$i})");
+            $this->assertUnattributedGoals($result->events, $awayTeam, $result->awayScore, $i);
+            $this->assertNoOwnGoals($result->events, $i);
         }
     }
 
-    public function test_empty_squad_remainder_scores_zero(): void
+    public function test_a_resimulated_remainder_backs_a_squadless_sides_goals(): void
     {
         $game = Game::factory()->create(['current_date' => '2025-10-01']);
         $homeTeam = Team::factory()->create();
@@ -124,7 +157,47 @@ class EmptySquadSimulationTest extends TestCase
                 fromMinute: 60,
             );
 
-            $this->assertEquals(0, $output->result->awayScore, "Empty squad should never score in remainder (iteration {$i})");
+            $this->assertUnattributedGoals($output->result->events, $awayTeam, $output->result->awayScore, $i);
+            $this->assertNoOwnGoals($output->result->events, $i);
         }
+    }
+
+    /**
+     * Every goal on a squad-less side's scoreline is an unattributed goal event
+     * for that side, and there are exactly as many as the scoreline says.
+     *
+     * @param  Collection<MatchEventData>  $events
+     */
+    private function assertUnattributedGoals(Collection $events, Team $team, int $score, int $iteration): void
+    {
+        $goals = $events->filter(
+            fn (MatchEventData $e) => $e->type === 'goal' && $e->teamId === $team->id,
+        );
+
+        $this->assertCount(
+            $score,
+            $goals,
+            "A squad-less side's goals must each have an event (iteration {$iteration})",
+        );
+
+        $this->assertTrue(
+            $goals->every(fn (MatchEventData $e) => $e->gamePlayerId === MatchEvent::UNATTRIBUTED_PLAYER_ID),
+            "A squad-less side has no scorer to credit (iteration {$iteration})",
+        );
+    }
+
+    /**
+     * The opponent's players are never charged with an own goal to explain a
+     * ghost's scoreline — the thing this model exists to stop.
+     *
+     * @param  Collection<MatchEventData>  $events
+     */
+    private function assertNoOwnGoals(Collection $events, int $iteration): void
+    {
+        $this->assertCount(
+            0,
+            $events->filter(fn (MatchEventData $e) => $e->type === 'own_goal'),
+            "No own goal should be invented for a squad-less side's goals (iteration {$iteration})",
+        );
     }
 }

--- a/tests/Unit/GhostTeamUpsetTest.php
+++ b/tests/Unit/GhostTeamUpsetTest.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Modules\Match\Support\GhostStrength;
+use App\Modules\Match\Support\MatchOutcomeModel;
+use Tests\TestCase;
+
+/**
+ * Cup ties against a squad-less side, sampled through the production outcome
+ * math with fixed strengths — the same approach GoalScoringBalanceTest takes,
+ * so these are fast and need no database.
+ *
+ * Two things were wrong before. A ghost's rating was one constant, so a
+ * second-tier club with 30,000 seats was exactly as hard to beat as a village
+ * side. And it was charged twice for having no squad: once through the rating
+ * gap, then again through the missing-goalkeeper penalty, which doubled the
+ * opponent's xG on top of it. A user's side faced 8.87 xG and won these ties
+ * about 6-0.
+ */
+class GhostTeamUpsetTest extends TestCase
+{
+    /** A ~75-rated XI once energy has eroded it, i.e. an ordinary top-flight side. */
+    private const TOP_FLIGHT = 0.68;
+
+    private const RUNS = 20000;
+
+    public function test_a_tie_against_a_ghost_is_no_longer_a_rout(): void
+    {
+        [$userXG] = $this->expectedGoals('local');
+
+        // Comfortable, not absurd. It used to be 8.87.
+        $this->assertGreaterThan(2.0, $userXG);
+        $this->assertLessThan(5.0, $userXG);
+    }
+
+    public function test_a_better_reputed_ghost_is_harder_to_beat(): void
+    {
+        $conceded = [];
+        foreach (GhostStrength::levels() as $level) {
+            [$userXG] = $this->expectedGoals($level);
+            $conceded[$level] = $userXG;
+        }
+
+        $ordered = array_values($conceded);
+        $sorted = $ordered;
+        rsort($sorted);
+
+        $this->assertSame(
+            $sorted,
+            $ordered,
+            'reputation is ranked local to elite, so each tier should concede no more than the one below it',
+        );
+        $this->assertGreaterThan(
+            0.5,
+            reset($ordered) - end($ordered),
+            'the tiers should be far enough apart to be felt across a cup run',
+        );
+    }
+
+    public function test_an_upset_is_possible_but_rare(): void
+    {
+        foreach (['local', 'elite'] as $level) {
+            $rate = $this->upsetRate($level);
+
+            $this->assertGreaterThan(0.001, $rate, "a {$level} ghost should be able to cause an upset");
+            $this->assertLessThan(0.10, $rate, "a {$level} ghost causing upsets this often is not an upset");
+        }
+    }
+
+    public function test_the_better_ghost_causes_more_upsets(): void
+    {
+        $this->assertGreaterThan(
+            $this->upsetRate('local'),
+            $this->upsetRate('elite'),
+            'a second-tier club should knock out a top-flight side more often than a village side does',
+        );
+    }
+
+    /**
+     * Share of ties the ghost does not lose in normal time — it wins outright,
+     * or draws and takes its chance in the shootout.
+     */
+    private function upsetRate(string $level): float
+    {
+        [$userXG, $ghostXG] = $this->expectedGoals($level);
+
+        $upsets = 0;
+        for ($i = 0; $i < self::RUNS; $i++) {
+            [$user, $ghost] = MatchOutcomeModel::sampleScoreline($userXG, $ghostXG);
+
+            if ($ghost > $user) {
+                $upsets++;
+            } elseif ($ghost === $user) {
+                // A level tie goes to penalties, which for a squad-less side
+                // MatchSimulator resolves as a coin flip.
+                $upsets += 0.5;
+            }
+        }
+
+        return $upsets / self::RUNS;
+    }
+
+    /** @return array{0: float, 1: float} [userXG, ghostXG] */
+    private function expectedGoals(string $level): array
+    {
+        return MatchOutcomeModel::expectedGoals(
+            self::TOP_FLIGHT,
+            GhostStrength::forReputation($level),
+            false,
+        );
+    }
+}


### PR DESCRIPTION
A ghost — a cup entrant seeded with no players, so a cup can field the
whole pyramid — was punished three times over for it. Its strength was one
hardcoded constant, so a second-tier club with 30,000 seats was exactly as
hard to beat as a village side. The missing-goalkeeper penalty then
doubled the opponent's xG on top of that gap, charging it twice for the
same fact. And its goals were forced to zero. A top-flight side faced 8.87
xG and won about 6-0; the ghost's only route to an upset was a 0-0 and a
shootout, at roughly one tie in eight thousand.

Strength now comes from the reputation every team already carries, so the
tier is in the database already and costs no new data. The goalkeeper
penalty applies only to a side that picked an outfielder in goal, which is
what it was for.

A ghost can score, and the goal is its own. It has nobody to credit, so
the goal is unattributed: an ordinary goal event for its team whose scorer
is a constant that references no player row. That sentinel is why
match_events loses its foreign key on game_player_id. The column stays NOT
NULL, so a genuinely missing scorer still fails loudly and exactly one
known value is exempt; the cascade it gives up never fired, because the
season archive deletes a game's events before the only processor that
deletes a player runs. Where a scorer's name would go, the club's name
goes — the substitution the live-match JS already makes for a goal it has
to synthesise.

The event has to exist at all because the score is recomputed from events:
a goal without one vanishes on a half-time change and takes a cup tie's
extra-time trigger with it. That constraint is what the zero-forcing was
protecting, and it is the reason the goal cannot simply be added to the
scoreboard.

AIMatchResolver had the same bug the guard was written to prevent — it
sampled a scoreline, found no player to attach a ghost's goals to, and
dropped the events while keeping the score. It now resolves them the same
way, so the two engines agree. Two squad-less sides drawn against each
other get a real scoreline for the first time, backed on both sides.

A top-flight side now faces 3.94 xG rather than 8.87, and loses these ties
somewhere under one time in forty, rising with the ghost's standing. The
band is a config knob.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01P3JbEt3qb1yk77MzGqpXTS