### PR TITLE
Stop a failed pre-contract from vanishing without a trace

### DIFF
--- a/app/Http/Actions/NegotiatePreContract.php
+++ b/app/Http/Actions/NegotiatePreContract.php
@@ -59,6 +59,17 @@ class NegotiatePreContract
             ], 422);
         }
 
+        // Free agents are signed through NegotiateFreeAgent, not here — that
+        // action carries the mirror-image guard. A pre-contract on a club-less
+        // player would stamp selling_team_id = null and leave a committed deal
+        // on a row the season-close free-agent sweep is entitled to delete.
+        if ($player->team_id === null) {
+            return response()->json([
+                'status' => 'error',
+                'message' => __('messages.pre_contract_not_available'),
+            ], 422);
+        }
+
         // Validate pre-contract eligibility
         if (!$game->isPreContractPeriod()) {
             return response()->json([

--- a/app/Models/TransferOffer.php
+++ b/app/Models/TransferOffer.php
@@ -515,6 +515,29 @@ class TransferOffer extends Model
     }
 
     /**
+     * Ids of every player in the game who is the subject of a committed deal
+     * (fee agreed or fully agreed, in either direction), as a set
+     * (id => true) for O(1) lookup in bulk processors.
+     *
+     * Wider than lockedPlayerIds(): that set answers "may the market move
+     * him?", which an ordinary agreed bid does not forbid. This one answers
+     * "may we destroy him?", which nothing does — a delete leaves the user no
+     * notification, no offer and no player, so a deal in any committed state
+     * must outlive a cleanup sweep even if it is later allowed to fail.
+     *
+     * @return array<string, true>
+     */
+    public static function committedPlayerIds(string $gameId): array
+    {
+        $ids = static::where('game_id', $gameId)
+            ->committed()
+            ->pluck('game_player_id')
+            ->all();
+
+        return array_fill_keys($ids, true);
+    }
+
+    /**
      * Ids of every player in the game held in place by a locking deal, as a
      * set (id => true) for O(1) lookup in bulk processors.
      *

--- a/app/Modules/Season/Jobs/ProcessSeasonTransition.php
+++ b/app/Modules/Season/Jobs/ProcessSeasonTransition.php
@@ -112,7 +112,13 @@ class ProcessSeasonTransition implements ShouldQueue, ShouldBeUnique
         $game->refresh()->setRelations([]);
         $setupPipeline->run($game, $data, $closingProcessorCount, $lastStep);
 
-        // Archive transition log for debugging (exclude bulky/irrelevant keys)
+        // Archive transition log for debugging (exclude bulky/irrelevant keys).
+        //
+        // The success lists are excluded because they are bulky and already
+        // reconstructable from game_transfers. Do NOT add the *Failed keys
+        // here: a deal that did not complete leaves no game_transfers row and
+        // no transfer_offers row (the market resets at closing priority 70),
+        // so this log is the only surviving record of it.
         $excludeKeys = [
             'loanReturns', 'preContractTransfers', 'agreedTransfers',
             'contractRenewals', 'retiredPlayers', 'retirementAnnouncements',

--- a/app/Modules/Season/Processors/AgreedTransferCompletionProcessor.php
+++ b/app/Modules/Season/Processors/AgreedTransferCompletionProcessor.php
@@ -3,6 +3,7 @@
 namespace App\Modules\Season\Processors;
 
 use App\Models\Game;
+use App\Models\TransferOffer;
 use App\Modules\Season\Contracts\SeasonProcessor;
 use App\Modules\Season\DTOs\SeasonTransitionData;
 use App\Modules\Transfer\Services\TransferService;
@@ -40,15 +41,32 @@ class AgreedTransferCompletionProcessor implements SeasonProcessor
             'transferFee' => $offer->transfer_fee,
         ])->toArray();
 
-        $incomingData = $incoming->map(fn ($offer) => [
+        // As in PreContractTransferProcessor: completion re-asserts ownership
+        // and rejects the deal when the seller no longer holds the player, so
+        // split on the status left behind instead of reporting a rejected deal
+        // to the season summary as a completed signing.
+        [$incomingCompleted, $incomingFailed] = $incoming->partition(
+            fn (TransferOffer $offer) => $offer->status === TransferOffer::STATUS_COMPLETED,
+        );
+
+        $incomingData = $incomingCompleted->map(fn ($offer) => [
             'playerId' => $offer->game_player_id,
             'playerName' => $offer->gamePlayer->name,
             'fromTeamId' => $offer->selling_team_id,
             'fromTeamName' => $offer->sellingTeam->name ?? 'Unknown',
             'toTeamId' => $game->team_id,
             'transferFee' => $offer->transfer_fee,
-        ])->toArray();
+        ])->values()->toArray();
 
-        return $data->setMetadata('agreedTransfers', array_merge($outgoingData, $incomingData));
+        return $data
+            ->setMetadata('agreedTransfers', array_merge($outgoingData, $incomingData))
+            ->setMetadata('agreedTransfersFailed', $incomingFailed->map(fn ($offer) => [
+                'playerId' => $offer->game_player_id,
+                'playerName' => $offer->gamePlayer->name,
+                'expectedSellerId' => $offer->selling_team_id,
+                'playerTeamId' => $offer->gamePlayer->team_id,
+                'offerType' => $offer->offer_type,
+                'status' => $offer->status,
+            ])->values()->toArray());
     }
 }

--- a/app/Modules/Season/Processors/ContractExpirationProcessor.php
+++ b/app/Modules/Season/Processors/ContractExpirationProcessor.php
@@ -43,9 +43,20 @@ class ContractExpirationProcessor implements SeasonProcessor
         // Clean up any stale renewal negotiations
         $this->contractService->expireStaleNegotiations($game);
 
-        // Clean up unsigned free agents from the previous season
+        // Clean up unsigned free agents from the previous season.
+        //
+        // This is a hard delete, and transfer_offers.game_player_id is
+        // ON DELETE CASCADE, so destroying a player here takes any deal
+        // attached to him with it: no offer left to complete at priority
+        // 30/35, no "transfer fell through" notification, no trace at all.
+        // Anyone the user has a committed deal for therefore survives the
+        // sweep — his deal is allowed to fail, but only visibly, through the
+        // completion path that tells him why.
+        $committedPlayerIds = array_keys(TransferOffer::committedPlayerIds($game->id));
+
         GamePlayer::where('game_id', $game->id)
             ->whereNull('team_id')
+            ->when($committedPlayerIds !== [], fn ($query) => $query->whereNotIn('id', $committedPlayerIds))
             ->delete();
 
         // Season ends on June 30 of the season year

--- a/app/Modules/Season/Processors/PreContractTransferProcessor.php
+++ b/app/Modules/Season/Processors/PreContractTransferProcessor.php
@@ -6,6 +6,7 @@ use App\Modules\Season\Contracts\SeasonProcessor;
 use App\Modules\Season\DTOs\SeasonTransitionData;
 use App\Modules\Transfer\Services\TransferService;
 use App\Models\Game;
+use App\Models\TransferOffer;
 
 /**
  * Completes pre-contract transfers at end of season.
@@ -41,19 +42,41 @@ class PreContractTransferProcessor implements SeasonProcessor
             'toTeamName' => $offer->offeringTeam->name,
         ])->toArray();
 
-        // Process incoming pre-contracts (user signed players on free transfers)
+        // Process incoming pre-contracts (user signed players on free transfers).
+        // completeIncomingTransfer re-asserts the player is still at the club
+        // that agreed to sell him and rejects the deal when he is not, so the
+        // returned offers are a mix of completed and rejected — split on the
+        // status it left behind rather than reporting every attempt to the
+        // season summary as a signing the user actually got.
         $incomingTransfers = $this->transferService->completeIncomingPreContracts($game);
 
-        $incomingData = $incomingTransfers->map(fn ($offer) => [
+        [$incomingCompleted, $incomingFailed] = $incomingTransfers->partition(
+            fn (TransferOffer $offer) => $offer->status === TransferOffer::STATUS_COMPLETED,
+        );
+
+        $incomingData = $incomingCompleted->map(fn ($offer) => [
             'playerId' => $offer->game_player_id,
             'playerName' => $offer->gamePlayer->name,
             'fromTeamId' => $offer->selling_team_id,
             'fromTeamName' => $offer->sellingTeam->name ?? 'Unknown',
             'toTeamId' => $game->team_id,
-        ])->toArray();
+        ])->values()->toArray();
 
         $allTransfers = array_merge($outgoingData, $incomingData);
 
-        return $data->setMetadata('preContractTransfers', $allTransfers);
+        // Failures are published separately and, unlike the success list, are
+        // NOT stripped from the archived transition_log (see
+        // ProcessSeasonTransition). A signing that never arrived leaves no
+        // GameTransfer row and no offer once the market resets at priority 70,
+        // so without this there is nothing left to diagnose it with.
+        return $data
+            ->setMetadata('preContractTransfers', $allTransfers)
+            ->setMetadata('preContractTransfersFailed', $incomingFailed->map(fn ($offer) => [
+                'playerId' => $offer->game_player_id,
+                'playerName' => $offer->gamePlayer->name,
+                'expectedSellerId' => $offer->selling_team_id,
+                'playerTeamId' => $offer->gamePlayer->team_id,
+                'status' => $offer->status,
+            ])->values()->toArray());
     }
 }

--- a/app/Modules/Season/Processors/StatsResetProcessor.php
+++ b/app/Modules/Season/Processors/StatsResetProcessor.php
@@ -57,9 +57,25 @@ class StatsResetProcessor implements SeasonProcessor
             'morale' => 80,
         ]);
 
-        // Mark all previous-season notifications as read so the new season starts clean
+        // Mark last season's notifications as read so the new season starts clean.
+        //
+        // Scoped to notifications raised BEFORE this transition. current_date
+        // does not move during the closing pipeline, so everything the
+        // transition itself raises carries exactly that date — and some of it
+        // is the transition's report to the manager, not last season's
+        // chatter: a pre-contract that fell through
+        // (TransferCompletionService::completeIncomingTransfer, priority 30/35),
+        // a loan coming home, a reserve player promoted. Sweeping those too
+        // meant the only explanation for a signing that never arrived was
+        // marked read before the user could open the new season's inbox.
+        //
+        // Legacy rows with no game_date keep the old behaviour and are swept.
         GameNotification::where('game_id', $game->id)
             ->unread()
+            ->where(function ($query) use ($game) {
+                $query->whereNull('game_date')
+                    ->orWhere('game_date', '<', $game->current_date);
+            })
             ->update(['read_at' => now()]);
 
         $this->notifyCarriedOverInjuries($game, $data);

--- a/app/Modules/Season/Processors/TransferMarketResetProcessor.php
+++ b/app/Modules/Season/Processors/TransferMarketResetProcessor.php
@@ -7,6 +7,7 @@ use App\Models\TransferListing;
 use App\Models\TransferOffer;
 use App\Modules\Season\Contracts\SeasonProcessor;
 use App\Modules\Season\DTOs\SeasonTransitionData;
+use App\Modules\Transfer\Exceptions\AgreedOfferDiscardedException;
 use App\Models\Game;
 
 /**
@@ -24,6 +25,17 @@ class TransferMarketResetProcessor implements SeasonProcessor
     public function process(Game $game, SeasonTransitionData $data): SeasonTransitionData
     {
         ScoutReport::where('game_id', $game->id)->delete();
+
+        // The delete below is unconditional and leaves no trace, so anything
+        // still fully agreed at this point disappears without a GameTransfer
+        // row, without a notification, and without an offer to inspect after
+        // the fact. Every agreed deal should already have been completed (or
+        // rejected loudly) at priority 30/35 — surface the ones that were not
+        // instead of erasing them silently. See AgreedOfferDiscardedException.
+        TransferOffer::where('game_id', $game->id)
+            ->agreed()
+            ->get()
+            ->each(fn (TransferOffer $offer) => report(AgreedOfferDiscardedException::forOffer($offer)));
 
         TransferOffer::where('game_id', $game->id)->delete();
 

--- a/app/Modules/Transfer/Exceptions/AgreedOfferDiscardedException.php
+++ b/app/Modules/Transfer/Exceptions/AgreedOfferDiscardedException.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Modules\Transfer\Exceptions;
+
+use App\Models\TransferOffer;
+
+/**
+ * An offer the user had fully agreed was still waiting to complete when
+ * TransferMarketResetProcessor cleared the market at season close.
+ *
+ * This is an invariant violation, not a game event. Every agreed deal is
+ * meant to be resolved earlier in the closing pipeline — pre-contracts by
+ * PreContractTransferProcessor (priority 30), everything else by
+ * AgreedTransferCompletionProcessor (priority 35) — either completing or
+ * failing loudly with a "transfer fell through" notification. Reaching the
+ * reset at priority 70 still agreed means no completion query matched it,
+ * and the reset's unconditional delete then erases the only evidence the
+ * deal ever existed. That is why "mis fichajes han desaparecido" has been
+ * impossible to diagnose after the fact.
+ *
+ * Reported (not thrown) in production so a save never gets stuck on it; the
+ * base TestCase rethrows it so any pipeline test that strands an agreed deal
+ * fails instead of surfacing months later as a support ticket.
+ *
+ * STATUS_FEE_AGREED is deliberately not covered: a deal whose club fee is
+ * settled but whose personal terms are not is an unfinished negotiation, and
+ * abandoning it at season end is correct.
+ */
+class AgreedOfferDiscardedException extends \RuntimeException
+{
+    public static function forOffer(TransferOffer $offer): self
+    {
+        return new self(sprintf(
+            'Agreed offer %s (player %s, %s, direction %s, seller %s, buyer %s) was still '
+            . 'awaiting completion when the transfer market was reset at season close. '
+            . 'No completion pass picked it up.',
+            $offer->id,
+            $offer->game_player_id,
+            $offer->offer_type,
+            $offer->direction ?? 'null',
+            $offer->selling_team_id ?? 'null',
+            $offer->offering_team_id,
+        ));
+    }
+}

--- a/app/Modules/Transfer/Services/TransferService.php
+++ b/app/Modules/Transfer/Services/TransferService.php
@@ -1524,6 +1524,15 @@ class TransferService
             throw new \InvalidArgumentException(__('messages.pre_contract_not_available'));
         }
 
+        // A free agent has no club to pre-contract around, and the offer would
+        // record selling_team_id = null. The dossier UI already routes him to
+        // the free-agent flow; this is the server-side half of that rule, and
+        // it also keeps a committed deal off a player the season-close
+        // free-agent sweep would otherwise have deleted.
+        if ($player->team_id === null) {
+            throw new \InvalidArgumentException(__('messages.pre_contract_not_available'));
+        }
+
         $seasonEnd = $game->getSeasonEndDate();
         if (!$player->contract_until || !$player->contract_until->lte($seasonEnd)) {
             throw new \InvalidArgumentException(__('messages.player_not_expiring'));

--- a/tests/Feature/SeasonClosingPreContractDeliveryTest.php
+++ b/tests/Feature/SeasonClosingPreContractDeliveryTest.php
@@ -1,0 +1,277 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Game;
+use App\Models\GameFinances;
+use App\Models\GameInvestment;
+use App\Models\GameNotification;
+use App\Models\GamePlayer;
+use App\Models\GameStanding;
+use App\Models\GameTransfer;
+use App\Models\Loan;
+use App\Models\Team;
+use App\Models\TransferOffer;
+use App\Modules\Season\Services\SeasonClosingPipeline;
+use App\Modules\Transfer\Exceptions\LockedPlayerMovedException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Exceptions;
+use Tests\TestCase;
+
+/**
+ * A pre-contract the user signs has to survive the *whole* season close, not
+ * just the two or three processors an isolated test happens to name.
+ *
+ * IncomingPreContractCompletionTest runs ContractExpirationProcessor and
+ * PreContractTransferProcessor by hand, which is the right shape for pinning
+ * those two interactions but leaves the other 27 closing processors untested.
+ * Several of them relocate players before completion runs at priority 30 —
+ * the two reserve auto-promotions at priorities 4 and 6 especially — and each
+ * one silently kills the deal if it forgets TransferOffer::locksPlayer():
+ * TransferCompletionService re-asserts the player is still at the club that
+ * agreed to sell him, finds he is not, and rejects it as "transfer fell
+ * through". That is the recurring shape behind "mis fichajes han
+ * desaparecido", so it is pinned here against the real pipeline.
+ *
+ * Every case also implicitly asserts no offer reaches TransferMarketReset-
+ * Processor (priority 70) still agreed: the base TestCase rethrows both
+ * LockedPlayerMovedException and AgreedOfferDiscardedException.
+ */
+class SeasonClosingPreContractDeliveryTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const SEASON = '2024';
+    private const CURRENT_DATE = '2025-06-10';
+    private const CONTRACT_END = '2025-06-30';
+
+    private Game $game;
+    private Team $userTeam;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->userTeam = Team::factory()->create();
+        $this->game = Game::factory()->forTeam($this->userTeam)->create([
+            'season' => self::SEASON,
+            'current_date' => self::CURRENT_DATE,
+        ]);
+
+        $this->seedSeasonFixtures();
+
+        // The club never renews, so every pre-contracted player reaches the
+        // boundary via the Bosman path the feature exists to model.
+        config()->set('transfers.ai_contract_renewal.veteran_non_renewal', 1.0);
+        config()->set('transfers.ai_contract_renewal.non_veteran_non_renewal_base', 1.0);
+        config()->set('transfers.ai_contract_renewal.non_veteran_non_renewal_max', 1.0);
+    }
+
+    public function test_pre_contract_from_an_ai_first_team_is_delivered(): void
+    {
+        $sellingTeam = Team::factory()->create();
+        $player = $this->expiringPlayerAt($sellingTeam, '1998-01-01');
+        $this->agreedPreContractFor($player, $sellingTeam->id);
+
+        app(SeasonClosingPipeline::class)->run($this->game);
+
+        $this->assertJoinedUserTeam($player, 'the ordinary Bosman signing');
+    }
+
+    /**
+     * The player sits in an AI club's reserve and is old enough that
+     * ReserveOveragePromotionProcessor (priority 4) would move him up to the
+     * parent first team — long before completion at priority 30 gets to look
+     * at him, and to a club that is not the one the offer names as seller.
+     */
+    public function test_pre_contract_for_an_overage_ai_reserve_player_is_delivered(): void
+    {
+        $reserve = $this->aiReserveTeam();
+        // Born before the next season's U-23 cutoff (2025 - 23 = 2002-01-01).
+        $player = $this->expiringPlayerAt($reserve, '1998-01-01');
+        $this->agreedPreContractFor($player, $reserve->id);
+
+        app(SeasonClosingPipeline::class)->run($this->game);
+
+        $this->assertJoinedUserTeam($player, 'a signing from an AI reserve squad');
+    }
+
+    /**
+     * Same club, the other promotion: still U-23 next season but a good enough
+     * blend of ability and potential that AIReserveCallUpProcessor (priority 6)
+     * would call him up to the parent first team.
+     */
+    public function test_pre_contract_for_an_ai_reserve_prospect_is_delivered(): void
+    {
+        $reserve = $this->aiReserveTeam();
+        // After the cutoff, so he is still U-23; blend (74 + 80) / 2 = 77
+        // clears ReserveTeamService::MIN_PROSPECT_BLEND.
+        $player = $this->expiringPlayerAt($reserve, '2003-06-01', [
+            'overall_score' => 74,
+            'potential' => 80,
+        ]);
+        $this->agreedPreContractFor($player, $reserve->id);
+
+        app(SeasonClosingPipeline::class)->run($this->game);
+
+        $this->assertJoinedUserTeam($player, 'a signing from an AI reserve prospect pool');
+    }
+
+    /**
+     * The user already holds the player on loan, so his team_id is the user's
+     * club while the selling team still owns his contract. LoanReturnProcessor
+     * (priority 5) sends him home before completion.
+     */
+    public function test_pre_contract_for_a_player_the_user_holds_on_loan_is_delivered(): void
+    {
+        $sellingTeam = Team::factory()->create();
+        $player = $this->expiringPlayerAt($this->userTeam, '1998-01-01');
+
+        Loan::create([
+            'game_id' => $this->game->id,
+            'game_player_id' => $player->id,
+            'parent_team_id' => $sellingTeam->id,
+            'loan_team_id' => $this->userTeam->id,
+            'started_at' => '2024-08-01',
+            'return_at' => self::CONTRACT_END,
+            'status' => Loan::STATUS_ACTIVE,
+        ]);
+
+        $this->agreedPreContractFor($player, $player->owningTeamId());
+
+        app(SeasonClosingPipeline::class)->run($this->game);
+
+        $this->assertJoinedUserTeam($player, 'a signing the club already had on loan');
+    }
+
+    /**
+     * When a deal genuinely does fall through, the user has to be told. The
+     * notification is raised at priority 30 and StatsResetProcessor sweeps the
+     * inbox at priority 65 — it must spare what this transition itself just
+     * produced, or the only explanation for a missing signing is marked read
+     * before the user can open the new season.
+     */
+    public function test_a_failed_pre_contract_leaves_an_unread_notification(): void
+    {
+        // This case moves a locked player on purpose to force the failure.
+        Exceptions::fake([LockedPlayerMovedException::class]);
+
+        $sellingTeam = Team::factory()->create();
+        $elsewhere = Team::factory()->create();
+        $player = $this->expiringPlayerAt($elsewhere, '1998-01-01');
+        $this->agreedPreContractFor($player, $sellingTeam->id);
+
+        $lastSeasonsNews = GameNotification::create([
+            'game_id' => $this->game->id,
+            'type' => GameNotification::TYPE_TRANSFER_OFFER_RECEIVED,
+            'title' => 'Older news',
+            'priority' => GameNotification::PRIORITY_INFO,
+            'game_date' => '2025-02-01',
+        ]);
+
+        app(SeasonClosingPipeline::class)->run($this->game);
+
+        $failure = GameNotification::where('game_id', $this->game->id)
+            ->where('type', GameNotification::TYPE_TRANSFER_FAILED)
+            ->first();
+
+        $this->assertNotNull($failure, 'A pre-contract that fell through must notify the user.');
+        $this->assertNull(
+            $failure->read_at,
+            'The transition must not mark its own report read before the user can see it.',
+        );
+        $this->assertNotNull(
+            $lastSeasonsNews->fresh()?->read_at,
+            'Last season\'s notifications should still be swept so the new season starts clean.',
+        );
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────
+
+    private function assertJoinedUserTeam(GamePlayer $player, string $what): void
+    {
+        $this->assertSame(
+            $this->userTeam->id,
+            $player->fresh()?->team_id,
+            "The season close must deliver {$what}.",
+        );
+
+        $this->assertTrue(
+            GameTransfer::where('game_id', $this->game->id)
+                ->where('game_player_id', $player->id)
+                ->where('to_team_id', $this->userTeam->id)
+                ->exists(),
+            "A delivered signing must leave a GameTransfer row ({$what}).",
+        );
+    }
+
+    /** An AI club with a reserve squad; returns the reserve. */
+    private function aiReserveTeam(): Team
+    {
+        $parent = Team::factory()->create();
+
+        return Team::factory()->create(['parent_team_id' => $parent->id]);
+    }
+
+    private function expiringPlayerAt(Team $team, string $dateOfBirth, array $attributes = []): GamePlayer
+    {
+        return GamePlayer::factory()->forGame($this->game)->forTeam($team)->create(array_merge([
+            'date_of_birth' => $dateOfBirth,
+            'contract_until' => self::CONTRACT_END,
+            'annual_wage' => 100_000_000,
+            'market_value_cents' => 1_000_000_000,
+        ], $attributes));
+    }
+
+    private function agreedPreContractFor(GamePlayer $player, string $sellingTeamId): TransferOffer
+    {
+        return TransferOffer::create([
+            'game_id' => $this->game->id,
+            'game_player_id' => $player->id,
+            'offering_team_id' => $this->userTeam->id,
+            'selling_team_id' => $sellingTeamId,
+            'offer_type' => TransferOffer::TYPE_PRE_CONTRACT,
+            'direction' => TransferOffer::DIRECTION_INCOMING,
+            'transfer_fee' => 0,
+            'offered_wage' => 150_000_000,
+            'offered_years' => 3,
+            'status' => TransferOffer::STATUS_AGREED,
+            'expires_at' => self::CURRENT_DATE,
+            'game_date' => '2025-02-05',
+            'resolved_at' => '2025-02-05',
+        ]);
+    }
+
+    /** The rows the closing pipeline expects a played-out season to have left. */
+    private function seedSeasonFixtures(): void
+    {
+        GameInvestment::create([
+            'game_id' => $this->game->id,
+            'season' => self::SEASON,
+            'transfer_budget' => 50_000_000_00,
+            'scouting_tier' => 1,
+        ]);
+
+        GameFinances::create([
+            'game_id' => $this->game->id,
+            'season' => self::SEASON,
+            'projected_revenue' => 100_000_000_00,
+            'projected_wages' => 50_000_000_00,
+            'projected_position' => 10,
+        ]);
+
+        GameStanding::create([
+            'game_id' => $this->game->id,
+            'competition_id' => $this->game->competition_id,
+            'team_id' => $this->game->team_id,
+            'position' => 10,
+            'played' => 38,
+            'won' => 10,
+            'drawn' => 8,
+            'lost' => 20,
+            'goals_for' => 40,
+            'goals_against' => 60,
+            'points' => 38,
+        ]);
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,6 +2,7 @@
 
 namespace Tests;
 
+use App\Modules\Transfer\Exceptions\AgreedOfferDiscardedException;
 use App\Modules\Transfer\Exceptions\LockedPlayerMovedException;
 use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
@@ -24,6 +25,14 @@ abstract class TestCase extends BaseTestCase
         // with Exceptions::fake([LockedPlayerMovedException::class]).
         $this->app->make(ExceptionHandler::class)->reportable(
             fn (LockedPlayerMovedException $e) => throw $e,
+        );
+
+        // Same contract for a deal that reached the season-close market reset
+        // still agreed: in production it is reported so the save survives, but
+        // under test a stranded agreed offer is a pipeline bug and must fail
+        // the run. Opt out with Exceptions::fake([AgreedOfferDiscardedException::class]).
+        $this->app->make(ExceptionHandler::class)->reportable(
+            fn (AgreedOfferDiscardedException $e) => throw $e,
         );
     }
 }


### PR DESCRIPTION
From player feedback, on the build that already carries #1364/#1366/#1367:

> *"Primero gracias por la actualización. He vuelto a jugar una temporada, al finalizarla todos los fichajes que había hecho para la 27/28 han desaparecido, únicamente he perdido a los jugadores que acababan contrato pero no ha cargado los fichajes."*

Same reporter as the "mis precontratos no llegan" thread, same symptom, on the fixed build. Confirmed scope: **agreed incoming pre-contracts** — deals struck in the Jan–May window that `PreContractTransferProcessor` (closing priority 30) should deliver at the boundary.

## What I could not find

A remaining relocation hole. After #1367 every site that moves a player for a reason other than completing his own deal consults `TransferOffer::locksPlayer()` — including the two I most suspected, which run *before* completion and are not covered by any existing test:

| Site | Priority | Lock honoured |
|---|---|---|
| `ReserveOveragePromotionProcessor` → `autoPromoteOverageReservePlayers` | 4 | `ReserveTeamService.php:263` |
| `AIReserveCallUpProcessor` → `autoPromoteAIReserveProspects` | 6 | `ReserveTeamService.php:473` |
| `ContractExpirationProcessor` (expiry sweep) | 20 | `ContractExpirationProcessor.php:148` |
| `SquadReplenishmentProcessor` (trim to 28) | 42 | `SquadReplenishmentProcessor.php:139` |
| `AITransferMarketService` (AI churn, window close) | in-season | `AITransferMarketService.php:1456` |
| `RollAIContractRenewals` | in-season | skips active pre-contracts |

So this PR does not assert a root cause. It fixes what it *can* establish, which is why the same report has now survived three PRs.

## What was wrong

**1. The user is never told.** `TransferCompletionService::completeIncomingTransfer` raises a "transfer fell through" notification at priority 30/35. `StatsResetProcessor` then marked **every** unread notification read at priority 65, to start the new season clean. `current_date` does not move during the closing pipeline, so the sweep is now scoped to notifications stamped before it: last season's chatter still goes, the transition's own report to the manager survives unread. This alone turns any failure into "ha desaparecido, sin más".

**2. A rejected deal was reported as a signing.** `completeIncomingPreContracts()` pushes every offer it attempted into its return value regardless of the boolean `completeIncomingTransfer()` hands back, and both processors mapped the lot into the season summary. They now split on the status completion left behind.

**3. Nothing survives to diagnose it with.** A deal that never completed leaves no `game_transfers` row, and no `transfer_offers` row either once the market resets at priority 70. `ProcessSeasonTransition` also strips the pre-contract metadata from the archived `transition_log`. The new `preContractTransfersFailed` / `agreedTransfersFailed` keys are deliberately **not** added to `$excludeKeys` — that log is the only record left.

**4. The market reset was silent.** `TransferOffer::where('game_id', …)->delete()` is unconditional, so an agreed deal no completion pass picked up disappeared outright. Anything still `agreed` is now `report()`ed as `AgreedOfferDiscardedException` first, rethrown under test like `LockedPlayerMovedException` so a stranded deal fails a pipeline test instead of surfacing months later as a ticket. `STATUS_FEE_AGREED` is excluded — an unfinished negotiation is meant to lapse.

**5. The free-agent purge ate committed deals.** `ContractExpirationProcessor` hard-deletes every team-less player at priority 20 and `transfer_offers.game_player_id` is `ON DELETE CASCADE`, so any deal attached to one went with it — before completion could either deliver it or fail it with a notification. Players carrying a committed offer are now spared. `committedPlayerIds()` is deliberately wider than `lockedPlayerIds()`: *"may the market move him?"* and *"may we destroy him?"* are different questions, and only the first has a legitimate yes. Both pre-contract entry points also reject a club-less player now, matching the dossier UI, which already routes free agents to the free-agent flow.

## Testing

`SeasonClosingPreContractDeliveryTest` runs the **whole** closing pipeline, not the two or three processors `IncomingPreContractCompletionTest` names by hand — which is precisely how an interaction with any of the other 26 goes unnoticed. Four shapes a pre-contracted player can be in:

- an AI first team, club declining to renew (the ordinary Bosman);
- an AI reserve squad, old enough for the overage promotion at priority 4;
- an AI reserve prospect, good enough for the call-up at priority 6;
- a player the user already holds on loan, sent home at priority 5.

Plus a case that forces a failure on purpose and asserts the notification survives the transition unread while last season's news is still swept. Every case also asserts, through the base `TestCase`, that no offer reaches the market reset still agreed.

**Not verified locally** — `.github/workflows/tests.yml` only triggers on `pull_request`, and per CLAUDE.md I left the suite to CI. The `AgreedOfferDiscardedException` rethrow in `tests/TestCase.php` is load-bearing: if an existing pipeline test strands an agreed offer, it will now fail, and that failure is the bug we are looking for.

## Still open

The diagnosis is set up, not finished. `game_notifications` survives the rollover, so on the reporter's save `type = 'transfer_failed'` rows say immediately whether the ownership guard rejected his deals — and his `game_transfers` rows then name the processor that moved the player — or whether the offers never reached completion at all. Pablo has access to the game id; that is the next step, and it is what step 5 of the fix depends on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013f48cEXUnD1SYxA97SW5WG

---
_Generated by [Claude Code](https://claude.ai/code/session_013f48cEXUnD1SYxA97SW5WG)_