### PR TITLE
Record player ownership, not location, on every deal that turns on it

### DIFF
--- a/app/Http/Views/ShowScoutingHub.php
+++ b/app/Http/Views/ShowScoutingHub.php
@@ -33,7 +33,7 @@ class ShowScoutingHub
             ->with(['gamePlayer.team', 'gamePlayer.activeLoan.parentTeam'])
             ->get()
             ->map(fn (ShortlistedPlayer $entry) => $entry->gamePlayer)
-            ->filter(fn (?GamePlayer $gp) => $gp && $gp->team_id !== $game->team_id)
+            ->filter(fn (?GamePlayer $gp) => $gp && ! $gp->isUserOwned($game))
             ->values();
 
         $shortlistedPlayerIds = $shortlistedPlayers->pluck('id')->all();

--- a/app/Models/GamePlayer.php
+++ b/app/Models/GamePlayer.php
@@ -344,10 +344,7 @@ class GamePlayer extends Model
      */
     public function isLoanedOut(string $userTeamId): bool
     {
-        return Loan::where('game_player_id', $this->id)
-            ->where('parent_team_id', $userTeamId)
-            ->where('status', Loan::STATUS_ACTIVE)
-            ->exists();
+        return $this->resolvedActiveLoan()?->parent_team_id === $userTeamId;
     }
 
     /**
@@ -356,14 +353,7 @@ class GamePlayer extends Model
      */
     public function isLoanedIn(string $userTeamId): bool
     {
-        if ($this->relationLoaded('activeLoan')) {
-            return $this->activeLoan !== null && $this->activeLoan->loan_team_id === $userTeamId;
-        }
-
-        return Loan::where('game_player_id', $this->id)
-            ->where('loan_team_id', $userTeamId)
-            ->where('status', Loan::STATUS_ACTIVE)
-            ->exists();
+        return $this->resolvedActiveLoan()?->loan_team_id === $userTeamId;
     }
 
     /**
@@ -421,24 +411,21 @@ class GamePlayer extends Model
      */
     public function scopeOwnedByTeam($query, string $teamId)
     {
-        return $query->where(function ($q) use ($teamId) {
-            $q->where(function ($present) use ($teamId) {
-                $present->where('team_id', $teamId)
-                    ->whereDoesntHave('activeLoan');
-            })->orWhereHas('activeLoan', fn ($loanQuery) => $loanQuery->where('parent_team_id', $teamId));
-        });
+        return $query->ownedByAny([$teamId]);
     }
 
     /**
-     * Limit a query to players owned by the user in the given game — i.e.,
-     * by the first team or the reserve team. Generalizes scopeOwnedByTeam
-     * across the user's whole organization, including filial call-ups (which
-     * appear loaned-in to the first team but are still user-owned through
-     * the reserve as parent).
+     * Scope: players owned by any of the given teams.
+     *
+     * The one definition of ownership as a query. scopeOwnedByTeam and
+     * scopeUserOwned are both this scope with a different team list, so the
+     * "present and not borrowed, or lent out from here" rule is stated once.
+     *
+     * @param  list<string>  $teamIds
      */
