### PR TITLE
Charge pre-contract wages to next season's salary cap, not this one

### DIFF
--- a/app/Http/Actions/NegotiatePreContract.php
+++ b/app/Http/Actions/NegotiatePreContract.php
@@ -184,11 +184,13 @@ class NegotiatePreContract
             'clause' => ['nullable', 'integer', 'min:0'],
         ]);
 
-        // Salary cap: block the offer before the player can accept it.
-        if (! $this->salaryCapService->canCommitWage($game, $validated['wage'] * 100)) {
+        // Salary cap: block the offer before the player can accept it. A
+        // pre-contract wage starts next season, so it is gated on next
+        // season's bill (see SalaryCapService::canCommitNextSeasonWage).
+        if (! $this->salaryCapService->canCommitNextSeasonWage($game, $validated['wage'] * 100)) {
             return response()->json([
                 'status' => 'error',
-                'message' => $this->salaryCapService->blockMessage($game, $player->name, $validated['wage'] * 100),
+                'message' => $this->salaryCapService->nextSeasonBlockMessage($game, $player->name, $validated['wage'] * 100),
             ], 422);
         }
 
@@ -206,7 +208,9 @@ class NegotiatePreContract
                 'game_id' => $game->id,
                 'game_player_id' => $player->id,
                 'offering_team_id' => $game->team_id,
-                'selling_team_id' => $player->team_id,
+                // The owning club, not the player's current location — see
+                // TransferService::submitPreContractOffer.
+                'selling_team_id' => $player->owningTeamId(),
                 'offer_type' => TransferOffer::TYPE_PRE_CONTRACT,
                 'direction' => TransferOffer::DIRECTION_INCOMING,
                 'transfer_fee' => 0,
@@ -287,10 +291,10 @@ class NegotiatePreContract
         }
 
         // Salary cap: re-check against the wage the player is holding out for.
