### PR TITLE
Stop AI clubs selling players the user has pre-contracted

### DIFF
--- a/app/Modules/Notification/Services/NotificationService.php
+++ b/app/Modules/Notification/Services/NotificationService.php
@@ -422,13 +422,23 @@ class NotificationService
      * or a budget guard fired). The reserved budget is released by rejecting the
      * offer; this tells the user why the signing did not go through.
      */
-    public function notifyTransferFellThrough(Game $game, GamePlayer $player, ?Team $seller = null): GameNotification
-    {
+    public function notifyTransferFellThrough(
+        Game $game,
+        GamePlayer $player,
+        ?Team $seller = null,
+        bool $wasPreContract = false,
+    ): GameNotification {
+        // A pre-contract gets its own wording. The generic "agreed move" text
+        // lands months after the deal was struck and never names the mechanic,
+        // so a failed pre-contract read as an unrelated transfer and the player
+        // simply appeared never to arrive.
+        $key = $wasPreContract ? 'pre_contract' : 'transfer';
+
         return $this->create(
             game: $game,
             type: GameNotification::TYPE_TRANSFER_FAILED,
-            title: __('notifications.transfer_failed_title', ['player' => $player->name]),
-            message: __('notifications.transfer_failed_message', [
+            title: __("notifications.{$key}_failed_title", ['player' => $player->name]),
+            message: __("notifications.{$key}_failed_message", [
                 'player' => $player->name,
                 'team' => $seller?->name ?? '',
             ]),

--- a/app/Modules/Transfer/Services/AITransferMarketService.php
+++ b/app/Modules/Transfer/Services/AITransferMarketService.php
@@ -1443,17 +1443,32 @@ class AITransferMarketService
             ->get(['id', 'game_id', 'game_player_id', 'from_team_id', 'to_team_id', 'transfer_fee', 'window']);
         $alreadyTransferredSet = array_flip($seasonTransfers->pluck('game_player_id')->all());
 
-        // Players the user has locked in with a paid release clause must not be
-        // sold out from under them by AI churn — the clause is non-refusable.
-        // Folding their ids into $alreadyTransferredSet excludes them from every
-        // AI sell path that already honours that set (buildSellOffers etc.).
-        $clauseLockedIds = TransferOffer::where('game_id', $game->id)
+        // Players the user has locked in must not be sold out from under them by
+        // AI churn. Folding their ids into $alreadyTransferredSet excludes them
+        // from every AI sell path that already honours that set (buildSellOffers
+        // etc.). Two kinds of lock-in qualify:
+        //
+        //  - a paid release clause, which is non-refusable;
+        //  - an agreed pre-contract, which only completes while the player is
+        //    still at the club that agreed to sell him — TransferCompletionService
+        //    re-asserts that at season end, so an AI club buying him mid-season
+        //    silently kills a signing the user has already committed wages to.
+        //
+        // Pre-contracts need the protection most: one can only target a player in
+        // his final contract year, and that is precisely what scoreClearingCandidate
+        // ranks highest (a +6 contract bonus, and the "never clear a core player"
+        // rule is lifted for them). Without this the AI is most motivated to sell
+        // exactly the players the user has locked in.
+        $lockedIds = TransferOffer::where('game_id', $game->id)
             ->where('direction', TransferOffer::DIRECTION_INCOMING)
-            ->where('triggered_release_clause', true)
             ->whereIn('status', [TransferOffer::STATUS_FEE_AGREED, TransferOffer::STATUS_AGREED])
+            ->where(function ($query) {
+                $query->where('triggered_release_clause', true)
+                    ->orWhere('offer_type', TransferOffer::TYPE_PRE_CONTRACT);
+            })
             ->pluck('game_player_id')
             ->all();
-        foreach ($clauseLockedIds as $lockedId) {
+        foreach ($lockedIds as $lockedId) {
             $alreadyTransferredSet[$lockedId] = true;
         }
 

--- a/app/Modules/Transfer/Services/TransferCompletionService.php
+++ b/app/Modules/Transfer/Services/TransferCompletionService.php
@@ -207,7 +207,7 @@ class TransferCompletionService
         // dropping an agreed deal in silence.
         if ($investment && $offer->transfer_fee > $investment->transfer_budget) {
             $offer->update(['status' => TransferOffer::STATUS_REJECTED, 'resolved_at' => $game->current_date]);
-            $this->notificationService->notifyTransferFellThrough($game, $offer->gamePlayer, $offer->sellingTeam);
+            $this->notificationService->notifyTransferFellThrough($game, $offer->gamePlayer, $offer->sellingTeam, $offer->isPreContract());
             return false;
         }
 
@@ -227,7 +227,7 @@ class TransferCompletionService
         // different completion path, so selling_team_id is always set here.
         if ($offer->selling_team_id !== null && $player->team_id !== $offer->selling_team_id) {
             $offer->update(['status' => TransferOffer::STATUS_REJECTED, 'resolved_at' => $game->current_date]);
-            $this->notificationService->notifyTransferFellThrough($game, $player, $sellerTeam);
+            $this->notificationService->notifyTransferFellThrough($game, $player, $sellerTeam, $offer->isPreContract());
             return false;
         }
 

--- a/lang/en/notifications.php
+++ b/lang/en/notifications.php
@@ -67,6 +67,8 @@ return [
     'transfer_complete_outgoing_message' => ':player has been transferred :team_a for :fee.',
     'transfer_failed_title' => 'Transfer fell through: :player',
     'transfer_failed_message' => 'The agreed move for :player could not be completed and any reserved budget has been released.',
+    'pre_contract_failed_title' => 'Pre-contract fell through: :player',
+    'pre_contract_failed_message' => 'The pre-contract you agreed with :player could not be completed: he was no longer at :team at the end of the season. He does not join your squad.',
     'loan_out_complete_title' => ':player loaned out',
     'loan_out_complete_message' => ':player has been loaned :team_a until the end of the season.',
 

--- a/lang/es/notifications.php
+++ b/lang/es/notifications.php
@@ -67,6 +67,8 @@ return [
     'transfer_complete_outgoing_message' => ':player ha sido traspasado :team_a por :fee.',
     'transfer_failed_title' => 'Fichaje frustrado: :player',
     'transfer_failed_message' => 'El traspaso acordado de :player no pudo completarse y se ha liberado el presupuesto reservado.',
+    'pre_contract_failed_title' => 'Precontrato frustrado: :player',
+    'pre_contract_failed_message' => 'El precontrato que acordaste con :player no pudo completarse: ya no estaba en :team al final de la temporada. No se incorpora a tu plantilla.',
     'loan_out_complete_title' => ':player cedido',
     'loan_out_complete_message' => ':player ha sido cedido :team_a hasta final de temporada.',
 

--- a/tests/Feature/PreContractAiChurnTest.php
+++ b/tests/Feature/PreContractAiChurnTest.php
@@ -1,0 +1,169 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Competition;
+use App\Models\Game;
+use App\Models\GameNotification;
+use App\Models\GamePlayer;
+use App\Models\Team;
+use App\Models\TransferOffer;
+use App\Models\User;
+use App\Modules\Notification\Services\NotificationService;
+use App\Modules\Transfer\Services\AITransferMarketService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * A player the user has signed on a pre-contract must not be sold out from
+ * under him by AI churn.
+ *
+ * The deal only completes while the player is still at the club that agreed to
+ * sell him — TransferCompletionService re-asserts that at season end — so an AI
+ * club buying him mid-season silently kills a signing the user has already
+ * committed wages to. It is not a rare case either: a pre-contract can only
+ * target a player in his final contract year, and scoreClearingCandidate ranks
+ * exactly those highest, so the AI is most motivated to sell precisely the
+ * players the user has locked in.
+ *
+ * The lock rides on $alreadyTransferredSet, which every AI sell path already
+ * honours, the same way a paid release clause is protected. These tests drive
+ * loadTransferContext directly (as ReleaseClauseAITransferTest does for the
+ * clause recompute) so the assertion is deterministic rather than riding on the
+ * market's random candidate selection.
+ */
+class PreContractAiChurnTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private AITransferMarketService $service;
+    private Game $game;
+    private Team $sellingClub;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->service = app(AITransferMarketService::class);
+
+        $user = User::factory()->create();
+        $userTeam = Team::factory()->create(['name' => 'User Team']);
+        $this->sellingClub = Team::factory()->create(['name' => 'Selling Club']);
+
+        Competition::factory()->league()->create(['id' => 'ESP1', 'name' => 'LaLiga']);
+
+        $this->game = Game::factory()->create([
+            'user_id' => $user->id,
+            'team_id' => $userTeam->id,
+            'competition_id' => 'ESP1',
+            'season' => '2026',
+            'current_date' => '2027-02-15', // inside the pre-contract window
+        ]);
+    }
+
+    public function test_a_pre_contracted_player_is_locked_against_ai_churn(): void
+    {
+        $target = $this->finalYearPlayerAtSellingClub();
+        $this->preContract($target, TransferOffer::STATUS_AGREED);
+
+        $this->assertTrue(
+            $this->isLocked($target),
+            'An agreed pre-contract must exclude the player from every AI sell path.',
+        );
+    }
+
+    public function test_the_lock_is_specific_to_players_the_user_has_locked_in(): void
+    {
+        // Same club, same final-year contract, no pre-contract: the AI must
+        // still be free to sell him, or this would freeze the whole market.
+        $untouched = $this->finalYearPlayerAtSellingClub();
+
+        $this->assertFalse(
+            $this->isLocked($untouched),
+            'A player with no agreed deal stays available to AI churn.',
+        );
+    }
+
+    public function test_a_pending_pre_contract_does_not_lock_the_player(): void
+    {
+        // Nothing is agreed yet — the player has not accepted, so the user has
+        // committed nothing and the AI is entitled to sell him.
+        $target = $this->finalYearPlayerAtSellingClub();
+        $this->preContract($target, TransferOffer::STATUS_PENDING);
+
+        $this->assertFalse(
+            $this->isLocked($target),
+            'Only an agreed pre-contract locks a player.',
+        );
+    }
+
+    public function test_a_failed_pre_contract_is_reported_as_a_pre_contract(): void
+    {
+        // The generic "agreed move" wording lands months after the deal was
+        // struck and never names the mechanic, so a failed pre-contract read as
+        // an unrelated transfer and the player just appeared never to arrive.
+        $target = $this->finalYearPlayerAtSellingClub();
+
+        app(NotificationService::class)->notifyTransferFellThrough(
+            $this->game,
+            $target,
+            $this->sellingClub,
+            wasPreContract: true,
+        );
+
+        // Notifications are UUID-keyed with no wall-clock timestamps, so there
+        // is no meaningful ordering to take a "latest" from — this test creates
+        // exactly one.
+        $notification = GameNotification::where('game_id', $this->game->id)->sole();
+
+        $this->assertNotNull($notification);
+        $this->assertSame(
+            __('notifications.pre_contract_failed_title', ['player' => $target->name]),
+            $notification->title,
+        );
+        $this->assertStringContainsString($this->sellingClub->name, $notification->message);
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────
+
+    /**
+     * Whether the AI market treats the player as untouchable, i.e. his id is in
+     * the $alreadyTransferredSet that buildSellOffers filters against.
+     */
+    private function isLocked(GamePlayer $player): bool
+    {
+        $load = new \ReflectionMethod(AITransferMarketService::class, 'loadTransferContext');
+        $load->setAccessible(true);
+        $context = $load->invoke($this->service, $this->game, 'winter');
+
+        return isset($context['alreadyTransferredSet'][$player->id]);
+    }
+
+    private function finalYearPlayerAtSellingClub(): GamePlayer
+    {
+        return GamePlayer::factory()->forGame($this->game)->forTeam($this->sellingClub)->create([
+            'date_of_birth' => '1996-01-01',
+            'contract_until' => '2027-06-30',
+            'annual_wage' => 100_000_000,
+            'market_value_cents' => 1_000_000_000,
+        ]);
+    }
+
+    private function preContract(GamePlayer $player, string $status): TransferOffer
+    {
+        return TransferOffer::create([
+            'game_id' => $this->game->id,
+            'game_player_id' => $player->id,
+            'offering_team_id' => $this->game->team_id,
+            'selling_team_id' => $player->owningTeamId(),
+            'offer_type' => TransferOffer::TYPE_PRE_CONTRACT,
+            'direction' => TransferOffer::DIRECTION_INCOMING,
+            'transfer_fee' => 0,
+            'offered_wage' => 150_000_000,
+            'offered_years' => 3,
+            'status' => $status,
+            'expires_at' => $this->game->current_date,
+            'game_date' => $this->game->current_date,
+        ]);
+    }
+}


### PR DESCRIPTION
Third report from the same player: *"Un par de jugadores que les había hecho precontrato la temporada pasada no se me han pasado a la plantilla de la temporada siguiente."*

The main cause was the contract-expiry defect fixed in #1364. This is the **second, independent one**, and it was still live.

## The bug

An agreed pre-contract only completes while the player is still at the club that agreed to sell him — `TransferCompletionService::completeIncomingTransfer` re-asserts ownership at season end. Nothing stopped an AI club buying him mid-season, and when that happened the deal was rejected as "transfer fell through", months after the user agreed it and committed the wage against the cap.

It is not a rare case — it is close to the *expected* one. A pre-contract can only target a player in his final contract year (`submitPreContractOffer` requires `contract_until <= seasonEnd`), and that is exactly what `scoreClearingCandidate` ranks highest:

```php
if ($yearsLeft <= 1) {
    $score += (int) round(6 * $scale);   // the largest contract bonus
}
```

…with the "never clear a core player" rule explicitly lifted for them, so the club can *"recoup something rather than lose the player for free"*. The AI was most motivated to sell precisely the players the user had locked in.

## The fix

`loadTransferContext` already protects one class of user lock-in this way, and its comment states the principle outright — players locked in with a paid release clause *"must not be sold out from under them by AI churn"*. An agreed pre-contract is the same kind of commitment, so it now rides the same lock:

```php
$lockedIds = TransferOffer::where('game_id', $game->id)
    ->where('direction', TransferOffer::DIRECTION_INCOMING)
    ->whereIn('status', [TransferOffer::STATUS_FEE_AGREED, TransferOffer::STATUS_AGREED])
    ->where(function ($query) {
        $query->where('triggered_release_clause', true)
            ->orWhere('offer_type', TransferOffer::TYPE_PRE_CONTRACT);
    })
```

Folding the ids into `$alreadyTransferredSet` means every AI sell path that already honours that set honours this too — no new filter to keep in sync. Release-clause behaviour is unchanged. Only *agreed* pre-contracts lock; a pending one commits nothing and leaves the AI free to sell.

**A design call worth your veto:** locking treats the pre-contract as binding on the selling club. The alternative reading is that a club with a player leaving on a free is entitled to cash in, and the user should lose him. I went with locking because the codebase already sets that precedent for release clauses, and because silently losing a signing you committed cap space to — with no warning and no recourse — is the worst of both worlds. Easy to invert if you disagree.

## Also: the notification never said "pre-contract"

The generic *"El traspaso acordado de :player no pudo completarse"* lands months after the deal was struck and never names the mechanic. That is why three rounds of feedback described this as "precontratos falla" rather than as a specific failure — from the manager's chair the player simply never arrived. Failed pre-contracts now get their own wording in both locales, naming the club he was no longer at.

## Testing

`PreContractAiChurnTest` drives `loadTransferContext` through reflection, the way `ReleaseClauseAITransferTest` drives the clause recompute, so the assertion is deterministic rather than riding on the market's random candidate selection:

- an agreed pre-contract locks the player;
- a player with no agreed deal stays available (the lock is specific, not a market freeze);
- a *pending* pre-contract does not lock;
- a failed pre-contract is reported as a pre-contract, naming the selling club.

Verified by CI only — this container ships PHP 8.4 against the project's required 8.5, and `composer install` cannot complete because GitHub archive downloads are blocked by the environment's network policy.

## Note on the affected save

This does not repair games already hit. Under the #1364 cause the lost players were left at `team_id = null` and then deleted by the next season's free-agent cleanup (`ContractExpirationProcessor:46`); under this one they are alive at whichever club bought them. Both fixes are forward-looking only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QdPf8RR985bLGwoxGYEvMs

---
_Generated by [Claude Code](https://claude.ai/code/session_01QdPf8RR985bLGwoxGYEvMs)_