### PR TITLE
Send loaned players home to cup-only entrants, and say who a player is on loan from

### DIFF
--- a/app/Modules/Season/Jobs/SetupNewGame.php
+++ b/app/Modules/Season/Jobs/SetupNewGame.php
@@ -507,10 +507,12 @@ class SetupNewGame implements ShouldQueue, ShouldBeUnique
             ->pluck('id', 'transfermarkt_id')
             ->toArray();
 
-        // Teams that actually field a squad in this game. An owner outside this
-        // set (foreign/unknown club, or one excluded from the game) yields a
-        // null parent → the player becomes a free agent when the loan ends.
-        $participatingTeamIds = DB::table('game_players')
+        // Teams entered in any of this game's competitions. Read from
+        // competition_entries rather than game_players so squad-less cup
+        // entrants still count as present. An owner outside this set (foreign
+        // or excluded club) yields a null parent → the player becomes a free
+        // agent when the loan ends.
+        $participatingTeamIds = DB::table('competition_entries')
             ->where('game_id', $this->gameId)
             ->distinct()
             ->pluck('team_id')

--- a/app/Modules/Season/Jobs/SetupNewGame.php
+++ b/app/Modules/Season/Jobs/SetupNewGame.php
@@ -507,15 +507,24 @@ class SetupNewGame implements ShouldQueue, ShouldBeUnique
             ->pluck('id', 'transfermarkt_id')
             ->toArray();
 
-        // Teams entered in any of this game's competitions. Read from
-        // competition_entries rather than game_players so squad-less cup
-        // entrants still count as present. An owner outside this set (foreign
-        // or excluded club) yields a null parent → the player becomes a free
-        // agent when the loan ends.
+        // Clubs present in this game, taken from both directions because
+        // neither table alone covers them. game_players misses a club entered
+        // solely in a cup: it fields no squad here, so its loans were stored
+        // parentless. competition_entries misses a club filtered out of the
+        // entries it would otherwise have had — a reserve team is dropped from
+        // domestic cups in copyCompetitionTeamsToGame — yet it still fields a
+        // squad. An owner in neither (foreign or excluded club) keeps a null
+        // parent → the player becomes a free agent when the loan ends.
         $participatingTeamIds = DB::table('competition_entries')
             ->where('game_id', $this->gameId)
             ->distinct()
             ->pluck('team_id')
+            ->merge(
+                DB::table('game_players')
+                    ->where('game_id', $this->gameId)
+                    ->distinct()
+                    ->pluck('team_id')
+            )
             ->flip()
             ->toArray();
 