-    public function scopeUserOwned($query, Game $game)
+    public function scopeOwnedByAny($query, array $teamIds)
     {
-        $teamIds = $game->userTeamIds();
+        $teamIds = array_values(array_filter($teamIds));
 
         if (empty($teamIds)) {
             return $query->whereRaw('1 = 0');
@@ -453,13 +440,31 @@ class GamePlayer extends Model
     }
 
     /**
-     * Whether this player is part of the user's organization in the given
-     * game — owned by the first team or the reserve team, including filial
-     * call-ups loaned internally between them.
-     *
-     * Loaned-out players (gone elsewhere but parent-owned by the user) count.
-     * Loaned-in players from a third-party club do not.
+     * Limit a query to players owned by the user in the given game — i.e.,
+     * by the first team or the reserve team. Generalizes scopeOwnedByTeam
+     * across the user's whole organization, including filial call-ups (which
+     * appear loaned-in to the first team but are still user-owned through
+     * the reserve as parent).
      */
+    public function scopeUserOwned($query, Game $game)
+    {
+        return $query->ownedByAny($game->userTeamIds());
+    }
+
+    /**
+     * The active loan for this player, honouring an already-loaded relation.
+     *
+     * Every ownership predicate below goes through here. An unloaded relation
+     * costs one query per player, so callers that iterate a collection should
+     * eager load with('activeLoan') rather than let this fall through in a loop.
+     */
+    private function resolvedActiveLoan(): ?Loan
+    {
+        return $this->relationLoaded('activeLoan')
+            ? $this->activeLoan
+            : $this->activeLoan()->first();
+    }
+
     /**
      * The id of the club that actually owns the player's contract.
      *
@@ -470,33 +475,34 @@ class GamePlayer extends Model
      * instead and completion stops recognising the seller the moment the loan
      * ends, because TransferCompletionService re-asserts that the player is
      * still at the club that agreed to sell him.
+     *
+     * Null means nobody owns him. That is a free agent (team_id null), but
+     * also a loanee whose parent club is not in the game: loans.parent_team_id
+     * is nullable and such a player is freed rather than returned when the
+     * loan ends. An active loan therefore answers with its parent even when
+     * that parent is null — falling back to team_id there would name the
+     * borrowing club as owner, which is the very confusion this resolves.
      */
     public function owningTeamId(): ?string
     {
-        $loan = $this->relationLoaded('activeLoan')
-            ? $this->activeLoan
-            : $this->activeLoan()->first();
+        $loan = $this->resolvedActiveLoan();
 
-        return $loan?->parent_team_id ?? $this->team_id;
+        return $loan !== null ? $loan->parent_team_id : $this->team_id;
     }
 
+    /**
+     * Whether this player is part of the user's organization in the given
+     * game — owned by the first team or the reserve team, including filial
+     * call-ups loaned internally between them.
+     *
+     * Loaned-out players (gone elsewhere but parent-owned by the user) count.
+     * Loaned-in players from a third-party club do not.
+     */
     public function isUserOwned(Game $game): bool
     {
-        $teamIds = $game->userTeamIds();
+        $owner = $this->owningTeamId();
 
-        if (empty($teamIds)) {
-            return false;
-        }
-
-        $loan = $this->relationLoaded('activeLoan')
-            ? $this->activeLoan
-            : $this->activeLoan()->first();
-
-        if ($loan) {
-            return in_array($loan->parent_team_id, $teamIds, true);
-        }
-
-        return in_array($this->team_id, $teamIds, true);
+        return $owner !== null && in_array($owner, $game->userTeamIds(), true);
     }
 
     /**
@@ -511,9 +517,7 @@ class GamePlayer extends Model
             return false;
         }
 
-        $loan = $this->relationLoaded('activeLoan')
-            ? $this->activeLoan
-            : $this->activeLoan()->first();
+        $loan = $this->resolvedActiveLoan();
 
         return $loan !== null
             && $loan->parent_team_id === $game->reserve_team_id
@@ -595,6 +599,13 @@ class GamePlayer extends Model
      * Without the distinction such a signing reads as "leaving on a free"
      * across the squad and transfer surfaces, because a loaned-in player's
      * team_id is the borrowing club (see LoanService::completeLoanIn).
+     *
+     * Deliberately keyed on location, not owningTeamId(): this answers "is the
+     * player I am looking at about to leave me", and the surfaces that ask it
+     * list players by where they sit. Keyed on the owner, a loanee the user is
+     * signing permanently would show the departure badge on the user's own
+     * squad page — the #1364 bug. The owner's side of the question is a query
+     * over his whole club, and belongs to TransferOffer::scopeDepartingFrom().
      */
     public function hasAgreedPreContractDeparture(): bool
     {
@@ -750,9 +761,7 @@ class GamePlayer extends Model
      */
     public function ownerCountry(): ?string
     {
-        $loan = $this->relationLoaded('activeLoan')
-            ? $this->activeLoan
-            : $this->activeLoan()->first();
+        $loan = $this->resolvedActiveLoan();
 
         if ($loan) {
             $parent = $loan->relationLoaded('parentTeam')

--- a/app/Models/TransferOffer.php
+++ b/app/Models/TransferOffer.php
@@ -469,7 +469,7 @@ class TransferOffer extends Model
 
     /**
      * Offers that would take a player *away* from the given team(s): made by
-     * a club outside them, for a player currently sitting at one of them.
+     * a club outside them, for a player one of them owns.
      * Pass Game::userTeamIds() so a filial's reserve players count too —
      * their deals complete from the reserve like any other.
      *
@@ -477,6 +477,11 @@ class TransferOffer extends Model
      * the borrowing club's team_id (LoanService::completeLoanIn). Without it,
      * a deal the user made for a player he holds on loan reads as one of his
      * own players leaving.
+     *
+     * The player side matches on ownership rather than team_id for the mirror
+     * case: a player the club owns but has lent out sits at the borrower's
+     * team_id, so a location match dropped him from the departures list of the
+     * one club that is about to lose him.
      *
      * @param  string|list<string>  $teamIds
      */
@@ -486,7 +491,7 @@ class TransferOffer extends Model
 
         return $query
             ->whereNotIn('offering_team_id', $teamIds)
-            ->whereHas('gamePlayer', fn ($player) => $player->whereIn('team_id', $teamIds));
+            ->whereHas('gamePlayer', fn ($player) => $player->ownedByAny($teamIds));
     }
 
     /**

--- a/app/Modules/Finance/Services/BudgetProjectionService.php
+++ b/app/Modules/Finance/Services/BudgetProjectionService.php
@@ -466,11 +466,18 @@ class BudgetProjectionService
 
     /**
      * Calculate total squad market value.
+     *
+     * By ownership, unlike calculateProjectedWages() above, and the difference
+     * is deliberate: wages are what the club pays, so they follow whoever
+     * trains there and exclude a loanee's parent-paid portion; value is what
+     * the club holds, so it follows the contract. Read by location this counted
+     * a borrowed player's full market value as the club's own asset while
+     * omitting the player it owns but has lent out.
      */
     public function calculateSquadValue(Game $game): int
     {
         return GamePlayer::where('game_id', $game->id)
-            ->where('team_id', $game->team_id)
+            ->ownedByTeam($game->team_id)
             ->sum('market_value_cents');
     }
 

--- a/app/Modules/Season/Processors/LoanReturnProcessor.php
+++ b/app/Modules/Season/Processors/LoanReturnProcessor.php
@@ -52,9 +52,10 @@ class LoanReturnProcessor implements SeasonProcessor
             'loanTeamName' => $loan->loanTeam->name,
         ])->toArray();
 
-        // Create notifications for players returning to user's team
+        // Create notifications for players returning to the user's club —
+        // either of his teams, since a filial's reserve lends players out too.
         foreach ($returnedLoans as $loan) {
-            if ($loan->parent_team_id === $game->team_id) {
+            if (in_array($loan->parent_team_id, $game->userTeamIds(), true)) {
                 $this->notificationService->notifyLoanReturn(
                     $game,
                     $loan->gamePlayer,

--- a/app/Modules/Transfer/Exceptions/LockedPlayerMovedException.php
+++ b/app/Modules/Transfer/Exceptions/LockedPlayerMovedException.php
@@ -6,7 +6,7 @@ use App\Models\TransferOffer;
 
 /**
  * A player held in place by a locking deal (TransferOffer::locksPlayer())
- * was found at a different club when that deal came to complete.
+ * turned out to be owned by a different club when that deal came to complete.
  *
  * This is an invariant violation, not a game event: some code path moved a
  * locked player without going through his deal. TransferCompletionService
@@ -14,20 +14,23 @@ use App\Models\TransferOffer;
  * any escrow, sends a notification), but it reports this exception so the
  * offending path is visible in the logs — and in the test suite, where the
  * base TestCase rethrows it so any test that trips the invariant fails.
+ *
+ * Ownership, not location: a loan moves a player's team_id without changing
+ * who owns him, and that is not a violation. Only a change of owner is.
  */
 class LockedPlayerMovedException extends \RuntimeException
 {
-    public static function forOffer(TransferOffer $offer, ?string $playerTeamId): self
+    public static function forOffer(TransferOffer $offer, ?string $currentOwnerTeamId): self
     {
         return new self(sprintf(
-            'Locked player %s (offer %s, %s, %s) was expected at team %s but is at %s. '
+            'Locked player %s (offer %s, %s, %s) was expected to be owned by team %s but is owned by %s. '
             . 'Some path moved him without completing or rejecting the deal.',
             $offer->game_player_id,
             $offer->id,
             $offer->offer_type,
             $offer->status,
             $offer->selling_team_id ?? 'null',
-            $playerTeamId ?? 'null',
+            $currentOwnerTeamId ?? 'null',
         ));
     }
 }

--- a/app/Modules/Transfer/Services/LoanService.php
+++ b/app/Modules/Transfer/Services/LoanService.php
@@ -121,7 +121,9 @@ class LoanService
                         'game_id' => $game->id,
                         'game_player_id' => $player->id,
                         'offering_team_id' => $destination->id,
-                        'selling_team_id' => $game->team_id,
+                        // The club lending him out is the one that owns him —
+                        // the reserve, in a filial, not always the first team.
+                        'selling_team_id' => $player->owningTeamId(),
                         'offer_type' => TransferOffer::TYPE_LOAN_OUT,
                         'direction' => TransferOffer::DIRECTION_OUTGOING,
                         'transfer_fee' => 0,
@@ -423,6 +425,30 @@ class LoanService
     }
 
     /**
+     * Close any active loan because the player has changed owner, without
+     * moving him.
+     *
+     * returnLoan() is the wrong tool here: it sends the player back to his
+     * parent and assigns him a squad number there, both of which the caller
+     * immediately undoes when it moves him to his new club. This only retires
+     * the loan row.
+     *
+     * Completion used to get this for free from ordering — LoanReturnProcessor
+     * (priority 5) had already ended every loan before the transfer processors
+     * (30 and 35) ran. Mid-season completions never had that, and a new
+     * processor between the two would have taken it away, leaving a bought
+     * player looking loaned-in to his buyer from his former parent.
+     */
+    public function endLoanOnOwnershipChange(GamePlayer $player): void
+    {
+        Loan::where('game_player_id', $player->id)
+            ->where('status', Loan::STATUS_ACTIVE)
+            ->update(['status' => Loan::STATUS_COMPLETED]);
+
+        $player->unsetRelation('activeLoan');
+    }
+
+    /**
      * Create a pending loan-in request (user-initiated).
      */
     public function requestLoanIn(Game $game, GamePlayer $player): TransferOffer
@@ -445,7 +471,13 @@ class LoanService
 
     private function createLoanInOffer(Game $game, GamePlayer $player, array $extra = []): TransferOffer
     {
-        if ($player->team_id === null) {
+        // The club that can lend him is the one that owns him. Read as team_id
+        // this would name his current borrower when he is already out on loan —
+        // a club with no right to lend him on — and completeLoanIn reads this
+        // value straight back as the new loan's parent_team_id.
+        $lenderTeamId = $player->owningTeamId();
+
+        if ($lenderTeamId === null) {
             throw new \InvalidArgumentException('Cannot loan a free agent — no parent team.');
         }
 
@@ -453,7 +485,7 @@ class LoanService
             'game_id' => $game->id,
             'game_player_id' => $player->id,
             'offering_team_id' => $game->team_id,
-            'selling_team_id' => $player->team_id,
+            'selling_team_id' => $lenderTeamId,
             'offer_type' => TransferOffer::TYPE_LOAN_IN,
             'direction' => TransferOffer::DIRECTION_INCOMING,
             'transfer_fee' => 0,
@@ -476,8 +508,21 @@ class LoanService
             ->where('status', Loan::STATUS_ACTIVE)
             ->get();
 
-        $loansIn = $allLoans->filter(fn ($loan) => $loan->loan_team_id === $game->team_id);
-        $loansOut = $allLoans->filter(fn ($loan) => $loan->parent_team_id === $game->team_id);
+        // The user's club is both its teams, so a loan into or out of the
+        // reserve is still his. Internal call-ups (ReserveTeamService creates a
+        // loan with the reserve as parent and the first team as borrower) sit
+        // inside the club at both ends and are not market loans — they have
+        // their own surfaces, so they belong on neither list.
+        $teamIds = $game->userTeamIds();
+        $isInternal = fn ($loan) => in_array($loan->parent_team_id, $teamIds, true)
+            && in_array($loan->loan_team_id, $teamIds, true);
+
+        $loansIn = $allLoans->filter(
+            fn ($loan) => in_array($loan->loan_team_id, $teamIds, true) && ! $isInternal($loan),
+        );
+        $loansOut = $allLoans->filter(
+            fn ($loan) => in_array($loan->parent_team_id, $teamIds, true) && ! $isInternal($loan),
+        );
 
         return [
             'in' => $loansIn,
@@ -534,7 +579,7 @@ class LoanService
     public function completeLoanIn(TransferOffer $offer, Game $game): void
     {
         $player = $offer->gamePlayer;
-        $parentTeamId = $offer->selling_team_id ?? $player->team_id;
+        $parentTeamId = $offer->selling_team_id ?? $player->owningTeamId();
 
         if ($parentTeamId === null) {
             $offer->transitionTo(TransferOffer::STATUS_REJECTED, $game->current_date);
@@ -598,13 +643,17 @@ class LoanService
     {
         $player = $offer->gamePlayer;
         $destinationTeamId = $offer->offering_team_id;
+        // The club lending him out — the reserve for a filial player, and never
+        // simply the first team. Recorded on the loan so returnLoan() sends him
+        // back to the squad he actually came from.
+        $parentTeamId = $player->owningTeamId() ?? $game->team_id;
         $effectiveStart = $game->getLoanEffectiveStartDate();
         $returnDate = $game->getSeasonEndDateFor($effectiveStart);
 
         Loan::create([
             'game_id' => $game->id,
             'game_player_id' => $player->id,
-            'parent_team_id' => $game->team_id,
+            'parent_team_id' => $parentTeamId,
             'loan_team_id' => $destinationTeamId,
             'started_at' => $effectiveStart,
             'return_at' => $returnDate,
@@ -620,7 +669,7 @@ class LoanService
         GameTransfer::record(
             gameId: $game->id,
             gamePlayerId: $player->id,
-            fromTeamId: $game->team_id,
+            fromTeamId: $parentTeamId,
             toTeamId: $destinationTeamId,
             transferFee: 0,
             type: GameTransfer::TYPE_LOAN,

--- a/app/Modules/Transfer/Services/ScoutSearchQueryBuilder.php
+++ b/app/Modules/Transfer/Services/ScoutSearchQueryBuilder.php
@@ -24,10 +24,13 @@ class ScoutSearchQueryBuilder
      */
     public function buildCandidateQuery(Game $game, array $filters, array $positions): Builder
     {
+        // Excluded by ownership, not location: a player the user has loaned out
+        // sits at the borrowing club's team_id, and filtering on that alone
+        // offered his own player back to him as a scouting target to bid for.
         $query = GamePlayer::with(['team'])
             ->where('game_id', $game->id)
             ->whereNotNull('team_id')
-            ->whereNotIn('team_id', $game->userTeamIds());
+            ->whereNot(fn ($q) => $q->userOwned($game));
 
         $this->applyPositionFilter($query, $positions);
 

--- a/app/Modules/Transfer/Services/TransferCompletionService.php
+++ b/app/Modules/Transfer/Services/TransferCompletionService.php
@@ -9,6 +9,7 @@ use App\Models\GamePlayer;
 use App\Models\GameTransfer;
 use App\Models\Loan;
 use App\Models\ShortlistedPlayer;
+use App\Models\Team;
 use App\Models\TransferListing;
 use App\Models\TransferOffer;
 use App\Models\UserSquadCareerRecord;
@@ -32,6 +33,7 @@ class TransferCompletionService
         private readonly SquadNumberService $squadNumberService,
         private readonly ContractService $contractService,
         private readonly NotificationService $notificationService,
+        private readonly LoanService $loanService,
     ) {}
     /**
      * Complete an outgoing transfer (user's player sold to AI team).
@@ -47,7 +49,16 @@ class TransferCompletionService
 
         // Where he is leaving from: the first team or, in a filial, the
         // reserve. A loan returns him there, and the transfer record names it.
-        $fromTeamId = $player->team_id;
+        // The owner rather than team_id, so selling a player who is himself out
+        // on loan credits the club that owns him and not his borrower.
+        $fromTeamId = $player->owningTeamId();
+
+        // A permanent sale ends any loan he is on — otherwise he arrives at the
+        // buyer still carrying an active loan from his former parent. A loan-out
+        // is the opposite case and creates one below.
+        if (! $isLoan) {
+            $this->loanService->endLoanOnOwnershipChange($player);
+        }
 
         // Transfer player to the buying team
         TransferListing::where('game_player_id', $player->id)->delete();
@@ -137,8 +148,18 @@ class TransferCompletionService
         $buyerName = $buyer->name;
         $buyerNameWithA = $buyer->nameWithA();
         $game = $player->game;
-        $fromTeamId = $player->team_id;
-        $fromTeamName = $player->team->name ?? null;
+        $fromTeamId = $player->owningTeamId();
+        // Name the club he is actually leaving. $player->team is his location,
+        // which is the borrowing club while he is out on loan; the offer's
+        // sellingTeam is the owner (stamped by TransferService), with a lookup
+        // for offers agreed before that was recorded.
+        $fromTeamName = $fromTeamId === $player->team_id
+            ? ($player->team->name ?? null)
+            : ($offer->sellingTeam?->name ?? Team::find($fromTeamId)?->name);
+
+        // He may still be out on loan when his pre-contract lands — completion
+        // no longer relies on LoanReturnProcessor having run first.
+        $this->loanService->endLoanOnOwnershipChange($player);
 
         // Transfer player to the buying team
         TransferListing::where('game_player_id', $player->id)->delete();
@@ -221,7 +242,7 @@ class TransferCompletionService
         $sellerTeam = $offer->sellingTeam ?? $player->team;
         $sellerName = $sellerTeam->name ?? 'Unknown';
         $sellerNameWithDe = $sellerTeam?->nameWithDe() ?? 'de Unknown';
-        $fromTeamId = $offer->selling_team_id ?? $player->team_id;
+        $fromTeamId = $offer->selling_team_id ?? $player->owningTeamId();
 
         // Re-assert ownership before mutating: between agreement and completion
         // an AI-to-AI move (or a parallel deal) could have relocated the player.
@@ -230,7 +251,19 @@ class TransferCompletionService
         // escrowed fee is released (rejected offers drop out of committedBudget())
         // and the user is told why. Free-agent signings (no selling club) take a
         // different completion path, so selling_team_id is always set here.
-        if ($offer->selling_team_id !== null && $player->team_id !== $offer->selling_team_id) {
+        //
+        // Owner against owner. selling_team_id records the club that agreed to
+        // sell — his owner, not wherever he was sitting (GamePlayer::owningTeamId).
+        // Comparing it to team_id compared an owner to a location, which matched
+        // only once the loan had ended, and held solely because LoanReturnProcessor
+        // runs at priority 5 and the transfer processors at 30 and 35. Any
+        // processor added between them would have broken agreed deals silently,
+        // and mid-season completions had no such ordering to rely on at all.
+        // A null owner (a loanee whose parent club has left the game) matches
+        // nobody and correctly fails here.
+        $currentOwnerId = $player->owningTeamId();
+
+        if ($offer->selling_team_id !== null && $currentOwnerId !== $offer->selling_team_id) {
             // For an ordinary agreed bid this is a legitimate race the market is
             // allowed to win. For a locking deal it is not: every path that moves
             // players is required to skip TransferOffer::locksPlayer() players,
@@ -238,13 +271,20 @@ class TransferCompletionService
             // offending path is visible instead of surfacing months later as a
             // support ticket; the user-facing handling below is unchanged.
             if ($offer->locksPlayer()) {
-                report(LockedPlayerMovedException::forOffer($offer, $player->team_id));
+                report(LockedPlayerMovedException::forOffer($offer, $currentOwnerId));
             }
 
             $offer->transitionTo(TransferOffer::STATUS_REJECTED, $game->current_date);
             $this->notificationService->notifyTransferFellThrough($game, $player, $sellerTeam, $offer->isPreContract());
             return false;
         }
+
+        // Ownership has passed to the buyer, so any loan he is on is over —
+        // including the loan-to-buy case, where the club completing the deal is
+        // the one currently borrowing him. Without this he would keep an active
+        // loan row naming his former parent and read as loaned-in to his own
+        // new club.
+        $this->loanService->endLoanOnOwnershipChange($player);
 
         // Transfer player to user's team
         $age = $player->age($game->current_date);
@@ -253,7 +293,11 @@ class TransferCompletionService
         $newContractEnd = Carbon::createFromDate($seasonYear + $contractYears + 1, 6, 30);
 
         TransferListing::where('game_player_id', $player->id)->delete();
-        $previousTeamId = $player->team_id;
+        // The club he came from is the seller resolved above, not his location:
+        // the two differ when the user buys a player he already holds on loan,
+        // where team_id is the user's own club. $sellerName is passed alongside
+        // as previousTeamName, so both must name the same club.
+        $previousTeamId = $fromTeamId;
         $player->update([
             'team_id' => $game->team_id,
             'number' => $this->squadNumberService->assignNumberForNewPlayer($game, $player),

--- a/app/Modules/Transfer/Services/TransferService.php
+++ b/app/Modules/Transfer/Services/TransferService.php
@@ -433,7 +433,10 @@ class TransferService
                     'game_id' => $game->id,
                     'game_player_id' => $player->id,
                     'offering_team_id' => $buyer->id,
-                    'selling_team_id' => $game->team_id,
+                    // The owning club. $game->team_id named the first team even
+                    // for a reserve player, and would name the wrong club again
+                    // for anyone the user has out on loan.
+                    'selling_team_id' => $player->owningTeamId(),
                     'offer_type' => TransferOffer::TYPE_UNSOLICITED,
                     'direction' => TransferOffer::DIRECTION_OUTGOING,
                     'transfer_fee' => $clauseCents,
@@ -890,7 +893,9 @@ class TransferService
                         'game_id' => $player->game_id,
                         'game_player_id' => $player->id,
                         'offering_team_id' => $offeringTeam->id,
-                        'selling_team_id' => $player->team_id,
+                        // The owning club, not his location — a player the user
+                        // has loaned out sits at the borrower's team_id.
+                        'selling_team_id' => $player->owningTeamId(),
                         'offer_type' => $offerType,
                         'direction' => TransferOffer::DIRECTION_OUTGOING,
                         'transfer_fee' => $clauseCents,
@@ -1661,7 +1666,9 @@ class TransferService
                 'game_id' => $game->id,
                 'game_player_id' => $player->id,
                 'offering_team_id' => $game->team_id,
-                'selling_team_id' => $player->team_id,
+                // The owning club, not his location: a loaned-out player's
+                // team_id is his borrower, who cannot sell him.
+                'selling_team_id' => $player->owningTeamId(),
                 'offer_type' => TransferOffer::TYPE_USER_BID,
                 'direction' => TransferOffer::DIRECTION_INCOMING,
                 'transfer_fee' => $clauseCents,
@@ -1741,7 +1748,8 @@ class TransferService
                 'game_id' => $game->id,
                 'game_player_id' => $player->id,
                 'offering_team_id' => $game->team_id,
-                'selling_team_id' => $player->team_id,
+                // The owning club, not his location — see submitPreContractOffer.
+                'selling_team_id' => $player->owningTeamId(),
                 'offer_type' => TransferOffer::TYPE_USER_BID,
                 'direction' => TransferOffer::DIRECTION_INCOMING,
                 'transfer_fee' => $bidCents,

--- a/database/factories/GamePlayerFactory.php
+++ b/database/factories/GamePlayerFactory.php
@@ -5,6 +5,7 @@ namespace Database\Factories;
 use App\Models\Game;
 use App\Models\GamePlayer;
 use App\Models\GamePlayerMatchState;
+use App\Models\Loan;
 use App\Models\Team;
 use App\Modules\Player\Services\PlayerTierService;
 use Carbon\Carbon;
@@ -146,6 +147,37 @@ class GamePlayerFactory extends Factory
         return $this->state(fn (array $attributes) => [
             'retiring_at_season' => $season,
         ]);
+    }
+
+    /**
+     * On loan at $borrower, owned by $parent.
+     *
+     * Encodes the invariant that trips people up: a loan rewrites team_id to
+     * the borrowing club (LoanService::completeLoanIn / completeLoanOut), so
+     * the player's location is $borrower while his contract still belongs to
+     * $parent. Pass a null $parent for a loan whose owning club is not in the
+     * game — such a player is owned by nobody and is freed when it ends.
+     */
+    public function onLoan(Game $game, Team $borrower, ?Team $parent): static
+    {
+        return $this
+            ->state(fn (array $attributes) => [
+                'game_id' => $game->id,
+                'team_id' => $borrower->id,
+            ])
+            ->afterCreating(function (GamePlayer $player) use ($game, $borrower, $parent) {
+                Loan::create([
+                    'game_id' => $game->id,
+                    'game_player_id' => $player->id,
+                    'parent_team_id' => $parent?->id,
+                    'loan_team_id' => $borrower->id,
+                    'started_at' => $game->getLoanEffectiveStartDate(),
+                    'return_at' => $game->getSeasonEndDate(),
+                    'status' => Loan::STATUS_ACTIVE,
+                ]);
+
+                $player->unsetRelation('activeLoan');
+            });
     }
 
     /**

--- a/docs/game-systems/transfer-market.md
+++ b/docs/game-systems/transfer-market.md
@@ -49,6 +49,19 @@ Buyer selection is weighted: younger players attract stronger teams, older playe
 
 See `LoanService` for destination scoring logic.
 
+### Ownership vs. location
+
+A loan rewrites the player's `team_id` to the borrowing club. For anyone on loan, `team_id` therefore answers **where he plays**, not **who owns him** — the owner is the active loan's `parent_team_id`. The same split applies to a filial: a called-up reserve player sits on the first team via an internal loan while the reserve still owns him.
+
+Two questions, two vocabularies on `GamePlayer`:
+
+- **Ownership** — `owningTeamId()`, `isUserOwned()`, and the `ownedByTeam()` / `ownedByAny()` / `userOwned()` scopes. Use for anything to do with the contract: transfers, pre-contracts, renewals, release clauses, squad value, whether a player is the user's at all. `owningTeamId()` returns `null` when nobody owns him — a free agent, or a loanee whose parent club is not in the save (`loans.parent_team_id` is nullable), and such a player never matches a team id.
+- **Location** — a plain `team_id` read. Use for what follows the body rather than the contract: squad lists, lineups, match eligibility, squad registration and minimums, shirt numbers, and the wage *bill* (a club pays whoever trains with it).
+
+Deals record the owner. `transfer_offers.selling_team_id` is the club that agreed to sell, and `TransferCompletionService` re-asserts ownership against it at completion — owner against owner, so a deal survives the player's loan ending, or not ending, at any point. Completion also retires any active loan it supersedes rather than relying on `LoanReturnProcessor` having run first.
+
+Note that several season processors still split the world on `team_id` (`ContractExpirationProcessor`, for one). That is correct only because `LoanReturnProcessor` runs at priority 5 and has already sent every loaned player home before they run. It is a real ordering dependency, not an accident — keep it in mind before reordering the closing pipeline.
+
 ## Contracts
 
 ### Wages

--- a/tests/Feature/IncomingPreContractCompletionTest.php
+++ b/tests/Feature/IncomingPreContractCompletionTest.php
@@ -111,6 +111,47 @@ class IncomingPreContractCompletionTest extends TestCase
         );
     }
 
+    public function test_pre_contract_for_a_loanee_completes_without_the_loan_return_processor(): void
+    {
+        // The same signing as above, with LoanReturnProcessor left out of the
+        // run. Completion used to depend on it: the offer recorded the owning
+        // club, the guard compared that to the player's location, and only a
+        // loan return at priority 5 made the two agree before the transfer
+        // processors ran at 30 and 35. Nothing declares that dependency, so any
+        // processor inserted between them would have broken agreed deals
+        // silently — and a mid-season completion never had the ordering at all.
+        //
+        // Ordering is now an optimisation, not a correctness requirement, and
+        // this test fails if that regresses.
+        $this->forceAiRenewal();
+
+        $player = $this->expiringPlayerAt($this->userTeam);
+        Loan::create([
+            'game_id' => $this->game->id,
+            'game_player_id' => $player->id,
+            'parent_team_id' => $this->sellingTeam->id,
+            'loan_team_id' => $this->userTeam->id,
+            'started_at' => '2026-08-01',
+            'return_at' => '2027-06-30',
+            'status' => Loan::STATUS_ACTIVE,
+        ]);
+
+        $this->agreedPreContractFor($player, $player->owningTeamId());
+
+        $this->runClosing(ContractExpirationProcessor::class, PreContractTransferProcessor::class);
+
+        $this->assertSame(
+            $this->userTeam->id,
+            $player->fresh()->team_id,
+            'Completion must not depend on LoanReturnProcessor having run first.',
+        );
+        $this->assertSame(
+            Loan::STATUS_COMPLETED,
+            Loan::where('game_player_id', $player->id)->value('status'),
+            'Completion owns retiring the loan it supersedes, rather than inheriting it from the pipeline.',
+        );
+    }
+
     // ── Helpers ───────────────────────────────────────────────────────────
 
     /**

--- a/tests/Feature/PlayerOwnershipTest.php
+++ b/tests/Feature/PlayerOwnershipTest.php
@@ -1,0 +1,224 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Game;
+use App\Models\GamePlayer;
+use App\Models\Loan;
+use App\Models\Team;
+use App\Models\TransferOffer;
+use App\Models\User;
+use App\Modules\Transfer\Services\LoanService;
+use App\Modules\Transfer\Services\TransferCompletionService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * GamePlayer::team_id says where a player plays; owningTeamId() says who holds
+ * his contract. A loan separates the two, and the codebase has repeatedly read
+ * one as the other — three of the six defects in #1364 were this confusion.
+ *
+ * These cases pin the distinction at the points where getting it wrong loses a
+ * deal or hides a player from the club that owns him.
+ */
+class PlayerOwnershipTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Game $game;
+    private Team $userTeam;
+    private Team $otherTeam;
+    private Team $thirdTeam;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $user = User::factory()->create();
+        $this->userTeam = Team::factory()->create();
+        $this->otherTeam = Team::factory()->create();
+        $this->thirdTeam = Team::factory()->create();
+
+        $this->game = Game::factory()->forTeam($this->userTeam)->create([
+            'user_id' => $user->id,
+            'season' => '2026',
+            'current_date' => '2027-02-15',
+        ]);
+    }
+
+    // ── Ownership resolves through the loan ───────────────────────────────
+
+    public function test_a_loan_moves_location_but_not_ownership(): void
+    {
+        $loanedIn = $this->playerOnLoan(borrower: $this->userTeam, parent: $this->otherTeam);
+
+        $this->assertSame($this->userTeam->id, $loanedIn->team_id);
+        $this->assertSame($this->otherTeam->id, $loanedIn->owningTeamId());
+        $this->assertFalse($loanedIn->isUserOwned($this->game));
+    }
+
+    public function test_a_loan_whose_parent_club_left_the_game_is_owned_by_nobody(): void
+    {
+        // loans.parent_team_id is nullable: the owning club isn't in this save,
+        // so the player is freed rather than returned when the loan ends.
+        // Resolving that to team_id would name his borrower as his owner.
+        $orphan = $this->playerOnLoan(borrower: $this->userTeam, parent: null);
+
+        $this->assertSame($this->userTeam->id, $orphan->team_id);
+        $this->assertNull($orphan->owningTeamId());
+        $this->assertFalse($orphan->isUserOwned($this->game));
+    }
+
+    // ── Completion no longer depends on processor ordering ────────────────
+
+    public function test_buying_a_player_the_club_holds_on_loan_completes_mid_season(): void
+    {
+        // No pipeline at all: the loan is still live, exactly as it is when a
+        // deal completes mid-season. The guard used to compare the player's
+        // location to the selling club and rejected this as "fell through",
+        // and only LoanReturnProcessor running first ever made it work.
+        $player = $this->playerOnLoan(borrower: $this->userTeam, parent: $this->otherTeam);
+        $offer = $this->agreedIncomingBid($player, $this->otherTeam);
+
+        $completed = app(TransferCompletionService::class)
+            ->completeIncomingTransfer($offer->fresh(), $this->game);
+
+        $this->assertTrue($completed, 'Buying a player the club already has on loan must complete.');
+        $this->assertSame($this->userTeam->id, $player->fresh()->team_id);
+    }
+
+    public function test_buying_a_loanee_retires_his_loan_rather_than_leaving_it_active(): void
+    {
+        // Ownership has passed, so the loan is over. Left active, he reads as
+        // loaned-in to the club that now owns him outright.
+        $player = $this->playerOnLoan(borrower: $this->userTeam, parent: $this->otherTeam);
+        $offer = $this->agreedIncomingBid($player, $this->otherTeam);
+
+        app(TransferCompletionService::class)->completeIncomingTransfer($offer->fresh(), $this->game);
+
+        $this->assertSame(
+            Loan::STATUS_COMPLETED,
+            Loan::where('game_player_id', $player->id)->value('status'),
+        );
+        $this->assertNull($player->fresh()->activeLoan()->first());
+        $this->assertSame($this->userTeam->id, $player->fresh()->owningTeamId());
+    }
+
+    public function test_completion_still_rejects_a_deal_whose_seller_no_longer_owns_the_player(): void
+    {
+        // The guard must keep doing its job: an AI-to-AI move between agreement
+        // and completion is a race the market is allowed to win.
+        $player = GamePlayer::factory()->forGame($this->game)->forTeam($this->otherTeam)->create();
+        $offer = $this->agreedIncomingBid($player, $this->otherTeam);
+
+        $player->update(['team_id' => $this->thirdTeam->id]);
+
+        $completed = app(TransferCompletionService::class)
+            ->completeIncomingTransfer($offer->fresh(), $this->game);
+
+        $this->assertFalse($completed);
+        $this->assertSame(TransferOffer::STATUS_REJECTED, $offer->fresh()->status);
+    }
+
+    // ── Offers record the owner, not the location ─────────────────────────
+
+    public function test_a_loan_in_request_names_the_owning_club_as_lender(): void
+    {
+        // He is already out on loan at a third club. That club cannot lend him
+        // on; his owner can. completeLoanIn reads selling_team_id straight back
+        // as the new loan's parent_team_id, so naming the borrower here would
+        // reparent him to a club that never owned him.
+        $player = $this->playerOnLoan(borrower: $this->thirdTeam, parent: $this->otherTeam);
+
+        $offer = app(LoanService::class)->requestLoanIn($this->game, $player);
+
+        $this->assertSame($this->otherTeam->id, $offer->selling_team_id);
+    }
+
+    // ── Departures are seen by the club that owns him ─────────────────────
+
+    public function test_a_player_loaned_out_is_still_a_departure_for_his_owner(): void
+    {
+        // The user owns him; he is away at another club; a third club signs him
+        // on a free. Matched by location he is nobody's departure — least of all
+        // the one club actually losing him.
+        $player = $this->playerOnLoan(borrower: $this->otherTeam, parent: $this->userTeam);
+        $poaching = $this->offer($player, [
+            'offering_team_id' => $this->thirdTeam->id,
+            'selling_team_id' => $this->userTeam->id,
+            'offer_type' => TransferOffer::TYPE_PRE_CONTRACT,
+            'direction' => TransferOffer::DIRECTION_OUTGOING,
+            'status' => TransferOffer::STATUS_AGREED,
+        ]);
+
+        $departing = TransferOffer::where('game_id', $this->game->id)
+            ->departingFrom($this->game->userTeamIds())
+            ->pluck('id')
+            ->all();
+
+        $this->assertContains($poaching->id, $departing);
+    }
+
+    public function test_a_loanee_signed_permanently_by_his_borrower_is_not_a_departure(): void
+    {
+        // The #1364 case, from the other side: the club he sits at is the one
+        // signing him, so he is arriving, not leaving.
+        $player = $this->playerOnLoan(borrower: $this->userTeam, parent: $this->otherTeam);
+        $this->offer($player, [
+            'offering_team_id' => $this->userTeam->id,
+            'selling_team_id' => $this->otherTeam->id,
+            'offer_type' => TransferOffer::TYPE_PRE_CONTRACT,
+            'direction' => TransferOffer::DIRECTION_INCOMING,
+            'status' => TransferOffer::STATUS_AGREED,
+        ]);
+
+        $departing = TransferOffer::where('game_id', $this->game->id)
+            ->departingFrom($this->game->userTeamIds())
+            ->pluck('id')
+            ->all();
+
+        $this->assertSame([], $departing);
+
+        // And the squad-page badge agrees: he is arriving, not leaving. This is
+        // the half hasAgreedPreContractDeparture() answers, keyed on where he
+        // sits rather than who owns him — see its docblock.
+        $this->assertFalse($player->fresh()->hasAgreedPreContractDeparture());
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────
+
+    private function playerOnLoan(Team $borrower, ?Team $parent): GamePlayer
+    {
+        return GamePlayer::factory()
+            ->onLoan($this->game, $borrower, $parent)
+            ->create([
+                'contract_until' => '2028-06-30',
+                'annual_wage' => 100_000_000,
+                'market_value_cents' => 1_000_000_000,
+            ]);
+    }
+
+    private function agreedIncomingBid(GamePlayer $player, Team $seller): TransferOffer
+    {
+        return $this->offer($player, [
+            'offering_team_id' => $this->userTeam->id,
+            'selling_team_id' => $seller->id,
+            'offer_type' => TransferOffer::TYPE_USER_BID,
+            'direction' => TransferOffer::DIRECTION_INCOMING,
+            'status' => TransferOffer::STATUS_AGREED,
+            'offered_wage' => 150_000_000,
+            'offered_years' => 3,
+        ]);
+    }
+
+    private function offer(GamePlayer $player, array $attributes): TransferOffer
+    {
+        return TransferOffer::create($attributes + [
+            'game_id' => $this->game->id,
+            'game_player_id' => $player->id,
+            'transfer_fee' => 0,
+            'expires_at' => $this->game->current_date,
+            'game_date' => $this->game->current_date,
+        ]);
+    }
+}


### PR DESCRIPTION
Follow-up to #1364 and #1367. #1364 added `GamePlayer::owningTeamId()` to resolve the club that actually holds a player's contract, and wired it into the three sites that produced the bug report. This closes the rest, and makes the completion guard stop depending on processor order.

## What was wrong

**1. Completion was correct by ordering, not by construction.** `completeIncomingTransfer` compared the player's `team_id` to the offer's `selling_team_id`. Since #1364 that column stores his *owner*, so this compared an owner to a location, and matched only once the loan had ended. It held solely because `LoanReturnProcessor` runs at priority 5 and the transfer processors at 30 and 35 — twenty-five free slots apart, with nothing declaring the dependency. A processor inserted between them would have started rejecting agreed deals as "transfer fell through", and a mid-season completion never had the ordering at all.

**2. Completion never ended the loan it superseded.** `LoanReturnProcessor` was quietly providing that too, so fixing the comparison alone would have left a player bought from his lender carrying an active loan naming his former parent — loaned-in to the club that now owns him outright.

**3. `owningTeamId()` named the borrower as owner in one case.** `$loan?->parent_team_id ?? $this->team_id` conflated "no loan" with "loan whose parent club has left the game". `loans.parent_team_id` is nullable and such a player is freed rather than returned, so the fallback resolved him to whichever club was borrowing him — the exact confusion the method exists to resolve.

**4. Four more `selling_team_id` stamps recorded the location.** `TransferService` (ordinary bid, both clause paths) and `LoanService::createLoanInOffer`. Two were argued safe as same-season deals that complete while the loan is live, which covers the loan *timing* but not a loaned-**out** player: his `team_id` is his borrower, so the borrower is recorded as seller, receives the fee, and is the club `assertSellerCanPartWith()` squad-minimum-checks. A loan-in request had a sharper version — `completeLoanIn` reads `selling_team_id` straight back as the new loan's `parent_team_id`, reparenting the player to a club that never owned him.

**5. `completeLoanOut` hardcoded the first team as loan parent**, mis-parenting every reserve loan-out, and recorded the same wrong club on the `GameTransfer`.

**6. Ownership questions answered by location.** A club could not see the player it owns but has lent out on its own departures list; the user was offered his own loaned-out player as a scouting target to bid for; and `calculateSquadValue()` counted a borrowed player's full market value as the club's asset while omitting the one it owns but has lent out.

## What changed

**The guard compares owner to owner**, and a null owner matches nobody and correctly fails. Completion now retires the loan it supersedes itself, via a narrow `LoanService::endLoanOnOwnershipChange()` — `returnLoan()` is the wrong tool, since it sends the player to his parent and assigns him a number there, both undone a line later. The same treatment applies to the outgoing and pre-contract paths, and `previousTeamId` now names the same club as the `previousTeamName` passed beside it.

**`owningTeamId()` answers null when nobody owns him.** An active loan answers with its parent even when that parent is null.

**Deals record the owner** at the remaining five stamps.

**`TransferOffer::departingFrom()` matches the player side on ownership.** `hasAgreedPreContractDeparture()` deliberately stays keyed on location — it answers "is the player I am looking at leaving me", and keyed on the owner a loanee signed permanently would show the departure badge on his new club's own squad page, which is #1364 from the other side. Its docblock now says so.

**Scouting excludes by ownership**; `getActiveLoans()` and the loan-return notification cover both of the user's teams, and internal call-ups no longer read as market loans.

**`calculateSquadValue()` counts what the club owns.** Projected wages stay location-based, which is correct — a club pays whoever trains with it — and the two docblocks now explain why they differ.

**Housekeeping:** four copies of the eager-load-or-query loan lookup folded into one `resolvedActiveLoan()`, which also makes `isLoanedOut()` honour an eager-loaded relation instead of querying per player in a squad loop; `scopeOwnedByTeam`/`scopeUserOwned` collapsed onto a new `scopeOwnedByAny`; and an orphaned docblock removed.

## Testing

Verified locally — PHP 8.4 against the project's 8.5 ran the suite fine.

New `PlayerOwnershipTest` (8 cases) and one case added to `IncomingPreContractCompletionTest` that runs the #1364 signing with `LoanReturnProcessor` **left out** of the processor list. Six of the nine fail without this change, confirmed by stashing it; the three that pass are the controls — a loan still moves location, the guard still rejects a genuine AI-to-AI race, and the squad badge still reads a permanent signing as an arrival.

`GamePlayerFactory::onLoan()` encodes the "team_id is the borrower, parent_team_id is the owner" invariant in one place; twelve tests had been hand-rolling the same `Loan::create`.

Full suite green: 1379 tests, 32125 assertions. `phpstan analyse` clean.

## Worth a second opinion

**Squad value will move on existing saves.** A borrowed player's market value no longer counts as the club's asset, and a lent-out player's now does. Correct on the balance sheet, but it is a visible number changing mid-beta.

## Not included

Several season processors still split the world on `team_id` — `ContractExpirationProcessor`, `ContractService::applyPendingWages`, `PlayerRetirementProcessor`. Each is correct **only** because `LoanReturnProcessor` has already run at priority 5. That is the same latent fragility as finding 1, but not a live defect, and the raw `DB::table()` queries carrying it are written that way for cost. Documented in `transfer-market.md` rather than rewritten.

Also deferred, as step 2: naming the *location* axis on `GamePlayer` (`isAt`, `atTeam`, …) so the ~40 deliberate location reads say so, and an architecture test in the style of `TransferOfferQueryVocabularyTest` to keep the vocabulary closed. Nothing here depends on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RW9Aw2dDiZVDruALWUt6bR

---
_Generated by [Claude Code](https://claude.ai/code/session_01RW9Aw2dDiZVDruALWUt6bR)_