### PR TITLE
Stop the sofascore backfill deadlocking against live gameplay

### DIFF
--- a/database/migrations/2026_09_07_000001_backfill_sofascore_ids.php
+++ b/database/migrations/2026_09_07_000001_backfill_sofascore_ids.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\QueryException;
 use Illuminate\Support\Facades\DB;
 
 /**
@@ -18,13 +19,20 @@ use Illuminate\Support\Facades\DB;
  * gap it left behind, in two hops:
  *
  *   1. templates  — from the map, keyed on transfermarkt_id
- *   2. game_players — from the templates, for careers already in progress
- *      (SetupNewGame copies the column at setup time, so saves created after
- *      the refresh baked in the null)
+ *   2. game_players — from the templates, for the saves already in progress
+ *      that copied the column at setup time and so baked in the null
  *
  * Both hops only ever fill NULLs, so this is safe to re-run — which matters,
  * because refreshing people.csv and rebuilding the map covers more players and
  * the same backfill then wants running again.
+ *
+ * Runs outside a transaction, save by save: game_players is written to by live
+ * gameplay, and a single table-wide UPDATE held row locks for nine minutes in a
+ * lock order no app transaction shares — production deadlocked and rolled the
+ * whole backfill back. Walking only the saves built from the broken reference
+ * data, in chunks that commit as they go, takes the same locks briefly, and the
+ * re-runnable NULL-only filter means a chunk that still loses a race can simply
+ * be retried.
  *
  * Deliberately NOT done via app:refresh-player-templates: both foreign keys
  * onto game_player_templates are ON DELETE CASCADE, so a clear-and-regenerate
@@ -33,13 +41,30 @@ use Illuminate\Support\Facades\DB;
  */
 return new class extends Migration
 {
-    /** Pairs per UPDATE ... FROM (VALUES ...) statement. */
+    /** Rows per UPDATE statement. */
     private const CHUNK = 1000;
+
+    /** Attempts per chunk before a lock conflict is treated as fatal. */
+    private const ATTEMPTS = 5;
+
+    /** First reference-data season whose templates shipped without the ids. */
+    private const BROKEN_FROM_SEASON = '2026';
+
+    /** Each chunk commits on its own — see the note above. */
+    public $withinTransaction = false;
 
     public function up(): void
     {
-        $this->backfillTemplates();
-        $this->backfillGamePlayers();
+        // Fail a blocked chunk fast rather than queue behind a long-running
+        // gameplay transaction while holding locks of our own.
+        DB::statement("SET lock_timeout = '5s'");
+
+        try {
+            $this->backfillTemplates();
+            $this->backfillGamePlayers();
+        } finally {
+            DB::statement('RESET lock_timeout');
+        }
     }
 
     /**
@@ -77,14 +102,14 @@ return new class extends Migration
             $placeholders = implode(',', array_fill(0, count($chunk), '(?,?)'));
             $bindings = array_merge(...$chunk);
 
-            DB::statement(
+            $this->retrying(fn () => DB::statement(
                 "UPDATE game_player_templates t
                  SET sofascore_id = v.sofascore_id
                  FROM (VALUES {$placeholders}) AS v(transfermarkt_id, sofascore_id)
                  WHERE t.transfermarkt_id = v.transfermarkt_id
                    AND t.sofascore_id IS NULL",
                 $bindings,
-            );
+            ));
         }
     }
 
@@ -93,18 +118,82 @@ return new class extends Migration
      *
      * sofascore_id is a pure function of transfermarkt_id, so the several
      * template rows a player can have across seasons all carry the same value
-     * and the row UPDATE ... FROM happens to pick does not matter.
+     * and which one the LIMIT 1 picks does not matter.
      */
     private function backfillGamePlayers(): void
     {
-        DB::statement(
-            'UPDATE game_players gp
-             SET sofascore_id = t.sofascore_id
-             FROM game_player_templates t
-             WHERE t.transfermarkt_id = gp.transfermarkt_id
-               AND t.sofascore_id IS NOT NULL
-               AND gp.sofascore_id IS NULL',
-        );
+        foreach ($this->affectedGameIds() as $gameId) {
+            // One save's rows reach through the game_id index and fit in memory
+            // (a squad database is a few thousand players), which keeps this off
+            // a full-table scan of what is by far the largest table here.
+            $ids = DB::table('game_players')
+                ->where('game_id', $gameId)
+                ->whereNull('sofascore_id')
+                ->whereNotNull('transfermarkt_id')
+                ->pluck('id');
+
+            foreach ($ids->chunk(self::CHUNK) as $chunk) {
+                $this->retrying(fn () => DB::table('game_players')
+                    ->whereIn('id', $chunk)
+                    ->whereNull('sofascore_id')
+                    ->update([
+                        'sofascore_id' => DB::raw(
+                            '(SELECT t.sofascore_id
+                                FROM game_player_templates t
+                               WHERE t.transfermarkt_id = game_players.transfermarkt_id
+                                 AND t.sofascore_id IS NOT NULL
+                               LIMIT 1)'
+                        ),
+                    ]));
+            }
+        }
+    }
+
+    /**
+     * The saves that could have copied a null.
+     *
+     * base_season is pinned at creation and names the data/{season}/ vintage a
+     * save's squads were copied from, so anything older than the refresh got a
+     * populated id at setup and has nothing to fix. Tournament saves come along
+     * regardless of it: they pin base_season to 2025 but
+     * SaveSquadSelection::createTournamentGamePlayers reads whatever templates
+     * are current, so one started after the refresh copied the null too.
+     *
+     * @return list<string>
+     */
+    private function affectedGameIds(): array
+    {
+        return DB::table('games')
+            ->where(fn ($q) => $q
+                ->where('base_season', '>=', self::BROKEN_FROM_SEASON)
+                ->orWhere('game_mode', 'tournament'))
+            ->orderBy('id')
+            ->pluck('id')
+            ->all();
+    }
+
+    /**
+     * Retry a chunk that lost a lock race with live gameplay.
+     *
+     * 40P01 deadlock, 40001 serialization failure, 55P03 lock_timeout — all
+     * transient, and the backfill only ever fills NULLs, so a replay is a no-op
+     * for whatever the failed attempt managed to commit.
+     */
+    private function retrying(callable $chunk): void
+    {
+        for ($attempt = 1; ; $attempt++) {
+            try {
+                $chunk();
+
+                return;
+            } catch (QueryException $e) {
+                if ($attempt >= self::ATTEMPTS || ! in_array($e->getCode(), ['40P01', '40001', '55P03'], true)) {
+                    throw $e;
+                }
+
+                usleep(250_000 * $attempt);
+            }
+        }
     }
 
     public function down(): void