--- a/lang/en/squad.php
+++ b/lang/en/squad.php
@@ -30,6 +30,8 @@ return [
 
     // Status labels
     'on_loan' => 'On Loan',
+    'loaned_from' => 'On loan from',
+    'loaned_to' => 'Loaned to',
     'leaving_free' => 'Leaving (Free)',
     'renewed' => 'Renewed',
     'sale_agreed' => 'Sale Agreed',

--- a/lang/es/squad.php
+++ b/lang/es/squad.php
@@ -30,6 +30,8 @@ return [
 
     // Status labels
     'on_loan' => 'Cedido',
+    'loaned_from' => 'Cedido por',
+    'loaned_to' => 'Cedido a',
     'leaving_free' => 'Se va (Libre)',
     'renewed' => 'Renovado',
     'sale_agreed' => 'Venta Acordada',

--- a/resources/views/components/player-banner.blade.php
+++ b/resources/views/components/player-banner.blade.php
@@ -6,6 +6,15 @@
     /** @var array<int, array{text: string, class: string}> $statusChips */
 
     $isCareerMode = $game->isCareerMode();
+    // The club only tells the reader something when the player sits outside
+    // their own clubs — on their own squad/reserve pages it is the page they
+    // are already on.
+    $showsClub = $isCareerMode
+        && $player->team
+        && !in_array($player->team_id, $game->userTeamIds(), true);
+    $positionNames = collect($player->positions)
+        ->map(fn ($pos) => \App\Support\PositionMapper::toDisplayName($pos))
+        ->implode(' · ');
     $nationalityFlag = $player->nationality_flag;
     $defaultPhoto = Storage::disk('assets')->url('img/default-player.jpg');
     $photo = $player->image_url ?? $defaultPhoto;
@@ -42,18 +51,14 @@
                         {{ __('countries.' . $nationalityFlag['name']) }}
                     </span>
                 @endif
-                @if($player->team && $isCareerMode)
+                @if($showsClub)
                     <span class="inline-flex items-center gap-1.5 min-w-0">
                         <x-team-crest :team="$player->team" class="w-4 h-4 shrink-0" />
                         <span class="truncate">{{ $player->team->name }}</span>
                     </span>
                 @endif
+                <span class="text-text-secondary">{{ $positionNames }}</span>
                 <span>{{ $player->age($game->current_date) }} {{ __('app.years') }}@if($player->height) · {{ $player->height }}@endif</span>
-            </div>
-            <div class="text-[11px] text-text-faint mt-1">
-                @foreach($player->positions as $pos)
-                    <span class="text-text-secondary">{{ \App\Support\PositionMapper::toDisplayName($pos) }}</span>@if(!$loop->last)<span class="text-text-faint/60"> · </span>@endif
-                @endforeach
             </div>
 
             {{-- Status badges (surface-specific, supplied by the caller) --}}

--- a/resources/views/components/team-crest.blade.php
+++ b/resources/views/components/team-crest.blade.php
@@ -1,5 +1,8 @@
 @props(['team'])
 
+{{-- A loan parent can be null (loaned in from a club outside the game), so
+     every caller would otherwise need its own guard. --}}
+@if($team)
 @php
     $isNational = ($team->type ?? 'club') === 'national';
 @endphp
@@ -18,4 +21,5 @@
 <img
     src="{{ $team->image }}"
     {{ $attributes->merge(['alt' => $team->name]) }}>
+@endif
 @endif

--- a/resources/views/incoming-transfers.blade.php
+++ b/resources/views/incoming-transfers.blade.php
@@ -233,7 +233,9 @@
                                                 <div class="font-medium text-sm text-text-primary truncate">{{ $loan->gamePlayer->name }}</div>
                                                 <div class="text-xs text-text-muted">
                                                     {{ $loan->gamePlayer->position_name }} &middot; {{ $loan->gamePlayer->age($game->current_date) }} {{ __('app.years') }}
+                                                    @if($loan->parentTeam)
                                                     &middot; {{ __('transfers.loaned_from', ['team_de' => $loan->parentTeam->nameWithDe()]) }}
+                                                    @endif
                                                 </div>
                                                 <div class="text-xs text-text-secondary mt-0.5">
                                                     {{ __('transfers.returns') }}: {{ $loan->return_at->format('M j, Y') }}

--- a/resources/views/partials/player-detail.blade.php
+++ b/resources/views/partials/player-detail.blade.php
@@ -41,6 +41,23 @@
     if ($isListed) {
         $statusChips[] = ['text' => __('squad.listed'), 'class' => 'bg-accent-blue/10 text-accent-blue'];
     }
+
+    // Loan spell with an outside club. A reserve call-up is also a loan
+    // internally (parent = the user's own B team), so exclude any loan whose
+    // parent is one of the user's teams — that is squad management, not a
+    // cession, and is already surfaced by the origin/call-up controls.
+    $loan = $gamePlayer->activeLoan;
+    $loanOtherClub = null;
+    if ($loan && !in_array($loan->parent_team_id, $game->userTeamIds(), true)) {
+        $loanOtherClub = $loan->parentTeam;
+        $loanLabel = __('squad.loaned_from');
+    } elseif ($loan && $loan->loan_team_id !== $game->team_id) {
+        $loanOtherClub = $loan->loanTeam;
+        $loanLabel = __('squad.loaned_to');
+    }
+    if ($loanOtherClub) {
+        $statusChips[] = ['text' => __('squad.on_loan'), 'class' => 'bg-accent-blue/10 text-accent-blue'];
+    }
 @endphp
 
 {{-- Header --}}
@@ -143,6 +160,21 @@
                         <span class="text-[11px] text-text-muted uppercase tracking-wide">{{ __('transfers.release_clause') }}</span>
                         <span class="text-xs font-semibold text-text-primary">{{ $gamePlayer->formatted_release_clause }}</span>
                     </div>
+                @endif
+                @if($loanOtherClub)
+                    <div class="flex items-center justify-between">
+                        <span class="text-[11px] text-text-muted uppercase tracking-wide">{{ $loanLabel }}</span>
+                        <span class="flex items-center gap-1.5 text-xs font-semibold text-text-primary">
+                            <x-team-crest :team="$loanOtherClub" class="w-4 h-4 shrink-0" />
+                            {{ $loanOtherClub->name }}
+                        </span>
+                    </div>
+                    @if($loan->return_at)
+                        <div class="flex items-center justify-between">
+                            <span class="text-[11px] text-text-muted uppercase tracking-wide">{{ __('transfers.returns') }}</span>
+                            <span class="text-xs font-semibold text-text-primary">{{ $loan->return_at->translatedFormat('M Y') }}</span>
+                        </div>
+                    @endif
                 @endif
                 @if($gamePlayer->careerRecord)
                     @php

--- a/tests/Feature/LoanImportTest.php
+++ b/tests/Feature/LoanImportTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature;
 
 use App\Models\Competition;
+use App\Models\CompetitionEntry;
 use App\Models\Game;
 use App\Models\GamePlayer;
 use App\Models\GamePlayerTemplate;
@@ -19,6 +20,9 @@ use Tests\TestCase;
  * turns a template's loan_from_transfermarkt_id into a per-game loan that
  * returns the player to the owning club at season end — or, when that club
  * isn't part of the game, leaves no parent so the player is freed.
+ *
+ * A club counts as part of the game if it fields a squad OR is entered in one
+ * of its competitions; the two are independent, so both are covered here.
  */
 class LoanImportTest extends TestCase
 {
@@ -30,7 +34,8 @@ class LoanImportTest extends TestCase
     private Team $userTeam;       // the manager's club
     private Team $borrowingTeam;  // where loaned players currently play
     private Team $ownerInGame;    // an owning club that fields a squad in the game
-    private Team $ownerOutOfGame; // an owning club with no squad in the game
+    private Team $ownerCupOnly;   // an owning club entered in a cup, with no squad
+    private Team $ownerOutOfGame; // an owning club in neither
     private Game $game;
     private int $nextSquadNumber = 7; // keep squad numbers unique per borrowing team
 
@@ -42,8 +47,10 @@ class LoanImportTest extends TestCase
         $this->userTeam = Team::factory()->create(['name' => 'User Team']);
         $this->borrowingTeam = Team::factory()->create(['name' => 'Borrowing Team']);
         $this->ownerInGame = Team::factory()->create(['name' => 'Owner In Game']);
+        $this->ownerCupOnly = Team::factory()->create(['name' => 'Owner Cup Only']);
         $this->ownerOutOfGame = Team::factory()->create(['name' => 'Owner Out Of Game']);
         Competition::factory()->league()->create(['id' => 'ESP1']);
+        Competition::factory()->knockoutCup()->create(['id' => 'ESPCUP']);
 
         $this->game = Game::factory()->create([
             'user_id' => $this->user->id,
@@ -53,8 +60,18 @@ class LoanImportTest extends TestCase
             'current_date' => '2024-08-15',
         ]);
 
-        // The owning club only counts as "in the game" if it fields a squad.
+        // One owner is present by fielding a squad...
         GamePlayer::factory()->forGame($this->game)->forTeam($this->ownerInGame)->create();
+
+        // ...and one only by being entered in a cup. A club can enter a
+        // domestic cup without being playable, so it has no squad in this game
+        // and appears nowhere in game_players.
+        CompetitionEntry::create([
+            'game_id' => $this->game->id,
+            'competition_id' => 'ESPCUP',
+            'team_id' => $this->ownerCupOnly->id,
+            'entry_round' => 1,
+        ]);
     }
 
     public function test_setup_materialises_loans_with_correct_parents(): void
@@ -70,6 +87,10 @@ class LoanImportTest extends TestCase
         // Player C: a normal squad member, no loan info.
         $playerC = $this->createGamePlayerOnBorrowingTeam();
         $this->createTemplate($playerC->player_id, loanFrom: null);
+
+        // Player D: owner is entered in a cup only, so it fields no squad here.
+        $playerD = $this->createGamePlayerOnBorrowingTeam();
+        $this->createTemplate($playerD->player_id, loanFrom: $this->ownerCupOnly->transfermarkt_id);
 
         $this->invokeLoanInit();
 
@@ -93,6 +114,13 @@ class LoanImportTest extends TestCase
         // C → never on loan, so no loan record.
         $this->assertFalse(Loan::where('game_player_id', $playerC->id)->exists(),
             'Players with no loan info must not get a loan record');
+
+        // D → a cup entry is enough to be an owner, even with no squad in the
+        // game. Without this the player would be freed instead of going home.
+        $loanD = Loan::where('game_player_id', $playerD->id)->first();
+        $this->assertNotNull($loanD, 'A loan should be created for a cup-only owner');
+        $this->assertSame($this->ownerCupOnly->id, $loanD->parent_team_id,
+            'A club entered only in a cup still owns its loaned-out players');
     }
 
     public function test_initialize_loans_is_idempotent(): void


### PR DESCRIPTION
Split out of #1347 so that branch stays purely 2026 season data. These two commits were written on top of it but do not depend on it — they touch no file the data commits touch, and cherry-picked onto `main` cleanly.

## Send loaned players home to clubs that only enter a cup

Loans materialised at game setup resolved their owner against `game_players`, so a club entered *solely* in a domestic cup — no squad in this game — was read as absent and the loan was stored with a null parent. Two consequences, one cosmetic and one not:

- The incoming-transfers page fell over rendering the missing club's crest.
- At season end those players would have been **freed rather than returned** to their owner.

Both were reproduced on a Dutch save carrying three Wolves players whose owner had vanished.

`SetupNewGame::initializeLoansFromTemplates()` now counts a club as present in the game if it **either** fields a squad **or** is entered in one of the game's competitions.

The two are genuinely independent, which the first revision of this branch got wrong: it simply swapped `game_players` for `competition_entries`, and `LoanImportTest` failed. That test was right — `copyCompetitionTeamsToGame()` drops reserve teams from domestic cups, so a club can field a squad and still be missing from `competition_entries`, and reading only that table would have broken the case the old code handled while fixing the new one. Reading both leaves no club worse off.

**This fixes games created from here on only.** An earlier revision carried a migration to repair saves already holding a null parent; it has been dropped, so those loans stay as they are and their players will still be freed rather than returned at season end. The crash is covered regardless — the null-tolerance below handles it — but the season-end behaviour on existing saves is not.

A null parent stays legitimate for an owner genuinely outside the game (a foreign or excluded club), so rather than have every caller guard for itself, `x-team-crest` and the loans-in row now tolerate one.

## Say who a player is on loan from

The player detail modal gave no hint that a player was borrowed — ter Stegen sat in the Ajax squad with nothing to say he belongs to Barcelona and leaves in June. It now carries an *On Loan* chip and, under Details, the other club with its crest plus the return date.

A reserve call-up is a loan internally (parent = the user's own B team), so loans whose parent is one of the user's own teams are excluded — that is squad management, not a cession, and the call-up controls already surface it.

The banner had grown to three stacked rows, one of them the club the reader is already looking at. Nationality, position and age now share a single line, and the club appears only for a player outside the user's teams, where scouting and explore need it.

New keys `squad.loaned_from` / `squad.loaned_to` added to both `lang/en` and `lang/es`.

## Verification

`LoanImportTest` gains the cup-only owner as a fourth case, alongside the squad-fielding owner it already covered and the owner in neither. That was the gap: nothing tested the situation this PR exists to fix.

Not verified locally — this environment has PHP 8.4 against the project's 8.5, so the suite could not be run here. CI is the check. The banner and modal changes were reviewed in both themes at 375px and desktop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014A9uRCuuUg4u9zo2uZcKWS