-        if (! $this->salaryCapService->canCommitWage($game, (int) $offer->wage_counter_offer)) {
+        if (! $this->salaryCapService->canCommitNextSeasonWage($game, (int) $offer->wage_counter_offer)) {
             return response()->json([
                 'status' => 'error',
-                'message' => $this->salaryCapService->blockMessage($game, $player->name, (int) $offer->wage_counter_offer),
+                'message' => $this->salaryCapService->nextSeasonBlockMessage($game, $player->name, (int) $offer->wage_counter_offer),
             ], 422);
         }
 

--- a/app/Http/Actions/SubmitPreContractOffer.php
+++ b/app/Http/Actions/SubmitPreContractOffer.php
@@ -31,11 +31,13 @@ class SubmitPreContractOffer
 
         $offeredWageCents = (int) ($validated['offered_wage'] * 100);
 
-        // Salary cap: a pre-contract is a free signing — block it if the
-        // committed wage bill would breach the cap.
-        if (! $this->salaryCapService->canCommitWage($game, $offeredWageCents)) {
+        // Salary cap: a pre-contract is a free signing whose wage starts next
+        // season, so it is gated on next season's committed bill — not this
+        // season's, which still carries contracts and loans that expire before
+        // the new wage ever begins.
+        if (! $this->salaryCapService->canCommitNextSeasonWage($game, $offeredWageCents)) {
             return redirect()->route('game.transfers', $gameId)
-                ->with('error', $this->salaryCapService->blockMessage($game, $player->name, $offeredWageCents));
+                ->with('error', $this->salaryCapService->nextSeasonBlockMessage($game, $player->name, $offeredWageCents));
         }
 
         try {

--- a/app/Http/Views/ShowOutgoingTransfers.php
+++ b/app/Http/Views/ShowOutgoingTransfers.php
@@ -46,11 +46,17 @@ class ShowOutgoingTransfers
         $unsolicitedOffers = $pendingOffers->where('offer_type', TransferOffer::TYPE_UNSOLICITED);
         $listedOffers = $pendingOffers->where('offer_type', TransferOffer::TYPE_LISTED);
 
-        // Pre-contract offers (players being poached)
+        // Pre-contract offers (players being poached).
+        //
+        // The offering_team_id guard keeps the user's *own* incoming deals out
+        // of the departures list. A player the user has loaned in sits at the
+        // user's team_id, so without it a pre-contract the user himself signed
+        // renders here as one of his players leaving on a free.
         $preContractOffers = TransferOffer::with(['gamePlayer', 'offeringTeam'])
             ->where('game_id', $gameId)
             ->where('status', TransferOffer::STATUS_PENDING)
             ->where('offer_type', TransferOffer::TYPE_PRE_CONTRACT)
+            ->where('offering_team_id', '!=', $game->team_id)
             ->whereHas('gamePlayer', function ($query) use ($game) {
                 $query->where('team_id', $game->team_id);
             })
@@ -63,6 +69,7 @@ class ShowOutgoingTransfers
             ->where('game_id', $gameId)
             ->where('status', TransferOffer::STATUS_AGREED)
             ->where('offer_type', TransferOffer::TYPE_PRE_CONTRACT)
+            ->where('offering_team_id', '!=', $game->team_id)
             ->whereHas('gamePlayer', function ($query) use ($game) {
                 $query->where('team_id', $game->team_id);
             })
@@ -73,6 +80,7 @@ class ShowOutgoingTransfers
             ->where('game_id', $gameId)
             ->where('status', TransferOffer::STATUS_AGREED)
             ->where('offer_type', '!=', TransferOffer::TYPE_PRE_CONTRACT)
+            ->where('offering_team_id', '!=', $game->team_id)
             ->whereHas('gamePlayer', function ($query) use ($game) {
                 $query->where('team_id', $game->team_id);
             })

--- a/app/Http/Views/ShowPlayerDetail.php
+++ b/app/Http/Views/ShowPlayerDetail.php
@@ -89,7 +89,7 @@ class ShowPlayerDetail
             && $gamePlayer->isUserOwned($game)
             && in_array($gamePlayer->team_id, $game->userTeamIds(), true)
             && !$gamePlayer->isRetiring()
-            && !$gamePlayer->hasPreContractAgreement()
+            && !$gamePlayer->hasAgreedPreContractDeparture()
             && !$gamePlayer->hasRenewalAgreed()
             && !$gamePlayer->hasAgreedTransfer()
             && !$gamePlayer->hasActiveLoanSearch();

--- a/app/Models/GamePlayer.php
+++ b/app/Models/GamePlayer.php
@@ -460,6 +460,26 @@ class GamePlayer extends Model
      * Loaned-out players (gone elsewhere but parent-owned by the user) count.
      * Loaned-in players from a third-party club do not.
      */
+    /**
+     * The id of the club that actually owns the player's contract.
+     *
+     * A loan rewrites team_id to wherever the player is playing (see
+     * LoanService::completeLoanOut / completeLoanIn), so for anyone on loan
+     * team_id is a location, not an owner. Any deal negotiated with the
+     * selling club must be recorded against this id: record the location
+     * instead and completion stops recognising the seller the moment the loan
+     * ends, because TransferCompletionService re-asserts that the player is
+     * still at the club that agreed to sell him.
+     */
+    public function owningTeamId(): ?string
+    {
+        $loan = $this->relationLoaded('activeLoan')
+            ? $this->activeLoan
+            : $this->activeLoan()->first();
+
+        return $loan?->parent_team_id ?? $this->team_id;
+    }
+
     public function isUserOwned(Game $game): bool
     {
         $teamIds = $game->userTeamIds();
@@ -550,7 +570,44 @@ class GamePlayer extends Model
     }
 
     /**
-     * Check if player has an agreed pre-contract (leaving on free transfer at end of season).
+     * Whether the player has agreed a pre-contract that takes him *away* from
+     * the club he currently sits at — i.e. he leaves on a free at season end.
+     *
+     * A pre-contract whose buying club is the club the player is already at is
+     * not a departure: that is a club signing a player it currently holds on
+     * loan, who joins permanently instead of going back to his parent club.
+     * Without the distinction such a signing reads as "leaving on a free"
+     * across the squad and transfer surfaces, because a loaned-in player's
+     * team_id is the borrowing club (see LoanService::completeLoanIn).
+     */
+    public function hasAgreedPreContractDeparture(): bool
+    {
+        // A free agent has no club to leave.
+        if ($this->team_id === null) {
+            return false;
+        }
+
+        if ($this->relationLoaded('transferOffers')) {
+            return $this->transferOffers->contains(function ($offer) {
+                return $offer->status === TransferOffer::STATUS_AGREED
+                    && $offer->offer_type === TransferOffer::TYPE_PRE_CONTRACT
+                    && $offer->offering_team_id !== $this->team_id;
+            });
+        }
+
+        return $this->transferOffers()
+            ->where('status', TransferOffer::STATUS_AGREED)
+            ->where('offer_type', TransferOffer::TYPE_PRE_CONTRACT)
+            ->where('offering_team_id', '!=', $this->team_id)
+            ->exists();
+    }
+
+    /**
+     * Check if player has any agreed pre-contract, in either direction.
+     *
+     * Use this where the question is "is this player's contract situation
+     * already settled" (so he should receive no further offers). Where the
+     * question is "is he leaving", use hasAgreedPreContractDeparture().
      */
     public function hasPreContractAgreement(): bool
     {
@@ -606,7 +663,7 @@ class GamePlayer extends Model
             return false;
         }
 
-        if ($this->hasRenewalAgreed() || $this->hasPreContractAgreement()) {
+        if ($this->hasRenewalAgreed() || $this->hasAgreedPreContractDeparture()) {
             return false;
         }
 
@@ -757,7 +814,7 @@ class GamePlayer extends Model
         }
 
         // Already agreed to leave on pre-contract
-        if ($this->hasPreContractAgreement()) {
+        if ($this->hasAgreedPreContractDeparture()) {
             return false;
         }
 

--- a/app/Modules/Finance/Services/SalaryCapService.php
+++ b/app/Modules/Finance/Services/SalaryCapService.php
@@ -6,6 +6,7 @@ use App\Models\Game;
 use App\Models\GamePlayer;
 use App\Models\TeamReputation;
 use App\Models\TransferOffer;
+use App\Modules\Squad\Services\NextSeasonProjectionService;
 use App\Support\Money;
 
 /**
@@ -34,6 +35,7 @@ class SalaryCapService
 
     public function __construct(
         private readonly BudgetProjectionService $budgetProjectionService,
+        private readonly NextSeasonProjectionService $nextSeasonProjectionService,
     ) {}
 
     /**
@@ -77,18 +79,22 @@ class SalaryCapService
     }
 
     /**
-     * The total annual wage the club is *committed* to, in cents.
+     * The total annual wage the club is *committed* to this season, in cents.
      *
      * Counts every player currently on the roster (including loaned-in players,
      * whose full wage the borrowing club pays — there is no loan subsidy) plus
      * any wages already agreed but not yet applied:
      *  - players with a pending renewal are counted at their pending wage;
-     *  - agreed-but-uncompleted incoming signings (free agents, pre-contracts,
-     *    transfers parked as AGREED) are counted at their offered wage.
+     *  - agreed-but-uncompleted incoming signings (free agents, transfers
+     *    parked as AGREED, loan-ins) are counted at their offered wage.
      *
      * Counting agreed-but-pending commitments stops a manager from stacking
      * several signings/renewals in one window that each fit individually but
-     * blow past the cap once they all apply.
+     * blow past the cap once they all apply. That reasoning holds only for
+     * deals that land *this* season, which is why pre-contracts are absent:
+     * they are explicitly held back from mid-season completion
+     * (TransferService::completeAgreedTransfers) and arrive at the season
+     * boundary, so they are charged to nextSeasonCommittedWageBill() instead.
      */
     public function committedWageBill(Game $game): int
     {
@@ -105,15 +111,36 @@ class SalaryCapService
             ->where('status', TransferOffer::STATUS_AGREED)
             ->whereIn('offer_type', [
                 TransferOffer::TYPE_USER_BID,
-                TransferOffer::TYPE_PRE_CONTRACT,
                 // Loaned-in players are paid in full, so an agreed-but-pending
                 // loan-in is a committed wage too (LoanService::requestLoanIn
                 // stamps offered_wage with the player's annual_wage).
                 TransferOffer::TYPE_LOAN_IN,
             ])
+            // A player already on the roster is in $squadWages at the wage he
+            // is actually being paid, so his agreed deal must not be added on
+            // top. This happens when the club buys a player it currently has
+            // on loan: a loaned-in player's team_id is the borrowing club
+            // (LoanService::completeLoanIn), so both halves would match him.
+            ->whereDoesntHave('gamePlayer', function ($query) use ($game) {
+                $query->where('team_id', $game->team_id);
+            })
             ->sum('offered_wage');
 
         return $squadWages + $agreedIncoming;
+    }
+
+    /**
+     * The total annual wage the club is committed to for the *start of next
+     * season*, in cents. Delegates to the squad planner's projection so the
+     * number always agrees with the roster the user is shown there.
+     *
+     * This is what a pre-contract must be measured against: its wage does not
+     * start until the season boundary, by which point contracts have run out,
+     * borrowed players have gone home and retirements have taken effect.
+     */
+    public function nextSeasonCommittedWageBill(Game $game): int
+    {
+        return $this->nextSeasonProjectionService->nextSeasonWageBill($game);
     }
 
     /**
@@ -181,6 +208,55 @@ class SalaryCapService
         }
 
         return ($committed - $freedWage + $newWage) <= $cap;
+    }
+
+    /**
+     * Whether committing $newWage *for next season* would keep the club within
+     * its cap — the gate for pre-contracts, whose wages start at the season
+     * boundary rather than now.
+     *
+     * Measured against the current cap because next season's revenue has not
+     * been projected yet: the pre-contract window runs January–May, and
+     * BudgetProjectionService only generates the new season's numbers during
+     * setup. The current ceiling is the honest available proxy, and a club
+     * that grows its revenue simply finds it has more room than it planned for.
+     *
+     * The over-the-cap freeze still applies. A club that has blown this
+     * season's bill cannot go on signing free agents for next season while
+     * the market is locked — the recovery path is selling, as it is everywhere
+     * else (see canCommitWage).
+     */
+    public function canCommitNextSeasonWage(Game $game, int $newWage): bool
+    {
+        if ($this->isOverCap($game)) {
+            return false;
+        }
+
+        return ($this->nextSeasonCommittedWageBill($game) + $newWage) <= $this->cap($game);
+    }
+
+    /**
+     * Localised "this would breach next season's cap" message for a blocked
+     * pre-contract. Mirrors blockMessage() but spells out that the shortfall is
+     * against next season's wage bill, so the number can be reconciled with the
+     * squad planner rather than with the current-season meter.
+     */
+    public function nextSeasonBlockMessage(Game $game, string $playerName, int $newWage): string
+    {
+        if ($this->isOverCap($game)) {
+            return __('messages.salary_cap_locked');
+        }
+
+        $projectedBill = $this->nextSeasonCommittedWageBill($game) + $newWage;
+        $cap = $this->cap($game);
+
+        return __('messages.pre_contract_exceeds_salary_cap', [
+            'player' => $playerName,
+            'wage' => Money::format($newWage),
+            'total' => Money::format($projectedBill),
+            'cap' => Money::format($cap),
+            'shortfall' => Money::format(max(0, $projectedBill - $cap)),
+        ]);
     }
 
     /**

--- a/app/Modules/Season/Processors/ContractExpirationProcessor.php
+++ b/app/Modules/Season/Processors/ContractExpirationProcessor.php
@@ -136,25 +136,32 @@ class ContractExpirationProcessor implements SeasonProcessor
             ->whereNull('pending_annual_wage')
             ->pluck('id');
 
-        // Players with agreed outgoing pre-contracts stay on their team
-        // until the pre-contract transfer processor moves them — skip them.
+        // Players with an agreed pre-contract stay at their club until
+        // PreContractTransferProcessor (priority 30) moves them — skip them
+        // here, in *both* directions and at every club, not just the user's.
+        //
+        // Outgoing: the player must still be at the user's club for
+        // completePreContractTransfers to find him.
+        //
+        // Incoming: the deal only completes while the player is still at the
+        // club that agreed to sell him — TransferCompletionService re-asserts
+        // that before moving him. Freeing him here sets team_id = null, so the
+        // signing the user negotiated is rejected as "transfer fell through".
+        // That is not an edge case: a club declining to renew is precisely why
+        // a pre-contract exists, so the ordinary Bosman signing was the one
+        // failing, and silently.
         $preContractPlayerIds = TransferOffer::where('game_id', $game->id)
             ->where('status', TransferOffer::STATUS_AGREED)
             ->where('offer_type', TransferOffer::TYPE_PRE_CONTRACT)
-            ->where(function ($query) {
-                $query->whereNull('direction')
-                    ->orWhere('direction', '!=', TransferOffer::DIRECTION_INCOMING);
-            })
             ->pluck('game_player_id')
             ->flip()
             ->all();
 
-        $userTeamFreeAgentIds = $userTeamExpiredIds
-            ->reject(fn ($id) => isset($preContractPlayerIds[$id]))
-            ->all();
-
         // Bulk operations
-        $freeAgentIds = array_merge($userTeamFreeAgentIds, $veteranFreeAgentIds, $nonVeteranFreeAgentIds);
+        $freeAgentIds = array_values(array_filter(
+            array_merge($userTeamExpiredIds->all(), $veteranFreeAgentIds, $nonVeteranFreeAgentIds),
+            fn ($id) => ! isset($preContractPlayerIds[$id]),
+        ));
         if (!empty($freeAgentIds)) {
             // A release clause is a contract attribute: non-null ⟺ under
             // contract. Becoming a free agent nulls it (harmless no-op for saves

--- a/app/Modules/Squad/Services/NextSeasonProjectionService.php
+++ b/app/Modules/Squad/Services/NextSeasonProjectionService.php
@@ -137,6 +137,103 @@ class NextSeasonProjectionService
     }
 
     /**
+     * The annual wage the club is committed to for the *start of next season*,
+     * in cents.
+     *
+     * The current-season bill (SalaryCapService::committedWageBill) answers a
+     * different question: what the club pays right now. The two diverge sharply
+     * during the January–May pre-contract window, because most of what changes
+     * at the season boundary is already known — contracts run out, borrowed
+     * players go home, players retire, and pre-contracts arrive. Gating a
+     * next-season commitment on the current-season bill therefore charges a
+     * wage against liabilities that will not exist when that wage starts.
+     *
+     * Counts, using the same staying/outgoing/incoming classification the
+     * squad planner shows the user:
+     *  - owned players still on the books, at their agreed renewal wage where
+     *    one is pending — minus anyone loaned out across the boundary, whose
+     *    wage the borrowing club carries while he is away;
+     *  - borrowed players whose loan runs past next-season kickoff (the
+     *    borrowing club pays in full — there is no loan subsidy). Loans that
+     *    end at the boundary are excluded: that freed wage is precisely what
+     *    makes room for next season;
+     *  - reserve players who age out of the filial and move up automatically;
+     *  - agreed incoming pre-contracts and transfers, at the wage agreed
+     *    rather than the wage the player earns at his current club.
+     *
+     * Agreed loan-ins are deliberately absent: a loan returns at season end, so
+     * it is a current-season cost, not a next-season commitment.
+     */
+    public function nextSeasonWageBill(Game $game): int
+    {
+        $seasonEndDate = $game->getSeasonEndDate();
+
+        $agreedIncoming = TransferOffer::query()
+            ->where('game_id', $game->id)
+            ->where('offering_team_id', $game->team_id)
+            ->where('direction', TransferOffer::DIRECTION_INCOMING)
+            ->where('status', TransferOffer::STATUS_AGREED)
+            ->whereIn('offer_type', [
+                TransferOffer::TYPE_USER_BID,
+                TransferOffer::TYPE_PRE_CONTRACT,
+            ])
+            ->get(['game_player_id', 'offered_wage']);
+
+        // A player can be both on the roster and the subject of an agreed
+        // incoming deal — signing someone the club currently has on loan. The
+        // deal supersedes his present wage, so charge the agreed wage only.
+        $agreedPlayerIds = $agreedIncoming->pluck('game_player_id')->flip();
+
+        $total = (int) $agreedIncoming->sum('offered_wage');
+
+        foreach ($this->loadOwnedPlayers($game) as $player) {
+            if (isset($agreedPlayerIds[$player->id])) {
+                continue;
+            }
+
+            $verdict = $this->classifyOwned($player, $seasonEndDate);
+
+            if ($verdict['status'] !== self::STATUS_STAYING
+                || $verdict['reason'] === self::REASON_STILL_ON_LOAN) {
+                continue;
+            }
+
+            $total += $this->nextSeasonWageFor($player);
+        }
+
+        foreach ($this->loadLoanedInPlayers($game) as $player) {
+            if (isset($agreedPlayerIds[$player->id])) {
+                continue;
+            }
+
+            if ($this->classifyLoanedIn($player, $game, $seasonEndDate) === self::REASON_LOAN_ENDING) {
+                continue;
+            }
+
+            $total += $this->nextSeasonWageFor($player);
+        }
+
+        foreach ($this->loadIncomingReservePromotions($game) as $player) {
+            if (isset($agreedPlayerIds[$player->id])) {
+                continue;
+            }
+
+            $total += $this->nextSeasonWageFor($player);
+        }
+
+        return $total;
+    }
+
+    /**
+     * What a player already on the books will earn next season: the wage agreed
+     * in a pending renewal if there is one, otherwise his current wage.
+     */
+    private function nextSeasonWageFor(GamePlayer $player): int
+    {
+        return $player->pending_annual_wage ?? $player->annual_wage ?? 0;
+    }
+
+    /**
      * Players the user owns: physically at the user's team (and not loaned-in
      * from elsewhere), or loaned-out from the user's team to another club.
      */
@@ -268,11 +365,11 @@ class NextSeasonProjectionService
             return ['status' => self::STATUS_OUTGOING, 'reason' => self::REASON_RETIRING];
         }
 
-        if ($player->hasAgreedTransfer() && ! $player->hasPreContractAgreement()) {
+        if ($player->hasAgreedTransfer() && ! $player->hasAgreedPreContractDeparture()) {
             return ['status' => self::STATUS_OUTGOING, 'reason' => self::REASON_TRANSFER_AGREED];
         }
 
-        if ($player->hasPreContractAgreement()) {
+        if ($player->hasAgreedPreContractDeparture()) {
             return ['status' => self::STATUS_OUTGOING, 'reason' => self::REASON_PRE_CONTRACT_DEPARTING];
         }
 

--- a/app/Modules/Transfer/Services/TransferHeaderService.php
+++ b/app/Modules/Transfer/Services/TransferHeaderService.php
@@ -41,6 +41,10 @@ class TransferHeaderService
     {
         return TransferOffer::where('game_id', $game->id)
             ->where('status', TransferOffer::STATUS_PENDING)
+            // Only offers from *other* clubs are departures. A player loaned in
+            // to the user sits at the user's team_id, so a pre-contract the user
+            // himself made for that player would otherwise inflate this badge.
+            ->where('offering_team_id', '!=', $game->team_id)
             ->whereHas('gamePlayer', function ($query) use ($game) {
                 $query->where('team_id', $game->team_id);
             })

--- a/app/Modules/Transfer/Services/TransferService.php
+++ b/app/Modules/Transfer/Services/TransferService.php
@@ -1523,7 +1523,10 @@ class TransferService
             'game_id' => $game->id,
             'game_player_id' => $player->id,
             'offering_team_id' => $game->team_id,
-            'selling_team_id' => $player->team_id,
+            // The owning club, not the player's current location: a player on
+            // loan is sold by his parent club, and the deal only completes
+            // after LoanReturnProcessor has sent him back there.
+            'selling_team_id' => $player->owningTeamId(),
             'offer_type' => TransferOffer::TYPE_PRE_CONTRACT,
             'direction' => TransferOffer::DIRECTION_INCOMING,
             'transfer_fee' => 0,

--- a/lang/en/messages.php
+++ b/lang/en/messages.php
@@ -23,6 +23,7 @@ return [
     'wage_budget_exceeded' => 'Signing this player would exceed your wage budget.',
     'signing_exceeds_salary_cap' => 'Signing :player at :wage/yr would push your wage bill to :total, over your :cap salary limit. Free up :shortfall by selling players first.',
     'salary_cap_locked' => "You're over your salary limit. Sell players to get back under the limit before signing or renewing.",
+    'pre_contract_exceeds_salary_cap' => "Signing :player at :wage/yr would push next season's wage bill to :total, over your :cap salary limit. You are :shortfall short.",
 
     // Bid/loan submission confirmations
     'bid_already_exists' => 'You already have a pending bid for this player.',

--- a/lang/es/messages.php
+++ b/lang/es/messages.php
@@ -23,6 +23,7 @@ return [
     'wage_budget_exceeded' => 'Fichar a este jugador superaría tu presupuesto salarial.',
     'signing_exceeds_salary_cap' => 'Fichar a :player por :wage/año elevaría tu masa salarial a :total, por encima de tu límite salarial de :cap. Libera :shortfall vendiendo jugadores primero.',
     'salary_cap_locked' => 'Estás por encima de tu límite salarial. Vende jugadores para volver por debajo del límite antes de fichar o renovar.',
+    'pre_contract_exceeds_salary_cap' => 'Fichar a :player por :wage/año elevaría tu masa salarial de la próxima temporada a :total, por encima de tu límite salarial de :cap. Te faltan :shortfall.',
 
     // Bid/loan submission confirmations
     'bid_already_exists' => 'Ya tienes una oferta pendiente por este jugador.',

--- a/resources/views/partials/player-detail.blade.php
+++ b/resources/views/partials/player-detail.blade.php
@@ -15,7 +15,7 @@
         && !$gamePlayer->isRetiring()
         && ($isCalledUpFromReserve || !$gamePlayer->isLoanedIn($game->team_id))
         && !$gamePlayer->isLoanedOut($game->team_id)
-        && !$gamePlayer->hasPreContractAgreement()
+        && !$gamePlayer->hasAgreedPreContractDeparture()
         && !$gamePlayer->hasAgreedTransfer()
         && !$gamePlayer->hasActiveLoanSearch();
     $canSell = $canManage && !$gamePlayer->isInSaleCooldown($game);

--- a/resources/views/partials/squad/player-status-icon.blade.php
+++ b/resources/views/partials/squad/player-status-icon.blade.php
@@ -19,7 +19,7 @@
         <svg x-data="" x-tooltip.raw="{{ __('squad.on_loan') }}" class="w-4 h-4 text-sky-500 shrink-0 cursor-help" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
             <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 9V5.25A2.25 2.25 0 0 1 10.5 3h6a2.25 2.25 0 0 1 2.25 2.25v13.5A2.25 2.25 0 0 1 16.5 21h-6a2.25 2.25 0 0 1-2.25-2.25V15M12 9l3 3m0 0-3 3m3-3H2.25" />
         </svg>
-    @elseif($gp->hasPreContractAgreement())
+    @elseif($gp->hasAgreedPreContractDeparture())
         <svg x-data="" x-tooltip.raw="{{ __('squad.leaving_free') }}" class="w-4 h-4 text-red-500 shrink-0 cursor-help" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
             <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 9V5.25A2.25 2.25 0 0 1 10.5 3h6a2.25 2.25 0 0 1 2.25 2.25v13.5A2.25 2.25 0 0 1 16.5 21h-6a2.25 2.25 0 0 1-2.25-2.25V15m-3 0-3-3m0 0 3-3m-3 3H15" />
         </svg>

--- a/tests/Feature/IncomingPreContractCompletionTest.php
+++ b/tests/Feature/IncomingPreContractCompletionTest.php
@@ -1,0 +1,178 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Game;
+use App\Models\GamePlayer;
+use App\Models\Loan;
+use App\Models\Team;
+use App\Models\TransferOffer;
+use App\Models\User;
+use App\Modules\Season\DTOs\SeasonTransitionData;
+use App\Modules\Season\Processors\ContractExpirationProcessor;
+use App\Modules\Season\Processors\LoanReturnProcessor;
+use App\Modules\Season\Processors\PreContractTransferProcessor;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * A pre-contract the user signs has to actually deliver the player at the
+ * season boundary. Two ways it could silently fail to, both ending the same
+ * way: TransferCompletionService::completeIncomingTransfer re-asserts that the
+ * player is still at the club that agreed to sell him, finds he is not, and
+ * rejects the deal with a "transfer fell through" notification.
+ *
+ *  - The selling club simply lets the contract run out, so
+ *    ContractExpirationProcessor (priority 20) frees the player before
+ *    PreContractTransferProcessor (priority 30) can move him. That is the
+ *    ordinary Bosman case — the whole point of a pre-contract — not an edge
+ *    case, and the AI's non-renewal roll decides how often it happens.
+ *  - The player was already at the user's club on loan, so the offer recorded
+ *    the borrowing club as the seller and stopped matching the moment
+ *    LoanReturnProcessor (priority 5) sent him back to his owner.
+ *
+ * These run the processors in their pipeline priority order rather than the
+ * whole SeasonClosingPipeline, so a failure points at the interaction under
+ * test instead of at unrelated season-transition fixtures.
+ */
+class IncomingPreContractCompletionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Game $game;
+    private Team $userTeam;
+    private Team $sellingTeam;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $user = User::factory()->create();
+        $this->userTeam = Team::factory()->create();
+        $this->sellingTeam = Team::factory()->create();
+
+        $this->game = Game::factory()->forTeam($this->userTeam)->create([
+            'user_id' => $user->id,
+            'season' => '2026',
+            'current_date' => '2027-06-30',
+        ]);
+    }
+
+    public function test_pre_contract_completes_when_the_selling_club_lets_the_contract_run_out(): void
+    {
+        // The AI club never renews, so the player reaches the boundary as a
+        // free agent — exactly the situation a pre-contract exists to exploit.
+        $this->forceAiNonRenewal();
+
+        $player = $this->expiringPlayerAt($this->sellingTeam);
+        $this->agreedPreContractFor($player, $this->sellingTeam);
+
+        $this->runClosing(ContractExpirationProcessor::class, PreContractTransferProcessor::class);
+
+        $this->assertSame(
+            $this->userTeam->id,
+            $player->fresh()->team_id,
+            'A pre-contracted player must join the user even when his old club declined to renew.',
+        );
+    }
+
+    public function test_pre_contract_completes_for_a_player_the_user_has_on_loan(): void
+    {
+        // Isolate the loan interaction: the owning club would have renewed him,
+        // so nothing but the loan return moves the player before completion.
+        $this->forceAiRenewal();
+
+        // A loan rewrites team_id to the borrowing club, so this player sits on
+        // the user's roster while the selling team still owns his contract.
+        $player = $this->expiringPlayerAt($this->userTeam);
+        Loan::create([
+            'game_id' => $this->game->id,
+            'game_player_id' => $player->id,
+            'parent_team_id' => $this->sellingTeam->id,
+            'loan_team_id' => $this->userTeam->id,
+            'started_at' => '2026-08-01',
+            'return_at' => '2027-06-30',
+            'status' => Loan::STATUS_ACTIVE,
+        ]);
+
+        // The deal is struck with the club that owns him, not the one he is at.
+        $this->agreedPreContractFor($player, $player->owningTeamId());
+
+        $this->runClosing(
+            LoanReturnProcessor::class,
+            ContractExpirationProcessor::class,
+            PreContractTransferProcessor::class,
+        );
+
+        $this->assertSame(
+            $this->userTeam->id,
+            $player->fresh()->team_id,
+            'Signing a player the club already has on loan must survive his loan returning home.',
+        );
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────
+
+    /**
+     * Run the named closing processors in order against the game under test.
+     *
+     * @param  class-string  ...$processors
+     */
+    private function runClosing(string ...$processors): void
+    {
+        $data = new SeasonTransitionData(
+            oldSeason: $this->game->season,
+            newSeason: '2027',
+            competitionId: $this->game->competition_id,
+        );
+
+        foreach ($processors as $processor) {
+            $data = app($processor)->process($this->game, $data);
+        }
+    }
+
+    private function expiringPlayerAt(Team $team): GamePlayer
+    {
+        return GamePlayer::factory()->forGame($this->game)->forTeam($team)->create([
+            'date_of_birth' => '1996-01-01',
+            'contract_until' => '2027-06-30',
+            'annual_wage' => 100_000_000,
+            'market_value_cents' => 1_000_000_000,
+        ]);
+    }
+
+    private function agreedPreContractFor(GamePlayer $player, Team|string $sellingTeam): TransferOffer
+    {
+        return TransferOffer::create([
+            'game_id' => $this->game->id,
+            'game_player_id' => $player->id,
+            'offering_team_id' => $this->userTeam->id,
+            'selling_team_id' => $sellingTeam instanceof Team ? $sellingTeam->id : $sellingTeam,
+            'offer_type' => TransferOffer::TYPE_PRE_CONTRACT,
+            'direction' => TransferOffer::DIRECTION_INCOMING,
+            'transfer_fee' => 0,
+            'offered_wage' => 150_000_000,
+            'offered_years' => 3,
+            'status' => TransferOffer::STATUS_AGREED,
+            'expires_at' => $this->game->current_date,
+            'game_date' => $this->game->current_date,
+            'resolved_at' => $this->game->current_date,
+        ]);
+    }
+
+    /** Make ContractExpirationProcessor's non-renewal roll a certainty. */
+    private function forceAiNonRenewal(): void
+    {
+        config()->set('transfers.ai_contract_renewal.veteran_non_renewal', 1.0);
+        config()->set('transfers.ai_contract_renewal.non_veteran_non_renewal_base', 1.0);
+        config()->set('transfers.ai_contract_renewal.non_veteran_non_renewal_max', 1.0);
+    }
+
+    /** Make it an impossibility, so every AI club re-ups instead. */
+    private function forceAiRenewal(): void
+    {
+        config()->set('transfers.ai_contract_renewal.veteran_non_renewal', 0.0);
+        config()->set('transfers.ai_contract_renewal.non_veteran_non_renewal_base', 0.0);
+        config()->set('transfers.ai_contract_renewal.non_veteran_non_renewal_max', 0.0);
+    }
+}

--- a/tests/Unit/NamingRightsServiceTest.php
+++ b/tests/Unit/NamingRightsServiceTest.php
@@ -12,7 +12,6 @@ use App\Models\GameStadium;
 use App\Models\GameStadiumNamingDeal;
 use App\Models\Team;
 use App\Models\TeamReputation;
-use App\Modules\Finance\Services\BudgetProjectionService;
 use App\Modules\Finance\Services\SalaryCapService;
 use App\Modules\Notification\Services\NotificationService;
 use App\Modules\Stadium\Services\FanLoyaltyService;
@@ -260,7 +259,7 @@ class NamingRightsServiceTest extends TestCase
         $offer = $this->seedOffer($game, status: GameStadiumNamingDeal::STATUS_PENDING, value: 1_000_000_00);
 
         config()->set('finances.wage_cap_ratio', 0.70);
-        $salaryCap = new SalaryCapService(Mockery::mock(BudgetProjectionService::class));
+        $salaryCap = app(SalaryCapService::class);
 
         $capBefore = $salaryCap->cap($game);
         $this->service->acceptOffer($game, $offer->id);

--- a/tests/Unit/SalaryCapServiceTest.php
+++ b/tests/Unit/SalaryCapServiceTest.php
@@ -7,6 +7,7 @@ use App\Models\Game;
 use App\Models\GameFinances;
 use App\Models\GameInvestment;
 use App\Models\GamePlayer;
+use App\Models\Loan;
 use App\Models\Team;
 use App\Models\TransferOffer;
 use App\Models\User;
@@ -189,6 +190,139 @@ class SalaryCapServiceTest extends TestCase
         $this->assertSame(280_000_000, $this->service->tradingAllowanceRoom($game));
     }
 
+    // ── Pre-contracts: charged to next season, not this one ───────────────
+
+    public function test_pre_contract_does_not_move_the_current_season_bill(): void
+    {
+        $game = $this->makeGame(projectedRevenue: 1_000_000_000);
+        $this->squadPlayer($game, annualWage: 100_000_000); // €1M
+
+        // A pre-contract's wage does not start until the season boundary, so
+        // it must not consume this season's room.
+        $target = GamePlayer::factory()->create([
+            'game_id' => $game->id,
+            'team_id' => Team::factory()->create()->id,
+            'annual_wage' => 30_000_000,
+        ]);
+        $this->agreedPreContract($game, $target, offeredWage: 200_000_000);
+
+        $this->assertSame(100_000_000, $this->service->committedWageBill($game));
+        // …and it is charged to next season instead: €1M staying + €2M arriving
+        $this->assertSame(300_000_000, $this->service->nextSeasonCommittedWageBill($game));
+    }
+
+    public function test_pre_contracting_a_loaned_in_player_counts_his_wage_once(): void
+    {
+        $game = $this->makeGame(projectedRevenue: 1_000_000_000);
+
+        // A player borrowed from another club sits at the user's team_id and
+        // the user pays his wage in full, then signs him on a pre-contract for
+        // next season. Both halves of the bill can see him — he must still be
+        // charged once, at the wage that actually applies in each season.
+        $loanee = $this->loanedInPlayer($game, annualWage: 300_000_000); // €3M
+        $this->agreedPreContract($game, $loanee, offeredWage: 400_000_000); // €4M
+
+        $this->assertSame(300_000_000, $this->service->committedWageBill($game));
+        $this->assertSame(400_000_000, $this->service->nextSeasonCommittedWageBill($game));
+    }
+
+    public function test_next_season_bill_drops_departing_loanees_and_expiring_contracts(): void
+    {
+        $game = $this->makeGame(projectedRevenue: 1_000_000_000);
+
+        $this->squadPlayer($game, annualWage: 100_000_000); // €1M, under contract
+        // Contract runs out at the season boundary with no renewal agreed.
+        $this->squadPlayer($game, annualWage: 200_000_000, contractUntil: '2025-06-30');
+        // Borrowed and going home at the boundary.
+        $this->loanedInPlayer($game, annualWage: 300_000_000);
+
+        $this->assertSame(600_000_000, $this->service->committedWageBill($game));
+        $this->assertSame(100_000_000, $this->service->nextSeasonCommittedWageBill($game));
+    }
+
+    public function test_next_season_bill_keeps_a_loan_that_runs_past_the_boundary(): void
+    {
+        $game = $this->makeGame(projectedRevenue: 1_000_000_000);
+        $this->loanedInPlayer($game, annualWage: 300_000_000, returnAt: '2026-06-30');
+
+        // Still at the club next season, still paid in full by the borrower.
+        $this->assertSame(300_000_000, $this->service->nextSeasonCommittedWageBill($game));
+    }
+
+    public function test_next_season_bill_uses_the_agreed_renewal_wage(): void
+    {
+        $game = $this->makeGame(projectedRevenue: 1_000_000_000);
+        $this->squadPlayer(
+            $game,
+            annualWage: 100_000_000,
+            pendingWage: 250_000_000,
+            contractUntil: '2025-06-30',
+        );
+
+        // The renewal keeps him past the boundary, at the wage he agreed.
+        $this->assertSame(250_000_000, $this->service->nextSeasonCommittedWageBill($game));
+    }
+
+    public function test_can_commit_next_season_wage_measures_next_season_room(): void
+    {
+        $game = $this->makeGame(projectedRevenue: 1_000_000_000); // cap €7M
+
+        $this->squadPlayer($game, annualWage: 300_000_000); // €3M, staying
+        // €3M of wage that expires at the boundary: it eats this season's room
+        // but leaves next season's untouched.
+        $this->squadPlayer($game, annualWage: 300_000_000, contractUntil: '2025-06-30');
+
+        $this->assertSame(600_000_000, $this->service->committedWageBill($game));
+        $this->assertSame(300_000_000, $this->service->nextSeasonCommittedWageBill($game));
+
+        // The old gate would have allowed only €1M; next season has €4M free.
+        $this->assertFalse($this->service->canCommitWage($game, 400_000_000));
+        $this->assertTrue($this->service->canCommitNextSeasonWage($game, 400_000_000));
+        $this->assertFalse($this->service->canCommitNextSeasonWage($game, 400_000_001));
+    }
+
+    public function test_next_season_gate_stays_locked_while_over_the_current_cap(): void
+    {
+        $game = $this->makeGame(projectedRevenue: 1_000_000_000); // cap €7M
+        // €8M committed this season, all of it expiring at the boundary — the
+        // freeze still applies, or an over-cap club could keep signing frees.
+        $this->squadPlayer($game, annualWage: 800_000_000, contractUntil: '2025-06-30');
+
+        $this->assertTrue($this->service->isOverCap($game));
+        $this->assertSame(0, $this->service->nextSeasonCommittedWageBill($game));
+        $this->assertFalse($this->service->canCommitNextSeasonWage($game, 1));
+        $this->assertSame(
+            __('messages.salary_cap_locked'),
+            $this->service->nextSeasonBlockMessage($game, 'Some Player', 100_000_000),
+        );
+    }
+
+    public function test_buying_a_loaned_in_player_does_not_double_count_him(): void
+    {
+        $game = $this->makeGame(projectedRevenue: 1_000_000_000);
+
+        // Same shape as the pre-contract case but a permanent bid: the player
+        // is already on the roster, so his agreed wage must replace — not
+        // stack on top of — the wage he is being paid today.
+        $loanee = $this->loanedInPlayer($game, annualWage: 300_000_000);
+        TransferOffer::create([
+            'game_id' => $game->id,
+            'game_player_id' => $loanee->id,
+            'offering_team_id' => $game->team_id,
+            'offer_type' => TransferOffer::TYPE_USER_BID,
+            'direction' => TransferOffer::DIRECTION_INCOMING,
+            'transfer_fee' => 0,
+            'offered_wage' => 450_000_000,
+            'status' => TransferOffer::STATUS_AGREED,
+            'expires_at' => $game->current_date,
+            'game_date' => $game->current_date,
+            'resolved_at' => $game->current_date,
+        ]);
+
+        $this->assertSame(300_000_000, $this->service->committedWageBill($game));
+        $this->assertSame(450_000_000, $this->service->nextSeasonCommittedWageBill($game));
+    }
+
     // ── Helpers ───────────────────────────────────────────────────────────
 
     private function makeGame(int $projectedRevenue, int $carriedSurplus = 0): Game
@@ -215,13 +349,67 @@ class SalaryCapServiceTest extends TestCase
         return $game;
     }
 
-    private function squadPlayer(Game $game, int $annualWage, ?int $pendingWage = null): GamePlayer
-    {
+    private function squadPlayer(
+        Game $game,
+        int $annualWage,
+        ?int $pendingWage = null,
+        string $contractUntil = '2027-06-30',
+    ): GamePlayer {
         return GamePlayer::factory()->create([
             'game_id' => $game->id,
             'team_id' => $game->team_id,
             'annual_wage' => $annualWage,
             'pending_annual_wage' => $pendingWage,
+            'contract_until' => $contractUntil,
+        ]);
+    }
+
+    /**
+     * A player borrowed from another club. A loan rewrites team_id to the
+     * borrowing club (LoanService::completeLoanIn), so he is indistinguishable
+     * from an owned player by team_id alone — which is exactly what makes the
+     * double-counting cases above possible.
+     */
+    private function loanedInPlayer(
+        Game $game,
+        int $annualWage,
+        string $returnAt = '2025-06-30',
+    ): GamePlayer {
+        $player = GamePlayer::factory()->create([
+            'game_id' => $game->id,
+            'team_id' => $game->team_id,
+            'annual_wage' => $annualWage,
+            'contract_until' => '2027-06-30',
+        ]);
+
+        Loan::create([
+            'game_id' => $game->id,
+            'game_player_id' => $player->id,
+            'parent_team_id' => Team::factory()->create()->id,
+            'loan_team_id' => $game->team_id,
+            'started_at' => '2024-08-01',
+            'return_at' => $returnAt,
+            'status' => Loan::STATUS_ACTIVE,
+        ]);
+
+        return $player;
+    }
+
+    private function agreedPreContract(Game $game, GamePlayer $player, int $offeredWage): TransferOffer
+    {
+        return TransferOffer::create([
+            'game_id' => $game->id,
+            'game_player_id' => $player->id,
+            'offering_team_id' => $game->team_id,
+            'selling_team_id' => $player->owningTeamId(),
+            'offer_type' => TransferOffer::TYPE_PRE_CONTRACT,
+            'direction' => TransferOffer::DIRECTION_INCOMING,
+            'transfer_fee' => 0,
+            'offered_wage' => $offeredWage,
+            'status' => TransferOffer::STATUS_AGREED,
+            'expires_at' => $game->current_date,
+            'game_date' => $game->current_date,
+            'resolved_at' => $game->current_date,
         ]);
     }
 


### PR DESCRIPTION
From player feedback: *"He hecho un par de precontratos para la temporada que viene pero me suma en el límite salarial de esta temporada […] he precontratado a uno que tengo ahora mismo también cedido y me ha contado 2 veces su sueldo."*

Both claims check out, and tracing the second one turned up three more defects on the same path — including one that made the ordinary Bosman signing fail silently.

## What was wrong

**1. Pre-contract wages were charged to the current season's cap.** `SalaryCapService::committedWageBill()` added every agreed incoming offer — pre-contracts included — to the *current* season's bill. The anti-stacking rationale holds for free agents, transfers and loan-ins, which complete mid-season, but pre-contracts are explicitly held back from mid-season completion (`TransferService::completeAgreedTransfers`) and arrive at the season boundary. So a next-season wage was measured against liabilities that expire before it ever starts: loanees going home, contracts running out, players retiring.

**2. A pre-contracted loanee was counted twice.** A loaned-in player's `team_id` is the borrowing club (`LoanService::completeLoanIn`), so both halves of the bill matched him — once at his current wage, once at the offered wage.

**3. That signing could never have completed.** Both pre-contract creation paths stamped `selling_team_id` with the player's *location* rather than his owner. For a loanee that is the buying club itself, so once `LoanReturnProcessor` (priority 5) sent him back to his parent, the ownership re-assertion in `TransferCompletionService::completeIncomingTransfer` no longer recognised the seller and rejected the deal as "transfer fell through". The user held cap space all season for a player who was never going to arrive.

**4. Agreed pre-contracts ignored direction.** `hasPreContractAgreement()` filtered on status and type but not on `direction`/`offering_team_id`, so the club's own incoming deal read as "leaving on a free". Same blind spot in the outgoing-transfer queries and the departures badge.

**5. Contract expiry cancelled incoming pre-contracts — the ordinary Bosman case.** `ContractExpirationProcessor` (priority 20) runs before `PreContractTransferProcessor` (priority 30), and its skip-list covered only *outgoing* pre-contracts, for the user's players alone — the AI queries had no pre-contract exclusion at all. A pre-contracted player whose club lost the non-renewal roll was set to `team_id = null` before his signing could complete, and rejected by the same ownership guard as finding 3. A club declining to renew is exactly why a pre-contract exists, so the common path was the broken one.

This one was pushed **test-first, without its fix**, so CI adjudicated it rather than me asserting it from code reading. It failed on `c9ace8c` with `Failed asserting that null is identical to '20e18e20-…'` — confirmed — and is fixed in `1b0c9a0`.

## What changed

- **Next-season wage bill.** `NextSeasonProjectionService::nextSeasonWageBill()` reuses the same staying/outgoing/incoming classification the squad planner already shows the user. `SalaryCapService::canCommitNextSeasonWage()` gates `SubmitPreContractOffer` and `NegotiatePreContract` against it. The over-the-cap freeze still applies, so an over-cap club cannot go on stacking free signings for next season. It is measured against the *current* cap because next season's revenue is not projected during the January–May pre-contract window — the docblock says so.
- **No double counting.** Agreed incoming offers now skip anyone already on the roster, so a player is charged once per season, at the wage that actually applies in each. This also covers the loan-to-buy variant with `TYPE_USER_BID`.
- **`selling_team_id` records the owning club**, via a new `GamePlayer::owningTeamId()` that resolves through the active loan's `parent_team_id`.
- **`GamePlayer::hasAgreedPreContractDeparture()`** carries the departure meaning (keyed on `offering_team_id !== team_id`); `hasPreContractAgreement()` keeps the direction-blind "contract situation is settled" meaning that `canReceivePreContractOffers()` and the release guard want. `ShowOutgoingTransfers` and `TransferHeaderService::getSalidaBadgeCount()` gained the missing `offering_team_id` guards.
- **`ContractExpirationProcessor`'s pre-contract skip-list is direction-blind** and applies to every club's expiry set, not just the user's.
- New `messages.pre_contract_exceeds_salary_cap` in both `es` and `en`.

## Testing

Verified by CI only — this container ships PHP 8.4 against the project's required 8.5, and `composer install` cannot complete because `phpstan/phpstan` is dist-only and GitHub archive downloads are blocked by the environment's network policy.

- `SalaryCapServiceTest` — 7 new cases covering both bills, the double-count scenarios (including the reported one), and the next-season gate.
- `IncomingPreContractCompletionTest` — 2 cases running the closing processors in priority order: completion when the selling club lets the contract run out (finding 5), and completion for a player the user holds on loan (finding 3).

Green on `1b0c9a0`: 1343 tests, 32017 assertions.

## Not included

The cap meter (`resources/views/components/salary-cap-meter.blade.php`) still shows a single number with no breakdown, which is why this read as a mystery rather than a bug. A "next season" line during the pre-contract window would make the mechanic legible — flagged for a later pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QdPf8RR985bLGwoxGYEvMs