### PR TITLE
Restore laravel/nightwatch, patch the Livewire XSS advisory

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -92,6 +92,13 @@ RUN_MIGRATIONS=true
 # CIDR list (e.g. "10.0.0.0/8,172.16.0.0/12") for tighter scoping.
 TRUSTED_PROXIES=
 
+# Laravel Nightwatch — first-party APM/error tracking. Token is issued from
+# the Nightwatch dashboard. Disabled by default; enable in production.
+# The ingest agent runs as a separate process (`artisan nightwatch:agent`);
+# on Forge it is the Nightwatch daemon, so the package must stay in `require`.
+NIGHTWATCH_ENABLED=false
+NIGHTWATCH_TOKEN=
+
 # Slack webhook for Laravel logging channel (and reused by Grafana alerts in
 # the monitoring stack). See config/logging.php → 'slack' channel.
 LOG_SLACK_WEBHOOK_URL=

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
         "jenssegers/agent": "^2.6",
         "laravel/framework": "^13.0",
         "laravel/horizon": "^5.43",
+        "laravel/nightwatch": "^1.30",
         "laravel/octane": "^2.13",
         "laravel/pulse": "^1.7",
         "symfony/http-client": "^8.1"

--- a/composer.lock
+++ b/composer.lock
@@ -2711,16 +2711,16 @@
         },
         {
             "name": "livewire/livewire",
-            "version": "v4.3.1",
+            "version": "v4.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/livewire/livewire.git",
-                "reference": "6a9dd03f45a4b200abfd0ff644745b23fa7baaaa"
+                "reference": "92f1427022714b34024459167aa6a85d4fb4af44"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/livewire/livewire/zipball/6a9dd03f45a4b200abfd0ff644745b23fa7baaaa",
-                "reference": "6a9dd03f45a4b200abfd0ff644745b23fa7baaaa",
+                "url": "https://api.github.com/repos/livewire/livewire/zipball/92f1427022714b34024459167aa6a85d4fb4af44",
+                "reference": "92f1427022714b34024459167aa6a85d4fb4af44",
                 "shasum": ""
             },
             "require": {
@@ -2775,7 +2775,7 @@
             "description": "A front-end framework for Laravel.",
             "support": {
                 "issues": "https://github.com/livewire/livewire/issues",
-                "source": "https://github.com/livewire/livewire/tree/v4.3.1"
+                "source": "https://github.com/livewire/livewire/tree/v4.4.3"
             },
             "funding": [
                 {
@@ -2783,7 +2783,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-06-02T08:58:52+00:00"
+            "time": "2026-08-31T15:40:58+00:00"
         },
         {
             "name": "mobiledetect/mobiledetectlib",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fc0f3750efa9c5ebced07ca17ad143f2",
+    "content-hash": "840cf431d0c18a94d1160e32271aefe8",
     "packages": [
         {
             "name": "brick/math",
@@ -1702,6 +1702,100 @@
                 "source": "https://github.com/laravel/horizon/tree/v5.47.2"
             },
             "time": "2026-06-03T15:11:37+00:00"
+        },
+        {
+            "name": "laravel/nightwatch",
+            "version": "v1.30.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/nightwatch.git",
+                "reference": "f20bc54ac22347d393882de6b9f6948a27d1f41a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/nightwatch/zipball/f20bc54ac22347d393882de6b9f6948a27d1f41a",
+                "reference": "f20bc54ac22347d393882de6b9f6948a27d1f41a",
+                "shasum": ""
+            },
+            "require": {
+                "ext-zlib": "*",
+                "guzzlehttp/promises": "^2.0|^3.0",
+                "laravel/framework": "^10.0|^11.0|^12.0|^13.0",
+                "monolog/monolog": "^3.6",
+                "nesbot/carbon": "^2.0|^3.0",
+                "php": "^8.2",
+                "psr/http-message": "^1.0|^2.0",
+                "psr/log": "^1.0|^2.0|^3.0",
+                "ramsey/uuid": "^4.0",
+                "symfony/console": "^6.0|^7.0|^8.0",
+                "symfony/http-foundation": "^6.0|^7.0|^8.0",
+                "symfony/polyfill-php84": "^1.29"
+            },
+            "require-dev": {
+                "aws/aws-sdk-php": "^3.349",
+                "ext-pcntl": "*",
+                "ext-pdo": "*",
+                "guzzlehttp/guzzle": "^7.0|^8.0",
+                "guzzlehttp/psr7": "^2.0|^3.0",
+                "laravel/horizon": "^5.4",
+                "laravel/pint": "1.21.0",
+                "laravel/vapor-core": "^2.38.2",
+                "livewire/livewire": "^2.0|^3.0",
+                "mockery/mockery": "^1.0",
+                "mongodb/laravel-mongodb": "^4.0|^5.0",
+                "orchestra/testbench": "^8.0|^9.0|^10.0|^11.0",
+                "orchestra/testbench-core": "^8.0|^9.0|^10.0|^11.0",
+                "orchestra/workbench": "^8.0|^9.0|^10.0|^11.0",
+                "phpstan/phpstan": "^1.0",
+                "phpunit/phpunit": "^10.0|^11.0|^12.0",
+                "singlestoredb/singlestoredb-laravel": "^1.0|^2.0",
+                "spatie/laravel-ignition": "^2.0",
+                "symfony/mailer": "^6.0|^7.0|^8.0",
+                "symfony/mime": "^6.0|^7.0|^8.0",
+                "symfony/var-dumper": "^6.0|^7.0|^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "aliases": {
+                        "Nightwatch": "Laravel\\Nightwatch\\Facades\\Nightwatch"
+                    },
+                    "providers": [
+                        "Laravel\\Nightwatch\\NightwatchServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "files": [
+                    "agent/helpers.php"
+                ],
+                "psr-4": {
+                    "Laravel\\Nightwatch\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "The official Laravel Nightwatch package.",
+            "homepage": "https://nightwatch.laravel.com",
+            "keywords": [
+                "Insights",
+                "laravel",
+                "monitoring"
+            ],
+            "support": {
+                "docs": "https://nightwatch.laravel.com/docs",
+                "issues": "https://github.com/laravel/nightwatch/issues",
+                "source": "https://github.com/laravel/nightwatch"
+            },
+            "time": "2026-08-26T00:31:27+00:00"
         },
         {
             "name": "laravel/octane",


### PR DESCRIPTION
## Why

The Nightwatch daemon on Forge has been crash-looping on:

```
ERROR  There are no commands defined in the "nightwatch" namespace.
```

Root cause: **#1322 removed `laravel/nightwatch` as an unreferenced production dependency.** It *was* referenced — just not from anywhere in this repo. Forge runs the ingest agent as a dashboard-configured daemon:

```
php8.5 artisan nightwatch:agent --no-interaction --listen-on=127.0.0.1:2408
```

Forge daemons live in the Forge dashboard, not the working tree, so a grep for "who uses this package" came back empty and the dependency looked dead. The next deploy dropped it from `vendor/`, and the daemon has been restarting into that error ever since.

(For the record: `91979d73` installed it → `a8a005ce` removed → `882579e2` reverted the removal → `23dbf002` removed it again. This is the third round trip.)

## What

**`Restore laravel/nightwatch`** — re-adds the package (`^1.30`, was `^1.22`) and the `.env.example` block. The comment now names the Forge daemon explicitly, so the next dependency audit doesn't repeat the same reasoning:

```
# The ingest agent runs as a separate process (`artisan nightwatch:agent`);
# on Forge it is the Nightwatch daemon, so the package must stay in `require`.
```

**`Patch the Livewire DOM XSS advisory`** — unrelated, found by `composer audit` while the lockfile was already open. `livewire/livewire` v4.3.1 → v4.4.3, closing CVE-2026-81887 (medium, DOM-based XSS in client-side state handling, affects `<=4.3.3`). Transitive via `laravel/pulse`, so lockfile-only; updated without `--with-dependencies` to keep it to the one package that needed it.

## Verified

- `php artisan list nightwatch` in the 8.5 container registers `nightwatch:agent`, `nightwatch:deploy`, `nightwatch:status`
- `composer audit` → "No security vulnerability advisories found"
- `php artisan about` boots clean on Laravel 13.15.0 / PHP 8.5.6

## After merge — manual steps on Forge

1. Set `NIGHTWATCH_TOKEN` and `NIGHTWATCH_ENABLED=true` in the site `.env` (dashboard, not this repo)
2. Deploy
3. **Restart the Nightwatch daemon** — it won't pick up the new `vendor/` on its own

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A8nnJ3SmvrzGhREG7QPCue