--- a/tests/Feature/BackfillSofascoreIdsMigrationTest.php
+++ b/tests/Feature/BackfillSofascoreIdsMigrationTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Game;
+use App\Models\GamePlayer;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+/**
+ * The 2026_09_07 backfill deadlocked in production against live gameplay, so it
+ * was rewritten to run outside a transaction, save by save, over only the saves
+ * built from the broken reference data. This pins what that rewrite could get
+ * wrong: which saves it visits, and that it still fills every matchable row.
+ */
+class BackfillSofascoreIdsMigrationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_fills_players_in_saves_built_from_the_broken_data(): void
+    {
+        $broken = Game::factory()->create(['season' => '2026', 'base_season' => '2026']);
+        $tournament = Game::factory()->create(['game_mode' => Game::MODE_TOURNAMENT]);
+        $untouched = Game::factory()->create(['base_season' => '2025']);
+
+        $filled = collect([$broken, $tournament])->map(fn (Game $game) => $this->playerWithTemplate($game));
+        $skipped = $this->playerWithTemplate($untouched);
+
+        // Same save as $broken, but no template carries its transfermarkt_id.
+        $unmatched = GamePlayer::factory()->create([
+            'game_id' => $broken->id,
+            'transfermarkt_id' => 'no-template-'.Str::uuid(),
+            'sofascore_id' => null,
+        ]);
+
+        $this->runMigration();
+
+        foreach ($filled as $player) {
+            $this->assertSame('sofa-'.$player->transfermarkt_id, $player->fresh()->sofascore_id);
+        }
+
+        $this->assertNull($skipped->fresh()->sofascore_id);
+        $this->assertNull($unmatched->fresh()->sofascore_id);
+    }
+
+    /** A player missing its id, with a template that can supply one. */
+    private function playerWithTemplate(Game $game): GamePlayer
+    {
+        $player = GamePlayer::factory()->create([
+            'game_id' => $game->id,
+            'sofascore_id' => null,
+        ]);
+
+        DB::table('game_player_templates')->insert([
+            'season' => 2026,
+            'player_id' => (string) Str::uuid(),
+            'position' => 'Central Midfield',
+            'transfermarkt_id' => $player->transfermarkt_id,
+            'sofascore_id' => 'sofa-'.$player->transfermarkt_id,
+        ]);
+
+        return $player;
+    }
+
+    private function runMigration(): void
+    {
+        (require base_path('database/migrations/2026_09_07_000001_backfill_sofascore_ids.php'))->up();
+    }
+}


### PR DESCRIPTION
The `2026_09_07_000001_backfill_sofascore_ids` migration failed in production:

```
2026_09_07_000001_backfill_sofascore_ids ....................... 8m 59s FAIL
SQLSTATE[40P01]: Deadlock detected ... while updating tuple (204699,35) in relation "game_players"
```

## What went wrong

The migration ran as **one transaction** — Laravel wraps migrations and Postgres supports transactional DDL — so the single table-wide `UPDATE game_players` held row locks over the whole table for nine minutes while live gameplay wrote to the same rows in its own lock order. Deadlock, and the entire backfill rolled back (the migration was never logged, so `migrate` will pick it up again as-is).

## What changed

- **`public $withinTransaction = false`** — the root cause. Chunks now commit as they go instead of accumulating locks for the length of the run.
- **Scoped to the saves that could actually have copied a null** — `base_season >= '2026'`, plus tournaments, which pin `base_season` to 2025 but take their squads from whatever templates are current (`SaveSquadSelection::createTournamentGamePlayers`). Those, with `SetupNewGame` and `SetupTournamentGame`, are the only writers that copy the column, so nothing affected falls outside the filter. Each save's rows come through the `game_id` index rather than scanning the largest table in the schema end to end.
- **`SET lock_timeout = '5s'` + retry on `40P01`/`40001`/`55P03`** — a chunk that loses a lock race fails fast and replays instead of queueing behind a long gameplay transaction while holding locks of its own. Safe to replay: the backfill only ever fills NULLs.

## Test

`tests/Feature/BackfillSofascoreIdsMigrationTest` pins the scope and the fill: a 2026 save and a tournament save get their ids, a 2025 career save is skipped, and a player whose `transfermarkt_id` has no template is left null.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DqXGiiSjzgVM5pCunrXTg5